### PR TITLE
Chore(suite-desktop): restrict updaterURL

### DIFF
--- a/docs/releases/desktop_updates.md
+++ b/docs/releases/desktop_updates.md
@@ -10,33 +10,41 @@ In addition of what `electron-updater` provides us, we check signatures of downl
 
 ## Development
 
-How to mock app update configuration for Suite desktop DEV build:
+### Running a custom update server locally
+
+How to mock app update configuration locally for a development Suite Desktop build:
 
 1. In any folder, run:
 
-```
+```bash
 curl https://data.trezor.io/suite/releases/desktop/latest/latest.yml > latest.yml
 curl https://data.trezor.io/suite/releases/desktop/latest/latest-mac.yml > latest-mac.yml
 curl https://data.trezor.io/suite/releases/desktop/latest/latest-linux.yml > latest-linux.yml
+```
+
+2. Edit the files any way you want them.
+   Note that `latest.yml` is for Windows.
+3. _OPTIONAL:_ The `latest*.yml` files are enough to mock the "update available" flow, but if you want the update itself to proceed,
+   there needs to be the production (codesign) installation file as per your platform + the corresponding `.asc` key. For example on Windows:
+
+```bash
+curl https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.7.2-win-x64.exe > Trezor-Suite-26.7.2-win-x64.exe
+curl https://data.trezor.io/suite/releases/desktop/latest/Trezor-Suite-26.7.2-win-x64.exe.asc > Trezor-Suite-26.7.2-win-x64.exe.asc
+```
+
+4. Run the local server:
+
+```bash
 npm i -g http-server
 http-server -p 8989
 ```
 
-2. Edit the files any way you want them.
-   Note that "latest" without suffix is for Windows.
-3. Go to `packages/suite-desktop-core/src/modules/auto-updater.ts` and replace this constant:
+5. Run Suite in terminal with flag `--updater-url=http://localhost:8989`
 
-```javascript
-const defaultFeedURL = {
-    latest: 'http://localhost:8989',
-    preRelease: 'http://localhost:8989',
-};
-```
+### Notes
 
-4. Change this line in the same file to turn on the updater (by default disabled in dev build):
+Please be aware that it is not allowed to update to a dev (non-codesign) installation file, even from a dev installation!
+Signature verification is a hard requirement for Desktop Update because of its autonomous nature, so reinstalling to a dev installation
+has to be installed manually.
 
-```javascript
-autoUpdater.forceDevUpdateConfig = true;
-```
-
-5. Run `yarn suite:dev:desktop`
+But it is possible vice versa: a dev installation can be autoupdated to production.

