### PR TITLE
ci(definitions): publish HyperEVM token definitions

### DIFF
--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -48,7 +48,7 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche hyperevm
           yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood hyperevm cardano solana stellar tron
           yarn coins advanced solana stellar
 
@@ -61,7 +61,7 @@ jobs:
           yarn install
           cd suite-common/token-definitions
 
-          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
+          yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche hyperevm
           yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood hyperevm cardano solana stellar tron
           yarn coins advanced solana stellar
 

--- a/.github/workflows/release-suite-definitions.yml
+++ b/.github/workflows/release-suite-definitions.yml
@@ -49,7 +49,7 @@ jobs:
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
-          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
+          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood hyperevm cardano solana stellar tron
           yarn coins advanced solana stellar
 
       - name: Build and sign ${{ github.event.inputs.environment }} token-definitions files
@@ -62,7 +62,7 @@ jobs:
           cd suite-common/token-definitions
 
           yarn nfts simple ethereum polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche
-          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood cardano solana stellar tron
+          yarn coins simple ethereum ethereum-classic polygon-pos binance-smart-chain optimistic-ethereum base arbitrum-one avalanche robinhood hyperevm cardano solana stellar tron
           yarn coins advanced solana stellar
 
       - name: Upload ${{ github.event.inputs.environment }} token-definitions files


### PR DESCRIPTION
## Description

- Add CoinGecko platform `hyperevm` (chain ID `999`) to simple token-definition generation.
- Generate both coin and NFT definitions for HyperEVM.
- Apply the platform to both token-definition build stages: develop and production.

## Testing

- Verified CoinGecko’s `/nfts/list` endpoint with `asset_platform_id=hyperevm`.
- The endpoint returned 26 NFT collections with valid contract addresses at verification time.



## Related context

- HyperEVM Suite network support: #30238
- [CoinGecko HyperEVM NFT collections](https://www.coingecko.com/en/nft/chains/hyperevm)
- [HyperEVM documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm)