### PR TITLE
refactor(connect): canonicalize permission coin to lowercase CoinSymbol

### DIFF
--- a/packages/connect-common/src/types/method.ts
+++ b/packages/connect-common/src/types/method.ts
@@ -1,5 +1,6 @@
 import type { UiRequestConfirmation } from '../events/ui-request';
 import type { PrecomposeResultFinal } from './api/bitcoin/composeTransaction';
+import type { CoinSymbol } from './coinInfo';
 
 /**
  * Permission category requested by a `@trezor/connect` method.
@@ -26,13 +27,14 @@ export type MethodPermission =
 /**
  * A single permission request scoped (optionally) to a specific coin.
  *
- * `coin` is `coinInfo.shortcut` (e.g. `btc`, `eth`, `ltc`, `sol`, `ada`) when
- * the underlying method targets a coin; it is left `undefined` for coin-less
- * permissions such as `read_features` or `management`.
+ * `coin` is the canonical, lowercase coin symbol (`CoinSymbol`, e.g. `btc`,
+ * `eth`, `ada`) — the lowercased `coinInfo.shortcut` — when the underlying
+ * method targets a coin; it is left `undefined` for coin-less permissions such
+ * as `read_features` or `management`.
  */
 export type PermissionRequest = {
     permission: MethodPermission;
-    coin?: string;
+    coin?: CoinSymbol;
 };
 
 /**

--- a/packages/connect-explorer/src/pages/details/permissions.mdx
+++ b/packages/connect-explorer/src/pages/details/permissions.mdx
@@ -30,9 +30,10 @@ to a third-party application. `push_tx` is additionally unavailable to deeplink 
 
 ## Coin scoping
 
-Coin-specific permissions carry a `coin` field, which is the coin's shortcut (for example `BTC`,
-`ETH`, `ADA`). Coin-less permissions such as `read_features` omit it. Coin shortcuts are matched
-case-insensitively, so `btc` and `BTC` refer to the same coin.
+Coin-specific permissions carry a `coin` field, which is the coin's symbol — the lowercase coin
+shortcut (for example `btc`, `eth`, `ada`). Coin-less permissions such as `read_features` omit it.
+Casing is not significant: a declared coin is normalized to lowercase, so `BTC` and `btc` refer to
+the same coin.
 
 ```javascript
 { permission: 'read_address', coin: 'btc' } // a specific coin

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -3,6 +3,7 @@ import type {
     CallMethodPayload,
     CallMethodResponse,
     CoinInfo,
+    CoinSymbol,
     CoreEventMessage,
     DeviceState,
     FirmwareCapability,
@@ -137,20 +138,27 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
 
     abstract get requiredPermissions(): PermissionRequest[];
 
-    // Build a `PermissionRequest` for a single coin (or coin-less when `coin`
-    // is undefined). The coin key is `coinInfo.shortcut`.
-    protected coinPerm(permission: MethodPermission, coin?: CoinInfo): PermissionRequest {
-        return coin ? { permission, coin: coin.shortcut } : { permission };
+    // `coinInfo.shortcut` keeps its original casing (e.g. `BTC`, `tDASH`) but a
+    // permission `coin` is the lowercase `CoinSymbol`. Every shortcut lowercases
+    // to a known `CoinSymbol` (both derive from the same coin definitions), so
+    // the cast is sound.
+    private toCoinSymbol(shortcut: string): CoinSymbol {
+        return shortcut.toLowerCase() as CoinSymbol;
     }
 
-    // Build a list of `PermissionRequest` entries from a list of coins,
-    // deduplicating by `coinInfo.shortcut`. Undefined coins collapse to a
-    // single coin-less entry.
+    // Build a `PermissionRequest` for a single coin (or coin-less when `coin` is
+    // undefined).
+    protected coinPerm(permission: MethodPermission, coin?: CoinInfo): PermissionRequest {
+        return coin ? { permission, coin: this.toCoinSymbol(coin.shortcut) } : { permission };
+    }
+
+    // Build `PermissionRequest` entries from a list of coins, de-duplicated by
+    // coin symbol. Undefined coins collapse to a single coin-less entry.
     protected coinPerms(
         permission: MethodPermission,
         coins: (CoinInfo | undefined)[],
     ): PermissionRequest[] {
-        const seen = new Set<string>();
+        const seen = new Set<CoinSymbol>();
         const out: PermissionRequest[] = [];
         let hasCoinless = false;
         for (const c of coins) {
@@ -161,9 +169,10 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
                 }
                 continue;
             }
-            if (seen.has(c.shortcut)) continue;
-            seen.add(c.shortcut);
-            out.push({ permission, coin: c.shortcut });
+            const coin = this.toCoinSymbol(c.shortcut);
+            if (seen.has(coin)) continue;
+            seen.add(coin);
+            out.push({ permission, coin });
         }
 
         return out;

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -27,7 +27,7 @@ import {
     Text,
     Tooltip,
 } from '@trezor/components';
-import { type MethodPermission, type PermissionRequest } from '@trezor/connect';
+import { type CoinSymbol, type MethodPermission, type PermissionRequest } from '@trezor/connect';
 import {
     BellSlashIcon,
     BroadcastIcon,
@@ -168,7 +168,7 @@ const PermissionPreview = ({ permissions }: { permissions: MethodPermission[] })
 };
 
 type PermissionGroupProps = {
-    coin?: string;
+    coin?: CoinSymbol;
     permissions: MethodPermission[];
     defaultIsOpen: boolean;
     onRemovePermission?: (permission: PermissionRequest) => void;

--- a/suite-common/connect-popup/src/__tests__/permissions.test.ts
+++ b/suite-common/connect-popup/src/__tests__/permissions.test.ts
@@ -1,6 +1,7 @@
 import { type PermissionRequest } from '@trezor/connect';
 
 import {
+    canonicalizePermissionCoins,
     deriveCardanoEnabledNetworks,
     groupPermissionsByCoin,
     mergePermissions,
@@ -33,21 +34,26 @@ describe('sanitizeRequestedPermissions', () => {
     });
 
     it('drops entries whose coin is not a known coin symbol', () => {
-        const requested: PermissionRequest[] = [
+        // Host-supplied input can carry arbitrary strings, so it violates the compile-time
+        // `CoinSymbol` type — cast to model the untrusted wire shape.
+        const requested = [
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_address', coin: 'not-a-coin' },
-        ];
+        ] as unknown as PermissionRequest[];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
         ]);
     });
 
-    it('accepts coin symbols regardless of casing', () => {
-        const requested: PermissionRequest[] = [
+    it('accepts coin symbols in any casing and canonicalizes them to lowercase', () => {
+        const requested = [
             { permission: 'read_address', coin: 'BTC' },
             { permission: 'read_address', coin: 'tADA' },
-        ];
-        expect(sanitizeRequestedPermissions(requested, false)).toEqual(requested);
+        ] as unknown as PermissionRequest[];
+        expect(sanitizeRequestedPermissions(requested, false)).toEqual([
+            { permission: 'read_address', coin: 'btc' },
+            { permission: 'read_address', coin: 'tada' },
+        ]);
     });
 
     it('drops unknown/garbage permission values', () => {
@@ -71,14 +77,14 @@ describe('mergePermissions', () => {
         ]);
     });
 
-    it('de-duplicates by permission and coin case-insensitively, keeping the base casing', () => {
-        const base: PermissionRequest[] = [{ permission: 'read_address', coin: 'BTC' }];
+    it('de-duplicates by permission and coin, base first', () => {
+        const base: PermissionRequest[] = [{ permission: 'read_address', coin: 'btc' }];
         const extra: PermissionRequest[] = [
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_xpub', coin: 'btc' },
         ];
         expect(mergePermissions(base, extra)).toEqual([
-            { permission: 'read_address', coin: 'BTC' },
+            { permission: 'read_address', coin: 'btc' },
             { permission: 'read_xpub', coin: 'btc' },
         ]);
     });
@@ -94,11 +100,11 @@ describe('mergePermissions', () => {
 
 describe('permissionsAreCovered', () => {
     const granted: PermissionRequest[] = [
-        { permission: 'read_address', coin: 'BTC' },
+        { permission: 'read_address', coin: 'btc' },
         { permission: 'read_features' },
     ];
 
-    it('matches coins case-insensitively', () => {
+    it('matches by permission and coin', () => {
         expect(permissionsAreCovered([{ permission: 'read_address', coin: 'btc' }], granted)).toBe(
             true,
         );
@@ -120,15 +126,15 @@ describe('permissionsAreCovered', () => {
 });
 
 describe('groupPermissionsByCoin', () => {
-    it('groups by coin (case-insensitively) with the coin-less group last', () => {
+    it('groups by coin with the coin-less group last', () => {
         const groups = groupPermissionsByCoin([
-            { permission: 'read_address', coin: 'BTC' },
+            { permission: 'read_address', coin: 'btc' },
             { permission: 'read_xpub', coin: 'btc' },
             { permission: 'read_features' },
             { permission: 'sign', coin: 'eth' },
         ]);
         expect(groups).toEqual([
-            { coin: 'BTC', permissions: ['read_address', 'read_xpub'] },
+            { coin: 'btc', permissions: ['read_address', 'read_xpub'] },
             { coin: 'eth', permissions: ['sign'] },
             { permissions: ['read_features'] },
         ]);
@@ -143,13 +149,37 @@ describe('groupPermissionsByCoin', () => {
     });
 });
 
-describe('deriveCardanoEnabledNetworks', () => {
-    it('projects only Cardano grants, lowercased and de-duplicated', () => {
-        const enabled = deriveCardanoEnabledNetworks([
+describe('canonicalizePermissionCoins', () => {
+    it('lowercases mixed-case coins persisted before canonicalization', () => {
+        // Legacy persisted grants kept the mixed-case `coinInfo.shortcut`.
+        const legacy = [
             { permission: 'read_address', coin: 'BTC' },
-            { permission: 'read_address', coin: 'ADA' },
+            { permission: 'read_xpub', coin: 'tDASH' },
+            { permission: 'read_features' },
+        ] as unknown as PermissionRequest[];
+        expect(canonicalizePermissionCoins(legacy)).toEqual([
+            { permission: 'read_address', coin: 'btc' },
+            { permission: 'read_xpub', coin: 'tdash' },
+            { permission: 'read_features' },
+        ]);
+    });
+
+    it('is idempotent on already-canonical coins', () => {
+        const canonical: PermissionRequest[] = [
+            { permission: 'read_address', coin: 'btc' },
+            { permission: 'read_features' },
+        ];
+        expect(canonicalizePermissionCoins(canonical)).toEqual(canonical);
+    });
+});
+
+describe('deriveCardanoEnabledNetworks', () => {
+    it('projects only Cardano grants, de-duplicated', () => {
+        const enabled = deriveCardanoEnabledNetworks([
+            { permission: 'read_address', coin: 'btc' },
+            { permission: 'read_address', coin: 'ada' },
             { permission: 'read_xpub', coin: 'ada' },
-            { permission: 'sign', coin: 'tADA' },
+            { permission: 'sign', coin: 'tada' },
         ]);
         expect(enabled).toEqual([{ coin: 'ada' }, { coin: 'tada' }]);
     });

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -10,6 +10,7 @@ import {
     type ConnectPopupCall,
     type ConnectPopupCallWithState,
 } from './connectPopupTypes';
+import { canonicalizePermissionCoins } from './permissions';
 
 export type ConnectPopupState = {
     activeCall?: ConnectPopupCall;
@@ -31,6 +32,12 @@ export const connectPopupInitialState: ConnectPopupState = {
     permissions: [],
 };
 
+// Canonicalize a persisted app's granted coins to their lowercase `CoinSymbol` (see storageLoad).
+const normalizeRememberedCoins = (app: AppRememberedPermission): AppRememberedPermission => ({
+    ...app,
+    allowedPermissions: canonicalizePermissionCoins(app.allowedPermissions),
+});
+
 export const prepareConnectPopupReducer = createReducerWithExtraDeps(
     connectPopupInitialState,
     (builder, extra) => {
@@ -43,18 +50,26 @@ export const prepareConnectPopupReducer = createReducerWithExtraDeps(
                             ? payload.connect.permissions
                             : [];
 
-                        state.permissions = permissions.filter(
-                            (permission): permission is AppRememberedPermission =>
-                                permission !== null &&
-                                typeof permission === 'object' &&
-                                'allowedPermissions' in permission &&
-                                Array.isArray(permission.allowedPermissions) &&
-                                // Drop entries that do not have the expected format.
-                                permission.allowedPermissions.every(
-                                    (t: unknown) =>
-                                        t !== null && typeof t === 'object' && 'permission' in t,
-                                ),
-                        );
+                        state.permissions = permissions
+                            .filter(
+                                (permission): permission is AppRememberedPermission =>
+                                    permission !== null &&
+                                    typeof permission === 'object' &&
+                                    'allowedPermissions' in permission &&
+                                    Array.isArray(permission.allowedPermissions) &&
+                                    // Drop entries that do not have the expected format.
+                                    permission.allowedPermissions.every(
+                                        (t: unknown) =>
+                                            t !== null &&
+                                            typeof t === 'object' &&
+                                            'permission' in t,
+                                    ),
+                            )
+                            // Grants persisted before coins were canonicalized at the
+                            // source keep the mixed-case `coinInfo.shortcut` (e.g. `BTC`);
+                            // lowercase them on load. This reducer is shared, so it covers
+                            // both the web IDB store and native.
+                            .map(normalizeRememberedCoins);
                     }
                 },
             )

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -1,18 +1,20 @@
 import { networks } from '@suite-common/wallet-config';
-import { type EnabledNetwork, type PermissionRequest, isCoinSymbol } from '@trezor/connect';
+import {
+    type CoinSymbol,
+    type EnabledNetwork,
+    type PermissionRequest,
+    isCoinSymbol,
+} from '@trezor/connect';
 import { unique } from '@trezor/utils/src/unique';
 
-// Coin symbols (`coinInfo.shortcut`) are unique regardless of casing, but a granted permission
-// keeps the shortcut's original casing (e.g. `BTC`, `tDASH`) while a declared/host-supplied one may
-// use any casing. Compare and de-duplicate coins case-insensitively so coverage and grouping match
-// across the two.
-const coinKey = (coin?: string) => coin?.toLowerCase();
-const sameCoin = (a?: string, b?: string) => coinKey(a) === coinKey(b);
+// A `PermissionRequest.coin` is the canonical lowercase `CoinSymbol`: call-derived permissions are
+// lowercased in `coinPerm`, host-declared ones in `sanitizeRequestedPermissions`. Everything below
+// therefore compares coins with `===`.
 
 // There are permissions that depend on a coin, e.g. `read_address` for Bitcoin.
 // There are also permissions that are not scoped to a coin, e.g. `management`.
 export type GroupedPermissions = {
-    coin?: string;
+    coin?: CoinSymbol;
     permissions: PermissionRequest['permission'][];
 };
 
@@ -21,10 +23,10 @@ export type GroupedPermissions = {
 export const PERMISSION_PREVIEW_LIMIT = 6;
 
 /**
- * Map a `PermissionRequest.coin` (which is `coinInfo.shortcut`, e.g. `BTC`,
- * `ETH`, `LTC`) to a human-readable network name. Falls back to the upper-case
- * shortcut when the coin is not known to suite (e.g. an altcoin recognised
- * only by `@trezor/connect`).
+ * Map a `PermissionRequest.coin` (the canonical lowercase `CoinSymbol`, e.g.
+ * `btc`, `eth`, `ltc`) to a human-readable network name. Falls back to the
+ * upper-case shortcut when the coin is not known to suite (e.g. an altcoin
+ * recognised only by `@trezor/connect`).
  */
 export const getCoinLabel = (shortcut: string): string => {
     const key = shortcut.toLowerCase() as keyof typeof networks;
@@ -56,34 +58,28 @@ export const permissionsAreCovered = (
     granted: PermissionRequest[],
 ): boolean =>
     requested.every(req =>
-        granted.some(g => g.permission === req.permission && sameCoin(g.coin, req.coin)),
+        granted.some(g => g.permission === req.permission && g.coin === req.coin),
     );
 
 export const groupPermissionsByCoin = (permissions: PermissionRequest[]): GroupedPermissions[] => {
-    const order: (string | undefined)[] = [];
-    // Keyed by the case-insensitive coin key; keeps the first-seen coin as the group's display coin.
-    const byCoin = new Map<
-        string | undefined,
-        { coin?: string; permissions: PermissionRequest['permission'][] }
-    >();
+    const order: (CoinSymbol | undefined)[] = [];
+    const byCoin = new Map<CoinSymbol | undefined, PermissionRequest['permission'][]>();
 
     for (const { coin, permission } of permissions) {
-        const key = coinKey(coin);
-        if (!byCoin.has(key)) {
-            byCoin.set(key, { coin, permissions: [] });
-            order.push(key);
+        if (!byCoin.has(coin)) {
+            byCoin.set(coin, []);
+            order.push(coin);
         }
-        byCoin.get(key)!.permissions.push(permission);
+        byCoin.get(coin)!.push(permission);
     }
 
-    const coinFirst = order.filter(c => c !== undefined);
-    const groups: GroupedPermissions[] = coinFirst.map(key => {
-        const group = byCoin.get(key)!;
-
-        return { coin: group.coin, permissions: unique(group.permissions) };
-    });
+    const coinFirst = order.filter((c): c is CoinSymbol => c !== undefined);
+    const groups: GroupedPermissions[] = coinFirst.map(coin => ({
+        coin,
+        permissions: unique(byCoin.get(coin)!),
+    }));
     if (byCoin.has(undefined)) {
-        groups.push({ permissions: unique(byCoin.get(undefined)!.permissions) });
+        groups.push({ permissions: unique(byCoin.get(undefined)!) });
     }
 
     return groups;
@@ -105,19 +101,34 @@ const GRANTABLE_PERMISSIONS: ReadonlySet<PermissionRequest['permission']> = new 
     'push_tx',
 ]);
 
+// Sanitize the host-declared `requestedPermissions`: drop entries whose permission is not
+// grantable, `push_tx` on deeplinks, and unknown coins; lowercase each `coin` to its `CoinSymbol`.
 export const sanitizeRequestedPermissions = (
     requested: PermissionRequest[] | undefined,
     isDeeplink: boolean,
 ): PermissionRequest[] =>
-    (requested ?? []).filter(
-        permission =>
-            GRANTABLE_PERMISSIONS.has(permission.permission) &&
-            !(permission.permission === 'push_tx' && isDeeplink) &&
-            (permission.coin === undefined || isCoinSymbol(permission.coin.toLowerCase())),
+    (requested ?? []).flatMap(({ permission, coin }) => {
+        if (!GRANTABLE_PERMISSIONS.has(permission)) return [];
+        if (permission === 'push_tx' && isDeeplink) return [];
+        if (coin === undefined) return [{ permission }];
+        const symbol = coin.toLowerCase();
+
+        return isCoinSymbol(symbol) ? [{ permission, coin: symbol }] : [];
+    });
+
+// Lowercase each permission's `coin` to its `CoinSymbol`. Normalizes grants persisted before coins
+// were canonicalized at the source.
+export const canonicalizePermissionCoins = (
+    permissions: PermissionRequest[],
+): PermissionRequest[] =>
+    permissions.map(permission =>
+        permission.coin === undefined
+            ? permission
+            : { ...permission, coin: permission.coin.toLowerCase() as CoinSymbol },
     );
 
-// Union two permission lists, de-duplicated by (permission, coin) with coin compared
-// case-insensitively. `base` comes first, so on a collision its entry (and coin casing) wins.
+// Union two permission lists, de-duplicated by (permission, coin). `base` comes first, so on a
+// collision its entry wins.
 export const mergePermissions = (
     base: PermissionRequest[],
     extra: PermissionRequest[],
@@ -125,7 +136,7 @@ export const mergePermissions = (
     const seen = new Set<string>();
     const out: PermissionRequest[] = [];
     for (const permission of [...base, ...extra]) {
-        const key = `${permission.permission}:${coinKey(permission.coin) ?? ''}`;
+        const key = `${permission.permission}:${permission.coin ?? ''}`;
         if (seen.has(key)) continue;
         seen.add(key);
         out.push(permission);
@@ -137,22 +148,18 @@ export const mergePermissions = (
 // Today `enabledNetworks` only gates Cardano `derive_cardano`, so project ONLY Cardano grants;
 // grants for other coins stay pure authorization for now.
 // TODO(#23879): generalize once enabledNetworks drives more than Cardano derivation.
-const CARDANO_COINS = new Set(['ada', 'tada']);
+const CARDANO_COINS: ReadonlySet<CoinSymbol> = new Set(['ada', 'tada']);
 
 /** Projects granted per-coin permissions into the Cardano networks to enable in `@trezor/connect`. */
 export const deriveCardanoEnabledNetworks = (
     permissions: PermissionRequest[],
 ): EnabledNetwork[] => {
-    const seen = new Set<string>();
+    const seen = new Set<CoinSymbol>();
     const enabledNetworks: EnabledNetwork[] = [];
     for (const { coin } of permissions) {
-        if (!coin) continue;
-        const key = coin.toLowerCase();
-        if (!CARDANO_COINS.has(key) || seen.has(key)) continue;
-        seen.add(key);
-        // Push the lowercased `key` (a canonical CoinSymbol, 'ada'/'tada') — the raw `coin` is the
-        // mixed-case shortcut (e.g. 'ADA') and is not a valid CoinSymbol.
-        enabledNetworks.push({ coin: key } as EnabledNetwork);
+        if (!coin || !CARDANO_COINS.has(coin) || seen.has(coin)) continue;
+        seen.add(coin);
+        enabledNetworks.push({ coin });
     }
 
     return enabledNetworks;


### PR DESCRIPTION
Stacked on #30261 (`connect-upfront-permissions`) — please review/merge that first; the base of this PR should be re-pointed to `develop` once #30261 lands.

## Description

Follow-up to #30261. That PR made the connect-popup permission helpers compare and de-duplicate coins **case-insensitively**, because a permission's `coin` was the `coinInfo.shortcut` in its original (mixed) casing (e.g. `BTC`, `tDASH`) while the host-declared and persisted forms were lowercase. This PR removes that asymmetry by **canonicalizing `coin` to the lowercase `CoinSymbol` at the source**, so every consumer can compare with plain `===`.

What changed:

- `AbstractMethod.coinPerm`/`coinPerms` now emit the lowercase `CoinSymbol` ([`AbstractMethod.ts`](https://github.com/trezor/trezor-suite/blob/817c3b613b121b6bdc82078dbbcb51192be5bb23/packages/connect/src/core/AbstractMethod.ts#L141-L179)), and `sanitizeRequestedPermissions` lowercases host-declared coins ([`permissions.ts`](https://github.com/trezor/trezor-suite/blob/817c3b613b121b6bdc82078dbbcb51192be5bb23/suite-common/connect-popup/src/permissions.ts#L104-L119)).
- `PermissionRequest.coin` is typed `CoinSymbol` instead of `string` ([`method.ts`](https://github.com/trezor/trezor-suite/blob/817c3b613b121b6bdc82078dbbcb51192be5bb23/packages/connect-common/src/types/method.ts#L27-L38)), which also tightens the public `ConnectSettings.requestedPermissions` contract added in #30261.
- The case-folding helpers (`sameCoin`/`coinKey`) are deleted; `permissionsAreCovered`, `groupPermissionsByCoin` and `mergePermissions` compare with `===`.

### Caveats covered

- **Coverage** — the lowercase coin-symbol set (`coinSymbols`) fully covers every `coinInfo.shortcut` across `coins.json` + `coins-eth.json` (bitcoin + eth + misc), so the `as CoinSymbol` cast is sound and the tightened type is accurate.
- **Persisted data (web IDB + native)** — grants written before this change keep the mixed-case shortcut. Rather than a versioned IDB migration (web-only), `storageLoad` normalizes them on load via `canonicalizePermissionCoins` ([`connectPopupReducer.ts`](https://github.com/trezor/trezor-suite/blob/817c3b613b121b6bdc82078dbbcb51192be5bb23/suite-common/connect-popup/src/connectPopupReducer.ts#L64-L72)). The reducer is shared, so this covers both the web IDB store and native persistence in one idempotent step, with no schema/version change.
- **Public introspection surface** — `requiredPermissions` is only surfaced internally via the `__info` flag consumed by the Suite popup host; no dapp-facing response casing relies on the old mixed case.

### Bonus fix

By canonicalizing at the source, the remember/forget reducer paths (which compared coins case-**sensitively**) now agree with the case-insensitive coverage/grouping from #30261. That closes a latent bug where an explicit revoke of a permission could leave a stale, still-honored grant when the same coin was persisted under two casings.

## Testing

- New/updated unit tests in `permissions.test.ts` (canonical `===` semantics + `sanitize` lowercasing + `canonicalizePermissionCoins` normalization/idempotence).
- `type-check` green across `@trezor/connect-common`, `@trezor/connect`, `@suite-common/connect-popup`, `@suite-native/module-connect-popup`, `@trezor/suite`; `@trezor/connect` unit tests green.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/methodpermission-coinsymbol-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->