### PR TITLE
fix(suite): stop legacy labeling requests when disabled

### DIFF
--- a/suite/metadata/src/__tests__/metadataActions.test.ts
+++ b/suite/metadata/src/__tests__/metadataActions.test.ts
@@ -9,9 +9,15 @@ import { asWalletDescriptor } from '@trezor/device-utils';
 
 import * as fixtures from '../__fixtures__/metadataActions';
 import * as metadataActions from '../metadataActions';
+import * as METADATA from '../metadataConstants';
+import { fetchIntervals } from '../metadataFetchIntervals';
 import * as metadataLabelingActions from '../metadataLabelingActions';
 import * as metadataProviderActions from '../metadataProviderThunks';
-import { type SuiteRootStateSliceForMetadata, metadataReducer } from '../metadataReducer';
+import {
+    type SuiteRootStateSliceForMetadata,
+    initialMetadataState,
+    metadataReducer,
+} from '../metadataReducer';
 import * as metadataThunks from '../metadataThunks';
 import { DropboxProvider } from '../providers/DropboxProvider';
 
@@ -96,6 +102,40 @@ const getInitialState = (state?: InitialState) => {
         },
     };
 };
+
+const DROPBOX_CLIENT_ID = 'dropbox-client-id';
+const STATIC_SESSION_ID = '1stTestnetAddress@device_id:0';
+
+const getMetadataFetchInitialState = (isMetadataEnabled: boolean) =>
+    getInitialState({
+        metadata: {
+            ...initialMetadataState,
+            enabled: isMetadataEnabled,
+            providers: [
+                {
+                    type: 'dropbox',
+                    clientId: DROPBOX_CLIENT_ID,
+                    data: {},
+                    isCloud: true,
+                    tokens: { refreshToken: 'token' },
+                    user: 'power-user',
+                },
+            ],
+            selectedProvider: { labels: DROPBOX_CLIENT_ID, passwords: '' },
+        },
+        device: {
+            state: { staticSessionId: STATIC_SESSION_ID },
+            metadata: {
+                1: {
+                    fileName: 'wallet.mtdt',
+                    aesKey: 'key',
+                    key: 'metadata-key',
+                },
+            },
+        },
+        accounts: [],
+        suite: { online: true },
+    });
 
 type State = ReturnType<typeof getInitialState>;
 const initStore = (state: State) => {
@@ -339,5 +379,80 @@ describe('Metadata Actions', () => {
         expect(store.getState().metadata.hasLegacyLabelsMigrated).toEqual({
             [otherWalletDescriptor]: true,
         });
+    });
+
+    it('does not fetch labeling data when metadata is disabled', async () => {
+        const store = initStore(getMetadataFetchInitialState(false));
+        const getProviderDetailsSpy = jest.spyOn(DropboxProvider.prototype, 'getProviderDetails');
+
+        try {
+            metadataProviderActions.providerInstance.labels = undefined;
+            await store.dispatch(metadataLabelingActions.fetchAndSaveMetadata(STATIC_SESSION_ID));
+
+            expect(getProviderDetailsSpy).not.toHaveBeenCalled();
+        } finally {
+            getProviderDetailsSpy.mockRestore();
+            metadataProviderActions.providerInstance.labels = undefined;
+        }
+    });
+
+    it('does not fetch labeling files after metadata is disabled during provider validation', async () => {
+        const store = initStore(getMetadataFetchInitialState(true));
+        let resolveProviderDetails:
+            | ((result: Awaited<ReturnType<DropboxProvider['getProviderDetails']>>) => void)
+            | undefined;
+        const providerDetailsPromise = new Promise<
+            Awaited<ReturnType<DropboxProvider['getProviderDetails']>>
+        >(resolve => {
+            resolveProviderDetails = resolve;
+        });
+        const getProviderDetailsSpy = jest
+            .spyOn(DropboxProvider.prototype, 'getProviderDetails')
+            .mockReturnValue(providerDetailsPromise);
+        const getFileContentSpy = jest.spyOn(DropboxProvider.prototype, 'getFileContent');
+
+        try {
+            metadataProviderActions.providerInstance.labels = undefined;
+            const fetchPromise = store.dispatch(
+                metadataLabelingActions.fetchAndSaveMetadata(STATIC_SESSION_ID),
+            );
+
+            store.dispatch({ type: METADATA.DISABLE });
+            resolveProviderDetails?.({
+                success: true,
+                payload: {
+                    type: 'dropbox',
+                    clientId: DROPBOX_CLIENT_ID,
+                    isCloud: true,
+                    tokens: { refreshToken: 'token' },
+                    user: 'power-user',
+                },
+            });
+            await fetchPromise;
+
+            expect(getFileContentSpy).not.toHaveBeenCalled();
+        } finally {
+            getProviderDetailsSpy.mockRestore();
+            getFileContentSpy.mockRestore();
+            metadataProviderActions.providerInstance.labels = undefined;
+        }
+    });
+
+    it('clears labeling fetch intervals when metadata is disabled', async () => {
+        const store = initStore(getInitialState());
+        const intervalId =
+            'labels-google-client-id-with-hyphens-1stTestnetAddress@device_id:0' as const;
+        const interval = setInterval(() => undefined, 60_000);
+
+        fetchIntervals[intervalId] = interval;
+
+        try {
+            await store.dispatch(metadataThunks.disableMetadata());
+
+            expect(fetchIntervals[intervalId]).toBeUndefined();
+        } finally {
+            clearInterval(interval);
+            delete fetchIntervals[intervalId];
+        }
     });
 });

