### PR TITLE
fix(connect): restrict getPublicKey to bitcoin-like coins

### DIFF
--- a/packages/connect/src/api/getPublicKey.ts
+++ b/packages/connect/src/api/getPublicKey.ts
@@ -7,6 +7,7 @@ import {
     UI_REQUEST,
     createUiMessage,
 } from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 import { Assert } from '@trezor/schema-utils';
 
@@ -19,7 +20,7 @@ import { validatePath } from '../utils/pathUtils';
 
 type Params = {
     proto: PROTO.GetPublicKey;
-    coinInfo?: BitcoinNetworkInfo;
+    coinInfo: BitcoinNetworkInfo;
     suppressBackupWarning?: boolean;
     unlockPath?: PROTO.UnlockPath;
 };
@@ -41,16 +42,21 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
             if (coinInfo && !batch.crossChain) {
                 validateCoinPath(address_n, coinInfo);
             } else if (!coinInfo) {
-                // NOTE: Some 3rd parties are calling getPublicKey with non-bitcoin coins, like "ETH".
-                // This is incorrect usage, but we need to keep backward compatibility.
-                // So if no coin is provided, we will keep coinInfo undefined, which will
-                // lead to getPublicKeyLabel returning a label based on the path
-                coinInfo = getBitcoinNetwork(address_n); // ?? getBitcoinNetwork('btc')!;
+                // coin not provided (or not bitcoin-like), try to derive network from the path
+                coinInfo = getBitcoinNetwork(address_n);
+            }
+
+            if (!coinInfo) {
+                // Non-bitcoin-like networks (e.g. "eth") used to be silently accepted here and
+                // fall back to btc for backward compatibility. Since connect 10 getPublicKey only
+                // supports bitcoin-like coins, so a network that resolves via neither the coin nor
+                // the path is rejected.
+                throw ERRORS.TypedError('Method_UnknownCoin');
             }
 
             const proto = {
                 address_n,
-                coin_name: coinInfo?.name,
+                coin_name: coinInfo.name,
                 show_display: batch.showOnTrezor,
                 script_type: batch.scriptType,
                 ignore_xpub_magic: batch.ignoreXpubMagic,
@@ -109,9 +115,7 @@ export default class GetPublicKey extends AbstractMethod<'getPublicKey', Params[
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const batch: (typeof params)[number] = params[i];
             const { coinInfo, unlockPath, proto } = batch;
-            // if coinInfo is not provided, use fallback (see above in init method)
-            const coinInfoFallback = coinInfo ?? getBitcoinNetwork('btc')!;
-            const response = await cmd.getHDNode(proto, { coinInfo: coinInfoFallback, unlockPath });
+            const response = await cmd.getHDNode(proto, { coinInfo, unlockPath });
             responses.push(response);
 
             if (this.hasBundle) {


### PR DESCRIPTION
## Description

`getPublicKey` previously accepted non-bitcoin coins (e.g. `coin: "eth"`) and silently fell back to `btc` for backward compatibility. Since connect 10 this is no longer supported: a request whose network resolves via neither the `coin` param nor the derivation path is now rejected with `Method_UnknownCoin`, mirroring the existing `getAddress` pattern (resolve from coin, else from path, then throw). As a result `Params.coinInfo` is now guaranteed defined, so the `?? getBitcoinNetwork('btc')` fallback in `run()` was removed. Note it still throws only after attempting path-based derivation, so a valid bitcoin path with an unresolved/non-bitcoin `coin` continues to work.

## Notes for QA

Focus on `TrezorConnect.getPublicKey`: bitcoin-like coins (btc/ltc/test), no-coin path-based calls, and bundles should all keep working; passing a non-bitcoin coin like `eth` together with a non-bitcoin path (or no coin + a non-bitcoin path) should now return a `Method_UnknownCoin` error instead of a btc xpub. 3rd-party integrations that misused `getPublicKey` for ethereum-like coins are the main breaking-change risk.

## Related Issue

Resolve #12676

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** LLM test selector skipped: Anthropic credit balance exhausted. Falling back to the full e2e suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/api/getPublicKey.ts`

</details>

_No test recommendations found._

_Updated: 2026-07-27T09:27:46.875Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/getpublickey-bitcoin-only/web/](https://dev.suite.sldev.cz/suite-web/getpublickey-bitcoin-only/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:31:04.221Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T09:30:54.981Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=getpublickey-bitcoin-only&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=getpublickey-bitcoin-only&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->