### PR TITLE
ci(connect): remove protobuf test from connect misc

### DIFF
--- a/.github/workflows/test-connect-misc.yml
+++ b/.github/workflows/test-connect-misc.yml
@@ -92,24 +92,3 @@ jobs:
 
       - name: Test local install
         run: ./packages/connect/e2e/test-connect-local.sh
-
-  test-protobuf:
-    runs-on: ubuntu-latest
-    if: github.repository == 'trezor/trezor-suite'
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-
-      - name: Setup node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: ".nvmrc"
-
-      - name: Install SafeDep PMG
-        uses: safedep/pmg@26d5c0ad71fd0e5f48c3183c9c74d4b3eb7f57c8 # v0.19.1
-        continue-on-error: true
-        with:
-          version: v0.19.1
-      - run: yarn workspaces focus trezor-suite @trezor/protobuf
-      - run: yarn workspace @trezor/protobuf update:protobuf


### PR DESCRIPTION
## Description

Remove protobuf test from connect misc, since we have a separate nightly CI job [update protobuf definitions](https://github.com/trezor/trezor-suite/actions/workflows/update-protobuf.yml) that covers this. 
I also don't see a need to run it on PRs.

## Notes for QA

N/A, CI only

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/split-protobuf-connect-misc/web/](https://dev.suite.sldev.cz/suite-web/ci/split-protobuf-connect-misc/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/split-protobuf-connect-misc&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/split-protobuf-connect-misc&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:53:24.734Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T07:53:07.594Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->