### PR TITLE
feat(suite): replace approval change button with clickable steps

### DIFF
--- a/packages/components/src/components/StepList/StepListItem.tsx
+++ b/packages/components/src/components/StepList/StepListItem.tsx
@@ -1,3 +1,5 @@
+import { type KeyboardEvent } from 'react';
+
 import styled, { css } from 'styled-components';
 
 import { CheckIcon } from '@trezor/icons';
@@ -21,17 +23,41 @@ import {
     mapStateToCounterColor,
     mapStateToTitleColor,
 } from './utils';
+import { commonFocusStyles } from '../../utils/utils';
 import { IconCircle } from '../IconCircle/IconCircle';
 import { Text } from '../typography/Text/Text';
 
-const Item = styled.li<{
+const Item = styled.li<{ $direction: StepListDirection }>`
+    ${({ $direction }) =>
+        $direction === 'horizontal' &&
+        css`
+            flex: 1;
+
+            &:last-child {
+                flex: 0;
+            }
+        `}
+`;
+
+const ItemLayout = styled.div<{
     $bulletGap: SpacingValue;
     $titleGap: SpacingValue;
     $size: BulletSize;
     $direction: StepListDirection;
+    $isClickable: boolean;
 }>`
     display: grid;
     grid-template-columns: ${mapSizeToDimension}px 1fr;
+
+    ${({ $isClickable }) =>
+        $isClickable &&
+        css`
+            cursor: pointer;
+
+            &:focus-visible {
+                ${commonFocusStyles}
+            }
+        `}
 
     ${({ $direction, $bulletGap, $titleGap }) =>
         $direction === 'vertical'
@@ -39,13 +65,25 @@ const Item = styled.li<{
                   column-gap: ${$bulletGap}px;
               `
             : css`
-                  flex: 1;
                   row-gap: ${$titleGap}px;
-
-                  &:last-child {
-                      flex: 0;
-                  }
               `}
+`;
+
+const ClickableDoneIndicator = styled.div`
+    > :last-child {
+        display: none;
+    }
+
+    ${ItemLayout}:hover &,
+    ${ItemLayout}:focus-visible & {
+        > :first-child {
+            display: none;
+        }
+
+        > :last-child {
+            display: flex;
+        }
+    }
 `;
 
 const StepIndicatorWrapper = styled.div<{ $direction: StepListDirection }>`
