### PR TITLE
fix(suite): honor Dropbox retry-after

### DIFF
--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -101,11 +101,13 @@ export type Error = {
     success: false;
     code: keyof typeof ProviderErrorReason;
     error: string;
+    retryAfterMs?: number;
 };
 export type Result<T> = Promise<Success<T> | Error>;
 
 export abstract class AbstractMetadataProvider {
     private apiRequestQueue: Promise<unknown> = Promise.resolve();
+    private apiRequestCooldownUntil = 0;
 
     /* isCloud means that this provider is not local and allows multi client sync. These providers are suitable for backing up data. */
     abstract isCloud: boolean;
@@ -152,14 +154,23 @@ export abstract class AbstractMetadataProvider {
         return { success } as const;
     }
 
-    error(code: keyof typeof ProviderErrorReason, reason: string) {
+    error(code: keyof typeof ProviderErrorReason, reason: string, retryAfterMs?: number) {
         const success = false as const;
 
         return {
             success,
             code,
             error: reason,
+            ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
         } as const;
+    }
+
+    private async waitForApiRequestCooldown() {
+        const delay = this.apiRequestCooldownUntil - Date.now();
+
+        if (delay > 0) {
+            await new Promise(resolve => setTimeout(resolve, delay));
+        }
     }
 
     private runApiRequest<T extends () => ReturnType<R>, R extends (...args: any) => Result<any>>(
@@ -171,15 +182,29 @@ export abstract class AbstractMetadataProvider {
         return new Promise<Awaited<ReturnType<R>>>(resolve => {
             const { retries, delay } = options;
             const run = async () => {
+                await this.waitForApiRequestCooldown();
+
                 const res = await fn();
 
                 if (res.success) {
                     return resolve(res);
                 }
 
+                const retryDelay =
+                    res.code === 'RATE_LIMIT_ERROR' && res.retryAfterMs !== undefined
+                        ? res.retryAfterMs
+                        : delay;
+
+                if (res.code === 'RATE_LIMIT_ERROR' && res.retryAfterMs !== undefined) {
+                    this.apiRequestCooldownUntil = Math.max(
+                        this.apiRequestCooldownUntil,
+                        Date.now() + retryDelay,
+                    );
+                }
+
                 if (retries > 0 && retried < retries) {
                     retried++;
-                    setTimeout(run, delay);
+                    setTimeout(run, retryDelay);
                 } else {
                     // reached retries limit, return error
                     resolve(res);

--- a/suite-common/metadata-types/src/metadataTypes.ts
+++ b/suite-common/metadata-types/src/metadataTypes.ts
@@ -107,6 +107,10 @@ export type Result<T> = Promise<Success<T> | Error>;
 
 export abstract class AbstractMetadataProvider {
     private apiRequestQueue: Promise<unknown> = Promise.resolve();
+
+    /**
+     * Prevent queued requests from bypassing Retry-After when the rate-limited request exhausts its retries.
+     */
     private apiRequestCooldownUntil = 0;
 
     /* isCloud means that this provider is not local and allows multi client sync. These providers are suitable for backing up data. */

--- a/suite/metadata/src/providers/DropboxProvider.ts
+++ b/suite/metadata/src/providers/DropboxProvider.ts
@@ -271,8 +271,20 @@ export class DropboxProvider extends AbstractMetadataProvider {
                 case 403:
                     return this.error('ACCESS_ERROR', message);
                 case 409: // endpoint specific error
-                case 429: // rate limit error
                     return this.error('RATE_LIMIT_ERROR', message);
+                case 429: {
+                    const retryAfter =
+                        err.headers?.get?.('retry-after') ??
+                        err.headers?.['retry-after'] ??
+                        err.headers?.['Retry-After'];
+                    const retryAfterSeconds = Number(retryAfter);
+                    const retryAfterMs =
+                        Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0
+                            ? retryAfterSeconds * 1000
+                            : undefined;
+
+                    return this.error('RATE_LIMIT_ERROR', message, retryAfterMs);
+                }
                 default:
                 // intentional fall-through
             }

--- a/suite/metadata/src/providers/__tests__/DropboxProvider.test.ts
+++ b/suite/metadata/src/providers/__tests__/DropboxProvider.test.ts
@@ -18,6 +18,7 @@ const emptySearchResult = {
 
 describe(DropboxProvider.name, () => {
     afterEach(() => {
+        jest.useRealTimers();
         jest.restoreAllMocks();
     });
 
@@ -45,5 +46,93 @@ describe(DropboxProvider.name, () => {
 
         secondRequest.resolve(emptySearchResult);
         await secondResult;
+    });
+
+    it('pauses the request queue according to Dropbox Retry-After', async () => {
+        jest.useFakeTimers();
+
+        const provider = new DropboxProvider({ token: 'token', clientId: 'client-id' });
+        const filesSearchSpy = jest
+            .spyOn(provider.client, 'filesSearchV2')
+            .mockRejectedValueOnce({
+                status: 429,
+                headers: {
+                    get: (name: string) => (name.toLowerCase() === 'retry-after' ? '2' : null),
+                },
+                error: { error_summary: 'too_many_requests' },
+            })
+            .mockResolvedValueOnce(emptySearchResult);
+
+        const result = provider.getFileContent('file.mtdt');
+
+        await jest.advanceTimersByTimeAsync(0);
+        expect(filesSearchSpy).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(1999);
+        expect(filesSearchSpy).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(1);
+        await result;
+
+        expect(filesSearchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('applies Retry-After to requests already waiting in the queue', async () => {
+        jest.useFakeTimers();
+
+        const provider = new DropboxProvider({ token: 'token', clientId: 'client-id' });
+        const firstRequest = jest
+            .fn()
+            .mockResolvedValue(provider.error('RATE_LIMIT_ERROR', 'too many requests', 2000));
+        const secondRequest = jest.fn().mockResolvedValue(provider.ok());
+
+        const firstResult = provider.scheduleApiRequest(firstRequest, {
+            retries: 0,
+            delay: 1000,
+        });
+        const secondResult = provider.scheduleApiRequest(secondRequest, {
+            retries: 0,
+            delay: 1000,
+        });
+
+        await jest.advanceTimersByTimeAsync(0);
+        await firstResult;
+
+        expect(firstRequest).toHaveBeenCalledTimes(1);
+        expect(secondRequest).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(1999);
+        expect(secondRequest).not.toHaveBeenCalled();
+
+        await jest.advanceTimersByTimeAsync(1);
+        await secondResult;
+
+        expect(secondRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the fixed retry delay when Retry-After is unavailable', async () => {
+        jest.useFakeTimers();
+
+        const provider = new DropboxProvider({ token: 'token', clientId: 'client-id' });
+        const filesSearchSpy = jest
+            .spyOn(provider.client, 'filesSearchV2')
+            .mockRejectedValueOnce({
+                status: 429,
+                headers: {
+                    get: () => null,
+                },
+                error: { error_summary: 'too_many_requests' },
+            })
+            .mockResolvedValueOnce(emptySearchResult);
+
+        const result = provider.getFileContent('file.mtdt');
+
+        await jest.advanceTimersByTimeAsync(999);
+        expect(filesSearchSpy).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(1);
+        await result;
+
+        expect(filesSearchSpy).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
## Description

Dropbox 429 responses specify how long clients should wait, but legacy labeling always retried after its fixed one-second delay. This parses `Retry-After`, applies it to the active retry and the shared provider queue, and retains the original fixed delay when the header is absent.

- Retry with `Retry-After: 2`: **1s -> 2s**
- Queued requests after a final 429: **immediate -> after 2s cooldown**

## QA Notes
- This is impossible to test from QA perspective
- I also trust the unit tests 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-honor-dropbox-retry-after&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-honor-dropbox-retry-after&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-honor-dropbox-retry-after&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-honor-dropbox-retry-after/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-honor-dropbox-retry-after/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:32:46.930Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:32:16.530Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/metadata-types/src/metadataTypes.ts`
- `suite/metadata/src/providers/DropboxProvider.ts`
- `suite/metadata/src/providers/__tests__/DropboxProvider.test.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-27T09:33:04.877Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->