### PR TITLE
test(bundler-security): co-locate test

### DIFF
--- a/packages/bundler-security/src/metroSecureResolver.test.ts
+++ b/packages/bundler-security/src/metroSecureResolver.test.ts
@@ -1,4 +1,4 @@
-import { checkSecurityViolation } from '../src/metroSecureResolver';
+import { checkSecurityViolation } from './metroSecureResolver';
 
 describe('checkSecurityViolation', () => {
     it('should detect violation when accessing @trezor scoped package from node_modules', () => {


### PR DESCRIPTION
## Description

Moves the bundler-security resolver test beside its source file without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test for the bundler-security package's metroSecureResolver, which is unrelated to the Playwright E2E test suite covering TrezorConnect webextension flows (Suite Web, Connect Explorer, permissions modal). There is no static or inferred coverage linking this change to the analyzed E2E test, as the two touch entirely separate parts of the codebase (bundler/module resolution security vs. TrezorConnect webextension popup flows). No E2E tests are recommended; verification should rely on running the package's own unit tests (metroSecureResolver.test.ts) rather than the E2E suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/bundler-security/src/metroSecureResolver.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/bundler-security/src/metroSecureResolver.test.ts`

_Updated: 2026-07-27T16:36:02.438Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/bundler-security-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/bundler-security-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/bundler-security-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/bundler-security-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:39:38.619Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:39:24.270Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->