### PR TITLE
fix(connect): declare normalized bitcoin paths

### DIFF
--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -79,10 +79,6 @@ export type ProtoWithDerivationPath<T> =
     | ProtoWithoutAddressN<T, number[]>
     | ProtoWithExtendedAddressN<T, number[], DerivationPath>;
 
-// unwrap original generic PROTO type from the replacement
-export type ProtoWithAddressN<P extends ProtoWithDerivationPath<any>> =
-    P extends ProtoWithDerivationPath<infer T> ? T : unknown;
-
 // Common fields for all *.getAddress methods
 export type GetAddress = Static<typeof GetAddress>;
 export const GetAddress = Type.Object({


### PR DESCRIPTION
## Description

fixPath previously reverse-inferred the protobuf input/output union through ProtoWithAddressN, which becomes unstable across emitted declaration boundaries and can retain string derivation paths. This replaces the conditional generic with explicit input/output overloads and adds a module-local type test for both normalized mappings.\n\nThe overloads leave ProtoWithAddressN unused, so this follow-up also removes the obsolete exported helper requested in #30071.\n\n- Return contracts: **1 conditional generic -> 2 explicit overloads**\n- Type assertions: **0 -> 4** (2 valid, 2 rejected)\n- Obsolete helper exports: **1 -> 0**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect-common/src/types/params.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-23T13:19:53.005Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/connect-remove-proto-with-address-n/web/](https://dev.suite.sldev.cz/suite-web/refactor/connect-remove-proto-with-address-n/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-remove-proto-with-address-n&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-remove-proto-with-address-n&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T13:23:36.583Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T13:23:32.634Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->