### PR TITLE
test(suite): co-locate view tests

### DIFF
--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/types.test.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/types.test.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@trezor/components';
 import { GradientIcon } from '@trezor/icons';
 
-import { type SecurityChecklistItem } from '../types';
+import { type SecurityChecklistItem } from './types';
 
 describe('SecurityChecklistItem', () => {
     describe('type tests', () => {

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/canLocktimeTxBeBroadcast.test.ts
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/canLocktimeTxBeBroadcast.test.ts
@@ -1,7 +1,7 @@
 import {
     type CanLocktimeTxBeBroadcastParams,
     canLocktimeTxBeBroadcast,
-} from '../canLocktimeTxBeBroadcast';
+} from './canLocktimeTxBeBroadcast';
 
 const data: Array<{
     it: string;

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
@@ -13,7 +13,7 @@ import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState'
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { EthereumNonce } from '../EthereumNonce';
+import { EthereumNonce } from './EthereumNonce';
 
 const ethAccount = mockWalletAccount({ symbol: 'eth' }) as any;
 

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/utils.test.ts
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/utils.test.ts
@@ -1,6 +1,6 @@
 import { type BuyTradeStatus } from 'invity-api';
 
-import { getBuyDetailHeaderMessages } from '../utils';
+import { getBuyDetailHeaderMessages } from './utils';
 
 describe('getBuyDetailHeaderMessages', () => {
     it('returns the processing header once the user has paid (APPROVAL_PENDING)', () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.test.ts
@@ -4,7 +4,7 @@ import { type RatesByKey, asCryptoBaseCurrencyCode } from '@suite-common/wallet-
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
-import { getFiatInputRules } from '../tradingFormInputFiatCryptoRules';
+import { getFiatInputRules } from './tradingFormInputFiatCryptoRules';
 
 const t = ((key: string, values?: Record<string, unknown>) =>
     values ? `${key}:${JSON.stringify(values)}` : key) as TranslationFunction;

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
@@ -8,7 +8,7 @@ import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { TradingLayout } from '../TradingLayout';
+import { TradingLayout } from './TradingLayout';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 
@@ -17,7 +17,7 @@ jest.mock('@suite/intl', () => ({
     Translation: ({ id }: { id: string }) => <span data-testid={id}>{id}</span>,
 }));
 
-jest.mock('../TradingLayoutNavigation', () => ({
+jest.mock('./TradingLayoutNavigation', () => ({
     TradingLayoutNavigation: ({ route }: { route?: string }) => (
         <div data-testid="trading-layout-navigation">{route}</div>
     ),

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.test.ts
@@ -2,7 +2,7 @@ import {
     getBackRoute,
     getTradingHeaderTitle,
     isTradingTopLevelRoute,
-} from '../tradingPageHeaderUtils';
+} from './tradingPageHeaderUtils';
 
 describe('tradingPageHeaderUtils', () => {
     describe('isTradingTopLevelRoute', () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
@@ -16,7 +16,7 @@ import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState'
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { TradingTransactionsList } from '../TradingTransactionsList';
+import { TradingTransactionsList } from './TradingTransactionsList';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
@@ -12,7 +12,7 @@ import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState'
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
-import { TradingFormOfferSellActions } from '../TradingFormOfferSellActions';
+import { TradingFormOfferSellActions } from './TradingFormOfferSellActions';
 
 const mockUseTradingFormContext = jest.fn();
 const mockUseTradingFormOfferCommon = jest.fn();

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/utils.test.ts
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/utils.test.ts
@@ -1,6 +1,6 @@
 import { type SellTradeStatus } from 'invity-api';
 
-import { getSellDetailHeaderMessages } from '../utils';
+import { getSellDetailHeaderMessages } from './utils';
 
 describe('getSellDetailHeaderMessages', () => {
     it.each<SellTradeStatus>([

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'src/support/suite/ThemeProvider';
 import { type Account } from 'src/types/wallet';
 
-import { WrapNativeTokenButton } from '../WrapNativeTokenButton';
+import { WrapNativeTokenButton } from './WrapNativeTokenButton';
 
 const mockDispatch = jest.fn();
 

--- a/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.test.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.test.ts
@@ -1,4 +1,4 @@
-import { shouldAttemptToLoadNextPageForVisibleTransactions } from '../transaction-fetch-utils';
+import { shouldAttemptToLoadNextPageForVisibleTransactions } from './transaction-fetch-utils';
 
 describe('TransactionFetchUtils', () => {
     it('should request fetching because the current number of visible transaction is 0 and there are still available', () => {


### PR DESCRIPTION
## Description

Moves all 12 Suite view tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This PR touches several isolated unit-test-covered utilities across the wallet/trading and onboarding areas: locktime broadcast eligibility, Ethereum nonce validation, trading buy/sell detail formatting, trading layout/header utilities, trading transactions list, fiat/crypto input validation rules, wrap-native-token button, transaction fetch utilities, and device authenticity step types. None of these files have direct static E2E mappings, so recommendations are inferred from behavioral overlap identified in the LLM test analysis. The highest-confidence targets are the trading buy/sell E2E flows, transaction list/pagination/pending-transaction tests, the Bitcoin locktime send-form test, the Ethereum send test, the trading navigation test, and the device authenticity onboarding test — all of which exercise the changed logic directly during their assertions. Recommend running the high-priority tests unconditionally and the medium/low ones for broader regression confidence, especially around trading forms and transaction rendering.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/types.test.tsx`
- `packages/suite/src/views/wallet/send/Options/BitcoinOptions/Locktime/canLocktimeTxBeBroadcast.test.ts`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/utils.test.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.test.ts`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/tradingPageHeaderUtils.test.ts`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingSellDetail/utils.test.ts`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/transaction-fetch-utils.test.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This is a unit test change to TradingSellDetail/utils.ts and TradingFormOfferSellActions.tsx which directly implement the sell offer confirmation and sell detail rendering logic exercised end-to-end by this test (confirmation screen fiat/crypto amount, provider, payment method, destination address all rendered via these utils/components).
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Exercises the sell flow's confirmation screen and offer actions which are backed by TradingSellDetail/utils and TradingFormOfferSellActions, both directly changed.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — TradingBuyDetail/utils.ts was changed and this test exercises the buy detail/confirmation screen (fiat/crypto amounts, provider, transaction status) which relies on that utility to format and display buy trade details.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Directly exercises the buy detail confirmation and success screens driven by the changed TradingBuyDetail/utils.ts formatting logic.
- `suite/e2e/tests/trading/swap-history.test.ts` — TradingTransactionsList.tsx was changed and this test directly validates the transaction/trade history list rendering, ordering, and detail navigation which is the component under test.
- `suite/e2e/tests/trading/navigation.test.ts` — TradingLayout.tsx and tradingPageHeaderUtils.ts were changed; this test verifies that navigating to Buy/Sell/Swap forms from various entry points opens the correct trading layout/header for the correct asset, directly exercising this changed code.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — canLocktimeTxBeBroadcast.ts was changed and this test directly exercises the locktime option in the Bitcoin send form (enabling locktime, filling block height, and submitting), which depends on this broadcast-eligibility logic.
- `suite/e2e/tests/wallet/send-eth.test.ts` — EthereumNonceValidation.tsx was changed; this test exercises the full Ethereum send form (fees, address, amount) and would surface nonce validation regressions during transaction composition.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — DeviceAuthenticityStep/types.ts was changed and this test directly exercises the device authenticity check flow during onboarding that uses this type/step definition.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM-compatible network sharing the same Ethereum send form and nonce validation logic that was changed, so this test provides additional coverage of the same code path on a different network.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — WrapNativeTokenButton.tsx was changed; this ETH staking test exercises transaction list/TradeBox UI elements for native token operations that could share rendering logic with the wrap button, providing incidental coverage on ETH transaction flows.
- `suite/e2e/tests/wallet/transactions.test.ts` — transaction-fetch-utils.ts was changed and this test directly exercises the transaction list/overview rendering and search functionality for a BTC account, which depends on transaction fetching utilities.
- `suite/e2e/tests/wallet/pagination.test.ts` — transaction-fetch-utils.ts changes affect how transactions are fetched/paginated for display, and this test directly exercises transaction list pagination behavior which depends on that fetch logic.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — transaction-fetch-utils.ts changes could affect how pending vs confirmed transactions are grouped and displayed, which this test directly validates.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — tradingFormInputFiatCryptoRules.ts was changed and this test directly exercises fiat/crypto input validation rules (decimals, insufficient funds, percentage buttons) in the sell form.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — The staking form shares crypto/fiat input validation patterns similar to trading form input rules that were changed, though it uses a separate staking-specific input component so the connection is indirect.
- `suite/e2e/tests/trading/buy-negative.test.ts` — This test exercises min/max/no-quotes validation error states on the buy form; while it targets the buy form rather than sell, similar input rule logic changed in tradingFormInputFiatCryptoRules.ts could plausibly affect shared validation behavior.

</details>

_Updated: 2026-07-27T16:05:05.762Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-views-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-views-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-views-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-views-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:07:45.479Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:07:27.392Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->