### PR TITLE
test(connect): co-locate typed call type test

### DIFF
--- a/packages/connect/src/device/typedCall.type-test.ts
+++ b/packages/connect/src/device/typedCall.type-test.ts
@@ -12,8 +12,8 @@
 
 import type { MessagesSchema as Messages } from '@trezor/protobuf';
 
-import { DeviceCommands } from '../src/device/DeviceCommands';
-import type { TypedCallProvider } from '../src/types/typed-call-provider';
+import { DeviceCommands } from './DeviceCommands';
+import type { TypedCallProvider } from '../types/typed-call-provider';
 
 declare const provider: TypedCallProvider;
 declare const wireOut: Messages.WireOutMessage;

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -1,6 +1,11 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
+    "exclude": [
+        "./src/**/*.test.ts",
+        "./src/**/*.test.tsx",
+        "./src/**/*.type-test.ts"
+    ],
     "compilerOptions": {
         "outDir": "./lib",
         "rootDir": "./src",

--- a/packages/connect/tsconfig.lib.json
+++ b/packages/connect/tsconfig.lib.json
@@ -1,11 +1,6 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
-    "exclude": [
-        "./src/**/*.test.ts",
-        "./src/**/*.test.tsx",
-        "./src/**/*.type-test.ts"
-    ],
     "compilerOptions": {
         "outDir": "./lib",
         "rootDir": "./src",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -26,6 +26,7 @@
         "**/__tests__",
         "**/__fixtures__",
         "**/__mocks__/**",
-        "**/*.test.ts"
+        "**/*.test.ts",
+        "**/*.type-test.ts"
     ]
 }


### PR DESCRIPTION
## Description

Moves the typed-call type regression test beside DeviceCommands and excludes type-test files through the shared library configuration while preserving inherited fixture exclusions.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-type-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-type-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-type-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-type-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-type-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:43:34.667Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T11:43:17.311Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->