### PR TITLE
test(address-validator): co-locate tests

### DIFF
--- a/networks/bitcoin/network-bitcoin-suite/src/addressValidator/bitcoinAddressValidator.test.ts
+++ b/networks/bitcoin/network-bitcoin-suite/src/addressValidator/bitcoinAddressValidator.test.ts
@@ -1,7 +1,7 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import type { BitcoinNetworkSymbol } from '../../supportedNetworks';
-import { bitcoinValidator } from '../bitcoinAddressValidator';
+import type { BitcoinNetworkSymbol } from '../supportedNetworks';
+import { bitcoinValidator } from './bitcoinAddressValidator';
 
 type BitcoinIsAddressValidCase = {
     address: string;

--- a/networks/cardano/network-cardano-suite/src/addressValidator/cardanoAddressValidator.test.ts
+++ b/networks/cardano/network-cardano-suite/src/addressValidator/cardanoAddressValidator.test.ts
@@ -1,6 +1,6 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import { adaValidator } from '../cardanoAddressValidator';
+import { adaValidator } from './cardanoAddressValidator';
 
 type CardanoIsAddressValidCase = {
     address: string;

--- a/networks/ethereum/network-ethereum-suite/src/addressValidator/ethereumAddressValidator.test.ts
+++ b/networks/ethereum/network-ethereum-suite/src/addressValidator/ethereumAddressValidator.test.ts
@@ -1,7 +1,7 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import { type EthereumNetworkSymbol, getSupportedNetworks } from '../../supportedNetworks';
-import { ethereumValidator } from '../ethereumAddressValidator';
+import { type EthereumNetworkSymbol, getSupportedNetworks } from '../supportedNetworks';
+import { ethereumValidator } from './ethereumAddressValidator';
 
 type EthereumIsAddressValidCase = {
     address: string;

--- a/networks/ripple/network-ripple-suite/src/addressValidator/rippleAddressValidator.test.ts
+++ b/networks/ripple/network-ripple-suite/src/addressValidator/rippleAddressValidator.test.ts
@@ -1,7 +1,7 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import type { RippleNetworkSymbol } from '../../supportedNetworks';
-import { rippleValidator } from '../rippleAddressValidator';
+import type { RippleNetworkSymbol } from '../supportedNetworks';
+import { rippleValidator } from './rippleAddressValidator';
 
 type RippleIsAddressValidCase = {
     address: string;

--- a/networks/solana/network-solana-suite/src/addressValidator/solanaAddressValidator.test.ts
+++ b/networks/solana/network-solana-suite/src/addressValidator/solanaAddressValidator.test.ts
@@ -1,6 +1,6 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import { solanaValidator } from '../solanaAddressValidator';
+import { solanaValidator } from './solanaAddressValidator';
 
 type SolanaIsAddressValidCase = {
     address: string;

--- a/networks/stellar/network-stellar-suite/src/addressValidator/stellarAddressValidator.test.ts
+++ b/networks/stellar/network-stellar-suite/src/addressValidator/stellarAddressValidator.test.ts
@@ -1,6 +1,6 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import { stellarValidator } from '../stellarAddressValidator';
+import { stellarValidator } from './stellarAddressValidator';
 
 type StellarIsAddressValidCase = {
     address: string;

--- a/networks/tron/network-tron-suite/src/addressValidator/tronAddressValidator.test.ts
+++ b/networks/tron/network-tron-suite/src/addressValidator/tronAddressValidator.test.ts
@@ -1,7 +1,7 @@
 import { type AddressType, addressType } from '@trezor/network-module-suite-types';
 
-import type { TronNetworkSymbol } from '../../supportedNetworks';
-import { tronValidator } from '../tronAddressValidator';
+import type { TronNetworkSymbol } from '../supportedNetworks';
+import { tronValidator } from './tronAddressValidator';
 
 type TronIsAddressValidCase = {
     address: string;


### PR DESCRIPTION
## Description

The network abstraction moved validators and their suites into per-network packages, leaving the former packages/address-validator paths obsolete. This rebases onto current develop, keeps the removed aggregate validator suite deleted, and moves each remaining test directly beside its network validator with updated relative imports.

- Validator suites in addressValidator/__tests__: **7 -> 0**
- Focused validation: **7 suites, 292 tests passing**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/address-validator-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/address-validator-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/address-validator-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/address-validator-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:52:29.371Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:52:05.233Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** These changes are isolated unit test files for network-specific address validators (BTC, ADA, ETH, XRP, SOL, XLM, TRX). No static E2E coverage mapping exists since these are unit-level test files, but functionally equivalent E2E flows that exercise real address validation (receive, verify, send, sign) provide the best regression safety net. Priority was given to E2E tests that directly assert on address formats/values for the affected networks (BTC, ETH, SOL, TRX, ADA), with lower priority given to tests where address validation is a secondary concern (sign/verify flows). Ripple and Stellar have no direct E2E test coverage in the provided catalog, representing a gap.

<details><summary><b>Changed files (7)</b></summary>

- `networks/bitcoin/network-bitcoin-suite/src/addressValidator/bitcoinAddressValidator.test.ts`
- `networks/cardano/network-cardano-suite/src/addressValidator/cardanoAddressValidator.test.ts`
- `networks/ethereum/network-ethereum-suite/src/addressValidator/ethereumAddressValidator.test.ts`
- `networks/ripple/network-ripple-suite/src/addressValidator/rippleAddressValidator.test.ts`
- `networks/solana/network-solana-suite/src/addressValidator/solanaAddressValidator.test.ts`
- `networks/stellar/network-stellar-suite/src/addressValidator/stellarAddressValidator.test.ts`
- `networks/tron/network-tron-suite/src/addressValidator/tronAddressValidator.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies receive address generation and format validation for BTC, ETH, SOL, and TRX (via regex checks matching each network's address format), directly exercising the same address-format logic that the changed bitcoin/ethereum/solana/tron address validators implement. A regression in any of these validators could break address display/copy behavior verified here.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test covers Cardano address reveal, verification, and formatting flows, which rely on the Cardano address validation logic that was changed; a broken validator could cause receive/verify address failures for ADA accounts.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test validates Cardano receive addresses under a hidden/passphrase wallet including error handling for incorrect passphrases (verify-address-error toast), which exercises the Cardano address validator indirectly during address confirmation flows.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies that Ethereum and Bitcoin addresses displayed in Suite UI match the expected addresses (both on-screen and on-device), which would surface any regression from the changed ethereum/bitcoin address validators.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends Bitcoin transactions including OP_RETURN and multiple outputs, requiring correct destination address validation; a regression in the Bitcoin address validator could break send form address input handling.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Sign and verify uses a Bitcoin address selection dropdown and address input; correctness of Bitcoin address parsing/validation logic could subtly affect address selection/matching in this flow.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — This test exercises Ethereum address handling during message signing/verification, which could be impacted if the Ethereum address validator regression affects address parsing.

</details>

⚠️ **Changes with no test coverage (2)**
- `networks/ripple/network-ripple-suite/src/addressValidator/rippleAddressValidator.test.ts`
- `networks/stellar/network-stellar-suite/src/addressValidator/stellarAddressValidator.test.ts`

_Updated: 2026-07-28T14:54:12.357Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->