### PR TITLE
test(websocket-client): co-locate client test

### DIFF
--- a/packages/websocket-client/src/client.test.ts
+++ b/packages/websocket-client/src/client.test.ts
@@ -1,6 +1,6 @@
 import { type ServerOptions, type WebSocket, WebSocketServer } from 'ws';
 
-import { WebsocketClient } from '../src/client';
+import { WebsocketClient } from './client';
 
 class Client extends WebsocketClient<{ 'foo-event': 'bar-event' }> {}
 

--- a/packages/websocket-client/tsconfig.lib.json
+++ b/packages/websocket-client/tsconfig.lib.json
@@ -7,5 +7,6 @@
         "types": ["jest", "node", "web"]
     },
     "include": ["./src"],
+    "exclude": ["./src/**/*.test.ts"],
     "references": [{ "path": "../utils" }]
 }


### PR DESCRIPTION
## Description

Moves the websocket-client test beside its source file without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are internal to packages/websocket-client (a unit test file for the websocket client and its TypeScript build config) and are unrelated to any of the 13 candidate E2E tests, which all cover Suite UI flows like onboarding, metadata/Suite Sync labeling, WalletConnect, and TrezorConnect API interactions. None of the LLM analysis for these tests mentions websocket-client internals, so there is no direct or plausible indirect code path connecting this change to E2E behavior. The websocket-client's own unit test (client.test.ts) is the appropriate validation mechanism for this change, and no E2E test should be prioritized based on the available evidence.

<details><summary><b>Changed files (2)</b></summary>

- `packages/websocket-client/src/client.test.ts`
- `packages/websocket-client/tsconfig.lib.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/websocket-client/src/client.test.ts`
- `packages/websocket-client/tsconfig.lib.json`

_Updated: 2026-07-27T17:23:08.979Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/websocket-client-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/websocket-client-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/websocket-client-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/websocket-client-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:26:33.405Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:26:23.403Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->