### PR TITLE
test(connect): co-locate API tests

### DIFF
--- a/packages/connect/src/api/bitcoin/enhanceSignTx.test.ts
+++ b/packages/connect/src/api/bitcoin/enhanceSignTx.test.ts
@@ -1,5 +1,5 @@
-import { initBlockchain } from '../../../backend/BlockchainLink';
-import { enhanceSignTx } from '../enhanceSignTx';
+import { enhanceSignTx } from './enhanceSignTx';
+import { initBlockchain } from '../../backend/BlockchainLink';
 
 describe('api/bitcoin/enhanceSignTx', () => {
     it('zcash/zcash testnet', () => {

--- a/packages/connect/src/api/bitcoin/inputs.test.ts
+++ b/packages/connect/src/api/bitcoin/inputs.test.ts
@@ -1,7 +1,7 @@
 import { networks } from '@trezor/utxo-lib';
 
-import * as fixtures from '../__fixtures__/inputs';
-import { validateTrezorInputs } from '../inputs';
+import * as fixtures from './__fixtures__/inputs';
+import { validateTrezorInputs } from './inputs';
 
 describe('core/methods/tx/inputs', () => {
     describe('validateTrezorInputs', () => {

--- a/packages/connect/src/api/bitcoin/outputs.test.ts
+++ b/packages/connect/src/api/bitcoin/outputs.test.ts
@@ -1,7 +1,7 @@
 import { networks } from '@trezor/utxo-lib';
 
-import * as fixtures from '../__fixtures__/outputs';
-import { validateTrezorOutputs } from '../outputs';
+import * as fixtures from './__fixtures__/outputs';
+import { validateTrezorOutputs } from './outputs';
 
 describe('core/methods/tx/outputs', () => {
     describe('validateTrezorOutputs', () => {

--- a/packages/connect/src/api/bitcoin/refTx.test.ts
+++ b/packages/connect/src/api/bitcoin/refTx.test.ts
@@ -1,9 +1,9 @@
-import * as fixtures from '../__fixtures__/refTx';
+import * as fixtures from './__fixtures__/refTx';
 import {
     getReferencedTransactions,
     requireReferencedTransactions,
     validateReferencedTransactions,
-} from '../refTx';
+} from './refTx';
 
 describe('core/methods/tx/refTx', () => {
     it('requireReferencedTransactions', () => {

--- a/packages/connect/src/api/bitcoin/signtxVerify.test.ts
+++ b/packages/connect/src/api/bitcoin/signtxVerify.test.ts
@@ -1,8 +1,8 @@
 import { promiseAllSequence } from '@trezor/utils';
 import { networks } from '@trezor/utxo-lib';
 
-import fixtures from '../__fixtures__/signtxVerify';
-import { deriveOutputScript, verifyTx } from '../signtxVerify';
+import fixtures from './__fixtures__/signtxVerify';
+import { deriveOutputScript, verifyTx } from './signtxVerify';
 
 describe('helpers/signtxVerify', () => {
     fixtures.forEach(({ description, network, inputs, outputs, tx, error, getHDNode }) => {

--- a/packages/connect/src/api/bitcoin/transactionBytes.test.ts
+++ b/packages/connect/src/api/bitcoin/transactionBytes.test.ts
@@ -1,7 +1,7 @@
 import { networks } from '@trezor/utxo-lib';
 
-import fixtures from '../__fixtures__/signtxVerify';
-import { getTransactionVbytes } from '../transactionBytes';
+import fixtures from './__fixtures__/signtxVerify';
+import { getTransactionVbytes } from './transactionBytes';
 
 describe('helpers/transactionBytes', () => {
     fixtures

--- a/packages/connect/src/api/cardano/cardanoUtils.test.ts
+++ b/packages/connect/src/api/cardano/cardanoUtils.test.ts
@@ -1,5 +1,5 @@
-import * as fixtures from '../__fixtures__/cardanoUtils';
-import { getTtl, prepareCertificates, transformUtxos } from '../cardanoUtils';
+import * as fixtures from './__fixtures__/cardanoUtils';
+import { getTtl, prepareCertificates, transformUtxos } from './cardanoUtils';
 
 describe('cardano utils', () => {
     let dateSpy: any;

--- a/packages/connect/src/api/common/paramsValidator.test.ts
+++ b/packages/connect/src/api/common/paramsValidator.test.ts
@@ -1,9 +1,9 @@
-import { config } from '../../../data/config';
-import * as fixtures from '../__fixtures__/paramsValidator';
-import { getFirmwareRange, validateParams } from '../paramsValidator';
+import * as fixtures from './__fixtures__/paramsValidator';
+import { getFirmwareRange, validateParams } from './paramsValidator';
+import { config } from '../../data/config';
 
-jest.mock('../../../data/config', () => {
-    const actual = jest.requireActual('../../../data/config');
+jest.mock('../../data/config', () => {
+    const actual = jest.requireActual('../../data/config');
 
     return {
         __esModule: true,
@@ -11,7 +11,7 @@ jest.mock('../../../data/config', () => {
     };
 });
 
-const originalConfig = jest.requireActual('../../../data/config').config;
+const originalConfig = jest.requireActual('../../data/config').config;
 
 const resetConfig = () => {
     Object.keys(config).forEach(key => {

--- a/packages/connect/src/api/ethereum/ethereumSignTx.test.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTx.test.ts
@@ -1,7 +1,7 @@
 import { keccak256, recoverTransactionAddress } from 'viem';
 
-import * as fixtures from '../__fixtures__/ethereumSignTx';
-import { serializeEthereumTx } from '../ethereumSignTx';
+import * as fixtures from './__fixtures__/ethereumSignTx';
+import { serializeEthereumTx } from './ethereumSignTx';
 
 describe('helpers/ethereumSignTx', () => {
     describe('serializeEthereumTx', () => {

--- a/packages/connect/src/api/ethereum/ethereumSignTypedData.test.ts
+++ b/packages/connect/src/api/ethereum/ethereumSignTypedData.test.ts
@@ -1,5 +1,5 @@
-import * as fixtures from '../__fixtures__/ethereumSignTypedData';
-import { encodeData, getFieldType, parseArrayType } from '../ethereumSignTypedData';
+import * as fixtures from './__fixtures__/ethereumSignTypedData';
+import { encodeData, getFieldType, parseArrayType } from './ethereumSignTypedData';
 
 describe('helpers/ethereumSignTypeData', () => {
     describe('parseArrayType', () => {

--- a/packages/connect/src/api/ethereum/transformTypedData.test.ts
+++ b/packages/connect/src/api/ethereum/transformTypedData.test.ts
@@ -3,10 +3,10 @@
 // Verifies byte-equivalence of the new viem-backed transformTypedData against
 // the firmware ground-truth fixtures in trezor-common.
 
+import { transformTypedData } from './ethereumSignTypedData';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import commonFixtures from '../../../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
-import { transformTypedData } from '../ethereumSignTypedData';
+import commonFixtures from '../../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json';
 
 // fixtures sometimes start with 0x, sometimes not — normalize for comparison
 function messageToHex(string: string) {

--- a/packages/connect/src/api/firmware/calculateFirmwareHash.test.ts
+++ b/packages/connect/src/api/firmware/calculateFirmwareHash.test.ts
@@ -1,6 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { calculateFirmwareHash } from '../calculateFirmwareHash';
+import { calculateFirmwareHash } from './calculateFirmwareHash';
 
 // NOTE: for unit test purposes create "firmware with empty bytes"
 // size doesn't matter, it will be padded by calculateFirmwareHash utility

--- a/packages/connect/src/api/firmware/calculateXPubHash.test.ts
+++ b/packages/connect/src/api/firmware/calculateXPubHash.test.ts
@@ -1,4 +1,4 @@
-import { calculateXPubHash, calculateXPubHashes, checkXPubWithHashes } from '../calculateXPubHash';
+import { calculateXPubHash, calculateXPubHashes, checkXPubWithHashes } from './calculateXPubHash';
 
 // all seed standard wallet
 const xpubs = {

--- a/packages/connect/src/api/firmware/parseFirmwareHeaders.test.ts
+++ b/packages/connect/src/api/firmware/parseFirmwareHeaders.test.ts
@@ -1,4 +1,4 @@
-import { parseFirmwareHeaders } from '../parseFirmwareHeaders';
+import { parseFirmwareHeaders } from './parseFirmwareHeaders';
 
 describe('parseFirmwareHeaders', () => {
     test('2.6.3', () => {

--- a/packages/connect/src/api/firmware/verifyEntropy.test.ts
+++ b/packages/connect/src/api/firmware/verifyEntropy.test.ts
@@ -1,4 +1,4 @@
-import { verifyEntropy } from '../verifyEntropy';
+import { verifyEntropy } from './verifyEntropy';
 
 describe('firmware/verifyEntropy', () => {
     it('bip39 success', async () => {

--- a/packages/connect/src/api/getSettings.test.ts
+++ b/packages/connect/src/api/getSettings.test.ts
@@ -1,6 +1,6 @@
-import * as enabledNetworksStore from '../../data/enabledNetworksStore';
-import * as settingsStore from '../../data/settingsStore';
-import GetSettings from '../getSettings';
+import GetSettings from './getSettings';
+import * as enabledNetworksStore from '../data/enabledNetworksStore';
+import * as settingsStore from '../data/settingsStore';
 
 // getSettings reads from settingsStore but overlays the dedicated enabledNetworksStore so the
 // live, sanitized set is what callers see. Constructing the method is enough — run() is sync.

--- a/packages/connect/src/api/solana/solanaDefinitions.test.ts
+++ b/packages/connect/src/api/solana/solanaDefinitions.test.ts
@@ -1,7 +1,7 @@
 import fetch from 'cross-fetch';
 
-import { loadProtobufModules } from '../../../data/protobufLoader';
-import { decodeSolanaTokenDefinition, getSolanaTokenDefinition } from '../solanaDefinitions';
+import { decodeSolanaTokenDefinition, getSolanaTokenDefinition } from './solanaDefinitions';
+import { loadProtobufModules } from '../../data/protobufLoader';
 
 jest.mock('cross-fetch');
 

--- a/packages/connect/src/api/tron/tronEncode.test.ts
+++ b/packages/connect/src/api/tron/tronEncode.test.ts
@@ -2,9 +2,9 @@ import { bytesToHex } from '@noble/hashes/utils.js';
 
 import type { TronContracts } from '@trezor/connect-common';
 
-import { loadProtobufModules } from '../../../data/protobufLoader';
-import { encodeTronContractRawData } from '../tronEncode';
-import { decodeBroadcastTransaction, encodeBroadcastTransaction } from '../tronProtobuf';
+import { encodeTronContractRawData } from './tronEncode';
+import { decodeBroadcastTransaction, encodeBroadcastTransaction } from './tronProtobuf';
+import { loadProtobufModules } from '../../data/protobufLoader';
 
 const OWNER_ADDRESS = '41f2cd810c48c401d392ead3c6e1e1cb9f57750a58';
 const TO_ADDRESS = '4141f82674a30ae1328745d08afe2d1a0a24195283';


### PR DESCRIPTION
## Description

Moves all 18 Connect API unit tests next to their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set consists entirely of unit tests for low-level packages/connect API modules (Bitcoin transaction construction/signing, Ethereum signing and typed data, Cardano utilities, firmware hash/entropy/header parsing, Solana definitions, Tron encoding, and common parameter validation) with no static E2E coverage mapping available. Since these are core signing/validation primitives used across many wallet flows, the recommended strategy is to run targeted E2E tests that exercise the corresponding coin's transaction signing, staking, and firmware flows (Bitcoin send/pending-tx, Ethereum send/sign, Cardano account/staking, custom firmware install, entropy-check failure) rather than the full suite, since these most directly surface regressions in the changed low-level logic. Tron encoding and getSettings changes have no identifiable E2E coverage and represent a residual risk area.

<details><summary><b>Changed files (18)</b></summary>

- `packages/connect/src/api/bitcoin/enhanceSignTx.test.ts`
- `packages/connect/src/api/bitcoin/inputs.test.ts`
- `packages/connect/src/api/bitcoin/outputs.test.ts`
- `packages/connect/src/api/bitcoin/refTx.test.ts`
- `packages/connect/src/api/bitcoin/signtxVerify.test.ts`
- `packages/connect/src/api/bitcoin/transactionBytes.test.ts`
- `packages/connect/src/api/cardano/cardanoUtils.test.ts`
- `packages/connect/src/api/common/paramsValidator.test.ts`
- `packages/connect/src/api/ethereum/ethereumSignTx.test.ts`
- `packages/connect/src/api/ethereum/ethereumSignTypedData.test.ts`
- `packages/connect/src/api/ethereum/transformTypedData.test.ts`
- `packages/connect/src/api/firmware/calculateFirmwareHash.test.ts`
- `packages/connect/src/api/firmware/calculateXPubHash.test.ts`
- `packages/connect/src/api/firmware/parseFirmwareHeaders.test.ts`
- `packages/connect/src/api/firmware/verifyEntropy.test.ts`
- `packages/connect/src/api/getSettings.test.ts`
- `packages/connect/src/api/solana/solanaDefinitions.test.ts`
- `packages/connect/src/api/tron/tronEncode.test.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test directly calls TrezorConnect.ethereumSignTransaction and verifies its successful completion, making it the most direct E2E coverage for the changed ethereumSignTx unit test.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly simulates and validates entropy check failures during wallet creation, which is the exact functionality covered by the changed verifyEntropy unit test.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — This E2E test exercises Bitcoin-like transaction signing (send flow with fee/amount/total confirmation) which relies on the same core bitcoin sign-tx logic (enhanceSignTx, inputs, outputs, refTx, transactionBytes) that was unit-tested in the changed files. A regression in these low-level bitcoin signing modules could surface as incorrect amounts/fees or signing errors in this flow.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions with multiple outputs on regtest and validates transaction construction/mining, directly exercising the bitcoin signing pipeline (inputs/outputs/refTx/enhanceSignTx) whose unit tests were modified.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Directly calls TrezorConnect.signTransaction for a Bitcoin transaction and validates error handling around scriptPubKey mismatches, which is closely tied to the bitcoin sign-tx verification and input/output construction logic covered by the changed unit tests.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test performs a full Ethereum send flow with custom fee parameters, directly exercising ethereum transaction signing logic covered by the changed ethereumSignTx unit test.
- `suite/e2e/tests/wallet/send-base.test.ts` — Exercises Ethereum-compatible (Base/EVM) transaction signing with custom fees, which relies on the same ethereumSignTx logic that was unit-tested in the changed files.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test exercises Cardano account details, address reveal, and public key operations which depend on the cardanoUtils module directly modified in this change set.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking involves constructing and signing Cardano transactions (stake key registration, delegation) that rely on cardanoUtils logic covered by the changed unit test.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test installs custom firmware on a device, a flow directly dependent on firmware header parsing and hash verification logic covered by the changed calculateFirmwareHash and parseFirmwareHeaders unit tests.

</details>

<details><summary>🟢 <b>Low priority (7)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Covers Ethereum message signing rather than transaction signing/typed data, but shares the ethereum API module family with the changed ethereumSignTx and transformTypedData files, so a regression in shared ethereum signing infrastructure could plausibly affect it.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Involves Cardano stake key deregistration transactions that use the same cardanoUtils construction/signing logic that was changed, providing additional coverage of Cardano transaction paths.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Exercises Cardano reward withdrawal transaction construction which touches cardanoUtils, providing incidental additional coverage for the changed Cardano unit test.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Device authenticity check during onboarding may rely on firmware hash/xpub verification utilities similar to those changed (calculateFirmwareHash, calculateXPubHash), providing plausible incidental coverage.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test verifies XPUB values displayed for BTC, LTC and ADA accounts, which relates to xpub hash calculation logic covered by the changed calculateXPubHash unit test.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking involves account/transaction validation that may exercise paramsValidator logic (common parameter validation across TrezorConnect API methods) which was changed; included as light additional coverage given lack of direct Solana-specific test.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana send flow exercises transaction construction that could depend on solanaDefinitions logic modified in this change set, though no direct static or behavioral link was found beyond shared Solana API surface.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/src/api/tron/tronEncode.test.ts`
- `packages/connect/src/api/getSettings.test.ts`
- `packages/connect/src/api/ethereum/transformTypedData.test.ts`

_Updated: 2026-07-27T15:40:21.711Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-api-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-api-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:37:23.815Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:37:28.278Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->