### PR TITLE
test(node-utils): co-locate tests

### DIFF
--- a/packages/node-utils/src/checkSocks5Proxy.test.ts
+++ b/packages/node-utils/src/checkSocks5Proxy.test.ts
@@ -1,6 +1,6 @@
 import net from 'net';
 
-import { checkSocks5Proxy } from '../checkSocks5Proxy';
+import { checkSocks5Proxy } from './checkSocks5Proxy';
 
 jest.mock('net');
 

--- a/packages/node-utils/src/ensureDirectoryExists.test.ts
+++ b/packages/node-utils/src/ensureDirectoryExists.test.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { ensureDirectoryExists } from '../ensureDirectoryExists';
+import { ensureDirectoryExists } from './ensureDirectoryExists';
 
 describe('ensureDirectoryExists', () => {
     let baseDir: string;

--- a/packages/node-utils/src/findProcessFromIncomingPort.test.ts
+++ b/packages/node-utils/src/findProcessFromIncomingPort.test.ts
@@ -1,7 +1,7 @@
 import net from 'net';
 
-import { findProcessFromIncomingPort } from '../findProcessFromIncomingPort';
-import { getFreePort } from '../getFreePort';
+import { findProcessFromIncomingPort } from './findProcessFromIncomingPort';
+import { getFreePort } from './getFreePort';
 
 describe('findProcessFromIncomingPort', () => {
     test('start a server on a random free port and try to detect it', async () => {

--- a/packages/node-utils/src/http.test.ts
+++ b/packages/node-utils/src/http.test.ts
@@ -1,6 +1,6 @@
 import { type Log } from '@trezor/utils';
 
-import { getFreePort } from '../getFreePort';
+import { getFreePort } from './getFreePort';
 import {
     HttpServer,
     type ParamsValidatorHandler,
@@ -9,8 +9,8 @@ import {
     parseBodyJSON,
     parseBodyJSONWithLimit,
     parseBodyText,
-} from '../http';
-import { parseRequestUrl } from '../parseRequestUrl';
+} from './http';
+import { parseRequestUrl } from './parseRequestUrl';
 
 type Events = {
     foo: (arg: string) => void;

--- a/packages/node-utils/src/parseRequestUrl.test.ts
+++ b/packages/node-utils/src/parseRequestUrl.test.ts
@@ -1,6 +1,6 @@
 import type { ParsedUrlQuery } from 'querystring';
 
-import { formatRequestUrl, parseRequestUrl } from '../parseRequestUrl';
+import { formatRequestUrl, parseRequestUrl } from './parseRequestUrl';
 
 type ParseFixture = {
     description: string;

--- a/packages/node-utils/src/validateJsonSchema.test.ts
+++ b/packages/node-utils/src/validateJsonSchema.test.ts
@@ -1,4 +1,4 @@
-import { validateJsonSchema } from '../validateJsonSchema';
+import { validateJsonSchema } from './validateJsonSchema';
 
 describe('validateJsonSchema', () => {
     const mockConfig = JSON.stringify({ key: 'value' });


### PR DESCRIPTION
## Description

Moves all 6 node-utils tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit test files within packages/node-utils (covering socks5 proxy checks, directory creation, process discovery by port, HTTP utilities, URL parsing, and JSON schema validation). These are isolated Node.js utility unit tests with no static E2E coverage mapping, and the LLM-analyzed E2E test suite is almost entirely focused on Suite UI flows (onboarding, trading, staking, wallet, settings) that do not directly exercise these low-level Node utility functions in a testable, observable way. Only the bridge-related E2E tests (which spawn Node processes and interact with bridge HTTP endpoints) have plausible but weak indirect exposure to these utilities, so they are included at low priority as a precaution. Given the unit-test nature of the changes and lack of concrete behavioral links to any E2E flow, the recommended strategy is to rely primarily on the Node-level unit tests themselves (already covered by the changed files) and only optionally run the two low-priority bridge E2E tests for extra confidence.

<details><summary><b>Changed files (6)</b></summary>

- `packages/node-utils/src/checkSocks5Proxy.test.ts`
- `packages/node-utils/src/ensureDirectoryExists.test.ts`
- `packages/node-utils/src/findProcessFromIncomingPort.test.ts`
- `packages/node-utils/src/http.test.ts`
- `packages/node-utils/src/parseRequestUrl.test.ts`
- `packages/node-utils/src/validateJsonSchema.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test relies on node-bridge process spawning and status checks, which may indirectly exercise packages/node-utils functionality such as process discovery (findProcessFromIncomingPort) or HTTP status endpoint checks (http.test.ts), but no direct static or behavioral link was found.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test checks bridge process lifecycle and HTTP API version endpoint, which could be affected by changes to http.test.ts or checkSocks5Proxy.test.ts if those underlie bridge networking utilities, though no direct coverage evidence exists.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/node-utils/src/checkSocks5Proxy.test.ts`
- `packages/node-utils/src/ensureDirectoryExists.test.ts`
- `packages/node-utils/src/findProcessFromIncomingPort.test.ts`
- `packages/node-utils/src/http.test.ts`
- `packages/node-utils/src/parseRequestUrl.test.ts`
- `packages/node-utils/src/validateJsonSchema.test.ts`

_Updated: 2026-07-27T16:52:10.732Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/node-utils-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/node-utils-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/node-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/node-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:55:25.692Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T16:54:55.948Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->