### PR TITLE
Add message-system kill switch for Cardano change-delegate action

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -16,6 +16,7 @@ import { Card, Column, Modal, Tooltip } from '@trezor/components';
 import { VotingDelegationsOptions } from 'src/components/earn';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import {
     ChangeDelegateFormContext,
     useChangeDelegateForm,
@@ -36,6 +37,8 @@ export const StakeChangeDelegateModalLoaded = ({
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const { account } = selectedAccount;
+
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const changeDelegateContextValues = useChangeDelegateForm({ selectedAccount });
 
@@ -62,7 +65,7 @@ export const StakeChangeDelegateModalLoaded = ({
         onCancel?.();
     };
 
-    const { isDisabled, errorType } = useMemo(() => {
+    const { isDisabled: isSelectionInvalid, errorType } = useMemo(() => {
         switch (selectedVotingDelegation.type) {
             case 'everstake': {
                 if (isEverstake) {
@@ -89,6 +92,20 @@ export const StakeChangeDelegateModalLoaded = ({
         return { isDisabled: false };
     }, [selectedVotingDelegation, currentDrepId, isEverstake]);
 
+    const isDisabled = isSelectionInvalid || isVotingDisabled;
+
+    const tooltipContent = useMemo(() => {
+        if (isVotingDisabled) {
+            return votingMessageContent;
+        }
+
+        if (isSelectionInvalid && errorType === 'current_delegate') {
+            return <Translation id="TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP" />;
+        }
+
+        return undefined;
+    }, [isVotingDisabled, votingMessageContent, isSelectionInvalid, errorType]);
+
     return (
         <ChangeDelegateFormContext.Provider value={changeDelegateContextValues}>
             <FormProvider {...methods}>
@@ -96,10 +113,7 @@ export const StakeChangeDelegateModalLoaded = ({
                     heading={<Translation id="TR_STAKE_CHANGE_DELEGATE" />}
                     onCancel={handleCancel}
                     bottomContent={
-                        <Tooltip
-                            isActive={isDisabled && errorType === 'current_delegate'}
-                            content={<Translation id="TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP" />}
-                        >
+                        <Tooltip content={tooltipContent}>
                             <Modal.Button
                                 isDisabled={isDisabled}
                                 onClick={() => handleSubmit(signTx)()}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -111,9 +111,11 @@ export const StakingCard = ({
         isStakingDisabled,
         isUnstakingDisabled,
         isClaimingDisabled,
+        isVotingDisabled,
         stakingMessageContent,
         unstakingMessageContent,
         claimingMessageContent,
+        votingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
     const {
@@ -217,7 +219,8 @@ export const StakingCard = ({
     };
 
     const openChangeDelegateModal = () => {
-        if (!isCardanoNetworkType || !isStakingActive || isStakeConfirming) return;
+        if (!isCardanoNetworkType || !isStakingActive || isStakeConfirming || isVotingDisabled)
+            return;
 
         dispatch(openModal({ type: 'change-delegate' }));
 
@@ -425,14 +428,19 @@ export const StakingCard = ({
                         </Button>
                     </Tooltip>
                     {isCardanoNetworkType && (
-                        <Button
-                            onClick={openChangeDelegateModal}
-                            isDisabled={!isStakingActive || isStakeConfirming}
-                            intent="neutral"
-                            priority="secondary"
-                        >
-                            <Translation id="TR_STAKE_CHANGE_DELEGATE" />
-                        </Button>
+                        <Tooltip content={votingMessageContent}>
+                            <Button
+                                onClick={openChangeDelegateModal}
+                                isDisabled={
+                                    !isStakingActive || isStakeConfirming || isVotingDisabled
+                                }
+                                iconLeft={isVotingDisabled ? InfoIcon : undefined}
+                                intent="neutral"
+                                priority="secondary"
+                            >
+                                <Translation id="TR_STAKE_CHANGE_DELEGATE" />
+                            </Button>
+                        </Tooltip>
                     )}
                 </Row>
             </Column>

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -55,6 +55,7 @@ export const Feature = {
         trx: 'trx.staking.claim',
     },
     vote: {
+        ada: 'ada.staking.vote',
         trx: 'trx.staking.vote',
     },
     withdraw: {

--- a/suite-common/message-system/src/useMessageSystemStaking.test.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.test.ts
@@ -42,6 +42,16 @@ const stateWithDisabledFeatures = {
                     feature: [{ domain: 'eth.staking.claim', flag: false }],
                 },
             },
+            {
+                message: {
+                    id: 'adaVoteDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    content: { en: 'Change delegate disabled' },
+                    feature: [{ domain: 'ada.staking.vote', flag: false }],
+                },
+            },
         ],
         experiments: [],
     },
@@ -49,7 +59,7 @@ const stateWithDisabledFeatures = {
         banner: [],
         context: [],
         modal: [],
-        feature: ['stakeDisabledMsg', 'claimDisabledMsg'],
+        feature: ['stakeDisabledMsg', 'claimDisabledMsg', 'adaVoteDisabledMsg'],
     },
 } as unknown as MessageSystemState;
 
@@ -80,6 +90,22 @@ describe('useMessageSystemStaking', () => {
             unstakingMessageContent: 'Staking disabled',
             claimingMessageContent: 'Claiming disabled',
         });
+    });
+
+    it('returns disabled state and message for ada change-delegate (vote) feature', () => {
+        const { result } = renderHook('ada');
+
+        expect(result.current).toMatchObject({
+            isVotingDisabled: true,
+            votingMessageContent: 'Change delegate disabled',
+        });
+    });
+
+    it('returns undefined voting state for networks without a vote feature key', () => {
+        const { result } = renderHook('eth');
+
+        expect(result.current.isVotingDisabled).toBeUndefined();
+        expect(result.current.votingMessageContent).toBeUndefined();
     });
 
     it('returns localized message content', () => {

--- a/suite-common/message-system/src/useMessageSystemStaking.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.ts
@@ -29,7 +29,7 @@ export const useMessageSystemStaking = ({
     const stake = isStaking ? Feature.stake[key] : undefined;
     const unstake = isStaking ? Feature.unstake[key] : undefined;
     const claim = isStaking ? Feature.claim[key] : undefined;
-    const vote = isStaking && key === 'trx' ? Feature.vote[key] : undefined;
+    const vote = isStaking && (key === 'trx' || key === 'ada') ? Feature.vote[key] : undefined;
     const withdraw = isStaking && key === 'trx' ? Feature.withdraw[key] : undefined;
 
     const isStakingDisabled = useSelector((state: MessageSystemRootState) =>


### PR DESCRIPTION
## Description

The Cardano change-delegate action had no message-system feature flag, unlike stake/unstake/claim on every other network, so it could never be disabled remotely. This adds an `ada` key to the `vote` flag and wires `isVotingDisabled`/`votingMessageContent` into the staking dashboard's "Change delegate" button and the modal's submit button.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30049

## Screenshots:
<img width="613" height="185" alt="Screenshot 2026-07-26 at 18 32 15" src="https://github.com/user-attachments/assets/d1194268-9454-4dd5-8353-76d46c3fde3c" />