### PR TITLE
fix(suite): queue metadata provider requests

### DIFF
--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -105,6 +105,8 @@ export type Error = {
 export type Result<T> = Promise<Success<T> | Error>;
 
 export abstract class AbstractMetadataProvider {
+    private apiRequestQueue: Promise<unknown> = Promise.resolve();
+
     /* isCloud means that this provider is not local and allows multi client sync. These providers are suitable for backing up data. */
     abstract isCloud: boolean;
 
@@ -160,9 +162,9 @@ export abstract class AbstractMetadataProvider {
         } as const;
     }
 
-    scheduleApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
+    private runApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
         fn: T,
-        options: { retries: number; delay: number } = { retries: 3, delay: 1000 },
+        options: { retries: number; delay: number },
     ) {
         let retried = 0;
 
@@ -185,6 +187,16 @@ export abstract class AbstractMetadataProvider {
             };
             run();
         });
+    }
+
+    scheduleApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
+        fn: T,
+        options: { retries: number; delay: number } = { retries: 3, delay: 1000 },
+    ) {
+        const request = this.apiRequestQueue.then(() => this.runApiRequest<T, R>(fn, options));
+        this.apiRequestQueue = request;
+
+        return request;
     }
 }
 

--- a/suite/metadata/src/providers/__tests__/DropboxProvider.test.ts
+++ b/suite/metadata/src/providers/__tests__/DropboxProvider.test.ts
@@ -1,0 +1,49 @@
+import { createDeferred } from '@trezor/utils';
+
+import { DropboxProvider } from '../DropboxProvider';
+
+const globalContext = globalThis as typeof globalThis & { window?: typeof globalThis };
+if (!globalContext.window) {
+    globalContext.window = globalThis as any;
+}
+
+const emptySearchResult = {
+    status: 200,
+    headers: {},
+    result: {
+        has_more: false,
+        matches: [],
+    },
+};
+
+describe(DropboxProvider.name, () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runs scheduled API requests one at a time', async () => {
+        const provider = new DropboxProvider({ token: 'token', clientId: 'client-id' });
+        const firstRequest = createDeferred<typeof emptySearchResult>();
+        const secondRequest = createDeferred<typeof emptySearchResult>();
+        const filesSearchSpy = jest
+            .spyOn(provider.client, 'filesSearchV2')
+            .mockReturnValueOnce(firstRequest.promise)
+            .mockReturnValueOnce(secondRequest.promise);
+
+        const firstResult = provider.getFileContent('first.mtdt');
+        const secondResult = provider.getFileContent('second.mtdt');
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(filesSearchSpy).toHaveBeenCalledTimes(1);
+
+        firstRequest.resolve(emptySearchResult);
+        await firstResult;
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(filesSearchSpy).toHaveBeenCalledTimes(2);
+
+        secondRequest.resolve(emptySearchResult);
+        await secondResult;
+    });
+});


### PR DESCRIPTION
## Description

Legacy labeling schedules one cloud request per labelable entity, so Dropbox searches could all start concurrently and trigger rate limiting. This adds a per-provider FIFO queue around the existing request runner while leaving its retry count, fixed delay, and error behavior unchanged.\n\n- Concurrent starts for 2 scheduled searches: **2 -> 1**\n- The second search starts only after the first request finishes.


For some reason we do a ton of Dropbox requests, but it is a legacy labeling so I prefer not to deep dive into it:

Before
<img width="798" height="1046" alt="image" src="https://github.com/user-attachments/assets/615a95ee-fef7-4a0a-91d1-662a7e499a5a" />

After:
<img width="798" height="1046" alt="image" src="https://github.com/user-attachments/assets/64d7172b-1e7d-4250-817c-ea16bc0a0e62" />



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-queue-metadata-provider-requests/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-queue-metadata-provider-requests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-queue-metadata-provider-requests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-queue-metadata-provider-requests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-queue-metadata-provider-requests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:16:59.146Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T11:16:44.546Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->