### PR TITLE
test(calldata): co-locate verifier tests

### DIFF
--- a/suite-common/calldata/src/verifier/createVerifier.test.ts
+++ b/suite-common/calldata/src/verifier/createVerifier.test.ts
@@ -2,10 +2,10 @@ import { parseAbi } from 'viem';
 
 import { BigNumber } from '@trezor/utils';
 
-import { buildApprove } from '../../builder/evm/approve';
-import { EVM_ABI } from '../../constants/evm';
-import { asEvmAddress } from '../../types/evm';
-import { createVerifier } from '../../verifier/createVerifier';
+import { createVerifier } from './createVerifier';
+import { buildApprove } from '../builder/evm/approve';
+import { EVM_ABI } from '../constants/evm';
+import { asEvmAddress } from '../types/evm';
 
 const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
 const SPENDER_CHECKSUMMED = asEvmAddress('0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE');

--- a/suite-common/calldata/src/verifier/evm/allowance.test.ts
+++ b/suite-common/calldata/src/verifier/evm/allowance.test.ts
@@ -1,6 +1,6 @@
-import { buildAllowance } from '../../../builder/evm/allowance';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildAllowance } from '../../builder/evm/allowance';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const OWNER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');

--- a/suite-common/calldata/src/verifier/evm/approve.test.ts
+++ b/suite-common/calldata/src/verifier/evm/approve.test.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildApprove } from '../../../builder/evm/approve';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildApprove } from '../../builder/evm/approve';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const SPENDER = asEvmAddress('0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae');
 const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');

--- a/suite-common/calldata/src/verifier/evm/claim.test.ts
+++ b/suite-common/calldata/src/verifier/evm/claim.test.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildClaim } from '../../../builder/evm/claim';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildClaim } from '../../builder/evm/claim';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const SENDER = asEvmAddress('0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3');
 const TOKEN = asEvmAddress('0x58D97B57BB95320F9a05dC918Aef65434969c2B2');

--- a/suite-common/calldata/src/verifier/evm/deposit.test.ts
+++ b/suite-common/calldata/src/verifier/evm/deposit.test.ts
@@ -1,8 +1,8 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildDeposit } from '../../../builder/evm/deposit';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildDeposit } from '../../builder/evm/deposit';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const RECEIVER = SENDER;

--- a/suite-common/calldata/src/verifier/evm/everstake/claimWithdrawRequest.test.ts
+++ b/suite-common/calldata/src/verifier/evm/everstake/claimWithdrawRequest.test.ts
@@ -1,4 +1,4 @@
-import { Verifier } from '../../../../verifier';
+import { Verifier } from '../../../verifier';
 
 const claimWithdrawRequestHex = '0x33986ffa';
 

--- a/suite-common/calldata/src/verifier/evm/everstake/stake.test.ts
+++ b/suite-common/calldata/src/verifier/evm/everstake/stake.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildStake } from '../../../../builder/evm/everstake/stake';
-import { Verifier } from '../../../../verifier';
+import { buildStake } from '../../../builder/evm/everstake/stake';
+import { Verifier } from '../../../verifier';
 
 const SOURCE = 1n;
 

--- a/suite-common/calldata/src/verifier/evm/everstake/unstake.test.ts
+++ b/suite-common/calldata/src/verifier/evm/everstake/unstake.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildUnstake } from '../../../../builder/evm/everstake/unstake';
-import { Verifier } from '../../../../verifier';
+import { buildUnstake } from '../../../builder/evm/everstake/unstake';
+import { Verifier } from '../../../verifier';
 
 const VALUE = 100000000000000000n;
 const ALLOWED_INTERCHANGE_NUM = 5;

--- a/suite-common/calldata/src/verifier/evm/redeem.test.ts
+++ b/suite-common/calldata/src/verifier/evm/redeem.test.ts
@@ -1,49 +1,49 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildWithdraw } from '../../../builder/evm/withdraw';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildRedeem } from '../../builder/evm/redeem';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const RECEIVER = SENDER;
 const OWNER = SENDER;
-const ASSETS = 1000000n;
+const SHARES = 1000000n;
 
