### PR TITLE
Feat/yield tasks

### DIFF
--- a/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
@@ -1,5 +1,10 @@
 import { isCryptoIconSymbol, isNetworkIconSymbol } from '@suite-common/icons';
-import { getCoingeckoId, getNetworkOptional, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getCoingeckoId,
+    getNetworkOptional,
+    isNetworkSymbol,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
 
 import { NativeTokenIcon } from './NativeTokenIcon';
 import { NonNativeTokenIcon } from './NonNativeTokenIcon';
@@ -16,8 +21,13 @@ export const TokenIcon = ({
     placeholder = '',
     customLogoUrl,
     isBordered = true,
+    wrappedTokenIcon = 'token',
     'data-testid': dataTestId,
 }: TokenIconProps) => {
+    if (wrappedTokenIcon === 'network' && isWrappedNativeToken(symbol, contractAddress)) {
+        contractAddress = null;
+    }
+
     if (!contractAddress) {
         if (showNetworkIcon) {
             const network = getNetworkOptional(symbol);
@@ -27,7 +37,10 @@ export const TokenIcon = ({
                 <NativeTokenIcon symbol={displaySymbol} size={size} data-testid={dataTestId} />
             );
 
-            if (networkSymbol !== symbol && isNetworkIconSymbol(symbol)) {
+            if (
+                (networkSymbol !== symbol || wrappedTokenIcon === 'network') &&
+                isNetworkIconSymbol(symbol)
+            ) {
                 return (
                     <NetworkIconBadge
                         networkSymbol={symbol}

--- a/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
+++ b/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
@@ -18,4 +18,8 @@ export interface TokenIconProps extends AllowedFrameProps {
     'data-testid'?: string;
     customLogoUrl?: string;
     isBordered?: boolean;
+    /**
+     * If the token is a wrapped native token (e.g. WETH), this prop determines whether to show the icon of the token itself or its network icon.
+     */
+    wrappedTokenIcon?: 'token' | 'network';
 }

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -41,6 +41,7 @@ export const EarnAccountCell = ({
                         showNetworkIcon={showAssetNetworkIcon}
                         size={32}
                         isBordered={false}
+                        wrappedTokenIcon="network"
                     />
                 ) : (
                     <TokenIcon symbol={networkSymbol} size={32} />

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -17,7 +17,10 @@ import {
     getYieldVaultContractAddress,
     isStablecoinYieldSupported,
 } from '@suite-common/wallet-core';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    getContractAddressForNetworkSymbol,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-utils';
 import { Card, Column, Icon, Row, Table } from '@trezor/components';
 import { ArrowDownIcon, ArrowRightIcon } from '@trezor/icons';
 import { BigNumber } from '@trezor/utils';
@@ -95,7 +98,11 @@ export const EarnYieldAccountOpportunity = ({
         const networkSymbol = opportunity.account?.symbol ?? opportunity.networkSymbol;
         const accountIndex = opportunity.account?.index ?? 0;
         const accountType = opportunity.account?.accountType ?? 'normal';
-        const tokenAddress = opportunity.vault.token.address;
+        // A wrapped-native (WETH) vault deposit spends the native asset (wrapped on the way in),
+        // so prefill a native buy rather than the wrapped ERC-20, which on-ramps don't sell.
+        const tokenAddress = isWrappedNativeToken(networkSymbol, opportunity.vault.token.address)
+            ? undefined
+            : opportunity.vault.token.address;
 
         if (opportunity.account) {
             const tokenCryptoId = tokenAddress

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
@@ -1,0 +1,216 @@
+import { renderHook } from '@testing-library/react';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { getYieldOpportunityData, useYieldTableData } from './useYieldTableData';
+
+jest.mock('src/hooks/suite', () => ({
+    useSelector: () => [],
+}));
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+const createMockVault = (
+    id: string,
+    token: { address: string; symbol: string; name: string; decimals: number },
+): YieldDtoV2 =>
+    ({
+        id,
+        network: 'ethereum',
+        chainId: 1,
+        providerId: 'morpho',
+        metadata: {
+            name: `${token.name} Vault`,
+            underMaintenance: false,
+            deprecated: false,
+        },
+        token: { ...token, network: 'ethereum' },
+        outputToken: {
+            address: '0xde6c23e561f3e55846207ec45a91b777e0f7c889',
+            symbol: `tr${token.symbol}p`,
+            name: `Trezor ${token.name} Prime`,
+            decimals: 18,
+            network: 'ethereum',
+        },
+        rewardRate: {
+            total: 0.05,
+            rateType: 'APY',
+            components: [],
+        },
+        status: {
+            enter: true,
+            exit: true,
+        },
+    }) satisfies YieldDtoV2 as unknown as YieldDtoV2;
+
+const wethVault = createMockVault('ethereum-weth-vault', {
+    address: WETH_ADDRESS,
+    symbol: 'WETH',
+    name: 'Wrapped Ether',
+    decimals: 18,
+});
+
+const usdcVault = createMockVault('ethereum-usdc-vault', {
+    address: USDC_ADDRESS,
+    symbol: 'USDC',
+    name: 'USD Coin',
+    decimals: 6,
+});
+
+describe(getYieldOpportunityData.name, () => {
+    describe('wrapped-native (WETH) vault', () => {
+        it('combines the token balance with the native balance minus the gas reserve', () => {
+            const account = mockWalletAccount({
+                symbol: 'eth',
+                formattedBalance: '1',
+                tokens: [
+                    mockAccountToken({
+                        contract: WETH_ADDRESS,
+                        symbol: 'WETH',
+                        decimals: 18,
+                        balance: '0.5',
+                    }),
+                ],
+            });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: wethVault,
+            });
+
+            expect(data.additionalDepositAmount).toBe('1.495');
+        });
+
+        it('counts a native-only account (no WETH token) as depositable', () => {
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: wethVault,
+            });
+
+            expect(data.matchedInputToken).toBeUndefined();
+            expect(data.additionalDepositAmount).toBe('0.995');
+            expect(data.hasRewardsData).toBe(true);
+        });
+
+        it('does not count a native balance below the gas reserve', () => {
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: wethVault,
+            });
+
+            expect(data.additionalDepositAmount).toBe('0');
+            expect(data.hasRewardsData).toBe(false);
+        });
+
+        it('denominates amounts in the native symbol without a token contract', () => {
+            const account = mockWalletAccount({
+                symbol: 'eth',
+                formattedBalance: '1',
+                tokens: [
+                    mockAccountToken({
+                        contract: WETH_ADDRESS,
+                        symbol: 'WETH',
+                        decimals: 18,
+                        balance: '0.5',
+                    }),
+                ],
+            });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: wethVault,
+            });
+
+            expect(data.depositedSymbol).toBe('ETH');
+            expect(data.depositedContractAddress).toBeNull();
+        });
+    });
+
+    describe('non-wrapped-native vault', () => {
+        it('uses only the matched token balance and keeps the token denomination', () => {
+            const account = mockWalletAccount({
+                symbol: 'eth',
+                formattedBalance: '1',
+                tokens: [
+                    mockAccountToken({
+                        contract: USDC_ADDRESS,
+                        symbol: 'USDC',
+                        decimals: 6,
+                        balance: '100',
+                    }),
+                ],
+            });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: usdcVault,
+            });
+
+            expect(data.additionalDepositAmount).toBe('100');
+            expect(data.depositedSymbol).toBe('USDC');
+            expect(data.depositedContractAddress).toBe(USDC_ADDRESS);
+        });
+
+        it('is not depositable without the matched token, regardless of native balance', () => {
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
+
+            const data = getYieldOpportunityData({
+                account,
+                networkSymbol: 'eth',
+                vault: usdcVault,
+            });
+
+            expect(data.additionalDepositAmount).toBe('0');
+            expect(data.hasRewardsData).toBe(false);
+        });
+    });
+});
+
+describe(useYieldTableData.name, () => {
+    it('classifies a native-only account as depositable, ahead of below-reserve accounts', () => {
+        const belowReserveAccount = mockWalletAccount({
+            symbol: 'eth',
+            descriptor: asAccountDescriptor('0xbe1030e5e50e5e0'),
+            formattedBalance: '0.001',
+        });
+        const nativeOnlyAccount = mockWalletAccount({
+            symbol: 'eth',
+            descriptor: asAccountDescriptor('0xde9051ab1e0e0e0'),
+            formattedBalance: '1',
+        });
+
+        const { result } = renderHook(() =>
+            useYieldTableData({
+                availableVaults: [wethVault],
+                visibleAccounts: [belowReserveAccount, nativeOnlyAccount],
+                visibleAccountSymbols: new Set<NetworkSymbol>(['eth']),
+            }),
+        );
+
+        const opportunities = result.current.yieldAccountOpportunities;
+
+        // The depositable bucket is ordered before the no-balance bucket.
+        expect(
+            opportunities.map(({ account, additionalDepositAmount }) => ({
+                key: account?.key,
+                additionalDepositAmount,
+            })),
+        ).toEqual([
+            { key: nativeOnlyAccount.key, additionalDepositAmount: '0.995' },
+            { key: belowReserveAccount.key, additionalDepositAmount: '0' },
+        ]);
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -1,10 +1,15 @@
 import { useMemo } from 'react';
 
 import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetworkByYieldXyzId,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
 import {
     doTokensMatch,
     getConvertedOutputTokenBalanceToInputTokenAmount,
+    getYieldDepositableBalance,
     selectDeviceSupportedNetworks,
 } from '@suite-common/wallet-core';
 import { type Account, type TokenInfoBranded, toTokenSymbol } from '@suite-common/wallet-types';
@@ -14,6 +19,7 @@ import {
     compareEarnByNetwork,
     compareEarnByNetworkTokenOrder,
     getApyPercent,
+    isWrappedNativeToken,
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -57,7 +63,7 @@ const getMatchedAccountToken = ({
     );
 };
 
-const getYieldOpportunityData = ({
+export const getYieldOpportunityData = ({
     account,
     networkSymbol,
     vault,
@@ -84,9 +90,19 @@ const getYieldOpportunityData = ({
         outputTokenBalance: matchedOutputToken?.balance,
         pricePerShareState: vault.state?.pricePerShareState,
     });
-    const additionalDepositAmount = matchedInputToken?.balance ?? '0';
+    // For a wrapped-native (WETH) vault the wrappable native balance counts in too, minus the
+    // fee reserve kept for the follow-up wrap + approve + deposit fees.
+    const additionalDepositAmount = getYieldDepositableBalance({
+        networkSymbol,
+        nativeFormattedBalance: account.formattedBalance,
+        vaultTokenAddress: vault.token.address,
+        matchedTokenBalance: matchedInputToken?.balance,
+    });
     const hasRewardsData =
         new BigNumber(depositedAmount).gt(0) || new BigNumber(additionalDepositAmount).gt(0);
+    // A wrapped-native vault is presented as its native asset (see #29881), so amounts are
+    // denominated in the native symbol and no token contract is exposed to the formatters.
+    const isWrappedNativeVault = isWrappedNativeToken(networkSymbol, vault.token.address);
 
     return {
         matchedInputToken,
@@ -94,15 +110,14 @@ const getYieldOpportunityData = ({
         hasRewardsData,
         depositedAmount,
         additionalDepositAmount,
-        depositedSymbol: matchedInputToken?.symbol ?? toTokenSymbol(vault.token.symbol),
-        depositedContractAddress: matchedInputToken?.contract ?? vault.token.address ?? null,
+        depositedSymbol: isWrappedNativeVault
+            ? toTokenSymbol(getNetworkDisplaySymbol(networkSymbol))
+            : (matchedInputToken?.symbol ?? toTokenSymbol(vault.token.symbol)),
+        depositedContractAddress: isWrappedNativeVault
+            ? null
+            : (matchedInputToken?.contract ?? vault.token.address ?? null),
     };
 };
-
-const getAvailableBalanceForSorting = (opportunity: YieldAccountOpportunity) =>
-    opportunity.matchedInputToken
-        ? opportunity.additionalDepositAmount
-        : (opportunity.account?.formattedBalance ?? '0');
 
 const toNetworkTokenSortKey = (opportunity: YieldAccountOpportunity) =>
     opportunity.account && {
@@ -154,7 +169,6 @@ export const useYieldTableData = ({
         const noBalanceOpportunities: YieldAccountOpportunity[] = [];
 
         allOpportunities.forEach(opportunity => {
-            const hasMatchedInputToken = opportunity.matchedInputToken !== undefined;
             const hasDepositableBalance = new BigNumber(opportunity.additionalDepositAmount).gt(0);
 
             if (opportunity.hasVaultPosition) {
@@ -163,7 +177,7 @@ export const useYieldTableData = ({
                 return;
             }
 
-            if (hasMatchedInputToken && hasDepositableBalance) {
+            if (hasDepositableBalance) {
                 depositableOpportunities.push(opportunity);
 
                 return;
@@ -177,7 +191,9 @@ export const useYieldTableData = ({
                 .toSorted(compareEarnByAmountDesc(opportunity => opportunity.depositedAmount))
                 .toSorted(compareEarnByNetwork(opportunity => opportunity.account?.symbol)),
             ...depositableOpportunities
-                .toSorted(compareEarnByAmountDesc(getAvailableBalanceForSorting))
+                .toSorted(
+                    compareEarnByAmountDesc(opportunity => opportunity.additionalDepositAmount),
+                )
                 .toSorted(compareEarnByNetworkTokenOrder(toNetworkTokenSortKey)),
             ...noBalanceOpportunities.toSorted(
                 compareEarnByNetworkTokenOrder(toNetworkTokenSortKey),

--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -8,9 +8,11 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { type Account } from '@suite-common/wallet-types';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { exhaustive } from '@trezor/type-utils';
 
+import { type AllowanceModalProvider } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo';
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useAllowanceContext } from 'src/hooks/wallet/allowance';
@@ -51,15 +53,22 @@ export const YieldApproveModal = ({
         select: yieldOpportunity => yieldOpportunity.metadata.name,
     });
 
-    const provider = {
+    const provider: AllowanceModalProvider = {
         name: vaultName,
         companyName: vaultName,
-        logo: getAssetLogoUrl({
-            coingeckoId: networkId,
-            contractAddress: parsedContract,
-            size: 80,
-        }),
-        label: 'TR_EARN_YIELD_VAULT' as const,
+        logo: isWrappedNativeToken(account.symbol, contractAddress)
+            ? {
+                  symbol: account.symbol,
+                  size: 20,
+                  showNetworkIcon: true,
+                  wrappedTokenIcon: 'network',
+              }
+            : getAssetLogoUrl({
+                  coingeckoId: networkId,
+                  contractAddress: parsedContract,
+                  size: 80,
+              }),
+        label: 'TR_EARN_YIELD_VAULT',
     };
 
     useEffect(() => {

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -16,6 +16,7 @@ import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon, InfoIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
 
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
 import { useDispatch } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
@@ -131,14 +132,30 @@ export const YieldPageHeader = ({
                             >
                                 {vaultName}
                             </Text>
-                            <AccountLabel
-                                account={account}
-                                showAccountTypeBadge
-                                accountTypeBadgeSize="small"
-                                intent="neutral"
-                                priority="secondary"
-                                typographyStyle="body-sm"
-                            />
+                            {/* The balance aligns with the right edge of the vault name above;
+                                when the name is shorter, the gap keeps it 24px from the label. */}
+                            <Row justifyContent="space-between" alignItems="center" gap={24}>
+                                <AccountLabel
+                                    account={account}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    typographyStyle="body-sm"
+                                />
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <FormattedCryptoAmount
+                                        value={account.formattedBalance}
+                                        symbol={account.symbol}
+                                        isBalance
+                                        data-testid="@yield/page-header/balance"
+                                    />
+                                </Text>
+                            </Row>
                         </Column>
                     </Row>
                 ) : (

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -121,6 +121,7 @@ export const YieldPageHeader = ({
                                 showNetworkIcon
                                 size={32}
                                 isBordered={false}
+                                wrappedTokenIcon="network"
                             />
                         )}
                         <Column gap={2} overflow="hidden">

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -2,11 +2,12 @@ import styled from 'styled-components';
 
 import { Translation, type TranslationKey } from '@suite/intl';
 import { CardList, Column, Image, Row, Text } from '@trezor/components';
+import { TokenIcon, type TokenIconProps } from '@trezor/product-components';
 
 export type AllowanceModalProvider = {
     name?: string;
     companyName?: string;
-    logo?: string;
+    logo?: string | TokenIconProps;
     label: TranslationKey;
 };
 
@@ -39,7 +40,11 @@ export const AllowanceModalProviderInfo = ({
                 <Logo>
                     {provider.logo && (
                         <Row alignItems="center" justifyContent="center">
-                            <Image imageSrc={provider.logo} maxHeight={20} borderRadius={4} />
+                            {typeof provider.logo === 'string' ? (
+                                <Image imageSrc={provider.logo} maxHeight={20} borderRadius={4} />
+                            ) : (
+                                <TokenIcon {...provider.logo} />
+                            )}
                         </Row>
                     )}
                     <Text typographyStyle="body-sm">{providerName}</Text>

--- a/suite-common/wallet-config/src/wrappedNativeToken.ts
+++ b/suite-common/wallet-config/src/wrappedNativeToken.ts
@@ -36,3 +36,23 @@ export const getWrappedNativeAddress = (networkSymbol: NetworkSymbol) =>
 
 export const getWrappedNativeSymbol = (networkSymbol: NetworkSymbol) =>
     WRAPPED_NATIVE[networkSymbol]?.symbol;
+
+export const isWrappedNativeToken = (
+    networkSymbol: NetworkSymbol,
+    contractAddress?: string | null,
+): boolean => {
+    const wrappedNativeAddress = getWrappedNativeAddress(networkSymbol);
+
+    // TLRD: Don't use `areEvmAddressesEqual` here as it would drag wasm-adjacent dependencies into its webpack build (and that break `build-connect`).
+    //
+    // Checksum-agnostic equality. One side is always a known-valid WRAPPED_NATIVE constant, so a
+    // case-insensitive comparison is equivalent to a full EVM address comparison — and it keeps
+    // this module dependency-free for light consumers (e.g. connect-explorer reaches it through
+    // the design system's TokenIcon, where an EVM address library would drag wasm-adjacent
+    // dependencies into its webpack build).
+    return (
+        !!wrappedNativeAddress &&
+        !!contractAddress &&
+        wrappedNativeAddress.toLowerCase() === contractAddress.toLowerCase()
+    );
+};

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -1,4 +1,3 @@
-import { areEvmAddressesEqual } from '@suite-common/address';
 import {
     type Explorer,
     type NetworkSymbol,
@@ -6,7 +5,6 @@ import {
     type NetworkType,
     getExplorerUrl,
     getNetworkType,
-    getWrappedNativeAddress,
 } from '@suite-common/wallet-config';
 import {
     type EthereumSpecific,
@@ -36,10 +34,8 @@ export const getContractAddressForNetworkSymbol = (
     }
 };
 
-export const isWrappedNativeToken = (
-    networkSymbol: NetworkSymbol,
-    contractAddress?: string | null,
-): boolean => areEvmAddressesEqual(getWrappedNativeAddress(networkSymbol), contractAddress);
+// Moved next to the WRAPPED_NATIVE config it reads; re-exported here for existing consumers.
+export { isWrappedNativeToken } from '@suite-common/wallet-config';
 
 export const getAssetLogoContractAddresses = async (
     symbol: NetworkSymbolExtended | undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Display ETH icon for WETH vaults. 
- Show ETH at WETH vaults instead of ETH units. 
- Show account balance in yield page header

## Related Issue

Resolve #29881
Resolve #29870
Resolve #29885

## Screenshots:

<img width="1219" height="1047" alt="Snímek obrazovky 2026-07-27 v 15 27 32" src="https://github.com/user-attachments/assets/0e838c85-9b0d-4f53-9505-299e6116e5f4" />

<img width="662" height="694" alt="Snímek obrazovky 2026-07-27 v 16 56 03" src="https://github.com/user-attachments/assets/823fca69-b556-45b2-b1f9-7c4633f7b5cf" />

<img width="517" height="532" alt="Snímek obrazovky 2026-07-27 v 15 24 18" src="https://github.com/user-attachments/assets/f071e597-d653-4027-ba31-68b6af0fdc93" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on Earn/Yield dashboard components (EarnAccountCell, EarnYieldAccountOpportunity, useYieldTableData, YieldApproveModal, YieldPageHeader) and shared token utilities (tokenUtils.ts, wrappedNativeToken.ts, TokenIcon). These are highly specific to the staking/earn feature and token display logic, so the most relevant E2E coverage is the ETH staking test suite, which exercises staking dashboards, approval flows, and token amount rendering. Although TokenIcon and tokenUtils are statically referenced by 133 tests (broad utility heuristic), only staking-related tests have concrete behavioral overlap with the changed components; other tests are omitted as the changes are unlikely to affect their specific flows. A unit test file (useYieldTableData.test.ts) exists for the hook change but has no E2E mapping, so it's flagged as uncovered from an E2E perspective while presumably covered by its own unit test.

<details><summary><b>Changed files (11)</b></summary>

- `packages/product-components/src/components/TokenIcon/TokenIcon.tsx`
- `packages/product-components/src/components/TokenIcon/tokenIconTypes.ts`
- `packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts`
- `packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx`
- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `suite-common/wallet-config/src/wrappedNativeToken.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the ETH staking dashboard and staking form, which display token/account information via EarnAccountCell and EarnYieldAccountOpportunity-like components and TokenIcon; changes to tokenUtils.ts and wrappedNativeToken.ts could affect token/amount display and approval flows in the ETH staking flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Covers ETH staking dashboard rendering (staked/pending/rewards amounts) which relies on EarnAccountCell and token utilities; the YieldApproveModal and YieldPageHeader changes could impact the staking approval/confirmation UI used in this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Involves the ETH staking dashboard and claim flows displaying token amounts and account cells; changes to token utilities and wrapped native token config could affect amount/claim rendering in this ETH-specific staking test.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly tests the ETH staking form validation and crypto/fiat conversion logic, which is closely tied to token utility functions and the YieldPageHeader/YieldApproveModal components that were modified.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests dashboard asset rendering with buy buttons and asset activation, which uses TokenIcon and token utilities for displaying coin/token info; a regression in tokenUtils or TokenIcon could subtly affect asset card rendering.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx`
- `packages/product-components/src/components/TokenIcon/tokenIconTypes.ts`

_Updated: 2026-07-28T12:18:29.451Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/weth-tasks/web/](https://dev.suite.sldev.cz/suite-web/feat/weth-tasks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/weth-tasks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/weth-tasks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/weth-tasks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:21:38.906Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:21:49.813Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->