--- a/packages/suite-desktop-core/src/config.ts
+++ b/packages/suite-desktop-core/src/config.ts
@@ -46,3 +46,11 @@ export const allowedDomains = [
 export const silentlyBlockedDomains = [
     'pulse.walletconnect.org', // WalletConnect analytics
 ];
+
+// Restrict Desktop Update to these URLs. Update installation is already gated by signature verification,
+// so this is only an additional layer – no need to allow any other domains.
+export const allowedDesktopUpdateDomains = [
+    'trezor.io', // Production server
+    'sldev.cz', // Test environment, available only with VPN
+    ...localhostDomains, // Allowed for local testing
+];

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
@@ -1,0 +1,49 @@
+import { parseCustomFeedURL } from './parseCustomFeedURL';
+
+const defaultFeedURL = 'https://data.trezor.io/suite/releases/desktop/latest';
+
+describe(parseCustomFeedURL.name, () => {
+    const fixtures = [
+        {
+            it: 'falls back to the default URL when the switch is empty',
+            customFeedURL: '',
+            result: defaultFeedURL,
+        },
+        {
+            it: 'falls back to the default URL when the switch is not a valid URL',
+            customFeedURL: 'not-a-url',
+            result: defaultFeedURL,
+        },
+        {
+            it: 'falls back to the default URL when the hostname is not allowed',
+            customFeedURL: 'https://example.com/update',
+            result: defaultFeedURL,
+        },
+        {
+            it: 'falls back to the default URL when the hostname is only a partial match',
+            customFeedURL: 'https://not-really-trezor.io/update',
+            result: defaultFeedURL,
+        },
+        {
+            it: 'allows an exact match from the update domain allowlist',
+            customFeedURL: 'https://trezor.io/update',
+            result: 'https://trezor.io/update',
+        },
+        {
+            it: 'allows a subdomain from the update domain allowlist',
+            customFeedURL: 'https://data.trezor.io/suite/releases/desktop/latest',
+            result: defaultFeedURL,
+        },
+        {
+            it: 'allows localhost overrides',
+            customFeedURL: 'http://127.0.0.1:8080/update',
+            result: 'http://127.0.0.1:8080/update',
+        },
+    ];
+
+    fixtures.forEach(({ it: testName, result, customFeedURL }) => {
+        it(testName, () =>
+            expect(parseCustomFeedURL({ customFeedURL, defaultFeedURL })).toBe(result),
+        );
+    });
+});

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts
@@ -2,8 +2,10 @@ import { parseCustomFeedURL } from './parseCustomFeedURL';
 
 const defaultFeedURL = 'https://data.trezor.io/suite/releases/desktop/latest';
 
+type Fixture = { it: string; customFeedURL: string; result: string; shouldWarn?: boolean };
+
 describe(parseCustomFeedURL.name, () => {
-    const fixtures = [
+    const fixtures: Fixture[] = [
         {
             it: 'falls back to the default URL when the switch is empty',
             customFeedURL: '',
@@ -13,16 +15,19 @@ describe(parseCustomFeedURL.name, () => {
             it: 'falls back to the default URL when the switch is not a valid URL',
             customFeedURL: 'not-a-url',
             result: defaultFeedURL,
+            shouldWarn: true,
         },
         {
             it: 'falls back to the default URL when the hostname is not allowed',
             customFeedURL: 'https://example.com/update',
             result: defaultFeedURL,
+            shouldWarn: true,
         },
         {
             it: 'falls back to the default URL when the hostname is only a partial match',
             customFeedURL: 'https://not-really-trezor.io/update',
             result: defaultFeedURL,
+            shouldWarn: true,
         },
         {
             it: 'allows an exact match from the update domain allowlist',
@@ -41,9 +46,17 @@ describe(parseCustomFeedURL.name, () => {
         },
     ];
 
-    fixtures.forEach(({ it: testName, result, customFeedURL }) => {
-        it(testName, () =>
-            expect(parseCustomFeedURL({ customFeedURL, defaultFeedURL })).toBe(result),
-        );
+    fixtures.forEach(({ it: testName, result, customFeedURL, shouldWarn }) => {
+        it(testName, () => {
+            const warn = jest.fn();
+
+            expect(parseCustomFeedURL({ customFeedURL, defaultFeedURL, warn })).toBe(result);
+
+            if (shouldWarn) {
+                expect(warn).toHaveBeenCalledWith(expect.any(String));
+            } else {
+                expect(warn).not.toHaveBeenCalled();
+            }
+        });
     });
 });

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
@@ -5,24 +5,33 @@ import { allowedDesktopUpdateDomains } from '../config';
 type ParseCustomFeedURLParams = {
     customFeedURL: string;
     defaultFeedURL: string;
+    warn?: (message: string) => void;
 };
 
 /**
  * Parse desktop updater feed URL from process switch and validate it, or keep default value.
  * Restricting the URL is only a secondary measure, see `allowedDesktopUpdateDomains`.
  */
-export const parseCustomFeedURL = ({ customFeedURL, defaultFeedURL }: ParseCustomFeedURLParams) => {
+export const parseCustomFeedURL = ({
+    customFeedURL,
+    defaultFeedURL,
+    warn,
+}: ParseCustomFeedURLParams) => {
     if (customFeedURL === '') {
         return defaultFeedURL;
     }
 
     if (!isUrl(customFeedURL)) {
+        warn?.(`Custom desktop update URL ${customFeedURL} is not a valid URL.`);
+
         return defaultFeedURL;
     }
 
     const { hostname } = new URL(customFeedURL);
 
     if (!isWhitelistedHost(hostname, allowedDesktopUpdateDomains)) {
+        warn?.(`Custom desktop update URL ${customFeedURL} is from a forbidden domain.`);
+
         return defaultFeedURL;
     }
 

--- a/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
+++ b/packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts
@@ -1,0 +1,30 @@
+import { isUrl, isWhitelistedHost } from '@trezor/utils';
+
+import { allowedDesktopUpdateDomains } from '../config';
+
+type ParseCustomFeedURLParams = {
+    customFeedURL: string;
+    defaultFeedURL: string;
+};
+
+/**
+ * Parse desktop updater feed URL from process switch and validate it, or keep default value.
+ * Restricting the URL is only a secondary measure, see `allowedDesktopUpdateDomains`.
+ */
+export const parseCustomFeedURL = ({ customFeedURL, defaultFeedURL }: ParseCustomFeedURLParams) => {
+    if (customFeedURL === '') {
+        return defaultFeedURL;
+    }
+
+    if (!isUrl(customFeedURL)) {
+        return defaultFeedURL;
+    }
+
+    const { hostname } = new URL(customFeedURL);
+
+    if (!isWhitelistedHost(hostname, allowedDesktopUpdateDomains)) {
+        return defaultFeedURL;
+    }
+
+    return customFeedURL;
+};

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -14,13 +14,14 @@ import { type HandshakeElectron } from '@trezor/suite-desktop-api';
 import { bytesToHumanReadable, serializeError } from '@trezor/utils';
 
 import { type ModuleInit, mainThreadEmitter } from './module';
+import { parseCustomFeedURL } from '../libs/parseCustomFeedURL';
 import { getSwitchValue, hasSwitch } from '../libs/process-switches';
 import { getSignatureFile, verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
 
-const defaultFeedURL = {
-    // This should correspond with the value in electron-builder-config.js file.
+const defaultFeedURLs = {
+    // This should correspond with the publish.url value in electron-builder-config.js file.
     latest: 'https://data.trezor.io/suite/releases/desktop/latest',
     preRelease: 'https://data.trezor.io/suite/releases/desktop/canary',
 };
@@ -29,7 +30,13 @@ const defaultFeedURL = {
 const enableUpdater = hasSwitch('enable-updater');
 const disableUpdater = hasSwitch('disable-updater');
 const preReleaseFlag = hasSwitch('pre-release');
-const updaterURL = getSwitchValue('updater-url');
+const customFeedURL = getSwitchValue('updater-url');
+
+const getFeedURL = ({ allowPrerelease = false }) => {
+    const defaultFeedURL = defaultFeedURLs[allowPrerelease ? 'preRelease' : 'latest'];
+
+    return parseCustomFeedURL({ customFeedURL, defaultFeedURL });
+};
 
 export const SERVICE_NAME = 'auto-updater';
 
@@ -85,7 +92,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     const updateSettings = store.getUpdateSettings();
     let allowPrerelease = preReleaseFlag || updateSettings.allowPrerelease;
     let { isAutomaticUpdateEnabled } = updateSettings;
-    let feedURL = updaterURL || defaultFeedURL[allowPrerelease ? 'preRelease' : 'latest'];
+    let feedURL = getFeedURL({ allowPrerelease });
 
     autoUpdater.logger = null;
 
@@ -311,7 +318,7 @@ export const init: ModuleInit = ({ mainWindowProxy, store }) => {
         store.setUpdateSettings({ ...settings, allowPrerelease: value });
         allowPrerelease = value;
 
-        feedURL = value ? defaultFeedURL.preRelease : defaultFeedURL.latest;
+        feedURL = getFeedURL({ allowPrerelease });
         autoUpdater.setFeedURL(feedURL);
         logger.info(SERVICE_NAME, `New feed url: ${feedURL}`);
     });

--- a/packages/suite-desktop-core/src/modules/auto-updater.ts
+++ b/packages/suite-desktop-core/src/modules/auto-updater.ts
@@ -20,6 +20,8 @@ import { getSignatureFile, verifySignature } from '../libs/update-checker';
 import { b2t } from '../libs/utils';
 import { app, ipcMain } from '../typed-electron';
 
+export const SERVICE_NAME = 'auto-updater';
+
 const defaultFeedURLs = {
     // This should correspond with the publish.url value in electron-builder-config.js file.
     latest: 'https://data.trezor.io/suite/releases/desktop/latest',
@@ -34,11 +36,10 @@ const customFeedURL = getSwitchValue('updater-url');
 
 const getFeedURL = ({ allowPrerelease = false }) => {
     const defaultFeedURL = defaultFeedURLs[allowPrerelease ? 'preRelease' : 'latest'];
+    const warn = (message: string) => global.logger.warn(SERVICE_NAME, message);
 
-    return parseCustomFeedURL({ customFeedURL, defaultFeedURL });
+    return parseCustomFeedURL({ customFeedURL, defaultFeedURL, warn });
 };
-
-export const SERVICE_NAME = 'auto-updater';
 
 export const init: ModuleInit = ({ mainWindowProxy, store }) => {
     const { logger } = global;


### PR DESCRIPTION
## Description

Followup to https://github.com/trezor/trezor-suite/pull/29760

Restrict `--updaterUrl` to allowed domains, which is a secondary defense (we are enforcing signature verification always).

Additionally, update docs how to work with the flag.


## Notes for QA

Update should work on all platforms, can be verified during next RC.

## Screenshots
[invalid URL](https://github.com/user-attachments/assets/86b1466f-f25d-4387-a7f1-d50b99cf36a5)
[no param](https://github.com/user-attachments/assets/4baaa782-1290-42d0-a9ff-9e8a38eed954)
[sldev](https://github.com/user-attachments/assets/399cf8c1-07b8-4c9f-a3be-3e70df923143)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (config.ts, parseCustomFeedURL.ts/.test.ts, auto-updater.ts) all live in packages/suite-desktop-core and relate to the Electron auto-update mechanism (custom update feed URL parsing and the auto-updater module). None of the 117 candidate E2E tests in the provided suite touch auto-update, feed URL parsing, or app update flows — the closest desktop-related tests (bridge daemon spawning, bridge restart) exercise a different subsystem (node-bridge lifecycle) and do not exercise the auto-updater config or URL parsing logic. There is a dedicated unit test (parseCustomFeedURL.test.ts) that already covers the parsing logic directly, so E2E coverage is not expected to add meaningful confidence here. Given no plausible E2E test maps to this functionality, no E2E tests are recommended to run for this change; verification should rely on the existing unit test and manual/desktop packaging smoke checks of the auto-update flow.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite-desktop-core/src/config.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/suite-desktop-core/src/config.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.test.ts`
- `packages/suite-desktop-core/src/libs/parseCustomFeedURL.ts`
- `packages/suite-desktop-core/src/modules/auto-updater.ts`

_Updated: 2026-07-28T17:51:54.009Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/restrict-updaterURL/web/](https://dev.suite.sldev.cz/suite-web/chore/restrict-updaterURL/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/restrict-updaterURL&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/restrict-updaterURL&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T20:14:15.042Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T07:44:58.991Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->