### PR TITLE
feat(suite): unify network badge on asset icons

### DIFF
--- a/packages/product-components/src/components/TokenIcon/NativeCoinIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/NativeCoinIcon.tsx
@@ -1,0 +1,55 @@
+import { isNetworkIconSymbol } from '@suite-common/icons';
+import {
+    getNetworkOptional,
+    isNetworkSymbol,
+    shouldShowNetworkBadge,
+} from '@suite-common/wallet-config';
+
+import { NativeTokenIcon } from './NativeTokenIcon';
+import { type TokenIconProps } from './tokenIconTypes';
+import { NetworkIconBadge } from '../NetworkIcon/NetworkIconBadge';
+
+type NativeCoinIconProps = Pick<
+    TokenIconProps,
+    | 'symbol'
+    | 'size'
+    | 'showNetworkIcon'
+    | 'showNativeNetworkBadge'
+    | 'wrappedTokenIcon'
+    | 'data-testid'
+>;
+
+export const NativeCoinIcon = ({
+    symbol,
+    size = 32,
+    showNetworkIcon = false,
+    showNativeNetworkBadge = false,
+    wrappedTokenIcon = 'token',
+    'data-testid': dataTestId,
+}: NativeCoinIconProps) => {
+    if (!showNetworkIcon) {
+        return <NativeTokenIcon symbol={symbol} size={size} data-testid={dataTestId} />;
+    }
+
+    const settlementSymbol = getNetworkOptional(symbol)?.settlementLayer ?? symbol;
+    const hasDistinctSettlementLayer = settlementSymbol !== symbol;
+    const isBadgeableTokenNetwork =
+        showNativeNetworkBadge && isNetworkSymbol(symbol) && shouldShowNetworkBadge(symbol);
+    const showBadge =
+        isNetworkIconSymbol(symbol) &&
+        (hasDistinctSettlementLayer ||
+            wrappedTokenIcon === 'network' ||
+            isBadgeableTokenNetwork);
+
+    const icon = <NativeTokenIcon symbol={settlementSymbol} size={size} data-testid={dataTestId} />;
+
+    if (!showBadge) {
+        return icon;
+    }
+
+    return (
+        <NetworkIconBadge networkSymbol={symbol} parentSize={size} data-testid={dataTestId}>
+            {icon}
+        </NetworkIconBadge>
+    );
+};

