### PR TITLE
Split `composeTransaction` and `sendTransaction`

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -73,6 +73,7 @@ const connectPublicCallableMethodGroups = {
         'getCoinInfo',
     ],
     bitcoin: [
+        'sendTransaction',
         'signTransaction',
         'composeTransaction',
         'authorizeCoinjoin',

--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -1,4 +1,8 @@
-import type { PrecomposedResult, TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import type {
+    PrecomposedResult,
+    SignedTransaction,
+    TrezorConnectPrivilegedAPI as TrezorConnect,
+} from '../../index';
 import { asDeviceUniquePath } from '../../index';
 
 export const getAddress = async (api: TrezorConnect) => {
@@ -497,17 +501,22 @@ export const pushTransaction = async (api: TrezorConnect) => {
     api.pushTransaction({ coin: 'btc' });
 };
 
-export const composeTransaction = async (api: TrezorConnect) => {
-    // Method with mixed params and mixed responses
-
-    const compose = await api.composeTransaction({
+export const sendTransaction = async (api: TrezorConnect) => {
+    const send = await api.sendTransaction({
         outputs: [],
         coin: 'btc',
+        push: true,
+        // @ts-expect-error
+        account: null as any,
     });
-    if (compose.success) {
-        compose.payload.serializedTx.toLowerCase();
-    }
 
+    if (send.success) {
+        const a: SignedTransaction = send.payload;
+        void a;
+    }
+};
+
+export const composeTransaction = async (api: TrezorConnect) => {
     const precompose = await api.composeTransaction({
         outputs: [],
         account: {
@@ -521,6 +530,8 @@ export const composeTransaction = async (api: TrezorConnect) => {
         },
         feeLevels: [{ feePerUnit: '1' }],
         coin: 'btc',
+        // @ts-expect-error
+        push: true,
     });
 
     if (precompose.success) {

--- a/packages/connect-common/src/types/api/bitcoin/common.ts
+++ b/packages/connect-common/src/types/api/bitcoin/common.ts
@@ -3,6 +3,10 @@ import type { BlockbookTransaction } from '@trezor/blockchain-link-types';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { Static } from '@trezor/schema-utils';
 import { Type } from '@trezor/schema-utils';
+import type {
+    ComposeOutput as ComposeOutputBase,
+    TransactionInputOutputSortingStrategy,
+} from '@trezor/utxo-lib';
 
 import type { AccountTransaction } from '../../account';
 import { type CoinSymbol, CoinSymbolParam } from '../../coinInfo';
@@ -121,3 +125,20 @@ export const VerifyMessage = Type.Object({
     coin: CoinSymbolParam(),
     hex: Type.Optional(Type.Boolean()),
 });
+
+// composeTransaction
+
+// for convenience ComposeOutput `type: "payment"` field is not required by @trezor/connect api
+type ComposeOutputPayment = Omit<Extract<ComposeOutputBase, { type: 'payment' }>, 'type'> & {
+    type?: 'payment';
+};
+
+export type ComposeOutput = Exclude<ComposeOutputBase, { type: 'payment' }> | ComposeOutputPayment;
+
+export type ComposeParams = {
+    outputs: ComposeOutput[];
+    coin: CoinSymbol;
+    sequence?: number;
+    baseFee?: number;
+    sortingStrategy?: TransactionInputOutputSortingStrategy;
+};

--- a/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
@@ -10,54 +10,21 @@ import type {
     ComposeResultError as ComposeResultErrorBase,
     ComposeResultFinal as ComposeResultFinalBase,
     ComposeResultNonFinal as ComposeResultNonFinalBase,
-    TransactionInputOutputSortingStrategy,
 } from '@trezor/utxo-lib';
 
-import type { CoinSymbol } from '../../coinInfo';
+import type { ComposeParams } from './common';
 import type { Params, Response } from '../../params';
-
-// for convenience ComposeOutput `type: "payment"` field is not required by @trezor/connect api
-export type ComposeOutputPayment = Omit<Extract<ComposeOutputBase, { type: 'payment' }>, 'type'> & {
-    type?: 'payment';
-};
-
-export type ComposeOutput = Exclude<ComposeOutputBase, { type: 'payment' }> | ComposeOutputPayment;
-
-export type ComposeParams = {
-    outputs: ComposeOutput[];
-    coin: CoinSymbol;
-    identity?: string;
-    account?: undefined;
-    feeLevels?: undefined;
-    push?: boolean;
-    sequence?: number;
-    baseFee?: number;
-    sortingStrategy?: TransactionInputOutputSortingStrategy;
-};
-
-export type SignedTransaction = {
-    signatures: string[];
-    serializedTx: string;
-    txid?: string;
-};
 
 // @trezor/utxo-lib `composeTx` ComposeInput required fields intersects AccountUtxo
 export type ComposeUtxo = AccountUtxo & Partial<ComposeInputBase>;
 
-export type PrecomposeParams = {
-    outputs: ComposeOutput[];
-    coin: CoinSymbol;
-    identity?: string;
+export type PrecomposeParams = ComposeParams & {
     account: {
         path: string;
         addresses: AccountAddresses;
         utxo: ComposeUtxo[];
     };
     feeLevels: { feePerUnit: string }[];
-    push?: undefined;
-    baseFee?: number;
-    sequence?: number;
-    sortingStrategy?: TransactionInputOutputSortingStrategy;
 };
 
 // @trezor/utxo-lib `composeTx` transaction.input (ComposeInput) response intersects AccountUtxo
@@ -96,10 +63,6 @@ export type PrecomposedResult =
     | PrecomposeResultError
     | PrecomposeResultNonFinal
     | PrecomposeResultFinal;
-
-export declare function composeTransaction(
-    params: Params<ComposeParams>,
-): Response<SignedTransaction>;
 
 export declare function composeTransaction(
     params: Params<PrecomposeParams>,

--- a/packages/connect-common/src/types/api/bitcoin/index.ts
+++ b/packages/connect-common/src/types/api/bitcoin/index.ts
@@ -4,11 +4,13 @@ import { Type } from '@trezor/schema-utils';
 import type { authorizeCoinjoin } from './authorizeCoinjoin';
 import type { cancelCoinjoinAuthorization } from './cancelCoinjoinAuthorization';
 import type { composeTransaction } from './composeTransaction';
+import type { sendTransaction } from './sendTransaction';
 import type { signTransaction } from './signTransaction';
 
 // Bitcoin-specific operations
 export const TrezorConnectBitcoin = Type.Object({
     signTransaction: Type.Unsafe<typeof signTransaction>(),
+    sendTransaction: Type.Unsafe<typeof sendTransaction>(),
     composeTransaction: Type.Unsafe<typeof composeTransaction>(),
     authorizeCoinjoin: Type.Unsafe<typeof authorizeCoinjoin>(),
     cancelCoinjoinAuthorization: Type.Unsafe<typeof cancelCoinjoinAuthorization>(),

--- a/packages/connect-common/src/types/api/bitcoin/sendTransaction.ts
+++ b/packages/connect-common/src/types/api/bitcoin/sendTransaction.ts
@@ -1,0 +1,6 @@
+import type { ComposeParams, SignedTransaction } from './common';
+import type { Params, Response } from '../../params';
+
+type SendParams = ComposeParams & { push?: boolean; identity?: string };
+
+export declare function sendTransaction(params: Params<SendParams>): Response<SignedTransaction>;

--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -23,7 +23,6 @@ export * from './api/nostr/common';
 
 // types used in @trezor/suite. if you need a type, reexport it from ./api/<method>
 export type {
-    ComposeOutput,
     PrecomposeResultError,
     PrecomposeResultNonFinal,
     PrecomposeResultFinal,

--- a/packages/connect-explorer/src/data/methods/bitcoin/sendTransaction.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/sendTransaction.ts
@@ -43,8 +43,8 @@ const examples: Partial<Record<CoinSymbol, Array<{ amount: string; address: stri
 
 export default [
     {
-        name: 'composeTransaction',
-        submitButton: 'Compose transaction',
+        name: 'sendTransaction',
+        submitButton: 'Send transaction',
         fields: [
             {
                 name: 'coin',

--- a/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/composeTransaction.mdx
@@ -3,16 +3,6 @@ import { Type } from '@sinclair/typebox';
 import { ApiPlayground } from '../../../components/ApiPlayground';
 import { CommonParamsLink } from '../../../components/CommonParamsLink';
 import { ParamsTable } from '../../../components/ParamsTable';
-import composeTransaction from '../../../data/methods/bitcoin/composeTransaction';
-
-<ApiPlayground options={[{ title: 'composeTransaction', legacyConfig: composeTransaction[0] }]} />
-
-export const RequestSchema = Type.Object({
-    outputs: Type.Array(Type.Object({}, { $id: 'Output' })),
-    coin: Type.String(),
-    push: Type.Optional(Type.Boolean()),
-    sequence: Type.Optional(Type.Number()),
-});
 
 export const PrecomposeSchema = Type.Object({
     outputs: Type.Array(Type.Object({}, { $id: 'Output' })),
@@ -33,7 +23,6 @@ export const PrecomposeSchema = Type.Object({
 export const paramDescriptions = {
     outputs: 'Array of output objects described [below](#accepted-output-objects)',
     coin: 'determines the network definition. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used — see [supported coins](/details/coins) for every accepted value.',
-    push: 'determines if composed transaction will be broadcasted into blockchain network. Default is set to false.',
     sequence: 'transaction input field used in RBF or locktime transactions',
     account:
         'containing essential data, partial result of [getAccountInfo method](../common/getAccountInfo#result)',
@@ -48,34 +37,15 @@ export const paramDescriptions = {
 
 This method works only for `Bitcoin` and `Bitcoin-like` coins.
 
-Can be used in two different ways and returned result depends on used parameters.
-
-## Requests a payment to a set of given outputs.
-
-An automated payment process separated in to following steps:
-
-1. Account discovery for requested coin is performed and the user is asked for source account selection. [[1]](#additional-notes)
-2. User is asked for fee level selection.
-3. Transaction is calculated, change output is added automatically if needed. [[2]](#additional-notes)
-4. Signing transaction with Trezor, user is asked for confirmation on device.
-
-Returned response is a signed transaction in hexadecimal format same as in [signTransaction method](signTransaction#result).
-
-### Params:
-
-<CommonParamsLink />
-
-<ParamsTable schema={RequestSchema} descriptions={paramDescriptions} />
-
-## Precompose, prepare transaction to be signed by Trezor.
-
-Skip first two steps of `payment request` (described above) by providing `account` and `feeLevels` params and perform **only** transaction calculation. [[2]](#additional-notes)
+Prepare transaction to be signed by Trezor by providing `account` and `feeLevels` params and perform **only** transaction calculation. [[1]](#additional-notes)
 
 The result, internally called [`PrecomposedTransaction`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts) is a set of params that can be used in [signTransaction method](signTransaction.md#params) afterwards.
 
-This useful for the quick preparation of multiple variants for the same transaction using different fee levels or using incomplete data (like missing output addresses just to calculate fee)
+This is useful for the quick preparation of multiple variants for the same transaction using different fee levels or using incomplete data (like missing output addresses just to calculate fee).
 
 _Device and backend connection is not required for this case since all data are provided._
+
+For an interactive flow that includes account discovery, fee selection, and signing, see [sendTransaction](sendTransaction).
 
 ### Params:
 
@@ -94,55 +64,13 @@ _Device and backend connection is not required for this case since all data are 
 - `opreturn` - [read more](https://trezor.io/learn/a/use-op_return-in-trezor-suite-app)
     - `type` - _required_ with `opreturn` value
     - `dataHex` - _required_ `hexadecimal string` with arbitrary data
-- `payment-noaddress` - incomplete output, target address is not known yet. used only in precompose
+- `payment-noaddress` - incomplete output, target address is not known yet
     - `type` - _required_ with `payment-noaddress` value
     - `amount` - _required_ `string` value to send in satoshi
-- `send-max-noaddress` - incomplete output, target address is not known yet. used only in precompose
+- `send-max-noaddress` - incomplete output, target address is not known yet
     - `type` - _required_ with `send-max-noaddress` value
 
-## Examples
-
-### Payment example
-
-Send 0.002 BTC to "18WL2iZKmpDYWk1oFavJapdLALxwSjcSk2"
-
-```javascript
-TrezorConnect.composeTransaction({
-    outputs: [
-        { amount: "200000", address: "18WL2iZKmpDYWk1oFavJapdLALxwSjcSk2" }
-    ]
-    coin: "btc",
-    push: true
-});
-```
-
-### Payment result
-
-[SignedTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts)
-
-```javascript
-{
-    success: true,
-    payload: {
-        signatures: Array<string>, // signer signatures
-        serializedTx: string,      // serialized transaction
-        txid?: string,             // blockchain transaction id
-    }
-}
-```
-
-Error
-
-```javascript
-{
-    success: false,
-    error: {
-        message: string // error message
-    }
-}
-```
-
-### Precompose example
+## Example
 
 Prepare multiple variants of the same transaction
 
@@ -191,7 +119,7 @@ TrezorConnect.composeTransaction({
 });
 ```
 
-### Precompose result
+## Result
 
 ```javascript
 {
@@ -243,9 +171,19 @@ TrezorConnect.composeTransaction({
 }
 ```
 
+Error
+
+```javascript
+{
+    success: false,
+    error: {
+        message: string // error message
+    }
+}
+```
+
 For more examples see [composeTransaction fixtures](https://github.com/trezor/trezor-suite/blob/develop/packages/connect/e2e/__fixtures__/composeTransaction.ts)
 
 ### Additional notes
 
-- [1] `UI.SELECT_ACCOUNT` and `UI.SELECT_FEE` events are emitted when using `trusted mode`
-- [2] Account utxo selection, fee and change calculation is performed by [@trezor/utxo-lib](https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib/src/compose) module
+- [1] Account utxo selection, fee and change calculation is performed by [@trezor/utxo-lib](https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib/src/compose) module

--- a/packages/connect-explorer/src/pages/methods/bitcoin/sendTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/sendTransaction.mdx
@@ -1,0 +1,104 @@
+import { Type } from '@sinclair/typebox';
+
+import { ApiPlayground } from '../../../components/ApiPlayground';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ParamsTable } from '../../../components/ParamsTable';
+import sendTransaction from '../../../data/methods/bitcoin/sendTransaction';
+
+<ApiPlayground options={[{ title: 'sendTransaction', legacyConfig: sendTransaction[0] }]} />
+
+export const RequestSchema = Type.Object({
+    outputs: Type.Array(Type.Object({}, { $id: 'Output' })),
+    coin: Type.String(),
+    push: Type.Optional(Type.Boolean()),
+    identity: Type.Optional(Type.String()),
+    sequence: Type.Optional(Type.Number()),
+    baseFee: Type.Optional(Type.Number()),
+    sortingStrategy: Type.Optional(Type.String()),
+});
+
+export const paramDescriptions = {
+    outputs: 'Array of output objects described [below](#accepted-output-objects)',
+    coin: 'determines network definition specified in [coins.json](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-data/files/coins.json) file. Coin `shortcut` (a `CoinSymbol`, e.g. `btc`) is used.',
+    push: 'determines if the resulting transaction will be broadcasted into the blockchain network. Default is set to false.',
+    identity: 'optional identity used to scope backend instances',
+    sequence: 'transaction input field used in RBF or locktime transactions',
+    baseFee: 'base fee for fee calculation',
+    sortingStrategy: 'transaction input/output sorting strategy',
+};
+
+# Send transaction
+
+This method works only for `Bitcoin` and `Bitcoin-like` coins.
+
+Requests a payment to a set of given outputs. An automated payment process separated into the following steps:
+
+1. Account discovery for requested coin is performed and the user is asked for source account selection. [[1]](#additional-notes)
+2. User is asked for fee level selection.
+3. Transaction is calculated, change output is added automatically if needed. [[2]](#additional-notes)
+4. Signing transaction with Trezor, user is asked for confirmation on device.
+
+Returned response is a signed transaction in hexadecimal format same as in [signTransaction method](signTransaction#result).
+
+For offline transaction composition without device interaction, see [composeTransaction](composeTransaction).
+
+### Params:
+
+<CommonParamsLink />
+
+<ParamsTable schema={RequestSchema} descriptions={paramDescriptions} />
+
+## Accepted output objects:
+
+- `regular output`
+    - `amount` - _required_ `string` value to send in satoshi
+    - `address` - _required_ `string` recipient address
+- `send-max` - spends all available inputs from account
+    - `type` - _required_ with `send-max` value
+    - `address` - _required_ `string` recipient address
+- `opreturn` - [read more](https://trezor.io/learn/a/use-op_return-in-trezor-suite-app)
+    - `type` - _required_ with `opreturn` value
+    - `dataHex` - _required_ `hexadecimal string` with arbitrary data
+
+## Example
+
+Send 0.002 BTC to "18WL2iZKmpDYWk1oFavJapdLALxwSjcSk2"
+
+```javascript
+TrezorConnect.sendTransaction({
+    outputs: [{ amount: '200000', address: '18WL2iZKmpDYWk1oFavJapdLALxwSjcSk2' }],
+    coin: 'btc',
+    push: true,
+});
+```
+
+## Result
+
+[SignedTransaction type](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/api/bitcoin/common.ts)
+
+```javascript
+{
+    success: true,
+    payload: {
+        signatures: Array<string>, // signer signatures
+        serializedTx: string,      // serialized transaction
+        txid?: string,             // blockchain transaction id
+    }
+}
+```
+
+Error
+
+```javascript
+{
+    success: false,
+    error: {
+        message: string // error message
+    }
+}
+```
+
+### Additional notes
+
+- [1] `UI.SELECT_ACCOUNT` and `UI.SELECT_FEE` events are emitted when using `trusted mode`
+- [2] Account utxo selection, fee and change calculation is performed by [@trezor/utxo-lib](https://github.com/trezor/trezor-suite/tree/develop/packages/utxo-lib/src/compose) module

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -2,61 +2,26 @@
 
 import {
     type BitcoinNetworkInfo,
-    type ComposeResultFinal,
     DEFAULT_SORTING_STRATEGY,
-    type DiscoveryAccount,
     ERRORS,
-    type FeeLevel,
     type PermissionRequest,
     type PrecomposeParams,
     type PrecomposedResult,
-    type RefTransaction,
-    type SignedTransaction,
-    UI_REQUEST,
-    UI_RESPONSE,
-    createUiMessage,
 } from '@trezor/connect-common';
-import { BigNumber } from '@trezor/utils/src/bigNumber';
-import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
-import { resolveAfter } from '@trezor/utils/src/resolveAfter';
-import { unique } from '@trezor/utils/src/unique';
-import type { ComposeOutput, TransactionInputOutputSortingStrategy } from '@trezor/utxo-lib';
+import type { ComposeOutput } from '@trezor/utxo-lib';
 
-import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
-import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
+import type { MethodMessage } from '../core/AbstractMethod';
 import { AbstractMethod } from '../core/AbstractMethod';
-import { requestExistingAccounts } from './common/requestExistingAccounts';
-import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';
-import { formatAmount } from '../utils/formatUtils';
+import { getBitcoinNetwork } from '../data/coinInfo';
 import * as pathUtils from '../utils/pathUtils';
 import { createComposer } from './bitcoin/TransactionComposer';
-import { enhanceSignTx } from './bitcoin/enhanceSignTx';
 import { inputToTrezor } from './bitcoin/inputs';
 import { outputToTrezor, validateHDOutput } from './bitcoin/outputs';
-import {
-    getReferencedTransactions,
-    parseTransactionHexes,
-    requireReferencedTransactions,
-    transformReferencedTransactions,
-} from './bitcoin/refTx';
-import { signTx } from './bitcoin/signtx';
-import { signTxLegacy } from './bitcoin/signtxLegacy';
-import { deriveOutputScript, verifyTx } from './bitcoin/signtxVerify';
-import { Discovery } from './common/Discovery';
 import { validateParams } from './common/paramsValidator';
-import { getOrInitFeeLevels } from '../backend/fees';
 
-type Params = {
+type Params = Omit<PrecomposeParams, 'coin' | 'outputs'> & {
     outputs: ComposeOutput[];
     coinInfo: BitcoinNetworkInfo;
-    identity?: string;
-    push: boolean;
-    account?: PrecomposeParams['account'];
-    feeLevels?: PrecomposeParams['feeLevels'];
-    baseFee?: PrecomposeParams['baseFee'];
-    sequence?: PrecomposeParams['sequence'];
-    total: BigNumber;
-    sortingStrategy?: TransactionInputOutputSortingStrategy;
 };
 
 export default class ComposeTransaction extends AbstractMethod<'composeTransaction', Params> {
@@ -66,10 +31,8 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         validateParams(payload, [
             { name: 'outputs', type: 'array', required: true },
             { name: 'coin', type: 'string', required: true },
-            { name: 'identity', type: 'string' },
-            { name: 'push', type: 'boolean' },
-            { name: 'account', type: 'object' },
-            { name: 'feeLevels', type: 'array' },
+            { name: 'account', type: 'object', required: true },
+            { name: 'feeLevels', type: 'array', required: true },
             { name: 'baseFee', type: 'number' },
             { name: 'sequence', type: 'number' },
             { name: 'sortingStrategy', type: 'string' },
@@ -79,84 +42,37 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         if (!coinInfo) {
             throw ERRORS.TypedError('Method_UnknownCoin');
         }
-        // validate backend
-        assertBackendSupported(coinInfo);
 
         // validate each output and transform into @trezor/utxo-lib/compose format
-        const outputs: ComposeOutput[] = [];
-        let total = new BigNumber(0);
-        payload.outputs.forEach(out => {
-            const output = validateHDOutput(out, coinInfo);
-            if ('amount' in output && typeof output.amount === 'string') {
-                total = total.plus(output.amount);
-            }
-            outputs.push(output);
-        });
-
-        // there should be only one output when using send-max option
-        // if (sendMax && outputs.length > 1) {
-        //     throw ERRORS.TypedError('Method_InvalidParameter', 'Only one output allowed when using "send-max" option');
-        // }
-
-        // if outputs contains regular items
-        // check if total amount is not lower than dust limit
-        // if (outputs.find(o => o.type === 'payment') !== undefined && total.lt(coinInfo.dustLimit)) {
-        //     throw error 'Total amount is too low';
-        // }
+        const outputs = payload.outputs.map(out => validateHDOutput(out, coinInfo));
 
         const params = {
             outputs,
             coinInfo,
-            identity: payload.identity,
             account: payload.account,
             feeLevels: payload.feeLevels,
             baseFee: payload.baseFee,
             sequence: payload.sequence,
             sortingStrategy: payload.sortingStrategy,
-            push: typeof payload.push === 'boolean' ? payload.push : false,
-            total,
         };
 
         super(message, params);
 
-        this.useDevice = !payload.account && !payload.feeLevels;
-
-        this.useUi = this.useDevice;
-
+        this.useDevice = false;
+        this.useUi = false;
         this.requiredFirmwareCoins = [coinInfo];
     }
 
-    discovery?: Discovery;
-    private disposed = false;
-
     get requiredPermissions(): PermissionRequest[] {
-        const permissions: PermissionRequest[] = [this.coinPerm('sign', this.params.coinInfo)];
-        if (this.params.push) {
-            permissions.push(this.coinPerm('push_tx', this.params.coinInfo));
-        }
-
-        return permissions;
+        return [];
     }
 
     get info() {
-        const sendMax = this.params.outputs.some(o => o.type === 'send-max');
-
-        if (sendMax) {
-            return 'Send maximum amount';
-        }
-
-        return `Send ${formatAmount(this.params.total.toString(), this.params.coinInfo)}`;
+        return `Compose transaction`;
     }
 
-    private getBlockchain(sendCoreMessage: MethodContext['sendCoreMessage']) {
-        return initBlockchain(this.params.coinInfo, sendCoreMessage, this.params.identity);
-    }
-
-    private precompose(
-        account: PrecomposeParams['account'],
-        feeLevels: PrecomposeParams['feeLevels'],
-    ): Promise<PrecomposedResult[]> {
-        const { coinInfo, outputs, baseFee, sortingStrategy } = this.params;
+    run(): Promise<PrecomposedResult[]> {
+        const { coinInfo, outputs, baseFee, sortingStrategy, account, feeLevels } = this.params;
         const address_n = pathUtils.validatePath(account.path);
 
         const compose = createComposer({
@@ -189,333 +105,5 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         });
 
         return Promise.resolve(levels);
-    }
-
-    run(context: MethodContext) {
-        if (this.params.account && this.params.feeLevels) {
-            return this.precompose(this.params.account, this.params.feeLevels);
-        } else {
-            return this.interactiveFlow(context);
-        }
-    }
-
-    private async interactiveFlow(context: MethodContext): Promise<SignedTransaction> {
-        // discover accounts and wait for user action
-        const { account, utxo: utxos } = await this.selectAccount(context);
-
-        const { coinInfo, outputs, sortingStrategy, push } = this.params;
-
-        // get backend instance (it should be initialized before)
-        const blockchain = await this.getBlockchain(context.sendCoreMessage);
-        const feeLevels = getOrInitFeeLevels(coinInfo);
-        await feeLevels.load(blockchain);
-
-        const compose = createComposer({
-            txType: account.type,
-            addresses: account.addresses,
-            utxos,
-            coinInfo,
-            outputs,
-            sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
-        });
-
-        const levels: FeeLevel[] = [];
-        const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
-        const composed = { levels, transactions };
-
-        // try to compose multiple transactions with different fee levels
-        // check if any of composed transactions is valid
-        for (const level of feeLevels.levels) {
-            if (level.feePerUnit === '0') continue;
-            const tx = compose(level.feePerUnit);
-            if (tx.type !== 'final') continue;
-            composed.levels.push(level);
-            composed.transactions.set(level.label, tx);
-        }
-
-        if (!composed.levels.length) {
-            const feePerUnit = String(coinInfo.minFee);
-            const minFeeTx = compose(feePerUnit);
-
-            if (minFeeTx.type === 'final') {
-                context.sendCoreMessage(
-                    createUiMessage(UI_REQUEST.SELECT_FEE, {
-                        feeLevels: [{ label: 'custom', blocks: -1, feePerUnit }],
-                        coinInfo: this.params.coinInfo,
-                    }),
-                );
-            } else {
-                // show error view
-                context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
-                // wait few seconds...
-                await resolveAfter(2000);
-
-                // and go back to discovery
-                return this.interactiveFlow(context);
-            }
-        } else {
-            // set select account view
-            // this view will be updated from discovery events
-            context.sendCoreMessage(
-                createUiMessage(UI_REQUEST.SELECT_FEE, {
-                    feeLevels: composed.levels,
-                    coinInfo: this.params.coinInfo,
-                }),
-            );
-        }
-
-        // wait for fee selection
-        const resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice())
-            .promise;
-
-        if (resp.payload.type === 'change-account') {
-            // check for interruption
-            if (this.disposed) {
-                throw ERRORS.TypedError(
-                    'Runtime',
-                    'ComposeTransaction: selectFee response received after dispose',
-                );
-            }
-
-            // back to account selection
-            return this.interactiveFlow(context);
-        }
-
-        const tx =
-            resp.payload.type === 'select-fee-custom'
-                ? compose(resp.payload.value) // recompose custom fee level with requested value
-                : composed.transactions.get(resp.payload.value);
-
-        if (tx?.type !== 'final') {
-            throw ERRORS.TypedError('Runtime', 'ComposeTransaction: Trying to sign unfinished tx');
-        }
-
-        const response = await this._sign(tx, context.sendCoreMessage);
-
-        if (push) {
-            const blockchain2 = await this.getBlockchain(context.sendCoreMessage);
-            const txid = await blockchain2.pushTransaction(response.serializedTx);
-
-            return {
-                ...response,
-                txid,
-            };
-        }
-
-        return response;
-    }
-
-    private async selectAccount(context: MethodContext) {
-        const { coinInfo } = this.params;
-        const blockchain = await this.getBlockchain(context.sendCoreMessage);
-
-        // Try to get existing accounts from the host (e.g. Suite) to skip device discovery
-        if (!this.discovery) {
-            const existingAccounts = await requestExistingAccounts({
-                postMessage: context.sendCoreMessage,
-                createUiPromise: context.createUiPromise,
-                device: this.getDevice(),
-                coinInfo,
-            });
-
-            if (existingAccounts) {
-                return this.selectFromExistingAccounts(existingAccounts, blockchain, context);
-            }
-        }
-
-        return this.selectFromDiscovery(blockchain, context);
-    }
-
-    private async selectFromExistingAccounts(
-        accounts: DiscoveryAccount[],
-        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
-        context: MethodContext,
-    ) {
-        const { coinInfo } = this.params;
-        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
-
-        context.sendCoreMessage(
-            createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
-                type: 'complete',
-                accountTypes: unique(accounts.map(a => a.type)),
-                coinInfo,
-                accounts,
-            }),
-        );
-
-        const uiResp = await dfd.promise;
-        const accountIndex = uiResp.payload;
-        // @ts-expect-error: noUncheckedIndexedAccess
-        const account: (typeof accounts)[number] = accounts[accountIndex];
-        this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
-        const utxo = await blockchain.getAccountUtxo(account.descriptor);
-
-        return { account, utxo };
-    }
-
-    private async selectFromDiscovery(
-        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
-        context: MethodContext,
-    ) {
-        const { coinInfo } = this.params;
-        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
-
-        if (this.discovery?.completed) {
-            const { discovery } = this;
-            context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
-                    {
-                        type: 'end',
-                        coinInfo,
-                        accountTypes: discovery.types.map(t => t.type),
-                        accounts: discovery.accounts,
-                    },
-                    { requestId: dfd.requestId },
-                ),
-            );
-            const uiResp = await dfd.promise;
-            const { accounts } = discovery;
-            const accountIndex = uiResp.payload;
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const account: (typeof accounts)[number] = accounts[accountIndex];
-            const utxo = await blockchain.getAccountUtxo(account.descriptor);
-
-            return { account, utxo };
-        }
-
-        const discovery =
-            this.discovery ||
-            new Discovery({
-                blockchain,
-                getDescriptor: path =>
-                    this.getDevice().getCommands().getAccountDescriptor(this.params.coinInfo, path),
-            });
-        this.discovery = discovery;
-
-        discovery.on('progress', accounts => {
-            context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
-                    {
-                        type: 'progress',
-                        coinInfo,
-                        accounts,
-                    },
-                    { requestId: dfd.requestId },
-                ),
-            );
-        });
-        discovery.on('complete', () => {
-            context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.SELECT_ACCOUNT,
-                    {
-                        type: 'end',
-                        coinInfo,
-                    },
-                    { requestId: dfd.requestId },
-                ),
-            );
-        });
-
-        // get accounts with addresses (tokens)
-        discovery.start('tokens').catch(error => {
-            // catch error from discovery process
-            dfd.reject(error);
-        });
-
-        // set select account view
-        // this view will be updated from discovery events
-        context.sendCoreMessage(
-            createUiMessage(
-                UI_REQUEST.SELECT_ACCOUNT,
-                {
-                    type: 'start',
-                    accountTypes: discovery.types.map(t => t.type),
-                    coinInfo,
-                },
-                { requestId: dfd.requestId },
-            ),
-        );
-
-        // wait for user action
-        const uiResp = await dfd.promise;
-        discovery.removeAllListeners();
-        discovery.stop();
-
-        if (!discovery.completed) {
-            await resolveAfter(501); // temporary solution, TODO: immediately resolve will cause "device call in progress"
-        }
-
-        const { accounts } = discovery;
-        const accountIndex = uiResp.payload;
-        // @ts-expect-error: noUncheckedIndexedAccess
-        const account: (typeof accounts)[number] = accounts[accountIndex];
-        this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
-        const utxo = await blockchain.getAccountUtxo(account.descriptor);
-
-        return { account, utxo };
-    }
-
-    private async _sign(tx: ComposeResultFinal, sendCoreMessage: MethodContext['sendCoreMessage']) {
-        const device = this.getDevice();
-        const { params } = this;
-
-        const { coinInfo } = params;
-
-        const options = enhanceSignTx({}, coinInfo);
-        const inputs = tx.inputs.map(inp => inputToTrezor(inp, params.sequence));
-        const outputs = tx.outputs.map(outputToTrezor);
-
-        let refTxs: RefTransaction[] = [];
-        const requiredRefTxs = requireReferencedTransactions(inputs, options, coinInfo);
-        const refTxsIds = getReferencedTransactions(inputs);
-        if (requiredRefTxs && refTxsIds.length > 0) {
-            refTxs = await this.getBlockchain(sendCoreMessage)
-                .then(blockchain => blockchain.getTransactionHexes(refTxsIds))
-                .then(parseTransactionHexes(coinInfo.network))
-                .then(transformReferencedTransactions);
-        }
-
-        const getHDNode = (address_n: number[]) =>
-            device.getCommands().getHDNode({ address_n }, { coinInfo: params.coinInfo });
-
-        const outputScripts = await promiseAllSequence(
-            outputs.map(output => () => deriveOutputScript(getHDNode, output, coinInfo.network)),
-        );
-
-        const signTxMethod = !device.unavailableCapabilities.replaceTransaction
-            ? signTx
-            : signTxLegacy;
-
-        const cmd = device.getCommands();
-        const response = await signTxMethod({
-            typedCall: cmd.typedCall,
-            inputs,
-            outputs,
-            refTxs,
-            options,
-            coinInfo,
-        });
-
-        verifyTx(response.serializedTx, {
-            inputs,
-            outputs,
-            outputScripts,
-            network: coinInfo.network,
-        });
-
-        return response;
-    }
-
-    dispose() {
-        this.disposed = true;
-        const { discovery } = this;
-        if (discovery) {
-            discovery.stop();
-            discovery.removeAllListeners();
-            this.discovery = undefined;
-        }
     }
 }

--- a/packages/connect/src/api/index.ts
+++ b/packages/connect/src/api/index.ts
@@ -50,6 +50,7 @@ export { default as requestLogin } from './requestLogin';
 export { default as resetDevice } from './resetDevice';
 export { default as loadDevice } from './loadDevice';
 export { default as selectAccount } from './selectAccount';
+export { default as sendTransaction } from './sendTransaction';
 export { default as setBrightness } from './setBrightness';
 export { default as setBusy } from './setBusy';
 export { default as signMessage } from './signMessage';

--- a/packages/connect/src/api/sendTransaction.ts
+++ b/packages/connect/src/api/sendTransaction.ts
@@ -1,0 +1,450 @@
+import {
+    type BitcoinNetworkInfo,
+    type ComposeParams,
+    type ComposeResultFinal,
+    DEFAULT_SORTING_STRATEGY,
+    type DiscoveryAccount,
+    ERRORS,
+    type FeeLevel,
+    type PermissionRequest,
+    type RefTransaction,
+    type SignedTransaction,
+    UI_REQUEST,
+    UI_RESPONSE,
+    createUiMessage,
+} from '@trezor/connect-common';
+import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { promiseAllSequence } from '@trezor/utils/src/promiseAllSequence';
+import { resolveAfter } from '@trezor/utils/src/resolveAfter';
+import { unique } from '@trezor/utils/src/unique';
+import type { ComposeOutput } from '@trezor/utxo-lib';
+
+import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
+import type { MethodContext, MethodMessage } from '../core/AbstractMethod';
+import { AbstractMethod } from '../core/AbstractMethod';
+import { requestExistingAccounts } from './common/requestExistingAccounts';
+import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';
+import { formatAmount } from '../utils/formatUtils';
+import { createComposer } from './bitcoin/TransactionComposer';
+import { enhanceSignTx } from './bitcoin/enhanceSignTx';
+import { inputToTrezor } from './bitcoin/inputs';
+import { outputToTrezor, validateHDOutput } from './bitcoin/outputs';
+import {
+    getReferencedTransactions,
+    parseTransactionHexes,
+    requireReferencedTransactions,
+    transformReferencedTransactions,
+} from './bitcoin/refTx';
+import { signTx } from './bitcoin/signtx';
+import { signTxLegacy } from './bitcoin/signtxLegacy';
+import { deriveOutputScript, verifyTx } from './bitcoin/signtxVerify';
+import { Discovery } from './common/Discovery';
+import { validateParams } from './common/paramsValidator';
+import { getOrInitFeeLevels } from '../backend/fees';
+
+type Params = Omit<ComposeParams, 'coin' | 'outputs'> & {
+    outputs: ComposeOutput[];
+    coinInfo: BitcoinNetworkInfo;
+    push: boolean;
+    identity?: string;
+    total: BigNumber;
+};
+
+export default class SendTransaction extends AbstractMethod<'sendTransaction', Params> {
+    constructor(message: MethodMessage<'sendTransaction'>) {
+        const { payload } = message;
+        // validate incoming parameters
+        validateParams(payload, [
+            { name: 'outputs', type: 'array', required: true },
+            { name: 'coin', type: 'string', required: true },
+            { name: 'identity', type: 'string' },
+            { name: 'push', type: 'boolean' },
+            { name: 'baseFee', type: 'number' },
+            { name: 'sequence', type: 'number' },
+            { name: 'sortingStrategy', type: 'string' },
+        ]);
+
+        const coinInfo = getBitcoinNetwork(payload.coin);
+        if (!coinInfo) {
+            throw ERRORS.TypedError('Method_UnknownCoin');
+        }
+        // validate backend
+        assertBackendSupported(coinInfo);
+
+        // validate each output and transform into @trezor/utxo-lib/compose format
+        const outputs: ComposeOutput[] = [];
+        let total = new BigNumber(0);
+        payload.outputs.forEach(out => {
+            const output = validateHDOutput(out, coinInfo);
+            if ('amount' in output && typeof output.amount === 'string') {
+                total = total.plus(output.amount);
+            }
+            outputs.push(output);
+        });
+
+        const params = {
+            outputs,
+            coinInfo,
+            identity: payload.identity,
+            baseFee: payload.baseFee,
+            sequence: payload.sequence,
+            sortingStrategy: payload.sortingStrategy,
+            push: typeof payload.push === 'boolean' ? payload.push : false,
+            total,
+        };
+
+        super(message, params);
+
+        this.requiredFirmwareCoins = [coinInfo];
+    }
+
+    discovery?: Discovery;
+    private disposed = false;
+
+    get requiredPermissions(): PermissionRequest[] {
+        const permissions: PermissionRequest[] = [this.coinPerm('sign', this.params.coinInfo)];
+        if (this.params.push) {
+            permissions.push(this.coinPerm('push_tx', this.params.coinInfo));
+        }
+
+        return permissions;
+    }
+
+    get info() {
+        const sendMax = this.params.outputs.some(o => o.type === 'send-max');
+
+        if (sendMax) {
+            return 'Send maximum amount';
+        }
+
+        return `Send ${formatAmount(this.params.total.toString(), this.params.coinInfo)}`;
+    }
+
+    private getBlockchain(sendCoreMessage: MethodContext['sendCoreMessage']) {
+        return initBlockchain(this.params.coinInfo, sendCoreMessage, this.params.identity);
+    }
+
+    run(context: MethodContext) {
+        return this.interactiveFlow(context);
+    }
+
+    private async interactiveFlow(context: MethodContext): Promise<SignedTransaction> {
+        // discover accounts and wait for user action
+        const { account, utxo: utxos } = await this.selectAccount(context);
+
+        const { coinInfo, outputs, sortingStrategy, push } = this.params;
+
+        // get backend instance (it should be initialized before)
+        const blockchain = await this.getBlockchain(context.sendCoreMessage);
+        const feeLevels = getOrInitFeeLevels(coinInfo);
+        await feeLevels.load(blockchain);
+
+        const compose = createComposer({
+            txType: account.type,
+            addresses: account.addresses,
+            utxos,
+            coinInfo,
+            outputs,
+            sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
+        });
+
+        const levels: FeeLevel[] = [];
+        const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
+        const composed = { levels, transactions };
+
+        // try to compose multiple transactions with different fee levels
+        // check if any of composed transactions is valid
+        for (const level of feeLevels.levels) {
+            if (level.feePerUnit === '0') continue;
+            const tx = compose(level.feePerUnit);
+            if (tx.type !== 'final') continue;
+            composed.levels.push(level);
+            composed.transactions.set(level.label, tx);
+        }
+
+        if (!composed.levels.length) {
+            const feePerUnit = String(coinInfo.minFee);
+            const minFeeTx = compose(feePerUnit);
+
+            if (minFeeTx.type === 'final') {
+                context.sendCoreMessage(
+                    createUiMessage(UI_REQUEST.SELECT_FEE, {
+                        feeLevels: [{ label: 'custom', blocks: -1, feePerUnit }],
+                        coinInfo: this.params.coinInfo,
+                    }),
+                );
+            } else {
+                // show error view
+                context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
+                // wait few seconds...
+                await resolveAfter(2000);
+
+                // and go back to discovery
+                return this.interactiveFlow(context);
+            }
+        } else {
+            // set select account view
+            // this view will be updated from discovery events
+            context.sendCoreMessage(
+                createUiMessage(UI_REQUEST.SELECT_FEE, {
+                    feeLevels: composed.levels,
+                    coinInfo: this.params.coinInfo,
+                }),
+            );
+        }
+
+        // wait for fee selection
+        const resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice())
+            .promise;
+
+        if (resp.payload.type === 'change-account') {
+            // check for interruption
+            if (this.disposed) {
+                throw ERRORS.TypedError(
+                    'Runtime',
+                    'SendTransaction: selectFee response received after dispose',
+                );
+            }
+
+            // back to account selection
+            return this.interactiveFlow(context);
+        }
+
+        const tx =
+            resp.payload.type === 'select-fee-custom'
+                ? compose(resp.payload.value) // recompose custom fee level with requested value
+                : composed.transactions.get(resp.payload.value);
+
+        if (tx?.type !== 'final') {
+            throw ERRORS.TypedError('Runtime', 'SendTransaction: Trying to sign unfinished tx');
+        }
+
+        const response = await this._sign(tx, context.sendCoreMessage);
+
+        if (push) {
+            const blockchain2 = await this.getBlockchain(context.sendCoreMessage);
+            const txid = await blockchain2.pushTransaction(response.serializedTx);
+
+            return {
+                ...response,
+                txid,
+            };
+        }
+
+        return response;
+    }
+
+    private async selectAccount(context: MethodContext) {
+        const { coinInfo } = this.params;
+        const blockchain = await this.getBlockchain(context.sendCoreMessage);
+
+        // Try to get existing accounts from the host (e.g. Suite) to skip device discovery
+        if (!this.discovery) {
+            const existingAccounts = await requestExistingAccounts({
+                postMessage: context.sendCoreMessage,
+                createUiPromise: context.createUiPromise,
+                device: this.getDevice(),
+                coinInfo,
+            });
+
+            if (existingAccounts) {
+                return this.selectFromExistingAccounts(existingAccounts, blockchain, context);
+            }
+        }
+
+        return this.selectFromDiscovery(blockchain, context);
+    }
+
+    private async selectFromExistingAccounts(
+        accounts: DiscoveryAccount[],
+        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
+        context: MethodContext,
+    ) {
+        const { coinInfo } = this.params;
+        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
+
+        context.sendCoreMessage(
+            createUiMessage(UI_REQUEST.SELECT_ACCOUNT, {
+                type: 'complete',
+                accountTypes: unique(accounts.map(a => a.type)),
+                coinInfo,
+                accounts,
+            }),
+        );
+
+        const uiResp = await dfd.promise;
+        const accountIndex = uiResp.payload;
+        // @ts-expect-error: noUncheckedIndexedAccess
+        const account: (typeof accounts)[number] = accounts[accountIndex];
+        this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
+        const utxo = await blockchain.getAccountUtxo(account.descriptor);
+
+        return { account, utxo };
+    }
+
+    private async selectFromDiscovery(
+        blockchain: Awaited<ReturnType<typeof this.getBlockchain>>,
+        context: MethodContext,
+    ) {
+        const { coinInfo } = this.params;
+        const dfd = context.createUiPromise(UI_RESPONSE.RECEIVE_ACCOUNT, this.getDevice());
+
+        if (this.discovery?.completed) {
+            const { discovery } = this;
+            context.sendCoreMessage(
+                createUiMessage(
+                    UI_REQUEST.SELECT_ACCOUNT,
+                    {
+                        type: 'end',
+                        coinInfo,
+                        accountTypes: discovery.types.map(t => t.type),
+                        accounts: discovery.accounts,
+                    },
+                    { requestId: dfd.requestId },
+                ),
+            );
+            const uiResp = await dfd.promise;
+            const { accounts } = discovery;
+            const accountIndex = uiResp.payload;
+            // @ts-expect-error: noUncheckedIndexedAccess
+            const account: (typeof accounts)[number] = accounts[accountIndex];
+            const utxo = await blockchain.getAccountUtxo(account.descriptor);
+
+            return { account, utxo };
+        }
+
+        const discovery =
+            this.discovery ||
+            new Discovery({
+                blockchain,
+                getDescriptor: path =>
+                    this.getDevice().getCommands().getAccountDescriptor(this.params.coinInfo, path),
+            });
+        this.discovery = discovery;
+
+        discovery.on('progress', accounts => {
+            context.sendCoreMessage(
+                createUiMessage(
+                    UI_REQUEST.SELECT_ACCOUNT,
+                    {
+                        type: 'progress',
+                        coinInfo,
+                        accounts,
+                    },
+                    { requestId: dfd.requestId },
+                ),
+            );
+        });
+        discovery.on('complete', () => {
+            context.sendCoreMessage(
+                createUiMessage(
+                    UI_REQUEST.SELECT_ACCOUNT,
+                    {
+                        type: 'end',
+                        coinInfo,
+                    },
+                    { requestId: dfd.requestId },
+                ),
+            );
+        });
+
+        // get accounts with addresses (tokens)
+        discovery.start('tokens').catch(error => {
+            // catch error from discovery process
+            dfd.reject(error);
+        });
+
+        // set select account view
+        // this view will be updated from discovery events
+        context.sendCoreMessage(
+            createUiMessage(
+                UI_REQUEST.SELECT_ACCOUNT,
+                {
+                    type: 'start',
+                    accountTypes: discovery.types.map(t => t.type),
+                    coinInfo,
+                },
+                { requestId: dfd.requestId },
+            ),
+        );
+
+        // wait for user action
+        const uiResp = await dfd.promise;
+        discovery.removeAllListeners();
+        discovery.stop();
+
+        if (!discovery.completed) {
+            await resolveAfter(501); // temporary solution, TODO: immediately resolve will cause "device call in progress"
+        }
+
+        const { accounts } = discovery;
+        const accountIndex = uiResp.payload;
+        // @ts-expect-error: noUncheckedIndexedAccess
+        const account: (typeof accounts)[number] = accounts[accountIndex];
+        this.params.coinInfo = fixCoinInfoNetwork(this.params.coinInfo, account.address_n);
+        const utxo = await blockchain.getAccountUtxo(account.descriptor);
+
+        return { account, utxo };
+    }
+
+    private async _sign(tx: ComposeResultFinal, sendCoreMessage: MethodContext['sendCoreMessage']) {
+        const device = this.getDevice();
+        const { params } = this;
+
+        const { coinInfo } = params;
+
+        const options = enhanceSignTx({}, coinInfo);
+        const inputs = tx.inputs.map(inp => inputToTrezor(inp, params.sequence));
+        const outputs = tx.outputs.map(outputToTrezor);
+
+        let refTxs: RefTransaction[] = [];
+        const requiredRefTxs = requireReferencedTransactions(inputs, options, coinInfo);
+        const refTxsIds = getReferencedTransactions(inputs);
+        if (requiredRefTxs && refTxsIds.length > 0) {
+            refTxs = await this.getBlockchain(sendCoreMessage)
+                .then(blockchain => blockchain.getTransactionHexes(refTxsIds))
+                .then(parseTransactionHexes(coinInfo.network))
+                .then(transformReferencedTransactions);
+        }
+
+        const getHDNode = (address_n: number[]) =>
+            device.getCommands().getHDNode({ address_n }, { coinInfo: params.coinInfo });
+
+        const outputScripts = await promiseAllSequence(
+            outputs.map(output => () => deriveOutputScript(getHDNode, output, coinInfo.network)),
+        );
+
+        const signTxMethod = !device.unavailableCapabilities.replaceTransaction
+            ? signTx
+            : signTxLegacy;
+
+        const cmd = device.getCommands();
+        const response = await signTxMethod({
+            typedCall: cmd.typedCall,
+            inputs,
+            outputs,
+            refTxs,
+            options,
+            coinInfo,
+        });
+
+        verifyTx(response.serializedTx, {
+            inputs,
+            outputs,
+            outputScripts,
+            network: coinInfo.network,
+        });
+
+        return response;
+    }
+
+    dispose() {
+        this.disposed = true;
+        const { discovery } = this;
+        if (discovery) {
+            discovery.stop();
+            discovery.removeAllListeners();
+            this.discovery = undefined;
+        }
+    }
+}

--- a/packages/suite-desktop-core/src/modules/mcp-server.ts
+++ b/packages/suite-desktop-core/src/modules/mcp-server.ts
@@ -359,7 +359,7 @@ const MCP_TOOLS = [
             'Send a cryptocurrency transaction using the Trezor device. ' +
             'Just provide "to" address, "value", and "coin" — everything else is automatic. ' +
             'For Bitcoin/UTXO chains (btc, ltc, bch, doge, zec): ' +
-            'handled by composeTransaction — account, UTXOs, and fees are resolved by Suite. ' +
+            'handled by sendTransaction — account, UTXOs, and fees are resolved by Suite. ' +
             'For Ethereum/EVM chains (eth, pol, bsc, arb, base, op, avax, rhc, etc): ' +
             'nonce and EIP-1559 gas fees are auto-filled; use "accountIndex" to select account. ' +
             'For ERC-20 token transfers: set "tokenContract" and "tokenDecimals" — the server encodes the transfer calldata automatically. ' +
@@ -825,7 +825,7 @@ const handleXrpSend = async (
 };
 
 /**
- * Handle BTC/UTXO transaction via a single composeTransaction call with push=true.
+ * Handle BTC/UTXO transaction via a single sendTransaction call with push=true.
  * TrezorConnect handles everything internally: account discovery, fee estimation,
  * UTXO selection, fee level selection, signing, and broadcasting.
  */
@@ -843,7 +843,7 @@ const handleUtxoSend = (
         });
     }
 
-    return callPopup(sendPopupCall, 'composeTransaction', {
+    return callPopup(sendPopupCall, 'sendTransaction', {
         outputs: [
             {
                 type: 'payment',
@@ -897,7 +897,7 @@ const handleSendTransaction = async (
             return autoBroadcast(sendPopupCall, coin, signResult, params.broadcast !== false);
         }
 
-        // Otherwise, single composeTransaction call — TrezorConnect handles everything
+        // Otherwise, single sendTransaction call — TrezorConnect handles everything
         return handleUtxoSend(params, sendPopupCall, coin);
     }
 

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -43,7 +43,8 @@ import {
     type SelectAccountCandidate,
     isUtxoNetwork,
 } from './connectPopupTypes';
-import { postCallHooks, preCallHooks } from './methodHooks';
+import { compatibilityHooks, postCallHooks, preCallHooks } from './methodHooks';
+import type { DistributiveOmit } from './methodHooks/types';
 import {
     deriveCardanoEnabledNetworks,
     mergePermissions,
@@ -52,8 +53,6 @@ import {
 } from './permissions';
 
 const CONNECT_POPUP_MODULE = '@common/connect-popup';
-
-type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;
 
 type ConnectPopupCallThunkParams<M extends CallMethodKeys> = {
     method: M;
@@ -66,8 +65,10 @@ export const connectPopupCallThunkInner = createThunk<
     ConnectPopupCallThunkParams<CallMethodKeys>
 >(
     `${CONNECT_POPUP_MODULE}/callThunk`,
-    async ({ method, payload, source }, { dispatch, getState, extra }) => {
+    async ({ source, ...params }, { dispatch, getState, extra }) => {
         try {
+            const { method, payload } = compatibilityHooks(params);
+
             if (!connectCallableMethods.includes(method)) throw TypedError('Method_Unsupported');
 
             const methodInfo = await TrezorConnect.call({
@@ -253,7 +254,7 @@ export const connectPopupCallThunkInner = createThunk<
             extra.services.analytics.report({
                 type: events.connectPopupErrorEvent.name,
                 payload: {
-                    method,
+                    method: params.method,
                     origin: source.origin,
                     error: error?.code,
                     appName: source.manifest.appName,

--- a/suite-common/connect-popup/src/methodHooks/composeTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/composeTransaction.ts
@@ -1,0 +1,17 @@
+import type { CallMethodKeys } from '@trezor/connect';
+
+import type { CompatibilityHookParams } from './types';
+
+const compatibilityHook = <M extends CallMethodKeys>({
+    method,
+    payload,
+}: CompatibilityHookParams<M>): CompatibilityHookParams<M> | undefined => {
+    if (method === 'composeTransaction') {
+        return 'account' in payload && payload.account
+            ? { method, payload }
+            : // Interactive flow of composeTransaction was deprecated in favour of sendTransaction
+              ({ method: 'sendTransaction', payload } as CompatibilityHookParams<M>);
+    }
+};
+
+export const composeTransaction = { compatibilityHook };

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -1,13 +1,22 @@
-import { type CallMethodKeys } from '@trezor/connect';
+import type { CallMethodKeys } from '@trezor/connect';
 
 import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { cardanoGetPublicKeyCompat } from './cardanoGetPublicKeyCompat';
+import { composeTransaction } from './composeTransaction';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
 import { selectAccountHooks } from './selectAccount';
 import { solanaSignTransaction } from './solanaSignTransaction';
-import { type PostCallHookParams, type PreCallHookParams } from './types';
+import type { CompatibilityHookParams, PostCallHookParams, PreCallHookParams } from './types';
+
+/**
+ * May change the method and its payload before any other actions,
+ * mostly in order to preserve backwards compatibility
+ */
+export const compatibilityHooks = <M extends CallMethodKeys>(
+    params: CompatibilityHookParams<M>,
+): CompatibilityHookParams<M> => composeTransaction.compatibilityHook(params) ?? params;
 
 export const preCallHooks = async <M extends CallMethodKeys>(params: PreCallHookParams<M>) => {
     await bitcoinSignTransaction.preCallHook(params);

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -11,6 +11,13 @@ import { type Err, type Ok } from '@trezor/type-utils';
 
 import { type ConnectCallSource } from '../connectPopupTypes';
 
+export type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : never;
+
+export type CompatibilityHookParams<M extends CallMethodKeys> = {
+    method: M;
+    payload: DistributiveOmit<CallMethodParams<M>, 'method'>;
+};
+
 export type PreCallHookParams<M extends CallMethodKeys> = {
     method: M;
     payload: Omit<CallMethodParams<M>, 'method'>;

--- a/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormBitcoinThunks.ts
@@ -118,7 +118,6 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
             : account.addresses.change;
 
         const params: Parameters<typeof TrezorConnect.composeTransaction>[0] = {
-            // needs to be present in order to correct resolve of @trezor/connect params overload
             account: {
                 path: account.path,
                 addresses: {
@@ -192,7 +191,6 @@ export const composeBitcoinTransactionFeeLevelsThunk = createThunk<
                 customLevels.length > 0
                     ? await TrezorConnect.composeTransaction({
                           ...params,
-                          account: params.account, // needs to be present in order to correct resolve type of @trezor/connect params overload
                           feeLevels: customLevels,
                       })
                     : ({ success: false } as const);

--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -149,7 +149,6 @@ const bitcoinRequestThunk = createThunk<
             const precomposedTransaction = await TrezorConnect.composeTransaction({
                 outputs,
                 coin: account.symbol,
-                identity: getAccountIdentity(account),
                 account: {
                     path: account.path,
                     addresses: account.addresses!,


### PR DESCRIPTION
## Description

In order not to have Connect methods with multiple completely different flows, input params and/or return types, interactive flow of `composeTransaction` was extracted into standalone new method `sendTransaction`.

Now, `composeTransaction` is meant to be used only from Suite, always returns precomposed transactions, doesn't emit events, doesn't communicate with backends and doesn't deal with signing or broadcasting.

Newly implemented `sendTransaction` is meant only for 3rd parties and handles the event-based flow of `account selection <-> fee selection -> signing -> pushing`.

Compatibility hook has been added into `connectPopupCallThunk` which translates `composeTransaction` calls without 
`account` param into `sendTransaction` calls in order not to break existing 3rd party implementers.

## Notes for QA

Please test that
a) bitcoin(-like) send form in Suite works as before (regarding composing tx, coin selection, fee selection, signing etc.) and 
b) interactive flow from 3rd party apps (or `composeTransaction` call from current connect explorer) also works as before even with this Suite.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (9)</b></summary>

- `packages/connect-common/src/callableMethods.ts`
- `packages/connect-common/src/types/api/bitcoin/common.ts`
- `packages/connect-common/src/types/api/bitcoin/composeTransaction.ts`
- `packages/connect-common/src/types/api/bitcoin/index.ts`
- `packages/connect-common/src/types/api/bitcoin/sendTransaction.ts`
- `packages/connect-common/src/types/index.ts`
- `packages/connect/src/api/composeTransaction.ts`
- `packages/connect/src/api/index.ts`
- `packages/connect/src/api/sendTransaction.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-24T12:08:07.655Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/sign-transaction/web/](https://dev.suite.sldev.cz/suite-web/feat/sign-transaction/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sign-transaction&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sign-transaction&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/sign-transaction&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:11:32.944Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:12:11.899Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->