### PR TITLE
refactor(suite-native): migrate form watch() reads to useWatch

### DIFF
--- a/suite-native/device-authorization/src/components/PinFormControlButtons.tsx
+++ b/suite-native/device-authorization/src/components/PinFormControlButtons.tsx
@@ -11,7 +11,7 @@ import { useSelector } from 'react-redux';
 
 import { useAlert } from '@suite-native/alerts';
 import { Box, Button, HStack, IconButton } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { useOpenLink } from '@suite-native/link';
 import TrezorConnect, { DEVICE, UI_REQUEST, UI_RESPONSE } from '@trezor/connect';
@@ -41,7 +41,7 @@ export const PinFormControlButtons = ({ onSuccess }: PinFormControlButtonsProps)
 
     const openLink = useOpenLink();
     const { showAlert } = useAlert();
-    const { handleSubmit, getValues, watch, setValue, reset } = useFormContext();
+    const { handleSubmit, getValues, setValue, reset, control } = useFormContext();
 
     const handleSuccess = useCallback(() => {
         onSuccess?.();
@@ -101,7 +101,7 @@ export const PinFormControlButtons = ({ onSuccess }: PinFormControlButtonsProps)
         setValue('pin', pin.slice(0, -1));
     };
 
-    const pinLength = watch('pin').length;
+    const pinLength = useWatch({ control, name: 'pin', compute: pin => pin.length });
 
     const cardAnimatedStyle = useAnimatedStyle(() => {
         animatedHeight.value = withTiming(pinLength ? containerHeight : 0, {

--- a/suite-native/device-authorization/src/components/PinFormProgress.tsx
+++ b/suite-native/device-authorization/src/components/PinFormProgress.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { Box, HStack, Text } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -34,11 +34,11 @@ type PinFormProgressProps = {
 export const PinFormProgress = ({ title }: PinFormProgressProps) => {
     const { applyStyle } = useNativeStyles();
     const {
-        watch,
+        control,
         formState: { isSubmitted },
     } = useFormContext();
 
-    const pinLength = watch('pin').length;
+    const pinLength = useWatch({ control, name: 'pin', compute: pin => pin.length });
 
     if (!pinLength) {
         return <Text variant="headline-sm">{title}</Text>;

--- a/suite-native/device-authorization/src/components/PinMatrixButton.tsx
+++ b/suite-native/device-authorization/src/components/PinMatrixButton.tsx
@@ -1,15 +1,15 @@
 import { formInputsMaxLength } from '@suite-common/validators';
 import { NumPadButton } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 
 type PinItemProps = {
     value: number;
 };
 
 export const PinMatrixButton = ({ value }: PinItemProps) => {
-    const { setValue, watch, getValues } = useFormContext();
+    const { setValue, getValues, control } = useFormContext();
 
-    const pinLength = watch('pin').length;
+    const pinLength = useWatch({ control, name: 'pin', compute: pin => pin.length });
 
     const handlePress = () => {
         const pin = getValues('pin');

--- a/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
+++ b/suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 import { View } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 
@@ -76,8 +77,8 @@ export const XpubScanScreen = ({
         validation: xpubFormValidationSchema,
         context: { symbol: networkSymbol },
     });
-    const { handleSubmit, setValue, watch } = form;
-    const watchXpubAddress = watch('xpubAddress');
+    const { handleSubmit, setValue, control } = form;
+    const watchXpubAddress = useWatch({ control, name: 'xpubAddress' });
 
     const isXpubFormFilled = watchXpubAddress?.length > 0;
 

--- a/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
+++ b/suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts
@@ -6,7 +6,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import {
     type DeviceNameStackParamList,
@@ -39,7 +39,7 @@ export const useChangeDeviceName = () => {
     });
 
     const deviceNameError = form.formState.errors.deviceName;
-    const deviceNameValue = form.watch('deviceName');
+    const deviceNameValue = useWatch({ control: form.control, name: 'deviceName' });
     const isMaxLengthReached = deviceNameValue.length >= MAX_LENGTH;
     const isSubmittable = form.formState.isValid && deviceNameValue.length <= MAX_LENGTH;
 

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -23,7 +23,7 @@ import { type NativeAccountsRootState, selectFreshAccountAddress } from '@suite-
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, HStack, Text, VStack } from '@suite-native/atoms';
 import { isDebugEnv } from '@suite-native/config';
-import { TextInputField, useFormContext } from '@suite-native/forms';
+import { TextInputField, useFormContext, useWatch } from '@suite-native/forms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import {
     type RootStackParamList,
@@ -64,7 +64,7 @@ export const AddressInput = ({ index, accountKey, onQrNetworkMismatch }: Address
     const utxoLabelFieldName = getOutputFieldName(index, 'label');
     const amountFieldName = getOutputFieldName(index, 'amount');
     const tokenFieldName = getOutputFieldName(index, 'token');
-    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { setValue, control } = useFormContext<SendOutputsFormValues>();
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -243,8 +243,8 @@ export const AddressInput = ({ index, accountKey, onQrNetworkMismatch }: Address
             });
     };
 
-    const utxoLabel = watch(utxoLabelFieldName);
-    const outputToken = watch(tokenFieldName);
+    const utxoLabel = useWatch({ control, name: utxoLabelFieldName });
+    const outputToken = useWatch({ control, name: tokenFieldName });
 
     return (
         <VStack spacing="sp12">

--- a/suite-native/module-send/src/components/SendMaxSwitch.tsx
+++ b/suite-native/module-send/src/components/SendMaxSwitch.tsx
@@ -1,3 +1,4 @@
+import { useWatch } from 'react-hook-form';
 import { Keyboard } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
@@ -46,9 +47,9 @@ export const SendMaxSwitch = ({
     });
 
     const converters = useCryptoFiatConverters({ symbol, tokenContract });
-    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { setValue, control } = useFormContext<SendOutputsFormValues>();
 
-    const [outputs, setMaxOutputId] = watch(['outputs', 'setMaxOutputId']);
+    const [outputs, setMaxOutputId] = useWatch({ control, name: ['outputs', 'setMaxOutputId'] });
 
     const isMainnetSendMaxAvailable = !tokenContract && outputs.length === 1;
     const isSendMaxAvailable = tokenContract || isMainnetSendMaxAvailable;

--- a/suite-native/module-send/src/components/SendOutputFields.tsx
+++ b/suite-native/module-send/src/components/SendOutputFields.tsx
@@ -10,7 +10,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Card, Text, VStack } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 import {
     NetworkReserveBanner,
@@ -42,7 +42,7 @@ export const SendOutputFields = ({
     maxAmount,
 }: SendOutputFieldsProps) => {
     const { applyStyle } = useNativeStyles();
-    const { control, watch } = useFormContext<SendOutputsFormValues>();
+    const { control } = useFormContext<SendOutputsFormValues>();
     const [qrNetworkSymbol, setQrNetworkSymbol] = useState<NetworkSymbol | null>(null);
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -52,7 +52,7 @@ export const SendOutputFields = ({
     );
     const outputsFieldArray = useFieldArray({ control, name: 'outputs' });
 
-    const amount = watch('outputs.0.amount');
+    const amount = useWatch({ control, name: 'outputs.0.amount' });
 
     const shouldShowBanner = useIsNetworkReserveBannerVisible({
         symbol,

--- a/suite-native/module-send/src/components/SolanaMemoInput.tsx
+++ b/suite-native/module-send/src/components/SolanaMemoInput.tsx
@@ -12,19 +12,19 @@ import {
     VStack,
     useBottomSheetModal,
 } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { type SendFieldName, type SendOutputsFormValues } from '../sendOutputsFormSchema';
 
 export const SolanaMemoInput = () => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
-    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { setValue, control } = useFormContext<SendOutputsFormValues>();
     const { translate } = useTranslate();
     const [localMemo, setLocalMemo] = useState('');
 
     const memoFieldName: SendFieldName = 'destinationTag';
-    const currentMemo = watch(memoFieldName) ?? '';
+    const currentMemo = useWatch({ control, name: memoFieldName }) ?? '';
     const memoByteSize = Buffer.from(localMemo, 'utf8').length;
 
     const handleOpen = () => {

--- a/suite-native/module-send/src/components/TronNoteInput.tsx
+++ b/suite-native/module-send/src/components/TronNoteInput.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 
 import { formInputsMaxLength } from '@suite-common/validators';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
@@ -25,13 +26,13 @@ type TronNoteInputProps = {
 
 export const TronNoteInput = ({ symbol }: TronNoteInputProps) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
-    const { setValue, watch } = useFormContext<SendOutputsFormValues>();
+    const { setValue, control } = useFormContext<SendOutputsFormValues>();
     const { translate } = useTranslate();
     const [localNote, setLocalNote] = useState('');
 
     const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
 
-    const value = watch('destinationTag') ?? '';
+    const value = useWatch({ control, name: 'destinationTag' }) ?? '';
     const hexByteSize = Buffer.from(localNote || '', 'utf8').length;
     const isHexTooLong = hexByteSize > formInputsMaxLength.tronNote;
 

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/__tests__/useAddressValidationAlerts.test.tsx
@@ -1,7 +1,7 @@
 import { useRoute } from '@react-navigation/native';
 
 import { useAlert } from '@suite-native/alerts';
-import { Form } from '@suite-native/forms';
+import { Form, useWatch } from '@suite-native/forms';
 import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import TrezorConnect from '@trezor/connect';
 
@@ -53,15 +53,21 @@ jest.mock('@suite-native/alerts', () => ({
     useAlert: jest.fn(),
 }));
 
+jest.mock('@suite-native/forms', () => ({
+    ...jest.requireActual('@suite-native/forms'),
+    useWatch: jest.fn(),
+}));
+
 const mockedUseRoute = useRoute as jest.MockedFunction<any>;
 const mockedUseAlert = useAlert as jest.MockedFunction<any>;
+const mockedUseWatch = useWatch as unknown as jest.Mock;
 
 const getAccountInfoSpy = jest.spyOn(TrezorConnect, 'getAccountInfo');
 
 describe('useAddressValidationAlerts', () => {
     let mockShowAlert: jest.Mock;
     let mockSetValue: jest.Mock;
-    let mockWatch: jest.Mock;
+    const mockWatch = mockedUseWatch;
 
     const mockRoute = {
         params: {
@@ -91,9 +97,7 @@ describe('useAddressValidationAlerts', () => {
             {
                 preloadedState,
                 wrapper: ({ children }) => (
-                    <Form form={{ setValue: mockSetValue, watch: mockWatch } as any}>
-                        {children}
-                    </Form>
+                    <Form form={{ setValue: mockSetValue } as any}>{children}</Form>
                 ),
             },
         );
@@ -111,7 +115,7 @@ describe('useAddressValidationAlerts', () => {
 
         mockShowAlert = jest.fn();
         mockSetValue = jest.fn();
-        mockWatch = jest.fn();
+        mockedUseWatch.mockReset();
 
         mockedUseRoute.mockReturnValue(mockRoute);
         mockedUseAlert.mockReturnValue({ showAlert: mockShowAlert });

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressChecksum.ts
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressChecksum.ts
@@ -6,7 +6,7 @@ import { type RouteProp, useRoute } from '@react-navigation/native';
 import { checkAddressChecksum, isAddressValid, toChecksumAddress } from '@suite-common/address';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { useAlert } from '@suite-native/alerts';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { type SendStackParamList, type SendStackRoutes } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
 
@@ -14,7 +14,7 @@ import { createChecksumAlert } from './alertBuilders';
 
 export const useAddressChecksum = (addressFieldName: string) => {
     const { showAlert } = useAlert();
-    const { setValue, watch } = useFormContext();
+    const { setValue, control } = useFormContext();
     const {
         params: { accountKey },
     } = useRoute<RouteProp<SendStackParamList, SendStackRoutes.SendOutputs>>();
@@ -24,7 +24,7 @@ export const useAddressChecksum = (addressFieldName: string) => {
 
     const [wasAddressChecksummed, setWasAddressChecksummed] = useState(false);
 
-    const addressValue = watch(addressFieldName);
+    const addressValue = useWatch({ control, name: addressFieldName });
     const isFilledValidAddress = !!addressValue && !!symbol && isAddressValid(addressValue, symbol);
 
     const convertAddressToChecksum = useCallback(() => {

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts
@@ -6,7 +6,7 @@ import { type RouteProp, useRoute } from '@react-navigation/native';
 import { checkAddressChecksum, isAddressValid } from '@suite-common/address';
 import { getNetworkType } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { type SendStackParamList, type SendStackRoutes } from '@suite-native/navigation';
 
 import { useAddressChecksum } from './useAddressChecksum';
@@ -22,13 +22,13 @@ export const useAddressValidationAlerts = ({ inputIndex }: UseAddressValidationA
     const {
         params: { tokenContract, accountKey },
     } = useRoute<RouteProp<SendStackParamList, SendStackRoutes.SendOutputs>>();
-    const { watch } = useFormContext();
+    const { control } = useFormContext();
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
 
     const addressFieldName = getOutputFieldName(inputIndex, 'address');
-    const addressValue = watch(addressFieldName);
+    const addressValue = useWatch({ control, name: addressFieldName });
 
     const { handleAddressChecksum, wasAddressChecksummed, resetAddressChecksummed } =
         useAddressChecksum(addressFieldName);

--- a/suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx
+++ b/suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx
@@ -3,7 +3,7 @@ import {
     type SuiteSyncServerTypeSelectValue,
 } from '@suite-common/suite-sync';
 import { Button, Card, Select, VStack } from '@suite-native/atoms';
-import { Form, TextInputField } from '@suite-native/forms';
+import { Form, TextInputField, useWatch } from '@suite-native/forms';
 import { Translation, useTranslate } from '@suite-native/intl';
 
 import { useSuiteSyncRelayUrlForm } from '../hooks/useSuiteSyncRelayUrlForm';
@@ -12,7 +12,7 @@ export const SuiteSyncRelayUrlCard = () => {
     const { translate } = useTranslate();
     const { form, serverTypes, submit } = useSuiteSyncRelayUrlForm();
 
-    const server = form.watch('server');
+    const server = useWatch({ control: form.control, name: 'server' });
 
     const setServer = (value: SuiteSyncServerTypeSelectValue) =>
         form.setValue('server', value, { shouldDirty: true });

--- a/suite-native/module-settings/src/hooks/useBackendServersForm.ts
+++ b/suite-native/module-settings/src/hooks/useBackendServersForm.ts
@@ -21,7 +21,7 @@ import {
 } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type SelectItemType } from '@suite-native/atoms';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import TrezorConnect, { BLOCKCHAIN, type BlockchainError } from '@trezor/connect';
 
@@ -102,8 +102,12 @@ export const useBackendServersForm = ({ symbol, backendOptions }: Network) => {
         }
     };
 
-    const selectedServerType = form.watch('serverType');
-    const isOnionAddress = form.watch('serverAddress').includes('.onion:');
+    const selectedServerType = useWatch({ control: form.control, name: 'serverType' });
+    const isOnionAddress = useWatch({
+        control: form.control,
+        name: 'serverAddress',
+        compute: serverAddress => serverAddress.includes('.onion:'),
+    });
     const [isConnecting, setIsConnecting] = useState(false);
 
     const setBackend = ({ serverType, serverAddress }: FormValues) => {

--- a/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
+++ b/suite-native/module-settings/src/hooks/useDustPhishingForm.ts
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { yup } from '@suite-common/validators';
 import { selectDustPhishingThreshold } from '@suite-common/wallet-core';
-import { useForm } from '@suite-native/forms';
+import { useForm, useWatch } from '@suite-native/forms';
 import { type Translate, useTranslate } from '@suite-native/intl';
 
 const validateIsEmpty = (value?: string) => {
@@ -59,10 +59,13 @@ export const useDustPhishingForm = () => {
         }),
     });
 
-    const dustThreshold = form.watch('dustThreshold');
+    const isSame = useWatch({
+        control: form.control,
+        name: 'dustThreshold',
+        compute: dustThreshold => dustThreshold.trim() === dustPhishingThreshold,
+    });
 
     const { isValid } = form.formState;
-    const isSame = dustThreshold.trim() === dustPhishingThreshold;
     const isDisabled = !isValid || isSame;
 
     return {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
@@ -4,7 +4,7 @@ import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 import { type NetworkSymbol, type NetworkType, getNetworkType } from '@suite-common/wallet-config';
 import { type AccountKey, type FormState } from '@suite-common/wallet-types';
 import { Box, Button, useBottomSheetModal } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { CustomFeeBottomSheet } from './CustomFeeBottomSheet';
@@ -45,13 +45,17 @@ const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: Cust
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
 
     const {
-        watch,
+        control,
         getValues,
         reset,
         formState: { defaultValues },
     } = useFormContext<FeesFormValues>();
 
-    const isCustomFeeSelected = watch('feeLevel') === 'custom';
+    const isCustomFeeSelected = useWatch({
+        control,
+        name: 'feeLevel',
+        compute: feeLevel => feeLevel === 'custom',
+    });
     const lastSavedValuesRef = useRef<FeesFormValues>(undefined);
     const initialFormValuesRef = useRef<FeesFormValues>(undefined);
 

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { BottomSheetModal, type BottomSheetModalRef, Box } from '@suite-native/atoms';
-import { Form, FormSubmitButton, useFormContext } from '@suite-native/forms';
+import { Form, FormSubmitButton, useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { CustomFeeContent } from './CustomFeeContent';
@@ -44,11 +44,11 @@ export const CustomFeeBottomSheet = ({
         handleSubmit,
         reset,
         formState: { isDirty },
-        watch,
+        control,
         getValues,
     } = form;
 
-    const feeLevelValue = watch('feeLevel');
+    const feeLevelValue = useWatch({ control, name: 'feeLevel' });
 
     const isButtonVisible = useMemo(
         () => (isDirty || feeLevelValue !== 'custom') && isSubmittable,

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.tsx
@@ -1,7 +1,7 @@
 import { type NetworkType } from '@suite-common/wallet-config';
 import { getFeeUnits } from '@suite-common/wallet-utils';
 import { HStack, Text } from '@suite-native/atoms';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
 
 import { type FeesFormValues } from '../../../feesFormSchema';
@@ -22,8 +22,8 @@ const getFormattedFeeUnits = (fee: string, networkType: NetworkType) => {
 export const CustomFeeLabel = ({ networkType }: CustomFeeLabelProps) => {
     const feeUnits = getFeeUnits(networkType);
 
-    const { watch } = useFormContext<FeesFormValues>();
-    const { customFeePerUnit } = watch();
+    const { control } = useFormContext<FeesFormValues>();
+    const customFeePerUnit = useWatch({ control, name: 'customFeePerUnit' });
 
     const formattedFeePerUnit = `${getFormattedFeeUnits(customFeePerUnit, networkType)} ${feeUnits}`;
 

--- a/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
@@ -16,7 +16,7 @@ import {
     type FormState,
     isFinalPrecomposedTransaction,
 } from '@suite-common/wallet-types';
-import { useFormContext } from '@suite-native/forms';
+import { useFormContext, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 import { useDebounce } from '@trezor/react-utils';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
@@ -64,16 +64,32 @@ export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
         setError,
         trigger,
         getValues,
-        watch,
+        control,
     } = useFormContext<FeesFormValues>();
 
     const { customFeePerUnit, customFeeLimit, customMaxFeePerGas, customMaxPriorityFeePerGas } =
         getValues();
 
-    const watchedFeePerUnit = watch(FEE_PER_UNIT_FIELD_NAME, '0');
-    const watchedFeeLimit = watch(FEE_LIMIT_FIELD_NAME, '1') as string;
-    const watchedMaxFeePerGas = watch(MAX_FEE_PER_GAS_FIELD_NAME, '0');
-    const watchedMaxPriorityFeePerGas = watch(MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME, '0');
+    const watchedFeePerUnit = useWatch({
+        control,
+        name: FEE_PER_UNIT_FIELD_NAME,
+        defaultValue: '0',
+    });
+    const watchedFeeLimit = useWatch({
+        control,
+        name: FEE_LIMIT_FIELD_NAME,
+        defaultValue: '1',
+    }) as string;
+    const watchedMaxFeePerGas = useWatch({
+        control,
+        name: MAX_FEE_PER_GAS_FIELD_NAME,
+        defaultValue: '0',
+    });
+    const watchedMaxPriorityFeePerGas = useWatch({
+        control,
+        name: MAX_PRIORITY_FEE_PER_GAS_FIELD_NAME,
+        defaultValue: '0',
+    });
 
     const normalLevelTransactionBytes = useSelector((state: NativeSendRootState) =>
         selectFeeLevelTransactionBytes(state, 'normal'),

--- a/suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts
@@ -8,6 +8,7 @@ import {
     type TokenAddress,
 } from '@suite-common/wallet-types';
 import { useBottomSheetModal } from '@suite-native/atoms';
+import { useWatch } from '@suite-native/forms';
 
 import { getFeeAvailability } from './feeAvailability';
 import { type CustomFeeParams } from './useFeeSelection';
@@ -124,7 +125,8 @@ export const useFeeSelector = ({
         ],
     );
 
-    const feeLimitSunOverride = isTrc20 ? form.watch('customFeeLimit') : undefined;
+    const customFeeLimit = useWatch({ control: form.control, name: 'customFeeLimit' });
+    const feeLimitSunOverride = isTrc20 ? customFeeLimit : undefined;
 
     return {
         form,


### PR DESCRIPTION
Description

Migrates remaining render-time `watch()` reads to `useWatch()` across suite-native form components/hooks. Calling `watch()` during render — or feeding it into `useEffect` — doesn't register as a proper hook subscription, so React Compiler can't reliably track it as reactive state, causing stale values and bugs. `useWatch()` fixes that.

`watch((values, { name, type }) => {...})` subscriptions inside `useEffect` (with `unsubscribe` cleanup) are left as-is — these are intended to not trigger re-render.

No behavior change intended.

## Notes for QA

Regression-test buy/sell/exchange forms (amount inputs, asset/account pickers, quote errors), send flow (address/memo/note inputs, checksum alerts), PIN entry, settings forms, and fee selection.

## Related Issue

Follow-up of #28982

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 21 changed files live exclusively under suite-native/ (React Native mobile app modules: device-authorization, module-accounts-import, module-device-settings, module-send, module-settings, module-trading, transaction-management). The entire E2E test suite catalogued here (suite/e2e/tests/*) targets the Trezor Suite desktop/web application (Playwright tests using onboardingPage, dashboardPage, settingsPage, walletPage, etc.), which is a separate codebase/package from suite-native. There is no static coverage mapping, and none of the 155 candidate E2E tests exercise suite-native components, hooks, or screens — they test the web/desktop Suite app's onboarding, staking, trading, metadata, and settings flows instead. Therefore no test in this suite can be confidently recommended; the appropriate verification for these changes would be suite-native's own unit/component tests or a mobile-specific E2E suite, which is not part of the provided candidate list.

<details><summary><b>Changed files (21)</b></summary>

- `suite-native/device-authorization/src/components/PinFormControlButtons.tsx`
- `suite-native/device-authorization/src/components/PinFormProgress.tsx`
- `suite-native/device-authorization/src/components/PinMatrixButton.tsx`
- `suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx`
- `suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts`
- `suite-native/module-send/src/components/AddressInput.tsx`
- `suite-native/module-send/src/components/SendMaxSwitch.tsx`
- `suite-native/module-send/src/components/SendOutputFields.tsx`
- `suite-native/module-send/src/components/SolanaMemoInput.tsx`
- `suite-native/module-send/src/components/TronNoteInput.tsx`
- `suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressChecksum.ts`
- `suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts`
- `suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx`
- `suite-native/module-settings/src/hooks/useBackendServersForm.ts`
- `suite-native/module-settings/src/hooks/useDustPhishingForm.ts`
- `suite-native/module-trading/package.json`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.tsx`
- `suite-native/transaction-management/src/hooks/fees/useCustomFee.ts`
- `suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (21)**
- `suite-native/device-authorization/src/components/PinFormControlButtons.tsx`
- `suite-native/device-authorization/src/components/PinFormProgress.tsx`
- `suite-native/device-authorization/src/components/PinMatrixButton.tsx`
- `suite-native/module-accounts-import/src/screens/XpubScanScreen.tsx`
- `suite-native/module-device-settings/src/hooks/useChangeDeviceName.ts`
- `suite-native/module-send/src/components/AddressInput.tsx`
- `suite-native/module-send/src/components/SendMaxSwitch.tsx`
- `suite-native/module-send/src/components/SendOutputFields.tsx`
- `suite-native/module-send/src/components/SolanaMemoInput.tsx`
- `suite-native/module-send/src/components/TronNoteInput.tsx`
- `suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressChecksum.ts`
- `suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.ts`
- `suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx`
- `suite-native/module-settings/src/hooks/useBackendServersForm.ts`
- `suite-native/module-settings/src/hooks/useDustPhishingForm.ts`
- `suite-native/module-trading/package.json`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeBottomSheet.tsx`
- `suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.tsx`
- `suite-native/transaction-management/src/hooks/fees/useCustomFee.ts`
- `suite-native/transaction-management/src/hooks/fees/useFeeSelector.ts`

_Updated: 2026-07-27T12:04:15.955Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite-native-use-watch/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite-native-use-watch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-native-use-watch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-native-use-watch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/suite-native-use-watch&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:07:40.568Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Trading - Swap inputs > Swap form inputs validation | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:06:44.919Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->