### PR TITLE
test(transport-common): co-locate tests

### DIFF
--- a/packages/transport-common/src/api/usb.test.ts
+++ b/packages/transport-common/src/api/usb.test.ts
@@ -1,13 +1,13 @@
 import { createDeferred } from '@trezor/utils';
 
-import { UsbApi } from '../src/api/usb';
-import { PathInternal } from '../src/types';
+import { PathInternal } from '../types';
+import { UsbApi } from './usb';
 import type {
     UsbDeviceLike,
     UsbInTransferResultLike,
     UsbInterfaceApi,
     UsbOutTransferResultLike,
-} from '../src/types/usbInterface';
+} from '../types/usbInterface';
 
 const createTransferInResult = (size = 64) =>
     ({

--- a/packages/transport-common/src/sessions/background.fuzz.test.ts
+++ b/packages/transport-common/src/sessions/background.fuzz.test.ts
@@ -1,8 +1,8 @@
 import fc from 'fast-check';
 
-import { SessionsBackground } from '../src/sessions/background';
-import { SessionsClient } from '../src/sessions/client';
-import { Descriptor, PathInternal, PathPublic, Session } from '../src/types';
+import { type Descriptor, PathInternal, PathPublic, Session } from '../types';
+import { SessionsBackground } from './background';
+import { SessionsClient } from './client';
 
 /**
  * Concurrency fuzz harness for the sessions lock / stealing protocol.

--- a/packages/transport-common/src/sessions/background.test.ts
+++ b/packages/transport-common/src/sessions/background.test.ts
@@ -1,7 +1,7 @@
-import { SessionsBackground } from '../src/sessions/background';
-import { SessionsClient } from '../src/sessions/client';
-import { type SessionsBackgroundInterface } from '../src/sessions/types';
-import { PathInternal, PathPublic, Session } from '../src/types';
+import { PathInternal, PathPublic, Session } from '../types';
+import { SessionsBackground } from './background';
+import { SessionsClient } from './client';
+import { type SessionsBackgroundInterface } from './types';
 
 describe('sessions', () => {
     let background: SessionsBackground;

--- a/packages/transport-common/src/thp/index.test.ts
+++ b/packages/transport-common/src/thp/index.test.ts
@@ -2,12 +2,9 @@ import { protobufManager } from '@trezor/protobuf';
 import * as thpProto from '@trezor/protobuf/src/definitions/messages-thp_pb';
 import { thp as protocolThp, v2 } from '@trezor/protocol';
 
-import { parseThpMessage, receiveThpMessage, sendThpMessage } from '../src/thp';
-import {
-    ATTEMPTS_LIMIT,
-    THP_ACK_DEADLINE,
-    THP_ACK_TIMEOUT,
-} from '../src/thp/receiveExpectedMessage';
+import { ATTEMPTS_LIMIT, THP_ACK_DEADLINE, THP_ACK_TIMEOUT } from './receiveExpectedMessage';
+
+import { parseThpMessage, receiveThpMessage, sendThpMessage } from './index';
 
 protobufManager.load([thpProto]);
 

--- a/packages/transport-common/src/transports/abstractApi.test.ts
+++ b/packages/transport-common/src/transports/abstractApi.test.ts
@@ -4,9 +4,9 @@ import * as commonProto from '@trezor/protobuf/src/definitions/messages-common_p
 import * as messagesProto from '@trezor/protobuf/src/definitions/messages_pb';
 import { v1 as v1Protocol } from '@trezor/protocol';
 
-import { UsbApi } from '../src/api/usb';
-import { AbstractApiTransport } from '../src/transports/abstractApi';
-import { PathPublic, Session } from '../src/types';
+import { UsbApi } from '../api/usb';
+import { PathPublic, Session } from '../types';
+import { AbstractApiTransport } from './abstractApi';
 
 protobufManager.load([commonProto, messagesProto, bitcoinProto]);
 

--- a/packages/transport-common/src/utils/bridgeProtocolMessage.test.ts
+++ b/packages/transport-common/src/utils/bridgeProtocolMessage.test.ts
@@ -1,7 +1,4 @@
-import {
-    type BridgeProtocolMessage,
-    validateProtocolMessage,
-} from '../src/utils/bridgeProtocolMessage';
+import { type BridgeProtocolMessage, validateProtocolMessage } from './bridgeProtocolMessage';
 
 type Fixture = {
     description: string;

--- a/packages/transport-common/src/utils/readMessageBuffer.test.ts
+++ b/packages/transport-common/src/utils/readMessageBuffer.test.ts
@@ -1,5 +1,5 @@
-import { ABORTED_BY_SIGNAL, INTERFACE_DATA_TRANSFER } from '../src/errors';
-import { readMessageBuffer } from '../src/utils/readMessageBuffer';
+import { ABORTED_BY_SIGNAL, INTERFACE_DATA_TRANSFER } from '../errors';
+import { readMessageBuffer } from './readMessageBuffer';
 
 describe('readMessageBuffer', () => {
     it('read from readBuffer', async () => {

--- a/packages/transport-common/src/utils/receive.test.ts
+++ b/packages/transport-common/src/utils/receive.test.ts
@@ -3,8 +3,8 @@ import * as stellarProto from '@trezor/protobuf/src/definitions/messages-stellar
 import * as messagesProto from '@trezor/protobuf/src/definitions/messages_pb';
 import { bridge as bridgeProtocol, v1 as protocolV1, v2 as protocolV2 } from '@trezor/protocol';
 
-import { receive, receiveAndParse } from '../src/utils/receive';
-import { buildMessage, createChunks } from '../src/utils/send';
+import { receive, receiveAndParse } from './receive';
+import { buildMessage, createChunks } from './send';
 
 protobufManager.load([messagesProto, stellarProto]);
 

--- a/packages/transport-common/tsconfig.lib.json
+++ b/packages/transport-common/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.lib.json",
     "include": ["./src"],
+    "exclude": ["./src/**/*.test.ts"],
     "compilerOptions": {
         "lib": ["ES2023"],
         "outDir": "./lib",


### PR DESCRIPTION
## Description

Moves all 8 transport-common tests beside their source files without changing test behavior.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/transport-common-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/transport-common-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/transport-common-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:22:04.972Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:22:02.511Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->