### PR TITLE
feat(suite-native): add receive QR icon

### DIFF
--- a/suite-native/module-receive/package.json
+++ b/suite-native/module-receive/package.json
@@ -30,6 +30,7 @@
         "@suite-native/device": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/formatters": "workspace:*",
+        "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/module-receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressCard.tsx
@@ -7,7 +7,7 @@ import {
     selectAccountDeviceState,
     selectAccountNetworkSymbol,
 } from '@suite-common/wallet-core';
-import { type AccountKey } from '@suite-common/wallet-types';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { Box, InlineAlertBox, type InlineAlertBoxProps, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
@@ -16,13 +16,13 @@ import { ReceiveAddressDetails } from './ReceiveAddressDetails';
 type ReceiveAddressCardProps = {
     accountKey: AccountKey;
     address: string;
-    isTokenAddress?: boolean;
+    tokenContract?: TokenAddress;
 };
 
 export const ReceiveAddressCard = ({
     accountKey,
     address,
-    isTokenAddress = false,
+    tokenContract,
 }: ReceiveAddressCardProps) => {
     const accountDescriptor = useSelector((state: AccountsRootState) =>
         selectAccountDescriptor(state, accountKey),
@@ -39,6 +39,7 @@ export const ReceiveAddressCard = ({
     }
 
     const { name: networkName } = getNetwork(symbol);
+    const isTokenAddress = tokenContract !== undefined;
 
     const getCardAlertProps = (): InlineAlertBoxProps | undefined => {
         if (symbol === 'ada') {
@@ -73,6 +74,7 @@ export const ReceiveAddressCard = ({
                 address={address}
                 deviceStaticSessionId={deviceStaticSessionId}
                 networkSymbol={symbol}
+                tokenContract={tokenContract}
                 showLabelEdit={!isTokenAddress}
             />
             {cardAlertProps && (

--- a/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
@@ -72,7 +72,7 @@ export const ReceiveAddressContent = ({
                 <ReceiveAddressCard
                     accountKey={accountKey}
                     address={address}
-                    isTokenAddress={!!tokenContract}
+                    tokenContract={tokenContract}
                 />
                 <ReceiveDestinationTagInfo accountKey={accountKey} tokenContract={tokenContract} />
             </VStack>

--- a/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
@@ -1,11 +1,12 @@
 import { Pressable, useWindowDimensions } from 'react-native';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
-import { type AccountDescriptor } from '@suite-common/wallet-types';
+import { type AccountDescriptor, type TokenAddress } from '@suite-common/wallet-types';
 import { AddressLabelEditable } from '@suite-native/address';
 import { Card, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { AddressFormatter } from '@suite-native/formatters';
+import { TokenIcon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
 import { QRCode } from '@suite-native/qr-code';
 import type { StaticSessionId } from '@trezor/connect';
@@ -16,6 +17,7 @@ type ReceiveAddressDetailsProps = {
     deviceStaticSessionId: StaticSessionId;
     accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
+    tokenContract?: TokenAddress;
     showLabelEdit?: boolean;
 };
 
@@ -36,6 +38,7 @@ export const ReceiveAddressDetails = ({
     deviceStaticSessionId,
     accountDescriptor,
     networkSymbol,
+    tokenContract,
     showLabelEdit = true,
 }: ReceiveAddressDetailsProps) => {
     const copyToClipboard = useCopyToClipboard();
@@ -66,6 +69,14 @@ export const ReceiveAddressDetails = ({
                         qrCodeSize={qrCodeSize}
                         paddingHorizontal="sp16"
                         paddingVertical="sp16"
+                        centerIcon={
+                            <TokenIcon
+                                symbol={networkSymbol}
+                                contractAddress={tokenContract}
+                                showNetworkIcon={tokenContract !== undefined}
+                                size="large"
+                            />
+                        }
                     />
                 </Card>
             </Pressable>

--- a/suite-native/module-receive/tsconfig.json
+++ b/suite-native/module-receive/tsconfig.json
@@ -27,6 +27,7 @@
         { "path": "../device" },
         { "path": "../device-mutex" },
         { "path": "../formatters" },
+        { "path": "../icons" },
         { "path": "../intl" },
         { "path": "../link" },
         { "path": "../navigation" },

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -1,3 +1,4 @@
+import { type ReactElement } from 'react';
 import { Dimensions, View } from 'react-native';
 import ReactQRCode from 'react-qr-code';
 
@@ -10,6 +11,7 @@ type QRCodeProps = {
     qrCodeSize?: number;
     paddingHorizontal?: NativeSpacing;
     paddingVertical?: NativeSpacing;
+    centerIcon?: ReactElement;
 };
 
 const SCREEN_WIDTH = Dimensions.get('screen').width;
@@ -19,6 +21,11 @@ const QRCODE_PADDING = 24;
 
 const QRCODE_SIZE =
     SCREEN_WIDTH < MAX_QRCODE_SIZE + QRCODE_PADDING ? SCREEN_WIDTH : MAX_QRCODE_SIZE;
+
+// 25% squared equals 4% total covered area, which is well within safe limits for
+// "High" level QR code.
+const QR_CENTER_ICON_MAX_RATIO = '25%';
+const QR_CENTER_ICON_PADDING = 4;
 
 const getQRCodePadding = (padding: NativeSpacing | undefined) =>
     padding === undefined ? QRCODE_PADDING : nativeSpacingToNumber(padding) * 2;
@@ -35,16 +42,37 @@ const qrCodeContainerStyle = prepareNativeStyle<{
     backgroundColor: colorVariants.standard.surfaceFillRaised,
 }));
 
+const qrCodeCenterIconWrapperStyle = prepareNativeStyle(() => ({
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+}));
+
+const qrCodeCenterIconStyle = prepareNativeStyle(utils => ({
+    maxWidth: QR_CENTER_ICON_MAX_RATIO,
+    maxHeight: QR_CENTER_ICON_MAX_RATIO,
+    padding: QR_CENTER_ICON_PADDING,
+    borderRadius: utils.borders.radii.round,
+    overflow: 'hidden',
+    backgroundColor: utils.colors.surfaceFillRaised,
+}));
+
 export const QRCode = ({
     data,
     qrCodeSize = QRCODE_SIZE,
     paddingHorizontal,
     paddingVertical,
+    centerIcon,
 }: QRCodeProps) => {
     const { applyStyle } = useNativeStyles();
 
     const horizontalPadding = getQRCodePadding(paddingHorizontal);
     const verticalPadding = getQRCodePadding(paddingVertical);
+    const hasCenterIcon = centerIcon !== undefined;
 
     return (
         <Box alignItems="center">
@@ -58,10 +86,15 @@ export const QRCode = ({
                 <ReactQRCode
                     bgColor={colorVariants.standard.surfaceFillRaised}
                     fgColor={colorVariants.standard.legacyBackgroundNeutralBold}
-                    level="Q"
+                    level={hasCenterIcon ? 'H' : 'Q'}
                     size={qrCodeSize}
                     value={data}
                 />
+                {hasCenterIcon && (
+                    <View pointerEvents="none" style={applyStyle(qrCodeCenterIconWrapperStyle)}>
+                        <View style={applyStyle(qrCodeCenterIconStyle)}>{centerIcon}</View>
+                    </View>
+                )}
             </View>
         </Box>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13180,6 +13180,7 @@ __metadata:
     "@suite-native/device": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/formatters": "workspace:*"
+    "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/navigation": "workspace:*"


### PR DESCRIPTION
## Description

Adds an optional center icon slot to the native QR code component and uses it on the receive address QR code to show the relevant asset icon. The QR code switches to high error correction when the icon is present, matching the desktop approach.

Part of https://github.com/trezor/trezor-suite/issues/29625

## Notes for QA

Check the mobile receive address screen for native coins and token receive addresses. The QR code should show the asset icon centered in the QR code and remain scannable.

## Screenshots:

https://github.com/user-attachments/assets/643b1f7e-9adb-4038-b5ee-09921c4ace98


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are entirely within the suite-native mobile app (module-receive components and the shared qr-code component) and its package/tsconfig metadata. The existing E2E test suite (suite/e2e) targets the desktop/web Trezor Suite application and has no static or direct coverage of suite-native mobile modules, so no tests statically map to these changes. The recommendations below are inferred analogs from the web E2E suite that exercise conceptually similar receive-address and QR/address-display flows, included at reduced confidence since they do not run against the actual changed mobile code. True verification of this change set would require suite-native's own test suite (e.g., Detox/RN testing), which is outside the scope of the available E2E test catalog.

<details><summary><b>Changed files (6)</b></summary>

- `suite-native/module-receive/package.json`
- `suite-native/module-receive/src/components/ReceiveAddressCard.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`
- `suite-native/module-receive/tsconfig.json`
- `suite-native/qr-code/src/components/QRCode.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the receive address reveal/copy flow for multiple coins (BTC, ETH, SOL, TRX), which is the core user-facing functionality of the changed ReceiveAddressCard, ReceiveAddressContent, and ReceiveAddressDetails components (though those are suite-native mobile components, the receive address display/copy/verify logic they implement mirrors this web flow closely). No static mapping exists since suite-native is a separate app, but this is the closest E2E analog for receive address rendering and QR/address display regressions.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test covers the global receive flow including address reveal and on-device verification, which is conceptually the same feature area as the changed receive address components. Included as an inferred (non-statically-mapped) relevant coverage for receive address display regressions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — This test includes a receive flow with address reveal/copy and QR-adjacent address formatting (cardanoTetragrams) for Cardano, which shares conceptual overlap with the changed receive address and QR code components, though it targets the desktop web app rather than suite-native.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-native/module-receive/package.json`
- `suite-native/module-receive/tsconfig.json`
- `suite-native/module-receive/src/components/ReceiveAddressCard.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`
- `suite-native/qr-code/src/components/QRCode.tsx`

_Updated: 2026-07-28T07:07:26.379Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/mobile-receive-qr-icon/web/](https://dev.suite.sldev.cz/suite-web/juriczech/mobile-receive-qr-icon/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/mobile-receive-qr-icon&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/mobile-receive-qr-icon&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/mobile-receive-qr-icon&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T07:08:51.265Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T07:08:23.702Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->