### PR TITLE
chore(eslint): run type-aware rules only in CI

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -86,6 +86,8 @@ jobs:
             '!**/node_modules'
           key: ${{ runner.os }}-node-${{ hashFiles('./eslint.config.mjs') }} }}
       - name: Lint JS
+        env:
+          ESLINT_TYPE_AWARE: "true"
         run: yarn lint:js --output-style=stream
       - name: Lint Styles
         run: yarn lint:styles --output-style=stream

--- a/nx.json
+++ b/nx.json
@@ -57,7 +57,10 @@
             "inputs": [
                 "{projectRoot}/**/*",
                 "{workspaceRoot}/eslint.config.mjs",
-                "{workspaceRoot}/packages/eslint/**/*"
+                "{workspaceRoot}/packages/eslint/**/*",
+                {
+                    "env": "ESLINT_TYPE_AWARE"
+                }
             ],
             "outputs": ["{projectRoot}/.eslintcache"],
             "cache": true

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -1,5 +1,9 @@
 import tseslint from 'typescript-eslint';
 
+// Type-aware ESLint rules create a TypeScript project service.
+// Enable them only when a linting environment explicitly opts in.
+const areTypeAwareRulesEnabled = process.env.ESLINT_TYPE_AWARE === 'true';
+
 // Deny importing from build artifact directories — consumers should resolve
 // through the package root, not from `lib/` or `libDev/`.
 const buildArtifactPatterns = {
@@ -150,4 +154,12 @@ export const typescriptConfig = [
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         },
     },
+    ...(areTypeAwareRulesEnabled
+        ? []
+        : [
+              {
+                  ...tseslint.configs.disableTypeChecked,
+                  files: ['**/src/**/*.{ts,tsx}'],
+              },
+          ]),
 ];


### PR DESCRIPTION
## Description

Type-aware ESLint rules create an additional TypeScript project service, significantly increasing editor memory usage and lint latency in this large monorepo. This change disables type-aware linting by default, giving all developers a faster experience regardless of their IDE, while retaining syntax-based ESLint rules such as `consistent-type-imports`.

The CI lint job now explicitly enables type-aware rules with `ESLINT_TYPE_AWARE=true`. The environment variable is also included in the Nx lint cache inputs so untyped local results cannot satisfy typed CI lint tasks.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/eslint-disable-type-aware-rules&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/eslint-disable-type-aware-rules&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Metadata - Output labeling > dropbox provider | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T10:24:50.322Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T10:23:50.240Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/eslint-disable-type-aware-rules/web/](https://dev.suite.sldev.cz/suite-web/feat/eslint-disable-type-aware-rules/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->