### PR TITLE
test(suite): co-locate component tests

### DIFF
--- a/packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 
 import { ThemeProvider } from 'src/support/suite/ThemeProvider';
 
-import { EarnDashboardTableHeader } from '../EarnDashboardTableHeader';
+import { EarnDashboardTableHeader } from './EarnDashboardTableHeader';
 
 jest.mock('@suite/intl', () => ({
     ...jest.requireActual('@suite/intl'),

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 
 import { type Account } from '@suite-common/wallet-types';
 
-import { useStakingAccountsVisibility } from '../useStakingAccountsVisibility';
+import { useStakingAccountsVisibility } from './useStakingAccountsVisibility';
 
 const mockGetAccountTotalStakingBalance = jest.fn<string | null, [Account]>();
 

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx
@@ -2,8 +2,8 @@ import { renderHook } from '@testing-library/react';
 
 import { type Account } from '@suite-common/wallet-types';
 
-import { type YieldAccountOpportunity } from '../../types';
-import { useYieldAccountsVisibility } from '../useYieldAccountsVisibility';
+import { useYieldAccountsVisibility } from './useYieldAccountsVisibility';
+import { type YieldAccountOpportunity } from '../types';
 
 const createMockAccount = (overrides: Partial<Account>): Account =>
     ({

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.test.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.test.ts
@@ -4,7 +4,7 @@ import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     findTrackedWrappedNativeTransaction,
     getWrappedNativePendingTxStatus,
-} from '../useWrappedNativePendingTx';
+} from './useWrappedNativePendingTx';
 
 const wrappedNativeAddress = getWrappedNativeAddress('eth')!;
 

--- a/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts
@@ -1,7 +1,7 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import TrezorConnect from '@trezor/connect';
 
-import { ensureDeviceSession } from '../ensureDeviceSession';
+import { ensureDeviceSession } from './ensureDeviceSession';
 
 const device = mockSuiteDevice({
     connected: true,

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -1,6 +1,6 @@
 import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
 
-import { getYieldFlowSteps } from '../yieldFlowUtils';
+import { getYieldFlowSteps } from './yieldFlowUtils';
 
 const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
 const depositWithWrapSequence = getYieldFlowStepSequence({

--- a/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
@@ -17,18 +17,18 @@ import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { Preloader } from '../Preloader';
-import { selectShouldDisplayDeviceCompromisedOnRoute } from '../selectShouldDisplayDeviceCompromisedOnRoute';
+import { Preloader } from './Preloader';
+import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),
     isLinux: jest.fn(() => true),
 }));
 
-jest.mock('../selectShouldDisplayDeviceCompromisedOnRoute', () => ({
-    ...jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute'),
+jest.mock('./selectShouldDisplayDeviceCompromisedOnRoute', () => ({
+    ...jest.requireActual('./selectShouldDisplayDeviceCompromisedOnRoute'),
     selectShouldDisplayDeviceCompromisedOnRoute: jest.fn(
-        jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute')
+        jest.requireActual('./selectShouldDisplayDeviceCompromisedOnRoute')
             .selectShouldDisplayDeviceCompromisedOnRoute,
     ),
 }));
@@ -543,7 +543,7 @@ describe(`${Preloader.name} component`, () => {
 
         unmount();
         (selectShouldDisplayDeviceCompromisedOnRoute as jest.Mock).mockImplementation(
-            jest.requireActual('../selectShouldDisplayDeviceCompromisedOnRoute')
+            jest.requireActual('./selectShouldDisplayDeviceCompromisedOnRoute')
                 .selectShouldDisplayDeviceCompromisedOnRoute,
         );
     });

--- a/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -5,7 +5,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { type AcquiredDevice, type AppState } from 'src/types/suite';
 
-import { selectShouldDisplayDeviceCompromisedOnRoute } from '../selectShouldDisplayDeviceCompromisedOnRoute';
+import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
 
 type Fixture = {
     description: string;

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
@@ -12,7 +12,7 @@ import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { DeviceCompromised } from '../DeviceCompromised';
+import { DeviceCompromised } from './DeviceCompromised';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
@@ -11,12 +11,12 @@ import { BigNumber } from '@trezor/utils';
 
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
 
-import { type AccountWithTokensOption } from '../../types';
+import { type AccountWithTokensOption } from '../types';
 import {
     getAccountsWithTokenDisplayNames,
     getTokenDisplayNameSources,
     useAccountsWithTokenDisplayNames,
-} from '../useAccountsWithTokenDisplayNames';
+} from './useAccountsWithTokenDisplayNames';
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),

--- a/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
@@ -9,7 +9,7 @@ import {
     type TokenDisplayNameSource,
     getTokenDisplaySymbolName,
     getTokensDisplaySymbolNames,
-} from '../tokenDisplayNames';
+} from './tokenDisplayNames';
 
 const createAsset = (
     overrides: Partial<TradingAssetOptionWithContractAddress> &

--- a/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
+++ b/packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx
@@ -27,7 +27,7 @@ jest.mock('src/hooks/suite/useLocalNetworkAccessPermission', () => ({
 
 import { useLocalNetworkAccessPermission } from 'src/hooks/suite/useLocalNetworkAccessPermission';
 
-import { useLegacyBridgeDetection } from '../BridgeDeprecatedBanner';
+import { useLegacyBridgeDetection } from './BridgeDeprecatedBanner';
 
 const mockIsWeb = isWeb as jest.MockedFunction<typeof isWeb>;
 const mockUseLna = useLocalNetworkAccessPermission as jest.MockedFunction<

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.test.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.test.ts
@@ -1,4 +1,4 @@
-import { getDashboardParamModal } from '../useGlobalSendReceiveModal';
+import { getDashboardParamModal } from './useGlobalSendReceiveModal';
 
 describe('getDashboardParamModal', () => {
     it('returns the modal type for valid params', () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/getTransactionReviewState.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/getTransactionReviewState.test.ts
@@ -1,4 +1,4 @@
-import { getTransactionReviewState } from '../getTransactionReviewState';
+import { getTransactionReviewState } from './getTransactionReviewState';
 
 describe(getTransactionReviewState.name, () => {
     it('returns "confirmed" state for signed transactions', () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.test.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.test.ts
@@ -2,7 +2,7 @@ import { type UnavailableCapability } from '@trezor/connect';
 
 import { type Account } from 'src/types/wallet';
 
-import { verifyAvailability } from '../verifyAvailability';
+import { verifyAvailability } from './verifyAvailability';
 
 const getMockAccount = (account: Partial<Account> = {}): Account =>
     ({

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
@@ -8,8 +8,8 @@ import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState'
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { type NotificationViewProps } from '../../Notifications/NotificationGroup/NotificationList/NotificationView';
-import { NotificationRenderer } from '../NotificationRenderer';
+import { NotificationRenderer } from './NotificationRenderer';
+import { type NotificationViewProps } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
 
 type TradingErrorNotification = Extract<NotificationEntry, { type: 'trading-error' }>;
 

--- a/packages/suite/src/components/wallet/getPages.test.ts
+++ b/packages/suite/src/components/wallet/getPages.test.ts
@@ -1,4 +1,4 @@
-import { getPages } from '../Pagination';
+import { getPages } from './Pagination';
 
 describe('getPages', () => {
     it('should show all pages when there page count is less or equal to stride + 2', () => {


### PR DESCRIPTION
## Description

Moves 17 Suite component tests beside their source files while deferring two cross-package integration tests with ambiguous ownership.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is dominated by unit-test-only files with no e2e static coverage mapping, spanning earn/staking dashboard visibility hooks, Preloader/device-compromised security logic, asset-picker token display utilities, global send/receive modal hooks, transaction review state, account-add availability checks, notification rendering, and wallet page routing. Because there is no static E2E mapping, recommendations here are inferred from the LLM behavioral descriptions of each e2e test, matching to the closest functional area touched by each unit test. Priority is highest for DeviceCompromised/Preloader-route logic (security-critical, user-visible) and the global send/receive + asset-picker token display changes (visible across many trading/wallet flows), with staking dashboard, transaction review, account availability, and notification/routing changes treated as medium/low since their e2e overlap is more indirect.

<details><summary><b>Changed files (17)</b></summary>

- `packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.test.tsx`
- `packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.test.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx`
- `packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.test.ts`
- `packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.test.tsx`
- `packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts`
- `packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx`
- `packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts`
- `packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts`
- `packages/suite/src/components/suite/banners/SuiteBanners/BridgeDeprecatedBanner.test.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/hooks/useGlobalSendReceiveModal.test.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/getTransactionReviewState.test.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/verifyAvailability.test.ts`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx`
- `packages/suite/src/components/wallet/getPages.test.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly exercises the 'device compromised' modal flow, which is unit-tested by the changed DeviceCompromised.test.tsx and selectShouldDisplayDeviceCompromisedOnRoute.test.ts files, making it the closest e2e coverage for this security-critical logic.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the global Send/Receive modal flow (asset picker, account selection) which is unit-tested by the changed useGlobalSendReceiveModal.test.ts and useAccountsWithTokenDisplayNames.test.ts files.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Changes to earn/dashboard staking visibility hooks (useStakingAccountsVisibility) and yield flow utils directly relate to how the ETH staking dashboard displays staking state, which this e2e test exercises end-to-end.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers ETH staking dashboard behaviors (staked/pending/rewards visibility) that are unit-tested by the changed useStakingAccountsVisibility and yieldFlowUtils files, making it a good end-to-end sanity check for staking display logic.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstaking flow relies on staking dashboard visibility state (staked/rewards/unstaking amounts) which is directly unit-tested by the changed useStakingAccountsVisibility hook.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test relies on the Preloader/suite-layout initialization flow that is directly unit-tested by the changed Preloader.test.tsx, providing end-to-end confidence that app initialization/routing still works after the change.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — The changed BridgeDeprecatedBanner.test.tsx unit test covers the bridge deprecation banner component, and this e2e test exercises real bridge lifecycle/version scenarios where such a banner would be shown.
- `suite/e2e/tests/trading/navigation.test.ts` — This test covers asset picker navigation for Buy/Sell/Swap flows including token-level assets, directly related to the changed tokenDisplayNames and useAccountsWithTokenDisplayNames utilities that control how tokens are displayed/selected in asset pickers.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test uses the swap asset picker to select sell/buy assets including tokens (USDC, USDT), directly exercising the changed tokenDisplayNames and useAccountsWithTokenDisplayNames logic for token asset display.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds new accounts and validates account availability/type logic, closely related to the changed verifyAvailability.test.ts which unit-tests account-add availability checks.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test's transaction review/confirmation flow (preview screens showing crypto/fiat amounts) is related to the changed getTransactionReviewState.test.ts which governs transaction review modal state.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send flow involves reviewing transaction outputs before signing, directly exercising logic covered by the changed getTransactionReviewState.test.ts for the TransactionReviewOutputList component.

</details>

<details><summary>🟢 <b>Low priority (6)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking dashboard also depends on shared staking visibility logic, though the changed hook file appears ETH/staking-account focused rather than ADA-specific.
- `suite/e2e/tests/wallet/without-device.test.ts` — Preloader logic governs device-connection-dependent rendering states, and this test exercises disconnected-device UI paths that could be affected by Preloader changes.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — This test includes adding a new Bitcoin account, which touches the AddAccountModal availability-check logic that was directly changed.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test heavily relies on notification/status rendering (toast notifications, device status banners) which could be affected by changes to NotificationRenderer, though the connection is indirect.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test relies on toast/notification behavior for transaction status changes, which is unit-tested by the changed NotificationRenderer.test.tsx.
- `suite/e2e/tests/wallet/discovery.test.ts` — Wallet navigation across multiple activated coins depends on route/page generation logic possibly covered by the changed getPages.test.ts, providing broad regression coverage for wallet routing.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/components/earn/dashboard/common/EarnDashboardTableHeader.test.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx`
- `packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.test.ts`
- `packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.test.ts`

_Updated: 2026-07-27T15:57:24.473Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-components-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-components-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:00:27.246Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:00:01.993Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-components-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-components-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->