### PR TITLE
chore(eslint): run expensive rules only in CI

### DIFF
--- a/.github/workflows/check-code-validation.yml
+++ b/.github/workflows/check-code-validation.yml
@@ -87,7 +87,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('./eslint.config.mjs') }} }}
       - name: Lint JS
         env:
-          ESLINT_TYPE_AWARE: "true"
+          ESLINT_RUN_EXPENSIVE_CHECKS: "true"
         run: yarn lint:js --output-style=stream
       - name: Lint Styles
         run: yarn lint:styles --output-style=stream

--- a/nx.json
+++ b/nx.json
@@ -59,7 +59,7 @@
                 "{workspaceRoot}/eslint.config.mjs",
                 "{workspaceRoot}/packages/eslint/**/*",
                 {
-                    "env": "ESLINT_TYPE_AWARE"
+                    "env": "ESLINT_RUN_EXPENSIVE_CHECKS"
                 }
             ],
             "outputs": ["{projectRoot}/.eslintcache"],

--- a/packages/eslint/src/expensiveChecks.mjs
+++ b/packages/eslint/src/expensiveChecks.mjs
@@ -1,3 +1,3 @@
-// Type-aware TypeScript and React Compiler rules have substantial runtime overhead.
+// Some ESLint checks have substantial runtime overhead.
 // Enable them only when a linting environment explicitly opts in.
 export const areExpensiveChecksEnabled = process.env.ESLINT_RUN_EXPENSIVE_CHECKS === 'true';

--- a/packages/eslint/src/expensiveChecks.mjs
+++ b/packages/eslint/src/expensiveChecks.mjs
@@ -1,0 +1,3 @@
+// Type-aware TypeScript and React Compiler rules have substantial runtime overhead.
+// Enable them only when a linting environment explicitly opts in.
+export const areExpensiveChecksEnabled = process.env.ESLINT_RUN_EXPENSIVE_CHECKS === 'true';

--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -2,6 +2,7 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 import playwright from 'eslint-plugin-playwright';
 import globals from 'globals';
 
+import { areExpensiveChecksEnabled } from './expensiveChecks.mjs';
 import { globalNoExtraneousDependenciesDevDependencies, importConfig } from './importConfig.mjs';
 import { javascriptConfig, noCastedObjectHelpersSyntax } from './javascriptConfig.mjs';
 import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
@@ -41,6 +42,11 @@ export const eslint = [
         ],
     },
     { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'] },
+    {
+        linterOptions: {
+            reportUnusedDisableDirectives: areExpensiveChecksEnabled ? 'warn' : 'off',
+        },
+    },
     { languageOptions: { globals: globals.browser } },
     {
         languageOptions: {

--- a/packages/eslint/src/reactConfig.mjs
+++ b/packages/eslint/src/reactConfig.mjs
@@ -1,5 +1,7 @@
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
+
+import { areExpensiveChecksEnabled } from './expensiveChecks.mjs';
 /**
  * @typedef {import('eslint').Linter.Config} Config
  */
@@ -36,4 +38,22 @@ export const reactConfig = [
             'react-hooks/use-memo': 'off', // Too restrictive: enforces inline function in useMemo (forbids using variable)
         },
     },
+    ...(areExpensiveChecksEnabled
+        ? []
+        : [
+              {
+                  rules: {
+                      'react-hooks/preserve-manual-memoization': 'off',
+                      'react-hooks/incompatible-library': 'off',
+                      'react-hooks/immutability': 'off',
+                      'react-hooks/globals': 'off',
+                      'react-hooks/error-boundaries': 'off',
+                      'react-hooks/purity': 'off',
+                      'react-hooks/set-state-in-render': 'off',
+                      'react-hooks/unsupported-syntax': 'off',
+                      'react-hooks/config': 'off',
+                      'react-hooks/gating': 'off',
+                  },
+              },
+          ]),
 ];

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -1,8 +1,6 @@
 import tseslint from 'typescript-eslint';
 
-// Type-aware ESLint rules create a TypeScript project service.
-// Enable them only when a linting environment explicitly opts in.
-const areTypeAwareRulesEnabled = process.env.ESLINT_TYPE_AWARE === 'true';
+import { areExpensiveChecksEnabled } from './expensiveChecks.mjs';
 
 // Deny importing from build artifact directories — consumers should resolve
 // through the package root, not from `lib/` or `libDev/`.
@@ -154,7 +152,7 @@ export const typescriptConfig = [
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',
         },
     },
-    ...(areTypeAwareRulesEnabled
+    ...(areExpensiveChecksEnabled
         ? []
         : [
               {

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -50,7 +50,6 @@ const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
     'packages/connect-common/libDev/src/types/api/callable.d.ts',
     'packages/connect-common/libDev/src/types/api/cardano/common.d.ts',
     'packages/connect-common/libDev/src/types/api/internal/index.d.ts',
-    'packages/connect-common/libDev/src/types/api/stellar/common.d.ts',
     'suite-common/calldata/libDev/src/calldata.d.ts',
     'suite-common/calldata/libDev/src/verifier.d.ts',
     'suite-common/earn-stablecoin-api/libDev/src/hooks/useAllYieldOpportunities.d.ts',


### PR DESCRIPTION
## Description

Type-aware TypeScript rules and React Compiler-backed Hooks rules add substantial CPU and memory overhead to local and editor linting. This replaces `ESLINT_TYPE_AWARE` with the shared `ESLINT_RUN_EXPENSIVE_CHECKS` flag, keeps both expensive rule groups disabled by default, enables them explicitly in CI, and includes the mode in Nx cache inputs. The fundamental `rules-of-hooks` and `exhaustive-deps` checks remain enabled everywhere. Closes #30294.

- `packages/suite/src` wall time: **75 s -> 40 s (47% faster)**
- 400 TSX files wall time: **15.13 s -> 9.98 s (34% faster)**
- 400 TSX files peak RSS: **1,058.7 MiB -> 700.9 MiB (34% lower)**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/eslint-expensive-checks-ci/web/](https://dev.suite.sldev.cz/suite-web/chore/eslint-expensive-checks-ci/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/eslint-expensive-checks-ci&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/eslint-expensive-checks-ci&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:02:24.757Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:02:36.094Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->