### PR TITLE
test(suite-sync): co-locate relay tests

### DIFF
--- a/suite-common/suite-sync/src/relay/createChangeRelayUrl.test.ts
+++ b/suite-common/suite-sync/src/relay/createChangeRelayUrl.test.ts
@@ -2,8 +2,8 @@ import type { UnknownAction } from '@reduxjs/toolkit';
 
 import { mock } from '@suite-common/dependency-injection';
 
-import { setSuiteSyncRelayUrl } from '../../suiteSyncSlice';
-import { type ChangeRelayUrlDeps, createChangeRelayUrl } from '../createChangeRelayUrl';
+import { setSuiteSyncRelayUrl } from '../suiteSyncSlice';
+import { type ChangeRelayUrlDeps, createChangeRelayUrl } from './createChangeRelayUrl';
 
 describe(createChangeRelayUrl.name, () => {
     it('saves relay url and reconnects all storages', async () => {

--- a/suite-common/suite-sync/src/relay/createDisconnectAllRelays.test.ts
+++ b/suite-common/suite-sync/src/relay/createDisconnectAllRelays.test.ts
@@ -5,7 +5,7 @@ import { type StaticSessionId } from '@trezor/connect';
 import {
     type DisconnectAllRelaysDeps,
     createDisconnectAllRelays,
-} from '../createDisconnectAllRelays';
+} from './createDisconnectAllRelays';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 

--- a/suite-common/suite-sync/src/relay/createReconnectAllRelays.test.ts
+++ b/suite-common/suite-sync/src/relay/createReconnectAllRelays.test.ts
@@ -3,8 +3,8 @@ import { mockSuiteSyncStorage } from '@suite-common/suite-sync-storage/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 import { isCodesignBuild } from '@trezor/env-utils';
 
-import { type WithSuiteSyncState } from '../../suiteSyncSlice';
-import { type ReconnectAllRelaysDeps, createReconnectAllRelays } from '../createReconnectAllRelays';
+import { type WithSuiteSyncState } from '../suiteSyncSlice';
+import { type ReconnectAllRelaysDeps, createReconnectAllRelays } from './createReconnectAllRelays';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),

--- a/suite-common/suite-sync/src/relay/createUpdateRelayConnectionStatus.test.ts
+++ b/suite-common/suite-sync/src/relay/createUpdateRelayConnectionStatus.test.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { createUpdateRelayConnectionStatus } from '../createUpdateRelayConnectionStatus';
+import { createUpdateRelayConnectionStatus } from './createUpdateRelayConnectionStatus';
 
 describe(createUpdateRelayConnectionStatus.name, () => {
     it.each([

--- a/suite-common/suite-sync/src/relay/isUsingTrezorServer.test.ts
+++ b/suite-common/suite-sync/src/relay/isUsingTrezorServer.test.ts
@@ -1,4 +1,4 @@
-import { isUsingTrezorServer } from '../isUsingTrezorServer';
+import { isUsingTrezorServer } from './isUsingTrezorServer';
 
 describe(isUsingTrezorServer.name, () => {
     it.each([

--- a/suite-common/suite-sync/src/relay/relayConnectionSelectors.test.ts
+++ b/suite-common/suite-sync/src/relay/relayConnectionSelectors.test.ts
@@ -1,9 +1,9 @@
-import { type WithSuiteSyncState, initialSuiteSyncState } from '../../suiteSyncSlice';
+import { type WithSuiteSyncState, initialSuiteSyncState } from '../suiteSyncSlice';
 import {
     selectIsSuiteSyncRelayConnected,
     selectLastSuiteSyncRelayDisconnectedTimestamp,
-} from '../relayConnectionSelectors';
-import { type SuiteSyncRelayConnection } from '../relayConnectionStatus';
+} from './relayConnectionSelectors';
+import { type SuiteSyncRelayConnection } from './relayConnectionStatus';
 
 const createState = (relayConnectionStatuses: SuiteSyncRelayConnection[]): WithSuiteSyncState => ({
     suiteSync: {

--- a/suite-common/suite-sync/src/relay/relayUrl.test.ts
+++ b/suite-common/suite-sync/src/relay/relayUrl.test.ts
@@ -1,11 +1,11 @@
 import { isCodesignBuild } from '@trezor/env-utils';
 
-import { type WithSuiteSyncState } from '../../suiteSyncSlice';
+import { type WithSuiteSyncState } from '../suiteSyncSlice';
 import {
     getSuiteSyncDefaultRelayUrl,
     getSuiteSyncRelayUrl,
     selectSuiteSyncRelayUrl,
-} from '../relayUrl';
+} from './relayUrl';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),


### PR DESCRIPTION
## Description

Moves all 7 Suite Sync relay tests beside their source files without changing test behavior.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-sync-relay-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-sync-relay-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-sync-relay-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-sync-relay-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-sync-relay-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:42:31.278Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:42:27.267Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->