### PR TITLE
test(connect-web): co-locate tests

### DIFF
--- a/packages/connect-web/src/bootstrap/bootstrap.test.ts
+++ b/packages/connect-web/src/bootstrap/bootstrap.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { BootstrapError } from '../bootstrap-errors';
+import { BootstrapError } from './bootstrap-errors';
 
 class MockBroadcastChannel {
     static instances: MockBroadcastChannel[] = [];
@@ -76,7 +76,7 @@ describe('bootstrap (popup mode)', () => {
         setLocation(`${POPUP_URL}?connect-popup-req=abc123`);
 
         jest.isolateModules(() => {
-            ({ bootstrap } = require('../bootstrap'));
+            ({ bootstrap } = require('./bootstrap'));
         });
     });
 
@@ -147,7 +147,7 @@ describe('bootstrap (popup mode)', () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
         jest.isolateModules(() => {
-            ({ bootstrap } = require('../bootstrap'));
+            ({ bootstrap } = require('./bootstrap'));
         });
 
         await bootstrap();
@@ -190,7 +190,7 @@ describe('bootstrap (iframe mode)', () => {
         );
 
         jest.isolateModules(() => {
-            ({ bootstrap } = require('../bootstrap'));
+            ({ bootstrap } = require('./bootstrap'));
         });
     });
 
@@ -298,7 +298,7 @@ describe('bootstrap (getParams failures)', () => {
         delete (global as any).URLSearchParams;
 
         jest.isolateModules(() => {
-            ({ bootstrap } = require('../bootstrap'));
+            ({ bootstrap } = require('./bootstrap'));
         });
 
         bootstrap();
@@ -317,7 +317,7 @@ describe('bootstrap (getParams failures)', () => {
         setLocation(POPUP_URL);
 
         jest.isolateModules(() => {
-            ({ bootstrap } = require('../bootstrap'));
+            ({ bootstrap } = require('./bootstrap'));
         });
 
         bootstrap();

--- a/packages/connect-web/src/impl/getSuiteWebUrl.test.ts
+++ b/packages/connect-web/src/impl/getSuiteWebUrl.test.ts
@@ -1,4 +1,4 @@
-import { extractBranch, getSuiteWebUrl } from '../getSuiteWebUrl';
+import { extractBranch, getSuiteWebUrl } from './getSuiteWebUrl';
 
 const DEV_ORIGIN = 'https://dev.suite.sldev.cz';
 


### PR DESCRIPTION
## Description

Moves both connect-web tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to two connect-web unit test files covering the bootstrap process and the Suite Web URL resolution logic used when opening the TrezorConnect popup. Since these modules directly underpin how connect-web initializes and where it points the popup, the most relevant E2E coverage is the popup-based getAddress flows (web and webextension) that actually launch and interact with the Suite Web popup. Other TrezorConnect E2E tests that use suite-desktop core mode are less directly affected since they bypass the connect-web popup/URL-resolution path, but are included at low priority as a precaution.</summary>
<parameter name="uncovered_changes">[]

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect-web/src/bootstrap/bootstrap.test.ts`
- `packages/connect-web/src/impl/getSuiteWebUrl.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the connect-web popup flow end-to-end (TrezorConnect.getAddress/cardanoGetAddress via the web popup), which is the exact area exercised by the changed bootstrap.ts and getSuiteWebUrl.ts files that control how the connect-web popup initializes and resolves the Suite Web URL.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test verifies the webextension-to-Suite-Web popup flow, which relies on correctly resolving the Suite Web URL and bootstrapping the connect-web client (the popup opening, focusing, and closing logic) — directly related to the changed bootstrap and getSuiteWebUrl modules.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Permissions flow depends on TrezorConnect.init and popup initialization behavior (bootstrap logic), so a change in how the connect-web client bootstraps or resolves URLs could indirectly affect whether the permissions modal and remembered-app flow work correctly.
- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect in suite-desktop core mode and could catch regressions in shared bootstrap initialization code, though it does not exercise the connect-web popup/URL resolution path directly.

</details>

_Updated: 2026-07-27T16:42:31.543Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-web-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/connect-web-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-web-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-web-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:45:39.868Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:45:10.299Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->