### PR TITLE
fix(suite-native): connect worker in native storybook

### DIFF
--- a/suite-native/storybook/.storybook/main.ts
+++ b/suite-native/storybook/.storybook/main.ts
@@ -58,7 +58,26 @@ const main: StorybookConfig = {
             define: {
                 'process.version': '"v18.0.0"',
             },
-            plugins: [nodePolyfills()],
+            plugins: [
+                nodePolyfills(),
+                {
+                    // Vite ignores @trezor/connect's "react-native" package.json field and
+                    // resolves to workers.browser.ts, which Vite's worker plugin can't bundle.
+                    // Redirect to workers.native.ts, matching Metro's resolution in the real app.
+                    name: 'redirect-connect-workers-to-native',
+                    enforce: 'pre',
+                    resolveId(source) {
+                        if (
+                            source.endsWith('/workers/workers') ||
+                            source === '../workers/workers'
+                        ) {
+                            return require.resolve('@trezor/connect/src/workers/workers.native.ts');
+                        }
+
+                        return null;
+                    },
+                },
+            ],
         };
 
         return mergeConfig(config, myConfig);

--- a/suite-native/storybook/package.json
+++ b/suite-native/storybook/package.json
@@ -27,6 +27,7 @@
         "@storybook/react-native-web-vite": "^10.3.4",
         "@suite-native/alerts": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@trezor/connect": "workspace:*",
         "@trezor/eslint": "workspace:*",
         "@trezor/styles-native": "workspace:*",
         "@trezor/theme": "workspace:*",

--- a/suite-native/storybook/tsconfig.json
+++ b/suite-native/storybook/tsconfig.json
@@ -4,6 +4,7 @@
     "references": [
         { "path": "../alerts" },
         { "path": "../intl" },
+        { "path": "../../packages/connect" },
         { "path": "../../packages/eslint" },
         {
             "path": "../../packages/styles-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13836,6 +13836,7 @@ __metadata:
     "@storybook/react-native-web-vite": "npm:^10.3.4"
     "@suite-native/alerts": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@trezor/connect": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     "@trezor/theme": "workspace:*"


### PR DESCRIPTION

## Description

`yarn storybook:web:build` failed because Vite doesn't support @trezor/connect's package.json `"react-native"` field remap, so it always resolved the worker import to `workers.browser.ts`, whose `new URL()`-based Worker construction Vite's worker plugin can't bundle. Redirect it to `workers.native.ts` instead, matching what Metro already resolves for the real app.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all confined to suite-native/storybook (Storybook config, package.json, and tsconfig for the React Native storybook tooling). This is a development/tooling-only package used for isolated component previews and is not part of the suite (web/desktop) E2E test surface, which lives under suite/e2e/tests and exercises the Trezor Suite web/desktop application. None of the 98 candidate E2E tests reference or exercise suite-native storybook configuration, build tooling, or TypeScript compilation settings, so there is no plausible regression path from these changes into the E2E suite. No tests are recommended; if verification is needed, it should be done via building/running the storybook itself (e.g., `yarn storybook` in suite-native) rather than the Playwright E2E suite.

<details><summary><b>Changed files (3)</b></summary>

- `suite-native/storybook/.storybook/main.ts`
- `suite-native/storybook/package.json`
- `suite-native/storybook/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-native/storybook/.storybook/main.ts`
- `suite-native/storybook/package.json`
- `suite-native/storybook/tsconfig.json`

_Updated: 2026-07-27T14:03:57.118Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/storybook-native-web-build-worker-resolution/web/](https://dev.suite.sldev.cz/suite-web/fix/storybook-native-web-build-worker-resolution/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/storybook-native-web-build-worker-resolution&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/storybook-native-web-build-worker-resolution&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/storybook-native-web-build-worker-resolution&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T14:07:21.423Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->