### PR TITLE
test(ipc-proxy): co-locate tests

### DIFF
--- a/packages/ipc-proxy/mocks/mockedElectron.ts
+++ b/packages/ipc-proxy/mocks/mockedElectron.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { type ElectronIpcMainInvokeEvent } from '../types';
+import { type ElectronIpcMainInvokeEvent } from '../src/types';
 
 const ipcMainEvent: ElectronIpcMainInvokeEvent = {
     senderFrame: {

--- a/packages/ipc-proxy/src/proxy.test.ts
+++ b/packages/ipc-proxy/src/proxy.test.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 
-import { createIpcProxy } from '../proxy';
-import { exposeIpcProxy } from '../proxy-generator';
-import { createIpcProxyHandler } from '../proxy-handler';
-import { exposeInMainWorld, ipcMain, ipcRenderer } from './mockedElectron';
+import { createIpcProxy } from './proxy';
+import { exposeIpcProxy } from './proxy-generator';
+import { createIpcProxyHandler } from './proxy-handler';
+import { exposeInMainWorld, ipcMain, ipcRenderer } from '../mocks/mockedElectron';
 
 class TestApi extends EventEmitter {
     field = 'some-static-field';

--- a/packages/ipc-proxy/src/validateIpcMessage.test.ts
+++ b/packages/ipc-proxy/src/validateIpcMessage.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import { type ElectronIpcMainInvokeEvent } from '../types';
-import { validateIpcMessage } from '../validateIpcMessage';
+import { type ElectronIpcMainInvokeEvent } from './types';
+import { validateIpcMessage } from './validateIpcMessage';
 
 const createSenderFrame = (url: string, destroyed?: boolean): ElectronIpcMainInvokeEvent => ({
     senderFrame: { url: encodeURI(url), isDestroyed: () => destroyed === true },


### PR DESCRIPTION
## Description

Moves both ipc-proxy tests beside their source files and relocates their Electron mock without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all within packages/ipc-proxy (mockedElectron.ts, proxy.test.ts, validateIpcMessage.test.ts), which is a low-level IPC proxy module used internally by the Electron desktop build, not by the Playwright E2E test suite examined here. Neither of the two candidate E2E tests (connectPopupWebextension.test.ts and passthru-swap-eth-to-btc.test.ts) reference or exercise ipc-proxy functionality based on their documented behaviors, entry points, or source hints — they focus on webextension popup flows and swap trading UI respectively. Since proxy.test.ts and validateIpcMessage.test.ts are themselves unit tests (not E2E), and mockedElectron.ts is a test mock consumed only by those unit tests, this change is best validated by running the ipc-proxy package's own unit test suite rather than any Playwright E2E test. No E2E test recommendations are warranted given the available evidence.

<details><summary><b>Changed files (3)</b></summary>

- `packages/ipc-proxy/mocks/mockedElectron.ts`
- `packages/ipc-proxy/src/proxy.test.ts`
- `packages/ipc-proxy/src/validateIpcMessage.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/ipc-proxy/mocks/mockedElectron.ts`
- `packages/ipc-proxy/src/proxy.test.ts`
- `packages/ipc-proxy/src/validateIpcMessage.test.ts`

_Updated: 2026-07-27T16:50:01.181Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/ipc-proxy-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/ipc-proxy-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/ipc-proxy-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/ipc-proxy-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:53:35.623Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:52:58.632Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->