### PR TITLE
test(calldata): co-locate builder tests

### DIFF
--- a/suite-common/calldata/src/builder/createBuilder.test.ts
+++ b/suite-common/calldata/src/builder/createBuilder.test.ts
@@ -1,6 +1,6 @@
-import { createBuilder } from '../../builder/createBuilder';
-import { type Encoder } from '../../types/builder';
-import { type IssueWithSeverity } from '../../types/policy';
+import { createBuilder } from './createBuilder';
+import { type Encoder } from '../types/builder';
+import { type IssueWithSeverity } from '../types/policy';
 
 describe('createBuilder', () => {
     it('calls params and encode, returns encoded data when all valid', () => {

--- a/suite-common/calldata/src/builder/createCrossValidator.test.ts
+++ b/suite-common/calldata/src/builder/createCrossValidator.test.ts
@@ -1,5 +1,5 @@
-import { createCrossValidator } from '../../builder/createCrossValidator';
-import { createPolicy } from '../../policy/createPolicy';
+import { createCrossValidator } from './createCrossValidator';
+import { createPolicy } from '../policy/createPolicy';
 
 describe('createCrossValidator', () => {
     it('returns empty array when validate returns null', () => {

--- a/suite-common/calldata/src/builder/createParam.test.ts
+++ b/suite-common/calldata/src/builder/createParam.test.ts
@@ -1,4 +1,4 @@
-import { createParam } from '../../builder/createParam';
+import { createParam } from './createParam';
 
 describe('createParam', () => {
     it('calls validate and policy, returns combined result', () => {

--- a/suite-common/calldata/src/builder/evm/allowance.test.ts
+++ b/suite-common/calldata/src/builder/evm/allowance.test.ts
@@ -1,5 +1,5 @@
-import { buildAllowance } from '../../../builder/evm/allowance';
-import { asEvmAddress } from '../../../types/evm';
+import { buildAllowance } from './allowance';
+import { asEvmAddress } from '../../types/evm';
 
 const OWNER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');

--- a/suite-common/calldata/src/builder/evm/approve.test.ts
+++ b/suite-common/calldata/src/builder/evm/approve.test.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildApprove } from '../../../builder/evm/approve';
-import { asEvmAddress } from '../../../types/evm';
-import { UINT256_MAX } from '../../../validation/shared/uint256';
+import { buildApprove } from './approve';
+import { asEvmAddress } from '../../types/evm';
+import { UINT256_MAX } from '../../validation/shared/uint256';
 
 const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
 const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');

--- a/suite-common/calldata/src/builder/evm/claim.test.ts
+++ b/suite-common/calldata/src/builder/evm/claim.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildClaim } from '../../../builder/evm/claim';
-import { asEvmAddress } from '../../../types/evm';
+import { buildClaim } from './claim';
+import { asEvmAddress } from '../../types/evm';
 
 const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 const TOKEN = asEvmAddress('0x58D97B57BB95320F9a05dC918Aef65434969c2B2');

--- a/suite-common/calldata/src/builder/evm/deposit.test.ts
+++ b/suite-common/calldata/src/builder/evm/deposit.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildDeposit } from '../../../builder/evm/deposit';
-import { asEvmAddress } from '../../../types/evm';
+import { buildDeposit } from './deposit';
+import { asEvmAddress } from '../../types/evm';
 
 const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 

--- a/suite-common/calldata/src/builder/evm/everstake/claimWithdrawRequest.test.ts
+++ b/suite-common/calldata/src/builder/evm/everstake/claimWithdrawRequest.test.ts
@@ -1,4 +1,4 @@
-import { buildClaimWithdrawRequest } from '../../../../builder/evm/everstake/claimWithdrawRequest';
+import { buildClaimWithdrawRequest } from './claimWithdrawRequest';
 
 describe('buildClaimWithdrawRequest', () => {
     it('encodes claimWithdrawRequest selector with no args', () => {

--- a/suite-common/calldata/src/builder/evm/everstake/stake.test.ts
+++ b/suite-common/calldata/src/builder/evm/everstake/stake.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildStake } from '../../../../builder/evm/everstake/stake';
+import { buildStake } from './stake';
 
 describe('buildStake', () => {
     it('encodes valid stake calldata for source = 1', () => {

--- a/suite-common/calldata/src/builder/evm/everstake/unstake.test.ts
+++ b/suite-common/calldata/src/builder/evm/everstake/unstake.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildUnstake } from '../../../../builder/evm/everstake/unstake';
+import { buildUnstake } from './unstake';
 
 describe('buildUnstake', () => {
     it('encodes valid unstake calldata', () => {

--- a/suite-common/calldata/src/builder/evm/redeem.test.ts
+++ b/suite-common/calldata/src/builder/evm/redeem.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildRedeem } from '../../../builder/evm/redeem';
-import { asEvmAddress } from '../../../types/evm';
+import { buildRedeem } from './redeem';
+import { asEvmAddress } from '../../types/evm';
 
 const SENDER = asEvmAddress('0x44Ab691a7492C3dCb88241AF8aC5371d84B61BB6');
 

--- a/suite-common/calldata/src/builder/evm/transfer.test.ts
+++ b/suite-common/calldata/src/builder/evm/transfer.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildTransfer } from '../../../builder/evm/transfer';
-import { asEvmAddress } from '../../../types/evm';
+import { buildTransfer } from './transfer';
+import { asEvmAddress } from '../../types/evm';
 
 const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 const RECIPIENT = asEvmAddress('0xB836472D21991eB9842e15BEaE1AF6c8B63D6a96');

--- a/suite-common/calldata/src/builder/evm/weth/deposit.test.ts
+++ b/suite-common/calldata/src/builder/evm/weth/deposit.test.ts
@@ -1,4 +1,4 @@
-import { buildWethDeposit } from '../../../../builder/evm/weth/deposit';
+import { buildWethDeposit } from './deposit';
 
 describe('buildWethDeposit', () => {
     it('encodes the deposit selector with no args', () => {

--- a/suite-common/calldata/src/builder/evm/weth/withdraw.test.ts
+++ b/suite-common/calldata/src/builder/evm/weth/withdraw.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildWethWithdraw } from '../../../../builder/evm/weth/withdraw';
-import { Calldata } from '../../../../calldata';
+import { buildWethWithdraw } from './withdraw';
+import { Calldata } from '../../../calldata';
 
 describe('buildWethWithdraw', () => {
     it('encodes valid withdraw calldata', () => {

--- a/suite-common/calldata/src/builder/evm/withdraw.test.ts
+++ b/suite-common/calldata/src/builder/evm/withdraw.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildWithdraw } from '../../../builder/evm/withdraw';
-import { asEvmAddress } from '../../../types/evm';
+import { buildWithdraw } from './withdraw';
+import { asEvmAddress } from '../../types/evm';
 
 const SENDER = asEvmAddress('0x22E228AdE324185123A54Ad25F3459a99CF51E7a');
 

--- a/suite-common/calldata/src/builder/tron/trc20/transfer.test.ts
+++ b/suite-common/calldata/src/builder/tron/trc20/transfer.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildTrc20Transfer } from '../../../../builder/tron/trc20/transfer';
-import { asTronAddress } from '../../../../types/tron';
+import { buildTrc20Transfer } from './transfer';
+import { asTronAddress } from '../../../types/tron';
 
 const SENDER = asTronAddress('TX5XiRXdyz7sdFwF5mnhT1QoGCpbkncpke');
 const RECIPIENT = asTronAddress('TKWJhMU8NAviZ9TN5hroaFQPZ83FNctzz4');


### PR DESCRIPTION
## Description

Moves all 16 calldata builder tests beside their source files without changing test behavior.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/calldata-builder-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/calldata-builder-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/calldata-builder-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:29:53.910Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:29:23.327Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/calldata-builder-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/calldata-builder-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit tests within the suite-common/calldata package covering low-level EVM/TRON calldata encoding builders (transfer, approve, allowance, deposit, withdraw, redeem, claim, everstake staking/unstaking, WETH deposit/withdraw, TRC20 transfer, and core builder/validator/param utilities). These are unit-level test files, not E2E tests, and there is no static E2E coverage mapping for them. Since these builders underpin transaction data construction for staking (Everstake) and token transfer/approve flows, the most relevant E2E risk surface is in the staking (ETH stake/unstake) and swap/send flows that display and broadcast calldata-derived transactions on-device — these are included as inferred, lower-confidence recommendations. Given the changes are isolated to unit tests for calldata builders, the primary safety net is the unit test suite itself; E2E runs should be limited to a few staking/swap/send smoke tests to catch any transaction-encoding regressions surfaced at the UI/device level.

<details><summary><b>Changed files (16)</b></summary>

- `suite-common/calldata/src/builder/createBuilder.test.ts`
- `suite-common/calldata/src/builder/createCrossValidator.test.ts`
- `suite-common/calldata/src/builder/createParam.test.ts`
- `suite-common/calldata/src/builder/evm/allowance.test.ts`
- `suite-common/calldata/src/builder/evm/approve.test.ts`
- `suite-common/calldata/src/builder/evm/claim.test.ts`
- `suite-common/calldata/src/builder/evm/deposit.test.ts`
- `suite-common/calldata/src/builder/evm/everstake/claimWithdrawRequest.test.ts`
- `suite-common/calldata/src/builder/evm/everstake/stake.test.ts`
- `suite-common/calldata/src/builder/evm/everstake/unstake.test.ts`
- `suite-common/calldata/src/builder/evm/redeem.test.ts`
- `suite-common/calldata/src/builder/evm/transfer.test.ts`
- `suite-common/calldata/src/builder/evm/weth/deposit.test.ts`
- `suite-common/calldata/src/builder/evm/weth/withdraw.test.ts`
- `suite-common/calldata/src/builder/evm/withdraw.test.ts`
- `suite-common/calldata/src/builder/tron/trc20/transfer.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This E2E test exercises ETH staking transactions on the Everstake contract, which rely on the calldata builder functions for staking/deposit encoding (e.g. everstake/stake, deposit). Changes to the calldata builders could break the encoded transaction data used in this staking flow.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test performs a first-time ETH stake via the Everstake contract, directly depending on calldata encoding logic (stake/deposit builders) that was modified in this changeset.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test performs ETH unstaking and claiming flows, which likely rely on the everstake unstake/claimWithdrawRequest and withdraw calldata builders that were changed, risking malformed transaction data if encoding logic regresses.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This DEX swap test involves approve/transfer-style calldata for token swaps; if the approve or transfer calldata builders changed, the encoded contract call amounts/fees shown on-device could be affected.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Basic ETH sends may use the transfer calldata builder for token/native transfers; a regression in transfer encoding could subtly break send transaction data despite this being primarily a native ETH send test.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/calldata/src/builder/createBuilder.test.ts`
- `suite-common/calldata/src/builder/createCrossValidator.test.ts`
- `suite-common/calldata/src/builder/createParam.test.ts`
- `suite-common/calldata/src/builder/evm/allowance.test.ts`
- `suite-common/calldata/src/builder/evm/redeem.test.ts`
- `suite-common/calldata/src/builder/evm/weth/deposit.test.ts`
- `suite-common/calldata/src/builder/evm/weth/withdraw.test.ts`
- `suite-common/calldata/src/builder/tron/trc20/transfer.test.ts`

_Updated: 2026-07-27T17:31:30.225Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->