@@ -159,57 +197,88 @@ export type StepListItemProps = {
     children?: React.ReactNode;
     title: React.ReactNode;
     state?: StepListItemState;
+    onClick?: () => void;
     'data-testid'?: string;
 };
 
 export const StepListItem = ({
     state = 'default',
     title,
+    onClick,
     'data-testid': dataTestId,
     children,
 }: StepListItemProps) => {
     const { itemGap, bulletGap, titleGap, bulletSize, isOrdered, direction, lineWidth } =
         useStepList();
+    const isClickable = !!onClick;
+
+    const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick?.();
+        }
+    };
+
+    const renderStepIndicator = () => {
+        if (state !== 'done') {
+            return <StepIndicator $state={state} $isOrdered={isOrdered} $size={bulletSize} />;
+        }
+
+        const doneIcon = (
+            <IconCircle
+                icon={CheckIcon}
+                size={mapSizeToDimension({ $size: bulletSize })}
+                intent="brand"
+            />
+        );
+
+        if (!isClickable) {
+            return doneIcon;
+        }
+
+        return (
+            <ClickableDoneIndicator>
+                {doneIcon}
+                <StepIndicator $state={state} $isOrdered={isOrdered} $size={bulletSize} />
+            </ClickableDoneIndicator>
+        );
+    };
 
     return (
-        <Item
-            $bulletGap={bulletGap}
-            $titleGap={titleGap}
-            $size={bulletSize}
-            $direction={direction}
-            data-testid={dataTestId}
-        >
-            <StepIndicatorWrapper $direction={direction}>
-                {state === 'done' ? (
-                    <IconCircle
-                        icon={CheckIcon}
-                        size={mapSizeToDimension({ $size: bulletSize })}
-                        intent="brand"
-                    />
-                ) : (
-                    <StepIndicator $state={state} $isOrdered={isOrdered} $size={bulletSize} />
+        <Item $direction={direction} data-testid={dataTestId}>
+            <ItemLayout
+                $bulletGap={bulletGap}
+                $titleGap={titleGap}
+                $size={bulletSize}
+                $direction={direction}
+                $isClickable={isClickable}
+                onClick={onClick}
+                {...(isClickable && { role: 'button', tabIndex: 0, onKeyDown: handleKeyDown })}
+            >
+                <StepIndicatorWrapper $direction={direction}>
+                    {renderStepIndicator()}
+                </StepIndicatorWrapper>
+                <Title $direction={direction}>
+                    <Text
+                        as="div"
+                        typographyStyle={mapPropsToTypographyStyle(direction, state)}
+                        color={mapStateToTitleColor(state)}
+                        ellipsisLineCount={direction === 'vertical' ? 2 : undefined}
+                    >
+                        {title}
+                    </Text>
+                </Title>
+                <Line $direction={direction} $bulletGap={bulletGap} $lineWidth={lineWidth} />
+                {direction === 'vertical' && (
+                    <Content $itemGap={itemGap} $titleGap={titleGap}>
+                        {children && (
+                            <Text as="div" typographyStyle="body-sm">
+                                {children}
+                            </Text>
+                        )}
+                    </Content>
                 )}
-            </StepIndicatorWrapper>
-            <Title $direction={direction}>
-                <Text
-                    as="div"
-                    typographyStyle={mapPropsToTypographyStyle(direction, state)}
-                    color={mapStateToTitleColor(state)}
-                    ellipsisLineCount={direction === 'vertical' ? 2 : undefined}
-                >
-                    {title}
-                </Text>
-            </Title>
-            <Line $direction={direction} $bulletGap={bulletGap} $lineWidth={lineWidth} />
-            {direction === 'vertical' && (
-                <Content $itemGap={itemGap} $titleGap={titleGap}>
-                    {children && (
-                        <Text as="div" typographyStyle="body-sm">
-                            {children}
-                        </Text>
-                    )}
-                </Content>
-            )}
+            </ItemLayout>
         </Item>
     );
 };

--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -1,18 +1,37 @@
 import { type ReactNode } from 'react';
 
+import styled from 'styled-components';
+
 import { Translation } from '@suite/intl';
 import { type YieldFlowStepId } from '@suite-common/wallet-core';
-import { Column, Row, StepList, Text } from '@trezor/components';
+import { Column, IconCircle, Row, StepList, Text } from '@trezor/components';
+import { CaretLeftIcon } from '@trezor/icons';
 
 import { type YieldFlowStepView, getYieldFlowSteps } from '../yieldFlowUtils';
+
+const EditableTitle = styled.span`
+    li > :hover &,
+    li > :focus-visible & {
+        color: ${({ theme }) => theme.contentPrimary};
+    }
+`;
+
+const EditIndicator = styled.div`
+    opacity: 0;
+
+    li > :hover &,
+    li > :focus-visible & {
+        opacity: 1;
+    }
+`;
 
 export type YieldFlowStepDefinition = {
     /** Label on the title row next to the step number. */
     title?: ReactNode;
     /** Supplementary text tight under the title; shown only while the step is active. */
     description?: ReactNode;
-    /** Right side of the title row (e.g. a modify action); receives the view for state-dependent actions. */
-    rightContent?: (view: YieldFlowStepView) => ReactNode;
+    /** Makes the finished step clickable — clicking anywhere on it returns to the step to edit it. */
+    onEdit?: () => void;
     /**
      * Renders the step as a StepList item and counts it into the step numbering. A non-list
      * step takes over the whole area while active (e.g. a final complete screen). Default true.
@@ -71,11 +90,13 @@ export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>(
             {listSteps.map(stepId => {
                 const view = views[stepId];
                 const definition = stepDefinitions[stepId];
+                const onEdit = view.state === 'done' ? definition?.onEdit : undefined;
 
                 return (
                     <StepList.Item
                         key={stepId}
                         state={view.state}
+                        onClick={onEdit}
                         title={
                             <Column gap={8} width="100%">
                                 <Text
@@ -94,8 +115,20 @@ export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>(
                                         width="100%"
                                         gap={16}
                                     >
-                                        {definition?.title}
-                                        {definition?.rightContent?.(view)}
+                                        {onEdit ? (
+                                            <EditableTitle>{definition?.title}</EditableTitle>
+                                        ) : (
+                                            definition?.title
+                                        )}
+                                        {onEdit && (
+                                            <EditIndicator>
+                                                <IconCircle
+                                                    icon={CaretLeftIcon}
+                                                    size={24}
+                                                    intent="brand"
+                                                />
+                                            </EditIndicator>
+                                        )}
                                     </Row>
 
                                     {view.state === 'active' && definition?.description && (

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -5,7 +5,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
-import { Banner, Button, Column, Text } from '@trezor/components';
+import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
@@ -46,6 +46,7 @@ export const YieldDepositForm = () => {
         isSubmittingAction,
         setAmountInput,
         completeWrapStep,
+        returnToWrapStep,
         submitApprovalAction,
         submitAction,
         revokeAllowance,
@@ -202,6 +203,7 @@ export const YieldDepositForm = () => {
                                         values={{ nativeSymbol }}
                                     />
                                 ),
+                                onEdit: returnToWrapStep,
                                 content: () => (
                                     <YieldWrapStep
                                         token={token}
@@ -215,17 +217,7 @@ export const YieldDepositForm = () => {
                             },
                             approve: {
                                 title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
-                                rightContent: view =>
-                                    view.state === 'done' && (
-                                        <Button
-                                            size="small"
-                                            intent="neutral"
-                                            priority="secondary"
-                                            onClick={handleOnModify}
-                                        >
-                                            <Translation id="TR_MODIFY" />
-                                        </Button>
-                                    ),
+                                onEdit: handleOnModify,
                                 content: () => (
                                     <YieldApproveStep
                                         token={token}

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -93,6 +93,7 @@ export type UseYieldFlowResult = {
     isSubmittingAction: boolean;
     setAmountInput: (amount: string) => void;
     completeWrapStep: () => void;
+    returnToWrapStep: () => void;
     completeUnwrapStep: () => void;
     submitApprovalAction: () => void;
     submitAction: () => void;
@@ -296,6 +297,10 @@ export const useYieldFlow = ({
     // and unwrap transactions themselves come with the shared wrap thunks.
     const completeWrapStep = useCallback(() => {
         setIsWrapStepCompleted(true);
+    }, []);
+
+    const returnToWrapStep = useCallback(() => {
+        setIsWrapStepCompleted(false);
     }, []);
 
     const completeUnwrapStep = useCallback(() => {
@@ -620,6 +625,7 @@ export const useYieldFlow = ({
         isSubmittingAction: session.action.isSubmitting,
         setAmountInput,
         completeWrapStep,
+        returnToWrapStep,
         completeUnwrapStep,
         submitApprovalAction,
         submitAction,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10263,10 +10263,6 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_MODIFY_APPROVAL',
         defaultMessage: 'Change approval',
     },
-    TR_MODIFY: {
-        id: 'TR_MODIFY',
-        defaultMessage: 'Change',
-    },
     TR_EARN_YIELD_INCREASE_APPROVAL: {
         id: 'TR_EARN_YIELD_INCREASE_APPROVAL',
         defaultMessage: 'Increase approval',


### PR DESCRIPTION
## Description

Replaces the `Change` button on the approval step with clickable finished steps - the whole row navigates back to the step, per the design.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30109

## Screenshots:

https://github.com/user-attachments/assets/185fdbd5-ac05-402a-84a6-411d474f73d0

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-clickable-steps/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-clickable-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-clickable-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-clickable-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:54:12.485Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:54:37.199Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set focuses on the earn/yield staking deposit flow (YieldDepositForm, useYieldFlow hook, YieldFlowStepList) and the shared StepListItem UI component, plus an update to the global intl messages file. The highest risk is to ETH/SOL staking and stake-more flows that directly render these components and depend on the flow hook's state/step management logic; these should be run unconditionally. Broader staking tests (unstake, other networks) are included at lower priority since they share step-list UI patterns but are less directly coupled to the deposit-specific changes. The intl messages.ts change has no direct static test mapping, but since it's a large shared translation file, any test asserting on specific translation keys (many staking/onboarding tests do) could be indirectly affected — however no test showed evidence of referencing keys that appear uniquely tied to this change, so it's left as uncovered without over-broadening the recommendation set.

<details><summary><b>Changed files (5)</b></summary>

- `packages/components/src/components/StepList/StepListItem.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking form and flow which directly uses YieldDepositForm.tsx, useYieldFlow.ts, and the step list UI (StepListItem/YieldFlowStepList) for guiding users through the staking/deposit process. Changes to these components could break form rendering, step progression, or transaction submission.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Stake-more flow uses the same yield deposit form, step list, and useYieldFlow hook as initial staking; any regression in step progression or amount calculation logic would surface here.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly validates the staking/deposit form's amount validation, percentage buttons, and crypto/fiat switching — core behaviors implemented in YieldDepositForm.tsx and its supporting hook, making it the most direct coverage of the changed form logic.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — The unstake/claim flow shares the staking dashboard and progress-indicator UI patterns (step list) with the deposit flow, so regressions in shared step-list or flow-hook logic could manifest here even though this test targets unstaking rather than deposit.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana initial staking uses the same generic yield deposit form and step list components; since these are shared across networks, a change to YieldDepositForm or useYieldFlow could affect SOL staking too.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Stake-more on Solana uses the same shared yield deposit form/step components as ETH stake-more, so this test provides cross-network regression coverage for the changed deposit flow code.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking flow likely uses a similar deposit form structure with step confirmations, so it may be indirectly affected by shared yield flow components, though Cardano staking has more custom device confirmation logic that is less tied to the generic form.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-07-27T12:51:06.944Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->