### PR TITLE
test(crypto-utils): co-locate tests

### DIFF
--- a/packages/crypto-utils/src/bipPath/comparePath.test.ts
+++ b/packages/crypto-utils/src/bipPath/comparePath.test.ts
@@ -1,4 +1,4 @@
-import { comparePath } from '../comparePath';
+import { comparePath } from './comparePath';
 
 describe(comparePath.name, () => {
     it.each([

--- a/packages/crypto-utils/src/bipPath/getAddressPathIndex.test.ts
+++ b/packages/crypto-utils/src/bipPath/getAddressPathIndex.test.ts
@@ -1,4 +1,4 @@
-import { getAddressPathIndex } from '../getAddressPathIndex';
+import { getAddressPathIndex } from './getAddressPathIndex';
 
 describe(getAddressPathIndex.name, () => {
     it.each([

--- a/packages/crypto-utils/src/bipPath/getHDPath.test.ts
+++ b/packages/crypto-utils/src/bipPath/getHDPath.test.ts
@@ -1,6 +1,6 @@
 import { err, ok } from '@trezor/type-utils';
 
-import { getHDPath } from '../getHDPath';
+import { getHDPath } from './getHDPath';
 
 describe(getHDPath.name, () => {
     it.each([

--- a/packages/crypto-utils/src/bipPath/hardened.test.ts
+++ b/packages/crypto-utils/src/bipPath/hardened.test.ts
@@ -1,4 +1,4 @@
-import { HD_HARDENED_PATH_PART, fromHardenedPathPart, toHardenedPathPart } from '../hardened';
+import { HD_HARDENED_PATH_PART, fromHardenedPathPart, toHardenedPathPart } from './hardened';
 
 describe('hardened path part', () => {
     it('converts path parts to and from hardened values', () => {


### PR DESCRIPTION
## Description

Moves all 4 crypto-utils tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit test files within packages/crypto-utils/src/bipPath, covering low-level BIP32/44 HD path comparison, address path index extraction, HD path construction, and hardened-path helper logic. No E2E test in the provided catalog statically or behaviorally references these specific utility functions, and none of the 51 E2E test descriptions mention bipPath, comparePath, getHDPath, getAddressPathIndex, or hardened path logic directly. Since these are unit-test-only changes to a foundational crypto utility, the primary safety net should be the unit tests themselves (already being modified); E2E coverage is only weakly and speculatively relevant via wallet account discovery and address derivation flows, so we recommend only minimal, low-confidence E2E checks as a sanity net. The overall risk to the broader Suite E2E surface from these specific test file changes appears low, since changes to *.test.ts files typically do not alter production behavior unless accompanied by source changes (which are not in this changeset).

<details><summary><b>Changed files (4)</b></summary>

- `packages/crypto-utils/src/bipPath/comparePath.test.ts`
- `packages/crypto-utils/src/bipPath/getAddressPathIndex.test.ts`
- `packages/crypto-utils/src/bipPath/getHDPath.test.ts`
- `packages/crypto-utils/src/bipPath/hardened.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test relies on correct derivation and formatting of HD wallet paths for a hidden/passphrase-protected Solana account, which could be affected if bipPath comparison/hardened path logic changes account indexing behavior. However, these are unit tests for a low-level utility with no direct static or behavioral link established to this E2E flow.
- `suite/e2e/tests/wallet/discovery.test.ts` — Account discovery across multiple coins depends on correct BIP path generation and indexing per account; if getHDPath, hardened, or getAddressPathIndex logic is altered, discovery of accounts across networks could silently break, though this is inferred rather than directly evidenced.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/crypto-utils/src/bipPath/comparePath.test.ts`
- `packages/crypto-utils/src/bipPath/getAddressPathIndex.test.ts`
- `packages/crypto-utils/src/bipPath/getHDPath.test.ts`
- `packages/crypto-utils/src/bipPath/hardened.test.ts`

_Updated: 2026-07-27T16:43:56.469Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/crypto-utils-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/crypto-utils-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/crypto-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/crypto-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:47:06.519Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:46:51.720Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->