### PR TITLE
feat(suite): refine native token wrap and unwrap flows

### DIFF
--- a/packages/suite/src/actions/wallet/__tests__/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/unwrapNativeTokenThunks.test.ts
@@ -7,6 +7,7 @@ import { submitUnwrapNativeTokenThunk } from '../unwrapNativeTokenThunks';
 
 const mockComposeYieldUnwrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
+const mockSendYieldTransaction = jest.fn();
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
@@ -19,7 +20,7 @@ jest.mock('@suite/modal', () => ({
 }));
 
 jest.mock('../stablecoin-yield/signingHelpers', () => ({
-    sendYieldTransaction: jest.fn(),
+    sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
 }));
 
 const account = mockWalletAccount({ symbol: 'eth' }) as Account;
@@ -66,6 +67,35 @@ describe('submitUnwrapNativeTokenThunk', () => {
             expect.objectContaining({
                 type: 'earn-yield-tx-simulation',
                 data: expect.objectContaining({ flow: 'unwrap' }),
+            }),
+        );
+    });
+
+    it('uses the parent yield flow identity when provided', async () => {
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+
+        await store
+            .dispatch(
+                submitUnwrapNativeTokenThunk({
+                    account,
+                    token,
+                    unwrapAmount: '1',
+                    yieldFlow: {
+                        flowKey: 'yield-flow',
+                        flowType: 'redeem',
+                    },
+                }),
+            )
+            .unwrap();
+
+        expect(mockSendYieldTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flowKey: 'yield-flow',
+                flowType: 'redeem',
             }),
         );
     });

--- a/packages/suite/src/actions/wallet/__tests__/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/__tests__/wrapNativeTokenThunks.test.ts
@@ -7,6 +7,7 @@ import { submitWrapNativeTokenThunk } from '../wrapNativeTokenThunks';
 
 const mockComposeYieldWrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
+const mockSendYieldTransaction = jest.fn();
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),
@@ -19,7 +20,7 @@ jest.mock('@suite/modal', () => ({
 }));
 
 jest.mock('../stablecoin-yield/signingHelpers', () => ({
-    sendYieldTransaction: jest.fn(),
+    sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
 }));
 
 const account = mockWalletAccount({ symbol: 'eth' }) as Account;
