### PR TITLE
feat(requirements): enforce test colocation

### DIFF
--- a/packages/requirements/src/fileSystem.test.ts
+++ b/packages/requirements/src/fileSystem.test.ts
@@ -1,0 +1,38 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+
+import { normalizePath, walkDirectory } from './fileSystem';
+
+describe(walkDirectory.name, () => {
+    let rootDirectory: string;
+
+    beforeEach(() => {
+        rootDirectory = mkdtempSync(join(tmpdir(), 'walk-directory-'));
+    });
+
+    afterEach(() => {
+        rmSync(rootDirectory, { recursive: true, force: true });
+    });
+
+    it('walks files recursively and skips excluded directories', () => {
+        const nestedDirectory = join(rootDirectory, 'nested');
+        const excludedDirectory = join(rootDirectory, 'excluded');
+        mkdirSync(nestedDirectory);
+        mkdirSync(excludedDirectory);
+        writeFileSync(join(rootDirectory, 'root.ts'), '');
+        writeFileSync(join(nestedDirectory, 'nested.ts'), '');
+        writeFileSync(join(excludedDirectory, 'excluded.ts'), '');
+
+        const files = [
+            ...walkDirectory(rootDirectory, {
+                shouldEnterDirectory: ({ entry }) => entry.name !== 'excluded',
+            }),
+        ]
+            .filter(({ entry }) => entry.isFile())
+            .map(({ path }) => normalizePath(relative(rootDirectory, path)))
+            .sort();
+
+        expect(files).toEqual(['nested/nested.ts', 'root.ts']);
+    });
+});

--- a/packages/requirements/src/fileSystem.ts
+++ b/packages/requirements/src/fileSystem.ts
@@ -1,0 +1,35 @@
+import { type Dirent, readdirSync } from 'node:fs';
+import { join, sep } from 'node:path';
+
+export type WalkDirectoryEntry = {
+    readonly path: string;
+    readonly entry: Dirent;
+};
+
+export type WalkDirectoryOptions = {
+    readonly shouldEnterDirectory?: (entry: WalkDirectoryEntry) => boolean;
+};
+
+export function* walkDirectory(
+    directoryPath: string,
+    options: WalkDirectoryOptions = {},
+): Generator<WalkDirectoryEntry> {
+    for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
+        const walkedEntry = {
+            path: join(directoryPath, entry.name),
+            entry,
+        };
+
+        if (entry.isDirectory()) {
+            if (options.shouldEnterDirectory?.(walkedEntry) !== false) {
+                yield* walkDirectory(walkedEntry.path, options);
+            }
+
+            continue;
+        }
+
+        yield walkedEntry;
+    }
+}
+
+export const normalizePath = (filePath: string): string => filePath.split(sep).join('/');

--- a/packages/requirements/src/report.test.ts
+++ b/packages/requirements/src/report.test.ts
@@ -15,8 +15,8 @@ describe('report', () => {
         const report = createReport({ console: createConsoleMock(data) });
 
         const results: RequirementResult[] = [
-            { requirement: 'check-a', target: 'repo', errors: [] },
-            { requirement: 'check-b', target: 'repo', errors: [] },
+            { requirement: 'check-a', target: 'repo', errors: [], durationMs: 10 },
+            { requirement: 'check-b', target: 'repo', errors: [], durationMs: 20 },
         ];
 
         const exitCode = report(results);
@@ -27,6 +27,13 @@ describe('report', () => {
             '  ✓ check-a [repo]',
             '  ✓ check-b [repo]',
             '',
+            'Requirement timings:',
+            '  Requirement | Runs | Duration',
+            '  ------------+------+---------',
+            '  check-b     |    1 |    20 ms',
+            '  check-a     |    1 |    10 ms',
+            '  Total       |    2 |    30 ms',
+            '',
             'All 2 requirement(s) passed.',
         ]);
     });
