### PR TITLE
test(transport-native-bluetooth): co-locate utils test

### DIFF
--- a/packages/transport-native-bluetooth/src/api/utils.test.ts
+++ b/packages/transport-native-bluetooth/src/api/utils.test.ts
@@ -1,6 +1,6 @@
 import { type Device } from 'react-native-ble-plx';
 
-import { base64ToByteArray, toBluetoothDevice } from '../../api/utils';
+import { base64ToByteArray, toBluetoothDevice } from './utils';
 
 describe(base64ToByteArray.name, () => {
     test.each([


### PR DESCRIPTION
## Description

Moves the transport-native-bluetooth utils test beside its source file without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file (utils.test.ts) within packages/transport-native-bluetooth, which is a native Bluetooth transport module unrelated to the Playwright E2E test suite. None of the 7 candidate E2E tests exercise bluetooth transport utility functions directly — the closest conceptual match (forget-device.test.ts) mocks Bluetooth state at a UI level and does not depend on this low-level utils module. Since this is a self-contained unit test change with no evidence linking it to any E2E flow's code path, no E2E tests are recommended; the change should be validated via its own unit test run instead.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport-native-bluetooth/src/api/utils.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/transport-native-bluetooth/src/api/utils.test.ts`

_Updated: 2026-07-27T17:19:34.315Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/transport-native-bluetooth-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/transport-native-bluetooth-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/transport-native-bluetooth-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/transport-native-bluetooth-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:23:10.492Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:22:55.347Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->