### PR TITLE
test(utils): co-locate J-R tests

### DIFF
--- a/packages/utils/src/logs.test.ts
+++ b/packages/utils/src/logs.test.ts
@@ -1,4 +1,4 @@
-import { LogsManager } from '../src/logsManager';
+import { LogsManager } from './logsManager';
 
 describe('utils/debug', () => {
     it('max entries', () => {

--- a/packages/utils/src/mergeDeepObject.test.ts
+++ b/packages/utils/src/mergeDeepObject.test.ts
@@ -1,4 +1,4 @@
-import { mergeDeepObject } from '../src/mergeDeepObject';
+import { mergeDeepObject } from './mergeDeepObject';
 
 interface INamedObject {
     propertyA: string[];

--- a/packages/utils/src/noop.test.ts
+++ b/packages/utils/src/noop.test.ts
@@ -1,4 +1,4 @@
-import { noop } from '../src/noop';
+import { noop } from './noop';
 
 describe(noop.name, () => {
     it('returns undefined', () => {

--- a/packages/utils/src/number.test.ts
+++ b/packages/utils/src/number.test.ts
@@ -1,4 +1,4 @@
-import { clamp, roundTo } from '../src/number';
+import { clamp, roundTo } from './number';
 
 describe('clamp', () => {
     it('value within bounds', () => {

--- a/packages/utils/src/objectPartition.test.ts
+++ b/packages/utils/src/objectPartition.test.ts
@@ -1,4 +1,4 @@
-import { objectPartition } from '../src/objectPartition';
+import { objectPartition } from './objectPartition';
 
 describe('objectPartition', () => {
     it('two parts', () => {

--- a/packages/utils/src/parseElectrumUrl.test.ts
+++ b/packages/utils/src/parseElectrumUrl.test.ts
@@ -1,4 +1,4 @@
-import { parseElectrumUrl } from '../src/parseElectrumUrl';
+import { parseElectrumUrl } from './parseElectrumUrl';
 
 const FIXTURE = [
     ['electrum.example.com:50001:t', 'electrum.example.com', 50001, 't'],

--- a/packages/utils/src/parseHostname.test.ts
+++ b/packages/utils/src/parseHostname.test.ts
@@ -1,4 +1,4 @@
-import { parseHostname } from '../src/parseHostname';
+import { parseHostname } from './parseHostname';
 
 const fixtures = [
     ['localHOst', 'localhost'],

--- a/packages/utils/src/promiseAllSequence.test.ts
+++ b/packages/utils/src/promiseAllSequence.test.ts
@@ -1,5 +1,5 @@
+import { promiseAllSequence } from './promiseAllSequence';
 import { mockTime, unmockTime } from '../mocks/mockTime';
-import { promiseAllSequence } from '../src/promiseAllSequence';
 
 describe('promiseAllSequence', () => {
     beforeEach(() => {

--- a/packages/utils/src/removeTrailingSlashes.test.ts
+++ b/packages/utils/src/removeTrailingSlashes.test.ts
@@ -1,4 +1,4 @@
-import { removeTrailingSlashes } from '../src/removeTrailingSlashes'; // Adjust path as needed
+import { removeTrailingSlashes } from './removeTrailingSlashes'; // Adjust path as needed
 
 describe('removeTrailingSlashes', () => {
     it('should remove multiple trailing slashes', () => {

--- a/packages/utils/src/resolveAfter.test.ts
+++ b/packages/utils/src/resolveAfter.test.ts
@@ -1,4 +1,4 @@
-import { resolveAfter } from '../src/resolveAfter';
+import { resolveAfter } from './resolveAfter';
 
 describe('resolveAfter', () => {
     jest.useFakeTimers();


### PR DESCRIPTION
## Description

Moves all 10 J–R utility tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit test files within packages/utils/src (e.g., logs.test.ts, mergeDeepObject.test.ts, number.test.ts, parseElectrumUrl.test.ts, etc.), which are low-level pure utility unit tests, not part of the Playwright E2E suite. None of the 46 candidate E2E tests reference these utility modules directly in their behaviors, entry points, or source hints (aside from generic mentions of unrelated @trezor/utils functions like BigNumber or capitalizeFirstLetter, which are not among the changed files). Since these changes are isolated unit test files for small pure functions (logging, object merging, number formatting, URL/hostname parsing, promise sequencing, string trimming, delayed promises) with no evidence of E2E behavioral impact, no E2E tests are recommended to run for this change set — the appropriate validation is the corresponding unit test suite itself (e.g., `yarn jest packages/utils`), not Playwright E2E tests.

<details><summary><b>Changed files (10)</b></summary>

- `packages/utils/src/logs.test.ts`
- `packages/utils/src/mergeDeepObject.test.ts`
- `packages/utils/src/noop.test.ts`
- `packages/utils/src/number.test.ts`
- `packages/utils/src/objectPartition.test.ts`
- `packages/utils/src/parseElectrumUrl.test.ts`
- `packages/utils/src/parseHostname.test.ts`
- `packages/utils/src/promiseAllSequence.test.ts`
- `packages/utils/src/removeTrailingSlashes.test.ts`
- `packages/utils/src/resolveAfter.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `packages/utils/src/logs.test.ts`
- `packages/utils/src/mergeDeepObject.test.ts`
- `packages/utils/src/noop.test.ts`
- `packages/utils/src/number.test.ts`
- `packages/utils/src/objectPartition.test.ts`
- `packages/utils/src/parseElectrumUrl.test.ts`
- `packages/utils/src/parseHostname.test.ts`
- `packages/utils/src/promiseAllSequence.test.ts`
- `packages/utils/src/removeTrailingSlashes.test.ts`
- `packages/utils/src/resolveAfter.test.ts`

_Updated: 2026-07-28T15:41:07.656Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/utils-j-r-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/utils-j-r-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/utils-j-r-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/utils-j-r-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:44:50.329Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:44:42.573Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->