### PR TITLE
fix(suite-native-30295): use traded token symbol for amount validation

### DIFF
--- a/suite-native/module-settings/src/components/ToggleNetworkReserveCheckCard.tsx
+++ b/suite-native/module-settings/src/components/ToggleNetworkReserveCheckCard.tsx
@@ -16,6 +16,8 @@ export const ToggleNetworkReserveCheckCard = () => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const openLink = useOpenLink();
 
+    const supportedNetworks = getNetworksWithNativeTokenReserve();
+
     const toggleNetworkReserve = (value: boolean) => {
         analytics.report({
             type: events.settingsNetworkReserveToggleEvent.name,
@@ -35,12 +37,16 @@ export const ToggleNetworkReserveCheckCard = () => {
             icon="graph"
             text={<Translation id="moduleSettings.advanced.networkReserve.title" />}
             accessibilityLabel="network reserve"
-            description={<Translation id="moduleSettings.advanced.networkReserve.subtitle" />}
-            additionalInfo={
+            description={
                 <Translation
-                    id="moduleSettings.availableOn"
-                    values={{ supportedNetworks: getNetworksWithNativeTokenReserve() }}
+                    id="moduleSettings.advanced.networkReserve.subtitle"
+                    values={{
+                        supportedNetworks,
+                    }}
                 />
+            }
+            additionalInfo={
+                <Translation id="moduleSettings.availableOn" values={{ supportedNetworks }} />
             }
             onLearnMorePress={handleLearnMorePress}
             isChecked={isNetworkReserveEnabled}

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
@@ -4,6 +4,7 @@ import { type EnhancedStore } from '@reduxjs/toolkit';
 import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { selectTradingProviderMetadata, tradingBuyActions } from '@suite-common/trading';
+import { type TokenAddress } from '@suite-common/wallet-types';
 import {
     type TestStore,
     act,
@@ -459,6 +460,83 @@ describe('useBuyForm', () => {
             const { invalid } = result.current.getFieldState('cryptoValue');
 
             expect(invalid).toBe(false);
+        });
+
+        it('should format a token named BTC as a token', async () => {
+            const store = getInitializedStore(true);
+            const { result } = renderUseTradingBuyForm(store);
+            const btcTokenAsset: TradeableAsset = {
+                ...btcAsset,
+                cryptoId: 'ethereum--0x123' as CryptoId,
+                networkId: 'ethereum',
+                contractAddress: '0x123' as TokenAddress,
+            };
+
+            act(() => {
+                result.current.setValue('amountInCrypto', true);
+                result.current.setValue('asset', btcTokenAsset);
+            });
+            act(() => {
+                store.dispatch(
+                    tradingBuyActions.setAmountLimits({
+                        minCrypto: '0.1',
+                        currency: 'BTC',
+                    }),
+                );
+            });
+            act(() => {
+                result.current.setValue('cryptoValue', '0.01');
+            });
+
+            await act(() => result.current.trigger('cryptoValue'));
+
+            const { error, invalid } = result.current.getFieldState('cryptoValue');
+
+            expect(invalid).toBe(true);
+            expect(error).toEqual(expect.objectContaining({ message: 'Minimum is 0.1 BTC' }));
+        });
+
+        it('should validate a token named BTC in base units when SATS are enabled', async () => {
+            const store = getInitializedStore(true);
+            const { result } = renderUseTradingBuyForm(store);
+            const btcTokenAsset: TradeableAsset = {
+                ...btcAsset,
+                cryptoId: 'ethereum--0x123' as CryptoId,
+                networkId: 'ethereum',
+                contractAddress: '0x123' as TokenAddress,
+            };
+
+            act(() => {
+                result.current.setValue('amountInCrypto', true);
+                result.current.setValue('asset', btcTokenAsset);
+            });
+            act(() => {
+                store.dispatch(
+                    tradingBuyActions.setAmountLimits({
+                        minCrypto: '0.1',
+                        maxCrypto: '2',
+                        currency: 'BTC',
+                    }),
+                );
+            });
+            act(() => {
+                result.current.setValue('cryptoValue', '0.2');
+            });
+
+            await act(() => result.current.trigger('cryptoValue'));
+
+            expect(result.current.getFieldState('cryptoValue').invalid).toBe(false);
+
+            act(() => {
+                result.current.setValue('cryptoValue', '3');
+            });
+
+            await act(() => result.current.trigger('cryptoValue'));
+
+            const { error, invalid } = result.current.getFieldState('cryptoValue');
+
+            expect(invalid).toBe(true);
+            expect(error).toEqual(expect.objectContaining({ message: 'Maximum is 2 BTC' }));
         });
 
         it('should trigger validation once limits are loaded', async () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -4,7 +4,11 @@ import { useSelector } from 'react-redux';
 
 import type { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
 
-import { type TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@suite-common/trading';
+import {
+    type TradingAmountLimitProps,
+    cryptoIdToNetwork,
+    selectTradingBuyQuotesRequest,
+} from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
@@ -145,7 +149,7 @@ const useValidations = (
 export const useBuyForm = (): BuyFormType => {
     const defaultValues = useSelector(selectBuyFormDefaultValues);
     const limits = useSelector(selectBuyAmountLimits);
-    const { context } = useContextForTradingForm(limits);
+    const { context, setContractAddress, setSendNetworkSymbol } = useContextForTradingForm(limits);
 
     const form = useForm<BuyFormValues>({
         defaultValues,
@@ -154,6 +158,11 @@ export const useBuyForm = (): BuyFormType => {
     });
     const { control, setValue } = form;
     const asset = useWatch({ control, name: 'asset' });
+
+    useEffect(() => {
+        setContractAddress(asset?.contractAddress);
+        setSendNetworkSymbol(cryptoIdToNetwork(asset?.cryptoId)?.symbol);
+    }, [asset?.contractAddress, asset?.cryptoId, setContractAddress, setSendNetworkSymbol]);
 
     useReceiveAccountChangeEffect(setValue, selectBuySelectedReceiveAccount);
     useReceiveAccountPreselectionEffect({

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -201,8 +201,14 @@ const useValidations = (
 
 export const useExchangeForm = () => {
     const limits = useSelector(selectExchangeAmountLimits);
-    const { context, setBalance, setSendSymbol, setContractAddress, setAccountKey } =
-        useContextForTradingForm(limits);
+    const {
+        context,
+        setBalance,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
+        setContractAddress,
+        setAccountKey,
+    } = useContextForTradingForm(limits);
 
     const form = useForm<ExchangeFormValues>({
         validation: exchangeFormValidationSchema,
@@ -231,7 +237,8 @@ export const useExchangeForm = () => {
     useSendAccountAssetBalance({
         control,
         setBalance,
-        setSendSymbol,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
         setContractAddress,
         setAccountKey,
     });

--- a/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
@@ -1,4 +1,5 @@
 import { type TradingAmountLimitProps } from '@suite-common/trading';
+import { type TokenAddress } from '@suite-common/wallet-types';
 import { act } from '@suite-native/test-utils-store';
 
 import { useContextForTradingForm } from './useContextForTradingForm';
@@ -42,18 +43,22 @@ describe('useContextForTradingForm', () => {
         expect(result.current.context).toEqual(expect.objectContaining(limits));
     });
 
-    it('should append balance and sendSymbol when specified', () => {
+    it('should append send asset data and balance when specified', () => {
         const { result } = renderUseContextForTradingForm(undefined);
 
         act(() => {
             result.current.setBalance('0.5');
-            result.current.setSendSymbol('ETH');
+            result.current.setSendNetworkSymbol('eth');
+            result.current.setSendAssetSymbol('USDT');
+            result.current.setContractAddress('0x123' as TokenAddress);
         });
 
         expect(result.current.context).toEqual(
             expect.objectContaining({
                 balance: '0.5',
-                sendSymbol: 'ETH',
+                sendNetworkSymbol: 'eth',
+                sendAssetSymbol: 'USDT',
+                contractAddress: '0x123',
             }),
         );
     });

--- a/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.ts
@@ -27,19 +27,22 @@ export const useContextForTradingForm = (limits: TradingAmountLimitProps | undef
     );
 
     const [balance, setBalance] = useState<string | undefined>(undefined);
-    const [sendSymbol, setSendSymbol] = useState<string | undefined>(undefined);
+    const [sendNetworkSymbol, setSendNetworkSymbol] = useState<NetworkSymbol | undefined>(
+        undefined,
+    );
+    const [sendAssetSymbol, setSendAssetSymbol] = useState<string | undefined>(undefined);
     const [contractAddress, setContractAddress] = useState<TokenAddress | undefined>(undefined);
     const [accountKey, setAccountKey] = useState<AccountKey | undefined>(undefined);
 
     const { maxSpendableAmount } = useMaxSpendableAmount({
         accountKey,
         tokenContract: contractAddress,
-        symbol: sendSymbol as NetworkSymbol,
+        symbol: sendNetworkSymbol,
     });
 
-    const networkReserve = sendSymbol
+    const networkReserve = sendNetworkSymbol
         ? getNetworkReserve({
-              symbol: sendSymbol.toLowerCase() as NetworkSymbol,
+              symbol: sendNetworkSymbol,
               contractAddress,
               isEnabled: isNetworkReserveEnabled,
           })
@@ -48,7 +51,9 @@ export const useContextForTradingForm = (limits: TradingAmountLimitProps | undef
     const context = useMemo<TradingFormContext>(
         () => ({
             ...limits,
-            sendSymbol,
+            sendNetworkSymbol,
+            sendAssetSymbol,
+            contractAddress,
             translate,
             balance: balance || undefined,
             FiatAmountFormatter: BaseCurrencyAmountFormatter,
@@ -59,7 +64,9 @@ export const useContextForTradingForm = (limits: TradingAmountLimitProps | undef
         }),
         [
             limits,
-            sendSymbol,
+            sendNetworkSymbol,
+            sendAssetSymbol,
+            contractAddress,
             translate,
             balance,
             BaseCurrencyAmountFormatter,
@@ -73,7 +80,8 @@ export const useContextForTradingForm = (limits: TradingAmountLimitProps | undef
     return {
         context,
         setBalance,
-        setSendSymbol,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
         setContractAddress,
         setAccountKey,
     };

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
@@ -11,7 +11,8 @@ type HookProps = {
     sendAccount: Account | undefined;
     sendAsset: TradeableAsset | undefined;
     setBalance: (balance: string | undefined) => unknown;
-    setSendSymbol: (currency: string | undefined) => unknown;
+    setSendNetworkSymbol: (networkSymbol: Account['symbol'] | undefined) => unknown;
+    setSendAssetSymbol: (symbol: string | undefined) => unknown;
     setContractAddress: (contractAddress: TokenAddress | undefined) => unknown;
     setAccountKey: (accountKey: AccountKey | undefined) => void;
 };
@@ -22,7 +23,8 @@ describe('useSendAccountAssetBalance', () => {
                 sendAccount,
                 sendAsset,
                 setBalance,
-                setSendSymbol,
+                setSendNetworkSymbol,
+                setSendAssetSymbol,
                 setContractAddress,
                 setAccountKey,
             }) => {
@@ -33,7 +35,8 @@ describe('useSendAccountAssetBalance', () => {
                 useSendAccountAssetBalance({
                     control: form.control,
                     setBalance,
-                    setSendSymbol,
+                    setSendNetworkSymbol,
+                    setSendAssetSymbol,
                     setContractAddress,
                     setAccountKey,
                 });
@@ -46,25 +49,29 @@ describe('useSendAccountAssetBalance', () => {
 
     it('should watch for balance and asset symbol', () => {
         const setBalance = jest.fn();
-        const setSendSymbol = jest.fn();
+        const setSendNetworkSymbol = jest.fn();
+        const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
         renderUseSendAccountAssetBalance({
             sendAccount: getBtcAccount(),
             sendAsset: btcAsset,
             setBalance,
-            setSendSymbol,
+            setSendNetworkSymbol,
+            setSendAssetSymbol,
             setContractAddress,
             setAccountKey,
         });
 
         expect(setBalance).toHaveBeenCalledWith('0.01');
-        expect(setSendSymbol).toHaveBeenCalledWith('btc');
+        expect(setSendNetworkSymbol).toHaveBeenCalledWith('btc');
+        expect(setSendAssetSymbol).toHaveBeenCalledWith('BTC');
     });
 
     it('should set balance to undefined when account is undefined', () => {
         const setBalance = jest.fn();
-        const setSendSymbol = jest.fn();
+        const setSendNetworkSymbol = jest.fn();
+        const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
 
@@ -72,7 +79,8 @@ describe('useSendAccountAssetBalance', () => {
             sendAccount: undefined,
             sendAsset: btcAsset,
             setBalance,
-            setSendSymbol,
+            setSendNetworkSymbol,
+            setSendAssetSymbol,
             setContractAddress,
             setAccountKey,
         });
@@ -82,7 +90,8 @@ describe('useSendAccountAssetBalance', () => {
 
     it('should set balance to undefined when symbol is undefined', () => {
         const setBalance = jest.fn();
-        const setSendSymbol = jest.fn();
+        const setSendNetworkSymbol = jest.fn();
+        const setSendAssetSymbol = jest.fn();
         const setContractAddress = jest.fn();
         const setAccountKey = jest.fn();
 
@@ -90,7 +99,8 @@ describe('useSendAccountAssetBalance', () => {
             sendAccount: getBtcAccount(),
             sendAsset: undefined,
             setBalance,
-            setSendSymbol,
+            setSendNetworkSymbol,
+            setSendAssetSymbol,
             setContractAddress,
             setAccountKey,
         });

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import type { DeviceRootState } from '@suite-common/device';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
@@ -16,7 +17,8 @@ import { type ExchangeFormValues } from '@suite-native/trading-types';
 type UseSendAccountAssetBalanceParams<TFieldValues extends FieldValues> = {
     control: Control<TFieldValues>;
     setBalance: (balance: string | undefined) => unknown;
-    setSendSymbol: (currency: string | undefined) => unknown;
+    setSendNetworkSymbol: (networkSymbol: NetworkSymbol | undefined) => unknown;
+    setSendAssetSymbol: (symbol: string | undefined) => unknown;
     setContractAddress: (contractAddress: TokenAddress | undefined) => unknown;
     setAccountKey: (accountKey: AccountKey | undefined) => void;
 };
@@ -24,7 +26,8 @@ type UseSendAccountAssetBalanceParams<TFieldValues extends FieldValues> = {
 export const useSendAccountAssetBalance = <TFieldValues extends FieldValues>({
     control,
     setBalance,
-    setSendSymbol,
+    setSendNetworkSymbol,
+    setSendAssetSymbol,
     setContractAddress,
     setAccountKey,
 }: UseSendAccountAssetBalanceParams<TFieldValues>) => {
@@ -58,14 +61,17 @@ export const useSendAccountAssetBalance = <TFieldValues extends FieldValues>({
     }, [setBalance, balance]);
 
     useEffect(() => {
-        setSendSymbol(sendAccount?.symbol);
+        setSendNetworkSymbol(sendAccount?.symbol);
+        setSendAssetSymbol(sendAsset?.symbol);
         setContractAddress(sendAsset?.contractAddress);
         setAccountKey(accountKey);
     }, [
-        setSendSymbol,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
         setContractAddress,
         setAccountKey,
         sendAsset?.contractAddress,
+        sendAsset?.symbol,
         sendAccount?.symbol,
         accountKey,
     ]);

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -135,8 +135,14 @@ const useValidations = (
 export const useSellForm = (): SellFormType => {
     const defaultValues = useSelector(selectSellFormDefaultValues);
     const limits = useSelector(selectSellAmountLimits);
-    const { context, setBalance, setSendSymbol, setContractAddress, setAccountKey } =
-        useContextForTradingForm(limits);
+    const {
+        context,
+        setBalance,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
+        setContractAddress,
+        setAccountKey,
+    } = useContextForTradingForm(limits);
 
     const form = useForm<SellFormValues>({
         defaultValues,
@@ -156,7 +162,8 @@ export const useSellForm = (): SellFormType => {
     useSendAccountAssetBalance({
         control,
         setBalance,
-        setSendSymbol,
+        setSendNetworkSymbol,
+        setSendAssetSymbol,
         setContractAddress,
         setAccountKey,
     });

--- a/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
+++ b/suite-native/module-trading/src/utils/buy/buyFormValidationSchema.ts
@@ -23,8 +23,14 @@ export const buyFormValidationSchema = yup.object({
                 translate,
                 CryptoAmountFormatter,
                 convertNumberToBaseUnit,
+                contractAddress,
+                sendNetworkSymbol,
             } = getAmountLimitContext(testContext);
-            const convertedValue = convertNumberToBaseUnit(value, currency.toLowerCase());
+            if (sendNetworkSymbol === undefined) {
+                return true;
+            }
+
+            const convertedValue = convertNumberToBaseUnit(value, sendNetworkSymbol);
 
             if (
                 convertedValue === undefined ||
@@ -36,7 +42,12 @@ export const buyFormValidationSchema = yup.object({
 
             return testContext.createError({
                 message: translate('moduleTrading.validators.min', {
-                    min: formatCryptoAmount(minCrypto, currency, CryptoAmountFormatter),
+                    min: formatCryptoAmount({
+                        amount: minCrypto,
+                        symbol: currency,
+                        contractAddress,
+                        CryptoAmountFormatter,
+                    }),
                 }),
             });
         })
@@ -47,8 +58,14 @@ export const buyFormValidationSchema = yup.object({
                 translate,
                 CryptoAmountFormatter,
                 convertNumberToBaseUnit,
+                contractAddress,
+                sendNetworkSymbol,
             } = getAmountLimitContext(testContext);
-            const convertedValue = convertNumberToBaseUnit(value, currency.toLowerCase());
+            if (sendNetworkSymbol === undefined) {
+                return true;
+            }
+
+            const convertedValue = convertNumberToBaseUnit(value, sendNetworkSymbol);
 
             if (
                 convertedValue === undefined ||
@@ -60,7 +77,12 @@ export const buyFormValidationSchema = yup.object({
 
             return testContext.createError({
                 message: translate('moduleTrading.validators.max', {
-                    max: formatCryptoAmount(maxCrypto, currency, CryptoAmountFormatter),
+                    max: formatCryptoAmount({
+                        amount: maxCrypto,
+                        symbol: currency,
+                        contractAddress,
+                        CryptoAmountFormatter,
+                    }),
                 }),
             });
         }),

--- a/suite-native/module-trading/src/utils/general/validationSchemes.test.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.test.ts
@@ -25,7 +25,8 @@ const createContext = (overrides: Partial<TradingFormContext> = {}): TradingForm
         FiatAmountFormatter: formatters.BaseCurrencyAmountFormatter,
         CryptoAmountFormatter: formatters.CryptoAmountFormatter,
         convertNumberToBaseUnit: (amount: number | undefined) => amount,
-        sendSymbol: 'btc',
+        sendNetworkSymbol: 'btc',
+        sendAssetSymbol: 'BTC',
         currency: 'usd',
         balance: undefined,
         ...overrides,
@@ -125,9 +126,9 @@ describe('validationSchemes', () => {
             ).resolves.toBeUndefined();
         });
 
-        it('skips all checks when sendSymbol is undefined', async () => {
+        it('skips all checks when sendAssetSymbol is undefined', async () => {
             const context = createContext({
-                sendSymbol: undefined,
+                sendAssetSymbol: undefined,
                 minCrypto: '10',
                 maxCrypto: '20',
                 balance: '0',
@@ -145,7 +146,7 @@ describe('validationSchemes', () => {
         });
 
         describe('min', () => {
-            const buildContext = () => createContext({ sendSymbol: 'btc', minCrypto: '10' });
+            const buildContext = () => createContext({ sendAssetSymbol: 'BTC', minCrypto: '10' });
 
             it('rejects when value is below min', async () => {
                 await expect(
@@ -171,7 +172,7 @@ describe('validationSchemes', () => {
         });
 
         describe('max', () => {
-            const buildContext = () => createContext({ sendSymbol: 'btc', maxCrypto: '100' });
+            const buildContext = () => createContext({ sendAssetSymbol: 'BTC', maxCrypto: '100' });
 
             it('rejects when value is above max', async () => {
                 await expect(
@@ -196,19 +197,88 @@ describe('validationSchemes', () => {
             });
         });
 
+        describe('token on a network with a different symbol', () => {
+            const buildContext = (overrides: Partial<TradingFormContext> = {}) =>
+                createContext({ sendNetworkSymbol: 'trx', sendAssetSymbol: 'USDT', ...overrides });
+
+            it('converts the amount using the network symbol', async () => {
+                const convertNumberToBaseUnit = jest.fn((amount: number | undefined) => amount);
+
+                await validate(
+                    sendCryptoAmountValidationSchema,
+                    5,
+                    buildContext({ convertNumberToBaseUnit }),
+                );
+
+                expect(convertNumberToBaseUnit).toHaveBeenCalledWith(5, 'trx');
+            });
+
+            it('reports min in the token symbol', async () => {
+                await expect(
+                    validate(
+                        sendCryptoAmountValidationSchema,
+                        5,
+                        buildContext({ minCrypto: '10' }),
+                    ),
+                ).rejects.toThrow(
+                    getTranslation('moduleTrading.validators.min', { min: '10 USDT' }),
+                );
+            });
+
+            it('reports max in the token symbol', async () => {
+                await expect(
+                    validate(
+                        sendCryptoAmountValidationSchema,
+                        101,
+                        buildContext({ maxCrypto: '100' }),
+                    ),
+                ).rejects.toThrow(
+                    getTranslation('moduleTrading.validators.max', { max: '100 USDT' }),
+                );
+            });
+        });
+
+        describe('token with a network symbol', () => {
+            it('formats the amount using the token symbol when a contract address is present', async () => {
+                const CryptoAmountFormatter = {
+                    format: jest.fn(() => '10 BTC'),
+                } as unknown as TradingFormContext['CryptoAmountFormatter'];
+                const context = {
+                    ...createContext({
+                        sendNetworkSymbol: 'eth',
+                        sendAssetSymbol: 'BTC',
+                        minCrypto: '10',
+                        CryptoAmountFormatter,
+                    }),
+                    contractAddress: '0x123',
+                } as TradingFormContext;
+
+                await expect(
+                    validate(sendCryptoAmountValidationSchema, 5, context),
+                ).rejects.toThrow(
+                    getTranslation('moduleTrading.validators.min', { min: '10 BTC' }),
+                );
+
+                expect(CryptoAmountFormatter.format).toHaveBeenCalledWith('10', {
+                    symbol: 'BTC',
+                    isBalance: true,
+                });
+            });
+        });
+
         describe('balance', () => {
             it('passes when balance is undefined', async () => {
                 await expect(
                     validate(
                         sendCryptoAmountValidationSchema,
                         1000,
-                        createContext({ sendSymbol: 'btc', balance: undefined }),
+                        createContext({ sendAssetSymbol: 'BTC', balance: undefined }),
                     ),
                 ).resolves.toBe(1000);
             });
 
             it('rejects with insufficient-balance when value exceeds balance', async () => {
-                const context = createContext({ sendSymbol: 'btc', balance: '50' });
+                const context = createContext({ sendAssetSymbol: 'BTC', balance: '50' });
 
                 await expect(
                     validate(sendCryptoAmountValidationSchema, 51, context),
@@ -217,7 +287,8 @@ describe('validationSchemes', () => {
 
             it('rejects with network-reserve when value exceeds maxSpendableAmount but is within balance', async () => {
                 const context = createContext({
-                    sendSymbol: 'btc',
+                    sendAssetSymbol: 'ETH',
+                    sendNetworkSymbol: 'arb',
                     balance: '100',
                     maxSpendableAmount: '90',
                 });
@@ -226,14 +297,15 @@ describe('validationSchemes', () => {
                     validate(sendCryptoAmountValidationSchema, 95, context),
                 ).rejects.toThrow(
                     getTranslation('moduleTrading.validators.networkReserve', {
-                        displaySymbol: 'BTC',
+                        displaySymbol: 'ETH',
                     }),
                 );
             });
 
             it('accepts when value is within maxSpendableAmount', async () => {
                 const context = createContext({
-                    sendSymbol: 'btc',
+                    sendAssetSymbol: 'BTC',
+                    sendNetworkSymbol: 'btc',
                     balance: '100',
                     maxSpendableAmount: '90',
                 });
@@ -245,7 +317,8 @@ describe('validationSchemes', () => {
 
             it('passes when maxSpendableAmount is undefined and value is within balance', async () => {
                 const context = createContext({
-                    sendSymbol: 'btc',
+                    sendAssetSymbol: 'BTC',
+                    sendNetworkSymbol: 'btc',
                     balance: '100',
                     maxSpendableAmount: undefined,
                 });

--- a/suite-native/module-trading/src/utils/general/validationSchemes.ts
+++ b/suite-native/module-trading/src/utils/general/validationSchemes.ts
@@ -1,6 +1,10 @@
 import { yup } from '@suite-common/validators';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbol,
+    isNetworkSymbol,
+} from '@suite-common/wallet-config';
+import { type TokenSymbol, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type TradingFormContext } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -17,13 +21,25 @@ export const getAmountLimitContext = ({
     };
 };
 
-export const formatCryptoAmount = (
-    amount: string,
-    currency: string,
-    CryptoAmountFormatter: TradingFormContext['CryptoAmountFormatter'],
-) =>
+type FormatCryptoAmountParams = Pick<
+    TradingFormContext,
+    'contractAddress' | 'CryptoAmountFormatter'
+> & {
+    amount: string;
+    symbol: string;
+};
+
+export const formatCryptoAmount = ({
+    amount,
+    symbol,
+    contractAddress,
+    CryptoAmountFormatter,
+}: FormatCryptoAmountParams) =>
     CryptoAmountFormatter.format(amount, {
-        symbol: currency.toLowerCase() as NetworkSymbol,
+        symbol:
+            !contractAddress && isNetworkSymbol(symbol.toLowerCase())
+                ? (symbol.toLowerCase() as NetworkSymbol)
+                : (symbol as NetworkSymbol | TokenSymbol),
         isBalance: true,
     });
 
@@ -73,13 +89,20 @@ export const sendCryptoAmountValidationSchema = yup
     .typeError('Invalid number')
     .min(0, 'Invalid value')
     .test('send-crypto-min', (value, testContext) => {
-        const { sendSymbol, minCrypto, translate, CryptoAmountFormatter, convertNumberToBaseUnit } =
-            getAmountLimitContext(testContext);
-        if (sendSymbol === undefined) {
+        const {
+            sendAssetSymbol,
+            minCrypto,
+            translate,
+            CryptoAmountFormatter,
+            convertNumberToBaseUnit,
+            sendNetworkSymbol,
+            contractAddress,
+        } = getAmountLimitContext(testContext);
+        if (sendAssetSymbol === undefined || sendNetworkSymbol === undefined) {
             return true;
         }
 
-        const convertedValue = convertNumberToBaseUnit(value, sendSymbol.toLowerCase());
+        const convertedValue = convertNumberToBaseUnit(value, sendNetworkSymbol);
 
         if (
             convertedValue === undefined ||
@@ -91,18 +114,30 @@ export const sendCryptoAmountValidationSchema = yup
 
         return testContext.createError({
             message: translate('moduleTrading.validators.min', {
-                min: formatCryptoAmount(minCrypto, sendSymbol, CryptoAmountFormatter),
+                min: formatCryptoAmount({
+                    amount: minCrypto,
+                    symbol: sendAssetSymbol,
+                    contractAddress,
+                    CryptoAmountFormatter,
+                }),
             }),
         });
     })
     .test('send-crypto-max', (value, testContext) => {
-        const { sendSymbol, maxCrypto, translate, CryptoAmountFormatter, convertNumberToBaseUnit } =
-            getAmountLimitContext(testContext);
-        if (sendSymbol === undefined) {
+        const {
+            sendAssetSymbol,
+            maxCrypto,
+            translate,
+            CryptoAmountFormatter,
+            convertNumberToBaseUnit,
+            sendNetworkSymbol,
+            contractAddress,
+        } = getAmountLimitContext(testContext);
+        if (sendAssetSymbol === undefined || sendNetworkSymbol === undefined) {
             return true;
         }
 
-        const convertedValue = convertNumberToBaseUnit(value, sendSymbol.toLowerCase());
+        const convertedValue = convertNumberToBaseUnit(value, sendNetworkSymbol);
 
         if (
             convertedValue === undefined ||
@@ -114,19 +149,30 @@ export const sendCryptoAmountValidationSchema = yup
 
         return testContext.createError({
             message: translate('moduleTrading.validators.max', {
-                max: formatCryptoAmount(maxCrypto, sendSymbol, CryptoAmountFormatter),
+                max: formatCryptoAmount({
+                    amount: maxCrypto,
+                    symbol: sendAssetSymbol,
+                    contractAddress,
+                    CryptoAmountFormatter,
+                }),
             }),
         });
     })
     .test('send-crypto-balance', (value, testContext) => {
-        const { balance, translate, convertNumberToBaseUnit, sendSymbol, maxSpendableAmount } =
-            getAmountLimitContext(testContext);
+        const {
+            balance,
+            translate,
+            convertNumberToBaseUnit,
+            sendAssetSymbol,
+            sendNetworkSymbol,
+            maxSpendableAmount,
+        } = getAmountLimitContext(testContext);
 
-        if (sendSymbol === undefined) {
+        if (sendAssetSymbol === undefined || sendNetworkSymbol === undefined) {
             return true;
         }
 
-        const convertedValue = convertNumberToBaseUnit(value, sendSymbol.toLowerCase());
+        const convertedValue = convertNumberToBaseUnit(value, sendNetworkSymbol);
 
         if (convertedValue === undefined || convertedValue === 0 || balance === undefined) {
             return true;
@@ -149,7 +195,7 @@ export const sendCryptoAmountValidationSchema = yup
             return testContext.createError({
                 type: 'network-reserve',
                 message: translate('moduleTrading.validators.networkReserve', {
-                    displaySymbol: sendSymbol.toUpperCase(),
+                    displaySymbol: getNetworkDisplaySymbol(sendNetworkSymbol),
                 }),
             });
         }

--- a/suite-native/trading-types/src/general.ts
+++ b/suite-native/trading-types/src/general.ts
@@ -90,7 +90,9 @@ export type TradingFormContext = Partial<TradingAmountLimitProps> & {
     FiatAmountFormatter: Formatters['BaseCurrencyAmountFormatter'];
     CryptoAmountFormatter: Formatters['CryptoAmountFormatter'];
     convertNumberToBaseUnit: ConvertNumberToBaseUnit;
-    sendSymbol: string | undefined;
+    sendNetworkSymbol: NetworkSymbol | undefined;
+    sendAssetSymbol: string | undefined;
+    contractAddress: TokenAddress | undefined;
     balance: string | undefined;
     networkReserve?: string;
     maxSpendableAmount?: string;

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.ts
@@ -13,7 +13,7 @@ type UseMaxSpendableAmountProps = {
     tokenContract?: TokenAddress;
     formState?: FormState;
     enabled?: boolean;
-    symbol: NetworkSymbol | null;
+    symbol?: NetworkSymbol | null;
 };
 
 const buildDefaultFormState = ({ tokenContract }: { tokenContract?: TokenAddress }): FormState => ({


### PR DESCRIPTION
## Description

- Use separate account-network and traded-asset symbols in trading form context.
- Display minimum and maximum amount validation errors using the traded asset symbol.
- Add coverage for tokens on networks with different symbols.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Verify minimum and maximum amount errors for token trades, especially when the token symbol differs from the network symbol.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30295

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30295-trade-minimum-amount-validation-shows-the-network-symbol-instead-of-the-traded-token&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->