### PR TITLE
test(suite-sync): co-locate owner and root tests

### DIFF
--- a/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.test.ts
+++ b/suite-common/suite-sync/src/createEnsureSuiteSyncKeys.test.ts
@@ -10,8 +10,8 @@ import { ok } from '@trezor/type-utils';
 import {
     type EnsureSuiteSyncKeysDeps,
     createEnsureSuiteSyncKeys,
-} from '../createEnsureSuiteSyncKeys';
-import { type GetDeviceForStaticSessionId } from '../getDeviceForStaticSessionId';
+} from './createEnsureSuiteSyncKeys';
+import { type GetDeviceForStaticSessionId } from './getDeviceForStaticSessionId';
 
 const createMockDeps = () =>
     ({

--- a/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
+++ b/suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts
@@ -15,7 +15,7 @@ import { err, ok } from '@trezor/type-utils';
 import {
     type CreateSuiteSyncInternalErrorHandlerDeps,
     createSuiteSyncInternalErrorHandler,
-} from '../createSuiteSyncInternalErrorHandler';
+} from './createSuiteSyncInternalErrorHandler';
 
 const ownerId = asSuiteSyncOwnerId('owner-id');
 const walletDescriptor = asWalletDescriptor('wallet-descriptor');

--- a/suite-common/suite-sync/src/createTurnOffSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/createTurnOffSuiteSync.test.ts
@@ -3,9 +3,9 @@ import type { Dispatch } from '@reduxjs/toolkit';
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { type CreateTurnOffSuiteSyncDeps, createTurnOffSuiteSync } from '../createTurnOffSuiteSync';
-import { clearAll } from '../data/suiteSyncDataReducer';
-import { updateSuiteSyncEnabled } from '../suiteSyncSlice';
+import { type CreateTurnOffSuiteSyncDeps, createTurnOffSuiteSync } from './createTurnOffSuiteSync';
+import { clearAll } from './data/suiteSyncDataReducer';
+import { updateSuiteSyncEnabled } from './suiteSyncSlice';
 
 const deviceStaticSessionId1: StaticSessionId = '1@2:3';
 const deviceStaticSessionId2: StaticSessionId = '4@5:6';

--- a/suite-common/suite-sync/src/createTurnOnSuiteSync.test.ts
+++ b/suite-common/suite-sync/src/createTurnOnSuiteSync.test.ts
@@ -5,11 +5,11 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
-import { createSuiteSyncStorageMock } from '../../tests/createSuiteSyncStorageMock.mock';
-import { SuiteSyncUnavailableOnDeviceError } from '../createEnsureSuiteSyncKeys';
-import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from '../createTurnOnSuiteSync';
-import type { GetDeviceForStaticSessionIdDep } from '../getDeviceForStaticSessionId';
-import { setSuiteSyncError, updateSuiteSyncEnabled } from '../suiteSyncSlice';
+import { SuiteSyncUnavailableOnDeviceError } from './createEnsureSuiteSyncKeys';
+import { type CreateTurnOnSuiteSyncDeps, createTurnOnSuiteSync } from './createTurnOnSuiteSync';
+import type { GetDeviceForStaticSessionIdDep } from './getDeviceForStaticSessionId';
+import { setSuiteSyncError, updateSuiteSyncEnabled } from './suiteSyncSlice';
+import { createSuiteSyncStorageMock } from '../tests/createSuiteSyncStorageMock.mock';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
 

--- a/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts
@@ -6,8 +6,8 @@ import { err, ok } from '@trezor/type-utils';
 import {
     type CreateEnsureSuiteSyncOwnerDeps,
     createEnsureSuiteSyncOwner,
-} from '../createEnsureSuiteSyncOwner';
-import { type RetrieveSuiteSyncOwnerParams } from '../createRetrieveSuiteSyncOwner';
+} from './createEnsureSuiteSyncOwner';
+import { type RetrieveSuiteSyncOwnerParams } from './createRetrieveSuiteSyncOwner';
 
 const device: RetrieveSuiteSyncOwnerParams['device'] = {
     instance: 0,

--- a/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts
+++ b/suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts
@@ -12,7 +12,7 @@ import {
     type RetrieveSuiteSyncOwnerDeps,
     type RetrieveSuiteSyncOwnerParams,
     createRetrieveSuiteSyncOwner,
-} from '../createRetrieveSuiteSyncOwner';
+} from './createRetrieveSuiteSyncOwner';
 
 const device: RetrieveSuiteSyncOwnerParams['device'] = {
     instance: 0,

--- a/suite-common/suite-sync/src/suiteSyncSelectors.test.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.test.ts
@@ -8,9 +8,9 @@ import type { SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage'
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import type { StaticSessionId, UnavailableCapabilities } from '@trezor/connect';
 
-import { selectIsSuiteSyncInitPossible, selectSuiteSyncInteraction } from '../suiteSyncSelectors';
-import type { WithSuiteSyncAndDeviceState } from '../suiteSyncSelectors';
-import { type SuiteSyncState, initialSuiteSyncState } from '../suiteSyncSlice';
+import { selectIsSuiteSyncInitPossible, selectSuiteSyncInteraction } from './suiteSyncSelectors';
+import type { WithSuiteSyncAndDeviceState } from './suiteSyncSelectors';
+import { type SuiteSyncState, initialSuiteSyncState } from './suiteSyncSlice';
 
 const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
 

--- a/suite-common/suite-sync/src/suiteSyncSlice.test.ts
+++ b/suite-common/suite-sync/src/suiteSyncSlice.test.ts
@@ -10,7 +10,7 @@ import {
     removeSuiteSyncRelayConnection,
     setSuiteSyncRelayConnection,
     suiteSyncReducer,
-} from '../suiteSyncSlice';
+} from './suiteSyncSlice';
 
 const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
 

--- a/suite-common/suite-sync/src/suiteSyncUtils.test.ts
+++ b/suite-common/suite-sync/src/suiteSyncUtils.test.ts
@@ -1,11 +1,11 @@
 import { portfolioTrackerDevice } from '@suite-common/device';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 
-import { type SuiteSyncInteraction } from '../suiteSyncTypes';
+import { type SuiteSyncInteraction } from './suiteSyncTypes';
 import {
     getIsSuiteSyncLabelingActionEnabled,
     isSuiteSyncSupportedByDevice,
-} from '../suiteSyncUtils';
+} from './suiteSyncUtils';
 
 describe(isSuiteSyncSupportedByDevice.name, () => {
     it.each([


### PR DESCRIPTION
## Description

Moves the 2 Suite Sync owner tests and 7 package-root tests beside their source files without changing test behavior.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are entirely within the suite-common/suite-sync package's unit test suite, covering core Suite Sync logic: owner key management (ensure/retrieve/create), turning sync on/off, internal error handling, Redux slice/selectors, and utility functions. No static E2E coverage mapping exists for these files, so recommendations are inferred from the LLM behavior descriptions of E2E tests that exercise Suite Sync flows (enabling/disabling sync, label CRUD, multi-wallet owner secrets, and unsupported-device error banners). Given the breadth of Suite Sync functionality touched, the full suite-sync E2E test folder should be run to catch regressions in sync enablement, key/owner derivation, and label synchronization across account/wallet/address/output entities.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/suite-sync/src/createEnsureSuiteSyncKeys.test.ts`
- `suite-common/suite-sync/src/createSuiteSyncInternalErrorHandler.test.ts`
- `suite-common/suite-sync/src/createTurnOffSuiteSync.test.ts`
- `suite-common/suite-sync/src/createTurnOnSuiteSync.test.ts`
- `suite-common/suite-sync/src/owner/createEnsureSuiteSyncOwner.test.ts`
- `suite-common/suite-sync/src/owner/createRetrieveSuiteSyncOwner.test.ts`
- `suite-common/suite-sync/src/suiteSyncSelectors.test.ts`
- `suite-common/suite-sync/src/suiteSyncSlice.test.ts`
- `suite-common/suite-sync/src/suiteSyncUtils.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test directly exercises turning Suite Sync on/off and declining per passphrase wallet, verifying owner secrets and enable/disable state transitions — behavior implemented by createTurnOnSuiteSync, createTurnOffSuiteSync, createEnsureSuiteSyncOwner, and createRetrieveSuiteSyncOwner which were all changed.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Enabling Suite Sync and pulling labels from the Evolu relay requires ensuring/retrieving the Suite Sync owner and keys, directly testing the createEnsureSuiteSyncKeys and owner-creation logic that changed.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Creating and syncing new labels via Suite Sync exercises the core write/sync path built on suiteSyncSlice, suiteSyncSelectors, and suiteSyncUtils, all of which were modified.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Removing labels and confirming null propagation to the relay tests the same suiteSyncSlice/suiteSyncSelectors state management logic that was changed, including how sync state and errors are represented.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test covers downloading, updating, and removing labels through Suite Sync end-to-end, directly validating the slice/selector/util logic and owner/key management functions that were all modified.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test validates error/banner handling when Suite Sync is enabled on an unsupported device, which likely depends on createSuiteSyncInternalErrorHandler logic that was changed to surface such error states.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Migrating legacy Dropbox labels to Suite Sync exercises the turn-on flow and owner/key setup, sharing code paths with the changed createTurnOnSuiteSync and owner creation modules.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This migration test triggers Suite Sync enablement and label sync for multiple entity types (account/output/address), touching the turn-on flow and slice/selector logic that changed.

</details>

_Updated: 2026-07-27T17:40:57.211Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-sync-owner-root-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-sync-owner-root-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-sync-owner-root-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-sync-owner-root-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-sync-owner-root-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:43:57.315Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-27T17:43:43.616Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->