### PR TITLE
chore(wallet): change Robinhood representative tokens to avoid dups

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -283,7 +283,7 @@ export const networks = {
         decimals: 18,
         testnet: false,
         explorer: getExplorerUrls('https://robinscan.io', 'ethereum'),
-        features: ['rbf', 'sign-verify', 'tokens', 'coin-definitions', 'graph'],
+        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'coin-definitions', 'graph'],
         backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {

--- a/suite-common/wallet-config/src/representativeAssets.ts
+++ b/suite-common/wallet-config/src/representativeAssets.ts
@@ -52,9 +52,9 @@ const representativeAssets: Partial<Record<NetworkSymbol, readonly Representativ
     rhc: [
         { symbol: 'ETH' },
         { symbol: 'USDG', contract: '0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168' },
-        { symbol: 'AAPL', contract: '0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9' },
+        { symbol: 'USDE', contract: '0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34' },
+        { symbol: 'VIRTUAL', contract: '0xc6911796042b15d7fa4f6cde69e245ddcd3d9c31' },
         { symbol: 'NVDA', contract: '0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC' },
-        { symbol: 'TSLA', contract: '0x322F0929c4625eD5bAd873c95208D54E1c003b2d' },
     ],
     avax: [
         { symbol: 'AVAX' },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- update representative assets of robinhood to avoid robinhood icon duplicates
- enable nfts, there are no nft definitions unfortunately

## Screenshots:

<img width="591" height="117" alt="Screenshot 2026-07-27 at 10 19 11" src="https://github.com/user-attachments/assets/1d7647e5-732d-4f04-8520-ddc3e0125856" />

<img width="1258" height="580" alt="Screenshot 2026-07-27 at 12 38 55" src="https://github.com/user-attachments/assets/80317cff-10fb-4f03-a7d8-adeace53d41c" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/representativeAssets.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-27T08:24:58.498Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/assets-robinhood/web/](https://dev.suite.sldev.cz/suite-web/chore/assets-robinhood/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/assets-robinhood&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/assets-robinhood&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/assets-robinhood&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T08:28:08.203Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T08:27:58.022Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->