### PR TITLE
test(suite): co-locate storage tests

### DIFF
--- a/packages/suite/src/storage/migrations/versions/25.10.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/25.10.0.test.ts
@@ -3,7 +3,7 @@ import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../25.10.0';
+import migration from './25.10.0';
 
 const DB_NAME = 'suite-idb-test-25.10.0';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/25.11.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/25.11.0.test.ts
@@ -2,13 +2,12 @@ import '@suite-common/test-utils/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
-import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.5.0.1';
+import migration from './25.11.0';
 
-const DB_NAME = 'suite-idb-test-26.5.0.1';
+const DB_NAME = 'suite-idb-test-25.11.0';
 const INITIAL_VERSION = 1;
 
 const runMigration = () =>
@@ -18,35 +17,32 @@ const runMigration = () =>
         },
     });
 
-describe('migration 26.5.0.1', () => {
+describe('migration 25.11.0', () => {
     beforeEach(async () => {
         await deleteDB(DB_NAME);
     });
 
-    test('migrates addressDisplayType from suiteSettings to walletSettings', async () => {
+    test('migrates autoEject and autoForget from suiteSettings to walletSettings', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('suiteSettings');
                 db.createObjectStore('walletSettings');
             },
         });
-        await db.put(
-            'suiteSettings',
-            { settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL } },
-            'suite',
-        );
-        await db.put('walletSettings', {}, 'wallet');
+        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
+        await db.put('walletSettings', { isAutoEjectEnabled: false }, 'wallet');
         db.close();
 
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.ORIGINAL);
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(true);
 
         migratedDb.close();
     });
 
-    test('defaults to chunked if addressDisplayType is missing from suiteSettings', async () => {
+    test('prefills defaults into walletSettings if original values are missing', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('suiteSettings');
@@ -60,12 +56,13 @@ describe('migration 26.5.0.1', () => {
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.CHUNKED);
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(false);
 
         migratedDb.close();
     });
 
-    test('defaults to chunked if suiteSettings store is missing', async () => {
+    test('prefills defaults into walletSettings if suiteSettings store is missing', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('walletSettings');
@@ -77,7 +74,8 @@ describe('migration 26.5.0.1', () => {
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.CHUNKED);
+        expect(wallet).toBeDefined();
+        expect(wallet?.isAutoEjectEnabled).toBe(false);
 
         migratedDb.close();
     });
@@ -89,11 +87,7 @@ describe('migration 26.5.0.1', () => {
                 db.createObjectStore('walletSettings');
             },
         });
-        await db.put(
-            'suiteSettings',
-            { settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL } },
-            'suite',
-        );
+        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
         db.close();
 
         const migratedDb = await runMigration();
@@ -101,7 +95,7 @@ describe('migration 26.5.0.1', () => {
         const wallet = await migratedDb.get('walletSettings', 'wallet');
         expect(wallet).toEqual({
             ...initialWalletSettingsState,
-            addressDisplayType: AddressDisplayOptions.ORIGINAL,
+            isAutoEjectEnabled: true,
         });
 
         migratedDb.close();

--- a/packages/suite/src/storage/migrations/versions/26.4.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.1.test.ts
@@ -3,7 +3,7 @@ import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.4.0.1';
+import migration from './26.4.0.1';
 
 const DB_NAME = 'suite-idb-test-26.4.0.1';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/26.5.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.5.0.1.test.ts
@@ -2,12 +2,13 @@ import '@suite-common/test-utils/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../25.11.0';
+import migration from './26.5.0.1';
 
-const DB_NAME = 'suite-idb-test-25.11.0';
+const DB_NAME = 'suite-idb-test-26.5.0.1';
 const INITIAL_VERSION = 1;
 
 const runMigration = () =>
@@ -17,32 +18,35 @@ const runMigration = () =>
         },
     });
 
-describe('migration 25.11.0', () => {
+describe('migration 26.5.0.1', () => {
     beforeEach(async () => {
         await deleteDB(DB_NAME);
     });
 
-    test('migrates autoEject and autoForget from suiteSettings to walletSettings', async () => {
+    test('migrates addressDisplayType from suiteSettings to walletSettings', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('suiteSettings');
                 db.createObjectStore('walletSettings');
             },
         });
-        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
-        await db.put('walletSettings', { isAutoEjectEnabled: false }, 'wallet');
+        await db.put(
+            'suiteSettings',
+            { settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL } },
+            'suite',
+        );
+        await db.put('walletSettings', {}, 'wallet');
         db.close();
 
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet).toBeDefined();
-        expect(wallet?.isAutoEjectEnabled).toBe(true);
+        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.ORIGINAL);
 
         migratedDb.close();
     });
 
