### PR TITLE
fix(blockchain-link): expose worker entries

### DIFF
--- a/packages/blockchain-link/package.json
+++ b/packages/blockchain-link/package.json
@@ -40,6 +40,38 @@
                 "types": "./lib/index.d.ts",
                 "default": "./lib/index.js"
             },
+            "./workers/baseWorker": {
+                "types": "./lib/workers/baseWorker.d.ts",
+                "default": "./lib/workers/baseWorker.js"
+            },
+            "./workers/blockbook": {
+                "types": "./lib/workers/blockbook/index.d.ts",
+                "default": "./lib/workers/blockbook/index.js"
+            },
+            "./workers/blockfrost": {
+                "types": "./lib/workers/blockfrost/index.d.ts",
+                "default": "./lib/workers/blockfrost/index.js"
+            },
+            "./workers/electrum": {
+                "types": "./lib/workers/electrum/index.d.ts",
+                "default": "./lib/workers/electrum/index.js"
+            },
+            "./workers/evm-rpc": {
+                "types": "./lib/workers/evm-rpc/index.d.ts",
+                "default": "./lib/workers/evm-rpc/index.js"
+            },
+            "./workers/ripple": {
+                "types": "./lib/workers/ripple/index.d.ts",
+                "default": "./lib/workers/ripple/index.js"
+            },
+            "./workers/solana": {
+                "types": "./lib/workers/solana/index.d.ts",
+                "default": "./lib/workers/solana/index.js"
+            },
+            "./workers/stellar": {
+                "types": "./lib/workers/stellar/index.d.ts",
+                "default": "./lib/workers/stellar/index.js"
+            },
             "./lib/*": "./lib/*"
         },
         "browser": {

--- a/packages/blockchain-link/src/workers/baseWorker.ts
+++ b/packages/blockchain-link/src/workers/baseWorker.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 // Abstract class extended by WorkerModule (see /src/workers/*/index.ts)
 // Provides an interface of WorkerGlobalScope to behave as regular WebWorker (see /src/index.ts)
 // Goal is to Make no difference from the implementation point of view between:

--- a/packages/blockchain-link/workers/baseWorker/index.ts
+++ b/packages/blockchain-link/workers/baseWorker/index.ts
@@ -1,0 +1,1 @@
+export * from '../../src/workers/baseWorker';

--- a/packages/blockchain-link/workers/blockbook/index.ts
+++ b/packages/blockchain-link/workers/blockbook/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockbook';

--- a/packages/blockchain-link/workers/blockfrost/index.ts
+++ b/packages/blockchain-link/workers/blockfrost/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/blockfrost';

--- a/packages/blockchain-link/workers/electrum/index.ts
+++ b/packages/blockchain-link/workers/electrum/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/electrum';

--- a/packages/blockchain-link/workers/evm-rpc/index.ts
+++ b/packages/blockchain-link/workers/evm-rpc/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/evm-rpc';

--- a/packages/blockchain-link/workers/ripple/index.ts
+++ b/packages/blockchain-link/workers/ripple/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/ripple';

--- a/packages/blockchain-link/workers/solana/index.ts
+++ b/packages/blockchain-link/workers/solana/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/solana';

--- a/packages/blockchain-link/workers/stellar/index.ts
+++ b/packages/blockchain-link/workers/stellar/index.ts
@@ -1,0 +1,1 @@
+export { default } from '../../src/workers/stellar';

--- a/packages/connect/e2e/vitest.config.ts
+++ b/packages/connect/e2e/vitest.config.ts
@@ -17,7 +17,7 @@ const alias = [
     },
 ];
 
-// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/src/workers/blockbook)
+// Plugin to resolve bare module specifiers (e.g. @trezor/blockchain-link/workers/blockbook)
 // inside new Worker(new URL(..., import.meta.url)) calls.
 // In dev mode, Vite doesn't bundle — the browser constructs the URL at runtime and has no way to
 // resolve bare package specifiers, so we must expand them to /@fs/ paths that the dev server