-const withdrawHex = buildWithdraw(
+const redeemHex = buildRedeem(
     {
-        assets: new BigNumber(ASSETS.toString()),
+        shares: new BigNumber(SHARES.toString()),
         receiver: RECEIVER,
         owner: OWNER,
     },
     { sender: SENDER },
 ).data!;
 
-describe('verifyWithdraw', () => {
+describe('verifyRedeem', () => {
     it('returns isValid true on full match', () => {
         expect(
-            Verifier.evm.erc4626.withdraw(withdrawHex, {
-                assets: ASSETS,
+            Verifier.evm.erc4626.redeem(redeemHex, {
+                shares: SHARES,
                 receiver: RECEIVER,
                 owner: OWNER,
             }),
         ).toEqual({ isValid: true, issues: [] });
     });
 
-    it('returns VALUE_MISMATCH on full mismatch', () => {
+    it('returns VALUE_MISMATCH on shares mismatch', () => {
         expect(
-            Verifier.evm.erc4626.withdraw(withdrawHex, {
-                assets: 999n,
+            Verifier.evm.erc4626.redeem(redeemHex, {
+                shares: 999n,
                 receiver: RECEIVER,
                 owner: OWNER,
             }),
-        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'assets' }] });
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'shares' }] });
     });
 
     it('returns isValid true when partial checked fields match', () => {
         expect(
-            Verifier.evm.erc4626.withdraw(
-                withdrawHex,
-                { assets: 999n, receiver: RECEIVER, owner: OWNER },
+            Verifier.evm.erc4626.redeem(
+                redeemHex,
+                { shares: 999n, receiver: RECEIVER, owner: OWNER },
                 ['receiver', 'owner'],
             ),
         ).toEqual({ isValid: true, issues: [] });

--- a/suite-common/calldata/src/verifier/evm/weth/deposit.test.ts
+++ b/suite-common/calldata/src/verifier/evm/weth/deposit.test.ts
@@ -1,5 +1,5 @@
-import { buildWethDeposit } from '../../../../builder/evm/weth/deposit';
-import { Verifier } from '../../../../verifier';
+import { buildWethDeposit } from '../../../builder/evm/weth/deposit';
+import { Verifier } from '../../../verifier';
 
 const depositHex = buildWethDeposit({}).data!;
 

--- a/suite-common/calldata/src/verifier/evm/weth/withdraw.test.ts
+++ b/suite-common/calldata/src/verifier/evm/weth/withdraw.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildWethWithdraw } from '../../../../builder/evm/weth/withdraw';
-import { Verifier } from '../../../../verifier';
+import { buildWethWithdraw } from '../../../builder/evm/weth/withdraw';
+import { Verifier } from '../../../verifier';
 
 const WAD = 1_000_000_000_000_000_000n;
 const withdrawHex = buildWethWithdraw({ wad: new BigNumber(WAD.toString()) }).data!;

--- a/suite-common/calldata/src/verifier/evm/withdraw.test.ts
+++ b/suite-common/calldata/src/verifier/evm/withdraw.test.ts
@@ -1,49 +1,49 @@
 import { BigNumber } from '@trezor/utils';
 
-import { buildRedeem } from '../../../builder/evm/redeem';
-import { asEvmAddress } from '../../../types/evm';
-import { Verifier } from '../../../verifier';
+import { buildWithdraw } from '../../builder/evm/withdraw';
+import { asEvmAddress } from '../../types/evm';
+import { Verifier } from '../../verifier';
 
 const SENDER = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const RECEIVER = SENDER;
 const OWNER = SENDER;
-const SHARES = 1000000n;
+const ASSETS = 1000000n;
 
-const redeemHex = buildRedeem(
+const withdrawHex = buildWithdraw(
     {
-        shares: new BigNumber(SHARES.toString()),
+        assets: new BigNumber(ASSETS.toString()),
         receiver: RECEIVER,
         owner: OWNER,
     },
     { sender: SENDER },
 ).data!;
 
-describe('verifyRedeem', () => {
+describe('verifyWithdraw', () => {
     it('returns isValid true on full match', () => {
         expect(
-            Verifier.evm.erc4626.redeem(redeemHex, {
-                shares: SHARES,
+            Verifier.evm.erc4626.withdraw(withdrawHex, {
+                assets: ASSETS,
                 receiver: RECEIVER,
                 owner: OWNER,
             }),
         ).toEqual({ isValid: true, issues: [] });
     });
 
-    it('returns VALUE_MISMATCH on shares mismatch', () => {
+    it('returns VALUE_MISMATCH on full mismatch', () => {
         expect(
-            Verifier.evm.erc4626.redeem(redeemHex, {
-                shares: 999n,
+            Verifier.evm.erc4626.withdraw(withdrawHex, {
+                assets: 999n,
                 receiver: RECEIVER,
                 owner: OWNER,
             }),
-        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'shares' }] });
+        ).toEqual({ isValid: false, issues: [{ code: 'VALUE_MISMATCH', field: 'assets' }] });
     });
 
     it('returns isValid true when partial checked fields match', () => {
         expect(
-            Verifier.evm.erc4626.redeem(
-                redeemHex,
-                { shares: 999n, receiver: RECEIVER, owner: OWNER },
+            Verifier.evm.erc4626.withdraw(
+                withdrawHex,
+                { assets: 999n, receiver: RECEIVER, owner: OWNER },
                 ['receiver', 'owner'],
             ),
         ).toEqual({ isValid: true, issues: [] });


### PR DESCRIPTION
## Description

Moves all 12 calldata verifier tests beside the verifier implementation without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit tests within the suite-common/calldata verifier package (EVM calldata verification logic for approve, allowance, claim, deposit, redeem, withdraw, WETH deposit/withdraw, and Everstake stake/unstake/claimWithdrawRequest operations). These are unit-level test files with no direct static E2E coverage mapping, so recommendations are inferred based on functional overlap: E2E tests that exercise ETH staking/unstaking via Everstake contracts are the most direct behavioral analogs since they invoke the same calldata construction/verification logic during transaction signing. Since these are unit test changes to a narrowly-scoped calldata verification library (not consumed broadly across dozens of E2E flows per the static mapping), the primary confidence should come from running the unit tests themselves; the recommended E2E tests serve as an additional integration-level sanity check on ETH/Everstake staking flows.

<details><summary><b>Changed files (12)</b></summary>

- `suite-common/calldata/src/verifier/createVerifier.test.ts`
- `suite-common/calldata/src/verifier/evm/allowance.test.ts`
- `suite-common/calldata/src/verifier/evm/approve.test.ts`
- `suite-common/calldata/src/verifier/evm/claim.test.ts`
- `suite-common/calldata/src/verifier/evm/deposit.test.ts`
- `suite-common/calldata/src/verifier/evm/everstake/claimWithdrawRequest.test.ts`
- `suite-common/calldata/src/verifier/evm/everstake/stake.test.ts`
- `suite-common/calldata/src/verifier/evm/everstake/unstake.test.ts`
- `suite-common/calldata/src/verifier/evm/redeem.test.ts`
- `suite-common/calldata/src/verifier/evm/weth/deposit.test.ts`
- `suite-common/calldata/src/verifier/evm/weth/withdraw.test.ts`
- `suite-common/calldata/src/verifier/evm/withdraw.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises ETH staking (stake more) transactions via Everstake, which involves signing and verifying calldata for stake/deposit operations on the Everstake contract - directly related to the changed evm/everstake/stake.test.ts and deposit.test.ts verifier logic.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Initial ETH staking flow signs a stake transaction to the Everstake contract, exercising the same calldata verification path (stake/deposit) that was changed in the verifier test files.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claiming flows exercise Everstake unstake and claim-withdraw-request calldata verification, directly corresponding to the changed everstake/unstake.test.ts and everstake/claimWithdrawRequest.test.ts files.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send transactions may pass through generic EVM calldata verification (approve/allowance) if any contract interaction data is included, but this test primarily covers plain ETH transfers so relevance is limited.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Ethereum swap transactions with custom fees may involve calldata verification for approve/redeem operations during token swaps, touching the same verifier code paths that were changed.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-common/calldata/src/verifier/createVerifier.test.ts`
- `suite-common/calldata/src/verifier/evm/claim.test.ts`
- `suite-common/calldata/src/verifier/evm/weth/deposit.test.ts`
- `suite-common/calldata/src/verifier/evm/weth/withdraw.test.ts`

_Updated: 2026-07-27T17:31:18.492Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/calldata-verifier-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/calldata-verifier-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/calldata-verifier-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/calldata-verifier-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/calldata-verifier-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:34:15.447Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:34:12.921Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->