### PR TITLE
fix(suite-desktop): isolate connect-ws popup calls per connection

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -137,6 +137,7 @@ export type InvokeResult<Payload = undefined> =
 
 export type ConnectPopupCall = {
     id: string;
+    connectionId?: string;
     method: string;
     payload: any;
     sourceType?: string;
@@ -160,6 +161,7 @@ export type ConnectPopupCall = {
 export type ConnectPopupCancel = {
     error?: string;
     callId?: string;
+    connectionId?: string;
 };
 
 export type ConnectPopupResponse = {

--- a/packages/suite-desktop-core/src/__tests__/connect-popup-messages.test.ts
+++ b/packages/suite-desktop-core/src/__tests__/connect-popup-messages.test.ts
@@ -1,0 +1,102 @@
+// Captured IPC handlers registered by the module under test.
+const ipcHandlers: Record<string, (...args: any[]) => any> = {};
+
+jest.mock('../typed-electron', () => ({
+    ipcMain: {
+        handle: (channel: string, handler: (...args: any[]) => any) => {
+            ipcHandlers[channel] = handler;
+        },
+    },
+}));
+
+(global as any).logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+};
+
+import {
+    addMessage,
+    deleteMessage,
+    initConnectPopupResponseHandler,
+    rejectMessage,
+} from '../libs/connect-popup-messages';
+
+const respond = (response: unknown) => {
+    const handler = ipcHandlers['connect-popup/response'];
+    if (!handler) throw new Error('connect-popup/response handler not registered');
+
+    return handler(undefined, response);
+};
+
+describe('connect-popup-messages', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+        initConnectPopupResponseHandler();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    // Response deferreds are keyed by id. connect-ws namespaces the caller-supplied numeric id
+    // per connection (`${connectionId}:${id}`), so two connections that reuse the same numeric
+    // request id ("1") end up with distinct keys and MUST NOT cross-deliver. This is the
+    // regression guard for the cross-client response-correlation issue.
+    it('routes a response only to the deferred with the matching (namespaced) id', async () => {
+        const victim = addMessage('ws-1:1');
+        const attacker = addMessage('ws-2:1');
+
+        let victimResolved = false;
+        victim.promise.then(() => {
+            victimResolved = true;
+        });
+
+        const attackerResponse = { id: 'ws-2:1', success: true, payload: 'ATTACKER_OWNED' };
+        respond(attackerResponse);
+
+        await expect(attacker.promise).resolves.toEqual(attackerResponse);
+        // Flush any pending microtasks so a mistaken victim resolution would be observable.
+        await Promise.resolve();
+        expect(victimResolved).toBe(false);
+
+        // Clean up the still-pending victim deferred.
+        deleteMessage('ws-1:1');
+    });
+
+    it('ignores a response whose id has no registered deferred', () => {
+        expect(() => respond({ id: 'ws-9:42', success: true, payload: 'x' })).not.toThrow();
+    });
+
+    it('ignores a malformed response without resolving anything', async () => {
+        const pending = addMessage('ws-3:7');
+        let resolved = false;
+        pending.promise.then(() => {
+            resolved = true;
+        });
+
+        expect(() => respond(undefined)).not.toThrow();
+        expect(() => respond({ id: 123 })).not.toThrow();
+
+        await Promise.resolve();
+        expect(resolved).toBe(false);
+
+        deleteMessage('ws-3:7');
+    });
+
+    it('rejectMessage settles the deferred so an awaiter unblocks', async () => {
+        const pending = addMessage('ws-4:1');
+        const error = new Error('Connection closed');
+
+        rejectMessage('ws-4:1', error);
+
+        await expect(pending.promise).rejects.toBe(error);
+        // A subsequent response for the same id is a no-op (entry already removed).
+        expect(() => respond({ id: 'ws-4:1', success: true, payload: 'x' })).not.toThrow();
+    });
+
+    it('rejectMessage is a no-op for an unknown id', () => {
+        expect(() => rejectMessage('ws-nope:1', new Error('x'))).not.toThrow();
+    });
+});

--- a/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
+++ b/packages/suite-desktop-core/src/libs/connect-popup-messages.ts
@@ -27,13 +27,28 @@ export const addMessage = (id: string): Deferred<any> => {
         }
     }, DEFERRED_TIMEOUT_MS);
 
