### PR TITLE
fix(components): emit styled theme types

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+// Include the styled-components theme augmentation in the emitted public declarations.
 import './styled';
 
 export * as variables from './config/variables';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,5 @@
+import './styled';
+
 export * as variables from './config/variables';
 export * as animations from './config/animations';
 export { motionAnimation, motionEasing } from './config/motion';

--- a/packages/components/src/styled.ts
+++ b/packages/components/src/styled.ts
@@ -1,8 +1,8 @@
-// import original module declarations
 import 'styled-components';
-import { BoxShadows, Colors } from '@trezor/theme';
 
-import { SuiteThemeColors, ThemeVariant } from './src';
+import { type BoxShadows, type Colors, type ThemeVariant } from '@trezor/theme';
+
+import { type SuiteThemeColors } from './config/colors';
 
 declare module 'styled-components' {
     export interface DefaultTheme extends SuiteThemeColors, Colors, BoxShadows {

--- a/packages/connect-explorer/src/pages/_app.tsx
+++ b/packages/connect-explorer/src/pages/_app.tsx
@@ -31,7 +31,7 @@ const ThemeComponent = ({ Component, pageProps }: AppProps) => {
     }, [router]);
 
     return (
-        <ThemeProvider theme={intermediaryTheme[theme]}>
+        <ThemeProvider theme={{ variant: theme, ...intermediaryTheme[theme] }}>
             <Provider store={store}>
                 <Component {...pageProps} />
             </Provider>


### PR DESCRIPTION
## Description

Preparation for https://github.com/trezor/trezor-suite/pull/27060. The styled-components DefaultTheme augmentation lived in packages/components/styled.d.ts, outside the Components declaration build rooted in src, so consumers of the emitted entrypoint did not load the shared theme contract. This moves the augmentation into src/styled.ts, uses direct type-only imports to avoid a barrel cycle, and loads it from src/index.ts. Exposing that contract revealed Connect Explorer was omitting the required theme variant, so its provider now supplies the selected light/dark variant. The change remains separate from the monorepo workspace declaration-contract PR because it changes Components entrypoint behavior and has an independently testable consumer migration.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files include the shared @trezor/components package's public export barrel (index.ts) and its styled-components base (styled.ts), plus the Connect Explorer app's root _app.tsx wrapper. No static test coverage mapping exists for these files since components and styling are foundational/shared code with no direct test-to-file linkage recorded. Because packages/components is a broad, widely-used dependency, only tests with concrete evidence of touching Connect Explorer UI (which directly imports _app.tsx and likely uses shared components for modals/dialogs) were selected; other Suite-wide UI tests were treated with caution to avoid over-broad recommendations. Given the low specificity of static evidence, a manual visual/smoke check of Connect Explorer and a broader UI regression pass (e.g. check-links) is advised in addition to the targeted tests listed.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/index.ts`
- `packages/components/src/styled.ts`
- `packages/connect-explorer/src/pages/_app.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the Connect Explorer application UI (permissions modal, address confirmation, popup lifecycle) which is built using the shared @trezor/components package and its styled-components base; a change to the components index or styling primitives could visibly affect rendering or behavior of these UI elements.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Uses the same Connect Explorer webextension build which likely imports the shared components library; changes to component exports or styled-component base could impact rendering of the extension's UI elements like the permissions modal and confirmation dialogs.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Exercises Connect Explorer's permissions modal and settings connect-apps UI, which may rely on shared component exports; included as a lower-confidence check since no direct evidence ties this specific flow to the change.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Involves Connect Explorer permissions modal checkboxes and settings UI that could be styled via the shared components package; included at low priority as a plausible but not confirmed impact area.
- `suite/e2e/tests/general/check-links.test.ts` — This crawls every route in the Suite app and checks rendering/links across the entire UI, which would surface widespread breakage if the shared components/styling exports were broken, though it's a broad and slow test not specifically targeted at this change.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/components/src/index.ts`
- `packages/components/src/styled.ts`
- `packages/connect-explorer/src/pages/_app.tsx`

_Updated: 2026-07-27T12:16:48.494Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/components-styled-theme-types/web/](https://dev.suite.sldev.cz/suite-web/fix/components-styled-theme-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/components-styled-theme-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/components-styled-theme-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:19:58.113Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:20:05.829Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->