--- a/suite/metadata/src/metadataDataThunks.ts
+++ b/suite/metadata/src/metadataDataThunks.ts
@@ -12,6 +12,7 @@ import { selectAccounts } from '@suite-common/wallet-core';
 
 import { setAccountAdd } from './metadataActions';
 import * as METADATA from './metadataConstants';
+import { clearFetchIntervals } from './metadataFetchIntervals';
 import * as METADATA_LABELING from './metadataLabelingConstants';
 import { type MetadataRootState, selectSelectedProviderForLabels } from './metadataReducer';
 import * as metadataUtils from './metadataUtils';
@@ -62,6 +63,8 @@ export const disposeMetadataKeys =
     };
 
 export const disableMetadata = () => (dispatch: Dispatch) => {
+    clearFetchIntervals({ dataType: 'labels' });
+
     dispatch({
         type: METADATA.DISABLE,
     });

--- a/suite/metadata/src/metadataFetchIntervals.ts
+++ b/suite/metadata/src/metadataFetchIntervals.ts
@@ -1,0 +1,22 @@
+import { type DataType } from '@suite-common/metadata-types';
+import { typedObjectKeys } from '@trezor/utils';
+
+import { type FetchIntervalTrackingId } from './metadataUtils';
+
+export const fetchIntervals: { [id: FetchIntervalTrackingId]: ReturnType<typeof setInterval> } = {};
+
+type ClearFetchIntervalsParams = {
+    dataType: DataType;
+    clientId?: string;
+};
+
+export const clearFetchIntervals = ({ dataType, clientId }: ClearFetchIntervalsParams) => {
+    const trackingIdPrefix = clientId ? `${dataType}-${clientId}-` : `${dataType}-`;
+
+    typedObjectKeys(fetchIntervals).forEach(trackingId => {
+        if (trackingId.startsWith(trackingIdPrefix)) {
+            clearInterval(fetchIntervals[trackingId]);
+            delete fetchIntervals[trackingId];
+        }
+    });
+};

--- a/suite/metadata/src/metadataLabelingActions.ts
+++ b/suite/metadata/src/metadataLabelingActions.ts
@@ -26,6 +26,7 @@ import type { MetadataAction } from './metadataActions';
 import * as metadataActions from './metadataActions';
 import * as METADATA from './metadataConstants';
 import * as metadataDataThunks from './metadataDataThunks';
+import { fetchIntervals } from './metadataFetchIntervals';
 import * as METADATA_LABELING from './metadataLabelingConstants';
 import * as metadataProviderActions from './metadataProviderThunks';
 import {
@@ -52,7 +53,11 @@ const fetchMetadata =
         entity: LabelableEntity;
         encryptionVersion?: MetadataEncryptionVersion;
     }) =>
