### PR TITLE
test(transport-bridge): co-locate tests

### DIFF
--- a/packages/transport-bridge/src/core.test.ts
+++ b/packages/transport-bridge/src/core.test.ts
@@ -1,6 +1,6 @@
-import { AbstractApi, PathPublic } from '@trezor/transport-common';
+import { type AbstractApi, PathPublic } from '@trezor/transport-common';
 
-import { createCore } from '../src/core';
+import { createCore } from './core';
 
 /**
  * Lock-safety of the node-bridge core acquire/release wrappers around

--- a/packages/transport-bridge/src/http.test.ts
+++ b/packages/transport-bridge/src/http.test.ts
@@ -2,10 +2,10 @@ import EventEmitter from 'events';
 
 import { getFreePort } from '@trezor/node-utils';
 import { UdpApi } from '@trezor/transport/src/api/udp';
-import { AbstractApi, AbstractApiArgs, bridgeApiCall } from '@trezor/transport-common';
+import { type AbstractApi, type AbstractApiArgs, bridgeApiCall } from '@trezor/transport-common';
 import { resolveAfter } from '@trezor/utils';
 
-import { TrezordNode } from '../src/http';
+import { TrezordNode } from './http';
 
 const muteLogger = {
     info: (..._args: string[]) => {},


### PR DESCRIPTION
## Description

Moves both transport-bridge tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to unit tests for the transport-bridge package's core logic and HTTP server (core.test.ts, http.test.ts), with no static E2E coverage mapping available. Since these files test the bridge daemon's fundamental process and API behavior, the most relevant E2E tests are those that directly exercise bridge spawning, HTTP endpoints, and session/connection management (spawn-bridge-daemon, spawn-bridge, multiple-sessions, and the bridge page test). Recovery dry-run tests are included at low priority since they incidentally exercise bridge stop/start during disconnect simulation, but are less directly tied to the core bridge changes.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport-bridge/src/core.test.ts`
- `packages/transport-bridge/src/http.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test directly exercises the bridge daemon process lifecycle (spawning, running, stopping) which is core functionality implemented in packages/transport-bridge/src/core.ts and http.ts - the files whose unit tests were changed. Any regression in bridge core logic or HTTP server handling would likely break this daemon spawning/stopping behavior.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test exercises the bundled bridge process lifecycle including HTTP API version endpoint checks, restart/reconnect behavior, and device reconnection after bridge restart - all of which depend on the bridge core and HTTP handling logic covered by the changed test files.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/suite/bridge.test.ts` — This test exercises the Bridge page and connect device prompt flow, which relies on the bridge transport/HTTP layer being correctly functional; a regression in core bridge logic could affect the WebUSB fallback and connect prompt behavior tested here.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test heavily exercises bridge session management (enumerate/acquire, session takeover, reclaim) which is directly implemented in the bridge core logic; changes to core.ts or http.ts session handling could cause regressions in session stealing/reclaiming flows.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — This test includes bridge stop/start scenarios during a recovery dry run to simulate disconnect/reconnect, exercising bridge core connection handling that could be affected by changes to the bridge's core logic.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Similar to the other dry-run test, this exercises bridge stop/start behavior during device recovery, touching the same bridge core connection logic that was modified.

</details>

_Updated: 2026-07-27T17:15:37.390Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/transport-bridge-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/transport-bridge-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/transport-bridge-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/transport-bridge-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:19:40.925Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:18:56.205Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->