### PR TITLE
error handling in earn-staking 

### DIFF
--- a/suite-common/wallet-core/src/stake/__tests__/stakeThunks.test.ts
+++ b/suite-common/wallet-core/src/stake/__tests__/stakeThunks.test.ts
@@ -1,0 +1,181 @@
+import {
+    type StakingBatchDataItem,
+    type StakingBatchErrorsItem,
+    getStakingBatch,
+} from '@suite-common/earn-staking-api';
+import { configureMockStore } from '@suite-common/test-utils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+
+import { stakeDataActions, stakeDataInitialState } from '../stakeDataSlice';
+import { stakeInitialState } from '../stakeReducer';
+import type { StakeState } from '../stakeReducerTypes';
+import { initStakeDataThunk } from '../stakeThunks';
+
+jest.mock('@suite-common/earn-staking-api', () => ({
+    getStakingBatch: jest.fn(),
+}));
+
+const getStakingBatchMock = jest.mocked(getStakingBatch);
+
+const ethSection = {
+    symbol: 'eth',
+    stats: { apy: 3.1, nextRewardPayout: 3600 },
+    validators: {},
+} satisfies StakingBatchDataItem;
+
+const solSection = {
+    symbol: 'sol',
+    stats: { apy: 6.2 },
+} satisfies StakingBatchDataItem;
+
+const adaSection = {
+    symbol: 'ada',
+    pools: [{ apy: 2.5, saturation: 40, id: 'pool1' }],
+} satisfies StakingBatchDataItem;
+
+const trxSection = {
+    symbol: 'trx',
+    representatives: [{ address: 'TSr1', name: 'SR', url: 'https://example.com', apr: 4.1 }],
+} satisfies StakingBatchDataItem;
+
+const unknownError = {
+    code: 'upstream_unknown_error',
+    message: 'Failed to fetch from upstream',
+} satisfies StakingBatchErrorsItem;
+
+const validationError = {
+    code: 'upstream_validation_error',
+    message: 'Invalid response shape',
+} satisfies StakingBatchErrorsItem;
+
+const initStore = ({
+    enabledNetworks = ['eth', 'sol', 'ada', 'trx'],
+    stake = stakeInitialState,
+}: {
+    enabledNetworks?: NetworkSymbol[];
+    stake?: StakeState;
+} = {}) =>
+    configureMockStore({
+        preloadedState: {
+            wallet: {
+                settings: { enabledNetworks },
+                stake,
+            },
+        },
+    });
+
+// The suite-common jest environment has no console trap, so both spies are asserted
+// explicitly — console.error is captured as a Sentry event on web, desktop and mobile
+// (captureConsoleIntegration) and must never fire on expected staking failure paths.
+const spyOnConsole = () => ({
+    warnSpy: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+    errorSpy: jest.spyOn(console, 'error').mockImplementation(() => {}),
+});
+
+describe('initStakeDataThunk', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    it('stores fetched staking data on success without logging', async () => {
+        const { warnSpy, errorSpy } = spyOnConsole();
+        getStakingBatchMock.mockResolvedValueOnce({
+            data: [ethSection, solSection, adaSection, trxSection],
+            errors: [],
+        });
+        const store = initStore();
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(store.getActions()).toContainEqual(
+            stakeDataActions.fetchStakeDataSuccess([
+                ethSection,
+                solSection,
+                adaSection,
+                trxSection,
+            ]),
+        );
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('stores partial data and logs a warning string instead of a Sentry-captured error when part of the batch fails', async () => {
+        const { warnSpy, errorSpy } = spyOnConsole();
+        getStakingBatchMock.mockResolvedValueOnce({
+            data: [ethSection, adaSection, trxSection],
+            errors: [unknownError],
+        });
+        const store = initStore();
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(store.getActions()).toContainEqual(
+            stakeDataActions.fetchStakeDataSuccess([ethSection, adaSection, trxSection]),
+        );
+
+        // A single string argument keeps the log out of Sentry object-serialization traps
+        // ("[object Object]") on every platform capturing console output.
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            'Staking batch upstream error (sol): upstream_unknown_error: Failed to fetch from upstream',
+        );
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('lists every failed network and error when multiple batch requests fail', async () => {
+        const { warnSpy, errorSpy } = spyOnConsole();
+        getStakingBatchMock.mockResolvedValueOnce({
+            data: [adaSection, trxSection],
+            errors: [unknownError, validationError],
+        });
+        const store = initStore();
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(store.getActions()).toContainEqual(
+            stakeDataActions.fetchStakeDataSuccess([adaSection, trxSection]),
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+            'Staking batch upstream error (eth, sol): upstream_unknown_error: Failed to fetch from upstream; upstream_validation_error: Invalid response shape',
+        );
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('dispatches failure and logs a warning when the whole batch request fails', async () => {
+        const { warnSpy, errorSpy } = spyOnConsole();
+        getStakingBatchMock.mockRejectedValueOnce(new Error('Network down'));
+        const store = initStore();
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(store.getActions()).toContainEqual(
+            stakeDataActions.fetchStakeDataFailure('Network down'),
+        );
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith('Staking batch request failed: Network down');
+        expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips fetching when current data is fresh', async () => {
+        const store = initStore({
+            stake: {
+                ...stakeInitialState,
+                data: { ...stakeDataInitialState, lastSuccessAt: Date.now() },
+            },
+        });
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(getStakingBatchMock).not.toHaveBeenCalled();
+    });
+
+    it('skips fetching when bitcoin is the only enabled network', async () => {
+        const store = initStore({ enabledNetworks: ['btc'] });
+
+        await store.dispatch(initStakeDataThunk());
+
+        expect(getStakingBatchMock).not.toHaveBeenCalled();
+    });
+});

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -43,19 +43,33 @@ export const initStakeDataThunk = createThunk(
                 params: { networks: PROD_STAKING_SYMBOLS },
             });
 
-            // A part of the batch requests failed
+            // A part of the batch requests failed.
             if (stakingData.errors.length) {
-                console.error('Upstream error', stakingData.errors);
+                const failedNetworkSymbols = PROD_STAKING_SYMBOLS.filter(
+                    symbol => !stakingData.data.some(item => item.symbol === symbol),
+                );
+                const errorSummary = stakingData.errors
+                    .map(({ code, message }) => `${code}: ${message}`)
+                    .join('; ');
+
+                // Deliberately console.warn, not console.error: captureConsoleIntegration turns
+                // error-level logs into Sentry events on all platforms (objects render there as
+                // "[object Object]"), and these partial upstream failures are user-unactionable
+                // and already reported with full fidelity by the earn-staking worker itself.
+                console.warn(
+                    `Staking batch upstream error (${failedNetworkSymbols.join(', ')}): ${errorSummary}`,
+                );
             }
 
             dispatch(stakeDataActions.fetchStakeDataSuccess(stakingData.data));
         } catch (error) {
-            console.error(error);
-            dispatch(
-                stakeDataActions.fetchStakeDataFailure(
-                    error instanceof Error ? error.message : 'Unknown error',
-                ),
-            );
+            const message = error instanceof Error ? error.message : 'Unknown error';
+
+            // Also console.warn: a whole-batch failure is transient network noise (client
+            // offline, worker outage) and this thunk retries every 60 seconds, so an
+            // error-level log would flood Sentry for the outage duration.
+            console.warn(`Staking batch request failed: ${message}`);
+            dispatch(stakeDataActions.fetchStakeDataFailure(message));
         }
     },
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix(suite-common-wallet-core): stop passing the same error to sentry as earn-staking worker does

[Relates to this worker's PR](https://github.com/trezor/cloudflare-workers/pull/95)

## Related Issue

Resolve #27983

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/stake/__tests__/stakeThunks.test.ts`
- `suite-common/wallet-core/src/stake/stakeThunks.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-24T07:18:08.480Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/staking-batch-error-handling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/staking-batch-error-handling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/staking-batch-error-handling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:22:19.293Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:21:05.622Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/staking-batch-error-handling/web/](https://dev.suite.sldev.cz/suite-web/fix/staking-batch-error-handling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->