### PR TITLE
test(suite): increase verbosity of thp pairing validation

### DIFF
--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -122,8 +122,14 @@ export class OnboardingPage {
             await this.pairingInputAtIndex(i).fill(getIndexOrThrow(code, i));
         }
 
-        await expect(this.thpPairingModal).toBeHidden();
-        await expect(this.devicePrompt.acquireDeviceButton).toBeHidden();
+        await expect(
+            this.thpPairingModal,
+            'expected THP pairing modal to be hidden after entering the pairing code',
+        ).toBeHidden();
+        await expect(
+            this.devicePrompt.acquireDeviceButton,
+            'expected device prompt acquire button to be hidden',
+        ).toBeHidden();
     }
 
     @step()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

better verbosity to analyze underlying instability of thp pairing in e2e tests

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/thp-piaring-verobisty/web/](https://dev.suite.sldev.cz/suite-web/thp-piaring-verobisty/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=thp-piaring-verobisty&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=thp-piaring-verobisty&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |

</details>

_Updated: 2026-07-23T09:46:57.917Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-07-23T09:46:39.636Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->