### PR TITLE
fix(trading): check session state instead of connected in asset picker guard

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingAssetPickerModal.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingAssetPickerModal.ts
@@ -21,14 +21,14 @@ export const useTradingAssetPickerModal = () => {
             return;
         }
 
-        if (!device?.connected) {
+        if (!device?.state?.staticSessionId) {
             dispatch(setConnectionModal(true));
 
             return;
         }
 
         openAssetPicker();
-    }, [dispatch, hasEnabledNetworks, device?.connected, openAssetPicker]);
+    }, [dispatch, hasEnabledNetworks, device?.state?.staticSessionId, openAssetPicker]);
 
     return { open, openModal: handleOpenModal, closeModal, toggleModal } as const;
 };


### PR DESCRIPTION
## Description

The asset picker modal guard in `useTradingAssetPickerModal` checked `device?.connected` which only reflects physical USB connection. For remembered wallets (session persisted in IndexedDB), the device is not physically connected but has a valid `staticSessionId`.

This changes the guard to `device?.state?.staticSessionId`, aligning with other trading hooks (`useTradingReceiveAddress`, `useTradingVerifyAccount`) and avoiding showing the connection modal unnecessarily for remembered wallets.

## Notes for QA

Open any trading form (buy/sell/swap) with a remembered wallet (no device plugged in). The asset picker should open without showing the connection modal.

## Related Issue

Resolve #30251

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingAssetPickerModal.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-27T05:25:32.304Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-asset-picker-session-guard/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-asset-picker-session-guard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-asset-picker-session-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-asset-picker-session-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T05:28:38.223Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T05:29:21.859Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->