### PR TITLE
fix(product-components): SidebarBanner component overflow issue

### DIFF
--- a/packages/components/src/components/Banner/Banner.tsx
+++ b/packages/components/src/components/Banner/Banner.tsx
@@ -93,6 +93,7 @@ export const Banner = ({
             backgroundColor={mapIntentToBackgroundColor(intent)}
             borderColor={mapIntentToBorderColor(intent)}
             borderWidth={1}
+            borderOffset={-1}
             borderRadius={8}
             data-testid={dataTest}
             overflow="hidden"

--- a/packages/components/src/components/Box/Box.stories.tsx
+++ b/packages/components/src/components/Box/Box.stories.tsx
@@ -30,6 +30,7 @@ export const Box: StoryObj<typeof BoxComponent> = {
         backgroundColor: undefined,
         backgroundColorOnInteraction: undefined,
         borderColor: undefined,
+        borderOffset: undefined,
     },
     argTypes: {
         backgroundColor: {
@@ -53,6 +54,9 @@ export const Box: StoryObj<typeof BoxComponent> = {
         borderWidth: {
             control: 'select',
             options: ['undefined', ...borderWidthValues],
+        },
+        borderOffset: {
+            control: 'number',
         },
         ...getFramePropsStory(allowedBoxFrameProps).argTypes,
     },

--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -41,7 +41,8 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedBoxFrameProps)[number]>
 
 const Container = styled.div<
     TransientProps<AllowedFrameProps> & {
-        $borderWidth?: BoxBorderWidth;
+        $borderWidth?: BorderWidth;
+        $borderOffset?: number;
         $backgroundColor?: Color;
         $backgroundColorOnInteraction?: Color;
         $borderColor?: Color;
@@ -50,26 +51,20 @@ const Container = styled.div<
 >`
     background: unset;
     box-shadow: unset;
-    border-width: 0;
-    border-style: solid;
-    border-color: ${({ $borderColor, theme }) => theme[$borderColor ?? 'borderNeutral']};
+    outline: ${({ $borderColor, theme }) => theme[$borderColor ?? 'borderNeutral']} solid 0;
     transition: 0.2s ease-in-out;
 
-    ${({ $borderWidth }) => {
-        if ($borderWidth == null) return null;
-        if (typeof $borderWidth === 'object') {
-            return css`
-                border-width: ${getValueWithUnit($borderWidth.top ?? $borderWidth.vertical ?? 0)}
-                    ${getValueWithUnit($borderWidth.right ?? $borderWidth.horizontal ?? 0)}
-                    ${getValueWithUnit($borderWidth.bottom ?? $borderWidth.vertical ?? 0)}
-                    ${getValueWithUnit($borderWidth.left ?? $borderWidth.horizontal ?? 0)};
-            `;
-        }
+    ${({ $borderWidth }) =>
+        $borderWidth &&
+        css`
+            outline-width: ${getValueWithUnit($borderWidth)};
+        `}
 
-        return css`
-            border-width: ${getValueWithUnit($borderWidth)};
-        `;
-    }}
+    ${({ $borderOffset }) =>
+        $borderOffset !== undefined &&
+        css`
+            outline-offset: ${getValueWithUnit($borderOffset)};
+        `}
 
     ${({ $backgroundColor, theme }) =>
         $backgroundColor &&
@@ -99,24 +94,14 @@ const Container = styled.div<
     ${withFrameProps};
 `;
 
-type BoxBorderWidth =
-    | {
-          top?: BorderWidth;
-          bottom?: BorderWidth;
-          left?: BorderWidth;
-          right?: BorderWidth;
-          horizontal?: BorderWidth;
-          vertical?: BorderWidth;
-      }
-    | BorderWidth;
-
 export type BoxProps = Pick<
     HTMLProps<HTMLElement>,
     'onClick' | 'onMouseEnter' | 'onMouseLeave' | 'tabIndex'
 > &
     AllowedFrameProps & {
         children?: React.ReactNode;
-        borderWidth?: BoxBorderWidth;
+        borderWidth?: BorderWidth;
+        borderOffset?: number;
         backgroundColor?: Color;
         backgroundColorOnInteraction?: Color;
         borderColor?: Color;
@@ -130,6 +115,7 @@ export type BoxProps = Pick<
 export const Box = ({
     children,
     borderWidth,
+    borderOffset,
     backgroundColor,
     backgroundColorOnInteraction,
     borderColor,
@@ -152,6 +138,7 @@ export const Box = ({
             data-testid={dataTestId}
             aria-hidden={ariaHidden}
             $borderWidth={borderWidth}
+            $borderOffset={borderOffset}
             $backgroundColor={backgroundColor}
             $backgroundColorOnInteraction={backgroundColorOnInteraction}
             $borderColor={borderColor}

--- a/packages/product-components/src/components/SidebarBanner/SidebarBanner.stories.tsx
+++ b/packages/product-components/src/components/SidebarBanner/SidebarBanner.stories.tsx
@@ -57,14 +57,7 @@ export const SidebarBannerWithHeroContent: StoryObj<typeof SidebarBannerComponen
         ctaLabel: 'Learn more',
         description: 'Your labels stay secure and in sync across your devices.',
         heading: 'Turn on Suite Sync',
-        heroContent: (
-            <Box
-                backgroundColor="elementFillNeutralSofter"
-                borderRadius={8}
-                height={80}
-                width="100%"
-            />
-        ),
+        heroContent: <Box backgroundColor="elementFillBrandSofter" height={80} width="100%" />,
         onClick: action('onClick'),
     },
 };

--- a/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
+++ b/packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx
@@ -102,6 +102,7 @@ export const SidebarBanner = ({
             backgroundColor="surfaceFillModeless"
             borderWidth={1}
             borderColor="surfaceBorderModeless"
+            overflow="hidden"
         >
             <Column gap={16} padding={12}>
                 {icon ? (

--- a/packages/suite/src/components/connection/AnimationCard.tsx
+++ b/packages/suite/src/components/connection/AnimationCard.tsx
@@ -11,6 +11,7 @@ export const AnimationCard = ({ aspectRatio, maxHeight, children }: AnimationCar
     <Box
         borderRadius={16}
         borderWidth={1}
+        borderOffset={-1}
         borderColor="elementBorderNeutralSofterAlt"
         backgroundColor="elementFillNeutralSofter"
         overflow="hidden"

--- a/packages/suite/src/components/suite/ConnectAppBar.tsx
+++ b/packages/suite/src/components/suite/ConnectAppBar.tsx
@@ -21,6 +21,8 @@ export const ConnectBarWrapper = styled.div`
     top: 0;
     left: 0;
     width: 100%;
+    background: ${({ theme }) => theme.surfaceFillFixed};
+    border-bottom: 1px solid ${({ theme }) => theme.surfaceBorderFixed};
 `;
 
 interface ConnectAppBarProps {
@@ -46,13 +48,10 @@ export const ConnectAppBar = ({ canSwitchDevice }: ConnectAppBarProps) => {
     return (
         <ConnectBarWrapper>
             <Box
-                backgroundColor="surfaceFillPage"
                 padding={{
                     horizontal: 24,
                     vertical: 16,
                 }}
-                borderWidth={{ bottom: 2 }}
-                borderColor="elementBorderNeutralSofter"
             >
                 <TrafficLightOffset>
                     <Row gap={12} alignItems="center" justifyContent="space-between">


### PR DESCRIPTION
## Notes for QA
Fixed sidebar banners overflow issue.

## Screenshots:

### Before
<img width="608" height="722" alt="image" src="https://github.com/user-attachments/assets/0ccafb2d-30a7-4458-b259-b84750ad13de" />

### After
<img width="319" height="304" alt="image" src="https://github.com/user-attachments/assets/64a7c4a0-7cde-48d6-8255-77741e33a9b5" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are primarily to shared UI primitives (Banner, Box) and product-components (SidebarBanner) plus two Suite connection UI components (AnimationCard, ConnectAppBar) that map broadly across almost the entire e2e suite (133 tests each), indicating they are low-level shared building blocks. Since a style/structural change to Box or a generic component rarely causes functional regressions unless directly exercised, we narrowed recommendations to tests that specifically assert on banner visibility, dismissal, or content (a direct behavioral surface of Banner.tsx/SidebarBanner.tsx) or on connection/disconnection UI states (AnimationCard/ConnectAppBar). Box.tsx and its stories file have no test-specific behavioral assertions found in the LLM analysis, so no test was elevated solely due to Box usage. Recommended strategy: run the banner-focused and connection-status tests above as a fast smoke check; a broader regression pass (visual/snapshot testing) is advisable given the wide blast radius of Box.tsx and Banner.tsx but is out of scope for targeted E2E selection.

<details><summary><b>Changed files (7)</b></summary>

- `packages/components/src/components/Banner/Banner.tsx`
- `packages/components/src/components/Box/Box.stories.tsx`
- `packages/components/src/components/Box/Box.tsx`
- `packages/product-components/src/components/SidebarBanner/SidebarBanner.stories.tsx`
- `packages/product-components/src/components/SidebarBanner/SidebarBanner.tsx`
- `packages/suite/src/components/connection/AnimationCard.tsx`
- `packages/suite/src/components/suite/ConnectAppBar.tsx`

</details>

**Recommended tests (8)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — This test verifies a dismissible warning Banner component behavior (visibility, CTA button, dismiss button) which directly exercises Banner.tsx's rendering and interaction logic that was changed.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test asserts an error banner (TR_FAILED_BACKUP) is visible on the dashboard and a failed backup setting banner with link, directly exercising the Banner component's rendering, link, and disabled-state behavior that changed.
- `suite/e2e/tests/wallet/without-device.test.ts` — This test checks a disconnected-device banner on the device settings page, directly exercising the changed Banner component's visibility logic.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test verifies an offline disconnection banner persists throughout onboarding, directly exercising the changed Banner component as well as connection-related UI (AnimationCard/ConnectAppBar) that shows connection status.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test involves device disconnection status and modal bullet content banners; the Banner component change could plausibly affect the displayed bullet/notice content styling.
- `suite/e2e/tests/staking/ada/claim.test.ts` — This test asserts a warning banner (TR_EARN_REWARDS_NETWORK_FEE_WARNING) is shown/hidden based on reward conditions, which exercises the changed Banner component's conditional rendering.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test verifies an instant staking banner appears with specific text and can be dismissed via a 'Got it' button, directly touching the changed Banner component's dismiss behavior.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test extensively covers a dismissible unsupported-device banner that persists/resets across navigation, directly touching the changed Banner component's dismiss and persistence logic.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/components/src/components/Box/Box.stories.tsx`
- `packages/components/src/components/Box/Box.tsx`
- `packages/product-components/src/components/SidebarBanner/SidebarBanner.stories.tsx`

_Updated: 2026-07-28T11:23:03.900Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/sidebar-banner/web/](https://dev.suite.sldev.cz/suite-web/fix/sidebar-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/sidebar-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/sidebar-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:26:25.298Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:26:02.566Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->