### PR TITLE
refactor(suite-desktop): improve displaying of labels on the tx label

### DIFF
--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 
 import {
     type TransactionNotificationToken,
@@ -40,6 +44,24 @@ export const TransactionIcon = ({
 }: TransactionIconProps) => {
     if (icon) {
         return icon;
+    }
+
+    // A wrap (ETH→WETH) is denominated in the wrapped-native token, so show its logo (e.g. WETH) to
+    // match the amount. An unwrap is denominated in the native coin and uses the native icon below.
+    if (notificationType === 'tx-wrap') {
+        const wrappedNativeAddress = getWrappedNativeAddress(symbol);
+
+        if (wrappedNativeAddress) {
+            return (
+                <TokenIcon
+                    symbol={symbol}
+                    contractAddress={wrappedNativeAddress}
+                    placeholder={getWrappedNativeSymbol(symbol) ?? symbol}
+                    size={20}
+                    shouldTryToFetch
+                />
+            );
+        }
     }
 
     if (shouldDisplayAssetLogo({ notificationType, token }) && token) {

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -181,6 +181,26 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'tx-wrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Wrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 WETH',
+        transaction: {
+            notificationType: 'tx-wrap',
+            symbol: 'eth',
+        },
+    },
+    'tx-unwrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Unwrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 ETH',
+        transaction: {
+            notificationType: 'tx-unwrap',
+            symbol: 'eth',
+        },
+    },
 };
 
 export const Default: Story = {

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -28,7 +28,9 @@ export type TransactionNotificationType =
     | 'tx-revoked'
     | 'tx-yield-deposit'
     | 'tx-yield-withdraw'
-    | 'tx-yield-claim';
+    | 'tx-yield-claim'
+    | 'tx-wrap'
+    | 'tx-unwrap';
 
 type TransactionNotificationWithToken = Extract<
     NotificationEntry,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -6,6 +6,7 @@ import {
     getNetwork,
     getNetworkDisplaySymbol,
     getWrappedNativeAddress,
+    getWrappedNativeSymbol,
 } from '@suite-common/wallet-config';
 import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
@@ -20,9 +21,9 @@ import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/
 
 import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
 
-// Standalone wrap flow for the debug "Wrap" action on the dashboard native-asset row. It reuses the
-// shared yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield
-// flow thunks stay untouched.
+// Standalone wrap flow for the debug "Wrap" action in the account TradeBox. It reuses the shared
+// yield building blocks/signer but deliberately keeps its own thunks so the stablecoin-yield flow
+// thunks stay untouched.
 const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
 
 export type ComposeWrapNativeTokenErrorReason =
@@ -196,9 +197,14 @@ export const submitWrapNativeTokenThunk = createThunk(
                 return;
             }
 
+            const wrappedSymbol =
+                getWrappedNativeSymbol(account.symbol) ?? getNetworkDisplaySymbol(account.symbol);
+
             dispatch(
                 notificationsActions.addToast({
-                    type: 'raw-tx-sent',
+                    type: 'tx-wrap',
+                    // Amount shown in the destination unit — the wrapped-native token (e.g. WETH).
+                    formattedAmount: `${wrapAmount} ${wrappedSymbol}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/components/suite/WrapTxAmount.tsx
+++ b/packages/suite/src/components/suite/WrapTxAmount.tsx
@@ -14,11 +14,9 @@ import { FormattedCryptoAmount } from './FormattedCryptoAmount';
 
 interface WrapTxAmountProps {
     transaction: WalletAccountTransaction;
-    /** Render the wrapped-token symbol (e.g. WETH) instead of the native one (e.g. ETH). */
-    wrapped?: boolean;
 }
 
-export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
+export const WrapTxAmount = ({ transaction }: WrapTxAmountProps) => {
     const { symbol } = transaction;
 
     const amount = useMemo(() => {
@@ -26,8 +24,8 @@ export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
 
         if (!kind) return undefined;
 
-        // Wrapping is 1:1, so both legs show the same amount and only differ in symbol. The amount
-        // is the transaction value for a wrap and the withdraw(uint256) calldata for an unwrap.
+        // Wrapping is 1:1, so the wrapped amount equals the native one. The amount is the
+        // transaction value for a wrap and the withdraw(uint256) calldata for an unwrap.
         const subunits =
             kind === 'wrap'
                 ? transaction.amount
@@ -41,9 +39,6 @@ export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
     if (!amount) return null;
 
     return (
-        <FormattedCryptoAmount
-            value={amount}
-            symbol={wrapped ? (getWrappedNativeSymbol(symbol) ?? symbol) : symbol}
-        />
+        <FormattedCryptoAmount value={amount} symbol={getWrappedNativeSymbol(symbol) ?? symbol} />
     );
 };

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -652,6 +652,34 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-wrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_WRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
+        case 'tx-unwrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_UNWRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'successful-claim':
             return renderNotificationView(render, notification, {
                 variant: 'success',

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -138,8 +138,8 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
             <Translation
                 id={wrapKind === 'wrap' ? 'TR_TX_WRAP' : 'TR_TX_UNWRAP'}
                 values={{
-                    nativeAmount: <WrapTxAmount transaction={transaction} />,
-                    wrappedAmount: <WrapTxAmount transaction={transaction} wrapped />,
+                    nativeSymbol: getNetworkDisplaySymbol(transaction.symbol),
+                    wrappedAmount: <WrapTxAmount transaction={transaction} />,
                 }}
             />
         );

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -81,6 +81,17 @@ type YieldClaimTransactionNotification = {
     type: 'tx-yield-claim';
 } & BaseTransactionNotificationPayload;
 
+// Wrap/unwrap toasts show the amount in the destination unit: the wrapped-native token (WETH) for
+// a wrap, the native coin (ETH) for an unwrap. That destination unit is baked into `formattedAmount`
+// by the dispatcher.
+type WrapNativeTokenTransactionNotification = {
+    type: 'tx-wrap';
+} & TransactionNotificationPayload;
+
+type UnwrapNativeTokenTransactionNotification = {
+    type: 'tx-unwrap';
+} & TransactionNotificationPayload;
+
 export type ErrorToastPayload = {
     type:
         | 'error'
@@ -207,6 +218,8 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | YieldDepositTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
+    | WrapNativeTokenTransactionNotification
+    | UnwrapNativeTokenTransactionNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11276,11 +11276,11 @@ export const messages = defineMessages({
     },
     TR_TX_WRAP: {
         id: 'TR_TX_WRAP',
-        defaultMessage: 'Wrap {nativeAmount} into {wrappedAmount}',
+        defaultMessage: 'Wrap {nativeSymbol} into {wrappedAmount}',
     },
     TR_TX_UNWRAP: {
         id: 'TR_TX_UNWRAP',
-        defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
+        defaultMessage: 'Unwrap {wrappedAmount} into {nativeSymbol}',
     },
     TR_WRAP_NATIVE_TOKEN: {
         id: 'TR_WRAP_NATIVE_TOKEN',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11524,6 +11524,14 @@ export const messages = defineMessages({
         id: 'TOAST_TX_YIELD_CLAIM',
         defaultMessage: 'Claim transaction from {account} has been broadcast',
     },
+    TOAST_TX_WRAP: {
+        id: 'TOAST_TX_WRAP',
+        defaultMessage: 'Wrap transaction from {account} has been broadcast',
+    },
+    TOAST_TX_UNWRAP: {
+        id: 'TOAST_TX_UNWRAP',
+        defaultMessage: 'Unwrap transaction from {account} has been broadcast',
+    },
     TOAST_SUCCESSFUL_CLAIM: {
         id: 'TOAST_SUCCESSFUL_CLAIM',
         defaultMessage: '{networkDisplaySymbol} claimed successfully',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tweak displaying of transaction labels to display a succinct information about wrapping/unwrapping transaction

## Notes for QA

You can use debug's "wrap" button to trigger wrapping

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29875

## Screenshots:

<img width="769" height="747" alt="Screenshot 2026-07-23 at 12 44 21" src="https://github.com/user-attachments/assets/2b1fbc11-bd00-44a3-b046-df2e6fc4e8f1" />
