### PR TITLE
test(suite-desktop-api): co-locate tests

### DIFF
--- a/packages/suite-desktop-api/mocks/mockIpcRenderer.ts
+++ b/packages/suite-desktop-api/mocks/mockIpcRenderer.ts
@@ -1,7 +1,7 @@
 import type { IpcRendererEvent } from 'electron';
 import { EventEmitter } from 'events';
 
-import { type StrictIpcRenderer } from '../ipc';
+import { type StrictIpcRenderer } from '../src/ipc';
 
 class IpcRendererMock extends EventEmitter implements StrictIpcRenderer<any, IpcRendererEvent> {
     send(..._args: any[]) {}

--- a/packages/suite-desktop-api/src/api.test.ts
+++ b/packages/suite-desktop-api/src/api.test.ts
@@ -1,5 +1,5 @@
-import { ipcRenderer } from './ipcRenderer';
-import { getDesktopApi } from '../main';
+import { getDesktopApi } from './main';
+import { ipcRenderer } from '../mocks/mockIpcRenderer';
 
 const api = getDesktopApi(ipcRenderer);
 if (!api) throw new Error('desktopApi not initialized');

--- a/packages/suite-desktop-api/src/renderer.test.ts
+++ b/packages/suite-desktop-api/src/renderer.test.ts
@@ -1,6 +1,6 @@
-import { factory } from '../factory';
-import { desktopApi, getDesktopApi } from '../renderer';
-import { ipcRenderer } from './ipcRenderer';
+import { factory } from './factory';
+import { desktopApi, getDesktopApi } from './renderer';
+import { ipcRenderer } from '../mocks/mockIpcRenderer';
 
 describe('Renderer', () => {
     it('api is not defined', async () => {

--- a/packages/suite-desktop-api/src/validation.test.ts
+++ b/packages/suite-desktop-api/src/validation.test.ts
@@ -1,4 +1,4 @@
-import * as validation from '../validation';
+import * as validation from './validation';
 
 describe('Validation', () => {
     it('isPrimitive', () => {


### PR DESCRIPTION
## Description

Moves all 3 suite-desktop-api tests beside their source files and relocates the IPC renderer mock to package mocks without changing test behavior.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-desktop-api-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-desktop-api-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-desktop-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-desktop-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:13:20.757Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:13:01.303Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->