### PR TITLE
test(transport): co-locate UDP API test

### DIFF
--- a/packages/transport/src/api/udp.test.ts
+++ b/packages/transport/src/api/udp.test.ts
@@ -2,7 +2,7 @@ import UDP from 'dgram';
 
 import { PathInternal } from '@trezor/transport-common';
 
-import { UdpApi } from '../src/api/udp';
+import { UdpApi } from './udp';
 
 // mock dgram api
 jest.mock('dgram', () => ({

--- a/packages/transport/tsconfig.lib.json
+++ b/packages/transport/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
+    "exclude": ["./src/**/*.test.ts"],
     "compilerOptions": {
         "outDir": "./lib",
         "rootDir": "./src",


### PR DESCRIPTION
## Description

Moves the transport UDP API test beside its source file without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to a unit test file for the UDP transport API and a TypeScript project config (tsconfig.lib.json) within the transport package — neither of these are part of the E2E test suite's static coverage graph, and no E2E test directly exercises UDP transport functionality. Since udp.test.ts is itself a test file (likely run via unit/jest test runners, not Playwright E2E) and tsconfig.lib.json only affects build/type-checking, the risk of breaking E2E-visible behavior is low. We recommend running the unit test suite for the transport package directly rather than E2E tests; only a low-priority E2E smoke check on session/transport-adjacent flows is suggested out of caution.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport/src/api/udp.test.ts`
- `packages/transport/tsconfig.lib.json`

</details>

**Recommended tests (1)**

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises Bridge transport session management (device status, session takeover) which is functionally adjacent to the UDP transport API being changed; a transport-layer regression could plausibly surface in session handling behavior, though the change is isolated to a unit test file and a tsconfig, making direct impact unlikely.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/transport/src/api/udp.test.ts`
- `packages/transport/tsconfig.lib.json`

_Updated: 2026-07-27T17:13:48.997Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/transport-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/transport-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/transport-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/transport-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:17:36.564Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:17:35.219Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->