### PR TITLE
test(connect-common): co-locate tests

### DIFF
--- a/packages/connect-common/src/data/connectSettings.test.ts
+++ b/packages/connect-common/src/data/connectSettings.test.ts
@@ -1,4 +1,4 @@
-import { corsValidator, parseConnectSettings } from '../connectSettings';
+import { corsValidator, parseConnectSettings } from './connectSettings';
 
 describe('data/connectSettings', () => {
     describe('parseConnectSettings enabledNetworks', () => {

--- a/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.test.ts
+++ b/packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { ServiceWorkerWindowExtConnectableChannel } from '../serviceworker-window-ext-connectable';
+import { ServiceWorkerWindowExtConnectableChannel } from './serviceworker-window-ext-connectable';
 
 type TestMessage = { type: 'test-message'; channel?: { peer: string; here: string } };
 

--- a/packages/connect-common/src/messageChannel/window-window.test.ts
+++ b/packages/connect-common/src/messageChannel/window-window.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { WindowWindowChannel } from '../window-window';
+import { WindowWindowChannel } from './window-window';
 
 type TestMessage = {
     type: 'test-message';

--- a/packages/connect-common/src/types/api/selectAccount.test.ts
+++ b/packages/connect-common/src/types/api/selectAccount.test.ts
@@ -1,6 +1,6 @@
 import { Validate } from '@trezor/schema-utils';
 
-import { MultiSelectBounds } from '../selectAccount';
+import { MultiSelectBounds } from './selectAccount';
 
 describe('MultiSelectBounds schema', () => {
     it('accepts valid whole-number bounds and one-sided/empty bounds', () => {

--- a/packages/connect-common/src/types/api/tiers.type-test.ts
+++ b/packages/connect-common/src/types/api/tiers.type-test.ts
@@ -1,8 +1,8 @@
 // Negative type tests: the public tier must not expose management or internal members.
 
-import type { TrezorConnectPrivilegedAPI, TrezorConnectPublicAPI } from '../../..';
-import type { TrezorConnectInternal } from '../internal';
-import type { TrezorConnectManagement } from '../management';
+import type { TrezorConnectInternal } from './internal';
+import type { TrezorConnectManagement } from './management';
+import type { TrezorConnectPrivilegedAPI, TrezorConnectPublicAPI } from '../../index';
 
 type AssertNever<T extends never> = T;
 

--- a/packages/connect-common/src/utils/cancelParams.test.ts
+++ b/packages/connect-common/src/utils/cancelParams.test.ts
@@ -1,4 +1,4 @@
-import { normalizeCancelParams } from '../cancelParams';
+import { normalizeCancelParams } from './cancelParams';
 
 describe('utils/cancelParams', () => {
     describe('normalizeCancelParams', () => {

--- a/packages/connect-common/src/utils/pathUtils.test.ts
+++ b/packages/connect-common/src/utils/pathUtils.test.ts
@@ -6,7 +6,7 @@ import {
     getOutputScriptType,
     getScriptType,
     validatePath,
-} from '../pathUtils';
+} from './pathUtils';
 
 describe('utils/pathUtils', () => {
     it('getScriptType', () => {

--- a/packages/connect-common/src/utils/pathUtils.type-test.ts
+++ b/packages/connect-common/src/utils/pathUtils.type-test.ts
@@ -1,7 +1,7 @@
 import type { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { ProtoWithDerivationPath } from '../../types/params';
-import { fixPath } from '../pathUtils';
+import { fixPath } from './pathUtils';
+import type { ProtoWithDerivationPath } from '../types/params';
 
 declare const inputWithDerivationPath: ProtoWithDerivationPath<PROTO.TxInputType>;
 declare const outputWithDerivationPath: ProtoWithDerivationPath<PROTO.TxOutputType>;


### PR DESCRIPTION
## Description

Moves all 8 tracked connect-common runtime and type-test files beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** These changes are isolated to the packages/connect-common library (message channel communication, cancel params, path utilities, account selection types, and connect settings data) rather than the Suite app itself, so no E2E test statically maps to them. Since connect-common underlies TrezorConnect's popup/webextension messaging, cancellation, and account selection APIs used by the Suite's trezor-connect E2E test group, we inferred a small set of relevant tests from that group as the closest proxies for regression risk. Recommended strategy: run the inferred TrezorConnect E2E tests (selectAccount, popup web/webextension, permissions) at medium priority, with getAddress/getAccountInfo at low priority as they touch derivation-path logic possibly affected by pathUtils changes; broader Suite E2E suite is unlikely to be impacted.

<details><summary><b>Changed files (8)</b></summary>

- `packages/connect-common/src/data/connectSettings.test.ts`
- `packages/connect-common/src/messageChannel/serviceworker-window-ext-connectable.test.ts`
- `packages/connect-common/src/messageChannel/window-window.test.ts`
- `packages/connect-common/src/types/api/selectAccount.test.ts`
- `packages/connect-common/src/types/api/tiers.type-test.ts`
- `packages/connect-common/src/utils/cancelParams.test.ts`
- `packages/connect-common/src/utils/pathUtils.test.ts`
- `packages/connect-common/src/utils/pathUtils.type-test.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test directly exercises TrezorConnect.selectAccount flow (multi/single selection, cancellation, privacy of xpub/publicKey), which corresponds to changes in packages/connect-common/src/types/api/selectAccount.test.ts covering the selectAccount API types.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect popup window messaging (window-window communication) and cancellation flows, which are plausibly affected by changes to messageChannel/window-window.test.ts and cancelParams.test.ts governing popup message channel and cancel parameter handling.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers webextension-based Connect popup flows including cancellation via TrezorConnect.cancel(), which relates to changes in cancelParams.test.ts (cancel parameter utilities) and messageChannel window communication logic used by extension-to-popup messaging.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — getAccountInfo relies on derivation path handling (account type p2wpkh selection), which could be indirectly affected by pathUtils.test.ts changes governing path utility logic used across account selection flows.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress uses BTC derivation paths (m/44'/0'/0'/0/x) for address export, which may be impacted by changes to pathUtils utilities that compute/validate derivation paths.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — The permissions test covers persisted connect settings (remembered/forgotten app permissions) which could relate to changes in connectSettings.test.ts governing how connect settings are structured or validated.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect-common/src/types/api/tiers.type-test.ts`

_Updated: 2026-07-27T16:40:49.813Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-common-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-common-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-common-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:43:53.059Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:43:45.445Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->