### PR TITLE
test(connect): co-locate data tests

### DIFF
--- a/packages/connect-common/src/data/thpSettings.test.ts
+++ b/packages/connect-common/src/data/thpSettings.test.ts
@@ -1,4 +1,4 @@
-import { parseThpSettings } from '@trezor/connect-common/src/data/thpSettings';
+import { parseThpSettings } from './thpSettings';
 
 describe('data/thpSettings', () => {
     it('parseThpSettings', () => {

--- a/packages/connect/src/data/coinInfo.test.ts
+++ b/packages/connect/src/data/coinInfo.test.ts
@@ -1,6 +1,6 @@
 import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
 
-import { getAllNetworks, getCoinInfoOrThrow, getMiscNetwork, getUniqueNetworks } from '../coinInfo';
+import { getAllNetworks, getCoinInfoOrThrow, getMiscNetwork, getUniqueNetworks } from './coinInfo';
 
 describe('data/coinInfo', () => {
     it('resolves a coin string by shortcut only (network name / label no longer accepted)', () => {

--- a/packages/connect/src/data/coinSymbol.test.ts
+++ b/packages/connect/src/data/coinSymbol.test.ts
@@ -1,6 +1,6 @@
 import { type CoinSymbol, coinSymbols, isCoinSymbol } from '@trezor/connect-common';
 
-import { getAllNetworks } from '../coinInfo';
+import { getAllNetworks } from './coinInfo';
 
 describe('data/coinSymbol', () => {
     // Guards `coinSymbols` against drift from the @trezor/connect-data coin definitions: it must

--- a/packages/connect/src/data/defaultFeeLevels.test.ts
+++ b/packages/connect/src/data/defaultFeeLevels.test.ts
@@ -1,4 +1,4 @@
-import { getEthereumFeeLevels } from '../defaultFeeLevels';
+import { getEthereumFeeLevels } from './defaultFeeLevels';
 
 describe('getEthereumFeeLevels', () => {
     const fixtures = {

--- a/packages/connect/src/data/enabledNetworksStore.test.ts
+++ b/packages/connect/src/data/enabledNetworksStore.test.ts
@@ -1,4 +1,4 @@
-import * as enabledNetworksStore from '../enabledNetworksStore';
+import * as enabledNetworksStore from './enabledNetworksStore';
 
 // Coins are referenced by symbol; the store keys by `coin`.
 const coins = (...symbols: string[]) => symbols.map(coin => ({ coin }));

--- a/packages/connect/src/data/firmwareInfo.test.ts
+++ b/packages/connect/src/data/firmwareInfo.test.ts
@@ -5,14 +5,14 @@ import { FirmwareType } from '@trezor/device-utils';
 import { DeviceModelInternal } from '@trezor/protobuf/src/definitions';
 import { versionUtils } from '@trezor/utils';
 
-import { getDeviceFeatures } from '../../../setupJest';
 import {
     getFirmwareReleaseConfigInfo,
     getFirmwareStatus,
     initializeFirmwareConfig,
-} from '../firmwareInfo';
-import * as firmwareReleaseStore from '../firmwareReleaseStore';
-import * as settingsStore from '../settingsStore';
+} from './firmwareInfo';
+import * as firmwareReleaseStore from './firmwareReleaseStore';
+import * as settingsStore from './settingsStore';
+import { getDeviceFeatures } from '../../setupJest';
 
 describe('data/firmwareInfo', () => {
     describe('getFirmwareStatus', () => {


### PR DESCRIPTION
## Description

Moves the six straightforward Connect data tests beside their owning sources, leaving the four multi-scenario getReleaseInfo tests for the separately tracked complex migration.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit test files for low-level data modules in @trezor/connect and @trezor/connect-common (coin info, coin symbol mapping, default fee levels, enabled networks store, firmware info, and THP settings). These are foundational data files with no direct static E2E coverage mapping, so recommendations are inferred based on which E2E flows most heavily depend on coin/network metadata, fee calculation, and device firmware/THP handling. Since these are unit-test-only changes to underlying data (likely just test file edits rather than logic changes), overall E2E regression risk is low-to-medium; a targeted smoke run of coin discovery, address/account info, and send-flow tests should provide sufficient confidence without running the full suite.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-common/src/data/thpSettings.test.ts`
- `packages/connect/src/data/coinInfo.test.ts`
- `packages/connect/src/data/coinSymbol.test.ts`
- `packages/connect/src/data/defaultFeeLevels.test.ts`
- `packages/connect/src/data/enabledNetworksStore.test.ts`
- `packages/connect/src/data/firmwareInfo.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test relies on TrezorConnect.getAccountInfo and account discovery which depend on coinInfo.ts, coinSymbol.ts, and defaultFeeLevels.ts (unit test files changed here suggest the underlying data modules were touched); regressions in coin/network data would break account discovery.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Address export flows use coin/network metadata (coinInfo, coinSymbol) and fee level defaults; since the changed unit tests target these data files, this E2E test exercises the same underlying data paths for BTC address derivation.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery activates multiple coins (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and depends heavily on coinInfo/coinSymbol data correctness for each network; a regression in these data modules would likely break multi-coin discovery.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Sending transactions relies on default fee levels for fee estimation; the defaultFeeLevels.ts data module changes make this Bitcoin send flow test relevant to catch fee-calculation regressions.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/wallet/public-keys.test.ts` — Public key display for BTC/LTC/ADA depends on correct coin metadata (coinInfo, coinSymbol); a low-priority check since it only reads static keys but could reveal misconfigured coin data.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Firmware and transport-related device status logic may be influenced by firmwareInfo.ts data changes; this test exercises device connection/session status which could be indirectly affected.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test involves THP pairing flow during onboarding, which is the primary consumer of thpSettings.ts; changes to THP settings data could affect device pairing behavior tested here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/data/enabledNetworksStore.test.ts`

_Updated: 2026-07-28T11:23:13.586Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-data-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-data-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-data-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-data-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-data-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:24:21.384Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:24:46.052Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->