### PR TITLE
fix(suite): restore data-testid passthrough in YieldTokenValue

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -16,7 +16,11 @@ type YieldTokenValueProps = {
     'data-testid'?: string;
 };
 
-export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => (
+export const YieldTokenValue = ({
+    token,
+    amount,
+    'data-testid': dataTestId,
+}: YieldTokenValueProps) => (
     <Row alignItems="center" gap={8}>
         <TokenIcon
             size={24}
@@ -34,7 +38,12 @@ export const YieldTokenValue = ({ token, amount }: YieldTokenValueProps) => (
                 showing the meaningful digits of small stablecoin/WETH amounts — a fixed decimal
                 cap instead rounded those down to zeroes.
             */}
-            <FormattedCryptoAmount value={amount} symbol={token.symbol} isBalance />
+            <FormattedCryptoAmount
+                value={amount}
+                symbol={token.symbol}
+                isBalance
+                data-testid={dataTestId}
+            />
         </Text>
     </Row>
 );


### PR DESCRIPTION
## Description

`c8006a05ad` dropped the `data-testid` passthrough in `YieldTokenValue`, so the yield flow-complete testids rendered as `undefined-with-symbol` and broke the deposit e2e test. This restores it.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29857

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx`

</details>

_No test recommendations found._

_Updated: 2026-07-27T07:55:04.661Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-token-value-testid/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-token-value-testid/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-token-value-testid&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-token-value-testid&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T07:58:42.821Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T07:58:14.903Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->