### PR TITLE
fix(suite): Allow activity tab without connected device

### DIFF
--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -130,6 +130,11 @@ export const isPrerequisiteGloballyExcluded = ({
         return true;
     }
 
+    // Activity (notifications) page does not depend on a connected device
+    if (router.app === 'notifications') {
+        return true;
+    }
+
     if (router.route?.name.startsWith('wallet-trading')) {
         return true;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- it's possible to open activity page without connected device

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change touches a shared prerequisites utility that maps statically to nearly all 134 E2E tests, indicating it's a broad/global dependency (likely computing gating conditions like firmware checks, device connection, analytics consent, or onboarding step readiness). Since almost every test transitively imports it, we apply the broad-utility heuristic and only recommend tests that directly exercise prerequisite-driven behaviors visible in their descriptions (onboarding gating, firmware/authenticity checks, initial-run persistence, and disconnected-device banners). Recommended strategy: run the onboarding and initial-run tests at medium priority as primary regression signal, with a couple of low-priority downstream flow tests as secondary checks, rather than the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/utils/suite/prerequisites.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The prerequisites util likely governs conditions (e.g. firmware/analytics/device checks) used to gate onboarding flow steps; this test directly exercises the onboarding prerequisite gating (analytics consent) and would surface regressions in prerequisite logic.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Authenticity check onboarding flow depends on prerequisite checks (firmware hash/revision, debug mode) that this util likely computes, making it a direct candidate to catch regressions in prerequisite evaluation logic.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — This test specifically validates firmware readiness detection during onboarding, which is a core prerequisite check likely implemented or affected by this utility file.
- `suite/e2e/tests/suite/initial-run.test.ts` — Initial run/onboarding persistence logic relies on prerequisite state (analytics consent, device connection, THP pairing) to determine what screens are shown across reloads, directly exercising prerequisite evaluation.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test validates prerequisite-driven UI states (disconnected device banners, connection modals) that would directly regress if device-connection prerequisite logic is broken.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Backup flow prerequisite gating (e.g., needs_backup state, device connection) could be affected, but this is a downstream flow rather than a direct prerequisite check test.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Recovery dry-run flow reinitializes after disconnect/reload, which depends on prerequisite-like state evaluation; a regression could plausibly appear here but it's an indirect flow.

</details>

_Updated: 2026-07-27T11:24:21.471Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/dcq-activity/web/](https://dev.suite.sldev.cz/suite-web/dcq-activity/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=dcq-activity&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=dcq-activity&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=dcq-activity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T11:27:12.397Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T11:26:57.489Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->