--- a/packages/connect/src/workers/workers.browser.ts
+++ b/packages/connect/src/workers/workers.browser.ts
@@ -1,4 +1,4 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
@@ -6,7 +6,7 @@ const BlockbookWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockbook-worker" */
-            '@trezor/blockchain-link/src/workers/blockbook',
+            '@trezor/blockchain-link/workers/blockbook',
             import.meta.url,
         ),
         { type: 'module' },
@@ -16,7 +16,7 @@ const BlockfrostWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/blockfrost-worker" */
-            '@trezor/blockchain-link/src/workers/blockfrost',
+            '@trezor/blockchain-link/workers/blockfrost',
             import.meta.url,
         ),
         { type: 'module' },
@@ -26,7 +26,7 @@ const RippleWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/ripple-worker" */
-            '@trezor/blockchain-link/src/workers/ripple',
+            '@trezor/blockchain-link/workers/ripple',
             import.meta.url,
         ),
         { type: 'module' },
@@ -36,7 +36,7 @@ const StellarWorker = () =>
     new Worker(
         new URL(
             /* webpackChunkName: "workers/stellar-worker" */
-            '@trezor/blockchain-link/src/workers/stellar',
+            '@trezor/blockchain-link/workers/stellar',
             import.meta.url,
         ),
         { type: 'module' },
@@ -46,14 +46,14 @@ const StellarWorker = () =>
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const ElectrumWorker = undefined;
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {

--- a/packages/connect/src/workers/workers.native.ts
+++ b/packages/connect/src/workers/workers.native.ts
@@ -1,9 +1,9 @@
-import BlockbookWorker from '@trezor/blockchain-link/src/workers/blockbook';
-import BlockfrostWorker from '@trezor/blockchain-link/src/workers/blockfrost';
-import ElectrumWorker from '@trezor/blockchain-link/src/workers/electrum';
-import RippleWorker from '@trezor/blockchain-link/src/workers/ripple';
-import SolanaWorker from '@trezor/blockchain-link/src/workers/solana';
-import StellarWorker from '@trezor/blockchain-link/src/workers/stellar';
+import BlockbookWorker from '@trezor/blockchain-link/workers/blockbook';
+import BlockfrostWorker from '@trezor/blockchain-link/workers/blockfrost';
+import ElectrumWorker from '@trezor/blockchain-link/workers/electrum';
+import RippleWorker from '@trezor/blockchain-link/workers/ripple';
+import SolanaWorker from '@trezor/blockchain-link/workers/solana';
+import StellarWorker from '@trezor/blockchain-link/workers/stellar';
 
 export {
     BlockbookWorker,

--- a/packages/connect/src/workers/workers.ts
+++ b/packages/connect/src/workers/workers.ts
@@ -1,42 +1,42 @@
-import type { BaseWorker } from '@trezor/blockchain-link/src/workers/baseWorker';
+import type { BaseWorker } from '@trezor/blockchain-link/workers/baseWorker';
 
 type WorkerAsyncImporter = () => Promise<BaseWorker<unknown>>;
 
 const BlockbookWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockbook-worker" */
-        '@trezor/blockchain-link/src/workers/blockbook'
+        '@trezor/blockchain-link/workers/blockbook'
     ).then(w => w.default());
 const RippleWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/ripple-worker" */
-        '@trezor/blockchain-link/src/workers/ripple'
+        '@trezor/blockchain-link/workers/ripple'
     ).then(w => w.default());
 const BlockfrostWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/blockfrost-worker" */
-        '@trezor/blockchain-link/src/workers/blockfrost'
+        '@trezor/blockchain-link/workers/blockfrost'
     ).then(w => w.default());
 const ElectrumWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/electrum-worker" */
-        '@trezor/blockchain-link/src/workers/electrum'
+        '@trezor/blockchain-link/workers/electrum'
     ).then(w => w.default());
 const SolanaWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/solana-worker" */
-        '@trezor/blockchain-link/src/workers/solana'
+        '@trezor/blockchain-link/workers/solana'
     ).then(w => w.default());
 const StellarWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/stellar-worker" */
