### PR TITLE
fix(connect): forward requestedPermissions through TrezorConnectDynamic.init

### DIFF
--- a/packages/connect-common/src/impl/dynamic.ts
+++ b/packages/connect-common/src/impl/dynamic.ts
@@ -78,6 +78,7 @@ export class TrezorConnectDynamic implements TrezorConnectCore<ConnectDynamicSet
             debug: settings.debug,
             version: parseVersion(settings.version),
             enabledNetworks: settings.enabledNetworks,
+            requestedPermissions: settings.requestedPermissions,
         };
 
         this.currentTarget = this.getInitTarget();


### PR DESCRIPTION
## Description

Stacked on #30261.

That PR adds `ConnectSettings.requestedPermissions` so a dapp can declare its permissions at `TrezorConnect.init`, forwarded to the Suite popup via the handshake. But `TrezorConnectDynamic.init` — the `init` that `@trezor/connect-web` (the **web and webextension** entry point) dispatches through — rebuilds the impl settings from the incoming `ConnectDynamicSettings` and never copies `requestedPermissions`:

https://github.com/trezor/trezor-suite/blob/connect-upfront-permissions/packages/connect-common/src/impl/dynamic.ts#L75-L81

So the declared list was dropped before it ever reached `core-in-suite-web` / `core-in-suite-desktop`, both of which read `requestedPermissions` off their `init` argument and pass it into the popup handshake. Net effect: the upfront-permissions feature was silently a **no-op on web and webextension** — the exact hosts the parent PR targets. Nothing surfaced downstream because only Core is documented to ignore the field, so the host-side drop was invisible.

This was flagged in review: https://github.com/trezor/trezor-suite/pull/30261#discussion_r3656755175

## Fix

Copy `settings.requestedPermissions` into `implSettings` alongside `enabledNetworks` — both host-side-only fields forwarded to the target impl the same way. One line.

## Notes for QA

On the parent PR's Suite web preview, a third-party app that declares `requestedPermissions` at init should now actually trigger the single combined-consent prompt on its first call. Before this fix, on web/webextension it would fall back to lazy per-call prompting as if nothing was declared.

## Related Issue

Follow-up to #30261.
