### PR TITLE
fix(suite): multishare backup availability

### DIFF
--- a/suite/backup/src/MultiShareBackup.tsx
+++ b/suite/backup/src/MultiShareBackup.tsx
@@ -16,9 +16,7 @@ export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }
     const device = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
     const isN4w1BackupEnabled = useSelector(selectIsN4w1BackupEnabled);
-
-    // "NotAvailable" means, that backup has been already done and thus is not available.
-    const isBackupDone = device?.features?.backup_availability === 'NotAvailable';
+    const isBackupRequired = device?.features?.backup_availability === 'Required';
 
     // When N4W1 backup is enabled, multi-share backup is replaced by the NFC-based
     // additional backup flow (CreateWalletBackup), which uses a different backup method.
@@ -26,7 +24,7 @@ export const MultiShareBackup = ({ isDeviceLocked }: { isDeviceLocked: boolean }
         isN4w1BackupEnabled ||
         !device?.features ||
         !doesSupportMultiShare(device.features) ||
-        !isBackupDone
+        isBackupRequired
     ) {
         return;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This bug is here for a while... https://github.com/trezor/trezor-suite/pull/12793

The original "fix" was meant to disable the possibility of creation multishare backup when **the backup was not created during the onboarding** https://github.com/trezor/trezor-suite/issues/12794 (backup_availability === 'Required')

but instead it disables it completely if backup_availability === 'Available'

This results with missing whole "Multi-share Backup" section when multishare backup creation is interrupted (for example by device disconnection)

## Notes for QA
- "Multi-share Backup" section **should not be visible** if you skip the backup during onboarding
- "Multi-share Backup" section **should be visible** if you interrupt creation:
  1. do a recovery of current seed
  2. disconnect the device in the middle of Shamir backup creation
  
## Related issues

fix: https://github.com/trezor/trezor-suite/issues/30020


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to suite/backup/src/MultiShareBackup.tsx, a component responsible for the Shamir/multi-share backup creation UI (shares, threshold, device confirmations, completion modal). No static coverage mapping exists, so tests were inferred from the LLM analysis by identifying flows that exercise Shamir-advanced/multi-share backup creation (onboarding wallet creation with shamir-advanced backup type, and the dedicated additional-share creation test). Recommended strategy is to run the dedicated multi-share backup test plus onboarding tests across device models (T2T1, T3T1, T3B1, T3W1) that use the shamir-advanced backup path, since these most directly exercise the changed component's logic.

<details><summary><b>Changed files (1)</b></summary>

- `suite/backup/src/MultiShareBackup.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — This test directly exercises the multi-share backup creation flow (createMultiShareBackupButton, proceedMultiShareBackupModal, multiShareBackupGotItButton) which is the UI feature implemented by MultiShareBackup.tsx. Any regression in this component would likely break this test's core assertions.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This onboarding test creates a wallet using Shamir (multi-share) advanced backup with configurable shares/threshold, directly using the MultiShareBackup component's flow during wallet creation.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test creates a wallet with Shamir advanced (multi-share) backup on a T3T1 device, exercising the same MultiShareBackup component logic for share/threshold configuration and confirmations.
- `suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts` — This test creates a wallet using Shamir advanced (multi-share) backup on a T3B1 device, directly exercising the MultiShareBackup component's share/threshold backup flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test includes wallet creation with Shamir-advanced backup (multi-share) on a T3W1 device, which relies on the same MultiShareBackup UI component, though it also covers single-share backup which is unaffected.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test performs Shamir advanced multi-share backup creation while offline, exercising the same MultiShareBackup component but with additional offline-specific concerns that dilute direct relevance.

</details>

_Updated: 2026-07-27T10:47:07.757Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->