### PR TITLE
test(suite-native): fix receive e2e address

### DIFF
--- a/suite-native/app/e2e/tests/receive.test.ts
+++ b/suite-native/app/e2e/tests/receive.test.ts
@@ -17,8 +17,7 @@ const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
     model === Model.T3W1 ? btcDiscoveryFinishedStateT3W1 : btcDiscoveryFinishedStateT3T1,
 );
-const expectedReceiveAddress =
-    model === Model.T3W1 ? 'bc1q czeu ... xlma n6' : 'bc1q s9al ... xuj7 s9';
+const expectedReceiveAddress = 'bc1q czeu ... xlma n6';
 
 describe('Receive [@androidOnly @T3T1 @T3W1]', () => {
     beforeEach(async () => {


### PR DESCRIPTION
## Description

Updates the mobile receive e2e test so T3T1 and T3W1 expect the same fresh BTC receive address for the shared account descriptor.

## Notes for QA

This is a test-only change. The relevant validation is the Android receive e2e flow for T3T1 and T3W1.

## Related Issue

Refs #29733

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/mobile-receive-e2e&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->