-    deferred.promise.finally(() => clearTimeout(timer));
+    // Swallow on this internal cleanup branch: the real awaiter handles the rejection on its own
+    // branch; without the catch, a rejected deferred (timeout, or rejectMessage on disconnect)
+    // would surface here as an unhandled promise rejection.
+    deferred.promise.finally(() => clearTimeout(timer)).catch(() => {});
 
     return deferred;
 };
 
 export const deleteMessage = (id: string) => {
     delete messages[id];
+};
+
+/**
+ * Settle a pending message with an error before removing it. Unlike deleteMessage, this rejects
+ * the deferred so any `await deferred.promise` unblocks (and releases its closure) instead of
+ * hanging forever — the timeout would otherwise no-op once the entry is gone.
+ */
+export const rejectMessage = (id: string, error: Error) => {
+    const deferred = messages[id];
+    if (!deferred) return;
+    delete messages[id];
+    deferred.reject(error);
 };
 
 export const setAppInit = (deferred: Deferred<void> | undefined) => {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -15,12 +15,17 @@ import { isLinux } from '@trezor/env-utils';
 import { type ProcessInfo, findProcessFromIncomingPort } from '@trezor/node-utils';
 import { createDeferred, resolveAfter } from '@trezor/utils';
 
-import { addMessage, deleteMessage, setAppInit } from './connect-popup-messages';
+import { addMessage, deleteMessage, rejectMessage, setAppInit } from './connect-popup-messages';
 import { type createHttpReceiver } from './http-receiver';
 import { getProcessIcon } from './process-icon';
 import { type Dependencies } from '../modules';
 
 const LOG_PREFIX = 'connect-ws';
+
+// Per-connection id used to namespace the process-global response store. The request id is
+// caller-controlled, so without namespacing two connections could reuse the same id and one
+// connection's response could be delivered to the other.
+let connectionCounter = 0;
 
 /**
  * allowed message from connect-in-suite-desktop implementation
@@ -89,6 +94,11 @@ export const exposeConnectWs = ({
     });
 
     wss.on('connection', (ws, req) => {
+        const connectionId = `ws-${++connectionCounter}`;
+        // Namespaces a caller-supplied request id to this connection. Internal to the main
+        // process; the original id is still echoed back to the client on the wire.
+        const getStoreId = (id: string) => `${connectionId}:${id}`;
+        // Namespaced store keys of this connection's in-flight calls.
         const connectionPendingMessages = new Set<string>();
         const ip = req.socket.remoteAddress;
         const port = req.socket.remotePort;
@@ -149,11 +159,15 @@ export const exposeConnectWs = ({
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.error,
                     callId: message.payload?.callId,
+                    // honored only if this connection owns the active call
+                    connectionId,
                 });
             } else if (message.type === CORE_CALL_CANCEL) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: message.payload?.reason,
                     callId: message.payload?.callId,
+                    // honored only if this connection owns the active call
+                    connectionId,
                 });
             } else if (message.type === CORE_CALL) {
                 if (!processOnPort) {
@@ -184,8 +198,23 @@ export const exposeConnectWs = ({
 
                 const { method, ...rest } = message.payload;
 
-                const deferred = addMessage(message.id);
-                connectionPendingMessages.add(message.id);
+                const storeId = getStoreId(message.id);
+                // Reject a request id that this connection already has in flight instead of
+                // overwriting its deferred (which would orphan the first call until timeout).
+                if (connectionPendingMessages.has(storeId)) {
+                    logger.error(LOG_PREFIX, `duplicate in-flight id ${message.id}`);
+                    ws.send(
+                        JSON.stringify({
+                            id: message.id,
+                            success: false,
+                            payload: { error: 'Duplicate in-flight request id' },
+                        }),
+                    );
+
+                    return;
+                }
+                const deferred = addMessage(storeId);
+                connectionPendingMessages.add(storeId);
 
                 try {
                     // check window exists, if not wait for it to be created
@@ -206,8 +235,8 @@ export const exposeConnectWs = ({
                             LOG_PREFIX,
                             'Main window not available after initialization timeout',
                         );
-                        deleteMessage(message.id);
-                        connectionPendingMessages.delete(message.id);
+                        deleteMessage(storeId);
+                        connectionPendingMessages.delete(storeId);
                         ws.send(
                             JSON.stringify({
                                 id: message.id,
@@ -221,9 +250,12 @@ export const exposeConnectWs = ({
                         return;
                     }
 
-                    // send call to renderer
+                    // `id` (namespaced) is echoed back on the response to resolve this
+                    // connection's deferred; `connectionId` marks the owner so a cancel from
+                    // another connection can be rejected.
                     mainWindow.webContents.send('connect-popup/call', {
-                        id: message.id,
+                        id: storeId,
+                        connectionId,
                         method,
                         payload: rest,
                         origin,
@@ -247,6 +279,7 @@ export const exposeConnectWs = ({
                     // wait for response
                     const response = await deferred.promise;
 
+                    // Echo back the original (client-facing) id, not the namespaced store id.
                     ws.send(
                         JSON.stringify({
                             ...response,
@@ -256,7 +289,7 @@ export const exposeConnectWs = ({
                 } catch (e) {
                     logger.error(LOG_PREFIX, 'error handling call: ' + e);
                 } finally {
-                    connectionPendingMessages.delete(message.id);
+                    connectionPendingMessages.delete(storeId);
                 }
             }
         });
@@ -266,10 +299,14 @@ export const exposeConnectWs = ({
             if (connectionPendingMessages.size > 0) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
                     error: 'Connection closed',
+                    // cancel the active call only if it belongs to the closed connection
+                    connectionId,
                 });
 
                 for (const id of connectionPendingMessages) {
-                    deleteMessage(id);
+                    // Reject (not just delete) so the awaiting message handler unblocks and
+                    // releases its closure instead of hanging until the deferred times out.
+                    rejectMessage(id, new Error('Connection closed'));
                 }
                 connectionPendingMessages.clear();
             }

--- a/packages/suite-desktop-core/src/modules/mcp-server.ts
+++ b/packages/suite-desktop-core/src/modules/mcp-server.ts
@@ -24,6 +24,8 @@ export const SERVICE_NAME = 'mcp-server';
 
 const LOG_PREFIX = 'mcp-server';
 
+const MCP_CONNECTION_ID = 'mcp';
+
 const MCP_MANIFEST = {
     appName: 'MCP Agent',
     appUrl: 'http://localhost',
@@ -1139,6 +1141,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
 
             mainWindow.webContents.send('connect-popup/call', {
                 id: call.id,
+                connectionId: MCP_CONNECTION_ID,
                 method: call.method,
                 payload: call.payload,
                 silent: call.silent,

--- a/packages/suite/src/support/suite/__tests__/connectPopupCallTracker.test.ts
+++ b/packages/suite/src/support/suite/__tests__/connectPopupCallTracker.test.ts
@@ -1,0 +1,114 @@
+import { createConnectPopupCallTracker } from '../connectPopupCallTracker';
+
+describe(createConnectPopupCallTracker.name, () => {
+    describe('ownsActiveCall', () => {
+        it('authorizes the connection that owns the active call', () => {
+            const tracker = createConnectPopupCallTracker();
+            tracker.setActive('ws-1');
+
+            expect(tracker.ownsActiveCall('ws-1')).toBe(true);
+        });
+
+        it('rejects a cancel from a different connection', () => {
+            const tracker = createConnectPopupCallTracker();
+            tracker.setActive('ws-1');
+
+            expect(tracker.ownsActiveCall('ws-2')).toBe(false);
+        });
+
+        it('isolates WS and MCP connections from each other', () => {
+            const tracker = createConnectPopupCallTracker();
+            tracker.setActive('mcp');
+
+            expect(tracker.ownsActiveCall('ws-1')).toBe(false);
+            expect(tracker.ownsActiveCall('mcp')).toBe(true);
+        });
+
+        it('cancels unconditionally when the requester has no per-connection transport', () => {
+            const tracker = createConnectPopupCallTracker();
+            tracker.setActive('ws-1');
+
+            expect(tracker.ownsActiveCall(undefined)).toBe(true);
+        });
+
+        it('rejects a scoped cancel when there is no active call', () => {
+            const tracker = createConnectPopupCallTracker();
+
+            expect(tracker.ownsActiveCall('ws-1')).toBe(false);
+        });
+    });
+
+    describe('setActive / clearActive', () => {
+        it('clears the active call only when it still belongs to the given connection', () => {
+            const tracker = createConnectPopupCallTracker();
+            tracker.setActive('ws-1');
+
+            // A later call from another connection took over; ws-1 finishing must not clear it.
+            tracker.setActive('ws-2');
+            tracker.clearActive('ws-1');
+            expect(tracker.ownsActiveCall('ws-2')).toBe(true);
+
+            tracker.clearActive('ws-2');
+            expect(tracker.ownsActiveCall('ws-2')).toBe(false);
+        });
+    });
+
+    describe('cancelQueued', () => {
+        it('flags the connection’s queued calls so they can self-reject', () => {
+            const tracker = createConnectPopupCallTracker();
+            const entry = tracker.register('ws-1');
+
+            tracker.cancelQueued('ws-1');
+
+            expect(entry.canceled).toBe(true);
+        });
+
+        it('does not flag calls belonging to other connections', () => {
+            const tracker = createConnectPopupCallTracker();
+            const own = tracker.register('ws-1');
+            const other = tracker.register('ws-2');
+
+            tracker.cancelQueued('ws-1');
+
+            expect(own.canceled).toBe(true);
+            expect(other.canceled).toBe(false);
+        });
+
+        it('does not affect a future call from the same connection (no lingering tombstone)', () => {
+            const tracker = createConnectPopupCallTracker();
+            const first = tracker.register('ws-1');
+
+            tracker.cancelQueued('ws-1');
+            expect(first.canceled).toBe(true);
+
+            const second = tracker.register('ws-1');
+            expect(second.canceled).toBe(false);
+        });
+
+        it('is a no-op for a requester without a per-connection transport', () => {
+            const tracker = createConnectPopupCallTracker();
+            const entry = tracker.register(undefined);
+
+            expect(() => tracker.cancelQueued(undefined)).not.toThrow();
+            expect(entry.canceled).toBe(false);
+        });
+    });
+
+    describe('register / unregister', () => {
+        it('registers with an un-canceled entry', () => {
+            const tracker = createConnectPopupCallTracker();
+
+            expect(tracker.register('ws-1')).toEqual({ canceled: false });
+        });
+
+        it('stops tracking an entry once unregistered', () => {
+            const tracker = createConnectPopupCallTracker();
+            const entry = tracker.register('ws-1');
+
+            tracker.unregister('ws-1', entry);
+            tracker.cancelQueued('ws-1');
+
+            expect(entry.canceled).toBe(false);
+        });
+    });
+});

--- a/packages/suite/src/support/suite/connectPopupCallTracker.ts
+++ b/packages/suite/src/support/suite/connectPopupCallTracker.ts
@@ -1,0 +1,64 @@
+/**
+ * Tracks per-connection ownership of desktop connect-popup calls so that a cancel can be scoped
+ * to the connection that issued it — one client must not be able to cancel another's call.
+ *
+ * A call is registered while it waits in the popup queue; the "active" call is the one currently
+ * being processed. This is framework-agnostic and side-effect-free so it can be unit-tested in
+ * isolation; the async orchestration (queue, dispatch, IPC) stays in useConnectPopupDesktop.
+ *
+ * `connectionId` is undefined only for callers without a per-connection transport
+ * (web/deeplink/walletconnect); those are single-client and cancel unconditionally.
+ */
+export type ConnectPopupCallEntry = { canceled: boolean };
+
+export const createConnectPopupCallTracker = () => {
+    const queuedByConnection = new Map<string, Set<ConnectPopupCallEntry>>();
+    let activeConnectionId: string | undefined;
+
+    return {
+        // Register a received call while it waits in the queue.
+        register(connectionId: string | undefined): ConnectPopupCallEntry {
+            const entry: ConnectPopupCallEntry = { canceled: false };
+            if (connectionId !== undefined) {
+                const set = queuedByConnection.get(connectionId) ?? new Set();
+                set.add(entry);
+                queuedByConnection.set(connectionId, set);
+            }
+
+            return entry;
+        },
+
+        // Forget a call once it has settled.
+        unregister(connectionId: string | undefined, entry: ConnectPopupCallEntry) {
+            if (connectionId === undefined) return;
+            const set = queuedByConnection.get(connectionId);
+            set?.delete(entry);
+            if (set?.size === 0) queuedByConnection.delete(connectionId);
+        },
+
+        // Mark the call that just left the queue as the active one.
+        setActive(connectionId: string | undefined) {
+            activeConnectionId = connectionId;
+        },
+
+        // Clear the active call, but only if it is still the given connection's.
+        clearActive(connectionId: string | undefined) {
+            if (activeConnectionId === connectionId) activeConnectionId = undefined;
+        },
+
+        // Flag a connection's queued calls so they self-reject instead of opening a popup.
+        cancelQueued(connectionId: string | undefined) {
+            if (connectionId === undefined) return;
+            queuedByConnection.get(connectionId)?.forEach(entry => {
+                entry.canceled = true;
+            });
+        },
+
+        // Whether a cancel from `connectionId` may act on the active call.
+        ownsActiveCall(connectionId: string | undefined): boolean {
+            return connectionId === undefined || connectionId === activeConnectionId;
+        },
+    };
+};
+
+export type ConnectPopupCallTracker = ReturnType<typeof createConnectPopupCallTracker>;

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -26,6 +26,8 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
+import { createConnectPopupCallTracker } from './connectPopupCallTracker';
+
 export const useConnectPopupDesktop = () => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -35,6 +37,10 @@ export const useConnectPopupDesktop = () => {
     selectedDeviceRef.current = selectedDevice;
     const lifecycle = useSelector(state => state.suite.lifecycle);
     const initialized = useRef(false);
+
+    // Tracks which connection owns each in-flight call so a cancel can be scoped to its issuer
+    // (see connectPopupCallTracker). Kept in a ref so it survives effect re-runs.
+    const callTracker = useRef(createConnectPopupCallTracker());
 
     useEffect(() => {
         const init = async () => {
@@ -93,46 +99,82 @@ export const useConnectPopupDesktop = () => {
                     return;
                 }
 
-                await queuePopupCall();
-                const deferred = getPopupCallDeferred(true);
-                const isMcp = params.sourceType === CALL_SOURCE_MCP;
-                dispatch(
-                    connectPopupCallThunk({
-                        method: params.method as CallMethodKeys,
-                        payload: params.payload,
-                        source: isMcp
-                            ? {
-                                  type: CALL_SOURCE_MCP,
-                                  process: params.process,
-                                  origin: params.origin,
-                                  manifest: params.manifest,
-                              }
-                            : {
-                                  type: CALL_SOURCE_DESKTOP_WS,
-                                  process: params.process ?? {
-                                      name: 'Unknown',
-                                      fullPath: 'Unknown',
-                                      warning: true,
+                const { connectionId } = params;
+                // Register this call while it waits in the queue, so a cancel that arrives before
+                // it becomes active can flag it to self-reject on wake (see below).
+                const entry = callTracker.current.register(connectionId);
+
+                try {
+                    await queuePopupCall();
+
+                    // Canceled (or its connection disconnected) while queued: don't open the
+                    // popup or start a device flow for a client that already gave up.
+                    if (entry.canceled) {
+                        desktopApi.connectPopupResponse({
+                            success: false,
+                            error: 'Request was canceled',
+                            payload: 'Request was canceled',
+                            id: params.id,
+                        });
+
+                        return;
+                    }
+
+                    callTracker.current.setActive(connectionId);
+                    const deferred = getPopupCallDeferred(true);
+                    const isMcp = params.sourceType === CALL_SOURCE_MCP;
+                    dispatch(
+                        connectPopupCallThunk({
+                            method: params.method as CallMethodKeys,
+                            payload: params.payload,
+                            source: isMcp
+                                ? {
+                                      type: CALL_SOURCE_MCP,
+                                      process: params.process,
+                                      origin: params.origin,
+                                      manifest: params.manifest,
+                                  }
+                                : {
+                                      type: CALL_SOURCE_DESKTOP_WS,
+                                      process: params.process ?? {
+                                          name: 'Unknown',
+                                          fullPath: 'Unknown',
+                                          warning: true,
+                                      },
+                                      origin: params.origin,
+                                      manifest: params.manifest,
                                   },
-                                  origin: params.origin,
-                                  manifest: params.manifest,
-                              },
-                    }),
-                );
-                const response = await deferred.promise;
-                if (response.success) {
-                    desktopApi.connectPopupResponse({ ...response, id: params.id });
-                } else {
-                    desktopApi.connectPopupResponse({
-                        success: false,
-                        error: response.error,
-                        payload: response.error, // for backward compatibility with v9
-                        id: params.id,
-                    });
+                        }),
+                    );
+                    const response = await deferred.promise;
+                    if (response.success) {
+                        desktopApi.connectPopupResponse({ ...response, id: params.id });
+                    } else {
+                        desktopApi.connectPopupResponse({
+                            success: false,
+                            error: response.error,
+                            payload: response.error, // for backward compatibility with v9
+                            id: params.id,
+                        });
+                    }
+                } finally {
+                    callTracker.current.unregister(connectionId, entry);
+                    callTracker.current.clearActive(connectionId);
                 }
             });
             desktopApi.on('connect-popup/cancel', params => {
-                dispatch(connectPopupCancelThunk(params));
+                const { connectionId } = params;
+                // Flag this connection's queued calls so they self-reject instead of opening a
+                // popup once they reach the front of the queue.
+                callTracker.current.cancelQueued(connectionId);
+                // Only cancel the active call when the request owns it (or there is no
+                // per-connection transport, e.g. web) — this stops one client from canceling
+                // another client's active call.
+                if (callTracker.current.ownsActiveCall(connectionId)) {
+                    dispatch(
+                        connectPopupCancelThunk({ error: params.error, callId: params.callId }),
+                    );
+                }
             });
             desktopApi.on('app/auto-start/popup-request', () => {
                 dispatch(openModal({ type: 'auto-start-before-quit' }));


### PR DESCRIPTION
## Description

Pending Connect popup responses in Suite Desktop were stored in a process-global map keyed only by a caller-controlled request id, so two `/connect-ws` clients reusing the same id could receive each other's responses, and cancels were unscoped — any local client could cancel another client's in-flight call. This scopes both by connection: responses are namespaced per connection, and cancels (queued and active) only affect calls owned by the requesting connection, tracked in a new `connectPopupCallTracker`. It also adds a duplicate-in-flight-id guard, fixes a pending-deferred leak (and latent unhandled rejection) on disconnect, and adds unit tests for the response-store routing and the cancel tracker.

## Notes for QA

Focus on Suite Desktop third-party Connect flows over `/connect-ws` (and MCP): a normal getAddress / getPublicKey / sign flow should behave unchanged, and cancelling a request should still cancel it. The key scenarios are multiple concurrent Connect clients — one client cancelling or disconnecting must not cancel or misroute another client's request.

## Related Issue

Resolve #12676

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite-desktop-api/src/messages.ts`
- `packages/suite-desktop-core/src/__tests__/connect-popup-messages.test.ts`
- `packages/suite-desktop-core/src/libs/connect-popup-messages.ts`
- `packages/suite-desktop-core/src/libs/connect-ws.ts`
- `packages/suite-desktop-core/src/modules/mcp-server.ts`
- `packages/suite/src/support/suite/__tests__/connectPopupCallTracker.test.ts`
- `packages/suite/src/support/suite/connectPopupCallTracker.ts`
- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx`

</details>

_No test recommendations found._

_Updated: 2026-07-24T13:11:25.491Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/connect-ws-response-correlation/web/](https://dev.suite.sldev.cz/suite-web/connect-ws-response-correlation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=connect-ws-response-correlation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-24T13:14:44.953Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->