### PR TITLE
test(requirements): co-locate tests

### DIFF
--- a/packages/requirements/src/execCliCommand.test.ts
+++ b/packages/requirements/src/execCliCommand.test.ts
@@ -1,4 +1,4 @@
-import { createExecCliCommand } from '../execCliCommand';
+import { createExecCliCommand } from './execCliCommand';
 
 const execCliCommand = createExecCliCommand({
     console: {

--- a/packages/requirements/src/getAffectedWorkspaces.test.ts
+++ b/packages/requirements/src/getAffectedWorkspaces.test.ts
@@ -1,5 +1,5 @@
-import { type ExecResult } from '../execCliCommand';
-import { createGetAffectedWorkspaces } from '../getAffectedWorkspaces';
+import { type ExecResult } from './execCliCommand';
+import { createGetAffectedWorkspaces } from './getAffectedWorkspaces';
 
 type CreateTestGetAffectedWorkspacesOptions = {
     readonly workspaceListResult: ExecResult;

--- a/packages/requirements/src/report.test.ts
+++ b/packages/requirements/src/report.test.ts
@@ -1,7 +1,7 @@
 import { stripVTControlCharacters } from 'node:util';
 
-import { type ReportDeps, createReport } from '../report';
-import type { RequirementResult } from '../runRequirements';
+import { type ReportDeps, createReport } from './report';
+import type { RequirementResult } from './runRequirements';
 
 const createConsoleMock = (journal: string[]): ReportDeps['console'] => ({
     log: (message: string) => {

--- a/packages/requirements/src/requirements/agents-skills/requireAgentsSkills.test.ts
+++ b/packages/requirements/src/requirements/agents-skills/requireAgentsSkills.test.ts
@@ -2,8 +2,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { RepoContext } from '../../Requirement';
-import { requireAgentsSkills } from '../requireAgentsSkills';
+import type { RepoContext } from '../Requirement';
+import { requireAgentsSkills } from './requireAgentsSkills';
 
 const createTempRepo = (): string => mkdtempSync(join(tmpdir(), 'agents-skills-'));
 

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.test.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import {
     ALLOWED_DRIFTS,
     requireUnifiedDependencyVersions,
-} from '../requireUnifiedDependencyVersions';
+} from './requireUnifiedDependencyVersions';
 
 // Pick any real entry from ALLOWED_DRIFTS so tests never depend on specific hardcoded names.
 const [SOME_ALLOWED_DEP = ''] = ALLOWED_DRIFTS;

--- a/packages/requirements/src/requirements/docs-summary/requireDocsSummary.test.ts
+++ b/packages/requirements/src/requirements/docs-summary/requireDocsSummary.test.ts
@@ -2,8 +2,8 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { RepoContext } from '../../Requirement';
-import { requireDocsSummary } from '../requireDocsSummary';
+import type { RepoContext } from '../Requirement';
+import { requireDocsSummary } from './requireDocsSummary';
 
 const createTempRepo = (): string => mkdtempSync(join(tmpdir(), 'docs-summary-'));
 

--- a/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.test.ts
+++ b/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import {
     findFirmwareReleaseRegressions,
     requireFirmwareReleaseVersionMonotonicity,
-} from '../requireFirmwareReleaseVersionMonotonicity';
+} from './requireFirmwareReleaseVersionMonotonicity';
 
 type ReleaseFields = {
     readonly version: ReadonlyArray<number>;

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.test.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.test.ts
@@ -2,8 +2,8 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { WorkspaceContext } from '../../Requirement';
-import { requirePackageJsonScripts } from '../requirePackageJsonScripts';
+import type { WorkspaceContext } from '../Requirement';
+import { requirePackageJsonScripts } from './requirePackageJsonScripts';
 
 const createTempWorkspace = (): string => mkdtempSync(join(tmpdir(), 'package-json-'));
 

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.test.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.test.ts
@@ -2,8 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { WorkspaceContext } from '../../Requirement';
-import { requirePublishConfig } from '../requirePublishConfig';
+import type { WorkspaceContext } from '../Requirement';
+import { requirePublishConfig } from './requirePublishConfig';
 
 const createTempWorkspace = (): string => mkdtempSync(join(tmpdir(), 'publish-config-'));
 

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 
 jest.mock('node:child_process');
 
-import type { RepoContext } from '../../Requirement';
-import { requireConnectPublicDependencies } from '../requireConnectPublicDependencies';
+import type { RepoContext } from '../Requirement';
+import { requireConnectPublicDependencies } from './requireConnectPublicDependencies';
 
 const createTempRepo = () => mkdtempSync(join(tmpdir(), 'connect-public-deps-'));
 

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts
@@ -2,16 +2,16 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { listAllWorkspaces } from '../../../workspaces';
-import type { RepoContext } from '../../Requirement';
+import { listAllWorkspaces } from '../../workspaces';
+import type { RepoContext } from '../Requirement';
 import {
     MAX_DECLARATION_SIZE_BYTES,
     MAX_DECLARATION_SOURCE_RATIO,
     MIN_DECLARATION_RATIO_SIZE_BYTES,
     requireTypeDeclarationSize,
-} from '../requireTypeDeclarationSize';
+} from './requireTypeDeclarationSize';
 
-jest.mock('../../../workspaces');
+jest.mock('../../workspaces');
 
 const mockListAllWorkspaces = jest.mocked(listAllWorkspaces);
 

--- a/packages/requirements/src/runRequirements.test.ts
+++ b/packages/requirements/src/runRequirements.test.ts
@@ -1,5 +1,5 @@
-import type { Requirement } from '../requirements/Requirement';
-import { runRequirements } from '../runRequirements';
+import type { Requirement } from './requirements/Requirement';
+import { runRequirements } from './runRequirements';
 
 const createRepoRequirement = (
     overrides: Partial<Requirement<'repo'>> & { name: string },


### PR DESCRIPTION
## Description

Moves all 12 legacy requirements tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all internal unit tests within the packages/requirements package, a Node.js CLI/build-tooling package unrelated to the Trezor Suite web/desktop application code. None of the 62 candidate Playwright E2E tests (which cover onboarding, wallet, staking, trading, analytics, and settings UI flows in suite/e2e) exercise or import this requirements package, since it is a separate internal tooling module used for repo-level checks (e.g., dependency versions, package.json scripts, docs summaries) rather than runtime application logic. Consequently, no E2E test is expected to be affected by these changes, and the appropriate validation is the requirements package's own unit test suite (already covered by the changed *.test.ts files themselves) plus any existing Jest/unit test run for that package, not the Playwright E2E suite.

<details><summary><b>Changed files (12)</b></summary>

- `packages/requirements/src/execCliCommand.test.ts`
- `packages/requirements/src/getAffectedWorkspaces.test.ts`
- `packages/requirements/src/report.test.ts`
- `packages/requirements/src/requirements/agents-skills/requireAgentsSkills.test.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.test.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.test.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.test.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.test.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.test.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts`
- `packages/requirements/src/runRequirements.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (12)**
- `packages/requirements/src/execCliCommand.test.ts`
- `packages/requirements/src/getAffectedWorkspaces.test.ts`
- `packages/requirements/src/report.test.ts`
- `packages/requirements/src/requirements/agents-skills/requireAgentsSkills.test.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.test.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.test.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.test.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.test.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.test.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.test.ts`
- `packages/requirements/src/runRequirements.test.ts`

_Updated: 2026-07-27T17:01:47.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/requirements-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/requirements-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/requirements-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/requirements-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:05:15.787Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:04:04.882Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->