### PR TITLE
refactor(trading): migrate buy/sell quotes to useTradingQuoteRequest

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/buy/__tests__/useBuyQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/__tests__/useBuyQuotes.test.tsx
@@ -8,10 +8,13 @@ import {
     type TradingAssetOption,
     type TradingBuyFormProps,
     type TradingCountryOption,
+    buyInitialState,
+    initialState as tradingInitialState,
 } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 
-import { useBuyQuotes } from './useBuyQuotes';
+import { DEBOUNCE_DELAY_MS } from '../../common/useTradingQuoteRequest';
+import { useBuyQuotes } from '../useBuyQuotes';
 
 const QUOTES: BuyTrade[] = [
     {
@@ -65,6 +68,8 @@ const VALID_DEFAULTS: TradingBuyFormProps = {
     receiveAddress: 'bc1qreceive',
 };
 
+const NO_REFETCH_WAIT_MS = DEBOUNCE_DELAY_MS + 200;
+
 const wait = (ms: number) =>
     act(
         () =>
@@ -75,16 +80,15 @@ const wait = (ms: number) =>
 
 const renderBuyQuotes = (
     defaultValues: TradingBuyFormProps,
-    options: { resolver?: Resolver<TradingBuyFormProps>; quotes?: BuyTrade[] } = {},
+    options: { resolver?: Resolver<TradingBuyFormProps> } = {},
 ) => {
-    const { resolver, quotes = QUOTES } = options;
+    const { resolver } = options;
     const store = configureMockStore({
         preloadedState: {
             wallet: {
                 trading: {
-                    quoteRefetchingState: { status: 'idle', lastFetchTimestamp: null },
-                    buy: { quotes },
-                    sell: { quotes: [] },
+                    ...tradingInitialState,
+                    buy: { ...buyInitialState, quotes: QUOTES },
                 },
             },
         },
@@ -192,7 +196,7 @@ describe('useBuyQuotes', () => {
             result.current.setValue('provider', 'provider-2');
             await result.current.trigger();
         });
-        await wait(700);
+        await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).toHaveBeenCalledTimes(1);
     });
@@ -207,7 +211,7 @@ describe('useBuyQuotes', () => {
         await act(async () => {
             await result.current.trigger();
         });
-        await wait(700);
+        await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).not.toHaveBeenCalled();
     });

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
@@ -1,4 +1,4 @@
-import { type Resolver, type ResolverResult, useForm } from 'react-hook-form';
+import { type Resolver, useForm } from 'react-hook-form';
 
 import { act, waitFor } from '@testing-library/react';
 import type { BuyTrade, CryptoId } from 'invity-api';
@@ -9,12 +9,23 @@ import {
     type TradingBuyFormProps,
     type TradingCountryOption,
 } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
 
 import { useBuyQuotes } from './useBuyQuotes';
 
 const QUOTES: BuyTrade[] = [
-    { paymentMethod: 'creditCard', paymentMethodName: 'Credit card', exchange: 'provider-1' },
-    { paymentMethod: 'bankTransfer', paymentMethodName: 'Bank transfer', exchange: 'provider-2' },
+    {
+        paymentMethod: 'creditCard',
+        paymentMethodName: 'Credit card',
+        exchange: 'provider-1',
+        rate: 1,
+    },
+    {
+        paymentMethod: 'bankTransfer',
+        paymentMethodName: 'Bank transfer',
+        exchange: 'provider-2',
+        rate: 2,
+    },
 ];
 
 const mockAbort = jest.fn();
@@ -27,10 +38,6 @@ const mockHandleRequest = jest.fn((payload: unknown) => {
 jest.mock('@suite-common/dependency-injection', () => ({
     ...jest.requireActual('@suite-common/dependency-injection'),
     useServices: () => ({ analytics: { report: jest.fn() } }),
-}));
-
-jest.mock('src/hooks/wallet/useBitcoinAmountUnit', () => ({
-    useBitcoinAmountUnit: () => ({ isBtcSatsAmountUnit: false }),
 }));
 
 jest.mock('@suite-common/trading', () => {
@@ -68,13 +75,16 @@ const wait = (ms: number) =>
 
 const renderBuyQuotes = (
     defaultValues: TradingBuyFormProps,
-    resolver?: Resolver<TradingBuyFormProps>,
+    options: { resolver?: Resolver<TradingBuyFormProps>; quotes?: BuyTrade[] } = {},
 ) => {
+    const { resolver, quotes = QUOTES } = options;
     const store = configureMockStore({
         preloadedState: {
             wallet: {
                 trading: {
                     quoteRefetchingState: { status: 'idle', lastFetchTimestamp: null },
+                    buy: { quotes },
+                    sell: { quotes: [] },
                 },
             },
         },
@@ -87,11 +97,7 @@ const renderBuyQuotes = (
                 defaultValues,
                 resolver,
             });
-            useBuyQuotes({
-                control: methods.control,
-                getValues: methods.getValues,
-                setValue: methods.setValue,
-            });
+            useBuyQuotes({ methods, network: getNetwork('btc'), shouldSendInSats: false });
 
             return methods;
         },
@@ -139,21 +145,6 @@ describe('useBuyQuotes', () => {
         );
     });
 
-    it('refetches when a quote-affecting field changes', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
-
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
-
-        await act(async () => {
-            result.current.setValue('fiatInput', '200');
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
-    });
-
     it('refetches immediately (without the debounce) when a select field changes', async () => {
         const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
@@ -189,7 +180,7 @@ describe('useBuyQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
     });
 
-    it('does not refetch when only a non-key field (payment method) changes', async () => {
+    it('does not refetch when only a non-key field (provider) changes', async () => {
         const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
@@ -211,7 +202,7 @@ describe('useBuyQuotes', () => {
             values: {},
             errors: { fiatInput: { type: 'manual', message: 'invalid' } },
         });
-        const { result } = renderBuyQuotes(VALID_DEFAULTS, invalidResolver);
+        const { result } = renderBuyQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
 
         await act(async () => {
             await result.current.trigger();
@@ -219,37 +210,5 @@ describe('useBuyQuotes', () => {
         await wait(700);
 
         expect(mockHandleRequest).not.toHaveBeenCalled();
-    });
-
-    it('refetches on invalid → valid recovery even when the values are identical', async () => {
-        let isValid = true;
-        const resolver: Resolver<TradingBuyFormProps> = (
-            values,
-        ): ResolverResult<TradingBuyFormProps> => {
-            if (isValid) {
-                return { values, errors: {} };
-            }
-
-            return { values: {}, errors: { fiatInput: { type: 'manual', message: 'invalid' } } };
-        };
-        const { result } = renderBuyQuotes(VALID_DEFAULTS, resolver);
-
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
-
-        isValid = false;
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await wait(700);
-        expect(mockHandleRequest).toHaveBeenCalledTimes(1);
-
-        isValid = true;
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts
@@ -1,19 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-    type Control,
-    type UseFormGetValues,
-    type UseFormSetValue,
-    useFormState,
-    useWatch,
-} from 'react-hook-form';
-
-import useDebounce from 'react-use/lib/useDebounce';
+import { type UseFormReturn } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_BUY_RECEIVE_ADDRESS,
-    TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
@@ -23,140 +13,69 @@ import {
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     type TradingBuyFormProps,
     buyThunks,
+    selectTradingSelectedPaymentMethodByType,
     tradingActions,
-    useTradingRefetchScheduler,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type Network } from '@suite-common/wallet-config';
 
 import { useDispatch } from 'src/hooks/suite';
-import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
+import { useStore } from 'src/hooks/suite/useStore';
 import { isBuyQuotesFetchAllowed } from 'src/utils/wallet/trading/buyQuotesRequestUtils';
 
+import { useTradingQuoteRequest } from '../common/useTradingQuoteRequest';
+
 type UseBuyQuotesProps = {
-    control: Control<TradingBuyFormProps>;
-    getValues: UseFormGetValues<TradingBuyFormProps>;
-    setValue: UseFormSetValue<TradingBuyFormProps>;
+    methods: UseFormReturn<TradingBuyFormProps>;
+    network: Network;
+    shouldSendInSats: boolean | undefined;
 };
 
-type AbortableRequest = {
-    abort: (message?: string) => void;
-} | null;
-
-const BUY_QUOTES_KEY_FIELDS = [
+const BUY_IMMEDIATE_FIELDS = [
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
     TRADING_FORM_FIAT_CURRENCY_SELECT,
-    TRADING_FORM_FIAT_INPUT,
-    TRADING_FORM_CRYPTO_INPUT,
     TRADING_BUY_RECEIVE_ADDRESS,
 ] as const;
 
-export const useBuyQuotes = ({ control, getValues, setValue }: UseBuyQuotesProps) => {
+const BUY_DEBOUNCED_FIELDS = [TRADING_FORM_FIAT_INPUT, TRADING_FORM_CRYPTO_INPUT] as const;
+
+export const useBuyQuotes = ({ methods, network, shouldSendInSats }: UseBuyQuotesProps) => {
     const dispatch = useDispatch();
+    const store = useStore();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
-    const previousRequest = useRef<AbortableRequest>(null);
-
-    // TODO: source control/getValues/setValue via useFormContext() once the trading-form family migrates to FormProvider
-    useWatch({ control, name: BUY_QUOTES_KEY_FIELDS });
-    const { isValid } = useFormState({ control });
-
-    const values = getValues();
-
-    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(
-        values.cryptoSelect?.networkSymbol,
-    );
-    const isFetchAllowed = isValid && isBuyQuotesFetchAllowed(values);
-
-    const amountKey = JSON.stringify({
-        fiatInput: values.fiatInput,
-        cryptoInput: values.cryptoInput,
-    });
-    const selectKey = JSON.stringify({
-        cryptoId: values.cryptoSelect?.id,
-        country: values.countrySelect?.value,
-        countrySubdivision: values.countrySubdivisionSelect?.value,
-        currency: values.currencySelect?.value,
-        receiveAddress: values.receiveAddress,
-    });
-
-    const fetchQuotes = useCallback(async () => {
-        const formValues = getValues();
-        const network = getNetwork(
-            formValues.cryptoSelect?.networkSymbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY,
-        );
-
-        if (previousRequest.current) {
-            previousRequest.current.abort('Request was replaced by another one.');
-        }
-
-        const request = dispatch(
-            buyThunks.handleRequestThunk({ formValues, network, shouldSendInSats }),
-        );
-        previousRequest.current = request;
-
-        try {
-            const quotes = await request.unwrap();
-
+    const { isScheduledQuotesRefresh } = useTradingQuoteRequest({
+        methods,
+        immediateFields: BUY_IMMEDIATE_FIELDS,
+        debouncedFields: BUY_DEBOUNCED_FIELDS,
+        isFetchAllowed: isBuyQuotesFetchAllowed,
+        requestQuotes: values =>
+            dispatch(
+                buyThunks.handleRequestThunk({ formValues: values, network, shouldSendInSats }),
+            ),
+        stopScheduler: () => dispatch(tradingActions.stopRefetchQuotes()),
+        onResolved: (quotes, values) => {
             analytics.report({
                 type: events.tradeReceivedQuotesEvent.name,
                 payload: {
                     type: 'buy',
-                    count: quotes?.length ?? 0,
+                    count: quotes.length,
                 },
             });
 
-            if (quotes) {
-                const bestQuote = quotes[0];
-                const bestQuotePaymentMethod = bestQuote?.paymentMethod;
-                const bestQuotePaymentMethodName =
-                    bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
-                const paymentMethodSelected = formValues.paymentMethod?.value;
-                const isSelectedPaymentMethodAvailable = quotes.some(
-                    quote => quote.paymentMethod === paymentMethodSelected,
-                );
+            const selectedPaymentMethod = values.paymentMethod?.value;
+            const paymentMethodOption = selectTradingSelectedPaymentMethodByType(
+                store.getState(),
+                'buy',
+                selectedPaymentMethod,
+            );
 
-                if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
-                    setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
-                        value: bestQuotePaymentMethod ?? '',
-                        label: bestQuotePaymentMethodName ?? '',
-                    });
-                }
+            if (paymentMethodOption && paymentMethodOption.value !== selectedPaymentMethod) {
+                methods.setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, paymentMethodOption);
             }
-        } catch (error) {
-            console.warn('Request was aborted:', error instanceof Error ? error.message : error);
-        }
-    }, [dispatch, getValues, shouldSendInSats, analytics, setValue]);
-
-    // Refetch if anything is being typed into the text fields, but debounced. Select fields are not debounced.
-    const [debouncedAmountKey, setDebouncedAmountKey] = useState(amountKey);
-    useDebounce(() => setDebouncedAmountKey(amountKey), 500, [amountKey]);
-
-    useEffect(() => {
-        if (isFetchAllowed) {
-            fetchQuotes();
-        }
-        // Reactivity on combination of fields, using the compouneded keys.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [debouncedAmountKey, selectKey, isFetchAllowed]);
-
-    useTradingRefetchScheduler({
-        onRefetch: () => {
-            if (!isFetchAllowed) {
-                return;
-            }
-            fetchQuotes();
         },
     });
 
-    useEffect(
-        () => () => {
-            if (previousRequest.current) {
-                previousRequest.current.abort('Request is canceled - page is unmounted.');
-            }
-            dispatch(tradingActions.stopRefetchQuotes());
-        },
-        [dispatch],
-    );
+    return { isScheduledQuotesRefresh };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
@@ -28,6 +28,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingCurrencySwitcher } from 'src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher';
 import { useServerEnvironment } from 'src/hooks/wallet/trading/useServerEnviroment';
+import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 import { type TradingBuyFormContextProps } from 'src/types/trading/tradingForm';
 
 import { useBuyFlow } from './useBuyFlow';
@@ -105,12 +106,14 @@ export const useTradingBuyForm = (): TradingBuyFormContextProps => {
     const noProviders = buyInfo?.buyInfo?.providers.length === 0;
     const formIsValid = Object.keys(formState.errors).length === 0;
     const hasValues = (fiatInput || cryptoInput) && !!currencySelect?.value;
-    const isFormLoading = formState.isSubmitting || isLoading;
+    const isFormLoadingBase = formState.isSubmitting || isLoading;
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     // based on selected cryptoSymbol, because of using for validation cryptoInput
     const network = getNetwork(cryptoSelect?.networkSymbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY);
+    const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(
+        cryptoSelect?.networkSymbol,
+    );
 
     const { toggleAmountInCrypto: baseToggleAmountInCrypto } = useTradingCurrencySwitcher({
         account,
@@ -128,7 +131,10 @@ export const useTradingBuyForm = (): TradingBuyFormContextProps => {
         baseToggleAmountInCrypto();
     };
 
-    useBuyQuotes({ control, getValues, setValue });
+    const { isScheduledQuotesRefresh } = useBuyQuotes({ methods, network, shouldSendInSats });
+
+    const isFormLoading = isFormLoadingBase || isScheduledQuotesRefresh;
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     useEffect(() => {
         setValue('receiveAddress', receiveAddress);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts
@@ -4,7 +4,7 @@ import { type FieldPath, type FieldValues, type UseFormReturn } from 'react-hook
 import { useTradingRefetchScheduler } from '@suite-common/trading';
 import { useCurrentRef } from '@trezor/react-utils';
 
-const DEBOUNCE_DELAY_MS = 500;
+export const DEBOUNCE_DELAY_MS = 500;
 
 type AbortableRequest<TResult> = {
     abort: () => void;
@@ -16,7 +16,7 @@ type UseTradingQuoteRequestProps<TFormProps extends FieldValues, TResult> = {
     immediateFields: readonly FieldPath<TFormProps>[];
     debouncedFields: readonly FieldPath<TFormProps>[];
     isFetchAllowed: (values: TFormProps) => boolean;
-    requestQuotes: (values: TFormProps) => AbortableRequest<TResult>;
+    requestQuotes: (values: TFormProps) => AbortableRequest<TResult> | null;
     stopScheduler: () => void;
     onResolved?: (result: TResult, values: TFormProps) => void;
     isRequestContextAvailable?: boolean;
@@ -89,9 +89,16 @@ export const useTradingQuoteRequest = <TFormProps extends FieldValues, TResult>(
 
         const currentValues = methods.getValues();
 
+        const request = configRef.current.requestQuotes(currentValues);
+
+        if (!request) {
+            stopQuoteRequests();
+
+            return;
+        }
+
         setIsScheduledQuotesRefresh(true);
 
-        const request = configRef.current.requestQuotes(currentValues);
         signal.addEventListener('abort', () => request.abort(), { once: true });
         isQuoteLifecycleActive.current = true;
 

--- a/packages/suite/src/hooks/wallet/trading/form/sell/__tests__/useSellQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/__tests__/useSellQuotes.test.tsx
@@ -1,18 +1,34 @@
-import { type Resolver, type ResolverResult, useForm } from 'react-hook-form';
+import { type Resolver, useForm } from 'react-hook-form';
 
 import { act, waitFor } from '@testing-library/react';
 import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
-import { type TradingAssetSellOption, type TradingSellFormProps } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import {
+    type TradingAssetSellOption,
+    type TradingSellFormProps,
+    sellInitialState,
+    initialState as tradingInitialState,
+} from '@suite-common/trading';
+import { type Network, getNetwork } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { useSellQuotes } from './useSellQuotes';
+import { DEBOUNCE_DELAY_MS } from '../../common/useTradingQuoteRequest';
+import { useSellQuotes } from '../useSellQuotes';
 
 const QUOTES: SellFiatTrade[] = [
-    { paymentMethod: 'bankTransfer', paymentMethodName: 'Bank transfer', exchange: 'provider-1' },
-    { paymentMethod: 'creditCard', paymentMethodName: 'Credit card', exchange: 'provider-2' },
+    {
+        paymentMethod: 'bankTransfer',
+        paymentMethodName: 'Bank transfer',
+        exchange: 'provider-1',
+        rate: 2,
+    },
+    {
+        paymentMethod: 'creditCard',
+        paymentMethodName: 'Credit card',
+        exchange: 'provider-2',
+        rate: 1,
+    },
 ];
 
 const mockAbort = jest.fn();
@@ -21,6 +37,7 @@ const mockHandleRequest = jest.fn((payload: unknown) => {
 
     return Object.assign(thunk, { payload });
 });
+const mockClearQuotes = jest.fn();
 
 jest.mock('@suite-common/dependency-injection', () => ({
     ...jest.requireActual('@suite-common/dependency-injection'),
@@ -35,6 +52,14 @@ jest.mock('@suite-common/trading', () => {
         sellThunks: {
             ...actual.sellThunks,
             handleRequestThunk: (payload: unknown) => mockHandleRequest(payload),
+        },
+        tradingSellActions: {
+            ...actual.tradingSellActions,
+            clearQuotes: () => {
+                mockClearQuotes();
+
+                return actual.tradingSellActions.clearQuotes();
+            },
         },
     };
 });
@@ -90,6 +115,8 @@ const VALID_DEFAULTS: TradingSellFormProps = {
     selectedUtxos: [],
 };
 
+const NO_REFETCH_WAIT_MS = DEBOUNCE_DELAY_MS + 200;
+
 const wait = (ms: number) =>
     act(
         () =>
@@ -100,37 +127,41 @@ const wait = (ms: number) =>
 
 const renderSellQuotes = (
     defaultValues: TradingSellFormProps,
-    resolver?: Resolver<TradingSellFormProps>,
+    options: { resolver?: Resolver<TradingSellFormProps> } = {},
 ) => {
+    const { resolver } = options;
+    const initialProps: { currentNetwork: Network | undefined } = {
+        currentNetwork: getNetwork('btc'),
+    };
+
     const store = configureMockStore({
         preloadedState: {
             wallet: {
                 trading: {
-                    quoteRefetchingState: { status: 'idle', lastFetchTimestamp: null },
+                    ...tradingInitialState,
+                    sell: { ...sellInitialState, quotes: QUOTES },
                 },
             },
         },
     });
 
     return renderHookWithStoreProvider(
-        () => {
+        ({ currentNetwork }) => {
             const methods = useForm<TradingSellFormProps>({
                 mode: 'onChange',
                 defaultValues,
                 resolver,
             });
             useSellQuotes({
-                control: methods.control,
-                getValues: methods.getValues,
-                setValue: methods.setValue,
-                network: getNetwork('btc'),
+                methods,
+                network: currentNetwork,
                 shouldSendInSats: false,
                 composeRequestCallback: jest.fn(),
             });
 
             return methods;
         },
-        { store },
+        { store, initialProps },
     );
 };
 
@@ -138,6 +169,7 @@ describe('useSellQuotes', () => {
     beforeEach(() => {
         mockHandleRequest.mockClear();
         mockAbort.mockClear();
+        mockClearQuotes.mockClear();
     });
 
     it('dispatches a quotes request after the debounce when the form is valid', async () => {
@@ -173,25 +205,6 @@ describe('useSellQuotes', () => {
         );
     });
 
-    it('debounces the refetch when the crypto amount changes', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
-
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
-
-        await act(async () => {
-            result.current.setValue('outputs.0.amount', '0.003');
-            await result.current.trigger();
-        });
-
-        await wait(150);
-        expect(mockHandleRequest).toHaveBeenCalledTimes(1);
-
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
-    });
-
     it('refetches immediately (without the debounce) when a select field changes', async () => {
         const { result } = renderSellQuotes(VALID_DEFAULTS);
 
@@ -208,6 +221,28 @@ describe('useSellQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 200 });
     });
 
+    it('does not refetch on an output-fiat edit but does on the synced output-amount edit', async () => {
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
+
+        await act(async () => {
+            await result.current.trigger();
+        });
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+
+        await act(async () => {
+            result.current.setValue('outputs.0.fiat', '99');
+            await result.current.trigger();
+        });
+        await wait(NO_REFETCH_WAIT_MS);
+        expect(mockHandleRequest).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            result.current.setValue('outputs.0.amount', '0.003');
+            await result.current.trigger();
+        });
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
+    });
+
     it('does not refetch when only a non-key field (provider) changes', async () => {
         const { result } = renderSellQuotes(VALID_DEFAULTS);
 
@@ -220,7 +255,7 @@ describe('useSellQuotes', () => {
             result.current.setValue('provider', 'provider-2');
             await result.current.trigger();
         });
-        await wait(700);
+        await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).toHaveBeenCalledTimes(1);
     });
@@ -230,45 +265,24 @@ describe('useSellQuotes', () => {
             values: {},
             errors: { feePerUnit: { type: 'manual', message: 'invalid' } },
         });
-        const { result } = renderSellQuotes(VALID_DEFAULTS, invalidResolver);
+        const { result } = renderSellQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
 
         await act(async () => {
             await result.current.trigger();
         });
-        await wait(700);
+        await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).not.toHaveBeenCalled();
     });
 
-    it('refetches on invalid → valid recovery even when the values are identical', async () => {
-        let isValid = true;
-        const resolver: Resolver<TradingSellFormProps> = (
-            values,
-        ): ResolverResult<TradingSellFormProps> => {
-            if (isValid) {
-                return { values, errors: {} };
-            }
+    it('clears quotes eagerly when the network becomes undefined', async () => {
+        const { rerender } = renderSellQuotes(VALID_DEFAULTS);
 
-            return { values: {}, errors: { feePerUnit: { type: 'manual', message: 'invalid' } } };
-        };
-        const { result } = renderSellQuotes(VALID_DEFAULTS, resolver);
-
-        await act(async () => {
-            await result.current.trigger();
-        });
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        expect(mockClearQuotes).not.toHaveBeenCalled();
 
-        isValid = false;
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await wait(700);
-        expect(mockHandleRequest).toHaveBeenCalledTimes(1);
+        rerender({ currentNetwork: undefined });
 
-        isValid = true;
-        await act(async () => {
-            await result.current.trigger();
-        });
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
+        await waitFor(() => expect(mockClearQuotes).toHaveBeenCalled());
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts
@@ -1,13 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-    type Control,
-    type UseFormGetValues,
-    type UseFormSetValue,
-    useFormState,
-    useWatch,
-} from 'react-hook-form';
-
-import useDebounce from 'react-use/lib/useDebounce';
+import { useEffect } from 'react';
+import { type UseFormReturn } from 'react-hook-form';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -16,169 +8,93 @@ import {
     TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_CURRENCY,
-    TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_PAYMENT_METHOD_SELECT,
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingSellFormProps,
+    selectTradingSelectedPaymentMethodByType,
     sellThunks,
     tradingActions,
     tradingSellActions,
-    useTradingRefetchScheduler,
 } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
 
 import { useDispatch } from 'src/hooks/suite';
+import { useStore } from 'src/hooks/suite/useStore';
 import { isSellQuotesFetchAllowed } from 'src/utils/wallet/trading/sellQuotesRequestUtils';
 
+import { useTradingQuoteRequest } from '../common/useTradingQuoteRequest';
+
 type UseSellQuotesProps = {
-    control: Control<TradingSellFormProps>;
-    getValues: UseFormGetValues<TradingSellFormProps>;
-    setValue: UseFormSetValue<TradingSellFormProps>;
+    methods: UseFormReturn<TradingSellFormProps>;
     network: Network | undefined;
     shouldSendInSats: boolean | undefined;
     composeRequestCallback: () => void;
 };
 
-type AbortableRequest = {
-    abort: (message?: string) => void;
-} | null;
-
-const SELL_QUOTES_KEY_FIELDS = [
+const SELL_IMMEDIATE_FIELDS = [
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_COUNTRY_SELECT,
     TRADING_FORM_COUNTRY_SUBDIVISION_SELECT,
     TRADING_FORM_OUTPUT_CURRENCY,
-    TRADING_FORM_OUTPUT_FIAT,
-    TRADING_FORM_OUTPUT_AMOUNT,
 ] as const;
 
+const SELL_DEBOUNCED_FIELDS = [TRADING_FORM_OUTPUT_AMOUNT] as const;
+
 export const useSellQuotes = ({
-    control,
-    getValues,
-    setValue,
+    methods,
     network,
     shouldSendInSats,
     composeRequestCallback,
 }: UseSellQuotesProps) => {
     const dispatch = useDispatch();
+    const store = useStore();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
-    const previousRequest = useRef<AbortableRequest>(null);
-
-    // TODO: source control/getValues/setValue via useFormContext() once the trading-form family  migrates to FormProvider
-    useWatch({ control, name: SELL_QUOTES_KEY_FIELDS });
-    const { isValid } = useFormState({ control });
-
-    const values = getValues();
-    const isFetchAllowed = isValid && isSellQuotesFetchAllowed(values);
-
-    const output = values.outputs?.[0];
-    const amountKey = JSON.stringify({
-        amount: output?.amount,
-    });
-    const selectKey = JSON.stringify({
-        cryptoId: values.sendCryptoSelect?.id,
-        accountKey: values.sendCryptoSelect?.accountKey,
-        country: values.countrySelect?.value,
-        countrySubdivision: values.countrySubdivisionSelect?.value,
-        currency: output?.currency?.value,
-    });
-
-    const fetchQuotes = useCallback(async () => {
-        if (!network) {
-            if (previousRequest.current) {
-                previousRequest.current.abort('Request was canceled - no asset selected.');
-            }
-            dispatch(tradingSellActions.clearQuotes());
-
-            return;
-        }
-
-        const formValues = getValues();
-
-        if (previousRequest.current) {
-            previousRequest.current.abort('Request was replaced by another one.');
-        }
-
-        const request = dispatch(
-            sellThunks.handleRequestThunk({
-                formValues,
-                network,
-                shouldSendInSats,
-                composeRequestCallback,
-            }),
-        );
-        previousRequest.current = request;
-
-        try {
-            const quotes = await request.unwrap();
-
+    const { isScheduledQuotesRefresh } = useTradingQuoteRequest({
+        methods,
+        immediateFields: SELL_IMMEDIATE_FIELDS,
+        debouncedFields: SELL_DEBOUNCED_FIELDS,
+        isFetchAllowed: isSellQuotesFetchAllowed,
+        requestQuotes: values =>
+            network
+                ? dispatch(
+                      sellThunks.handleRequestThunk({
+                          formValues: values,
+                          network,
+                          shouldSendInSats,
+                          composeRequestCallback,
+                      }),
+                  )
+                : null,
+        stopScheduler: () => dispatch(tradingActions.stopRefetchQuotes()),
+        onResolved: (quotes, values) => {
             analytics.report({
                 type: events.tradeReceivedQuotesEvent.name,
                 payload: {
                     type: 'sell',
-                    count: quotes?.length ?? 0,
+                    count: quotes.length,
                 },
             });
 
-            if (quotes) {
-                const bestQuote = quotes[0];
-                const bestQuotePaymentMethod = bestQuote?.paymentMethod;
-                const bestQuotePaymentMethodName =
-                    bestQuote?.paymentMethodName ?? bestQuotePaymentMethod;
-                const paymentMethodSelected = formValues.paymentMethod?.value;
-                const isSelectedPaymentMethodAvailable = quotes.some(
-                    quote => quote.paymentMethod === paymentMethodSelected,
-                );
+            const selectedPaymentMethod = values.paymentMethod?.value;
+            const paymentMethodOption = selectTradingSelectedPaymentMethodByType(
+                store.getState(),
+                'sell',
+                selectedPaymentMethod,
+            );
 
-                if (!paymentMethodSelected || !isSelectedPaymentMethodAvailable) {
-                    setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, {
-                        value: bestQuotePaymentMethod ?? '',
-                        label: bestQuotePaymentMethodName ?? '',
-                    });
-                }
+            if (paymentMethodOption && paymentMethodOption.value !== selectedPaymentMethod) {
+                methods.setValue(TRADING_FORM_PAYMENT_METHOD_SELECT, paymentMethodOption);
             }
-        } catch (error) {
-            console.warn('Request was aborted:', error instanceof Error ? error.message : error);
-        }
-    }, [
-        dispatch,
-        getValues,
-        network,
-        shouldSendInSats,
-        composeRequestCallback,
-        analytics,
-        setValue,
-    ]);
-
-    // Refetch if anything is being typed into the text fields, but debounced. Select fields are not debounced.
-    const [debouncedAmountKey, setDebouncedAmountKey] = useState(amountKey);
-    useDebounce(() => setDebouncedAmountKey(amountKey), 500, [amountKey]);
-
-    useEffect(() => {
-        if (isFetchAllowed) {
-            fetchQuotes();
-        }
-        // Reactivity on combination of fields, using the compouneded keys.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [debouncedAmountKey, selectKey, isFetchAllowed]);
-
-    useTradingRefetchScheduler({
-        onRefetch: () => {
-            if (!isFetchAllowed) {
-                return;
-            }
-            fetchQuotes();
         },
+        isRequestContextAvailable: !!network,
     });
 
-    useEffect(
-        () => () => {
-            if (previousRequest.current) {
-                previousRequest.current.abort('Request is canceled - page is unmounted.');
-            }
-            dispatch(tradingActions.stopRefetchQuotes());
-        },
-        [dispatch],
-    );
+    useEffect(() => {
+        if (!network) {
+            dispatch(tradingSellActions.clearQuotes());
+        }
+    }, [network, dispatch]);
+
+    return { isScheduledQuotesRefresh };
 };

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts
@@ -113,10 +113,9 @@ export const useTradingSellForm = (): TradingSellFormContextProps => {
         setShowReserveBanner,
     });
 
-    const isFormLoading =
+    const isFormLoadingBase =
         isInitialDataLoading || formState.isSubmitting || isLoading || isComposing;
     const isFormInvalid = !(formIsValid && hasValues);
-    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const { toggleAmountInCrypto } = useTradingCurrencySwitcher<TradingSellFormProps>({
         account,
@@ -127,16 +126,17 @@ export const useTradingSellForm = (): TradingSellFormContextProps => {
         },
     });
 
-    useSellQuotes({
-        control,
-        getValues,
-        setValue,
+    const { isScheduledQuotesRefresh } = useSellQuotes({
+        methods,
         network,
         shouldSendInSats,
         composeRequestCallback: () => {
             composeRequest(TRADING_FORM_OUTPUT_AMOUNT);
         },
     });
+
+    const isFormLoading = isFormLoadingBase || isScheduledQuotesRefresh;
+    const isLoadingOrInvalid = noProviders || isFormLoading || isFormInvalid;
 
     const helpers = useSellFormInputs({
         account,


### PR DESCRIPTION
## Description

Migrates buy & sell quotes onto the generic `useTradingQuoteRequest` hook (exchange already runs on it). Part of #26280 Phase 3. Also fixes a no-offer flash — folds `isScheduledQuotesRefresh` into `isFormLoading` so "no offer" no longer blinks during the debounce/fetch window.

## Notes for QA

Buy & sell: typing an amount must **not** flash "no offer" before quotes load; payment method still auto-selects. Sell: quotes clear when the send asset is deselected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30213

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the core buy/sell quote-fetching hooks (useBuyQuotes, useSellQuotes) and their shared quote-request logic (useTradingQuoteRequest), along with the form initialization hooks (useTradingBuyForm, useTradingSellForm). These are central to all trading buy/sell flows, so the highest priority is given to E2E tests that directly exercise quote fetching, best-offer selection, and form validation across multiple assets (BTC, ETH, SOL, tokens). Navigation and dashboard asset tests are included at lower priority since they touch the same hooks but focus on other behaviors. The two unit test files changed have no E2E mapping since they are Jest/unit tests validating the hooks directly, and the useTradingQuoteRequest.ts file has no direct static mapping but is inferred to be exercised by all buy/sell quote tests since it's shared logic used by both useBuyQuotes and useSellQuotes.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/buy/__tests__/useBuyQuotes.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.ts`
- `packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts`
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingQuoteRequest.ts`
- `packages/suite/src/hooks/wallet/trading/form/sell/__tests__/useSellQuotes.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.ts`
- `packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly exercises the buy quotes flow (best offer calculation, provider selection, quote request/response handling) which is the core logic changed in useBuyQuotes.ts and useTradingQuoteRequest.ts.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Covers the full buy quote-to-confirmation flow (best offer amount, quote sync) for a different asset, directly touching useBuyQuotes and useTradingBuyForm logic changed in this PR.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Explicitly tests edge cases of the buy quote request (min/max limits, empty quotes, disabled best-offer button) which is precisely the logic being modified in useBuyQuotes.ts and useTradingQuoteRequest.ts.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Exercises the buy quote sync and best offer display for an SPL token, directly validating the changed useBuyQuotes/useTradingBuyForm quote-fetching behavior across a different asset type.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Directly exercises the sell quote flow (best offer, provider display) which maps to useSellQuotes.ts and useTradingSellForm.ts, both changed in this PR.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Validates sell form input handling, percentage buttons, and quote syncing across multiple assets (BTC, SOL), directly exercising useSellQuotes/useTradingSellForm and the shared quote request hook.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Exercises the full sell quote-to-confirmation flow including offer comparison and best offer selection, directly touching the changed useSellQuotes/useTradingSellForm and useTradingQuoteRequest logic.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Verifies that buy/sell/swap forms open correctly for various entry points and preselect the correct currency; this depends on useTradingBuyForm/useTradingSellForm initialization logic but doesn't exercise quote-fetching itself as deeply as other tests.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Includes a buy button navigation test that touches useTradingBuyForm/useBuyQuotes indirectly, but the primary focus of this test is asset activation/discovery, not quote logic, so risk is lower.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/wallet/trading/form/buy/__tests__/useBuyQuotes.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/sell/__tests__/useSellQuotes.test.tsx`

_Updated: 2026-07-28T12:48:33.775Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/14-buysell-quotes-migration/web/](https://dev.suite.sldev.cz/suite-web/refactor/14-buysell-quotes-migration/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/14-buysell-quotes-migration&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/14-buysell-quotes-migration&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:52:03.045Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:51:39.772Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->