### PR TITLE
test(connect): co-locate device tests

### DIFF
--- a/packages/connect/src/device/DeviceList.test.ts
+++ b/packages/connect/src/device/DeviceList.test.ts
@@ -1,11 +1,11 @@
 import { parseConnectSettings } from '@trezor/connect-common/src/data/connectSettings';
 import { noopCreateLogger } from '@trezor/connect-common/src/utils/debug';
 
-import { initializeFirmwareConfig } from '../../data/firmwareInfo';
-import * as firmwareReleaseStore from '../../data/firmwareReleaseStore';
-import { loadProtobufModules } from '../../data/protobufLoader';
-import * as settingsStore from '../../data/settingsStore';
-import { DeviceList } from '../DeviceList';
+import { DeviceList } from './DeviceList';
+import { initializeFirmwareConfig } from '../data/firmwareInfo';
+import * as firmwareReleaseStore from '../data/firmwareReleaseStore';
+import { loadProtobufModules } from '../data/protobufLoader';
+import * as settingsStore from '../data/settingsStore';
 
 const { createTestTransport } = global.JestMocks;
 

--- a/packages/connect/src/device/calculateRevisionForDevice.test.ts
+++ b/packages/connect/src/device/calculateRevisionForDevice.test.ts
@@ -1,4 +1,4 @@
-import { calculateRevisionForDevice } from '../calculateRevisionForDevice';
+import { calculateRevisionForDevice } from './calculateRevisionForDevice';
 
 describe(calculateRevisionForDevice.name, () => {
     it('does not shorten hash for `version > 2.4.0`', () => {

--- a/packages/connect/src/device/checkFirmwareRevision.test.ts
+++ b/packages/connect/src/device/checkFirmwareRevision.test.ts
@@ -2,13 +2,13 @@ import type { FirmwareRevisionCheckResult } from '@trezor/connect-common/src/typ
 import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
-import { httpRequest } from '../../utils/assets';
-import type { CheckFirmwareRevisionParams } from '../checkFirmwareRevision';
-import { checkFirmwareRevision } from '../checkFirmwareRevision';
+import type { CheckFirmwareRevisionParams } from './checkFirmwareRevision';
+import { checkFirmwareRevision } from './checkFirmwareRevision';
+import { httpRequest } from '../utils/assets';
 
-jest.mock('../../utils/assets', () => ({
-    ...jest.requireActual('../../utils/assets'),
-    httpRequest: jest.fn(jest.requireActual('../../utils/assets').httpRequest),
+jest.mock('../utils/assets', () => ({
+    ...jest.requireActual('../utils/assets'),
+    httpRequest: jest.fn(jest.requireActual('../utils/assets').httpRequest),
 }));
 
 const EXPECTED_BOOTLOADER_HASH = '94f1c90db28db1f8ce5dca966976343658f5dadee83834987c8b049c49d1edd0';

--- a/packages/connect/src/device/resolveDescriptorForTaproot.test.ts
+++ b/packages/connect/src/device/resolveDescriptorForTaproot.test.ts
@@ -1,7 +1,7 @@
 import type { HDNodeResponse } from '@trezor/connect-common/src/types/api/account/getPublicKey';
 import type { MessagesSchema as Messages } from '@trezor/protobuf';
 
-import { resolveDescriptorForTaproot } from '../resolveDescriptorForTaproot';
+import { resolveDescriptorForTaproot } from './resolveDescriptorForTaproot';
 
 const originalResponse: HDNodeResponse = {
     path: [2147483734, 2147483648, 2147483648],

--- a/packages/connect/src/device/workflow/checkFirmwareHash.test.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHash.test.ts
@@ -8,7 +8,7 @@ import { getReleaseByVersion } from '../../data/firmwareInfo';
 import * as settingsStore from '../../data/settingsStore';
 import { Device } from '../Device';
 import type { TypedCallProvider } from '../DeviceCurrentSession';
-import { checkFirmwareHash } from '../workflow/checkFirmwareHash';
+import { checkFirmwareHash } from './checkFirmwareHash';
 
 const { createTestTransport } = global.JestMocks;
 

--- a/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.test.ts
+++ b/packages/connect/src/device/workflow/checkFirmwareHashWithRetries.test.ts
@@ -3,14 +3,12 @@ import type { Descriptor } from '@trezor/transport-common';
 import { Log } from '@trezor/utils';
 
 import { Device } from '../Device';
-import { checkFirmwareHash } from '../workflow/checkFirmwareHash';
-import { checkFirmwareHashWithRetries } from '../workflow/checkFirmwareHashWithRetries';
+import { checkFirmwareHash } from './checkFirmwareHash';
+import { checkFirmwareHashWithRetries } from './checkFirmwareHashWithRetries';
 
-jest.mock('../workflow/checkFirmwareHash', () => ({
-    ...jest.requireActual('../workflow/checkFirmwareHash'),
-    checkFirmwareHash: jest.fn(
-        jest.requireActual('../workflow/checkFirmwareHash').checkFirmwareHash,
-    ),
+jest.mock('./checkFirmwareHash', () => ({
+    ...jest.requireActual('./checkFirmwareHash'),
+    checkFirmwareHash: jest.fn(jest.requireActual('./checkFirmwareHash').checkFirmwareHash),
 }));
 
 const { createTestTransport } = global.JestMocks;

--- a/packages/connect/src/device/workflow/handshakeWorkflow.test.ts
+++ b/packages/connect/src/device/workflow/handshakeWorkflow.test.ts
@@ -6,7 +6,7 @@ import * as firmwareReleaseStore from '../../data/firmwareReleaseStore';
 import { loadProtobufModules } from '../../data/protobufLoader';
 import * as settingsStore from '../../data/settingsStore';
 import { Device } from '../Device';
-import { handshakeCancel } from '../workflow/handshake';
+import { handshakeCancel } from './handshake';
 
 const { createTestTransport } = global.JestMocks;
 


### PR DESCRIPTION
## Description

Moves all seven Connect device unit tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit tests within packages/connect covering low-level device communication logic: device listing/enumeration, firmware revision/hash checking, taproot descriptor resolution, and the handshake workflow. Since there's no static E2E coverage mapping for these unit test files, recommendations are inferred from E2E tests whose behaviors (firmware checks, device compromised/hash-check modals, THP pairing, bridge/device reconnection, session management) most closely align with the underlying source logic these unit tests validate. Given these are core device-connection primitives, the highest-risk E2E paths are onboarding flows involving firmware checks and device handshakes; broader wallet/receive flows carry only low incidental risk.

<details><summary><b>Changed files (7)</b></summary>

- `packages/connect/src/device/DeviceList.test.ts`
- `packages/connect/src/device/calculateRevisionForDevice.test.ts`
- `packages/connect/src/device/checkFirmwareRevision.test.ts`
- `packages/connect/src/device/resolveDescriptorForTaproot.test.ts`
- `packages/connect/src/device/workflow/checkFirmwareHash.test.ts`
- `packages/connect/src/device/workflow/checkFirmwareHashWithRetries.test.ts`
- `packages/connect/src/device/workflow/handshakeWorkflow.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test explicitly exercises firmware revision check bypass (disableNecessaryFirmwareChecks) and includes assertions around TR_FIRMWARE_REVISION_CHECK_OTHER_ERROR, directly relating to changes in checkFirmwareRevision.test.ts and calculateRevisionForDevice.test.ts logic.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Covers THP pairing and device connection prompt handling during onboarding, which relies on device handshake/connection workflow logic (handshakeWorkflow) and device list management (DeviceList) changed in this PR.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Tests the 'device compromised' modal that is directly tied to firmware hash check failures, which is the exact functionality modified in checkFirmwareHash.test.ts and checkFirmwareHashWithRetries.test.ts.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This test involves toggling firmware hash check settings (@suite/toggle-firmware-hash-check Redux action) and confirming an authenticity check with confirm-on-device prompt, directly touching firmware hash check and handshake device-communication logic.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test exercises device authenticity checks with firmware hash check dismissal and firmware revision check disabling logic, which are the areas of change in checkFirmwareRevision and checkFirmwareHash.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Session stealing/reclaiming across bridge connections relies on DeviceList session/device enumeration logic, which is modified in DeviceList.test.ts.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests device reconnection behavior after bridge restart, which depends on DeviceList's device enumeration/acquisition logic that was changed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Includes Bitcoin receive address verification which may involve descriptor resolution for taproot-style addresses, touched by resolveDescriptorForTaproot.test.ts changes, though this is a narrow overlap.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/connect/src/device/DeviceList.test.ts`
- `packages/connect/src/device/calculateRevisionForDevice.test.ts`
- `packages/connect/src/device/checkFirmwareRevision.test.ts`
- `packages/connect/src/device/resolveDescriptorForTaproot.test.ts`
- `packages/connect/src/device/workflow/checkFirmwareHash.test.ts`
- `packages/connect/src/device/workflow/checkFirmwareHashWithRetries.test.ts`
- `packages/connect/src/device/workflow/handshakeWorkflow.test.ts`

_Updated: 2026-07-27T15:34:36.713Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-device-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-device-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:37:31.070Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T15:37:14.040Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->