-    test('prefills defaults into walletSettings if original values are missing', async () => {
+    test('defaults to chunked if addressDisplayType is missing from suiteSettings', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('suiteSettings');
@@ -56,13 +60,12 @@ describe('migration 25.11.0', () => {
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet).toBeDefined();
-        expect(wallet?.isAutoEjectEnabled).toBe(false);
+        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.CHUNKED);
 
         migratedDb.close();
     });
 
-    test('prefills defaults into walletSettings if suiteSettings store is missing', async () => {
+    test('defaults to chunked if suiteSettings store is missing', async () => {
         const db = await openDB(DB_NAME, INITIAL_VERSION, {
             upgrade(db) {
                 db.createObjectStore('walletSettings');
@@ -74,8 +77,7 @@ describe('migration 25.11.0', () => {
         const migratedDb = await runMigration();
 
         const wallet = await migratedDb.get('walletSettings', 'wallet');
-        expect(wallet).toBeDefined();
-        expect(wallet?.isAutoEjectEnabled).toBe(false);
+        expect(wallet?.addressDisplayType).toBe(AddressDisplayOptions.CHUNKED);
 
         migratedDb.close();
     });
@@ -87,7 +89,11 @@ describe('migration 25.11.0', () => {
                 db.createObjectStore('walletSettings');
             },
         });
-        await db.put('suiteSettings', { settings: { autoEject: true } }, 'suite');
+        await db.put(
+            'suiteSettings',
+            { settings: { addressDisplayType: AddressDisplayOptions.ORIGINAL } },
+            'suite',
+        );
         db.close();
 
         const migratedDb = await runMigration();
@@ -95,7 +101,7 @@ describe('migration 25.11.0', () => {
         const wallet = await migratedDb.get('walletSettings', 'wallet');
         expect(wallet).toEqual({
             ...initialWalletSettingsState,
-            isAutoEjectEnabled: true,
+            addressDisplayType: AddressDisplayOptions.ORIGINAL,
         });
 
         migratedDb.close();

--- a/packages/suite/src/storage/migrations/versions/26.6.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.6.0.1.test.ts
@@ -6,7 +6,7 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.6.0.1';
+import migration from './26.6.0.1';
 
 const DB_NAME = 'suite-idb-test-26.6.0.1';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/26.6.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.6.0.test.ts
@@ -3,7 +3,7 @@ import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.6.0';
+import migration from './26.6.0';
 
 const DB_NAME = 'suite-idb-test-26.6.0';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/26.7.0.2.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.7.0.2.test.ts
@@ -3,7 +3,7 @@ import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.7.0.2';
+import migration from './26.7.0.2';
 
 const DB_NAME = 'suite-idb-test-26.7.0.2';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/26.8.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.1.test.ts
@@ -9,7 +9,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import { type SuiteDBSchema } from 'src/storage/definitions';
 import { serializeDevice } from 'src/utils/suite/storage';
 
-import migration from '../26.8.0.1';
+import migration from './26.8.0.1';
 
 const DB_NAME = 'suite-idb-test-26.8.0.1';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/migrations/versions/26.8.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.test.ts
@@ -5,7 +5,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from '../26.8.0';
+import migration from './26.8.0';
 
 const DB_NAME = 'suite-idb-test-26.8.0';
 const INITIAL_VERSION = 1;

--- a/packages/suite/src/storage/storage.test.ts
+++ b/packages/suite/src/storage/storage.test.ts
@@ -1,6 +1,6 @@
 import '@suite-common/test-utils/globalOverrides';
 
-import { db } from '../index';
+import { db } from './index';
 
 describe('storage', () => {
     test('2 calls to uninitiated db', async () => {


### PR DESCRIPTION
## Description

Moves all 10 Suite storage and migration tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies unit tests for the storage migration versioning system (multiple version-specific migration test files) and the core storage.test.ts module, which govern how IndexedDB schema and user data are transformed across Suite app upgrades. While these are unit tests themselves (not E2E), the underlying migration logic they validate is directly exercised end-to-end by the two dedicated DB migration E2E tests, which should be run with high priority to catch any regression in real migration behavior across app versions. Additionally, two E2E tests that load Suite from a seeded/remembered IndexedDB dump are included at lower priority since a broken migration path could cause their initialization to fail. No static coverage mapping exists for these files, so recommendations here are inferred from functional overlap with the LLM-described test behaviors.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/storage/migrations/versions/25.10.0.test.ts`
- `packages/suite/src/storage/migrations/versions/25.11.0.test.ts`
- `packages/suite/src/storage/migrations/versions/26.4.0.1.test.ts`
- `packages/suite/src/storage/migrations/versions/26.5.0.1.test.ts`
- `packages/suite/src/storage/migrations/versions/26.6.0.1.test.ts`
- `packages/suite/src/storage/migrations/versions/26.6.0.test.ts`
- `packages/suite/src/storage/migrations/versions/26.7.0.2.test.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.1.test.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.test.ts`
- `packages/suite/src/storage/storage.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This E2E test explicitly validates IndexedDB schema migration between Suite versions (25.10 -> develop), verifying that settings like autoEject are correctly transformed across storage schema versions - directly exercising the same migration version logic files that were changed (25.10.0, 26.x.x version migration test files and storage.test.ts).
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test directly verifies that user settings (language/locale) persist correctly across an IndexedDB migration between Suite versions (25.7 -> develop), which is the exact behavior implemented by the changed migration version files and the core storage module.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — This test loads Suite from a seeded IndexedDB dump and verifies correct initialization and rendering, which depends on the storage/migration layer being able to correctly read and process a pre-existing database state - a scenario directly impacted by changes to migration version scripts and core storage.test.ts logic.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test also seeds and loads a remembered wallet from an IndexedDB dump on app start, so a broken migration path could cause it to fail during initialization, though its primary focus is swap form validation rather than storage/migration behavior.

</details>

_Updated: 2026-07-27T16:13:28.491Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-storage-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-storage-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-storage-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-storage-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:16:54.942Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:16:37.698Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->