### PR TITLE
fix(components): declare Storybook Babel presets

### DIFF
--- a/packages/components/.depcheckrc.json
+++ b/packages/components/.depcheckrc.json
@@ -2,7 +2,9 @@
     "ignore-patterns": ["libDev", "lib"],
     "ignores": [
         "stylelint-config-standard",
+        "@babel/preset-env",
         "@babel/preset-react",
+        "@babel/preset-typescript",
         "postcss-styled-syntax",
         "typescript-styled-plugin",
         "@storybook/react-webpack5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,9 @@
         "styled-components": "^6.3.9"
     },
     "devDependencies": {
+        "@babel/preset-env": "7.29.7",
         "@babel/preset-react": "^7.29.7",
+        "@babel/preset-typescript": "^7.29.7",
         "@storybook/addon-docs": "^10.3.4",
         "@storybook/addon-links": "^10.3.4",
         "@storybook/react": "^10.3.4",

--- a/packages/product-components/.depcheckrc.json
+++ b/packages/product-components/.depcheckrc.json
@@ -2,7 +2,9 @@
     "ignore-patterns": ["libDev", "lib"],
     "ignores": [
         "stylelint-config-standard",
+        "@babel/preset-env",
         "@babel/preset-react",
+        "@babel/preset-typescript",
         "postcss-styled-syntax",
         "typescript-styled-plugin",
         "@storybook/react-webpack5",

--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -47,7 +47,9 @@
         "zxcvbn": "^4.4.2"
     },
     "devDependencies": {
+        "@babel/preset-env": "7.29.7",
         "@babel/preset-react": "^7.29.7",
+        "@babel/preset-typescript": "^7.29.7",
         "@storybook/addon-docs": "^10.3.4",
         "@storybook/addon-links": "^10.3.4",
         "@storybook/react": "^10.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16069,7 +16069,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/components@workspace:packages/components"
   dependencies:
+    "@babel/preset-env": "npm:7.29.7"
     "@babel/preset-react": "npm:^7.29.7"
+    "@babel/preset-typescript": "npm:^7.29.7"
     "@floating-ui/react": "npm:^0.27.17"
     "@storybook/addon-docs": "npm:^10.3.4"
     "@storybook/addon-links": "npm:^10.3.4"
@@ -16570,7 +16572,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/product-components@workspace:packages/product-components"
   dependencies:
+    "@babel/preset-env": "npm:7.29.7"
     "@babel/preset-react": "npm:^7.29.7"
+    "@babel/preset-typescript": "npm:^7.29.7"
     "@storybook/addon-docs": "npm:^10.3.4"
     "@storybook/addon-links": "npm:^10.3.4"
     "@storybook/react": "npm:^10.3.4"


### PR DESCRIPTION
## Description

Declare `@babel/preset-env` and `@babel/preset-typescript` in both Storybook workspaces and update the lockfile.

The nightly Storybook deployment uses a focused install for `@trezor/components` and `@trezor/product-components`. Their Webpack configurations reference these presets directly, but the packages did not declare them. The presets were previously available only through incidental Yarn hoisting from `@trezor/transport`; after the transport dependency refactor removed that provider, the components Storybook build started failing with `Cannot find package '@babel/preset-env'`, and the deployment steps were skipped.

This makes each Storybook workspace own its build-time dependencies and restores focused-install builds.

Failing run: https://github.com/trezor/trezor-suite/actions/runs/30227683620/job/89860600058

## Notes for QA

No application runtime behavior changes. Verified locally with the same focused workspace install used by CI, followed by successful production builds of both Storybooks:

- `yarn workspaces focus @trezor/components @trezor/product-components`
- `yarn workspace @trezor/components storybook-build`
- `yarn workspace @trezor/product-components storybook-build`
- `yarn constraints`
- `git diff --check`

## Related Issue

N/A

## Screenshots

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/agent/fix-storybook-babel-presets/web/](https://dev.suite.sldev.cz/suite-web/agent/fix-storybook-babel-presets/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=agent/fix-storybook-babel-presets&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=agent/fix-storybook-babel-presets&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:51:50.080Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:51:34.539Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (4)</b></summary>

- `packages/components/.depcheckrc.json`
- `packages/components/package.json`
- `packages/product-components/.depcheckrc.json`
- `packages/product-components/package.json`

</details>

_No test recommendations found._

_Updated: 2026-07-27T09:48:27.121Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->