-    async (dispatch: Dispatch) => {
+    async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+        if (!selectMetadata(getState()).enabled) {
+            return;
+        }
+
         const dataType = 'labels';
 
         const providerInstance = dispatch(
@@ -70,6 +75,10 @@ const fetchMetadata =
             entity[encryptionVersion] ?? throwError('trying to fetch entity without metadata');
 
         const response = await providerInstance.getFileContent(fileName);
+
+        if (!selectMetadata(getState()).enabled) {
+            return;
+        }
 
         if (!response.success) {
             throw response;
@@ -165,6 +174,10 @@ const syncMetadataKeys =
 export const fetchAndSaveMetadata =
     (deviceStateArg?: StaticSessionId) =>
     async (dispatch: Dispatch, getState: () => MetadataRootState) => {
+        if (!selectMetadata(getState()).enabled) {
+            return;
+        }
+
         const provider = selectSelectedProviderForLabels(getState());
         if (!provider) return;
 
@@ -199,6 +212,10 @@ export const fetchAndSaveMetadata =
             // to renew access token are issued by every provider.getFileContent
             const response = await providerInstance.getProviderDetails();
 
+            if (!selectMetadata(getState()).enabled) {
+                return;
+            }
+
             device = deviceStateArg
                 ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
                 : selectSelectedDevice(getState());
@@ -224,9 +241,9 @@ export const fetchAndSaveMetadata =
 
             // device is disconnected or something is wrong with it
             if (!device?.metadata?.[METADATA_LABELING.ENCRYPTION_VERSION]) {
-                if (metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
-                    clearInterval(metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]);
-                    delete metadataProviderActions.fetchIntervals[fetchIntervalTrackingId];
+                if (fetchIntervals[fetchIntervalTrackingId]) {
+                    clearInterval(fetchIntervals[fetchIntervalTrackingId]);
+                    delete fetchIntervals[fetchIntervalTrackingId];
                 }
 
                 return;
@@ -242,12 +259,16 @@ export const fetchAndSaveMetadata =
             );
             await Promise.all(promises);
         } catch (error) {
+            if (!selectMetadata(getState()).enabled) {
+                return;
+            }
+
             // This handles cases of providers that do not support token renewal.
             // We want those to work normally as long as their short-lived token allows. And only if
             // it expires, we want them to silently disconnect provider, keep metadata in place.
             // So that users will not notice that token expired until they will try to add or edit
             // already existing label
-            if (device?.state && metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
+            if (device?.state && fetchIntervals[fetchIntervalTrackingId]) {
                 return dispatch(
                     metadataProviderActions.disconnectProvider({
                         removeMetadata: false,
@@ -676,7 +697,11 @@ export const init =
             ? selectDeviceByStaticSessionId(getState(), deviceStateArg)
             : selectSelectedDevice(getState());
 
-        if (!device?.state?.staticSessionId || !selectedProvider) {
+        if (
+            !selectMetadata(getState()).enabled ||
+            !device?.state?.staticSessionId ||
+            !selectedProvider
+        ) {
             return true;
         }
 
@@ -687,12 +712,16 @@ export const init =
         );
 
         // 7. if interval for watching provider is not set, create it
-        if (device.state && !metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
+        if (device.state && !fetchIntervals[fetchIntervalTrackingId]) {
             // todo: possible race condition that has been around since always
             // user is editing label and at that very moment update arrives. updates to specific entities should be probably discarded in such case?
-            metadataProviderActions.fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
+            fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
                 const device = selectSelectedDevice(getState());
-                if (!getState().suite.online || !device?.state?.staticSessionId) {
+                if (
+                    !selectMetadata(getState()).enabled ||
+                    !getState().suite.online ||
+                    !device?.state?.staticSessionId
+                ) {
                     return;
                 }
                 dispatch(fetchAndSaveMetadata(device.state.staticSessionId));

--- a/suite/metadata/src/metadataPasswordsActions.ts
+++ b/suite/metadata/src/metadataPasswordsActions.ts
@@ -12,6 +12,7 @@ import { cloneObject } from '@trezor/utils';
 
 import * as METADATA from './metadataConstants';
 import * as metadataDataThunks from './metadataDataThunks';
+import { fetchIntervals } from './metadataFetchIntervals';
 import * as METADATA_PASSWORDS from './metadataPasswordsConstants';
 import * as METADATA_PROVIDER from './metadataProviderConstants';
 import * as metadataProviderActions from './metadataProviderThunks';
@@ -176,8 +177,8 @@ export const init = () => async (dispatch: Dispatch, getState: () => MetadataRoo
         device.state.staticSessionId,
     );
 
-    if (device?.state && !metadataProviderActions.fetchIntervals[fetchIntervalTrackingId]) {
-        metadataProviderActions.fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
+    if (device?.state && !fetchIntervals[fetchIntervalTrackingId]) {
+        fetchIntervals[fetchIntervalTrackingId] = setInterval(() => {
             device = selectSelectedDevice(getState());
             const { fileName, aesKey } = device?.passwords?.[1] || {};
 

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -15,13 +15,13 @@ import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { triggerWebDownloadFile } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { exhaustive } from '@trezor/type-utils';
-import { createDeferred, createZip, typedObjectKeys } from '@trezor/utils';
+import { createDeferred, createZip } from '@trezor/utils';
 
 import * as METADATA from './metadataConstants';
 import { disposeMetadata } from './metadataDataThunks';
+import { clearFetchIntervals } from './metadataFetchIntervals';
 import * as METADATA_PROVIDER from './metadataProviderConstants';
 import { type MetadataRootState, selectSelectedProviderForLabels } from './metadataReducer';
-import { type FetchIntervalTrackingId } from './metadataUtils';
 import { DropboxProvider } from './providers/DropboxProvider';
 import { FileSystemProvider } from './providers/FileSystemProvider';
 import { GoogleProvider } from './providers/GoogleProvider';
@@ -38,8 +38,6 @@ export const providerInstance: Record<DataType, ProviderInstance | undefined> = 
     labels: undefined,
     passwords: undefined,
 };
-
-export const fetchIntervals: { [id: FetchIntervalTrackingId]: any } = {}; // any because of native at the moment, otherwise number | undefined
 
 const createProviderInstance = (
     type: MetadataProvider['type'],
@@ -106,13 +104,7 @@ type DisconnectProviderParams = {
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
     async (dispatch: Dispatch, _getState: () => MetadataRootState, extra: ExtraDependencies) => {
-        typedObjectKeys(fetchIntervals).forEach((id: FetchIntervalTrackingId) => {
-            const [trackedDataType, trackedClientId] = id.split('-');
-            if (trackedDataType === dataType && trackedClientId === clientId) {
-                clearInterval(fetchIntervals[id]);
-                delete fetchIntervals[id];
-            }
-        });
+        clearFetchIntervals({ dataType, clientId });
 
         // dispose metadata values (not keys)
         if (removeMetadata) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Description

Stops legacy labeling providers from making requests after labeling is turned off.

- Guard metadata fetching against disabled state, including async race conditions.
- Clear polling intervals when labeling is disabled.
- Fix interval cleanup for provider IDs containing hyphens.
- Add regression tests for disabled and mid-request states.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-stop-legacy-labeling-requests/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-stop-legacy-labeling-requests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-stop-legacy-labeling-requests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-stop-legacy-labeling-requests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T10:01:27.249Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T10:01:44.956Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->