### PR TITLE
test(connect): fix `getLatestFirmware` utility

### DIFF
--- a/packages/connect/e2e/run.ts
+++ b/packages/connect/e2e/run.ts
@@ -29,14 +29,13 @@ const firmwareBtcOnly = process.env.TESTS_FIRMWARE_BTC_ONLY === 'true';
  * TODO: this code might be refactored and moved into TrezorUserEnvLink class later
  */
 const getEmulatorOptions = (availableFirmwares: Firmwares) => {
-    const getLatestFirmware = (model: keyof Firmwares) =>
-        availableFirmwares[model].find(fw => {
-            const withoutArm = fw.replace('-arm', '');
-            const semverVersion = !withoutArm.includes('-'); // there are only 2-main-arm or 2.9.0-arm
-            const mainVersion = withoutArm.endsWith('-main');
+    const getLatestFirmware = (model: keyof Firmwares) => {
+        const firmwares = availableFirmwares[model].map(fw => fw.replace('-arm', ''));
+        const semver = firmwares.find(fw => !fw.includes('-'));
 
-            return semverVersion || mainVersion; // return named (semver) version, or 'main' version fallback - this happens when new model is created but it has no stable firmware release yet.
-        });
+        // Fallback to '-main' version only when no semver release exists yet (e.g. newly created model).
+        return semver ?? firmwares.find(fw => fw.endsWith('-main'));
+    };
 
     const model =
         firmwareModel && typedObjectKeys(availableFirmwares).includes(firmwareModel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`getLatestFirmware` always returns `*-main` but it should return first semver from the list:

```
Testing env: node. Using: yarn workspace @trezor/connect test:e2e:node methods
  Firmware: 2-latest
  Firmware model: T3W1
  Firmware from url: 
  Firmware from branch: 
  Firmware BTC-only: false
  Test pattern: methods
  Included methods: ethereumSignTransaction
  Excluded methods: 
  TxCache: false
  WsCache: false
  Random: true
  Transport: node-bridge
waiting for trezor-user-env
trezor-user-env is online
Running @trezor/connect e2e tests in node mode...
FW: 2-latest
Methods: ethereumSignTransaction
Pattern: methods

Starting emulator with params {"type":"emulator-start","model":"T3W1","version":"2.12.1","wipe":true}

```

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/e2e/run.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-23T15:52:50.325Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/fix-latest-version/web/](https://dev.suite.sldev.cz/suite-web/test/fix-latest-version/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/fix-latest-version&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/fix-latest-version&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/fix-latest-version&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T15:55:46.694Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-23T15:55:55.090Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->