### PR TITLE
Fix/op return hex reactivity

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -43,6 +43,9 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     });
 
     const { ref: hexRef, ...hexField } = register(inputHexName, {
+        onChange: () => {
+            composeTransaction(inputHexName);
+        },
         required: translationString('DATA_NOT_SET'),
         validate: (value = '') => {
             if (!isHexValid(value)) return translationString('DATA_NOT_VALID_HEX');

--- a/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { type ChangeEvent } from 'react';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { formInputsMaxLength } from '@suite-common/validators';
@@ -33,7 +33,7 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     const hexError = outputError ? outputError.dataHex : undefined;
 
     const { ref: asciiRef, ...asciiField } = register(inputAsciiName, {
-        onChange: event => {
+        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
             setValue(inputHexName, Buffer.from(event.target.value, 'utf-8').toString('hex'), {
                 shouldValidate: true,
             });
@@ -43,7 +43,13 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
     });
 
     const { ref: hexRef, ...hexField } = register(inputHexName, {
-        onChange: () => {
+        onChange: (event: ChangeEvent<HTMLTextAreaElement>) => {
+            setValue(
+                inputAsciiName,
+                isHexValid(event.target.value)
+                    ? Buffer.from(event.target.value, 'hex').toString('utf-8')
+                    : '',
+            );
             composeTransaction(inputHexName);
         },
         required: translationString('DATA_NOT_SET'),
@@ -52,13 +58,6 @@ export const OpReturn = ({ outputId }: { outputId: number }) => {
             if (value.length > 80 * 2) return translationString('DATA_HEX_TOO_BIG');
         },
     });
-
-    useEffect(() => {
-        setValue(
-            inputAsciiName,
-            hexValue && !hexError ? Buffer.from(hexValue, 'hex').toString('utf-8') : '',
-        );
-    }, [inputAsciiName, hexValue, hexError, setValue]);
 
     return (
         <Column gap={16}>


### PR DESCRIPTION
## Description

Make Send form reactive on Hex ⌬ OP_RETURN input.
Cleanup the reactivity to not rely on useEffect.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30241

## Screenshots:

**Before**

https://github.com/user-attachments/assets/b0f79e0b-969b-49d7-99c2-d34c18f2721b

**After**

[fixed.webm](https://github.com/user-attachments/assets/ab8a1ea6-e343-4eb3-bcf5-3957852548ce)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/OpReturn.tsx`

</details>

_No test recommendations found._

_Updated: 2026-07-24T07:31:40.985Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/op_return_hex_reactivity/web/](https://dev.suite.sldev.cz/suite-web/fix/op_return_hex_reactivity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/op_return_hex_reactivity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/op_return_hex_reactivity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:35:02.832Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:34:29.021Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->