### PR TITLE
WETH token icon

### DIFF
--- a/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
@@ -1,5 +1,6 @@
 import { isCryptoIconSymbol, isNetworkIconSymbol } from '@suite-common/icons';
 import { getCoingeckoId, getNetworkOptional, isNetworkSymbol } from '@suite-common/wallet-config';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 
 import { NativeTokenIcon } from './NativeTokenIcon';
 import { NonNativeTokenIcon } from './NonNativeTokenIcon';
@@ -16,8 +17,13 @@ export const TokenIcon = ({
     placeholder = '',
     customLogoUrl,
     isBordered = true,
+    wrappedTokenIcon = 'token',
     'data-testid': dataTestId,
 }: TokenIconProps) => {
+    if (wrappedTokenIcon === 'network' && isWrappedNativeToken(symbol, contractAddress)) {
+        contractAddress = null;
+    }
+
     if (!contractAddress) {
         if (showNetworkIcon) {
             const network = getNetworkOptional(symbol);

--- a/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
+++ b/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
@@ -18,4 +18,8 @@ export interface TokenIconProps extends AllowedFrameProps {
     'data-testid'?: string;
     customLogoUrl?: string;
     isBordered?: boolean;
+    /**
+     * If the token is a wrapped native token (e.g. WETH), this prop determines whether to show the icon of the token itself or its network icon.
+     */
+    wrappedTokenIcon?: 'token' | 'network';
 }

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -41,6 +41,7 @@ export const EarnAccountCell = ({
                         showNetworkIcon={showAssetNetworkIcon}
                         size={32}
                         isBordered={false}
+                        wrappedTokenIcon="network"
                     />
                 ) : (
                     <TokenIcon symbol={networkSymbol} size={32} />

--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -8,9 +8,11 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { exhaustive } from '@trezor/type-utils';
 
+import { type AllowanceModalProvider } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo';
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
@@ -51,15 +53,17 @@ export const YieldApproveModal = ({
         select: yieldOpportunity => yieldOpportunity.metadata.name,
     });
 
-    const provider = {
+    const provider: AllowanceModalProvider = {
         name: vaultName,
         companyName: vaultName,
-        logo: getAssetLogoUrl({
-            coingeckoId: networkId,
-            contractAddress: parsedContract,
-            size: 80,
-        }),
-        label: 'TR_EARN_YIELD_VAULT' as const,
+        logo: isWrappedNativeToken(account.symbol, contractAddress)
+            ? { symbol: account.symbol, size: 20 }
+            : getAssetLogoUrl({
+                  coingeckoId: networkId,
+                  contractAddress: parsedContract,
+                  size: 80,
+              }),
+        label: 'TR_EARN_YIELD_VAULT',
     };
 
     useEffect(() => {

--- a/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx
@@ -37,6 +37,7 @@ export const YieldApprovedAmountCard = ({
                         placeholder={token.symbol}
                         showNetworkIcon
                         isBordered={false}
+                        wrappedTokenIcon="network"
                     />
                     <ApprovedAmountValue
                         amount={amount}

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx
@@ -53,6 +53,7 @@ export const YieldFlowCompleteDeposit = ({
             outputLabelId="TR_RECEIVED"
             input={input}
             output={output}
+            inputPresentsNative
         />
     </YieldFlowComplete>
 );

--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -38,6 +38,7 @@ export const YieldFlowCompleteWithdraw = ({
                     outputLabelId="TR_RECEIVED"
                     input={input}
                     output={output}
+                    outputPresentsNative
                 />
             ) : (
                 <Row
@@ -55,6 +56,7 @@ export const YieldFlowCompleteWithdraw = ({
                                 contractAddress: receivedValue.token.contractAddress ?? null,
                             }}
                             amount={receivedValue.amount}
+                            presentWrappedAsNative
                         />
                     </Column>
                 </Row>

--- a/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx
@@ -12,6 +12,10 @@ type YieldFlowTransferRowProps = {
     outputLabelId: TranslationId;
     input: YieldFlowCompleteValue;
     output: YieldFlowCompleteValue;
+    /** Present the input token as its native asset (set when the input is the wrapped-native deposit token, never the receipt token). */
+    inputPresentsNative?: boolean;
+    /** Present the output token as its native asset (set when the output is the wrapped-native deposit token, never the receipt token). */
+    outputPresentsNative?: boolean;
 };
 
 export const YieldFlowTransferRow = ({
@@ -19,6 +23,8 @@ export const YieldFlowTransferRow = ({
     outputLabelId,
     input,
     output,
+    inputPresentsNative = false,
+    outputPresentsNative = false,
 }: YieldFlowTransferRowProps) => {
     const { isBelowTablet } = useLayoutSize();
 
@@ -33,6 +39,7 @@ export const YieldFlowTransferRow = ({
                     contractAddress: input.token.contractAddress ?? null,
                 }}
                 amount={input.amount}
+                presentWrappedAsNative={inputPresentsNative}
                 data-testid="@yield/flow-complete/transfer/input"
             />
         </Column>
@@ -49,6 +56,7 @@ export const YieldFlowTransferRow = ({
                     contractAddress: output.token.contractAddress ?? null,
                 }}
                 amount={output.amount}
+                presentWrappedAsNative={outputPresentsNative}
                 data-testid="@yield/flow-complete/transfer/output"
             />
         </Column>

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -121,6 +121,7 @@ export const YieldPageHeader = ({
                                 showNetworkIcon
                                 size={32}
                                 isBordered={false}
+                                wrappedTokenIcon="network"
                             />
                         )}
                         <Column gap={2} overflow="hidden">

--- a/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx
@@ -13,12 +13,18 @@ type YieldTokenValueToken = {
 type YieldTokenValueProps = {
     token: YieldTokenValueToken;
     amount: string;
+    /**
+     * Present a wrapped-native deposit token (e.g. WETH) as its native asset (ETH). Must stay
+     * `false` for the vault receipt token (`vault.outputToken`, e.g. trSHETHp).
+     */
+    presentWrappedAsNative?: boolean;
     'data-testid'?: string;
 };
 
 export const YieldTokenValue = ({
     token,
     amount,
+    presentWrappedAsNative = false,
     'data-testid': dataTestId,
 }: YieldTokenValueProps) => (
     <Row alignItems="center" gap={8}>
@@ -29,6 +35,7 @@ export const YieldTokenValue = ({
             placeholder={token.symbol}
             showNetworkIcon
             isBordered={false}
+            wrappedTokenIcon={presentWrappedAsNative ? 'network' : 'token'}
         />
         <Text typographyStyle="body-md-strong">
             {/*

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -51,6 +51,7 @@ export const YieldWrapStep = ({
                         placeholder={token.symbol}
                         showNetworkIcon
                         isBordered={false}
+                        wrappedTokenIcon="network"
                     />
                     <Text typographyStyle="body-md">
                         <FormattedCryptoAmount value="0" symbol={token.symbol} />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -2,11 +2,12 @@ import styled from 'styled-components';
 
 import { Translation, type TranslationKey } from '@suite/intl';
 import { CardList, Column, Image, Row, Text } from '@trezor/components';
+import { TokenIcon, type TokenIconProps } from '@trezor/product-components';
 
 export type AllowanceModalProvider = {
     name?: string;
     companyName?: string;
-    logo?: string;
+    logo?: string | TokenIconProps;
     label: TranslationKey;
 };
 
@@ -39,7 +40,11 @@ export const AllowanceModalProviderInfo = ({
                 <Logo>
                     {provider.logo && (
                         <Row alignItems="center" justifyContent="center">
-                            <Image imageSrc={provider.logo} maxHeight={20} borderRadius={4} />
+                            {typeof provider.logo === 'string' ? (
+                                <Image imageSrc={provider.logo} maxHeight={20} borderRadius={4} />
+                            ) : (
+                                <TokenIcon {...provider.logo} />
+                            )}
                         </Row>
                     )}
                     <Text typographyStyle="body-sm">{providerName}</Text>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -145,6 +145,7 @@ export const ApproveModal = (props: ApproveModalProps) => {
                                     <TokenIcon
                                         symbol={account.symbol}
                                         contractAddress={token.contract}
+                                        wrappedTokenIcon="network"
                                         size={20}
                                         placeholder={displaySymbol}
                                     />

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -168,6 +168,7 @@ export const RevokeModal = (props: RevokeModalProps) => {
                                     <TokenIcon
                                         symbol={account.symbol}
                                         contractAddress={token.contract}
+                                        wrappedTokenIcon="network"
                                         size={20}
                                         placeholder={displaySymbol}
                                     />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Render WETH icon as ETH in context of Yield

## Notes for QA

Only WETH token icon -> ETH icon changes.

## Related Issue

Resolve #29881

## Screenshots:

### Before:

<img width="1210" height="1025" alt="Snímek obrazovky 2026-07-27 v 13 06 42" src="https://github.com/user-attachments/assets/d6b0f29f-6c0a-41c4-8941-cfb739b2903e" />

<img width="564" height="598" alt="Snímek obrazovky 2026-07-27 v 13 06 49" src="https://github.com/user-attachments/assets/484b2e8e-0e8c-4bdc-acb6-2dbcb360d6ed" />

<img width="547" height="577" alt="Snímek obrazovky 2026-07-27 v 13 06 53" src="https://github.com/user-attachments/assets/44506752-29be-4f97-87a0-9708bb650b75" />

<img width="388" height="64" alt="Snímek obrazovky 2026-07-27 v 13 07 07" src="https://github.com/user-attachments/assets/c5ce1ef2-67ce-48a5-8dd5-4ef2d69d9564" />

<img width="567" height="751" alt="Snímek obrazovky 2026-07-27 v 11 38 33" src="https://github.com/user-attachments/assets/3cd721d4-1fcd-470f-b518-71f1b88a9075" />


### After:
<img width="1202" height="807" alt="Snímek obrazovky 2026-07-24 v 14 56 07" src="https://github.com/user-attachments/assets/a4ebf9ff-40dc-4735-85e2-2304e6809740" />

<img width="1454" height="704" alt="Snímek obrazovky 2026-07-24 v 14 56 51" src="https://github.com/user-attachments/assets/79848408-d58a-4b58-afbf-eef524f089e1" />

<img width="576" height="550" alt="Snímek obrazovky 2026-07-27 v 12 53 08" src="https://github.com/user-attachments/assets/a8a78311-b27b-46e7-af4b-587309dbbe71" />

<img width="1170" height="674" alt="Snímek obrazovky 2026-07-27 v 13 10 05" src="https://github.com/user-attachments/assets/097971cd-acf2-4443-a6e7-8871c981fde2" />





<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches earn/yield UI components (Yield* modals, approval cards, transfer rows, wrap step), the shared TokenIcon component/types, an EarnAccountCell, and Allowance modal components (Approve/Revoke/ProviderInfo) used in token approval flows. None of these files have direct, exclusive static test coverage in the mapping (they all resolve to the full 134-test suite, indicating TokenIcon and EarnAccountCell are broadly imported globals), so recommendations here are inferred from LLM behavior descriptions rather than precise static mapping. The most relevant tests are the ETH staking/yield flows (initial-stake, stake-more, unstake) since they directly exercise the same yield/earn UI surface, plus a couple of low-confidence icon-rendering checks in asset/dashboard and swap/onboarding flows. Given the low direct static signal, a broader manual/visual smoke test of the earn/yield and allowance modal flows (deposit, withdraw, approve, revoke) is recommended in addition to the automated tests listed, since no e2e test in the current suite appears to directly target ApproveModal/RevokeModal/AllowanceModalProviderInfo behavior.

<details><summary><b>Changed files (14)</b></summary>

- `packages/product-components/src/components/TokenIcon/TokenIcon.tsx`
- `packages/product-components/src/components/TokenIcon/tokenIconTypes.ts`
- `packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApprovedAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteDeposit.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx`
- `packages/suite/src/components/earn/yield/common/YieldFlowTransferRow.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `packages/suite/src/components/earn/yield/common/YieldTokenValue.tsx`
- `packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking/yield flow UI (staking dashboard, stake form, progress indicators) which shares component tree with the changed Yield* components (YieldApproveModal, YieldFlowCompleteDeposit, YieldWrapStep, etc.) even though it's not in the static mapping list; a regression in shared yield/earn components could surface here.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Covers ETH staking flow including staking form, progress, and instant staking banner — directly related to the earn/yield UI components that were changed (YieldFlowTransferRow, YieldApprovedAmountCard, YieldWrapStep) and could be affected by regressions in these shared components.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Exercises unstake/claim flows for ETH staking including withdrawal completion screens, which likely render via YieldFlowCompleteWithdraw and related yield components that were modified in this change set.
- `suite/e2e/tests/dashboard/assets.test.ts` — This test verifies asset display in grid/table views on the dashboard including buy-asset flows that rely on TokenIcon rendering for coin identification; the changed TokenIcon component and its types could visually or functionally break asset rows/cards.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Swap quotes display provider/token info which may rely on TokenIcon rendering for cross-network tokens; a regression in TokenIcon type handling could affect token identification in swap UI, though this is a narrow overlap.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — The Activate Assets modal displays coin icons (likely via TokenIcon) when enabling multiple networks (BTC, ETH, POL, BSC, ARB); a TokenIcon regression could cause icons to render incorrectly in this modal, though the test's core assertions are about network activation rather than icon rendering.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx`
- `packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx`

_Updated: 2026-07-27T11:13:59.913Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/weth-icon&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T11:16:55.663Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/weth-icon/web/](https://dev.suite.sldev.cz/suite-web/feat/weth-icon/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->