### PR TITLE
Support Blockbook's `getBlock` pagination

### DIFF
--- a/packages/blockchain-link-types/src/blockbook.ts
+++ b/packages/blockchain-link-types/src/blockbook.ts
@@ -179,7 +179,10 @@ export type ContractInfoResponse = ContractInfoResult;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare function FSend(method: 'getInfo'): Promise<ServerInfo>;
 declare function FSend(method: 'getBlockHash', params: { height: number }): Promise<BlockHash>;
-declare function FSend(method: 'getBlock', params: { id: string }): Promise<Block>;
+declare function FSend(
+    method: 'getBlock',
+    params: { id: string; page?: number; pageSize?: number },
+): Promise<Block>;
 declare function FSend(
     method: 'getBlockFilter',
     params: WsBlockFilterReq & FilterRequestParams,

--- a/packages/blockchain-link/src/workers/blockbook/websocket.ts
+++ b/packages/blockchain-link/src/workers/blockbook/websocket.ts
@@ -69,8 +69,11 @@ export class BlockbookAPI extends BaseWebsocket<BlockbookEvents> {
         return this.send('getBlockHash', { height: block });
     }
 
-    getBlock(block: number | string) {
-        return this.send('getBlock', { id: `${block}` });
+    getBlock(
+        block: number | string,
+        { page, pageSize }: { page?: number; pageSize?: number } = {},
+    ) {
+        return this.send('getBlock', { id: `${block}`, page, pageSize });
     }
 
     getBlockFilter(blockHash: string, filterParams?: FilterRequestParams) {

--- a/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
+++ b/packages/coinjoin/src/backend/CoinjoinBackendClient.ts
@@ -56,8 +56,21 @@ export class CoinjoinBackendClient implements CoinjoinBackendClientShape {
 
     fetchBlock(height: number, options?: RequestOptions): Promise<BlockbookBlock> {
         const identity = this.identitiesBlockbook[height & 0x3]; // Works only when identities.length === 4
+        const pageSize = 1000;
 
-        return this.getBlockbookApi(api => api.getBlock(height), { identity, ...options });
+        return this.getBlockbookApi(
+            async api => {
+                const block = await api.getBlock(height, { pageSize });
+
+                for (let page = 2; page <= (block.totalPages ?? 1); ++page) {
+                    const { txs } = await api.getBlock(height, { page, pageSize });
+                    block.txs.push(...txs);
+                }
+
+                return block;
+            },
+            { identity, ...options },
+        );
     }
 
     fetchBlockHash(height: number, options?: RequestOptions): Promise<string> {


### PR DESCRIPTION
## Description

Since https://github.com/trezor/blockbook/pull/1476, `getBlock` endpoint only returns first 1000 transactions by default. In order to get all of them, it's therefore needed to iterate from 1 to `totalPages`.

**UPDATE**: `getBlock`'s default `pageSize` will be temporarily reverted to 10000 (in order not to break older Suites), so we'll explicitly ask for 1000 per page in this PR, to make re-reverting back to 1000 in the future easier.

<!--- Describe your changes in detail -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/blockbook-block-pagination/web/](https://dev.suite.sldev.cz/suite-web/fix/blockbook-block-pagination/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockbook-block-pagination&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockbook-block-pagination&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:36:04.233Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:36:26.604Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->