-        '@trezor/blockchain-link/src/workers/stellar'
+        '@trezor/blockchain-link/workers/stellar'
     ).then(w => w.default());
 
 const EvmRpcWorker: WorkerAsyncImporter = () =>
     import(
         /* webpackChunkName: "workers/evm-rpc-worker" */
-        '@trezor/blockchain-link/src/workers/evm-rpc'
+        '@trezor/blockchain-link/workers/evm-rpc'
     ).then(w => w.default());
 
 export {


### PR DESCRIPTION
## Description

Trezor Connect currently loads Blockchain Link workers through @trezor/blockchain-link/src/workers/*, coupling the consumer to Blockchain Link source layout and leaving those worker paths outside the published export contract. This adds thin workspace entry modules and eight explicit published worker subpaths, migrates the browser, native, and default Connect loaders to those public paths, and keeps the browser E2E URL resolver aligned. This is extracted from #30117 and should merge before that declaration-contract PR, whose development export map builds on these worker entrypoints.

- Connect worker deep references: **22 -> 0**
- Public worker references: **0 -> 22** across **8 subpaths**
- Published JS/type targets verified: **16/16**
- Validation: Blockchain Link and Connect type-checks; both library builds; changed-file ESLint

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies the core blockchain-link worker infrastructure (baseWorker.ts plus per-network workers: blockbook, blockfrost, electrum, evm-rpc, ripple, solana, stellar) as well as the TrezorConnect worker bootstrap layer (workers.browser.ts, workers.native.ts, workers.ts). These are foundational communication layers used by nearly every coin-specific E2E test, so the risk is broad but the most concrete signal comes from tests that explicitly configure custom backends (Blockbook/Blockfrost/Electrum) or exercise Solana/Cardano/Ethereum staking and send flows, since those directly invoke the changed worker code paths. Given the connect worker file maps to 134 tests (a clear broad-utility case), only a small, high-confidence subset of connect-worker-dependent tests is included at low priority; the bulk of high/medium recommendations target discovery, custom-backend, staking, and send/swap tests per network that map to the specific blockchain-link workers changed. Recommended strategy: run the high-priority discovery/custom-backend/staking tests unconditionally, the medium-priority send/swap tests for affected networks, and spot-check TrezorConnect worker initialization with a couple of low-priority connect tests.

<details><summary><b>Changed files (13)</b></summary>

- `packages/blockchain-link/package.json`
- `packages/blockchain-link/src/workers/baseWorker.ts`
- `packages/blockchain-link/workers/baseWorker/index.ts`
- `packages/blockchain-link/workers/blockbook/index.ts`
- `packages/blockchain-link/workers/blockfrost/index.ts`
- `packages/blockchain-link/workers/electrum/index.ts`
- `packages/blockchain-link/workers/evm-rpc/index.ts`
- `packages/blockchain-link/workers/ripple/index.ts`
- `packages/blockchain-link/workers/solana/index.ts`
- `packages/blockchain-link/workers/stellar/index.ts`
- `packages/connect/src/workers/workers.browser.ts`
- `packages/connect/src/workers/workers.native.ts`
- `packages/connect/src/workers/workers.ts`

</details>

**Recommended tests (28)**

<details><summary>🔴 <b>High priority (13)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test directly exercises custom Blockbook backend configuration and discovery for BTC/LTC, which relies on the blockbook worker implementation that was changed (workers/blockbook/index.ts) and the shared baseWorker.ts logic used by all blockchain-link workers.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests custom Blockbook backend configuration and discovery success/failure paths for BTC and ETH, directly exercising the blockbook worker and baseWorker code that changed, including error handling for wrong backend URLs.
- `suite/e2e/tests/wallet/discovery.test.ts` — Exercises account discovery across many networks (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) including reload/interruption resilience, directly testing the baseWorker discovery pipeline and multiple worker implementations (blockbook, evm-rpc, ripple) that were changed.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Uses a custom Solana backend and relies heavily on the Solana blockchain-link worker (workers/solana/index.ts) and baseWorker.ts for account/transaction data during the staking flow, both of which were modified.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Exercises Solana staking rewards fetching and epoch handling via the custom Solana backend and mocked blockchain-link worker, directly testing changed Solana worker/baseWorker logic.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Solana staking with custom backend relies on the Solana worker and baseWorker request/response handling, both changed in this diff.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstake/claim flow with custom backend mocks depends on Solana worker and baseWorker transaction/epoch handling code that was modified.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Sending a SOL transaction (send max, fee calculation) directly exercises the Solana worker's transaction construction and baseWorker communication layer that changed.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Uses a mocked Blockfrost backend for Cardano staking, directly exercising the Blockfrost worker (workers/blockfrost/index.ts) that was changed.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstake flow relies on the Blockfrost worker mock backend and staking transaction data derived from blockchain-link, both affected by the changed worker files.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano rewards claim flow uses the mocked Blockfrost backend, directly exercising the changed Blockfrost worker implementation.
- `suite/e2e/tests/settings/electrum.test.ts` — Configures a custom Electrum backend for the RegTest network and verifies discovery completes, directly testing the changed Electrum worker (workers/electrum/index.ts).
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Uses a custom Blockbook backend for ETH staking, transaction confirmation, and progress phases which depend on both the Blockbook worker and baseWorker changes plus EVM RPC worker for gas fee estimation.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — ETH staking with custom blockbook backend and instant-stake banner logic exercises the same worker code paths changed in this diff (blockbook/evm-rpc workers, baseWorker).
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake/claim lifecycle relies on mocked blockbook backend and transaction confirmation, using the same changed worker infrastructure.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests regtest Bitcoin balance updates after receiving funds, relying on blockbook worker communication for balance refresh, which is part of the changed worker code.
- `suite/e2e/tests/wallet/without-device.test.ts` — Involves enabling and funding a regtest network, exercising blockbook worker communication during account discovery and balance updates alongside device-disconnected handling.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Sends BTC regtest transactions with various options (locktime, OP_RETURN, unit switching), exercising blockbook worker transaction broadcasting logic that changed.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends LTC using a custom mocked blockbook backend, including MimbleWimble peg-out handling, directly testing the changed blockbook worker code.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Configures a custom DOGE blockbook backend and tests transaction signing error handling, exercising the changed blockbook worker.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Sends an ETH transaction with custom gas fees, relying on the EVM-RPC worker fee estimation and blockbook/evm worker transaction broadcasting logic that changed.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Bitcoin swap with custom fee involves blockbook worker fee/transaction handling and baseWorker communication used across swap flows.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum swap with custom gas fee settings exercises the EVM-RPC worker fee estimation and transaction construction that changed.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests receiving BTC, ETH, SOL, and TRX addresses which requires proper account discovery and address derivation across multiple blockchain-link workers (blockbook, evm-rpc, solana) that changed.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests standard wallet discovery for BTC after ejecting/adding a wallet, directly touching the blockbook worker and baseWorker discovery pipeline.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — Recovery dry-run relies on device communication via TrezorConnect workers (workers.browser.ts/workers.ts), which were changed; a regression in worker initialization could plausibly break device connection during recovery flows.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly initializes TrezorConnect and performs getAddress calls, exercising the connect worker bootstrap code (workers.browser.ts/workers.ts) that was modified.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Uses TrezorConnect.signTransaction which depends on the connect worker initialization layer that was changed; regressions there could break signing flows broadly.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/blockchain-link/package.json`
- `packages/blockchain-link/workers/stellar/index.ts`
- `packages/connect/src/workers/workers.native.ts`

_Updated: 2026-07-27T12:50:17.742Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/blockchain-link-worker-entries/web/](https://dev.suite.sldev.cz/suite-web/fix/blockchain-link-worker-entries/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/blockchain-link-worker-entries&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/blockchain-link-worker-entries&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/blockchain-link-worker-entries&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:52:57.415Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T12:52:55.060Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->