### PR TITLE
docs(tests): align suite-common test naming

### DIFF
--- a/skills/tests-common/SKILL.md
+++ b/skills/tests-common/SKILL.md
@@ -39,5 +39,5 @@ Before submitting code, ensure:
 - [ ] Correct render function used (`renderHookWithStoreProvider` for hooks needing store, `renderHook` otherwise)
 - [ ] Fixtures are properly typed
 - [ ] Tests focus on behavior, not implementation
-- [ ] Tests follow naming conventions (.hook.test.ts, .test.ts)
+- [ ] Tests follow the `.test.ts` or `.test.tsx` naming convention
 - [ ] All tests pass locally


### PR DESCRIPTION
## Description

Updates the suite-common test skill to use the plain .test.ts and .test.tsx naming convention decided in #25300.