--- a/packages/product-components/src/components/TokenIcon/TokenIcon.stories.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.stories.tsx
@@ -47,6 +47,9 @@ const meta: Meta<TokenIconProps> = {
         showNetworkIcon: {
             control: { type: 'boolean' },
         },
+        showNativeNetworkBadge: {
+            control: { type: 'boolean' },
+        },
         shouldTryToFetch: {
             control: { type: 'boolean' },
         },
@@ -84,6 +87,45 @@ export const Token: StoryObj<TokenIconProps> = {
         placeholder: 'USDC',
         shouldTryToFetch: true,
         showNetworkIcon: true,
+        isBordered: true,
+        ...getFramePropsStory(allowedTokenIconFrameProps).args,
+    },
+};
+
+export const NativeCoinWithNetworkBadge: StoryObj<TokenIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'eth',
+        placeholder: 'ETH',
+        shouldTryToFetch: true,
+        showNetworkIcon: true,
+        showNativeNetworkBadge: true,
+        isBordered: true,
+        ...getFramePropsStory(allowedTokenIconFrameProps).args,
+    },
+};
+
+export const NativeCoinWithoutNetworkBadge: StoryObj<TokenIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'btc',
+        placeholder: 'BTC',
+        shouldTryToFetch: true,
+        showNetworkIcon: true,
+        showNativeNetworkBadge: true,
+        isBordered: true,
+        ...getFramePropsStory(allowedTokenIconFrameProps).args,
+    },
+};
+
+export const NativeCoinLegacyNoBadge: StoryObj<TokenIconProps> = {
+    args: {
+        size: 40,
+        symbol: 'eth',
+        placeholder: 'ETH',
+        shouldTryToFetch: true,
+        showNetworkIcon: true,
+        showNativeNetworkBadge: false,
         isBordered: true,
         ...getFramePropsStory(allowedTokenIconFrameProps).args,
     },

--- a/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
@@ -4,6 +4,7 @@ import {
     getNetworkOptional,
     isNetworkSymbol,
     isWrappedNativeToken,
+    shouldShowNetworkBadge,
 } from '@suite-common/wallet-config';
 
 import { NativeTokenIcon } from './NativeTokenIcon';
@@ -16,6 +17,7 @@ export const TokenIcon = ({
     contractAddress,
     size = 32,
     showNetworkIcon = false,
+    showNativeNetworkBadge = false,
     shouldTryToFetch = true,
     placeholderWithTooltip = true,
     placeholder = '',
@@ -30,17 +32,21 @@ export const TokenIcon = ({
 
     if (!contractAddress) {
         if (showNetworkIcon) {
-            const network = getNetworkOptional(symbol);
-            const networkSymbol = network?.settlementLayer ?? symbol;
-            const displaySymbol = networkSymbol !== symbol ? networkSymbol : symbol;
+            const networkSymbol = getNetworkOptional(symbol)?.settlementLayer ?? symbol;
+            const hasDistinctSettlementLayer = networkSymbol !== symbol;
+            const isBadgeableTokenNetwork =
+                showNativeNetworkBadge && isNetworkSymbol(symbol) && shouldShowNetworkBadge(symbol);
             const tokenIcon = (
-                <NativeTokenIcon symbol={displaySymbol} size={size} data-testid={dataTestId} />
+                <NativeTokenIcon symbol={networkSymbol} size={size} data-testid={dataTestId} />
             );
 
-            if (
-                (networkSymbol !== symbol || wrappedTokenIcon === 'network') &&
-                isNetworkIconSymbol(symbol)
-            ) {
+            const showBadge =
+                isNetworkIconSymbol(symbol) &&
+                (hasDistinctSettlementLayer ||
+                    wrappedTokenIcon === 'network' ||
+                    isBadgeableTokenNetwork);
+
+            if (showBadge) {
                 return (
                     <NetworkIconBadge
                         networkSymbol={symbol}

--- a/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
@@ -1,16 +1,10 @@
-import { isCryptoIconSymbol, isNetworkIconSymbol } from '@suite-common/icons';
-import {
-    getCoingeckoId,
-    getNetworkOptional,
-    isNetworkSymbol,
-    isWrappedNativeToken,
-    shouldShowNetworkBadge,
-} from '@suite-common/wallet-config';
+import { isCryptoIconSymbol } from '@suite-common/icons';
+import { getCoingeckoId, isNetworkSymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 
+import { NativeCoinIcon } from './NativeCoinIcon';
 import { NativeTokenIcon } from './NativeTokenIcon';
 import { NonNativeTokenIcon } from './NonNativeTokenIcon';
 import { type TokenIconProps } from './tokenIconTypes';
-import { NetworkIconBadge } from '../NetworkIcon/NetworkIconBadge';
 
 export const TokenIcon = ({
     symbol,
@@ -31,37 +25,16 @@ export const TokenIcon = ({
     }
 
     if (!contractAddress) {
-        if (showNetworkIcon) {
-            const networkSymbol = getNetworkOptional(symbol)?.settlementLayer ?? symbol;
-            const hasDistinctSettlementLayer = networkSymbol !== symbol;
-            const isBadgeableTokenNetwork =
-                showNativeNetworkBadge && isNetworkSymbol(symbol) && shouldShowNetworkBadge(symbol);
-            const tokenIcon = (
-                <NativeTokenIcon symbol={networkSymbol} size={size} data-testid={dataTestId} />
-            );
-
-            const showBadge =
-                isNetworkIconSymbol(symbol) &&
-                (hasDistinctSettlementLayer ||
-                    wrappedTokenIcon === 'network' ||
-                    isBadgeableTokenNetwork);
-
-            if (showBadge) {
-                return (
-                    <NetworkIconBadge
-                        networkSymbol={symbol}
-                        parentSize={size}
-                        data-testid={dataTestId}
-                    >
-                        {tokenIcon}
-                    </NetworkIconBadge>
-                );
-            }
-
-            return tokenIcon;
-        }
-
-        return <NativeTokenIcon symbol={symbol} size={size} data-testid={dataTestId} />;
+        return (
+            <NativeCoinIcon
+                symbol={symbol}
+                size={size}
+                showNetworkIcon={showNetworkIcon}
+                showNativeNetworkBadge={showNativeNetworkBadge}
+                wrappedTokenIcon={wrappedTokenIcon}
+                data-testid={dataTestId}
+            />
+        );
     }
 
     const coingeckoId = isNetworkSymbol(symbol) ? getCoingeckoId(symbol) : undefined;

--- a/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
+++ b/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
@@ -12,6 +12,7 @@ export interface TokenIconProps extends AllowedFrameProps {
     contractAddress?: string | null;
     size?: TokenIconSize;
     showNetworkIcon?: boolean;
+    showNativeNetworkBadge?: boolean;
     shouldTryToFetch?: boolean;
     placeholderWithTooltip?: boolean;
     placeholder?: string;

--- a/packages/product-components/src/components/TokenIcon/tokenIconUtils.ts
+++ b/packages/product-components/src/components/TokenIcon/tokenIconUtils.ts
@@ -1,11 +1,4 @@
-import { isNetworkIconSymbol } from '@suite-common/icons/src/iconUtils';
-import {
-    type NetworkSymbolExtended,
-    getNetwork,
-    getNetworkByCoingeckoId,
-    getNetworkFeatures,
-    isNetworkSymbol,
-} from '@suite-common/wallet-config';
+import { getNetwork, getNetworkByCoingeckoId, isNetworkSymbol } from '@suite-common/wallet-config';
 
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -19,19 +12,6 @@ export const makeCacheKey = (coingeckoId: string, addressesKey: string) =>
 
 export const makeAddressKey = (coingeckoId: string, address: string) =>
     `${coingeckoId}::${address}`;
-
-export function shouldShowNetworkIcon(
-    networkSymbol?: NetworkSymbolExtended,
-    contractAddress?: string | null,
-) {
-    return (
-        networkSymbol &&
-        isNetworkIconSymbol(networkSymbol) &&
-        isNetworkSymbol(networkSymbol) &&
-        Boolean(contractAddress) &&
-        getNetworkFeatures(networkSymbol).includes('tokens')
-    );
-}
 
 export const getCoingeckoIdAndContractAddressIncludesNativeTokens = (
     coingeckoId: string,

--- a/packages/product-components/src/components/TopAssets/TopAssets.tsx
+++ b/packages/product-components/src/components/TopAssets/TopAssets.tsx
@@ -52,6 +52,7 @@ export function TopAssets({
                                     // @ts-expect-error
                                     symbol={asset.symbol}
                                     showNetworkIcon
+                                    showNativeNetworkBadge
                                 />
                             ) : (
                                 <TokenIcon
@@ -59,6 +60,7 @@ export function TopAssets({
                                     symbol={asset.networkSymbol}
                                     contractAddress={asset.contractAddress}
                                     placeholder={asset.displaySymbol}
+                                    showNetworkIcon
                                 />
                             )}
                             <Text typographyStyle="body-sm" intent="neutral">

--- a/packages/product-components/src/index.ts
+++ b/packages/product-components/src/index.ts
@@ -61,7 +61,6 @@ export {
     type TokenIconProps,
     type TokenIconSize,
 } from './components/TokenIcon/tokenIconTypes';
-export { shouldShowNetworkIcon } from './components/TokenIcon/tokenIconUtils';
 export * from './components/TokenIconSet/TokenIconSet';
 export { TooltipRow } from './components/TooltipRow/TooltipRow';
 export * from './components/TopAssets/TopAssets';

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
@@ -1,24 +1,17 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    shouldShowNetworkBadge,
+} from '@suite-common/wallet-config';
 import { Badge, Column, Row, Text } from '@trezor/components';
-import { hasOwn } from '@trezor/utils';
 
 type AssetDetailsProps = {
     name: string;
     displaySymbol: string;
-} & (
-    | {
-          networkSymbol: NetworkSymbol;
-      }
-    | {
-          networkName: string;
-      }
-);
+    networkSymbol: NetworkSymbol;
+};
 
-export function AssetDetails({ name, displaySymbol, ...props }: AssetDetailsProps) {
-    const badge = hasOwn(props, 'networkSymbol')
-        ? getNetwork(props.networkSymbol).name
-        : props.networkName;
-
+export function AssetDetails({ name, displaySymbol, networkSymbol }: AssetDetailsProps) {
     return (
         <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
             <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">
@@ -28,7 +21,9 @@ export function AssetDetails({ name, displaySymbol, ...props }: AssetDetailsProp
                 <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
                     {displaySymbol}
                 </Text>
-                {badge !== name && <Badge size="small">{badge}</Badge>}
+                {shouldShowNetworkBadge(networkSymbol) && (
+                    <Badge size="small">{getNetwork(networkSymbol).name}</Badge>
+                )}
             </Row>
         </Column>
     );

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
@@ -1,8 +1,9 @@
 import { getDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { Column, Row, Text } from '@trezor/components';
+import { Row } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
 
+import { AssetDetails } from '../AssetDetails';
 import { ItemClickableContainer } from '../ItemClickableContainer';
 import { AccountAmount } from './AccountAmount';
 
@@ -20,15 +21,17 @@ export function AssetRowAccountWithBalance({
     return (
         <ItemClickableContainer onClick={() => onClick(account)}>
             <Row data-testid={dataTestId} gap={12} alignItems="center" overflow="hidden">
-                <TokenIcon symbol={account.symbol} size={40} showNetworkIcon />
-                <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
-                    <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">
-                        {getNetworkDisplaySymbolName(account.symbol)}
-                    </Text>
-                    <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
-                        {getDisplaySymbol(account.symbol)}
-                    </Text>
-                </Column>
+                <TokenIcon
+                    symbol={account.symbol}
+                    size={40}
+                    showNetworkIcon
+                    showNativeNetworkBadge
+                />
+                <AssetDetails
+                    name={getNetworkDisplaySymbolName(account.symbol)}
+                    displaySymbol={getDisplaySymbol(account.symbol)}
+                    networkSymbol={account.symbol}
+                />
             </Row>
             <AccountAmount account={account} />
         </ItemClickableContainer>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -1,6 +1,6 @@
 import { type TradingAssetOption } from '@suite-common/trading';
 import { Row } from '@trezor/components';
-import { TokenIcon, shouldShowNetworkIcon } from '@trezor/product-components';
+import { TokenIcon } from '@trezor/product-components';
 
 import { AssetDetails } from '../AssetDetails';
 import { ItemClickableContainer } from '../ItemClickableContainer';
@@ -20,23 +20,25 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
         >
             <Row data-testid={dataTestId} gap={12} overflow="hidden" maxWidth="100%">
                 {asset.isNativeToken ? (
-                    <TokenIcon size={40} symbol={asset.symbol} showNetworkIcon />
+                    <TokenIcon
+                        size={40}
+                        symbol={asset.symbol}
+                        showNetworkIcon
+                        showNativeNetworkBadge
+                    />
                 ) : (
                     <TokenIcon
                         size={40}
                         symbol={asset.networkSymbol}
                         contractAddress={asset.contractAddress}
                         placeholder={asset.displaySymbol}
-                        showNetworkIcon={shouldShowNetworkIcon(
-                            asset.networkSymbol,
-                            asset.contractAddress,
-                        )}
+                        showNetworkIcon
                     />
                 )}
                 <AssetDetails
                     name={asset.displaySymbolName ?? asset.name}
                     displaySymbol={asset.displaySymbol}
-                    networkName={asset.networkName}
+                    networkSymbol={asset.networkSymbol}
                 />
             </Row>
         </ItemClickableContainer>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -1,7 +1,7 @@
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
-import { TokenIcon, shouldShowNetworkIcon } from '@trezor/product-components';
+import { TokenIcon } from '@trezor/product-components';
 
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
@@ -38,7 +38,7 @@ export function AssetRowToken({
                     symbol={account.symbol}
                     contractAddress={token.contract}
                     placeholder={getDisplaySymbol(token.symbol!, token.contract)}
-                    showNetworkIcon={shouldShowNetworkIcon(account.symbol, token.contract)}
+                    showNetworkIcon
                 />
                 <AssetDetails
                     name={token.name!}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/wallet-types';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Card, Column, Divider, H4, InfoItem, Row, Text } from '@trezor/components';
-import { TokenIcon, isCoinSymbol, shouldShowNetworkIcon } from '@trezor/product-components';
+import { TokenIcon, isCoinSymbol } from '@trezor/product-components';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { TransactionReviewOutputStatus } from 'src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputStatus';
@@ -62,13 +62,13 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
                     symbol={symbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol ?? ''}
-                    showNetworkIcon={shouldShowNetworkIcon(symbol, contractAddress)}
+                    showNetworkIcon
                 />
             );
         }
 
         if (isCoinSymbol(symbol)) {
-            return <TokenIcon size={24} symbol={symbol} showNetworkIcon />;
+            return <TokenIcon size={24} symbol={symbol} showNetworkIcon showNativeNetworkBadge />;
         }
 
         return null;

--- a/packages/suite/src/types/trading/trading.ts
+++ b/packages/suite/src/types/trading/trading.ts
@@ -74,7 +74,7 @@ export type TradingCoinLogoProps = {
     cryptoId: CryptoId;
     className?: string;
     size?: TokenIconProps['size'];
-} & Pick<TokenIconProps, 'showNetworkIcon' | 'margin'>;
+} & Pick<TokenIconProps, 'margin'>;
 
 export interface TradingGetAmountLabelsProps {
     type: TradingType;

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -120,9 +120,15 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                                 placeholder={selectedToken?.symbol || account.symbol}
                                 placeholderWithTooltip={false}
                                 shouldTryToFetch={isTokenKnown}
+                                showNetworkIcon
                             />
                         ) : (
-                            <TokenIcon symbol={account.symbol} size={40} showNetworkIcon />
+                            <TokenIcon
+                                symbol={account.symbol}
+                                size={40}
+                                showNetworkIcon
+                                showNativeNetworkBadge
+                            />
                         )}
                         <Column alignItems="flex-start">
                             <Row justifyContent="flex-start">

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -13,7 +13,6 @@ export const TradingCoinLogo = ({
     size = 24,
     margin,
     className,
-    showNetworkIcon,
 }: TradingCoinLogoProps) => {
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
     const networkSymbol = getNetworkByCoingeckoId(networkId)?.symbol;
@@ -28,7 +27,8 @@ export const TradingCoinLogo = ({
                 size={size}
                 placeholder={networkId.toUpperCase()}
                 margin={margin}
-                showNetworkIcon={showNetworkIcon}
+                showNetworkIcon
+                showNativeNetworkBadge
             />
         </Wrapper>
     );

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx
@@ -5,6 +5,7 @@ import {
     type TradingAssetOption,
     type TradingAssetSellOption,
 } from '@suite-common/trading';
+import { shouldShowNetworkBadge } from '@suite-common/wallet-config';
 import { Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
 
@@ -32,19 +33,19 @@ export function AssetPickerInputContent({ value }: AssetPickerInputContentProps)
         networkName,
         displaySymbolName,
     } = value;
-    const showNetwork = networkSymbol !== displaySymbol.toLowerCase();
+    const showNetwork = shouldShowNetworkBadge(networkSymbol);
 
     return (
         <Row gap={12}>
             {isNativeToken ? (
-                <TokenIcon size={32} symbol={symbol} showNetworkIcon />
+                <TokenIcon size={32} symbol={symbol} showNetworkIcon showNativeNetworkBadge />
             ) : (
                 <TokenIcon
                     size={32}
                     symbol={networkSymbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol}
-                    showNetworkIcon={showNetwork}
+                    showNetworkIcon
                 />
             )}
             <Column alignItems="start">

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -4,7 +4,7 @@ import { AccountLabel } from '@suite/account';
 import { Address } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
 import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@suite-common/trading';
-import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName, shouldShowNetworkBadge } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -56,7 +56,7 @@ export const TradingInfoItem = ({
 
     const displayName = isNativeToken ? getNetworkDisplaySymbolName(networkSymbol) : name;
 
-    const showNetwork = networkSymbol !== displaySymbol.toLowerCase();
+    const showNetwork = shouldShowNetworkBadge(networkSymbol);
 
     if (!amount || !currency) return null;
 
@@ -99,14 +99,19 @@ export const TradingInfoItem = ({
                     <Row padding={16} gap={8} justifyContent="space-between">
                         <Row gap={8} alignItems="center">
                             {isNativeToken ? (
-                                <TokenIcon size={40} symbol={symbol} showNetworkIcon />
+                                <TokenIcon
+                                    size={40}
+                                    symbol={symbol}
+                                    showNetworkIcon
+                                    showNativeNetworkBadge
+                                />
                             ) : (
                                 <TokenIcon
                                     size={40}
                                     symbol={networkSymbol}
                                     contractAddress={contractAddress}
                                     placeholder={displaySymbol}
-                                    showNetworkIcon={showNetwork}
+                                    showNetworkIcon
                                 />
                             )}
                             <Column alignItems="start">

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -9,6 +9,7 @@ import {
     isAccountBasedNetwork,
     isAccountOfNetwork,
     isNetworkUsingExternalBackend,
+    shouldShowNetworkBadge,
 } from './utils';
 
 const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
@@ -160,5 +161,31 @@ describe(getNetworksWithNativeTokenReserve.name, () => {
         expect(getNetworksWithNativeTokenReserve()).toEqual(
             'Base, Optimism, Robinhood Chain, Solana',
         );
+    });
+});
+
+describe(shouldShowNetworkBadge.name, () => {
+    it.each<NetworkSymbol>(['btc', 'ltc', 'bch', 'doge'])(
+        'returns false for single-asset network %s',
+        symbol => {
+            expect(shouldShowNetworkBadge(symbol)).toBe(false);
+        },
+    );
+
+    it.each<NetworkSymbol>([
+        'eth',
+        'pol',
+        'bsc',
+        'arb',
+        'base',
+        'op',
+        'avax',
+        'sol',
+        'trx',
+        'ada',
+        'etc',
+        'xlm',
+    ])('returns true for token-supporting network %s', symbol => {
+        expect(shouldShowNetworkBadge(symbol)).toBe(true);
     });
 });

--- a/suite-common/wallet-config/src/utils.ts
+++ b/suite-common/wallet-config/src/utils.ts
@@ -111,8 +111,10 @@ export const isAccountBasedNetwork = (symbol: NetworkSymbol) => {
 export const getNetworkFeatures = (symbol: NetworkSymbol): NetworkFeature[] =>
     networks[symbol]?.features;
 
-export const getCoingeckoId = (symbol: NetworkSymbol): string | undefined =>
-    networks[symbol].coingeckoId;
+export const shouldShowNetworkBadge = (symbol: NetworkSymbol): boolean =>
+    getNetworkFeatures(symbol).includes('tokens');
+
+export const getCoingeckoId = (symbol: NetworkSymbol) => networks[symbol].coingeckoId;
 
 export const isNetworkSymbol = (symbol: NetworkSymbolExtended): symbol is NetworkSymbol =>
     Object.hasOwn(networks, symbol);


### PR DESCRIPTION
## Description

One predicate `shouldShowNetworkBadge(symbol)` (= network supports tokens) now drives the network badge + label everywhere, replacing the scattered `symbol !== displaySymbol` / `shouldShowNetworkIcon` checks. Token-network coins (ETH, BNB, …) get the badge/pill like their tokens; single-asset coins (BTC, LTC, …) get none. Badge and label share the same rule, so they can't disagree.

Also splits the native branch of `TokenIcon` into a `NativeCoinIcon` component.

## Notes for QA

Badge + label should be consistent across trading pickers/amounts/confirm, asset-picker rows and Global Send: token-networks show them on natives **and** tokens, single-asset coins show neither. Native ETH/BNB account rows now show the pill (was missing). Test IDs unchanged.

## Related Issue

Fixes #29926

## Screenshots:

<!-- carried over from #29961; please re-capture "Your assets" for the new native ETH/BNB pill -->

<img width="929" height="557" alt="image" src="https://github.com/user-attachments/assets/30be1609-8120-4a4c-90f5-594b1f99ddd3" />
<img width="587" height="575" alt="image" src="https://github.com/user-attachments/assets/82429819-a63b-4e35-9c58-9862d326b38c" />
<img width="629" height="552" alt="image" src="https://github.com/user-attachments/assets/8e6bd9db-2a0b-4658-b591-f9ea63000c99" />
<img width="638" height="637" alt="image" src="https://github.com/user-attachments/assets/c89bb0b7-fd26-4a4f-b9e5-92ac2798266c" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29926-unify-network-badge/web/](https://dev.suite.sldev.cz/suite-web/feat/29926-unify-network-badge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29926-unify-network-badge&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29926-unify-network-badge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/29926-unify-network-badge&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T05:39:27.151Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T07:44:51.619Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in token/coin icon rendering, asset picker rows, and trading UI components. The highest risk lies in asset picker interactions and asset display across trading and send flows. A focused set of trading navigation, swap input, buy token, and send-form tests provides strong coverage without running the entire suite. Broad utility files like TokenIcon.tsx and wallet-config/utils.ts are used transitively by many tests, so only tests with concrete asset-picker or asset-display flows are recommended.

<details><summary><b>Changed files (19)</b></summary>

- `packages/product-components/src/components/TokenIcon/NativeCoinIcon.tsx`
- `packages/product-components/src/components/TokenIcon/TokenIcon.stories.tsx`
- `packages/product-components/src/components/TokenIcon/TokenIcon.tsx`
- `packages/product-components/src/components/TokenIcon/tokenIconTypes.ts`
- `packages/product-components/src/components/TokenIcon/tokenIconUtils.ts`
- `packages/product-components/src/components/TopAssets/TopAssets.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx`
- `packages/suite/src/types/trading/trading.ts`
- `packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputAssetPicker/AssetPickerInput/AssetPickerInputContent.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx`
- `suite-common/wallet-config/src/utils.test.ts`
- `suite-common/wallet-config/src/utils.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test directly opens Buy/Sell/Swap forms from multiple entry points and asserts that the correct cryptocurrency/token name is displayed. It exercises AssetPickerInputContent, TradingCoinLogo, and AssetRow components which are central to the changed files.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — The test fills the swap form, switches sell/buy assets, uses fraction buttons, and validates amounts. It directly interacts with the asset picker and crypto input components touched by the changes.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests searching and selecting Ethereum as a buy asset in the asset picker, then proceeding through quotes and confirmation. Directly covers AssetPickerInputContent and AssetRow rendering for a network asset.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Selects a Solana SPL token (Jupiter) from the asset picker with network/search filters. Directly exercises AssetRowToken, TokenIcon, and token type handling introduced by the changes.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Uses the global receive and send flows, filters/selects accounts in the asset picker, and verifies account labels and addresses. Covers AssetRowAccountWithBalance and TokenSelect changes.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Verifies asset cards in grid/table views and buy actions from the dashboard. The TradingCoinLogo and asset display components are used here, so a regression in coin icon rendering could affect asset visibility.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swaps SOL to BTC and verifies quotes, device prompts, and transaction details. Uses the swap asset picker and TradingInfoItem for provider/amount display.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Selects a DEX offer swapping ETH to USDC and reviews slippage, minimum received, and provider details. Exercises AssetRowToken and TradingInfoItem rendering for token/coin details.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swaps a Solana USDT token to BTC, confirming asset picker token selection and transaction review output assets. Covers AssetRowToken, TokenIcon, and TransactionReviewOutputAssets.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Selects a buy asset from a disabled network (XLM) in the swap form and checks provider info. Specifically tests asset picker behavior with network filtering and disabled networks.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Sells an ERC-20 token (USDC) through the sell flow and verifies confirmation details. Uses AssetRowToken and TokenIcon for token selection and display.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Validates sell form inputs and asset selection for BTC and SOL. Exercises the asset picker and trading input components affected by the changes.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Opens the ETH send form and reviews transaction details on the device. TokenSelect changes could affect send form rendering for ETH and token selection.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Uses the Solana send form and TokenSelect path. Verifies form state and review modal rendering, which may be impacted by token select and output asset components.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/product-components/src/components/TokenIcon/NativeCoinIcon.tsx`
- `packages/product-components/src/components/TokenIcon/TokenIcon.stories.tsx`
- `packages/product-components/src/index.ts`
- `packages/suite/src/types/trading/trading.ts`
- `suite-common/wallet-config/src/utils.test.ts`

_Updated: 2026-07-29T07:44:11.072Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->