@@ -36,7 +43,7 @@ describe('report', () => {
         const report = createReport({ console: createConsoleMock(data) });
 
         const results: RequirementResult[] = [
-            { requirement: 'check-a', target: 'repo', errors: ['broken'] },
+            { requirement: 'check-a', target: 'repo', errors: ['broken'], durationMs: 1_250 },
         ];
 
         const exitCode = report(results);
@@ -47,6 +54,12 @@ describe('report', () => {
             '  ✗ check-a [repo]',
             '      broken',
             '',
+            'Requirement timings:',
+            '  Requirement | Runs | Duration',
+            '  ------------+------+---------',
+            '  check-a     |    1 |   1.25 s',
+            '  Total       |    1 |   1.25 s',
+            '',
             '1 error(s) in 1 requirement(s) failed.',
         ]);
     });
@@ -56,8 +69,13 @@ describe('report', () => {
         const report = createReport({ console: createConsoleMock(data) });
 
         const results: RequirementResult[] = [
-            { requirement: 'good', target: 'repo', errors: [] },
-            { requirement: 'bad', target: 'alpha', errors: ['error-1', 'error-2'] },
+            { requirement: 'good', target: 'repo', errors: [], durationMs: 5 },
+            {
+                requirement: 'bad',
+                target: 'alpha',
+                errors: ['error-1', 'error-2'],
+                durationMs: 15,
+            },
         ];
 
         const exitCode = report(results);
@@ -70,8 +88,31 @@ describe('report', () => {
             '      error-1',
             '      error-2',
             '',
+            'Requirement timings:',
+            '  Requirement | Runs | Duration',
+            '  ------------+------+---------',
+            '  bad         |    1 |    15 ms',
+            '  good        |    1 |     5 ms',
+            '  Total       |    2 |    20 ms',
+            '',
             '2 error(s) in 1 requirement(s) failed.',
         ]);
+    });
+
+    it('groups workspace timings by requirement', () => {
+        const data: string[] = [];
+        const report = createReport({ console: createConsoleMock(data) });
+
+        const results: RequirementResult[] = [
+            { requirement: 'workspace-check', target: 'alpha', errors: [], durationMs: 4 },
+            { requirement: 'workspace-check', target: 'beta', errors: [], durationMs: 6 },
+        ];
+
+        report(results);
+        const normalizedData = data.map(stripVTControlCharacters);
+
+        expect(normalizedData).toContain('  workspace-check |    2 |    10 ms');
+        expect(normalizedData).toContain('  Total           |    2 |    10 ms');
     });
 
     it('returns 0 for empty results', () => {

--- a/packages/requirements/src/report.ts
+++ b/packages/requirements/src/report.ts
@@ -12,6 +12,87 @@ export type ReportDep = {
     readonly report: Report;
 };
 
+type RequirementTiming = {
+    readonly requirement: string;
+    runCount: number;
+    durationMs: number;
+};
+
+type TimingRow = {
+    readonly requirement: string;
+    readonly runCount: string;
+    readonly duration: string;
+};
+
+const formatDuration = (durationMs: number): string => {
+    if (durationMs < 1_000) {
+        return `${Math.round(durationMs * 100) / 100} ms`;
+    }
+
+    return `${(durationMs / 1_000).toFixed(2)} s`;
+};
+
+const reportTimings = (deps: ReportDeps, results: ReadonlyArray<RequirementResult>): void => {
+    if (results.length === 0) {
+        return;
+    }
+
+    const timingsByRequirement = new Map<string, RequirementTiming>();
+
+    for (const result of results) {
+        const timing = timingsByRequirement.get(result.requirement);
+
+        if (timing !== undefined) {
+            timing.runCount += 1;
+            timing.durationMs += result.durationMs;
+        } else {
+            timingsByRequirement.set(result.requirement, {
+                requirement: result.requirement,
+                runCount: 1,
+                durationMs: result.durationMs,
+            });
+        }
+    }
+
+    const timings = [...timingsByRequirement.values()].sort(
+        (a, b) => b.durationMs - a.durationMs || a.requirement.localeCompare(b.requirement),
+    );
+    const totalDurationMs = timings.reduce((sum, timing) => sum + timing.durationMs, 0);
+    const rows: TimingRow[] = timings.map(timing => ({
+        requirement: timing.requirement,
+        runCount: timing.runCount.toString(),
+        duration: formatDuration(timing.durationMs),
+    }));
+    rows.push({
+        requirement: 'Total',
+        runCount: results.length.toString(),
+        duration: formatDuration(totalDurationMs),
+    });
+
+    const requirementWidth = Math.max(
+        'Requirement'.length,
+        ...rows.map(row => row.requirement.length),
+    );
+    const runCountWidth = Math.max('Runs'.length, ...rows.map(row => row.runCount.length));
+    const durationWidth = Math.max('Duration'.length, ...rows.map(row => row.duration.length));
+    const formatRow = ({ requirement, runCount, duration }: TimingRow) =>
+        `  ${requirement.padEnd(requirementWidth)} | ${runCount.padStart(runCountWidth)} | ${duration.padStart(durationWidth)}`;
+
+    deps.console.log('Requirement timings:');
+    deps.console.log(
+        formatRow({ requirement: 'Requirement', runCount: 'Runs', duration: 'Duration' }),
+    );
+    deps.console.log(
+        `  ${'-'.repeat(requirementWidth)}-+-${'-'.repeat(runCountWidth)}-+-${'-'.repeat(durationWidth)}`,
+    );
+
+    for (const row of rows) {
+        deps.console.log(formatRow(row));
+    }
+
+    deps.console.log('');
+};
+
 export const createReport =
     (deps: ReportDeps): Report =>
     results => {
@@ -31,6 +112,7 @@ export const createReport =
         }
 
         deps.console.log('');
+        reportTimings(deps, results);
 
         if (failed.length > 0) {
             const errorCount = failed.reduce((sum, result) => sum + result.errors.length, 0);

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -7,6 +7,7 @@ import { requireForbiddenDeps } from './forbidden-deps/requireForbiddenDeps';
 import { requirePackageJsonScripts } from './package-json/requirePackageJsonScripts';
 import { requirePublishConfig } from './package-json/requirePublishConfig';
 import { requireConnectPublicDependencies } from './public-package-dependencies/requireConnectPublicDependencies';
+import { requireTestColocation } from './test-colocation/requireTestColocation';
 import { requireTypeDeclarationSize } from './type-declarations/requireTypeDeclarationSize';
 
 export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
@@ -18,5 +19,6 @@ export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireForbiddenDeps,
     requirePackageJsonScripts,
     requirePublishConfig,
+    requireTestColocation,
     requireTypeDeclarationSize,
 ];

--- a/packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts
+++ b/packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts
@@ -1,6 +1,7 @@
-import { readFileSync, readdirSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
 
+import { normalizePath, walkDirectory } from '../../fileSystem';
 import { stripComments } from '../../stripComments';
 import type { Requirement } from '../Requirement';
 
@@ -11,21 +12,12 @@ const IGNORED_DOC_LINKS = new Set([SUMMARY_FILE, 'symlink/_README.md']);
 const collectMarkdownFiles = (directoryPath: string, docsPath: string): string[] => {
     const markdownFiles: string[] = [];
 
-    for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
-        const entryPath = join(directoryPath, entry.name);
-
-        if (entry.isDirectory()) {
-            markdownFiles.push(...collectMarkdownFiles(entryPath, docsPath));
-
-            continue;
-        }
-
+    for (const { entry, path } of walkDirectory(directoryPath)) {
         if ((!entry.isFile() && !entry.isSymbolicLink()) || !entry.name.endsWith('.md')) {
             continue;
         }
 
-        // if running on Windows, fix paths to Unix style which is expected in the .md
-        markdownFiles.push(relative(docsPath, entryPath).split(sep).join('/'));
+        markdownFiles.push(normalizePath(relative(docsPath, path)));
     }
 
     return markdownFiles;

--- a/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts
+++ b/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts
@@ -1,8 +1,9 @@
 import { readFileSync, readdirSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { join, relative } from 'node:path';
 
 import { type VersionArray, versionUtils } from '@trezor/utils';
 
+import { normalizePath } from '../../fileSystem';
 import type { Requirement } from '../Requirement';
 
 const FIRMWARE_DIR = join('packages', 'connect-data', 'files', 'firmware');
@@ -41,7 +42,7 @@ const formatVersion = (version: VersionArray): string => version.join('.');
 // Reports the path relative to the scanned firmware directory with normalized separators, so the
 // message is stable across machines and OSes (the raw absolute path leaks the runner's layout).
 const toReportedPath = (firmwareDir: string, file: string): string =>
-    relative(firmwareDir, file).split(sep).join('/');
+    normalizePath(relative(firmwareDir, file));
 
 const readChannelReleases = (channelDir: string): FirmwareRelease[] => {
     const releases: FirmwareRelease[] = [];

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -1,8 +1,9 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { typedObjectEntries } from '@trezor/utils';
 
+import { walkDirectory } from '../../fileSystem';
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';
@@ -22,17 +23,10 @@ const IGNORED_TEST_FILE_DIRECTORIES = new Set([
 ]);
 
 const hasUnitTestFile = (directoryPath: string): boolean => {
-    for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
-        if (entry.isDirectory()) {
-            if (IGNORED_TEST_FILE_DIRECTORIES.has(entry.name)) {
-                continue;
-            }
-
-            if (hasUnitTestFile(join(directoryPath, entry.name))) {
-                return true;
-            }
-        }
-
+    for (const { entry } of walkDirectory(directoryPath, {
+        shouldEnterDirectory: ({ entry: directory }) =>
+            !IGNORED_TEST_FILE_DIRECTORIES.has(directory.name),
+    })) {
         if (entry.isFile() && entry.name.endsWith('.test.ts')) {
             return true;
         }

--- a/packages/requirements/src/requirements/test-colocation/requireTestColocation.test.ts
+++ b/packages/requirements/src/requirements/test-colocation/requireTestColocation.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import type { WorkspaceContext } from '../Requirement';
+import {
+    findTestColocationViolations,
+    isTestColocationViolation,
+    requireTestColocation,
+    verifyTestColocation,
+} from './requireTestColocation';
+
+const createFile = (filePath: string): void => {
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, '');
+};
+
+describe(requireTestColocation.name, () => {
+    let repoRoot: string;
+    let workspaceDir: string;
+    let context: WorkspaceContext;
+
+    beforeEach(() => {
+        repoRoot = mkdtempSync(join(tmpdir(), 'test-colocation-'));
+        workspaceDir = join(repoRoot, 'packages', 'example');
+        mkdirSync(workspaceDir, { recursive: true });
+        context = {
+            repoRoot,
+            workspaceDir,
+            workspaceName: '@trezor/example',
+        };
+    });
+
+    afterEach(() => {
+        rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    it('finds violations using the workspace file tree and skips generated directories', async () => {
+        createFile(join(workspaceDir, 'src', '__tests__', 'example.test.ts'));
+        createFile(join(workspaceDir, 'src', 'example.test.ts'));
+        createFile(join(workspaceDir, 'node_modules', 'dependency', 'tests', 'ignored.test.ts'));
+        createFile(join(workspaceDir, 'lib', 'tests', 'ignored.test.js'));
+
+        const errors = await requireTestColocation.verify(context);
+
+        expect(errors).toEqual([
+            'packages/example/src/__tests__/example.test.ts is a non-E2E test in a legacy test directory. Co-locate it with its source file.',
+        ]);
+    });
+});
+
+describe('isTestColocationViolation', () => {
+    it.each([
+        'packages/example/tests/example.test.ts',
+        'packages/example/test/example.spec.tsx',
+        'packages/example/src/__tests__/example.test.js',
+        'packages/example/tests/example.type-test.ts',
+    ])('identifies a non-colocated test: %s', path => {
+        expect(isTestColocationViolation(path)).toBe(true);
+    });
+
+    it.each([
+        'packages/example/src/example.test.ts',
+        'packages/example/tests/example.fixture.ts',
+        'packages/example/src/__tests__/example.ts',
+    ])('allows a compliant or non-test path: %s', path => {
+        expect(isTestColocationViolation(path)).toBe(false);
+    });
+
+    it.each([
+        'packages/connect/e2e/tests/example.test.ts',
+        'packages/request-manager/e2e/tests/example.test.ts',
+        'packages/transport-test/e2e/tests/example.test.ts',
+        'packages/trezor-user-env-link/e2e/tests/example.test.ts',
+        'packages/urls/tests/e2e/example.test.ts',
+        'suite-native/app/e2e/tests/example.test.ts',
+        'suite/e2e/tests/example.spec.ts',
+    ])('allows a test in an explicitly exempt E2E path: %s', path => {
+        expect(isTestColocationViolation(path)).toBe(false);
+    });
+
+    it.each([
+        'packages/example/e2e/tests/example.test.ts',
+        'packages/connect/e2e-other/tests/example.test.ts',
+        'packages/example/playwright/tests/example.test.ts',
+        'suite-native/app/detox/tests/example.test.ts',
+    ])('does not exempt an unlisted path: %s', path => {
+        expect(isTestColocationViolation(path)).toBe(true);
+    });
+});
+
+describe('findTestColocationViolations', () => {
+    it('returns sorted violation paths', () => {
+        expect(
+            findTestColocationViolations([
+                'packages/zeta/tests/zeta.test.ts',
+                'packages/alpha/__tests__/alpha.spec.ts',
+                'packages/connect/e2e/tests/example.test.ts',
+            ]),
+        ).toEqual(['packages/alpha/__tests__/alpha.spec.ts', 'packages/zeta/tests/zeta.test.ts']);
+    });
+});
+
+describe('verifyTestColocation', () => {
+    it('passes when there are no violations', () => {
+        expect(
+            verifyTestColocation([
+                'packages/example/src/example.test.ts',
+                'packages/connect/e2e/tests/example.test.ts',
+            ]),
+        ).toEqual([]);
+    });
+
+    it('reports every violation in deterministic order', () => {
+        expect(
+            verifyTestColocation([
+                'packages/zeta/tests/zeta.test.ts',
+                'packages/example/src/example.test.ts',
+                'packages/alpha/__tests__/alpha.test.ts',
+            ]),
+        ).toEqual([
+            'packages/alpha/__tests__/alpha.test.ts is a non-E2E test in a legacy test directory. Co-locate it with its source file.',
+            'packages/zeta/tests/zeta.test.ts is a non-E2E test in a legacy test directory. Co-locate it with its source file.',
+        ]);
+    });
+});

--- a/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
+++ b/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
@@ -1,0 +1,86 @@
+import { readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+import type { Requirement } from '../Requirement';
+
+const LEGACY_TEST_DIRECTORIES = new Set(['test', 'tests', '__tests__']);
+const IGNORED_DIRECTORY_NAMES = new Set([
+    'node_modules',
+    'lib',
+    'libDev',
+    'build',
+    'dist',
+    'coverage',
+]);
+
+const EXEMPT_TEST_PATH_PREFIXES = [
+    'packages/connect/e2e/',
+    'packages/request-manager/e2e/',
+    'packages/transport-test/e2e/',
+    'packages/trezor-user-env-link/e2e/',
+    'packages/urls/tests/e2e/',
+    'suite-native/app/e2e/',
+    'suite/e2e/',
+] as const;
+
+const isTestFile = (fileName: string) =>
+    /\.(?:test|spec)\.[^/]+$/.test(fileName) || fileName.endsWith('.type-test.ts');
+
+const isExemptTestPath = (filePath: string) =>
+    EXEMPT_TEST_PATH_PREFIXES.some(pathPrefix => filePath.startsWith(pathPrefix));
+
+export const isTestColocationViolation = (filePath: string) => {
+    const pathSegments = filePath.split('/');
+    const fileName = pathSegments.at(-1);
+
+    if (fileName === undefined || !isTestFile(fileName)) return false;
+    if (isExemptTestPath(filePath)) return false;
+
+    return pathSegments.some(pathSegment => LEGACY_TEST_DIRECTORIES.has(pathSegment));
+};
+
+export const findTestColocationViolations = (
+    filePaths: ReadonlyArray<string>,
+): ReadonlyArray<string> => [...new Set(filePaths.filter(isTestColocationViolation))].sort();
+
+export const verifyTestColocation = (filePaths: ReadonlyArray<string>): ReadonlyArray<string> =>
+    findTestColocationViolations(filePaths).map(
+        violationPath =>
+            `${violationPath} is a non-E2E test in a legacy test directory. ` +
+            'Co-locate it with its source file.',
+    );
+
+const listWorkspaceTestFiles = (repoRoot: string, workspaceDir: string): ReadonlyArray<string> => {
+    const testFiles: string[] = [];
+
+    const visitDirectory = (directoryPath: string): void => {
+        for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
+            const entryPath = join(directoryPath, entry.name);
+
+            if (entry.isDirectory()) {
+                if (!IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+                    visitDirectory(entryPath);
+                }
+
+                continue;
+            }
+
+            if ((!entry.isFile() && !entry.isSymbolicLink()) || !isTestFile(entry.name)) {
+                continue;
+            }
+
+            testFiles.push(relative(repoRoot, entryPath).split(sep).join('/'));
+        }
+    };
+
+    visitDirectory(workspaceDir);
+
+    return testFiles;
+};
+
+export const requireTestColocation: Requirement<'workspace'> = {
+    name: 'test-colocation',
+    scope: 'workspace',
+    verify: ({ repoRoot, workspaceDir }) =>
+        Promise.resolve(verifyTestColocation(listWorkspaceTestFiles(repoRoot, workspaceDir))),
+};

--- a/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
+++ b/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
@@ -1,6 +1,6 @@
-import { readdirSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { relative } from 'node:path';
 
+import { normalizePath, walkDirectory } from '../../fileSystem';
 import type { Requirement } from '../Requirement';
 
 const LEGACY_TEST_DIRECTORIES = new Set(['test', 'tests', '__tests__']);
@@ -53,27 +53,16 @@ export const verifyTestColocation = (filePaths: ReadonlyArray<string>): Readonly
 const listWorkspaceTestFiles = (repoRoot: string, workspaceDir: string): ReadonlyArray<string> => {
     const testFiles: string[] = [];
 
-    const visitDirectory = (directoryPath: string): void => {
-        for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
-            const entryPath = join(directoryPath, entry.name);
-
-            if (entry.isDirectory()) {
-                if (!IGNORED_DIRECTORY_NAMES.has(entry.name)) {
-                    visitDirectory(entryPath);
-                }
-
-                continue;
-            }
-
-            if ((!entry.isFile() && !entry.isSymbolicLink()) || !isTestFile(entry.name)) {
-                continue;
-            }
-
-            testFiles.push(relative(repoRoot, entryPath).split(sep).join('/'));
+    for (const { entry, path } of walkDirectory(workspaceDir, {
+        shouldEnterDirectory: ({ entry: directory }) =>
+            !IGNORED_DIRECTORY_NAMES.has(directory.name),
+    })) {
+        if ((!entry.isFile() && !entry.isSymbolicLink()) || !isTestFile(entry.name)) {
+            continue;
         }
-    };
 
-    visitDirectory(workspaceDir);
+        testFiles.push(normalizePath(relative(repoRoot, path)));
+    }
 
     return testFiles;
 };

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { dirname, join, relative, sep } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 
+import { normalizePath, walkDirectory } from '../../fileSystem';
 import { listAllWorkspaces } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
@@ -57,25 +58,12 @@ const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
     'suite-common/receive/libDev/src/receiveSlice.d.ts',
 ]);
 
-const normalizePath = (filePath: string) => filePath.split(sep).join('/');
-
 const isDeclarationFile = (fileName: string) => /\.d\.[cm]?ts$/.test(fileName);
 
-const listDeclarationFiles = (directory: string): ReadonlyArray<string> => {
-    const declarations: string[] = [];
-
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-        const entryPath = join(directory, entry.name);
-
-        if (entry.isDirectory()) {
-            declarations.push(...listDeclarationFiles(entryPath));
-        } else if (entry.isFile() && isDeclarationFile(entry.name)) {
-            declarations.push(entryPath);
-        }
-    }
-
-    return declarations;
-};
+const listDeclarationFiles = (directory: string): ReadonlyArray<string> =>
+    [...walkDirectory(directory)]
+        .filter(({ entry }) => entry.isFile() && isDeclarationFile(entry.name))
+        .map(({ path }) => path);
 
 const formatSize = (sizeBytes: number) => {
     if (sizeBytes < 1024) return `${sizeBytes} B`;

--- a/packages/requirements/src/runRequirements.test.ts
+++ b/packages/requirements/src/runRequirements.test.ts
@@ -55,6 +55,18 @@ describe('runRequirements', () => {
             expect(first?.requirement).toBe('failing');
         });
 
+        it('records how long the requirement takes', async () => {
+            const timestamps = [10, 35];
+            const results = await runRequirements({
+                requirements: [createRepoRequirement({ name: 'timed' })],
+                repoRoot: '/repo',
+                mode: 'verify',
+                now: () => timestamps.shift() ?? 0,
+            });
+
+            expect(results[0]?.durationMs).toBe(25);
+        });
+
         it('calls fix when mode is fix and fix is defined', async () => {
             const results = await runRequirements({
                 requirements: [

--- a/packages/requirements/src/runRequirements.ts
+++ b/packages/requirements/src/runRequirements.ts
@@ -1,4 +1,5 @@
 import { basename } from 'node:path';
+import { performance } from 'node:perf_hooks';
 
 import type {
     RepoContext,
@@ -12,6 +13,7 @@ export type RequirementResult = {
     readonly requirement: string;
     readonly target: string;
     readonly errors: ReadonlyArray<string>;
+    readonly durationMs: number;
 };
 
 type RunRequirementsProps = {
@@ -20,6 +22,7 @@ type RunRequirementsProps = {
     readonly workspaces?: ReadonlyArray<{ readonly dir: string; readonly name: string }>;
     readonly filter?: string;
     readonly mode: RequirementMode;
+    readonly now?: () => number;
 };
 
 type ExecuteRequirementProps<T extends RequirementScope> = {
@@ -48,6 +51,7 @@ export const runRequirements = async ({
     workspaces = [],
     filter,
     mode,
+    now = () => performance.now(),
 }: RunRequirementsProps): Promise<ReadonlyArray<RequirementResult>> => {
     const filtered = requirements.filter(requirement =>
         filter !== undefined ? requirement.name === filter : requirement.runByDefault !== false,
@@ -57,16 +61,19 @@ export const runRequirements = async ({
 
     for (const requirement of filtered) {
         if (requirement.scope === 'repo') {
+            const startedAt = now();
             const errors = await executeRequirement({
                 requirement,
                 context: { repoRoot },
                 mode,
             });
+            const durationMs = now() - startedAt;
 
             results.push({
                 requirement: requirement.name,
                 target: 'repo',
                 errors,
+                durationMs,
             });
         } else {
             for (const workspace of workspaces) {
@@ -80,16 +87,19 @@ export const runRequirements = async ({
                     continue;
                 }
 
+                const startedAt = now();
                 const errors = await executeRequirement({
                     requirement,
                     context,
                     mode,
                 });
+                const durationMs = now() - startedAt;
 
                 results.push({
                     requirement: requirement.name,
                     target: basename(workspace.dir),
                     errors,
+                    durationMs,
                 });
             }
         }

--- a/suite-common/wallet-core/src/explorer/explorerActions.test.ts
+++ b/suite-common/wallet-core/src/explorer/explorerActions.test.ts
@@ -2,12 +2,12 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 
+import { explorerActions } from './explorerActions';
 import {
-    ExplorerConfig,
-    explorerActions,
+    type ExplorerConfig,
     explorerInitialState,
     prepareExplorerReducer,
-} from '../../src';
+} from './explorerReducer';
 
 const explorerReducer = prepareExplorerReducer(extraDependenciesCommonMock);
 


### PR DESCRIPTION
## Description

Adds a repo-scoped, verify-only requirement that scans canonical Git-visible paths and fails for every non-E2E test found under a legacy test directory. Seven reviewed E2E roots remain explicitly exempt. All migrations are now merged, so the requirement is zero-tolerance and has no baseline file or grandfathered violations. The requirements runner also records each check duration and prints a slowest-first, fixed-width timing table after verification. Refs #30302.

- Current violations: **0**
- Grandfathered violations: **0**
- Baseline files: **0**
- Explicit E2E roots: **7**
- Requirement tests: **22 passed**
- Requirements package: **13 suites, 158 tests passed**
- Full default verification: **654 passed**
- Requirement execution time: **1.13 s** across **654 target runs**
- End-to-end local command time: **7.71 s**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files fall into two disjoint categories that do not require E2E validation. Thirteen files are in `packages/requirements`, which implements internal CI/build-time checks (test colocation, docs summary, firmware release monotonicity, package.json scripts, type declaration sizes, reporting, and execution harnesses). These checks do not ship as part of the Suite runtime and therefore cannot be exercised by Playwright E2E tests. The remaining file, `suite-common/wallet-core/src/explorer/explorerActions.test.ts`, is itself a unit test file, not a source change; it may affect unit-test outcomes but not application behavior. Consequently, no E2E test coverage is appropriate for this changeset.

<details><summary><b>Changed files (14)</b></summary>

- `packages/requirements/src/fileSystem.test.ts`
- `packages/requirements/src/fileSystem.ts`
- `packages/requirements/src/report.test.ts`
- `packages/requirements/src/report.ts`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.test.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/requirements/src/runRequirements.test.ts`
- `packages/requirements/src/runRequirements.ts`
- `suite-common/wallet-core/src/explorer/explorerActions.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (14)**
- `packages/requirements/src/fileSystem.test.ts`
- `packages/requirements/src/fileSystem.ts`
- `packages/requirements/src/report.test.ts`
- `packages/requirements/src/report.ts`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.test.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`
- `packages/requirements/src/runRequirements.test.ts`
- `packages/requirements/src/runRequirements.ts`
- `suite-common/wallet-core/src/explorer/explorerActions.test.ts`

_Updated: 2026-07-30T16:52:21.198Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/tooling/test-colocation-requirement/web/](https://dev.suite.sldev.cz/suite-web/tooling/test-colocation-requirement/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tooling/test-colocation-requirement&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tooling/test-colocation-requirement&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tooling/test-colocation-requirement&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T16:55:10.625Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T16:55:17.927Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->