@@ -66,6 +67,35 @@ describe('submitWrapNativeTokenThunk', () => {
             expect.objectContaining({
                 type: 'earn-yield-tx-simulation',
                 data: expect.objectContaining({ flow: 'wrap' }),
+            }),
+        );
+    });
+
+    it('uses the parent yield flow identity when provided', async () => {
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
+
+        await store
+            .dispatch(
+                submitWrapNativeTokenThunk({
+                    account,
+                    token,
+                    wrapAmount: '1',
+                    yieldFlow: {
+                        flowKey: 'yield-flow',
+                        flowType: 'deposit',
+                    },
+                }),
+            )
+            .unwrap();
+
+        expect(mockSendYieldTransaction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flowKey: 'yield-flow',
+                flowType: 'deposit',
             }),
         );
     });

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -4,6 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type YieldFlowDisplayToken,
+    type YieldWithdrawFlowType,
     composeYieldUnwrapTransactionThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -16,11 +17,18 @@ type UnwrapNativeTokenPayload = {
     account: Account;
     token: YieldFlowDisplayToken & { contractAddress: string };
     unwrapAmount: string;
+    yieldFlow?: {
+        flowKey: string;
+        flowType: YieldWithdrawFlowType;
+    };
 };
 
 export const submitUnwrapNativeTokenThunk = createThunk(
     `${UNWRAP_NATIVE_TOKEN_PREFIX}/submit`,
-    async ({ account, token, unwrapAmount }: UnwrapNativeTokenPayload, { dispatch, getState }) => {
+    async (
+        { account, token, unwrapAmount, yieldFlow }: UnwrapNativeTokenPayload,
+        { dispatch, getState },
+    ) => {
         try {
             const result = await dispatch(
                 composeYieldUnwrapTransactionThunk({ account, token, unwrapAmount }),
@@ -57,8 +65,8 @@ export const submitUnwrapNativeTokenThunk = createThunk(
                 amount: unwrapAmount,
                 token,
                 unsignedTransaction: result.unsignedTransaction,
-                flowKey: 'standalone-unwrap-native',
-                flowType: 'withdraw',
+                flowKey: yieldFlow?.flowKey ?? 'standalone-unwrap-native',
+                flowType: yieldFlow?.flowType ?? 'withdraw',
                 dispatch,
                 getState,
                 selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -17,11 +17,18 @@ type WrapNativeTokenPayload = {
     account: Account;
     token: YieldFlowDisplayToken & { contractAddress: string };
     wrapAmount: string;
+    yieldFlow?: {
+        flowKey: string;
+        flowType: 'deposit';
+    };
 };
 
 export const submitWrapNativeTokenThunk = createThunk(
     `${WRAP_NATIVE_TOKEN_PREFIX}/submit`,
-    async ({ account, token, wrapAmount }: WrapNativeTokenPayload, { dispatch, getState }) => {
+    async (
+        { account, token, wrapAmount, yieldFlow }: WrapNativeTokenPayload,
+        { dispatch, getState },
+    ) => {
         try {
             const result = await dispatch(
                 composeYieldWrapTransactionThunk({ account, token, wrapAmount }),
@@ -65,8 +72,8 @@ export const submitWrapNativeTokenThunk = createThunk(
                     contractAddress: null,
                 },
                 unsignedTransaction: result.unsignedTransaction,
-                flowKey: 'standalone-wrap-native',
-                flowType: 'deposit',
+                flowKey: yieldFlow?.flowKey ?? 'standalone-wrap-native',
+                flowType: yieldFlow?.flowType ?? 'deposit',
                 dispatch,
                 getState,
                 selectedFee: userAcceptedTxSimulation?.selectedFee ?? null,

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -16,11 +16,12 @@ import { YieldPendingTransaction } from './YieldPendingTransaction';
 type YieldWrapStepProps = {
     token: YieldFlowDisplayToken;
     nativeSymbol: string;
-    nativeBalance: string;
+    availableAmount: string;
     onMaxClick: () => void;
     onSubmit: () => void;
     onSkip?: () => void;
     shouldShowReceivingRow?: boolean;
+    receivingAmount?: string;
     isSubmitting?: boolean;
     isSubmitDisabled?: boolean;
     warning?: ReactNode;
@@ -31,11 +32,12 @@ type YieldWrapStepProps = {
 export const YieldWrapStep = ({
     token,
     nativeSymbol,
-    nativeBalance,
+    availableAmount,
     onMaxClick,
     onSubmit,
     onSkip,
     shouldShowReceivingRow = true,
+    receivingAmount = '0',
     isSubmitting = false,
     isSubmitDisabled = false,
     warning,
@@ -51,8 +53,8 @@ export const YieldWrapStep = ({
                 amountLabelTranslationId: 'TR_EARN_YIELD_WRAP_AMOUNT',
             }}
             summary={{
-                labelTranslationId: 'TR_BALANCE',
-                value: <FormattedCryptoAmount value={nativeBalance} symbol={nativeSymbol} />,
+                labelTranslationId: 'TR_EARN_YIELD_AVAILABLE_TO_WRAP',
+                value: <FormattedCryptoAmount value={availableAmount} symbol={nativeSymbol} />,
                 onMaxClick: pendingTransaction ? undefined : onMaxClick,
             }}
             warning={warning}
@@ -74,7 +76,7 @@ export const YieldWrapStep = ({
                             isBordered={false}
                         />
                         <Text typographyStyle="body-md">
-                            <FormattedCryptoAmount value="0" symbol={token.symbol} />
+                            <FormattedCryptoAmount value={receivingAmount} symbol={token.symbol} />
                         </Text>
                     </Row>
                 </Row>

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -31,6 +31,7 @@ export const YieldDepositForm = () => {
         completedAmount,
         completedReceiptAmount,
         maxAmount,
+        liveAmount,
         errorMessage,
         approveModalState,
         pendingTransaction,
@@ -45,7 +46,8 @@ export const YieldDepositForm = () => {
         isSubmittingApprove,
         isSubmittingAction,
         setAmountInput,
-        completeWrapStep,
+        submitWrap,
+        skipWrap,
         returnToWrapStep,
         submitApprovalAction,
         submitAction,
@@ -60,6 +62,8 @@ export const YieldDepositForm = () => {
 
     const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
+    const wrapPendingTransaction =
+        pendingTransaction?.type === 'wrap' ? pendingTransaction : undefined;
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
     const sequence = getYieldFlowStepSequence({
@@ -123,6 +127,34 @@ export const YieldDepositForm = () => {
         });
 
         submitAction();
+    };
+
+    const handleOnWrap = () => {
+        analytics.report({
+            type: events.yieldDepositEvent.name,
+            payload: {
+                type: 'wrap',
+                action: 'continue',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        submitWrap();
+    };
+
+    const handleOnSkipWrap = () => {
+        analytics.report({
+            type: events.yieldDepositEvent.name,
+            payload: {
+                type: 'wrap',
+                action: 'cancel',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        skipWrap();
     };
 
     const handleMaxClick = () => {
@@ -208,10 +240,24 @@ export const YieldDepositForm = () => {
                                     <YieldWrapStep
                                         token={token}
                                         nativeSymbol={nativeSymbol}
-                                        nativeBalance={account.formattedBalance}
-                                        onMaxClick={() => setAmountInput(account.formattedBalance)}
-                                        onSubmit={completeWrapStep}
-                                        onSkip={completeWrapStep}
+                                        availableAmount={maxAmount}
+                                        receivingAmount={liveAmount || '0'}
+                                        isSubmitting={isSubmittingAction}
+                                        isSubmitDisabled={
+                                            isAmountEmpty ||
+                                            isAmountTooHigh ||
+                                            isAmountInvalidDecimals
+                                        }
+                                        warning={
+                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                                <YieldActionStepWarning isInsufficientFunds />
+                                            ) : undefined
+                                        }
+                                        pendingTransaction={wrapPendingTransaction}
+                                        onMaxClick={handleMaxClick}
+                                        onSubmit={handleOnWrap}
+                                        onSkip={handleOnSkipWrap}
+                                        onPendingTxClick={openPendingTransaction}
                                     />
                                 ),
                             },
@@ -241,6 +287,7 @@ export const YieldDepositForm = () => {
                                         }
                                         isDisabled={
                                             isAmountEmpty ||
+                                            (flow.isWrappedNativeVault && isAmountTooHigh) ||
                                             isAmountInvalidDecimals ||
                                             isSubmittingApprove ||
                                             !!approvalPendingTransaction

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { type UseFormReturn, useForm, useWatch } from 'react-hook-form';
 
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -18,6 +18,7 @@ import {
     type YieldFlowToken,
     type YieldPendingTransactionState,
     type YieldPositionFlowType,
+    getWrappableNativeBalance,
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
@@ -36,6 +37,8 @@ import {
     submitYieldDepositThunk,
     submitYieldWithdrawThunk,
 } from 'src/actions/wallet/stablecoin-yield';
+import { submitUnwrapNativeTokenThunk } from 'src/actions/wallet/unwrapNativeTokenThunks';
+import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenThunks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { useEnsureYieldDeviceSession } from './useEnsureYieldDeviceSession';
@@ -78,6 +81,7 @@ export type UseYieldFlowResult = {
     actionAmount: string | null;
     completedAmount: string;
     completedReceiptAmount: string;
+    unwrappedAmount: string | null;
     errorMessage: TranslationKey | undefined;
     approveModalState: YieldApproveModalState | null;
     pendingTransaction: YieldPendingTransactionState | null;
@@ -92,9 +96,11 @@ export type UseYieldFlowResult = {
     isSubmittingApprove: boolean;
     isSubmittingAction: boolean;
     setAmountInput: (amount: string) => void;
-    completeWrapStep: () => void;
+    submitWrap: () => void;
+    skipWrap: () => void;
     returnToWrapStep: () => void;
-    completeUnwrapStep: () => void;
+    submitUnwrap: () => void;
+    skipUnwrap: () => void;
     submitApprovalAction: () => void;
     submitAction: () => void;
     revokeAllowance: () => void;
@@ -134,6 +140,7 @@ export const useYieldFlow = ({
     });
     const methodsRef = useCurrentRef(methods);
     const initAllowancePromiseRef = useRef<{ abort: () => void } | null>(null);
+    const unwrapDefaultAmountRef = useRef<string | null>(null);
 
     const { token, receiptToken, apy, depositedAmount, depositedSharesAmount, flowKey } =
         useResolvedYieldFlowData({
@@ -153,16 +160,22 @@ export const useYieldFlow = ({
     const sessionRef = useCurrentRef(session);
 
     const isWrappedNativeVault = isWrappedNativeToken(account.symbol, vault.token.address);
-    const hasWrapStep = flowType === 'deposit' && isWrappedNativeVault;
-    const hasUnwrapStep = isYieldWithdrawFlow(flowType) && isWrappedNativeVault;
-    const [isWrapStepCompleted, setIsWrapStepCompleted] = useState(false);
-    const [isUnwrapStepResolved, setIsUnwrapStepResolved] = useState(false);
+    const hasWrappedTokenBalanceRef = useCurrentRef(
+        isAmountGreaterThan({ amount: token?.balance ?? '0', threshold: '0' }),
+    );
 
     const isSharesInput = flowType === 'redeem';
     const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
 
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
+            if (session.step === 'wrap') {
+                return getWrappableNativeBalance(account.formattedBalance);
+            }
+
+            return token?.balance ?? '';
+        }
+        if (session.step === 'unwrap') {
             return token?.balance ?? '';
         }
         if (isSharesInput) {
@@ -183,17 +196,25 @@ export const useYieldFlow = ({
             return;
         }
 
-        dispatch(stablecoinYieldActions.initSession({ flowType, flowKey }));
-        dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey }));
+        dispatch(stablecoinYieldActions.initSession({ flowType, flowKey, isWrappedNativeVault }));
+        dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey, isWrappedNativeVault }));
+
+        if (flowType === 'deposit' && isWrappedNativeVault && hasWrappedTokenBalanceRef.current) {
+            dispatch(
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType,
+                    flowKey,
+                    step: 'wrap',
+                }),
+            );
+        }
 
         methodsRef.current.reset({ amountInput: '' });
-        setIsWrapStepCompleted(false);
-        setIsUnwrapStepResolved(false);
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
         };
-    }, [flowKey, flowType, dispatch, methodsRef]);
+    }, [flowKey, flowType, dispatch, isWrappedNativeVault, hasWrappedTokenBalanceRef, methodsRef]);
 
     const { allowanceStatus } = session.approval;
 
@@ -210,9 +231,14 @@ export const useYieldFlow = ({
             return;
         }
 
-        const { account, vault: currentVault, token, receiptToken } = allowanceFlowDataRef.current;
+        const {
+            account: currentAccount,
+            vault: currentVault,
+            token: currentToken,
+            receiptToken: currentReceiptToken,
+        } = allowanceFlowDataRef.current;
 
-        if (!token || !receiptToken || !currentVault) {
+        if (!currentToken || !currentReceiptToken || !currentVault) {
             return;
         }
 
@@ -220,7 +246,12 @@ export const useYieldFlow = ({
             initYieldAllowanceThunk({
                 flowKey,
                 flowType,
-                flowData: { account, vault: currentVault, token, receiptToken },
+                flowData: {
+                    account: currentAccount,
+                    vault: currentVault,
+                    token: currentToken,
+                    receiptToken: currentReceiptToken,
+                },
             }),
         );
 
@@ -232,7 +263,7 @@ export const useYieldFlow = ({
                     type: events.yieldInteractionEvent.name,
                     payload: {
                         element: 'allowance-error-banner',
-                        networkSymbol: token.networkSymbol,
+                        networkSymbol: currentToken.networkSymbol,
                         vaultId: currentVault.id,
                     },
                 });
@@ -245,11 +276,20 @@ export const useYieldFlow = ({
     }, [allowanceFlowDataRef, analytics, dispatch, flowKey, flowType]);
 
     useEffect(() => {
-        if (allowanceStatus !== 'idle') {
+        const canInitializeAllowance =
+            !isWrappedNativeVault || (session.isWrappedNativeVault && session.step === 'approve');
+
+        if (allowanceStatus !== 'idle' || !canInitializeAllowance) {
             return;
         }
         runInitAllowance();
-    }, [allowanceStatus, runInitAllowance]);
+    }, [
+        allowanceStatus,
+        isWrappedNativeVault,
+        runInitAllowance,
+        session.isWrappedNativeVault,
+        session.step,
+    ]);
 
     useYieldPendingTransactionTracking({
         account,
@@ -266,6 +306,14 @@ export const useYieldFlow = ({
         const nextStep = session.step;
 
         if (prevStep !== null && prevStep !== nextStep) {
+            if (prevStep === 'wrap' && nextStep === 'approve') {
+                methodsRef.current.reset({ amountInput: session.action.amount ?? '' });
+            }
+
+            if (nextStep === 'wrap') {
+                methodsRef.current.reset({ amountInput: '' });
+            }
+
             if (prevStep === 'approve' && nextStep === 'action') {
                 const actionAmount = session.action.amount ?? '';
                 const cappedAmount = isAmountGreaterThan({
@@ -293,36 +341,29 @@ export const useYieldFlow = ({
         prevStepRef.current = nextStep;
     }, [session.step, session.action.amount, methodsRef, maxAmount]);
 
-    // TODO(#29864, #29866): dummy wrap/unwrap steps — they only advance the UI; the wrap
-    // and unwrap transactions themselves come with the shared wrap thunks.
-    const completeWrapStep = useCallback(() => {
-        setIsWrapStepCompleted(true);
-    }, []);
+    useEffect(() => {
+        if (session.step !== 'unwrap') {
+            unwrapDefaultAmountRef.current = null;
 
-    const returnToWrapStep = useCallback(() => {
-        setIsWrapStepCompleted(false);
-    }, []);
-
-    const completeUnwrapStep = useCallback(() => {
-        setIsUnwrapStepResolved(true);
-    }, []);
-
-    const getCurrentStep = (): YieldFlowStepId => {
-        if (hasWrapStep && !isWrapStepCompleted) {
-            return 'wrap';
+            return;
         }
 
-        // The unwrap step is chained after the action confirms, before the complete screen.
-        if (hasUnwrapStep && !isUnwrapStepResolved && session.step === 'complete') {
-            return 'unwrap';
+        const nextDefaultAmount = token?.balance ?? '';
+        const currentAmount = methodsRef.current.getValues('amountInput');
+
+        if (
+            unwrapDefaultAmountRef.current === null ||
+            currentAmount === unwrapDefaultAmountRef.current
+        ) {
+            methodsRef.current.reset({ amountInput: nextDefaultAmount });
         }
 
-        return session.step;
-    };
-    const currentStep = getCurrentStep();
+        unwrapDefaultAmountRef.current = nextDefaultAmount;
+    }, [methodsRef, session.step, token?.balance]);
+
     const flow = useMemo(
-        () => ({ currentStep, isWrappedNativeVault }),
-        [currentStep, isWrappedNativeVault],
+        () => ({ currentStep: session.step, isWrappedNativeVault }),
+        [session.step, isWrappedNativeVault],
     );
 
     const openPendingTransaction = useCallback(
@@ -373,6 +414,153 @@ export const useYieldFlow = ({
     }, [device, dispatch]);
 
     const isDeviceConnected = !!device?.connected && !!device?.available;
+
+    const resolveWrappedNativeStep = useCallback(
+        (step: 'wrap' | 'unwrap') => {
+            dispatch(
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType,
+                    flowKey,
+                    step,
+                }),
+            );
+        },
+        [dispatch, flowKey, flowType],
+    );
+
+    const submitWrappedNative = useCallback(
+        async (step: 'wrap' | 'unwrap') => {
+            if (
+                (step === 'wrap' && flowType !== 'deposit') ||
+                (step === 'unwrap' && !isYieldWithdrawFlow(flowType))
+            ) {
+                return;
+            }
+
+            if (!isDeviceConnected) {
+                openDeviceConnectionModal();
+
+                return;
+            }
+
+            if (!token?.contractAddress) {
+                dispatch(
+                    stablecoinYieldActions.setError({
+                        flowType,
+                        flowKey,
+                        error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    }),
+                );
+
+                return;
+            }
+
+            const amount = methodsRef.current.getValues('amountInput');
+
+            if (!isAmountGreaterThan({ amount, threshold: '0' })) {
+                resolveWrappedNativeStep(step);
+
+                return;
+            }
+
+            const isSessionReady = await ensureDeviceSession();
+
+            if (!isSessionReady) {
+                return;
+            }
+
+            const wrappedToken = {
+                ...token,
+                contractAddress: token.contractAddress,
+            };
+
+            dispatch(stablecoinYieldActions.startSubmittingWrappedNative({ flowType, flowKey }));
+            try {
+                let txid: string | undefined;
+
+                if (step === 'wrap') {
+                    const result = await dispatch(
+                        submitWrapNativeTokenThunk({
+                            account,
+                            token: wrappedToken,
+                            wrapAmount: amount,
+                            yieldFlow: { flowType: 'deposit', flowKey },
+                        }),
+                    ).unwrap();
+                    txid = result?.txid;
+                } else if (isYieldWithdrawFlow(flowType)) {
+                    const result = await dispatch(
+                        submitUnwrapNativeTokenThunk({
+                            account,
+                            token: wrappedToken,
+                            unwrapAmount: amount,
+                            yieldFlow: { flowType, flowKey },
+                        }),
+                    ).unwrap();
+                    txid = result?.txid;
+                }
+
+                if (txid) {
+                    dispatch(
+                        stablecoinYieldActions.setPendingTx({
+                            flowType,
+                            flowKey,
+                            tx: {
+                                type: step,
+                                txid,
+                                amount,
+                            },
+                        }),
+                    );
+                }
+            } catch {
+                // The thunk handles compose/sign/broadcast failures itself (toast); this guards an
+                // unexpected throw around it so the step surfaces an error instead of silently
+                // rejecting. The step stays put, so the user can retry.
+                dispatch(
+                    stablecoinYieldActions.setError({
+                        flowType,
+                        flowKey,
+                        error: 'TR_EARN_YIELD_ERROR_GENERIC',
+                    }),
+                );
+            } finally {
+                dispatch(stablecoinYieldActions.finishSubmittingAction({ flowType, flowKey }));
+            }
+        },
+        [
+            account,
+            dispatch,
+            ensureDeviceSession,
+            flowKey,
+            flowType,
+            isDeviceConnected,
+            methodsRef,
+            openDeviceConnectionModal,
+            resolveWrappedNativeStep,
+            token,
+        ],
+    );
+
+    const submitWrap = useCallback(() => {
+        void submitWrappedNative('wrap');
+    }, [submitWrappedNative]);
+
+    const skipWrap = useCallback(() => {
+        resolveWrappedNativeStep('wrap');
+    }, [resolveWrappedNativeStep]);
+
+    const returnToWrapStep = useCallback(() => {
+        dispatch(stablecoinYieldActions.returnToWrapStep({ flowType, flowKey }));
+    }, [dispatch, flowKey, flowType]);
+
+    const submitUnwrap = useCallback(() => {
+        void submitWrappedNative('unwrap');
+    }, [submitWrappedNative]);
+
+    const skipUnwrap = useCallback(() => {
+        resolveWrappedNativeStep('unwrap');
+    }, [resolveWrappedNativeStep]);
 
     const submitApprove = useCallback(async () => {
         if (flowType !== 'deposit') {
@@ -607,6 +795,7 @@ export const useYieldFlow = ({
         actionAmount: session.action.amount,
         completedAmount: session.result.completedAmount,
         completedReceiptAmount: session.result.completedReceiptAmount,
+        unwrappedAmount: session.result.unwrappedAmount,
         errorMessage: session.error ?? undefined,
         approveModalState: session.approval.modalState,
         pendingTransaction: session.action.pendingTransaction,
@@ -624,9 +813,11 @@ export const useYieldFlow = ({
             session.approval.modalState !== null,
         isSubmittingAction: session.action.isSubmitting,
         setAmountInput,
-        completeWrapStep,
+        submitWrap,
+        skipWrap,
         returnToWrapStep,
-        completeUnwrapStep,
+        submitUnwrap,
+        skipUnwrap,
         submitApprovalAction,
         submitAction,
         revokeAllowance,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -9,13 +9,19 @@ import {
     type YieldPendingTransactionState,
     type YieldWithdrawFlowType,
     fetchAndUpdateAccountThunk,
+    isYieldWithdrawFlow,
     selectConvertedNetworkFeeInfo,
     selectStablecoinYieldSession,
     selectTransactionByAccountKeyAndTxid,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { getApyBreakdown, isPending } from '@suite-common/wallet-utils';
+import {
+    getApyBreakdown,
+    getNativeWrapTxKind,
+    getWrappedNativeTxTarget,
+    isPending,
+} from '@suite-common/wallet-utils';
 import { type Analytics } from '@trezor/analytics-uploader';
 import { useCurrentRef } from '@trezor/react-utils';
 
@@ -35,8 +41,15 @@ const getPollIntervalMs = (blockTime: number | undefined): number => {
 };
 
 type ResolutionEventType =
-    | { type: 'deposit'; successType: 'approve-success' | 'revoke-success' | 'success' }
-    | { type: 'withdraw'; operation: YieldWithdrawFlowType; successType: 'success' }
+    | {
+          type: 'deposit';
+          successType: 'approve-success' | 'revoke-success' | 'wrap-success' | 'success';
+      }
+    | {
+          type: 'withdraw';
+          operation: YieldWithdrawFlowType;
+          successType: 'unwrap-success' | 'success';
+      }
     | { type: 'claim'; successType: 'success' };
 
 const getResolutionEventType = (
@@ -56,6 +69,12 @@ const getResolutionEventType = (
             return { type: 'withdraw', operation: 'redeem', successType: 'success' };
         case 'claim':
             return flowType === 'claim' ? { type: 'claim', successType: 'success' } : null;
+        case 'wrap':
+            return flowType === 'deposit' ? { type: 'deposit', successType: 'wrap-success' } : null;
+        case 'unwrap':
+            return isYieldWithdrawFlow(flowType)
+                ? { type: 'withdraw', operation: flowType, successType: 'unwrap-success' }
+                : null;
         default:
             return null;
     }
@@ -109,8 +128,10 @@ const reportResolution = (
     }
 
     if (resolution.type === 'withdraw') {
-        const apyBreakdown =
-            outcome === 'success' ? getApyBreakdown(context.vault?.rewardRate?.components) : '';
+        const isWithdrawSuccess = outcome === 'success' && resolution.successType === 'success';
+        const apyBreakdown = isWithdrawSuccess
+            ? getApyBreakdown(context.vault?.rewardRate?.components)
+            : '';
 
         analytics.report({
             type: events.yieldWithdrawEvent.name,
@@ -225,7 +246,19 @@ export const useYieldPendingTransactionTracking = ({
             durationMs,
         };
 
-        if (trackedPendingTransaction.type === 'failed') {
+        const wrappedNativeFlowType =
+            pendingTransaction.type === 'wrap' || pendingTransaction.type === 'unwrap'
+                ? pendingTransaction.type
+                : null;
+
+        const confirmedWrappedNativeKind = getNativeWrapTxKind(trackedPendingTransaction);
+        const didWrappedNativeOperationChange =
+            wrappedNativeFlowType !== null &&
+            (confirmedWrappedNativeKind !== undefined
+                ? confirmedWrappedNativeKind !== wrappedNativeFlowType
+                : getWrappedNativeTxTarget(trackedPendingTransaction) === undefined);
+
+        if (trackedPendingTransaction.type === 'failed' || didWrappedNativeOperationChange) {
             if (resolution) {
                 reportResolution(analytics, resolution, 'error', context);
             }
@@ -257,6 +290,19 @@ export const useYieldPendingTransactionTracking = ({
                 }),
             );
             dispatch(stablecoinYieldActions.invalidateAllowance({ flowType, flowKey }));
+
+            return;
+        }
+
+        if (pendingTransaction.type === 'wrap' || pendingTransaction.type === 'unwrap') {
+            dispatch(
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType,
+                    flowKey,
+                    step: pendingTransaction.type,
+                    amount: pendingTransaction.amount,
+                }),
+            );
 
             return;
         }

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -44,7 +44,8 @@ export const YieldWithdrawForm = () => {
         toggleWithdrawFlowType,
         submitAction,
         setAmountInput,
-        completeUnwrapStep,
+        submitUnwrap,
+        skipUnwrap,
         openPendingTransaction,
         flow,
     } = useYieldWithdrawContext();
@@ -53,6 +54,8 @@ export const YieldWithdrawForm = () => {
         pendingTransaction,
         flowType,
     );
+    const unwrapPendingTransaction =
+        pendingTransaction?.type === 'unwrap' ? pendingTransaction : undefined;
     const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
@@ -76,6 +79,36 @@ export const YieldWithdrawForm = () => {
         });
 
         submitAction();
+    };
+
+    const handleOnUnwrap = () => {
+        analytics.report({
+            type: events.yieldWithdrawEvent.name,
+            payload: {
+                type: 'unwrap',
+                operation: flowType,
+                action: 'continue',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        submitUnwrap();
+    };
+
+    const handleOnSkipUnwrap = () => {
+        analytics.report({
+            type: events.yieldWithdrawEvent.name,
+            payload: {
+                type: 'unwrap',
+                operation: flowType,
+                action: 'cancel',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        skipUnwrap();
     };
 
     const handleToggleWithdrawInputUnit = () => {
@@ -232,8 +265,19 @@ export const YieldWithdrawForm = () => {
                                     tokenDecimals={token.decimals}
                                     tokenBalance={token.balance}
                                     onMaxClick={() => setAmountInput(token.balance)}
-                                    onSubmit={completeUnwrapStep}
-                                    onSkip={completeUnwrapStep}
+                                    isSubmitting={isSubmittingAction}
+                                    isSubmitDisabled={
+                                        isAmountEmpty || isAmountTooHigh || isAmountInvalidDecimals
+                                    }
+                                    warning={
+                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                            <YieldActionStepWarning isInsufficientFunds />
+                                        ) : undefined
+                                    }
+                                    pendingTransaction={unwrapPendingTransaction}
+                                    onSubmit={handleOnUnwrap}
+                                    onSkip={handleOnSkipUnwrap}
+                                    onPendingTxClick={openPendingTransaction}
                                 />
                             ),
                         },

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowCompleteValue,
     type YieldWithdrawFlowType,
@@ -92,27 +93,38 @@ export const useYieldWithdraw = ({
         return null;
     }
 
-    const { completedAmount } = flowResult;
+    const { completedAmount, unwrappedAmount } = flowResult;
     const isSharesInput = flowType === 'redeem';
     const pricePerShareState = vault.state?.pricePerShareState;
     const completedInput = {
         token: isSharesInput ? receiptToken : token,
         amount: completedAmount,
     };
-    const completedOutput = isSharesInput
-        ? {
-              token,
-              amount: pricePerShareState
-                  ? getConvertedOutputTokenBalanceToInputTokenAmount({
-                        networkSymbol: token.networkSymbol,
-                        token,
-                        outputToken: receiptToken,
-                        outputTokenBalance: completedAmount,
-                        pricePerShareState,
-                    })
-                  : completedAmount,
-          }
-        : undefined;
+    let completedOutput: YieldFlowCompleteValue | undefined;
+
+    if (unwrappedAmount !== null) {
+        completedOutput = {
+            token: {
+                networkSymbol: account.symbol,
+                symbol: getNetworkDisplaySymbol(account.symbol),
+                decimals: getNetwork(account.symbol).decimals,
+            },
+            amount: unwrappedAmount,
+        };
+    } else if (isSharesInput) {
+        completedOutput = {
+            token,
+            amount: pricePerShareState
+                ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                      networkSymbol: token.networkSymbol,
+                      token,
+                      outputToken: receiptToken,
+                      outputTokenBalance: completedAmount,
+                      pricePerShareState,
+                  })
+                : completedAmount,
+        };
+    }
 
     return {
         ...flowResult,

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -7,8 +7,11 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
-import { type YieldFlowDisplayToken, type YieldFlowFormValues } from '@suite-common/wallet-core';
+import {
+    type YieldFlowDisplayToken,
+    type YieldFlowFormValues,
+    getWrappableNativeBalance,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -53,10 +56,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
         decimals: token.decimals,
     };
 
-    const maxWrapAmount = BigNumber.max(
-        0,
-        new BigNumber(account.formattedBalance).minus(WETH_WRAP_GAS_RESERVE),
-    ).toString();
+    const maxWrapAmount = getWrappableNativeBalance(account.formattedBalance);
 
     const amountInput = useWatch({ control: methods.control, name: 'amountInput' });
     const amount = new BigNumber(amountInput || '');
@@ -145,7 +145,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                     <YieldWrapStep
                         token={token}
                         nativeSymbol={nativeSymbol}
-                        nativeBalance={account.formattedBalance}
+                        availableAmount={maxWrapAmount}
                         shouldShowReceivingRow={false}
                         isSubmitting={wrapMutation.isPending}
                         isSubmitDisabled={!isAmountValid}

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -1,7 +1,11 @@
 import { type ExtendedMessageDescriptor } from '@suite/intl';
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbol,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 import { type FormState, type StakeFormState } from '@suite-common/wallet-types';
-import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
+import { getEvmTransactionPurpose } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 
 interface GetTransactionReviewModalActionTranslationParams {
@@ -27,7 +31,11 @@ export const getTransactionReviewModalActionTranslation = ({
     isSending,
     source,
 }: GetTransactionReviewModalActionTranslationParams): ExtendedMessageDescriptor => {
-    const txSignature = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    const txPurpose = getEvmTransactionPurpose({
+        networkSymbol: symbol,
+        to: precomposedForm.outputs?.[0]?.address,
+        data: precomposedForm.transactionData,
+    });
 
     switch (stakeType) {
         case 'stake':
@@ -53,7 +61,7 @@ export const getTransactionReviewModalActionTranslation = ({
     }
 
     if (precomposedForm?.trading?.activeSection === 'exchange') {
-        switch (txSignature) {
+        switch (txPurpose) {
             case 'approve':
                 return {
                     id:
@@ -77,10 +85,10 @@ export const getTransactionReviewModalActionTranslation = ({
 
     if (
         (routeName === 'earn-yield-deposit' || routeName === 'earn-yield-withdraw') &&
-        (txSignature === 'approve' || txSignature === 'revoke')
+        (txPurpose === 'approve' || txPurpose === 'revoke')
     ) {
         return {
-            id: txSignature === 'approve' ? 'TR_APPROVE_DATA_TITLE' : 'TR_REVOKE_DATA_TITLE',
+            id: txPurpose === 'approve' ? 'TR_APPROVE_DATA_TITLE' : 'TR_REVOKE_DATA_TITLE',
         };
     }
 
@@ -92,13 +100,32 @@ export const getTransactionReviewModalActionTranslation = ({
         return { id: 'TR_CANCEL_TX_BUTTON' };
     }
 
+    if (txPurpose === 'wrap' || txPurpose === 'unwrap') {
+        if (source === 'heading') {
+            return {
+                id:
+                    txPurpose === 'wrap'
+                        ? 'TR_EARN_YIELD_WRAP_TITLE'
+                        : 'TR_EARN_YIELD_UNWRAP_TITLE',
+                values: {
+                    nativeSymbol: getNetworkDisplaySymbol(symbol),
+                    tokenSymbol: getWrappedNativeSymbol(symbol),
+                },
+            };
+        }
+
+        return {
+            id: txPurpose === 'wrap' ? 'TR_WRAP_NATIVE_TOKEN' : 'TR_UNWRAP_NATIVE_TOKEN',
+        };
+    }
+
     if (routeName === 'earn-yield-deposit') {
         return { id: 'TR_EARN_YIELD_DEPOSIT' };
     }
 
     if (routeName === 'earn-yield-withdraw') {
         return {
-            id: txSignature === 'redeem' ? 'TR_EARN_YIELD_REDEEM' : 'TR_EARN_YIELD_WITHDRAW',
+            id: txPurpose === 'redeem' ? 'TR_EARN_YIELD_REDEEM' : 'TR_EARN_YIELD_WITHDRAW',
         };
     }
 

--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -13,6 +13,8 @@ type Attributes = {
         | 'revoke-modal'
         | 'revoke-success'
         | 'modify-allowance'
+        | 'wrap'
+        | 'wrap-success'
         | 'deposit'
         | 'tx-simulation-modal'
         | 'success'
@@ -35,6 +37,7 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
         { version: '26.5.0', notes: 'added (as yield/supply)' },
         { version: '26.5.2', notes: 'renamed from yield/supply to yield/deposit' },
         { version: '26.7.1', notes: 'moved to suite-common, reported from mobile as well' },
+        { version: '26.8.0', notes: 'added wrap transaction events' },
     ],
 
     attributes: {
@@ -48,6 +51,7 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
                     version: '26.5.2',
                     notes: 'added `approve-success`, `revoke-success`, `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
                 },
+                { version: '26.8.0', notes: 'added `wrap` and `wrap-success` values' },
             ],
         },
         networkSymbol: {

--- a/suite-common/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite-common/analytics/src/events/yieldWithdrawEvent.ts
@@ -7,6 +7,8 @@ type Attributes = {
     action: AttributeDef<EarnModalAction>;
     type: AttributeDef<
         | 'withdraw'
+        | 'unwrap'
+        | 'unwrap-success'
         | 'tx-simulation-modal'
         | 'success'
         | 'error'
@@ -27,6 +29,7 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
     changelog: [
         { version: '26.5.0', notes: 'added' },
         { version: '26.7.1', notes: 'moved to suite-common, reported from mobile as well' },
+        { version: '26.8.0', notes: 'added unwrap transaction events' },
     ],
 
     attributes: {
@@ -42,6 +45,7 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
                     version: '26.5.2',
                     notes: 'added `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
                 },
+                { version: '26.8.0', notes: 'added `unwrap` and `unwrap-success` values' },
             ],
         },
         operation: {

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldReducer.test.ts
@@ -15,10 +15,14 @@ const FLOW_KEY = 'account-key:yield-id:0xtoken';
 const getSession = (state: StablecoinYieldState, flowType: YieldFlowType) =>
     state[flowType][getStablecoinYieldSessionKey(FLOW_KEY)];
 
-const initSession = (flowType: YieldFlowType, isNativeDeposit?: boolean) =>
+const initSession = (flowType: YieldFlowType, isWrappedNativeVault?: boolean) =>
     stablecoinYieldReducer(
         initialStablecoinYieldState,
-        stablecoinYieldActions.initSession({ flowType, flowKey: FLOW_KEY, isNativeDeposit }),
+        stablecoinYieldActions.initSession({
+            flowType,
+            flowKey: FLOW_KEY,
+            isWrappedNativeVault,
+        }),
     );
 
 describe('stablecoinYieldReducer', () => {
@@ -35,26 +39,168 @@ describe('stablecoinYieldReducer', () => {
             expect(getSession(state, 'deposit')?.step).toBe('wrap');
         });
 
+        it('preserves the wrapped-native flow when resetting a session', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.resetSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+            expect(getSession(state, 'deposit')?.isWrappedNativeVault).toBe(true);
+        });
+
         it('moves a native deposit from the wrap step to approve when it is skipped', () => {
             const state = stablecoinYieldReducer(
                 initSession('deposit', true),
-                stablecoinYieldActions.skipWrapStep({ flowType: 'deposit', flowKey: FLOW_KEY }),
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    step: 'wrap',
+                }),
             );
 
             expect(getSession(state, 'deposit')?.step).toBe('approve');
         });
 
+        it('seeds the deposit amount with the wrapped amount', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    step: 'wrap',
+                    amount: '0.2',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.amount).toBe('0.2');
+        });
+
+        it('keeps the deposit amount empty when the wrap step is skipped', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    step: 'wrap',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.amount).toBeNull();
+        });
+
         it('does not regress once the wrap step has been left', () => {
-            // skipWrapStep must only advance from the wrap step, so a repeat can't pull the
-            // flow back from approve/action.
-            const skipWrap = stablecoinYieldActions.skipWrapStep({
+            const resolveWrap = stablecoinYieldActions.resolveWrappedNativeStep({
                 flowType: 'deposit',
                 flowKey: FLOW_KEY,
+                step: 'wrap',
             });
-            const once = stablecoinYieldReducer(initSession('deposit', true), skipWrap);
-            const twice = stablecoinYieldReducer(once, skipWrap);
+            const once = stablecoinYieldReducer(initSession('deposit', true), resolveWrap);
+            const twice = stablecoinYieldReducer(once, resolveWrap);
 
             expect(getSession(twice, 'deposit')?.step).toBe('approve');
+        });
+
+        it('returns a wrapped-native deposit from approve back to the wrap step', () => {
+            const atApprove = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    step: 'wrap',
+                }),
+            );
+            const state = stablecoinYieldReducer(
+                atApprove,
+                stablecoinYieldActions.returnToWrapStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
+        });
+
+        it('does not return to the wrap step for a non-wrapped vault', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.returnToWrapStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it('does not return to the wrap step while a transaction is in flight', () => {
+            const atApprove = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    step: 'wrap',
+                }),
+            );
+            const withPendingTx = stablecoinYieldReducer(
+                atApprove,
+                stablecoinYieldActions.setPendingTx({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    tx: { type: 'approve', txid: '0xabc', amount: '1' },
+                }),
+            );
+            const state = stablecoinYieldReducer(
+                withPendingTx,
+                stablecoinYieldActions.returnToWrapStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('approve');
+        });
+
+        it.each(['withdraw', 'redeem'] as const)(
+            'moves a wrapped-native %s from action to unwrap',
+            flowType => {
+                const state = stablecoinYieldReducer(
+                    initSession(flowType, true),
+                    stablecoinYieldActions.completeAction({
+                        flowType,
+                        flowKey: FLOW_KEY,
+                        amount: '10',
+                    }),
+                );
+
+                expect(getSession(state, flowType)?.step).toBe('unwrap');
+            },
+        );
+
+        it('stores the unwrapped amount and completes the flow', () => {
+            const actionCompleteState = stablecoinYieldReducer(
+                initSession('withdraw', true),
+                stablecoinYieldActions.completeAction({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    amount: '10',
+                }),
+            );
+            const state = stablecoinYieldReducer(
+                actionCompleteState,
+                stablecoinYieldActions.resolveWrappedNativeStep({
+                    flowType: 'withdraw',
+                    flowKey: FLOW_KEY,
+                    step: 'unwrap',
+                    amount: '10',
+                }),
+            );
+
+            expect(getSession(state, 'withdraw')?.step).toBe('complete');
+            expect(getSession(state, 'withdraw')?.result.unwrappedAmount).toBe('10');
         });
 
         it.each(['withdraw', 'redeem', 'claim'] as const)(
@@ -90,6 +236,18 @@ describe('stablecoinYieldReducer', () => {
             );
 
             expect(getSession(state, 'deposit')?.step).toBe('action');
+        });
+
+        it('does not skip the wrap step when an allowance check resolves early', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit', true),
+                stablecoinYieldActions.skipApprovalStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('wrap');
         });
 
         it('keeps deposit on the action step when the approval skip repeats', () => {

--- a/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/__tests__/stablecoinYieldUtils.test.ts
@@ -9,6 +9,7 @@ import {
     buildYieldWithdrawCalldata,
     buildYieldWrapTransactionData,
     getNextYieldFlowStep,
+    getWrappableNativeBalance,
     getYieldDepositableBalance,
     getYieldFlowStepSequence,
     getYieldWrapAmount,
@@ -95,15 +96,23 @@ describe('stablecoinYieldUtils', () => {
 
     describe('getNextYieldFlowStep', () => {
         it('advances deposit through wrap → approve → action → complete', () => {
-            expect(getNextYieldFlowStep('deposit', 'wrap')).toBe('approve');
-            expect(getNextYieldFlowStep('deposit', 'approve')).toBe('action');
-            expect(getNextYieldFlowStep('deposit', 'action')).toBe('complete');
+            expect(getNextYieldFlowStep('deposit', 'wrap', true)).toBe('approve');
+            expect(getNextYieldFlowStep('deposit', 'approve', true)).toBe('action');
+            expect(getNextYieldFlowStep('deposit', 'action', true)).toBe('complete');
         });
 
         it.each(['withdraw', 'redeem', 'claim'] as const)(
             'advances %s from action to complete',
             flowType => {
                 expect(getNextYieldFlowStep(flowType, 'action')).toBe('complete');
+            },
+        );
+
+        it.each(['withdraw', 'redeem'] as const)(
+            'advances wrapped-native %s through unwrap',
+            flowType => {
+                expect(getNextYieldFlowStep(flowType, 'action', true)).toBe('unwrap');
+                expect(getNextYieldFlowStep(flowType, 'unwrap', true)).toBe('complete');
             },
         );
 
@@ -380,6 +389,20 @@ describe('stablecoinYieldUtils', () => {
                     matchedTokenBalance: undefined,
                 }),
             ).toBe('0.995');
+        });
+    });
+
+    describe('getWrappableNativeBalance', () => {
+        it('keeps the gas reserve aside', () => {
+            expect(getWrappableNativeBalance('0.2')).toBe('0.195');
+        });
+
+        it('floors at zero when the balance does not cover the reserve', () => {
+            expect(getWrappableNativeBalance('0.003')).toBe('0');
+        });
+
+        it('treats an empty balance as zero', () => {
+            expect(getWrappableNativeBalance('')).toBe('0');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -12,6 +12,7 @@ import { isSafeObjectKey } from '@trezor/utils';
 import { STABLECOIN_YIELD_PREFIX } from './stablecoinYieldConstants';
 import {
     type StablecoinYieldClaimUnsignedTransaction,
+    type WrappedNativeStepId,
     YIELD_FLOW_TYPES,
     type YieldApproveModalState,
     type YieldFlowCompleteRewardItem,
@@ -79,6 +80,7 @@ export type StablecoinYieldTxReviewState = {
 
 export type StablecoinYieldSessionState = {
     step: YieldFlowStepId;
+    isWrappedNativeVault: boolean;
     error: StablecoinYieldTranslationKey | null;
     approval: {
         allowanceAmount: string | null;
@@ -99,6 +101,7 @@ export type StablecoinYieldSessionState = {
         completedAmount: string;
         completedReceiptAmount: string;
         completedRewards: YieldFlowCompleteRewardItem[];
+        unwrappedAmount: string | null;
     };
 };
 
@@ -119,6 +122,7 @@ type StablecoinYieldSessionActionPayload = {
 
 export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
     step: 'approve',
+    isWrappedNativeVault: false,
     error: null,
     approval: {
         allowanceAmount: null,
@@ -139,6 +143,7 @@ export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
         completedAmount: '0',
         completedReceiptAmount: '0',
         completedRewards: [],
+        unwrappedAmount: null,
     },
 };
 
@@ -163,10 +168,11 @@ export const initialStablecoinYieldState: StablecoinYieldState = {
 
 const createInitialStablecoinYieldSessionState = (
     flowType: YieldFlowType,
-    isNativeDeposit = false,
+    isWrappedNativeVault = false,
 ): StablecoinYieldSessionState => ({
     ...initialStablecoinYieldSessionState,
-    step: getYieldFlowStepSequence({ flowType, isWrappedNativeVault: isNativeDeposit })[0],
+    step: getYieldFlowStepSequence({ flowType, isWrappedNativeVault })[0],
+    isWrappedNativeVault,
     approval: { ...initialStablecoinYieldSessionState.approval },
     action: { ...initialStablecoinYieldSessionState.action },
     result: {
@@ -202,10 +208,10 @@ const stablecoinYieldSlice = createSlice({
         initSession(
             state: StablecoinYieldState,
             action: PayloadAction<
-                StablecoinYieldSessionActionPayload & { isNativeDeposit?: boolean }
+                StablecoinYieldSessionActionPayload & { isWrappedNativeVault?: boolean }
             >,
         ) {
-            const { flowType, flowKey, isNativeDeposit } = action.payload;
+            const { flowType, flowKey, isWrappedNativeVault } = action.payload;
 
             if (!isSafeObjectKey(flowKey)) {
                 return;
@@ -216,7 +222,7 @@ const stablecoinYieldSlice = createSlice({
             if (!state[flowType][sessionKey]) {
                 state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(
                     flowType,
-                    isNativeDeposit,
+                    isWrappedNativeVault,
                 );
             }
         },
@@ -234,7 +240,9 @@ const stablecoinYieldSlice = createSlice({
         },
         resetSession(
             state: StablecoinYieldState,
-            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & { isWrappedNativeVault?: boolean }
+            >,
         ) {
             const { flowType, flowKey } = action.payload;
 
@@ -242,8 +250,16 @@ const stablecoinYieldSlice = createSlice({
                 return;
             }
 
-            state[flowType][getStablecoinYieldSessionKey(flowKey)] =
-                createInitialStablecoinYieldSessionState(flowType);
+            const sessionKey = getStablecoinYieldSessionKey(flowKey);
+            const isWrappedNativeVault =
+                action.payload.isWrappedNativeVault ??
+                state[flowType][sessionKey]?.isWrappedNativeVault ??
+                false;
+
+            state[flowType][sessionKey] = createInitialStablecoinYieldSessionState(
+                flowType,
+                isWrappedNativeVault,
+            );
         },
         setError(
             state: StablecoinYieldState,
@@ -371,13 +387,24 @@ const stablecoinYieldSlice = createSlice({
             >,
         ) {
             withSession(state, action.payload, session => {
+                // Approval completion only ever originates from the approve step (modify mode
+                // regresses there first) — the guard keeps a stray dispatch from yanking the
+                // flow out of another step.
+                if (session.step !== 'approve') {
+                    return;
+                }
+
                 session.approval.isModifyMode = false;
                 session.approval.modalState = null;
                 session.approval.isRevokeRequired = false;
                 session.action.amount = action.payload.amount;
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+                session.step = getNextYieldFlowStep(
+                    action.payload.flowType,
+                    'approve',
+                    session.isWrappedNativeVault,
+                );
             });
         },
         skipApprovalStep(
@@ -385,18 +412,70 @@ const stablecoinYieldSlice = createSlice({
             action: PayloadAction<StablecoinYieldSessionActionPayload>,
         ) {
             withSession(state, action.payload, session => {
-                session.step = getNextYieldFlowStep(action.payload.flowType, 'approve');
+                if (session.step !== 'approve') {
+                    return;
+                }
+
+                session.step = getNextYieldFlowStep(
+                    action.payload.flowType,
+                    'approve',
+                    session.isWrappedNativeVault,
+                );
             });
         },
-        skipWrapStep(
+        resolveWrappedNativeStep(
+            state: StablecoinYieldState,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & {
+                    step: WrappedNativeStepId;
+                    amount?: string;
+                }
+            >,
+        ) {
+            withSession(state, action.payload, session => {
+                if (session.step !== action.payload.step) {
+                    return;
+                }
+
+                session.action.pendingTransaction = null;
+                if (action.payload.step === 'unwrap') {
+                    session.result.unwrappedAmount = action.payload.amount ?? null;
+                }
+
+                if (action.payload.step === 'wrap' && action.payload.amount) {
+                    session.action.amount = action.payload.amount;
+                }
+                session.step = getNextYieldFlowStep(
+                    action.payload.flowType,
+                    action.payload.step,
+                    session.isWrappedNativeVault,
+                );
+            });
+        },
+        returnToWrapStep(
             state: StablecoinYieldState,
             action: PayloadAction<StablecoinYieldSessionActionPayload>,
         ) {
             withSession(state, action.payload, session => {
-                // Only advance from the wrap step, so repeated init calls can't regress the flow.
-                if (session.step === 'wrap') {
-                    session.step = getNextYieldFlowStep(action.payload.flowType, 'wrap');
+                // Editing the finished wrap step offers another wrap round. Only meaningful for
+                // a wrapped-native deposit, from a later pre-complete step, and never while an
+                // approval or action operation is in flight — a regression during e.g.
+                // `submitYieldApproveThunk` would let its completion yank the flow out of the
+                // re-entered wrap step.
+                if (
+                    action.payload.flowType !== 'deposit' ||
+                    !session.isWrappedNativeVault ||
+                    (session.step !== 'approve' && session.step !== 'action') ||
+                    session.approval.isSubmitting ||
+                    session.approval.modalState !== null ||
+                    session.approval.allowanceStatus === 'loading' ||
+                    session.action.isSubmitting ||
+                    session.action.pendingTransaction !== null
+                ) {
+                    return;
                 }
+
+                session.step = 'wrap';
             });
         },
         revokeSuccess(
@@ -432,6 +511,18 @@ const stablecoinYieldSlice = createSlice({
         ) {
             withSession(state, action.payload, session => {
                 session.action.isSubmitting = false;
+            });
+        },
+        // Unlike `startSubmittingAction`, a wrap/unwrap submit must not touch `action.amount` —
+        // that field holds the deposit/withdraw amount the later steps default to. The shared
+        // `finishSubmittingAction` closes both.
+        startSubmittingWrappedNative(
+            state: StablecoinYieldState,
+            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+        ) {
+            withSession(state, action.payload, session => {
+                session.action.isSubmitting = true;
+                session.error = null;
             });
         },
         storeActionReviewData(
@@ -491,7 +582,11 @@ const stablecoinYieldSlice = createSlice({
 
                 session.action.pendingTransaction = null;
                 session.action.review = null;
-                session.step = getNextYieldFlowStep(action.payload.flowType, 'action');
+                session.step = getNextYieldFlowStep(
+                    action.payload.flowType,
+                    'action',
+                    session.isWrappedNativeVault,
+                );
             });
         },
         transactionFailed(

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -11,6 +11,7 @@ export type WrappedNativeFlowType = 'wrap' | 'unwrap';
 export type YieldPositionFlowType = Exclude<YieldFlowType, 'claim'>;
 export type YieldWithdrawFlowType = Extract<YieldFlowType, 'withdraw' | 'redeem'>;
 export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
+export type WrappedNativeStepId = Extract<YieldFlowStepId, 'wrap' | 'unwrap'>;
 
 export type YieldFlowFormValues = {
     amountInput: string;

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -144,29 +144,20 @@ export const getYieldFlowStepSequence = <TFlowType extends YieldFlowType>({
     return sequence as YieldFlowStepSequence<TFlowType>;
 };
 
-/**
- * Returns the step that follows `step` in the flow's step sequence. Stays on `step`
- * when it is the last one or not part of the flow at all.
- *
- * The full sequence (wrap/unwrap included) is used to locate `step`, so an optional step
- * such as `wrap` can be advanced from. Optional steps are skipped as *targets* though —
- * they are entered explicitly (e.g. `wrap` is left via `skipWrapStep`), never as the
- * automatic next step of the preceding one.
- */
+/** Returns the next step in the sequence selected for the current vault. */
 export const getNextYieldFlowStep = (
     flowType: YieldFlowType,
     step: YieldFlowStepId,
+    isWrappedNativeVault = false,
 ): YieldFlowStepId => {
-    const sequence = getYieldFlowStepSequence({ flowType, isWrappedNativeVault: true });
+    const sequence = getYieldFlowStepSequence({ flowType, isWrappedNativeVault });
     const stepIndex = sequence.indexOf(step);
 
     if (stepIndex === -1) {
         return step;
     }
 
-    const nextStep = sequence.slice(stepIndex + 1).find(s => s !== 'wrap' && s !== 'unwrap');
-
-    return nextStep ?? step;
+    return sequence[stepIndex + 1] ?? step;
 };
 
 export const getYieldWithdrawInputToken = ({
@@ -382,6 +373,16 @@ type GetYieldDepositableBalanceParams = {
 };
 
 /**
+ * Native balance that can be wrapped, after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the
+ * follow-up wrap + approve + deposit (+ exit) fees.
+ */
+export const getWrappableNativeBalance = (nativeFormattedBalance: string): string =>
+    BigNumber.max(
+        0,
+        new BigNumber(nativeFormattedBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
+    ).toString();
+
+/**
  * Balance available for a yield deposit. For a wrapped-native (WETH) vault the native balance can
  * be wrapped, so it counts in after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the follow-up
  * wrap + approve + deposit (+ exit) fees.
@@ -399,14 +400,10 @@ export const getYieldDepositableBalance = ({
         return tokenDepositBalance;
     }
 
-    // Native-asset deposit: the native balance can also be wrapped, after keeping the fee reserve
-    // aside for the follow-up wrap + approve + deposit (+ exit) transactions.
-    const wrappableNativeBalance = BigNumber.max(
-        0,
-        new BigNumber(nativeFormattedBalance || '0').minus(WETH_WRAP_GAS_RESERVE),
-    );
-
-    return new BigNumber(tokenDepositBalance).plus(wrappableNativeBalance).toString();
+    // Native-asset deposit: the wrappable native balance also counts in.
+    return new BigNumber(tokenDepositBalance)
+        .plus(getWrappableNativeBalance(nativeFormattedBalance))
+        .toString();
 };
 
 type GetYieldWrapAmountParams = {

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -265,6 +265,8 @@ export type EvmTransactionPurpose =
     | 'withdraw'
     | 'redeem'
     | 'claim'
+    | 'wrap'
+    | 'unwrap'
     | '';
 
 export interface RbfTransactionParamsEthereum {

--- a/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/__tests__/ethUtils.test.ts
@@ -5,9 +5,11 @@ import { BigNumber } from '@trezor/utils';
 
 import {
     buildApprovalTransactionData,
+    getEvmTransactionPurpose,
     getEvmTransactionTextSignature,
     getNativeWrapTxKind,
     getUnwrapAmountByEthereumDataHex,
+    getWrappedNativeTxTarget,
     isUnwrapNativeTx,
     isWrapNativeTx,
     padLeftEven,
@@ -79,6 +81,10 @@ describe('eth utils', () => {
         it('should return "unknown" for data that starts with approve selector but is too short', () => {
             const shortData = '0x095ea7b3';
             expect(getEvmTransactionTextSignature(shortData)).toBe('unknown');
+        });
+
+        it('keeps WETH wrap calldata "unknown" — classifying it needs the tx target', () => {
+            expect(getEvmTransactionTextSignature('0xd0e30db0')).toBe('unknown');
         });
 
         it('should return "unknown" for data that starts with approve selector but has invalid parameters', () => {
@@ -157,6 +163,40 @@ describe('eth utils', () => {
             ).data;
 
             expect(getEvmTransactionTextSignature(claimData ?? undefined)).toBe('claim');
+        });
+    });
+
+    describe('getEvmTransactionPurpose', () => {
+        const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const OTHER = '0x1111111111111111111111111111111111111111';
+        const WRAP_DATA = '0xd0e30db0';
+        const UNWRAP_DATA =
+            '0x2e1a7d4d0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+        it('classifies WETH calldata as wrap/unwrap when the target is the wrapped-native contract', () => {
+            expect(
+                getEvmTransactionPurpose({ networkSymbol: 'eth', to: WETH, data: WRAP_DATA }),
+            ).toBe('wrap');
+            expect(
+                getEvmTransactionPurpose({ networkSymbol: 'eth', to: WETH, data: UNWRAP_DATA }),
+            ).toBe('unwrap');
+        });
+
+        it('keeps WETH calldata "unknown" for a non-wrapped-native target', () => {
+            expect(
+                getEvmTransactionPurpose({ networkSymbol: 'eth', to: OTHER, data: WRAP_DATA }),
+            ).toBe('unknown');
+        });
+
+        it('falls back to the calldata text signature', () => {
+            const approveData =
+                '0x095ea7b3' +
+                '000000000000000000000000742d35cc6634c0532925a3b8d40e592e43a73654' +
+                '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+            expect(
+                getEvmTransactionPurpose({ networkSymbol: 'eth', to: OTHER, data: approveData }),
+            ).toBe('approve');
         });
 
         it('returns "unknown" for selector-only claim (too short)', () => {
@@ -270,6 +310,40 @@ describe('eth utils', () => {
 
         it('returns undefined without a WETH target or data', () => {
             expect(getNativeWrapTxKind(tx({}))).toBeUndefined();
+        });
+    });
+
+    describe('getWrappedNativeTxTarget', () => {
+        const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+        const OTHER = '0x1111111111111111111111111111111111111111';
+
+        const tx = ({
+            targets = [],
+            internalTransfers = [],
+        }: {
+            targets?: { addresses?: string[] }[];
+            internalTransfers?: { from: string }[];
+        }) =>
+            ({
+                symbol: 'eth',
+                targets,
+                internalTransfers,
+            }) as unknown as WalletAccountTransaction;
+
+        it('finds the WETH contract among the value targets', () => {
+            expect(getWrappedNativeTxTarget(tx({ targets: [{ addresses: [WETH] }] }))).toBe(WETH);
+        });
+
+        it('finds the WETH contract among the internal ETH senders', () => {
+            expect(getWrappedNativeTxTarget(tx({ internalTransfers: [{ from: WETH }] }))).toBe(
+                WETH,
+            );
+        });
+
+        it('returns undefined for a transaction not touching the WETH contract', () => {
+            expect(
+                getWrappedNativeTxTarget(tx({ targets: [{ addresses: [OTHER] }] })),
+            ).toBeUndefined();
         });
     });
 

--- a/suite-common/wallet-utils/src/ethUtils.ts
+++ b/suite-common/wallet-utils/src/ethUtils.ts
@@ -38,6 +38,22 @@ export const strip = (str: string): string => {
     return padLeftEven(str);
 };
 
+type WrappedNativeTxParams = {
+    networkSymbol: NetworkSymbol;
+    to?: string | null;
+    data?: string | null;
+};
+
+// deposit() (0xd0e30db0) is a generic selector shared by many contracts, so the selector alone is
+// not enough — the target must also be the chain's wrapped-native contract.
+export const isWrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
+    isWrappedNativeToken(networkSymbol, to) &&
+    Calldata.evm.weth.deposit.decode(data ?? undefined) !== null;
+
+export const isUnwrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
+    isWrappedNativeToken(networkSymbol, to) &&
+    Calldata.evm.weth.withdraw.decode(data ?? undefined) !== null;
+
 export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPurpose => {
     if (!data) return '';
 
@@ -55,42 +71,50 @@ export const getEvmTransactionTextSignature = (data?: string): EvmTransactionPur
     return 'unknown';
 };
 
-type WrappedNativeTxParams = {
-    networkSymbol: NetworkSymbol;
-    to?: string | null;
-    data?: string | null;
+/**
+ * Purpose of an EVM transaction resolved from its full context. Extends the calldata-only
+ * `getEvmTransactionTextSignature` with the wrap/unwrap classification, which needs the
+ * transaction target — the WETH deposit()/withdraw() selectors are shared by many contracts,
+ * so they only count when the target is the chain's wrapped-native contract.
+ */
+export const getEvmTransactionPurpose = ({
+    networkSymbol,
+    to,
+    data,
+}: WrappedNativeTxParams): EvmTransactionPurpose => {
+    if (isWrapNativeTx({ networkSymbol, to, data })) return 'wrap';
+    if (isUnwrapNativeTx({ networkSymbol, to, data })) return 'unwrap';
+
+    return getEvmTransactionTextSignature(data ?? undefined);
 };
-
-// deposit() (0xd0e30db0) is a generic selector shared by many contracts, so the selector alone is
-// not enough — the target must also be the chain's wrapped-native contract.
-export const isWrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
-    isWrappedNativeToken(networkSymbol, to) &&
-    Calldata.evm.weth.deposit.decode(data ?? undefined) !== null;
-
-export const isUnwrapNativeTx = ({ networkSymbol, to, data }: WrappedNativeTxParams): boolean =>
-    isWrappedNativeToken(networkSymbol, to) &&
-    Calldata.evm.weth.withdraw.decode(data ?? undefined) !== null;
 
 // Amount (in wei) unwrapped by a WETH withdraw(uint256) call, or null when data is not one.
 export const getUnwrapAmountByEthereumDataHex = (data?: string): string | null =>
     Calldata.evm.weth.withdraw.decode(data)?.wad.toString() ?? null;
 
 /**
- * Classifies an EVM transaction as a native wrap/unwrap for display. The wrapped-native (WETH)
- * contract shows up as the value recipient for a wrap and as the internal ETH sender for an
- * unwrap, so both `targets` and `internalTransfers` are considered when resolving the target.
+ * The chain's wrapped-native (WETH) contract address when the transaction touches it. The contract
+ * shows up as the value recipient for a wrap and as the internal ETH sender for an unwrap, so both
+ * `targets` and `internalTransfers` are considered when resolving the target.
  */
+export const getWrappedNativeTxTarget = (
+    transaction: WalletAccountTransaction,
+): string | undefined => {
+    const candidateAddresses = [
+        ...transaction.targets.flatMap(target => target.addresses ?? []),
+        ...transaction.internalTransfers.map(transfer => transfer.from),
+    ];
+
+    return candidateAddresses.find(address => isWrappedNativeToken(transaction.symbol, address));
+};
+
+/** Classifies an EVM transaction as a native wrap/unwrap for display. */
 export const getNativeWrapTxKind = (
     transaction: WalletAccountTransaction,
 ): 'wrap' | 'unwrap' | undefined => {
     const { symbol } = transaction;
     const data = transaction.ethereumSpecific?.data;
-
-    const candidateAddresses = [
-        ...transaction.targets.flatMap(target => target.addresses ?? []),
-        ...transaction.internalTransfers.map(transfer => transfer.from),
-    ];
-    const to = candidateAddresses.find(address => isWrappedNativeToken(symbol, address));
+    const to = getWrappedNativeTxTarget(transaction);
 
     if (!to) return undefined;
     if (isWrapNativeTx({ networkSymbol: symbol, to, data })) return 'wrap';

--- a/suite/e2e/tests/general/check-links.test.ts
+++ b/suite/e2e/tests/general/check-links.test.ts
@@ -171,6 +171,8 @@ const SECTIONS = {
         '/earn/yield/deposit',
         '/earn/yield/withdraw',
         '/earn/yield/claim',
+        '/earn/yield/wrap',
+        '/earn/yield/unwrap',
         '/earn/tron',
         '/earn/tron/stake',
         '/earn/tron/vote',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10092,6 +10092,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_WRAP_AMOUNT',
         defaultMessage: 'Amount to wrap',
     },
+    TR_EARN_YIELD_AVAILABLE_TO_WRAP: {
+        id: 'TR_EARN_YIELD_AVAILABLE_TO_WRAP',
+        defaultMessage: 'Available to wrap',
+    },
     TR_EARN_YIELD_WRAP_RECEIVING: {
         id: 'TR_EARN_YIELD_WRAP_RECEIVING',
         defaultMessage: 'Receiving',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For wrapped-native (WETH) vaults, the **deposit flow gains a wrap step** — a real WETH `deposit()` transaction, skippable and validated against the wrappable native balance (gas reserve kept aside) — and the **withdraw/redeem flows chain an unwrap step** after the withdrawal confirms, defaulting to the full refreshed WETH balance with partial unwrap or skip supported. The complete screen shows the actually unwrapped amount.

Both steps run on the **stablecoin-yield session state machine** with shared pending-tx tracking (incl. RBF replacement checks), the finished wrap step is re-enterable via the clickable step list, and the review modal shows wrap/unwrap-specific copy. The new routes are also covered in the `check-links` e2e sections, which fixes the failing route-coverage test on develop.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29864
Resolve https://github.com/trezor/trezor-suite/issues/29866

## Screenshots:


https://github.com/user-attachments/assets/fa53fdce-fefc-403f-8640-dc39f86adc01

https://github.com/user-attachments/assets/eba5f2b6-9f1a-469b-b6ca-722ed05527fd




<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-wrap-unwrap-refinements/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-wrap-unwrap-refinements/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-wrap-unwrap-refinements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-wrap-unwrap-refinements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-wrap-unwrap-refinements&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:33:34.386Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:32:50.461Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->