### PR TITLE
fix(trading): prevent premature no-offer state in swap

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
@@ -73,7 +73,7 @@ export const useTradingBuyForm = (): TradingBuyFormContextProps => {
         mode: 'onChange',
         defaultValues: redirectValues || defaultValues,
     });
-    const { formState, reset, setValue, getValues, control } = methods;
+    const { formState, reset, setValue, getValues, clearErrors, control } = methods;
     // Watch only those values that are relevant in render function
     const [cryptoSelect, fiatInput, cryptoInput, currencySelect, paymentMethod] = useWatch({
         control,
@@ -124,6 +124,7 @@ export const useTradingBuyForm = (): TradingBuyFormContextProps => {
     const toggleAmountInCrypto = () => {
         setValue(TRADING_FORM_CRYPTO_INPUT, '');
         setValue(TRADING_FORM_FIAT_INPUT, '');
+        clearErrors([TRADING_FORM_CRYPTO_INPUT, TRADING_FORM_FIAT_INPUT]);
         baseToggleAmountInCrypto();
     };
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingFiatCryptoAmount.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/__tests__/useTradingFiatCryptoAmount.test.tsx
@@ -82,11 +82,11 @@ const TRADING_FIAT_VALUES: TradingFiatRatesReturn = {
     fiatRatesUpdater: jest.fn(() => Promise.resolve(null)),
 };
 
-const renderFiatCryptoAmount = () =>
+const renderFiatCryptoAmount = (defaultValues: TradingSellFormProps = DEFAULTS) =>
     renderHook(() => {
         const methods = useForm<TradingSellFormProps>({
             mode: 'onChange',
-            defaultValues: DEFAULTS,
+            defaultValues,
         });
         const amount = useTradingFiatCryptoAmount({
             methods,
@@ -123,7 +123,7 @@ describe('useTradingFiatCryptoAmount', () => {
         expect(result.current.amount.fractionButton).toBe(1);
     });
 
-    it('recalculates the crypto amount from the typed fiat amount after the debounce', async () => {
+    it('recalculates the crypto amount from the typed fiat amount', async () => {
         const { result } = renderFiatCryptoAmount();
 
         act(() => {
@@ -134,6 +134,20 @@ describe('useTradingFiatCryptoAmount', () => {
             () => expect(result.current.methods.getValues('outputs.0.amount')).toBe('0.00200000'),
             { timeout: 1500 },
         );
+    });
+
+    it('keeps a prefilled crypto amount on mount when the fiat is empty', async () => {
+        const { result } = renderFiatCryptoAmount({
+            ...DEFAULTS,
+            outputs: [{ ...DEFAULTS.outputs[0]!, amount: '0.5', fiat: '' }],
+        });
+
+        await new Promise(resolve => {
+            setTimeout(resolve, 700);
+        });
+
+        expect(result.current.methods.getValues('outputs.0.amount')).toBe('0.5');
+        expect(result.current.methods.formState.errors.outputs).toBeUndefined();
     });
 
     it('does not recalculate crypto while a fraction button is active', async () => {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
@@ -94,9 +94,15 @@ export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProp
     // recalculate the crypto amount from the fiat amount
     const calculateCryptoAmountFromFiat = useCallback(
         (fiatAmount: string | undefined) => {
+            if (!fiatAmount) {
+                setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldValidate: true });
+
+                return;
+            }
+
             const fiatCurrency = getValues(TRADING_FORM_OUTPUT_CURRENCY);
 
-            if (!tradingFiatValues || !fiatCurrency || !fiatAmount) {
+            if (!tradingFiatValues || !fiatCurrency) {
                 return;
             }
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
@@ -1,6 +1,5 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
-import { useDebounce } from 'react-use';
 
 import { type FiatCurrencyCode } from 'invity-api';
 
@@ -31,7 +30,7 @@ interface UseTradingFiatCryptoAmountProps<T extends TradingSellExchangeFormProps
 
 /**
  * Amount-conversion cluster shared by the sell and exchange form-input hooks:
- * the fraction-button state, fiat↔crypto conversion handlers and the debounced
+ * the fraction-button state, fiat↔crypto conversion handlers and the
  * fiat→crypto recalculation (skipped while a fraction button is active).
  */
 export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProps>({
@@ -46,6 +45,7 @@ export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProp
     const [fractionButtonState, setFractionButtonState] = useState<number | undefined>(undefined);
 
     const watchedFiat = useWatch({ control, name: TRADING_FORM_OUTPUT_FIAT });
+    const previousFiatRef = useRef(watchedFiat);
 
     const setFractionButton = (fraction: number | undefined) => {
         if (fraction !== 1) {
@@ -118,16 +118,15 @@ export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProp
         [getValues, tradingFiatValues, networkDecimals, shouldSendInSats, setValue],
     );
 
-    // recalculate crypto amount whenever the fiat amount is typed, with debounce
-    useDebounce(
-        () => {
-            if (fractionButtonState === undefined) {
-                calculateCryptoAmountFromFiat(getValues(TRADING_FORM_OUTPUT_FIAT));
-            }
-        },
-        500,
-        [watchedFiat],
-    );
+    useEffect(() => {
+        const currentFiat = getValues(TRADING_FORM_OUTPUT_FIAT);
+        const hasFiatChanged = currentFiat !== previousFiatRef.current;
+        previousFiatRef.current = currentFiat;
+
+        if (hasFiatChanged && fractionButtonState === undefined) {
+            calculateCryptoAmountFromFiat(currentFiat);
+        }
+    }, [watchedFiat, fractionButtonState, getValues, calculateCryptoAmountFromFiat]);
 
     return {
         fractionButton: fractionButtonState,

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
@@ -38,6 +38,7 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
     const abortActiveRequest = useCallback(() => {
         controllerRef.current?.abort();
         controllerRef.current = null;
+        setIsScheduledQuotesRefresh(false);
     }, []);
 
     const clearDebounceTimer = useCallback(() => {
@@ -69,7 +70,7 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
             return;
         }
 
-        abortActiveRequest();
+        controllerRef.current?.abort();
         const controller = new AbortController();
         controllerRef.current = controller;
         const { signal } = controller;
@@ -86,9 +87,11 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
             return;
         }
 
+        const currentValues = methods.getValues();
+
         setIsScheduledQuotesRefresh(true);
 
-        const request = configRef.current.requestQuotes(values);
+        const request = configRef.current.requestQuotes(currentValues);
         signal.addEventListener('abort', () => request.abort(), { once: true });
         isQuoteLifecycleActive.current = true;
 
@@ -99,14 +102,14 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
                 return;
             }
 
-            configRef.current.onResolved?.(result, values);
+            configRef.current.onResolved?.(result, currentValues);
             setIsScheduledQuotesRefresh(false);
         } catch {
             if (!signal.aborted) {
                 setIsScheduledQuotesRefresh(false);
             }
         }
-    }, [methods, configRef, stopQuoteRequests, abortActiveRequest]);
+    }, [methods, configRef, stopQuoteRequests]);
 
     useTradingRefetchScheduler({
         onRefetch: () => {

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
@@ -178,5 +178,6 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
     return {
         isScheduledQuotesRefresh,
         refreshQuotes,
+        abortActiveRequest,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type FieldPath, type FieldValues, type UseFormReturn } from 'react-hook-form';
+
+import { useTradingRefetchScheduler } from '@suite-common/trading';
+import { useCurrentRef } from '@trezor/react-utils';
+
+const DEBOUNCE_DELAY_MS = 500;
+
+type AbortableRequest<TResult> = {
+    abort: () => void;
+    unwrap: () => Promise<TResult>;
+};
+
+type UseTradingQuoteRequestProps<TFormProps extends FieldValues, TResult> = {
+    methods: UseFormReturn<TFormProps>;
+    immediateFields: readonly FieldPath<TFormProps>[];
+    debouncedFields: readonly FieldPath<TFormProps>[];
+    isFetchAllowed: (values: TFormProps) => boolean;
+    requestQuotes: (values: TFormProps) => AbortableRequest<TResult>;
+    stopScheduler: () => void;
+    onResolved?: (result: TResult, values: TFormProps) => void;
+    isRequestContextAvailable?: boolean;
+};
+
+export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>({
+    methods,
+    isRequestContextAvailable = true,
+    ...config
+}: UseTradingQuoteRequestProps<TFormProps, TResult>) => {
+    const controllerRef = useRef<AbortController | null>(null);
+    const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isQuoteLifecycleActive = useRef(false);
+
+    const [isScheduledQuotesRefresh, setIsScheduledQuotesRefresh] = useState(false);
+
+    const configRef = useCurrentRef(config);
+
+    const abortActiveRequest = useCallback(() => {
+        controllerRef.current?.abort();
+        controllerRef.current = null;
+    }, []);
+
+    const clearDebounceTimer = useCallback(() => {
+        if (debounceTimer.current !== null) {
+            clearTimeout(debounceTimer.current);
+            debounceTimer.current = null;
+        }
+    }, []);
+
+    const stopQuoteRequests = useCallback(() => {
+        abortActiveRequest();
+        clearDebounceTimer();
+        setIsScheduledQuotesRefresh(false);
+
+        if (!isQuoteLifecycleActive.current) {
+            return;
+        }
+
+        isQuoteLifecycleActive.current = false;
+        configRef.current.stopScheduler();
+    }, [abortActiveRequest, clearDebounceTimer, configRef]);
+
+    const refreshQuotes = useCallback(async () => {
+        const values = methods.getValues();
+
+        if (!configRef.current.isFetchAllowed(values)) {
+            stopQuoteRequests();
+
+            return;
+        }
+
+        abortActiveRequest();
+        const controller = new AbortController();
+        controllerRef.current = controller;
+        const { signal } = controller;
+
+        const isValid = await methods.trigger();
+
+        if (signal.aborted) {
+            return;
+        }
+
+        if (!isValid) {
+            stopQuoteRequests();
+
+            return;
+        }
+
+        setIsScheduledQuotesRefresh(true);
+
+        const request = configRef.current.requestQuotes(values);
+        signal.addEventListener('abort', () => request.abort(), { once: true });
+        isQuoteLifecycleActive.current = true;
+
+        try {
+            const result = await request.unwrap();
+
+            if (signal.aborted) {
+                return;
+            }
+
+            configRef.current.onResolved?.(result, values);
+            setIsScheduledQuotesRefresh(false);
+        } catch {
+            if (!signal.aborted) {
+                setIsScheduledQuotesRefresh(false);
+            }
+        }
+    }, [methods, configRef, stopQuoteRequests, abortActiveRequest]);
+
+    useTradingRefetchScheduler({
+        onRefetch: () => {
+            if (configRef.current.isFetchAllowed(methods.getValues())) {
+                refreshQuotes();
+            }
+        },
+    });
+
+    useEffect(() => {
+        const subscription = methods.watch((_, { name }) => {
+            if (!name) {
+                return;
+            }
+
+            const { immediateFields, debouncedFields, isFetchAllowed } = configRef.current;
+            const isImmediate = immediateFields.includes(name);
+
+            if (!isImmediate && !debouncedFields.includes(name)) {
+                return;
+            }
+
+            abortActiveRequest();
+
+            if (!isFetchAllowed(methods.getValues())) {
+                stopQuoteRequests();
+
+                return;
+            }
+
+            setIsScheduledQuotesRefresh(true);
+            clearDebounceTimer();
+
+            if (isImmediate) {
+                refreshQuotes();
+            } else {
+                debounceTimer.current = setTimeout(() => {
+                    refreshQuotes();
+                }, DEBOUNCE_DELAY_MS);
+            }
+        });
+
+        return () => subscription.unsubscribe();
+    }, [
+        methods,
+        configRef,
+        abortActiveRequest,
+        clearDebounceTimer,
+        stopQuoteRequests,
+        refreshQuotes,
+    ]);
+
+    // Runs on mount too — a form mounted already valid (e.g. buy redirect) fetches immediately.
+    useEffect(() => {
+        if (isRequestContextAvailable) {
+            refreshQuotes();
+        } else {
+            stopQuoteRequests();
+        }
+    }, [isRequestContextAvailable, stopQuoteRequests, refreshQuotes]);
+
+    useEffect(
+        () => () => {
+            stopQuoteRequests();
+        },
+        [stopQuoteRequests],
+    );
+
+    return {
+        isScheduledQuotesRefresh,
+        refreshQuotes,
+    };
+};

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
@@ -263,6 +263,39 @@ describe('useExchangeQuotes', () => {
         expect(mockHandleRequest).not.toHaveBeenCalled();
     });
 
+    it('aborts the in-flight request when the receive identity becomes incoherent', async () => {
+        mockHandleRequest.mockImplementationOnce((payload: unknown) => {
+            const thunk = () => ({
+                abort: mockAbort,
+                unwrap: () => new Promise<ExchangeTrade[]>(() => {}),
+            });
+
+            return Object.assign(thunk, { payload });
+        });
+
+        const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
+            receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
+        });
+
+        await act(async () => {
+            await result.current.methods.trigger();
+        });
+
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        expect(mockAbort).not.toHaveBeenCalled();
+
+        act(() => {
+            result.current.methods.setValue('receiveCryptoSelect', {
+                ...RECEIVE_CRYPTO_SELECT,
+                id: 'binancecoin' as CryptoId,
+            });
+        });
+
+        await waitFor(() => expect(mockAbort).toHaveBeenCalled());
+    });
+
     it('clears the selected quote when only the receive account changes', async () => {
         const { rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0xreceive',

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
@@ -263,7 +263,7 @@ describe('useExchangeQuotes', () => {
         expect(mockHandleRequest).not.toHaveBeenCalled();
     });
 
-    it('aborts the in-flight request when the receive identity becomes incoherent', async () => {
+    it('aborts the in-flight request and clears the loading state when the receive identity becomes incoherent', async () => {
         mockHandleRequest.mockImplementationOnce((payload: unknown) => {
             const thunk = () => ({
                 abort: mockAbort,
@@ -284,6 +284,7 @@ describe('useExchangeQuotes', () => {
         });
 
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        await waitFor(() => expect(result.current.quotes.isScheduledQuotesRefresh).toBe(true));
         expect(mockAbort).not.toHaveBeenCalled();
 
         act(() => {
@@ -294,15 +295,23 @@ describe('useExchangeQuotes', () => {
         });
 
         await waitFor(() => expect(mockAbort).toHaveBeenCalled());
+        await waitFor(() => expect(result.current.quotes.isScheduledQuotesRefresh).toBe(false));
     });
 
-    it('clears the selected quote when only the receive account changes', async () => {
-        const { rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
-            receiveAddress: '0xreceive',
+    it('clears the selected quote and refetches when only the receive account changes', async () => {
+        const { result, rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
+            receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
             receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
         });
 
-        expect(mockSaveSelectedQuote).not.toHaveBeenCalled();
+        await act(async () => {
+            await result.current.methods.trigger();
+        });
+
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        mockHandleRequest.mockClear();
+        mockSaveSelectedQuote.mockClear();
 
         rerender({
             currentNetwork: getNetwork('btc'),
@@ -313,6 +322,7 @@ describe('useExchangeQuotes', () => {
         });
 
         await waitFor(() => expect(mockSaveSelectedQuote).toHaveBeenCalledWith(undefined));
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
     });
 
     it('fetches quotes once the network becomes available again', async () => {

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx
@@ -11,7 +11,7 @@ import {
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeQuotes } from '../useExchangeQuotes';
@@ -127,14 +127,17 @@ const wait = (ms: number) =>
 
 const renderExchangeQuotes = (
     defaultValues: TradingExchangeFormProps,
-    {
-        receiveAddress,
-        resolver,
-    }: {
+    options: {
+        network?: Network;
         receiveAddress?: string;
+        receiveAccountKey?: ReturnType<typeof mockAccountKey>;
+        receiveAccountSymbol?: NetworkSymbol;
         resolver?: Resolver<TradingExchangeFormProps>;
     } = {},
 ) => {
+    const { receiveAddress, receiveAccountKey, receiveAccountSymbol, resolver } = options;
+    const network = 'network' in options ? options.network : getNetwork('btc');
+
     const store = configureMockStore({
         preloadedState: {
             wallet: {
@@ -146,26 +149,32 @@ const renderExchangeQuotes = (
     });
 
     return renderHookWithStoreProvider(
-        () => {
+        ({ currentNetwork, currentReceiveAccountKey }) => {
             const methods = useForm<TradingExchangeFormProps>({
                 mode: 'onChange',
                 defaultValues,
                 resolver,
             });
+
             const quotes = useExchangeQuotes({
-                control: methods.control,
-                getValues: methods.getValues,
-                setValue: methods.setValue,
-                network: getNetwork('btc'),
+                methods,
+                network: currentNetwork,
                 shouldSendInSats: false,
                 receiveAddress,
-                receiveAccountKey: undefined,
+                receiveAccountKey: currentReceiveAccountKey,
+                receiveAccountSymbol,
                 composeRequestCallback: jest.fn(),
             });
 
             return { methods, quotes };
         },
-        { store },
+        {
+            store,
+            initialProps: {
+                currentNetwork: network,
+                currentReceiveAccountKey: receiveAccountKey,
+            },
+        },
     );
 };
 
@@ -226,6 +235,75 @@ describe('useExchangeQuotes', () => {
         await waitFor(() => expect(mockSaveSelectedQuote).toHaveBeenCalledWith(undefined));
     });
 
+    it('does not dispatch a quotes request while the receive identity is incoherent (#28143/#30213)', async () => {
+        const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
+            receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
+        });
+
+        await act(async () => {
+            await result.current.methods.trigger();
+        });
+
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        mockHandleRequest.mockClear();
+        mockSaveSelectedQuote.mockClear();
+
+        act(() => {
+            result.current.methods.setValue('receiveCryptoSelect', {
+                ...RECEIVE_CRYPTO_SELECT,
+                id: 'binancecoin' as CryptoId,
+            });
+        });
+
+        await waitFor(() => expect(mockSaveSelectedQuote).toHaveBeenCalledWith(undefined));
+        await wait(700);
+
+        expect(mockHandleRequest).not.toHaveBeenCalled();
+    });
+
+    it('clears the selected quote when only the receive account changes', async () => {
+        const { rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
+            receiveAddress: '0xreceive',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+        });
+
+        expect(mockSaveSelectedQuote).not.toHaveBeenCalled();
+
+        rerender({
+            currentNetwork: getNetwork('btc'),
+            currentReceiveAccountKey: mockAccountKey({
+                descriptor: 'receiveaccount2',
+                symbol: 'eth',
+            }),
+        });
+
+        await waitFor(() => expect(mockSaveSelectedQuote).toHaveBeenCalledWith(undefined));
+    });
+
+    it('fetches quotes once the network becomes available again', async () => {
+        const { result, rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
+            network: undefined,
+            receiveAddress: '0xreceive',
+        });
+
+        await act(async () => {
+            await result.current.methods.trigger();
+        });
+
+        await wait(700);
+
+        expect(mockHandleRequest).not.toHaveBeenCalled();
+
+        rerender({
+            currentNetwork: getNetwork('btc'),
+            currentReceiveAccountKey: undefined,
+        });
+
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+    });
+
     it('switches a DEX selection to CEX when only CEX quotes are available', async () => {
         mockCexQuotes = QUOTES;
         mockDexQuotes = [];
@@ -240,15 +318,5 @@ describe('useExchangeQuotes', () => {
                 TRADING_EXCHANGE_FORM_CEX,
             ),
         );
-    });
-
-    it('resetSelectedOffer flags a scheduled quotes refresh', () => {
-        const { result } = renderExchangeQuotes(VALID_DEFAULTS);
-
-        act(() => {
-            result.current.quotes.resetSelectedOffer();
-        });
-
-        expect(result.current.quotes.isScheduledQuotesRefresh).toBe(true);
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
@@ -67,7 +67,7 @@ export const useExchangeQuotes = ({
         receiveAccountKey,
     });
 
-    const { isScheduledQuotesRefresh, refreshQuotes } = useTradingQuoteRequest({
+    const { isScheduledQuotesRefresh, refreshQuotes, abortActiveRequest } = useTradingQuoteRequest({
         methods,
         immediateFields: EXCHANGE_IMMEDIATE_FIELDS,
         debouncedFields: EXCHANGE_DEBOUNCED_FIELDS,
@@ -110,6 +110,8 @@ export const useExchangeQuotes = ({
                 receiveAccountSymbol,
             })
         ) {
+            abortActiveRequest();
+
             return;
         }
 
@@ -122,6 +124,7 @@ export const useExchangeQuotes = ({
         receiveAccountSymbol,
         dispatch,
         refreshQuotes,
+        abortActiveRequest,
     ]);
 
     const exchangeType = useWatch({ control: methods.control, name: TRADING_EXCHANGE_FORM });

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
@@ -1,13 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-    type Control,
-    type UseFormGetValues,
-    type UseFormSetValue,
-    useFormState,
-    useWatch,
-} from 'react-hook-form';
-
-import useDebounce from 'react-use/lib/useDebounce';
+import { useEffect, useRef } from 'react';
+import { type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -20,147 +12,88 @@ import {
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingExchangeFormProps,
     exchangeThunks,
+    isReceiveAddressCoherent,
     selectTradingExchangeCexQuotes,
     selectTradingExchangeDexQuotes,
     tradingActions,
     tradingExchangeActions,
-    useTradingRefetchScheduler,
 } from '@suite-common/trading';
-import { type Network } from '@suite-common/wallet-config';
+import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { isExchangeQuotesFetchAllowed } from 'src/utils/wallet/trading/exchangeQuotesRequestUtils';
 
+import { useTradingQuoteRequest } from '../common/useTradingQuoteRequest';
+
 type UseExchangeQuotesProps = {
-    control: Control<TradingExchangeFormProps>;
-    getValues: UseFormGetValues<TradingExchangeFormProps>;
-    setValue: UseFormSetValue<TradingExchangeFormProps>;
+    methods: UseFormReturn<TradingExchangeFormProps>;
     network: Network | undefined;
     shouldSendInSats: boolean | undefined;
-    // receiveAddress and receiveAccountKey are read from useTradingReceiveAddress
-    // rather than mirrored onto the outer form, keeping the receive identity a
-    // single source of truth (#28143).
     receiveAddress?: string;
     receiveAccountKey?: AccountKey;
+    receiveAccountSymbol?: NetworkSymbol;
     composeRequestCallback: () => void;
 };
 
-type AbortableRequest = {
-    abort: (message?: string) => void;
-} | null;
+const EXCHANGE_IMMEDIATE_FIELDS = [TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT] as const;
 
-const EXCHANGE_QUOTES_KEY_FIELDS = [
-    TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
-    TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
-    TRADING_EXCHANGE_FORM,
-    TRADING_FORM_OUTPUT_AMOUNT,
-] as const;
+const EXCHANGE_DEBOUNCED_FIELDS = [TRADING_FORM_OUTPUT_AMOUNT] as const;
 
 export const useExchangeQuotes = ({
-    control,
-    getValues,
-    setValue,
+    methods,
     network,
     shouldSendInSats,
     receiveAddress,
     receiveAccountKey,
+    receiveAccountSymbol,
     composeRequestCallback,
 }: UseExchangeQuotesProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
-    const previousRequest = useRef<AbortableRequest>(null);
-
     const dexQuotes = useSelector(selectTradingExchangeDexQuotes);
     const cexQuotes = useSelector(selectTradingExchangeCexQuotes);
 
-    // used for disabling approve/revoke controls when
-    // quotes are scheduled to refresh after changing swap form inputs
-    const [isScheduledQuotesRefresh, setIsScheduledQuotesRefresh] = useState(false);
-
-    // TODO: source control/getValues/setValue via useFormContext() once the trading-form family migrates to FormProvider
-    useWatch({ control, name: EXCHANGE_QUOTES_KEY_FIELDS });
-    const { isValid } = useFormState({ control });
-
-    const values = getValues();
-    const { exchangeType } = values;
-    const isFetchAllowed = isValid && isExchangeQuotesFetchAllowed(values);
-
-    const amountKey = JSON.stringify({
-        amount: values.outputs?.[0]?.amount,
+    // Subscribe to receiveCryptoSelect so the receiveIdentityKey effect fires on receive-asset changes.
+    const receiveCryptoSelect = useWatch({
+        control: methods.control,
+        name: TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
     });
-    const selectKey = JSON.stringify({
-        sendCryptoId: values.sendCryptoSelect?.id,
-        sendAccountKey: values.sendCryptoSelect?.accountKey,
-        receiveCryptoId: values.receiveCryptoSelect?.id,
-        exchangeType,
+
+    const receiveIdentityKey = JSON.stringify({
+        receiveCryptoId: receiveCryptoSelect?.id,
         receiveAddress,
         receiveAccountKey,
     });
-    const receiveIdentityKey = JSON.stringify({
-        receiveCryptoId: values.receiveCryptoSelect?.id,
-        receiveAddress,
-    });
 
-    const fetchQuotes = useCallback(async () => {
-        if (!network) {
-            setIsScheduledQuotesRefresh(false);
-
-            return;
-        }
-        const formValues = getValues();
-
-        if (previousRequest.current) {
-            previousRequest.current.abort('Request was replaced by another one.');
-        }
-
-        const request = dispatch(
-            exchangeThunks.handleRequestThunk({
-                formValues: {
-                    ...formValues,
-                    receiveAddress,
-                    receiveAccountKey,
-                },
-                network,
-                shouldSendInSats,
-                composeRequestCallback,
-            }),
-        );
-        previousRequest.current = request;
-
-        try {
-            const quotes = await request.unwrap();
-
+    const { isScheduledQuotesRefresh, refreshQuotes } = useTradingQuoteRequest({
+        methods,
+        immediateFields: EXCHANGE_IMMEDIATE_FIELDS,
+        debouncedFields: EXCHANGE_DEBOUNCED_FIELDS,
+        isFetchAllowed: values => !!network && isExchangeQuotesFetchAllowed(values),
+        requestQuotes: values =>
+            dispatch(
+                exchangeThunks.handleRequestThunk({
+                    formValues: { ...values, receiveAddress, receiveAccountKey },
+                    network: network!,
+                    shouldSendInSats,
+                    composeRequestCallback,
+                }),
+            ),
+        stopScheduler: () => dispatch(tradingActions.stopRefetchQuotes()),
+        onResolved: quotes => {
             analytics.report({
                 type: events.tradeReceivedQuotesEvent.name,
                 payload: {
                     type: 'exchange',
-                    count: quotes?.length ?? 0,
+                    count: quotes.length,
                 },
             });
-        } catch (error) {
-            console.warn('Request was aborted:', error instanceof Error ? error.message : error);
-        }
+        },
+        isRequestContextAvailable: !!network,
+    });
 
-        setIsScheduledQuotesRefresh(false);
-    }, [
-        dispatch,
-        getValues,
-        receiveAddress,
-        receiveAccountKey,
-        network,
-        shouldSendInSats,
-        composeRequestCallback,
-        analytics,
-    ]);
-
-    // Refetch if anything is being typed into the text fields, but debounced. Select fields are not debounced.
-    const [debouncedAmountKey, setDebouncedAmountKey] = useState(amountKey);
-    useDebounce(() => setDebouncedAmountKey(amountKey), 500, [amountKey]);
-
-    // Clear the stale selected quote whenever the receive identity changes, before
-    // the refetch fires below (the #28143/#28357 rapid-switch family).
     const previousReceiveIdentityKey = useRef(receiveIdentityKey);
     useEffect(() => {
         if (receiveIdentityKey === previousReceiveIdentityKey.current) {
@@ -168,17 +101,31 @@ export const useExchangeQuotes = ({
         }
         previousReceiveIdentityKey.current = receiveIdentityKey;
         dispatch(tradingExchangeActions.saveSelectedQuote(undefined));
-    }, [receiveIdentityKey, dispatch]);
 
-    useEffect(() => {
-        if (isFetchAllowed) {
-            fetchQuotes();
+        if (
+            !isReceiveAddressCoherent({
+                receiveAddress,
+                receiveCryptoId: receiveCryptoSelect?.id,
+                receiveAccountKey,
+                receiveAccountSymbol,
+            })
+        ) {
+            return;
         }
-        // Reactivity on combination of fields, using the compounded keys.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [debouncedAmountKey, selectKey, isFetchAllowed]);
 
-    // handle edge case when there are no longer quotes of selected exchange type
+        refreshQuotes();
+    }, [
+        receiveIdentityKey,
+        receiveAddress,
+        receiveCryptoSelect?.id,
+        receiveAccountKey,
+        receiveAccountSymbol,
+        dispatch,
+        refreshQuotes,
+    ]);
+
+    const exchangeType = useWatch({ control: methods.control, name: TRADING_EXCHANGE_FORM });
+
     useEffect(() => {
         const isSelectedDexButFoundOnlyCex =
             exchangeType === TRADING_EXCHANGE_FORM_DEX && !dexQuotes.length && cexQuotes.length;
@@ -188,55 +135,18 @@ export const useExchangeQuotes = ({
             exchangeType === TRADING_EXCHANGE_FORM_DEX && !dexQuotes.length && !cexQuotes.length;
 
         if (isSelectedDexButFoundOnlyCex) {
-            setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_CEX);
+            methods.setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_CEX);
         } else if (isSelectedCexButFoundOnlyDex) {
-            setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_DEX);
+            methods.setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_DEX);
         } else if (isSelectedDexButNotFoundAny) {
-            setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_CEX);
+            methods.setValue(TRADING_EXCHANGE_FORM, TRADING_EXCHANGE_FORM_CEX);
         }
-    }, [dexQuotes, exchangeType, cexQuotes, setValue]);
-
-    const onBeforeRefetch = useCallback(() => {
-        setIsScheduledQuotesRefresh(true);
-    }, []);
-
-    useTradingRefetchScheduler({
-        onRefetch: () => {
-            if (!isFetchAllowed) {
-                return;
-            }
-            fetchQuotes();
-        },
-        onBeforeRefetch,
-    });
-
-    useEffect(() => {
-        if (!network && previousRequest.current) {
-            previousRequest.current.abort('Request is canceled - network is no longer available.');
-            previousRequest.current = null;
-            setIsScheduledQuotesRefresh(false);
-        }
-    }, [network]);
-
-    useEffect(
-        () => () => {
-            if (previousRequest.current) {
-                previousRequest.current.abort('Request is canceled - page is unmounted.');
-            }
-            dispatch(tradingActions.stopRefetchQuotes());
-        },
-        [dispatch],
-    );
-
-    const resetSelectedOffer = useCallback(() => {
-        setIsScheduledQuotesRefresh(true);
-    }, []);
+    }, [dexQuotes, exchangeType, cexQuotes, methods]);
 
     return {
         cexQuotes,
         dexQuotes,
         isScheduledQuotesRefresh,
-        resetSelectedOffer,
-        refreshQuotes: fetchQuotes,
+        refreshQuotes,
     };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
@@ -89,7 +89,7 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         defaultValues,
     });
 
-    const { reset, register, getValues, setValue, formState, control } = methods;
+    const { reset, register, getValues, setValue, clearErrors, formState, control } = methods;
 
     // Watch only the values the orchestrator itself renders with; each atomic hook
     // owns its own narrow named subscription. Replaces the former broad useWatch.
@@ -149,11 +149,10 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         shouldSuppressComposeErrors: hasEip712SignDataType(selectedQuote),
     });
 
-    const isFormLoading = isInitialDataLoading || formState.isSubmitting || isLoading;
+    const isFormLoadingBase = isInitialDataLoading || formState.isSubmitting || isLoading;
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
-    const { toggleAmountInCrypto } = useTradingCurrencySwitcher({
+    const { toggleAmountInCrypto: baseToggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,
         methods,
         inputNames: {
@@ -162,19 +161,27 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         },
     });
 
-    const { cexQuotes, dexQuotes, isScheduledQuotesRefresh, resetSelectedOffer, refreshQuotes } =
-        useExchangeQuotes({
-            control,
-            getValues,
-            setValue,
-            network,
-            shouldSendInSats,
-            receiveAddress: tradingReceiveAddress.receiveAddress,
-            receiveAccountKey: tradingReceiveAddress.selectedAccount?.key,
-            composeRequestCallback: () => {
-                composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
-            },
-        });
+    const { cexQuotes, dexQuotes, isScheduledQuotesRefresh, refreshQuotes } = useExchangeQuotes({
+        methods,
+        network,
+        shouldSendInSats,
+        receiveAddress: tradingReceiveAddress.receiveAddress,
+        receiveAccountKey: tradingReceiveAddress.selectedAccount?.key,
+        receiveAccountSymbol: tradingReceiveAddress.selectedAccount?.symbol,
+        composeRequestCallback: () => {
+            composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
+        },
+    });
+
+    const isFormLoading = isFormLoadingBase || isScheduledQuotesRefresh;
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
+
+    const toggleAmountInCrypto = () => {
+        setValue(TRADING_FORM_OUTPUT_AMOUNT, '', { shouldDirty: true });
+        setValue(TRADING_FORM_OUTPUT_FIAT, '', { shouldDirty: true });
+        clearErrors([TRADING_FORM_OUTPUT_AMOUNT, TRADING_FORM_OUTPUT_FIAT]);
+        baseToggleAmountInCrypto();
+    };
 
     const helpers = useExchangeFormInputs({
         account,
@@ -293,7 +300,6 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
         confirmApproval,
         refreshQuotes,
         isScheduledQuotesRefresh,
-        resetSelectedOffer,
         fetchFeesAndCompose,
         tradingReceiveAddress,
         isLoadingQuote,

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -215,7 +215,6 @@ export interface TradingExchangeFormContextProps
     }) => Promise<ExchangeTrade | undefined>;
     refreshQuotes: () => Promise<void>;
     isScheduledQuotesRefresh: boolean;
-    resetSelectedOffer: () => void;
     fetchFeesAndCompose: () => Promise<void>;
     tradingReceiveAddress: ReturnType<typeof useTradingReceiveAddress>;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -65,7 +65,6 @@ export const TradingExchangeFormInputs = () => {
         changeFeeLevel,
         shouldSendInSats,
         showReserveBanner,
-        resetSelectedOffer,
         setAmountLimits,
     } = context;
     const asset = useSelectedTradingAsset(type);
@@ -108,17 +107,15 @@ export const TradingExchangeFormInputs = () => {
     // `useTradingExchangeForm` has some re-rendering issues, use refs to avoid them
     const setAmountLimitsRef = useCurrentRef(setAmountLimits);
     const setValueRef = useCurrentRef(setValue);
-    const resetSelectedOfferRef = useCurrentRef(resetSelectedOffer);
 
     const onCryptoCurrencyChangeRef = useCurrentRef(helpers.onCryptoCurrencyChange);
     const handleSellAssetSelect = useCallback<TradingFormInputSellAssetProps['onAssetSelect']>(
         async asset => {
             await onCryptoCurrencyChangeRef.current(asset);
 
-            resetSelectedOfferRef.current();
             setValueRef.current(TRADING_FORM_PROVIDER_SELECT, undefined, { shouldDirty: true });
         },
-        [onCryptoCurrencyChangeRef, resetSelectedOfferRef, setValueRef],
+        [onCryptoCurrencyChangeRef, setValueRef],
     );
 
     const handleReceiveAssetSelect = useCallback<TradingFormInputBuyAssetProps['onAssetSelect']>(
@@ -128,10 +125,9 @@ export const TradingExchangeFormInputs = () => {
             });
             setAmountLimitsRef.current(undefined);
             dispatch(tradingActions.setModalCryptoCurrency(asset.id));
-            resetSelectedOfferRef.current();
             setValueRef.current(TRADING_FORM_PROVIDER_SELECT, undefined, { shouldDirty: true });
         },
-        [dispatch, setAmountLimitsRef, setValueRef, resetSelectedOfferRef],
+        [dispatch, setAmountLimitsRef, setValueRef],
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -49,7 +49,6 @@ export const TradingFormApproval = () => {
         revokeApproval,
         refreshQuotes,
         confirmApproval,
-        resetSelectedOffer,
         selectedQuote,
         isScheduledQuotesRefresh,
         isComposing,
@@ -171,7 +170,6 @@ export const TradingFormApproval = () => {
             },
         });
 
-        resetSelectedOffer();
         await refreshQuotes();
     };
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputCurrency.tsx
@@ -67,7 +67,6 @@ export const TradingFormInputCurrency = ({
         }
 
         if (isTradingExchangeContext(context)) {
-            context.resetSelectedOffer();
             context.refreshQuotes();
         }
     };

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -31,7 +31,6 @@ import {
 } from 'src/types/trading/tradingForm';
 import {
     isTradingBuyContext,
-    isTradingExchangeContext,
     isTradingExchangeOrSellContext,
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 import { getFeeInUnits, tradingGetAccountLabel } from 'src/utils/wallet/trading/tradingUtils';
@@ -75,9 +74,6 @@ const TradingFormInputCryptoAmountContent = ({
     const isExchangeOrSellContext = isTradingExchangeOrSellContext(context);
     const setFractionButton = isExchangeOrSellContext
         ? context.form.helpers.setFractionButton
-        : undefined;
-    const handleResetSelectedOffer = isTradingExchangeContext(context)
-        ? context.resetSelectedOffer
         : undefined;
     const setShowReserveBanner = isExchangeOrSellContext ? context.setShowReserveBanner : undefined;
 
@@ -143,9 +139,8 @@ const TradingFormInputCryptoAmountContent = ({
             setValue(TRADING_FORM_OUTPUT_MAX, undefined, { shouldDirty: true });
             setFractionButton(undefined);
         }
-        handleResetSelectedOffer?.();
         clearErrors(fiatInputName);
-    }, [setValue, setFractionButton, handleResetSelectedOffer, clearErrors, fiatInputName]);
+    }, [setValue, setFractionButton, clearErrors, fiatInputName]);
 
     useEffect(() => {
         setShowReserveBanner?.(isNetworkReserveError);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -87,7 +87,6 @@ const TradingFormInputFiatContent = ({
     const setFractionButton = isExchangeOrSellContext
         ? context.form.helpers.setFractionButton
         : undefined;
-    const handleResetSelectedOffer = isExchangeContext ? context.resetSelectedOffer : undefined;
 
     const tokenAddress = (sendCryptoSelect?.contractAddress ?? undefined) as
         | TokenAddress
@@ -189,9 +188,8 @@ const TradingFormInputFiatContent = ({
 
     const handleChange = useCallback(() => {
         setFractionButton?.(undefined);
-        handleResetSelectedOffer?.();
         clearErrors(cryptoInputName);
-    }, [setFractionButton, handleResetSelectedOffer, clearErrors, cryptoInputName]);
+    }, [setFractionButton, clearErrors, cryptoInputName]);
 
     useEffect(() => {
         setShowReserveBanner?.(isNetworkReserveError);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFractionButtons.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFractionButtons.tsx
@@ -5,10 +5,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { FractionButton, Row } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
-import {
-    isTradingExchangeContext,
-    isTradingSellContext,
-} from 'src/utils/wallet/trading/tradingTypingUtils';
+import { isTradingSellContext } from 'src/utils/wallet/trading/tradingTypingUtils';
 
 import { generateFractionButtons } from './tradingFormInputsUtils';
 
@@ -37,9 +34,6 @@ export const TradingFractionButtons = () => {
                                 payload: { type: analyticsType, value: percentValue },
                             });
                             onClick();
-                            if (isTradingExchangeContext(context)) {
-                                context.resetSelectedOffer();
-                            }
                         }}
                     />
                 );

--- a/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
+++ b/suite-common/trading/src/hooks/useTradingRefetchScheduler.ts
@@ -10,26 +10,19 @@ import { selectTradingQuoteRefetchingState } from '../selectors/tradingSelectors
 
 type UseTradingRefetchSchedulerProps = {
     onRefetch: () => void;
-    onBeforeRefetch?: () => void;
 };
 
-export const useTradingRefetchScheduler = ({
-    onRefetch,
-    onBeforeRefetch,
-}: UseTradingRefetchSchedulerProps) => {
+export const useTradingRefetchScheduler = ({ onRefetch }: UseTradingRefetchSchedulerProps) => {
     const dispatch = useDispatch();
     const { lastFetchTimestamp, status } = useSelector(selectTradingQuoteRefetchingState);
     const onRefetchRef = useRef(onRefetch);
     onRefetchRef.current = onRefetch;
-    const onBeforeRefetchRef = useRef(onBeforeRefetch);
-    onBeforeRefetchRef.current = onBeforeRefetch;
 
     useEffect(() => {
         if (status !== 'running' || !lastFetchTimestamp) return;
         const elapsed = Date.now() - lastFetchTimestamp;
         const delay = clamp(Math.max(INVITY_API_RELOAD_QUOTES_AFTER_SECONDS * 1000 - elapsed, 0));
         const id = setTimeout(() => {
-            onBeforeRefetchRef.current?.();
             onRefetchRef.current();
         }, delay);
 

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -44,6 +44,7 @@ export * from './utils/tradeOperationUtils';
 export * from './utils/exchange/composeDexTxSimulationAction';
 export * from './utils/exchange/exchangeUtils';
 export * from './utils/exchange/getSimulatedReceiveAmount';
+export * from './utils/exchange/receiveAddressCoherence';
 export * from './utils/exchange/resolveExchangeTradeError';
 export * from './utils/exchange/signDataUtils';
 export * from './utils/sell/sellUtils';

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -42,10 +42,10 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.buy.isLoading = false;
             })
             .addCase(buyThunks.handleRequestThunk.rejected, (state, action) => {
+                state.buy.isLoading = false;
                 if (action.meta?.aborted) {
                     return;
                 }
-                state.buy.isLoading = false;
                 state.buy.amountLimits = undefined;
                 state.buy.quotes = [];
                 state.buy.quotesRequest = undefined;
@@ -57,10 +57,10 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.exchange.isLoading = false;
             })
             .addCase(exchangeThunks.handleRequestThunk.rejected, (state, action) => {
+                state.exchange.isLoading = false;
                 if (action.meta?.aborted) {
                     return;
                 }
-                state.exchange.isLoading = false;
                 state.exchange.amountLimits = undefined;
                 state.exchange.quotes = [];
                 state.exchange.quotesRequest = undefined;
@@ -72,13 +72,13 @@ const tradingSlice = createSliceWithExtraDeps({
                 state.sell.isLoading = false;
             })
             .addCase(sellThunks.handleRequestThunk.rejected, (state, action) => {
+                state.sell.isLoading = false;
                 if (action.meta?.aborted) {
                     return;
                 }
                 state.sell.amountLimits = undefined;
                 state.sell.quotes = [];
                 state.sell.quotesRequest = undefined;
-                state.sell.isLoading = false;
             })
             .addCase(sellThunks.handleTradeThunk.pending, state => {
                 state.exchange.isLoading = true;

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -41,7 +41,10 @@ const tradingSlice = createSliceWithExtraDeps({
             .addCase(buyThunks.handleRequestThunk.fulfilled, state => {
                 state.buy.isLoading = false;
             })
-            .addCase(buyThunks.handleRequestThunk.rejected, state => {
+            .addCase(buyThunks.handleRequestThunk.rejected, (state, action) => {
+                if (action.meta?.aborted) {
+                    return;
+                }
                 state.buy.isLoading = false;
                 state.buy.amountLimits = undefined;
                 state.buy.quotes = [];
@@ -53,7 +56,10 @@ const tradingSlice = createSliceWithExtraDeps({
             .addCase(exchangeThunks.handleRequestThunk.fulfilled, state => {
                 state.exchange.isLoading = false;
             })
-            .addCase(exchangeThunks.handleRequestThunk.rejected, state => {
+            .addCase(exchangeThunks.handleRequestThunk.rejected, (state, action) => {
+                if (action.meta?.aborted) {
+                    return;
+                }
                 state.exchange.isLoading = false;
                 state.exchange.amountLimits = undefined;
                 state.exchange.quotes = [];
@@ -65,7 +71,10 @@ const tradingSlice = createSliceWithExtraDeps({
             .addCase(sellThunks.handleRequestThunk.fulfilled, state => {
                 state.sell.isLoading = false;
             })
-            .addCase(sellThunks.handleRequestThunk.rejected, state => {
+            .addCase(sellThunks.handleRequestThunk.rejected, (state, action) => {
+                if (action.meta?.aborted) {
+                    return;
+                }
                 state.sell.amountLimits = undefined;
                 state.sell.quotes = [];
                 state.sell.quotesRequest = undefined;

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -3,9 +3,7 @@ import { type ExchangeTrade, type ExchangeTradeQuoteRequest } from 'invity-api';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
-import { isAddressValid } from '@trezor/address-validator';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
@@ -17,8 +15,9 @@ import {
     type MinimalExchangeFormProps,
     type TradingExchangeType,
 } from '../../types';
-import { addIdsToQuotes, cryptoIdToSymbol, getNetworkDecimalsWithFallback } from '../../utils';
+import { addIdsToQuotes, getNetworkDecimalsWithFallback } from '../../utils';
 import { exchangeUtils } from '../../utils/exchange/exchangeUtils';
+import { isReceiveAddressCoherent } from '../../utils/exchange/receiveAddressCoherence';
 
 type GetQuotesRequest = {
     requestData: ExchangeTradeQuoteRequest;
@@ -72,53 +71,6 @@ export const getQuoteRequestData = ({
     return request;
 };
 
-const isReceiveAddressValid = (
-    receiveAddress: string,
-    receiveSymbol: NonNullable<ReturnType<typeof cryptoIdToSymbol>>,
-): boolean => {
-    try {
-        return isAddressValid(receiveAddress, receiveSymbol);
-    } catch {
-        return false;
-    }
-};
-
-// Prevent stale receive addresses after TO-network changes (#28143).
-// Account keys prove selected-account chain membership for same-format networks,
-// but the submitted address must still be valid for the receive network.
-const isReceiveAddressCoherent = ({
-    receiveAddress,
-    receiveCryptoSelectId,
-    receiveAccountKey,
-    state,
-}: {
-    receiveAddress: string | undefined;
-    receiveCryptoSelectId: ExchangeTradeQuoteRequest['receive'];
-    receiveAccountKey: AccountKey | undefined;
-    state: Parameters<typeof selectAccountByKey>[0];
-}): boolean => {
-    if (!receiveAddress) {
-        return true;
-    }
-
-    const receiveSymbol = cryptoIdToSymbol(receiveCryptoSelectId);
-    if (!receiveSymbol) {
-        return false;
-    }
-
-    if (!isReceiveAddressValid(receiveAddress, receiveSymbol)) {
-        return false;
-    }
-
-    if (receiveAccountKey) {
-        const receiveAccount = selectAccountByKey(state, receiveAccountKey);
-
-        return receiveAccount?.symbol === receiveSymbol;
-    }
-
-    return true;
-};
-
 export const handleExchangeRequestThunk = createThunk<
     ExchangeTrade[],
     HandleExchangeRequestThunkProps,
@@ -148,12 +100,17 @@ export const handleExchangeRequestThunk = createThunk<
             return rejectWithValue('Invalid request data');
         }
 
+        const { receiveAccountKey } = formValues;
+        const receiveAccount = receiveAccountKey
+            ? selectAccountByKey(getState(), receiveAccountKey)
+            : undefined;
+
         if (
             !isReceiveAddressCoherent({
                 receiveAddress: requestData.receiveAddress,
-                receiveCryptoSelectId: requestData.receive,
-                receiveAccountKey: formValues.receiveAccountKey,
-                state: getState(),
+                receiveCryptoId: requestData.receive,
+                receiveAccountKey,
+                receiveAccountSymbol: receiveAccount?.symbol,
             })
         ) {
             dispatch(tradingActions.stopRefetchQuotes());

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -9,7 +9,10 @@ import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { invityAPI } from '../../invityAPI';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
-import { selectTradingCoinSymbolByCryptoId } from '../../selectors/tradingSelectors';
+import {
+    selectTradingCoinSymbolByCryptoId,
+    selectTradingExchangeQuotesRequest,
+} from '../../selectors/tradingSelectors';
 import {
     type HandleExchangeRequestThunkProps,
     type MinimalExchangeFormProps,
@@ -116,6 +119,11 @@ export const handleExchangeRequestThunk = createThunk<
             dispatch(tradingActions.stopRefetchQuotes());
 
             return rejectWithValue('Invalid request data');
+        }
+
+        const currentQuotesRequest = selectTradingExchangeQuotesRequest(getState());
+        if (currentQuotesRequest && requestData.receive !== currentQuotesRequest.receive) {
+            dispatch(tradingExchangeActions.clearQuotes());
         }
 
         let allQuotes: ExchangeTrade[] = [];

--- a/suite-common/trading/src/utils/exchange/__tests__/receiveAddressCoherence.test.ts
+++ b/suite-common/trading/src/utils/exchange/__tests__/receiveAddressCoherence.test.ts
@@ -1,0 +1,99 @@
+import { type CryptoId } from 'invity-api';
+
+import { isAddressValid } from '@trezor/address-validator';
+
+import { isReceiveAddressCoherent, isReceiveAddressValid } from '../receiveAddressCoherence';
+
+jest.mock('@trezor/address-validator', () => {
+    const actual = jest.requireActual('@trezor/address-validator');
+
+    return {
+        __esModule: true,
+        ...actual,
+        isAddressValid: jest.fn(actual.isAddressValid),
+    };
+});
+
+// Vitalik's address, all lowercase so no EIP-55 checksum is required.
+const VALID_ETH_ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
+
+const ETH_CRYPTO_ID = 'ethereum' as CryptoId;
+const BTC_CRYPTO_ID = 'bitcoin' as CryptoId;
+
+describe('isReceiveAddressValid', () => {
+    it('returns false instead of throwing when the validator throws', () => {
+        (isAddressValid as jest.Mock).mockImplementationOnce(() => {
+            throw new Error('validator blew up');
+        });
+
+        expect(isReceiveAddressValid(VALID_ETH_ADDRESS, 'eth')).toBe(false);
+    });
+});
+
+describe('isReceiveAddressCoherent', () => {
+    it('treats an empty receive address as coherent', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: undefined,
+                receiveCryptoId: BTC_CRYPTO_ID,
+                receiveAccountKey: 'account-1',
+                receiveAccountSymbol: 'eth',
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when the receive crypto id cannot be resolved to a symbol', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: VALID_ETH_ADDRESS,
+                receiveCryptoId: undefined,
+                receiveAccountKey: undefined,
+                receiveAccountSymbol: undefined,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when the address is invalid for the resolved symbol', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: VALID_ETH_ADDRESS,
+                receiveCryptoId: BTC_CRYPTO_ID,
+                receiveAccountKey: undefined,
+                receiveAccountSymbol: undefined,
+            }),
+        ).toBe(false);
+    });
+
+    it('returns true for a valid address without a bound receive account', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: VALID_ETH_ADDRESS,
+                receiveCryptoId: ETH_CRYPTO_ID,
+                receiveAccountKey: undefined,
+                receiveAccountSymbol: undefined,
+            }),
+        ).toBe(true);
+    });
+
+    it('returns true when a bound account symbol matches the resolved receive symbol', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: VALID_ETH_ADDRESS,
+                receiveCryptoId: ETH_CRYPTO_ID,
+                receiveAccountKey: 'account-1',
+                receiveAccountSymbol: 'eth',
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false when a bound account belongs to a different network than the receive asset', () => {
+        expect(
+            isReceiveAddressCoherent({
+                receiveAddress: VALID_ETH_ADDRESS,
+                receiveCryptoId: ETH_CRYPTO_ID,
+                receiveAccountKey: 'account-1',
+                receiveAccountSymbol: 'btc',
+            }),
+        ).toBe(false);
+    });
+});

--- a/suite-common/trading/src/utils/exchange/receiveAddressCoherence.ts
+++ b/suite-common/trading/src/utils/exchange/receiveAddressCoherence.ts
@@ -1,0 +1,50 @@
+import { type CryptoId } from 'invity-api';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { isAddressValid } from '@trezor/address-validator';
+
+import { cryptoIdToSymbol } from '../../utils';
+
+export const isReceiveAddressValid = (
+    receiveAddress: string,
+    receiveSymbol: NetworkSymbol,
+): boolean => {
+    try {
+        return isAddressValid(receiveAddress, receiveSymbol);
+    } catch {
+        return false;
+    }
+};
+
+type IsReceiveAddressCoherentProps = {
+    receiveAddress: string | undefined;
+    receiveCryptoId: CryptoId | undefined;
+    receiveAccountKey: string | undefined;
+    receiveAccountSymbol: NetworkSymbol | undefined;
+};
+
+export const isReceiveAddressCoherent = ({
+    receiveAddress,
+    receiveCryptoId,
+    receiveAccountKey,
+    receiveAccountSymbol,
+}: IsReceiveAddressCoherentProps): boolean => {
+    if (!receiveAddress) {
+        return true;
+    }
+
+    const receiveSymbol = receiveCryptoId ? cryptoIdToSymbol(receiveCryptoId) : undefined;
+    if (!receiveSymbol) {
+        return false;
+    }
+
+    if (!isReceiveAddressValid(receiveAddress, receiveSymbol)) {
+        return false;
+    }
+
+    if (receiveAccountKey) {
+        return receiveAccountSymbol === receiveSymbol;
+    }
+
+    return true;
+};

--- a/suite/e2e/support/pageObjects/trading/quotesSection.ts
+++ b/suite/e2e/support/pageObjects/trading/quotesSection.ts
@@ -28,7 +28,7 @@ export class TradingQuotesSection {
     async waitForSync() {
         await expect(this.loadingSpinner).toBeHidden({ timeout: 30000 });
         // Even though the offer sync is finished, the best offer might not be displayed correctly yet and show 0 BTC
-        await expect(this.bestOfferAmount).not.toHaveText(/^0( w+)?$/);
+        await expect(this.bestOfferAmount).not.toHaveText(/^0( \w+)?$/);
     }
 
     @step()

--- a/suite/e2e/tests/trading/buy-solana-token.test.ts
+++ b/suite/e2e/tests/trading/buy-solana-token.test.ts
@@ -40,7 +40,6 @@ test.describe('Trading - Buy Solana', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, (
                 searchFilter: 'Jupiter',
                 assetCryptoId: cryptoId,
             });
-            await tradingPage.quotes.waitForSync();
             await tradingPage.inputs.fiatCryptoSwitchButton.click();
             const isCryptoInput = true;
             await tradingPage.fillBuyForm({


### PR DESCRIPTION
## Description

- swap quote fetching moved to a new generic `useTradingQuoteRequest` hook (AbortController cancellation, immediate/debounced fields) — no premature "No offers found" flash
- stale quotes cleared on receive-asset change; clearing the fiat amount resets the crypto amount; crypto/fiat toggle clears inputs incl. stale validation errors (swap + buy)
- cleanup: dropped unused `resetSelectedOffer` and dead `setIsLoading` wiring

Follow-up: buy/sell quote hooks will migrate to `useTradingQuoteRequest` in separate PRs.

## Notes for QA

- Trading must work as before.
- Trading E2E suites must pass.

## Related Issue

Resolve #30213

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/exchange/__tests__/useExchangeQuotes.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts`
- `packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts`
- `suite-common/trading/src/reducers/tradingReducer.ts`
- `suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-23T13:46:37.300Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30213-swap-no-offer-flash/web/](https://dev.suite.sldev.cz/suite-web/fix/30213-swap-no-offer-flash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30213-swap-no-offer-flash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30213-swap-no-offer-flash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30213-swap-no-offer-flash&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-25T16:17:16.316Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-25T16:18:20.530Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
