### PR TITLE
test(utils): co-locate S-Z tests

### DIFF
--- a/packages/utils/src/safeBigIntStringify.test.ts
+++ b/packages/utils/src/safeBigIntStringify.test.ts
@@ -1,4 +1,4 @@
-import { safeBigIntStringify } from '../src';
+import { safeBigIntStringify } from './safeBigIntStringify';
 
 describe('safeStringify', () => {
     it('serializes regular objects normally', () => {

--- a/packages/utils/src/safeParseUrl.test.ts
+++ b/packages/utils/src/safeParseUrl.test.ts
@@ -1,4 +1,4 @@
-import { safeParseUrl } from '../src/safeParseUrl';
+import { safeParseUrl } from './safeParseUrl';
 
 describe('safeParseUrl', () => {
     it.each([

--- a/packages/utils/src/sanitizeFilename.test.ts
+++ b/packages/utils/src/sanitizeFilename.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeFilename } from '../src/sanitizeFilename';
+import { sanitizeFilename } from './sanitizeFilename';
 
 describe(sanitizeFilename.name, () => {
     it('valid wallet filenames', () => {

--- a/packages/utils/src/scheduleAction.test.ts
+++ b/packages/utils/src/scheduleAction.test.ts
@@ -1,5 +1,5 @@
+import { scheduleAction } from './scheduleAction';
 import { mockTime, unmockTime } from '../mocks/mockTime';
-import { scheduleAction } from '../src/scheduleAction';
 
 const ERR_SIGNAL = 'Aborted by signal';
 const ERR_DEADLINE = 'Aborted by deadline';

--- a/packages/utils/src/serializeError.test.ts
+++ b/packages/utils/src/serializeError.test.ts
@@ -1,4 +1,4 @@
-import { serializeError } from '../src/serializeError';
+import { serializeError } from './serializeError';
 
 class CustomError extends Error {
     somethingExtra = 'extra stuff';

--- a/packages/utils/src/splitStringEveryNCharacters.test.ts
+++ b/packages/utils/src/splitStringEveryNCharacters.test.ts
@@ -1,4 +1,4 @@
-import { splitStringEveryNCharacters } from '../src/splitStringEveryNCharacters';
+import { splitStringEveryNCharacters } from './splitStringEveryNCharacters';
 
 describe(splitStringEveryNCharacters.name, () => {
     it('splits string into parts of N characters', () => {

--- a/packages/utils/src/throttler.test.ts
+++ b/packages/utils/src/throttler.test.ts
@@ -1,4 +1,4 @@
-import { Throttler } from '../src/throttler';
+import { Throttler } from './throttler';
 
 const delay = (ms: number) => jest.advanceTimersByTime(ms);
 

--- a/packages/utils/src/topologicalSort.test.ts
+++ b/packages/utils/src/topologicalSort.test.ts
@@ -1,4 +1,4 @@
-import { topologicalSort } from '../src/topologicalSort';
+import { topologicalSort } from './topologicalSort';
 
 type Fixture<T> = {
     description: string;

--- a/packages/utils/src/typedEventEmitter.test.ts
+++ b/packages/utils/src/typedEventEmitter.test.ts
@@ -1,4 +1,4 @@
-import { TypedEmitter } from '../src/typedEventEmitter';
+import { TypedEmitter } from './typedEventEmitter';
 
 type PayloadUnion = { foo: number } | { bar: string };
 

--- a/packages/utils/src/typedObjectFromEntries.type-test.ts
+++ b/packages/utils/src/typedObjectFromEntries.type-test.ts
@@ -1,4 +1,4 @@
-import { typedObjectEntries, typedObjectFromEntries, typedObjectKeys } from '../src/typedObject';
+import { typedObjectEntries, typedObjectFromEntries, typedObjectKeys } from './typedObject';
 
 const map = {
     a: 1,

--- a/packages/utils/src/typedObjectKeys.type-test.ts
+++ b/packages/utils/src/typedObjectKeys.type-test.ts
@@ -1,4 +1,4 @@
-import { typedObjectKeys } from '../src/typedObject';
+import { typedObjectKeys } from './typedObject';
 
 type AB = { a: 'A'; b: 'B' } | { b: 'BB' };
 

--- a/packages/utils/src/typedObjectValues.type-test.ts
+++ b/packages/utils/src/typedObjectValues.type-test.ts
@@ -1,4 +1,4 @@
-import { typedObjectValues } from '../src/typedObject';
+import { typedObjectValues } from './typedObject';
 
 type AB = { a: 'A'; b: 'B' } | { b: 'BB' };
 

--- a/packages/utils/src/urlToOnion.test.ts
+++ b/packages/utils/src/urlToOnion.test.ts
@@ -1,4 +1,4 @@
-import { urlToOnion } from '../src/urlToOnion';
+import { urlToOnion } from './urlToOnion';
 
 const DICT = {
     'trezor.io': 'trezorioabcd.onion',

--- a/packages/utils/src/versionUtils.test.ts
+++ b/packages/utils/src/versionUtils.test.ts
@@ -5,7 +5,7 @@ import {
     isVersionArray,
     isWithinRange,
     normalizeVersion,
-} from '../src/versionUtils';
+} from './versionUtils';
 
 const fixture = [
     [[1, 0, 0], '1.0.0-beta'],

--- a/packages/utils/src/xssFilters.test.ts
+++ b/packages/utils/src/xssFilters.test.ts
@@ -1,4 +1,4 @@
-import { inDoubleQuotes, inHTML, inSingleQuotes } from '../src/xssFilters';
+import { inDoubleQuotes, inHTML, inSingleQuotes } from './xssFilters';
 
 describe('XSS filters', () => {
     describe('in HTML data', () => {


### PR DESCRIPTION
## Description

Moves all 15 S–Z utility runtime and type tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit-level tests for pure utility functions in packages/utils/src (e.g., string parsing, serialization, versioning, XSS filtering, scheduling, topological sort, typed object helpers). These are unit tests (.test.ts / .type-test.ts) run via Jest/TS type-checking, not through the Playwright E2E suite, and none of the 78 candidate E2E tests statically or semantically reference these specific utility modules in a way that ties their behavior to E2E user flows. None of the LLM-analyzed E2E test descriptions mention safeBigIntStringify, safeParseUrl, sanitizeFilename, scheduleAction, serializeError, splitStringEveryNCharacters, throttler, topologicalSort, typedEventEmitter, typedObjectFromEntries/Keys/Values, urlToOnion, versionUtils, or xssFilters as functionality under test. Given the isolated, low-level nature of these changes and lack of any concrete evidence connecting them to specific E2E flows, no E2E tests are recommended to run for this change set; standard unit test execution for the changed files themselves should suffice.

<details><summary><b>Changed files (15)</b></summary>

- `packages/utils/src/safeBigIntStringify.test.ts`
- `packages/utils/src/safeParseUrl.test.ts`
- `packages/utils/src/sanitizeFilename.test.ts`
- `packages/utils/src/scheduleAction.test.ts`
- `packages/utils/src/serializeError.test.ts`
- `packages/utils/src/splitStringEveryNCharacters.test.ts`
- `packages/utils/src/throttler.test.ts`
- `packages/utils/src/topologicalSort.test.ts`
- `packages/utils/src/typedEventEmitter.test.ts`
- `packages/utils/src/typedObjectFromEntries.type-test.ts`
- `packages/utils/src/typedObjectKeys.type-test.ts`
- `packages/utils/src/typedObjectValues.type-test.ts`
- `packages/utils/src/urlToOnion.test.ts`
- `packages/utils/src/versionUtils.test.ts`
- `packages/utils/src/xssFilters.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (15)**
- `packages/utils/src/safeBigIntStringify.test.ts`
- `packages/utils/src/safeParseUrl.test.ts`
- `packages/utils/src/sanitizeFilename.test.ts`
- `packages/utils/src/scheduleAction.test.ts`
- `packages/utils/src/serializeError.test.ts`
- `packages/utils/src/splitStringEveryNCharacters.test.ts`
- `packages/utils/src/throttler.test.ts`
- `packages/utils/src/topologicalSort.test.ts`
- `packages/utils/src/typedEventEmitter.test.ts`
- `packages/utils/src/typedObjectFromEntries.type-test.ts`
- `packages/utils/src/typedObjectKeys.type-test.ts`
- `packages/utils/src/typedObjectValues.type-test.ts`
- `packages/utils/src/urlToOnion.test.ts`
- `packages/utils/src/versionUtils.test.ts`
- `packages/utils/src/xssFilters.test.ts`

_Updated: 2026-07-28T15:41:14.161Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/utils-s-z-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/utils-s-z-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/utils-s-z-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/utils-s-z-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:45:07.182Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:45:58.429Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->