### PR TITLE
feat(suite-native): label wrap/unwrap transactions

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2173,6 +2173,8 @@ export const messages = {
             claiming: 'Claiming',
             changeDelegate: 'Change delegate',
             changingDelegate: 'Changing delegate',
+            wrap: 'Wrap {nativeSymbol} into {wrappedAmount}',
+            unwrap: 'Unwrap {wrappedAmount} into {nativeSymbol}',
             tron: {
                 createAccount: 'Create Account',
                 updateAccount: 'Update Account',

--- a/suite-native/module-transactions/src/components/TransactionDetailTitle.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailTitle.tsx
@@ -1,0 +1,73 @@
+import { getNativeWrapTxKind } from '@suite-common/wallet-utils';
+import { Text } from '@suite-native/atoms';
+import { TokenIcon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { type TypedTokenTransfer, type WalletAccountTransaction } from '@suite-native/tokens';
+import {
+    TransactionName,
+    UnstakeTransactionDetailTitle,
+    WrapTransactionName,
+    getUnstakeTxAmount,
+} from '@suite-native/transactions';
+
+type TransactionDetailTitleProps = {
+    transaction: WalletAccountTransaction;
+    isPending: boolean;
+    tokenTransfer?: TypedTokenTransfer;
+};
+
+// WETH wrap/unwrap and unstake render their own amount-bearing title directly, bypassing the
+// generic "<type> transaction" header template (which would append " transaction" to the label).
+export const TransactionDetailTitle = ({
+    transaction,
+    isPending,
+    tokenTransfer,
+}: TransactionDetailTitleProps) => {
+    const unstakeAmount = getUnstakeTxAmount(transaction);
+    const wrapKind = getNativeWrapTxKind(transaction);
+
+    if (unstakeAmount !== undefined) {
+        return (
+            <UnstakeTransactionDetailTitle
+                unstakeAmount={unstakeAmount}
+                symbol={transaction.symbol}
+                variant="body-md-strong"
+            />
+        );
+    }
+
+    if (wrapKind) {
+        return (
+            <WrapTransactionName
+                transaction={transaction}
+                kind={wrapKind}
+                variant="body-md-strong"
+            />
+        );
+    }
+
+    return (
+        <>
+            <TokenIcon
+                symbol={transaction.symbol}
+                contractAddress={tokenTransfer?.contract}
+                showNetworkIcon
+            />
+            <Text variant="body-md-strong">
+                <Translation
+                    id="transactions.detail.header"
+                    values={{
+                        transactionType: () => (
+                            <TransactionName
+                                key={transaction.txid}
+                                transaction={transaction}
+                                isPending={isPending}
+                                variant="body-md-strong"
+                            />
+                        ),
+                    }}
+                />
+            </Text>
+        </>
+    );
+};

--- a/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
+++ b/suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx
@@ -10,8 +10,7 @@ import {
     selectAccountByKey,
 } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Button, HStack, Text, VStack } from '@suite-native/atoms';
-import { TokenIcon } from '@suite-native/icons';
+import { Button, HStack, VStack } from '@suite-native/atoms';
 import { useInAppRating } from '@suite-native/in-app-rating';
 import { Translation } from '@suite-native/intl';
 import {
@@ -24,14 +23,13 @@ import {
 import { useTransactionDetails } from '@suite-native/transaction-management';
 import {
     InstantStakeBanner,
-    TransactionName,
-    UnstakeTransactionDetailTitle,
     getUnstakeTxAmount,
     useFetchMissingTransactionFiatRates,
 } from '@suite-native/transactions';
 
 import { TransactionDetailData } from '../components/TransactionDetailData';
 import { TransactionDetailHeader } from '../components/TransactionDetailHeader';
+import { TransactionDetailTitle } from '../components/TransactionDetailTitle';
 
 export const TransactionDetailScreen = ({
     route,
@@ -72,8 +70,7 @@ export const TransactionDetailScreen = ({
 
     if (!transaction) return null;
 
-    const unstakeAmount = getUnstakeTxAmount(transaction);
-    const isUnstakeTransaction = unstakeAmount !== undefined;
+    const isUnstakeTransaction = getUnstakeTxAmount(transaction) !== undefined;
 
     const handleOpenBlockchain = () => {
         analytics.report({
@@ -91,36 +88,11 @@ export const TransactionDetailScreen = ({
                     closeActionType={closeActionType}
                     customContent={
                         <HStack spacing="sp8" alignItems="center" justifyContent="center">
-                            {isUnstakeTransaction ? (
-                                <UnstakeTransactionDetailTitle
-                                    unstakeAmount={unstakeAmount}
-                                    symbol={transaction.symbol}
-                                    variant="body-md-strong"
-                                />
-                            ) : (
-                                <>
-                                    <TokenIcon
-                                        symbol={transaction.symbol}
-                                        contractAddress={tokenTransfer?.contract}
-                                        showNetworkIcon
-                                    />
-                                    <Text variant="body-md-strong">
-                                        <Translation
-                                            id="transactions.detail.header"
-                                            values={{
-                                                transactionType: () => (
-                                                    <TransactionName
-                                                        key={transaction.txid}
-                                                        transaction={transaction}
-                                                        isPending={isPending}
-                                                        variant="body-md-strong"
-                                                    />
-                                                ),
-                                            }}
-                                        />
-                                    </Text>
-                                </>
-                            )}
+                            <TransactionDetailTitle
+                                transaction={transaction}
+                                isPending={isPending}
+                                tokenTransfer={tokenTransfer}
+                            />
                         </HStack>
                     }
                 />

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -52,5 +52,8 @@
         "react-native": "0.85.3",
         "react-native-svg": "15.15.5",
         "react-redux": "9.3.0"
+    },
+    "devDependencies": {
+        "@suite-native/test-utils-store": "workspace:*"
     }
 }

--- a/suite-native/transactions/src/components/TransactionName.test.tsx
+++ b/suite-native/transactions/src/components/TransactionName.test.tsx
@@ -1,0 +1,44 @@
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { renderWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { TransactionName } from './TransactionName';
+
+// eth mainnet WETH contract + WETH deposit()/withdraw(uint256) calldata (withdraw wad = 1 ETH).
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const DEPOSIT = '0xd0e30db0';
+const WITHDRAW = '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+const ONE_ETH_WEI = '1000000000000000000';
+
+const wrapTx = {
+    symbol: 'eth',
+    amount: ONE_ETH_WEI,
+    targets: [{ addresses: [WETH] }],
+    internalTransfers: [],
+    ethereumSpecific: { data: DEPOSIT },
+} as unknown as WalletAccountTransaction;
+
+const unwrapTx = {
+    symbol: 'eth',
+    amount: '0',
+    targets: [],
+    internalTransfers: [{ from: WETH }],
+    ethereumSpecific: { data: WITHDRAW },
+} as unknown as WalletAccountTransaction;
+
+describe('TransactionName - WETH wrap/unwrap label', () => {
+    it('labels a wrap with the native symbol and the wrapped amount', () => {
+        const { getByText } = renderWithStoreProvider(
+            <TransactionName transaction={wrapTx} isPending={false} />,
+        );
+
+        expect(getByText('Wrap ETH into 1 WETH')).toBeTruthy();
+    });
+
+    it('labels an unwrap with the wrapped amount and the native symbol', () => {
+        const { getByText } = renderWithStoreProvider(
+            <TransactionName transaction={unwrapTx} isPending={false} />,
+        );
+
+        expect(getByText('Unwrap 1 WETH into ETH')).toBeTruthy();
+    });
+});

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -2,7 +2,7 @@ import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discree
 import { useFormatters } from '@suite-common/formatters';
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType, type WalletAccountTransaction } from '@suite-common/wallet-types';
-import { getTxStakeType } from '@suite-common/wallet-utils';
+import { getNativeWrapTxKind, getTxStakeType } from '@suite-common/wallet-utils';
 import { Text } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { type NativeTypographyStyle } from '@trezor/theme';
@@ -11,6 +11,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { getUnstakeTxAmount } from '../utils';
 import { UnstakeTransactionDetailTitle } from './UnstakeTransactionDetailTitle';
+import { WrapTransactionName } from './WrapTransactionName';
 
 type TransactionNameProps = {
     transaction: WalletAccountTransaction;
@@ -116,6 +117,13 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
     const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
     const { isDiscreetMode } = useDiscreetMode();
     const ethName = transaction.ethereumSpecific?.parsedData?.name;
+
+    // WETH wrap/unwrap get their own label (with the amount) instead of the generic contract-call
+    // method name ("deposit"/"withdraw") that the indexer parses.
+    const wrapKind = getNativeWrapTxKind(transaction);
+    if (wrapKind) {
+        return <WrapTransactionName transaction={transaction} kind={wrapKind} variant={variant} />;
+    }
 
     // Stellar trustline addition/removal (short version without asset code)
     if (

--- a/suite-native/transactions/src/components/WrapTransactionName.tsx
+++ b/suite-native/transactions/src/components/WrapTransactionName.tsx
@@ -1,0 +1,58 @@
+import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discreet-mode';
+import { useFormatters } from '@suite-common/formatters';
+import { getNetworkDisplaySymbol, getWrappedNativeSymbol } from '@suite-common/wallet-config';
+import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { getUnwrapAmountByEthereumDataHex } from '@suite-common/wallet-utils';
+import { Text } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { type NativeTypographyStyle } from '@trezor/theme';
+
+type WrapTransactionNameProps = {
+    transaction: WalletAccountTransaction;
+    kind: 'wrap' | 'unwrap';
+    variant?: NativeTypographyStyle;
+};
+
+// Mirrors desktop's `WrapTxAmount` (packages/suite/src/components/suite/WrapTxAmount.tsx): wrapping is
+// 1:1, so both legs share the same amount and differ only in symbol. The amount is the transaction
+// value for a wrap and the withdraw(uint256) calldata for an unwrap, and the label always shows it in
+// the wrapped-native token (e.g. WETH).
+export const WrapTransactionName = ({ transaction, kind, variant }: WrapTransactionNameProps) => {
+    const { CryptoAmountFormatter: cryptoAmountFormatter } = useFormatters();
+    const { isDiscreetMode } = useDiscreetMode();
+
+    const { symbol } = transaction;
+
+    const subunits =
+        kind === 'wrap'
+            ? transaction.amount
+            : getUnwrapAmountByEthereumDataHex(transaction.ethereumSpecific?.data);
+
+    const wrappedSymbol = getWrappedNativeSymbol(symbol) ?? getNetworkDisplaySymbol(symbol);
+
+    // The formatter's `symbol` drives both the subunit→unit conversion and the appended ticker, and
+    // the wrapped symbol (WETH) is not a NetworkSymbol. So convert using the native symbol's decimals
+    // (WETH shares them) with `withSymbol: false`, then append the wrapped ticker ourselves.
+    const formattedAmount = subunits
+        ? cryptoAmountFormatter.format(subunits, {
+              symbol,
+              isBalance: false,
+              withSymbol: false,
+              isEllipsisAppended: false,
+          })
+        : undefined;
+
+    const wrappedAmountText = formattedAmount ? `${formattedAmount} ${wrappedSymbol}` : '';
+    const wrappedAmount = isDiscreetMode
+        ? redactNumericalSubstring(wrappedAmountText)
+        : wrappedAmountText;
+
+    return (
+        <Text variant={variant}>
+            <Translation
+                id={kind === 'wrap' ? 'transactions.name.wrap' : 'transactions.name.unwrap'}
+                values={{ nativeSymbol: getNetworkDisplaySymbol(symbol), wrappedAmount }}
+            />
+        </Text>
+    );
+};

--- a/suite-native/transactions/src/index.ts
+++ b/suite-native/transactions/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/TransactionList';
 export * from './components/TransactionIcon';
 export * from './components/TransactionName';
 export * from './components/UnstakeTransactionDetailTitle';
+export * from './components/WrapTransactionName';
 export * from './components/TransactionOutputLabel';
 export * from './components/TransactionOutputLabelEditable';
 export * from './components/TokenTransferListItem';

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -65,6 +65,7 @@
         },
         { "path": "../../packages/theme" },
         { "path": "../../packages/type-utils" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/utils" },
+        { "path": "../test-utils-store" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14490,6 +14490,7 @@ __metadata:
     "@suite-native/navigation": "workspace:*"
     "@suite-native/scrollview": "workspace:*"
     "@suite-native/suite-sync": "workspace:*"
+    "@suite-native/test-utils-store": "workspace:*"
     "@suite-native/tokens": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Mirrors labels for desktop 

## Notes for QA

1) You don't have to trigger transaction from mobile, just browse history on account that has wrapping/unwrapping transactions

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29876

## Screenshots:

 
| Header | Header |
|--------|--------|
| <img width="402" height="874" alt="Simulator Screenshot - iPhone 17 - 2026-07-24 at 15 12 13" src="https://github.com/user-attachments/assets/f4dc7a24-d1c4-4274-b4d9-46be395a6126" /> | <img width="402" height="874" alt="Simulator Screenshot - iPhone 17 - 2026-07-24 at 15 17 37" src="https://github.com/user-attachments/assets/1cee82b4-e288-499f-8dcd-e1b3f0edfc94" /> | 
 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in suite-native (mobile app) packages and concern native transaction display components and messages. The available candidate tests are suite/e2e Playwright tests for the web/desktop application only, so there is no relevant overlap. None of the candidate E2E tests exercise the native mobile code paths touched by this change set; native unit tests (e.g., TransactionName.test.tsx) would be the appropriate coverage, but they are not part of the provided candidate list.

<details><summary><b>Changed files (9)</b></summary>

- `suite-native/intl/src/messages.ts`
- `suite-native/module-transactions/src/components/TransactionDetailTitle.tsx`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/transactions/package.json`
- `suite-native/transactions/src/components/TransactionName.test.tsx`
- `suite-native/transactions/src/components/TransactionName.tsx`
- `suite-native/transactions/src/components/WrapTransactionName.tsx`
- `suite-native/transactions/src/index.ts`
- `suite-native/transactions/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-transactions/src/components/TransactionDetailTitle.tsx`
- `suite-native/module-transactions/src/screens/TransactionDetailScreen.tsx`
- `suite-native/transactions/package.json`
- `suite-native/transactions/src/components/TransactionName.test.tsx`
- `suite-native/transactions/src/components/TransactionName.tsx`
- `suite-native/transactions/src/components/WrapTransactionName.tsx`
- `suite-native/transactions/src/index.ts`
- `suite-native/transactions/tsconfig.json`

_Updated: 2026-08-04T10:05:05.147Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/label-native-weth/web/](https://dev.suite.sldev.cz/suite-web/feat/label-native-weth/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/label-native-weth&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/label-native-weth&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/label-native-weth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:07:50.652Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:07:38.401Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->