### PR TITLE
test(analytics-docs): co-locate tests

### DIFF
--- a/packages/analytics-docs/src/utils/filterUtils.test.ts
+++ b/packages/analytics-docs/src/utils/filterUtils.test.ts
@@ -1,4 +1,4 @@
-import type { EventDoc } from '../../types';
+import type { EventDoc } from '../types';
 import {
     eventHasVersion,
     eventMatchesFullText,
@@ -9,7 +9,7 @@ import {
     getEventId,
     getVersionsWithEvents,
     toEventExportName,
-} from '../filterUtils';
+} from './filterUtils';
 
 describe('fuzzyMatch (event name)', () => {
     it('empty query matches everything', () => {

--- a/packages/analytics-docs/src/utils/normalizeChangelog.test.ts
+++ b/packages/analytics-docs/src/utils/normalizeChangelog.test.ts
@@ -1,4 +1,4 @@
-import { normalizeChangelog } from '../normalizeChangelog';
+import { normalizeChangelog } from './normalizeChangelog';
 
 describe('normalizeChangelog', () => {
     it('ignores "?" for added/updated versions and places it at the end', () => {

--- a/packages/analytics-docs/src/utils/normalizeEvents.test.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.test.ts
@@ -1,4 +1,4 @@
-import { normalizeEvents } from '../normalizeEvents';
+import { normalizeEvents } from './normalizeEvents';
 
 describe('normalizeEvents', () => {
     it('keeps event.changelog.entries event-scoped (attributes do not leak into entries)', () => {


### PR DESCRIPTION
## Description

Moves all 3 analytics-docs tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files themselves (Jest/Vitest-style tests) within the packages/analytics-docs package, which is a documentation/tooling utility package unrelated to the Playwright E2E test suite for Trezor Suite. None of the 72 candidate E2E tests reference or exercise analytics-docs utilities (filterUtils, normalizeChangelog, normalizeEvents) — these appear to be internal doc-generation helpers, not part of the Suite application runtime covered by E2E tests. Since these changes are isolated unit tests with no static or inferable coverage overlap with the E2E suite, no E2E tests need to be run for this change set; standard unit test execution for the analytics-docs package itself is the appropriate verification step.

<details><summary><b>Changed files (3)</b></summary>

- `packages/analytics-docs/src/utils/filterUtils.test.ts`
- `packages/analytics-docs/src/utils/normalizeChangelog.test.ts`
- `packages/analytics-docs/src/utils/normalizeEvents.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/analytics-docs/src/utils/filterUtils.test.ts`
- `packages/analytics-docs/src/utils/normalizeChangelog.test.ts`
- `packages/analytics-docs/src/utils/normalizeEvents.test.ts`

_Updated: 2026-07-27T16:30:22.373Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/analytics-docs-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/analytics-docs-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/analytics-docs-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/analytics-docs-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:34:06.526Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:34:01.750Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->