### PR TITLE
docs(connect): restructure v10 changelog and add migration guide

### DIFF
--- a/packages/connect-explorer/src/pages/guides/migrating-to-connect-10.mdx
+++ b/packages/connect-explorer/src/pages/guides/migrating-to-connect-10.mdx
@@ -1,0 +1,148 @@
+---
+description: What you need to change in your integration to move from Trezor Connect 9 to Connect 10, as a checklist.
+---
+
+import { Callout } from 'nextra/components';
+
+# Migrating from Connect 9 to Connect 10
+
+Connect 10 moves the Connect core out of the self-hosted iframe + popup and into **Trezor Suite**. Your app stays a thin client and keeps calling the same `TrezorConnect` methods — but a handful of parameters, return shapes and packaging details change, and a few methods move out of the public API.
+
+This guide is the single source of truth for the upgrade. It is edited as the alphas land. For the architecture behind the change, see [New Connect flow in Trezor Suite](/guides/new-connect-flow-in-trezor-suite). For the release-by-release list, see the [changelog](/changelog).
+
+<Callout type="info">
+    **v9 keeps working.** The v9 end-of-life timeline has not been announced yet — v9 stays
+    supported in the meantime, so you can move when the alpha is stable enough for your integration.
+</Callout>
+
+## Installing the alpha
+
+```bash
+npm install @trezor/connect-web@10.0.0-alpha.1
+```
+
+The Suite-hosted flow needs **Trezor Suite 26.7.2 or newer** to host the Connect core. Older Suite versions do not expose the local Connect server, so requests will not be handled.
+
+Found a bug, or have feedback on the alpha? Open an issue at [github.com/trezor/trezor-suite](https://github.com/trezor/trezor-suite/issues/new/choose).
+
+## API changes at a glance
+
+Most integrations only touch a few of these. Find your call site or your error in the table, then jump to the step that explains it.
+
+| v9 API                            | v10                              | What to do                                                                                                    |
+| --------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `getAccountDescriptor`            | Removed                          | Call the per-coin `*GetPublicKey`, read `displayablePublicKey` ([Step 2](#step-2-only-if-you-use-these-apis)) |
+| `getAccountInfo()` with no path   | Throws `Method_InvalidParameter` | Pass `path` or `descriptor`, or use `selectAccount` ([Step 2](#step-2-only-if-you-use-these-apis))            |
+| `coin: 'Bitcoin'` (name/label)    | Rejected                         | Use the shortcut: `coin: 'btc'` ([Step 2](#step-2-only-if-you-use-these-apis))                                |
+| `useCardanoDerivation`            | Removed                          | Declare `enabledNetworks` at init ([Cardano](#cardano))                                                       |
+| `on` / `off` / `uiResponse`       | Throws `TypeError`               | Remove — no replacement in the public tier ([Step 2](#step-2-only-if-you-use-these-apis))                     |
+| device-management methods         | Not in public API                | Suite's responsibility now — no replacement ([Step 2](#step-2-only-if-you-use-these-apis))                    |
+| `@trezor/connect-plugin-ethereum` | Stub that throws                 | Drop it, remove `transformTypedData` ([Step 2](#step-2-only-if-you-use-these-apis))                           |
+| `disableWebUSB()`                 | Removed                          | `updateConnectSettings({ transports })` ([Step 5](#step-5-only-if-you-host-connect-core-trezorconnect))       |
+| EOS, NEM                          | Removed                          | Remove that support ([Removed coins](#removed-coins))                                                         |
+
+## Step 0: Identify your integration
+
+Which package do you install?
+
+- **`@trezor/connect-web`, `@trezor/connect-webextension`, or `@trezor/connect-mobile`** → you are a thin client. Skip Step 5 entirely.
+- **`@trezor/connect` directly** (you host Connect Core) → do every step, including Step 5.
+
+## Step 1: Required for every integration
+
+- [ ] Add `manifest.appName` to your `init()` call. It is now **required**.
+- [ ] Add `manifest.appIcon`: a URL to an icon sized for a 64px circle. Optional, but it is what Suite shows in the permission prompt, so in practice you want it.
+- [ ] Remove all iframe and popup integration config. `core-in-popup` and iframe-with-popup modes no longer exist. `connect-iframe` is removed.
+- [ ] Migrate to ESM: `import TrezorConnect from '@trezor/connect'`. If you cannot migrate off CJS, use a dynamic `import()`, or stay on v9.
+- [ ] Leave `coreMode` at its default `'auto'` unless you have a specific reason to pin it to `'suite-desktop'` or `'suite-web'`.
+- [ ] Rename any direct dependency on `@trezor/coins-*` to `@trezor/network-*`.
+
+```javascript
+TrezorConnect.init({
+    manifest: {
+        email: 'developer@xyz.com',
+        appName: 'Your Application',
+        appUrl: 'https://your.application.com',
+        appIcon: 'https://your.application.com/icon-64.png',
+    },
+});
+```
+
+### If your integration runs in a browser page (web flow)
+
+- [ ] Add `frame-src` (or `child-src`) for `https://suite.trezor.io` to your Content-Security-Policy.
+- [ ] Make sure `Cross-Origin-Opener-Policy` on the hosting page is not `same-origin`. Use `same-origin-allow-popups` or `unsafe-none`.
+
+<Callout type="warning">
+    Symptom if you skip the header changes: a handshake timeout when the popup opens.
+</Callout>
+
+### Assumptions to drop
+
+- [ ] Remove any UI or logic that assumes the user picks a device or enters a passphrase once per request. The active device is chosen and unlocked in Suite, and passphrase handling is centralized there.
+- [ ] Stop relying on `Object.keys(TrezorConnect)` enumeration or on monkeypatching methods. Public `TrezorConnect` objects are now class instances.
+
+## Step 2: Only if you use these APIs
+
+- [ ] **`getAccountDescriptor` is removed.** Call the per-coin `*GetPublicKey` instead.
+    - `payload.descriptor` → Bitcoin: `result.descriptor`. Non-Bitcoin coins: `result.displayablePublicKey`.
+    - `payload.path` → `result.serializedPath` on every `*GetPublicKey`.
+    - Coin-agnostic consumers: read `result.displayablePublicKey`.
+- [ ] **`getAccountInfo` called without `path` or `descriptor` now throws** `Method_InvalidParameter`. Pass `path` (derive on device, then query backend) or `descriptor` (backend only). For the old discovery behaviour use `discoverAccounts`, or `selectAccount` for user-facing selection.
+- [ ] **`coin` accepts the coin shortcut only.** Replace names and labels: `'Bitcoin'` → `'btc'`, `'Bitcoin Cash'` → `'bch'`, `'cardano'` → `'ada'`. Pass lowercase so TypeScript type-checks, even though runtime matching is case-insensitive.
+    - Path-taking methods (`getAddress`, `getPublicKey`, …) fall back to deriving the network from `path`.
+    - These throw `Method_UnknownCoin` with no fallback: `getAccountInfo`, `selectAccount`, `verifyMessage`, `composeTransaction`, `signTransaction`, `signMessage`, `getOwnershipId`, `getOwnershipProof`, and the `blockchain*` family.
+- [ ] **`on`, `off`, `removeAllListeners`, `uiResponse` and `updateConnectSettings` are gone from the public tier** and now throw `TypeError`. Remove the calls. They were already non-functional in v10 thin packages.
+- [ ] **Device-management methods are no longer callable from third-party integrations:** `applyFlags`, `applySettings`, `authenticateDevice`, `backupDevice`, `bleUnpair`, `changeLanguage`, `changePin`, `changeWipeCode`, `getFirmwareHash`, `getNonce`, `getSettings`, `loadDevice`, `pingDevice`, `recoveryDevice`, `resetDevice`, `setBrightness`, `setBusy`, `telemetryGet`, `thpGetCredentials`, `thpRemoveCredentials`, `wipeDevice`.
+- [ ] **Update type imports:** the `TrezorConnect` type is replaced by `TrezorConnectPublicAPI` or `TrezorConnectPrivilegedAPI`.
+- [ ] **Update factory imports:** `factory` is replaced by `factoryPublic` or `factoryPrivileged`.
+- [ ] **Stop importing the API-schema values** (`TrezorConnectCallable`, `TrezorConnectBitcoin`, …) as runtime values. The names remain as types.
+- [ ] **Drop your direct dependency on `@trezor/connect-plugin-ethereum`** and remove manual `transformTypedData` calls. Its logic is inlined into `@trezor/connect`. The 10.x plugin is a stub that throws.
+
+### Cardano
+
+- [ ] `cardanoGetPublicKey`: `publicKey` is now the raw 32-byte key in hex. Read the new `xpub` field, or `displayablePublicKey`, for the extended key.
+- [ ] Remove the per-call `useCardanoDerivation` parameter. Declare `TrezorConnect.init({ enabledNetworks: [{ coin: 'ada' }] })` instead. Note: on thin packages, `enabledNetworks` is not honored — Cardano availability follows the host Suite wallet's enabled coins.
+
+### Removed coins
+
+- [ ] Remove all EOS support from your integration.
+- [ ] Remove all NEM support from your integration.
+
+## Step 3: Recommended, not required
+
+- [ ] Replace the "call `getAccountInfo` with no path to trigger on-device discovery" pattern with `selectAccount`.
+- [ ] Choose the narrowest `addressSelection` you can:
+    - `'firstFresh'` or `'manual'` export a single address, never reveal the xpub, and need only `read_address`. Request an optional SLIP-0019 `mac` if you need to re-prove device ownership later.
+    - `'fullAccount'` (default) shares the xpub and needs `read_xpub`.
+    - Account-based networks (EVM, Solana, …) always return an individual address.
+- [ ] Handle `selectAccount` returning an array of `{ symbol, path, address? | xpub?, accountType?, mac? }`, even for a single selection.
+- [ ] Configure `selectionType` (`'single'`, `'multi'`, or `{ minCount, maxCount }`), `accountType` filtering, and `requireOnDeviceVerification` (default `true`) to match your flow.
+- [ ] Review the per-coin scopes your methods request (`read_address`, `read_xpub`, `sign`, `sign_message`). Scopes are non-overlapping, so `read_address` does not grant `read_xpub`.
+- [ ] Remove per-coin branching where you render public keys. Every `*GetPublicKey` now returns `displayablePublicKey`.
+- [ ] Ethereum: pass only `data` to `ethereumSignTypedData`. Hashes are computed internally for T1B1. Caller-provided hashes still take precedence.
+- [ ] Solana: pass `chunkify` to `solanaSignTransaction` to render addresses in 4-character chunks on device. Requires firmware with chunked-address support in the Solana `SignTx` flow.
+- [ ] Tron: `tronGetAddress` and `tronSignTransaction` are available via `@trezor/network-tron`.
+
+## Step 4: Verify
+
+- [ ] Suite desktop running: Connect connects over the local WebSocket, no popup, no iframe.
+- [ ] Suite desktop not running: Suite Web opens as the approval surface.
+- [ ] Suite desktop started mid-session: `'auto'` switches back to it.
+- [ ] Mobile: `@trezor/connect-mobile` deep links into Trezor Suite Lite.
+- [ ] Suite's permission prompt shows your app name, origin and icon.
+- [ ] Permissions are grouped by coin in the prompt and cover only what you use.
+
+## Step 5: Only if you host Connect Core (`@trezor/connect`)
+
+- [ ] Pass `transports` as fully constructed `Transport` instances. String identifiers (`'BridgeTransport'`, …) and classes are no longer accepted:
+
+    ```javascript
+    import { BridgeTransport } from '@trezor/transport-common';
+
+    init({ transports: [new BridgeTransport({ id: 'my-app' })] });
+    ```
+
+- [ ] For WebUSB, import from `@trezor/transport-web`. Do not import the Node-only `@trezor/transport` barrel in web or React Native bundles.
+- [ ] Replace `disableWebUSB()` with `updateConnectSettings({ transports })` and a filtered list.
+- [ ] Remove any use of `TransportInfo.outdated`. Legacy `trezord-go` Bridge on port `21325` is no longer supported, and detecting an outdated Bridge is now your app's job.

--- a/packages/connect-explorer/src/pages/guides/new-connect-flow-in-trezor-suite.mdx
+++ b/packages/connect-explorer/src/pages/guides/new-connect-flow-in-trezor-suite.mdx
@@ -1,63 +1,75 @@
 ---
-description: We are introducing a new integration of Trezor Connect in Trezor Suite, replacing the Connect Popup.
+description: How Connect 10 routes every request through Trezor Suite instead of the self-hosted popup, and why.
 ---
+
+import { Callout } from 'nextra/components';
 
 import ZoomableIllustration from '../../components/ZoomableIllustration';
 
 # New Connect flow in Trezor Suite
 
-Starting with Connect version 9.6.0, we are introducing a new integration with Trezor Suite. The new flow is designed to provide a more seamless and user-friendly experience for users interacting with Trezor devices.
+With Connect 10, the self-hosted iframe + popup that Connect served from `connect.trezor.io` is gone. Every request is now handled by **Trezor Suite**, which hosts the Connect core and renders all approval, PIN, passphrase and confirmation UI. Your app stays a thin client that routes each call to Suite.
 
-This means that if you are using Trezor Suite, you will no longer see the Connect Popup when making requests to Trezor devices. Instead, all requests will be handled directly within the Trezor Suite application.
+<Callout type="info">
+    Upgrading an existing v9 integration? Start with the [migration
+    guide](/guides/migrating-to-connect-10). This page explains the architecture; the migration
+    guide is the checklist.
+</Callout>
 
 ## How does it work?
 
-Connect automatically detects if Trezor Suite is running and available to handle requests.
-Under the hood, Trezor Suite exposes a WebSocket server on localhost, allowing apps to communicate with it using the Connect protocol.
+Connect detects how to reach Suite and routes each call to it. Suite owns the core and the entire user-facing experience. This works with or without a local install:
 
-The first step of the flow is a permission approval, which looks like this:
+- **Desktop** — when Trezor Suite (desktop) is running, Connect talks to it automatically over a local (loopback) WebSocket connection — no popup window, no iframe. Suite identifies the calling application (name, origin, icon) in a single permission-approval prompt, then handles the request against the currently active, already-unlocked device.
+- **Web** — when Suite desktop is not running, Connect opens Suite Web as the approval surface (production: `https://suite.trezor.io/web/connect-popup`), giving the same flow with nothing to install. This is a first-class path, not a degraded mode.
+- **Mobile** — `@trezor/connect-mobile` routes calls to Trezor Suite Lite via a deep link.
+
+The permission prompt displays the application's name, origin URL, and icon, along with the process that initiated the request. In this example the request was initiated by Arc Browser, so the browser's name and icon are shown. This prevents a malicious process from impersonating the application.
 
 <ZoomableIllustration
     src="/images/connect-suite-permissions-grant.webp"
     alt="permission prompt for approving the connection to Trezor Suite"
 />
 
-The permission prompt displays the application's name, origin URL, and icon, along with the process that initiated the request.
-In this example, the request was initiated by Arc Browser, so the name and icon of the browser are displayed.
-This is a security feature to prevent malicious processes from impersonating the application.
-
-Unlike the Connect Popup, there is no need to select the device or the passphrase. This is based on the active device in Trezor Suite, which should already be selected and unlocked.
-
-Once the request is approved and processed, the application receives a response with the result of the request.
-Trezor Suite may display additional context based on the request type, such as transaction details or address information.
-This example shows a `getAddress` call, which also prompts the user to confirm the address on the device.
+Once the request is approved and processed, the application receives a response with the result. Suite may display additional context based on the request type, such as transaction details or address information. This example shows a `getAddress` call, which also prompts the user to confirm the address on the device.
 
 <ZoomableIllustration
     src="/images/connect-get-address.webp"
     alt="address confirmation prompt in Trezor Suite"
 />
 
-## Changes for developers
+## `coreMode`: choosing the surface
 
-From version 9.6.0 onwards, this mode is active by default when Trezor Suite is detected.
+We strongly recommend keeping the default **`coreMode: 'auto'`**. Users who have Trezor Suite desktop installed get the fastest, most convenient experience — a direct local connection — while everyone else falls back to Suite Web seamlessly. In `'auto'` mode Connect prefers desktop and switches back to it automatically as soon as it becomes available.
 
-We added a new `appName` field to the `manifest` object when initializing the Trezor Connect SDK, which is required.
-You can also optionally provide an `appIcon` field with a URL for an icon that will appear in Trezor Suite’s permission prompt
-It should fit in a circle with a 64px diameter.
+You can pin `coreMode` to `'suite-desktop'` or `'suite-web'` if you have a specific reason to, but most integrations should not.
+
+## No more per-request device and passphrase selection
+
+Because the active device is chosen and unlocked **in Suite**, users no longer pick a device or re-enter a passphrase per request as they did in the old popup. Passphrase handling is centralized in Suite's device management (see the [passphrases & hidden wallets guide](https://trezor.io/guides/backups-recovery/advanced-wallets/passphrases-and-hidden-wallets)).
+
+## Required headers for the web flow
+
+The web flow relies on a bootstrap iframe + popup to exchange messages with Suite Web, so integrator pages must ship the right headers for that channel to work:
+
+- A **Content-Security-Policy** that permits embedding the Suite Web origin: `frame-src` (or `child-src`) for `https://suite.trezor.io`.
+- A **`Cross-Origin-Opener-Policy`** that does not sever the popup's `window.opener`. Avoid `same-origin` on the hosting page — use `same-origin-allow-popups` or `unsafe-none`.
+
+<Callout type="warning">
+    Missing or over-strict headers surface as a handshake timeout when the popup opens.
+</Callout>
+
+## Manifest
+
+`manifest.appName` is now **required**, and an optional `manifest.appIcon` (URL, sized for a 64px circle) is shown in Suite's permission prompt.
 
 ```javascript
 TrezorConnect.init({
     manifest: {
         email: 'developer@xyz.com',
         appName: 'Your Application',
-        appUrl: 'http://your.application.com',
-        appIcon: 'http://your.application.com/icon-64.png',
+        appUrl: 'https://your.application.com',
+        appIcon: 'https://your.application.com/icon-64.png',
     },
 });
 ```
-
-## Availability
-
-In Trezor Suite version 25.5 the feature is not enabled by default, but is available under the `Settings > Experimental features` toggle.
-
-From Trezor Suite version 25.6 onwards, we plan to enable the feature by default.

--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,3 +1,12 @@
+<!-- PINNED: remove once v10 is stable -->
+
+> **Upgrading from Connect 9?**
+>
+> - [Migration guide: Connect 9 → 10](https://connect.trezor.io/10/guides/migrating-to-connect-10) — what you need to change in your code, as a checklist.
+> - [New Connect flow in Trezor Suite](https://connect.trezor.io/10/guides/new-connect-flow-in-trezor-suite) — how the Suite-hosted flow works and why.
+
+<!-- /PINNED -->
+
 |             Package              | Stable |     Canary     |
 | :------------------------------: | :----: | :------------: |
 |       npm @trezor/connect        |   -    | 10.0.0-alpha.1 |
@@ -13,88 +22,53 @@ Use the persistent link [connect.trezor.io/10](https://connect.trezor.io/10/) to
 
 # 10.0.0-alpha.1
 
-Connect 10 is a major release that changes how third-party apps talk to a Trezor. The self-hosted iframe + popup that Connect served from `connect.trezor.io` is gone; every request is now handled by **Trezor Suite**, which hosts the Connect core and renders all approval, PIN, passphrase and confirmation UI. This works with or without a local install: if Suite desktop is running, Connect talks to it directly; otherwise it uses Suite Web. Installing the desktop app is never required. Alongside that, the SDK gains a privacy-friendly account picker (`selectAccount`), a granular per-coin permission model, and a smaller, ESM-only surface.
+Connect 10 moves the Connect core out of the self-hosted iframe + popup and into **Trezor Suite**, which now hosts the core and renders every approval, PIN, passphrase and confirmation screen. Your app stays a thin client calling the same `TrezorConnect` methods — nothing to install, and it works whether or not Suite desktop is running. Alongside the move, the SDK gains a privacy-friendly account picker (`selectAccount`), granular per-coin permissions, and much smaller ESM-only client packages.
 
-## Highlights
+**Upgrading from v9?** The [migration guide](https://connect.trezor.io/10/guides/migrating-to-connect-10) is the checklist of what changes in your code. For the architecture behind the move, see [New Connect flow in Trezor Suite](https://connect.trezor.io/10/guides/new-connect-flow-in-trezor-suite).
 
-### 1. New Connect flow, powered by Trezor Suite
+## What's new
 
-The legacy web popup/iframe integration has been **removed** and replaced by a flow that runs inside Trezor Suite. Connect is now a thin client that routes each call to Suite; Suite owns the core and the entire user-facing experience. It works on both desktop and web:
-
-- **Desktop** — when Trezor Suite (desktop) is running, Connect talks to it automatically over a local (loopback) WebSocket connection — no popup window, no iframe. Suite identifies the calling application (name, origin, icon) in a single permission-approval prompt, then handles the request against the currently active, already-unlocked device.
-- **Web** — when Suite desktop is not running, Connect opens Suite Web as the approval surface (production: `https://suite.trezor.io/web/connect-popup`), giving the same flow with nothing to install. This is a first-class path, not a degraded mode; in the default `'auto'` mode Connect prefers desktop and switches back to it automatically as soon as it becomes available.
-- **Mobile** — `@trezor/connect-mobile` routes calls to Trezor Suite Lite via a deep link.
-
-We strongly recommend keeping the default **`coreMode: 'auto'`**: users who have Trezor Suite desktop installed get the fastest, most convenient experience (a direct local connection), while everyone else falls back to Suite Web seamlessly. You can pin `coreMode` to `'suite-desktop'` or `'suite-web'` if you have a specific reason to.
-
-The web flow relies on a bootstrap iframe + popup to exchange messages with Suite Web, so integrator pages must ship the right headers for that channel to work: a Content-Security-Policy that permits embedding the Suite Web origin (`frame-src`/`child-src` for `https://suite.trezor.io`), and a `Cross-Origin-Opener-Policy` that does not sever the popup's `window.opener` (avoid `same-origin` on the hosting page — use `same-origin-allow-popups` or `unsafe-none`). Missing or over-strict headers surface as a handshake timeout when the popup opens.
-
-Because the active device is chosen and unlocked **in Suite**, users no longer pick a device or re-enter a passphrase per request as they did in the old popup — passphrase handling is centralized in Suite's device management (see the [passphrases & hidden wallets guide](https://trezor.io/guides/backups-recovery/advanced-wallets/passphrases-and-hidden-wallets) and the ["New Connect flow in Trezor Suite" guide](../guides/new-connect-flow-in-trezor-suite)).
-
-**Required manifest change:** `manifest.appName` is now **required**, and an optional `manifest.appIcon` (URL, sized for a 64px circle) is shown in Suite's permission prompt.
-
-```javascript
-TrezorConnect.init({
-    manifest: {
-        email: 'developer@xyz.com',
-        appName: 'Your Application',
-        appUrl: 'https://your.application.com',
-        appIcon: 'https://your.application.com/icon-64.png',
-    },
-});
-```
-
-### 2. `selectAccount` — private, friendlier account selection
-
-New method for asking the user to choose one or more accounts, replacing the old "call `getAccountInfo` with no path to trigger on-device discovery" pattern. The picker, derivation and on-device verification run entirely inside Suite.
-
-- **More private:** for UTXO coins you can request only what you need. `addressSelection: 'firstFresh' | 'manual'` exports a single **address** (with an optional SLIP-0019 `mac` to later re-prove device ownership) and never reveals the account xpub — requiring only the narrow `read_address` permission. The full-account/watch-only flow (`addressSelection: 'fullAccount'`, the default) shares the xpub and requires `read_xpub`. Account-based networks (EVM, Solana, …) always return an individual address.
-- **Better UX:** `selectionType` supports `'single'` (default), `'multi'`, or bounded multi-select (`{ minCount, maxCount }`); `accountType` filters/tabs the allowed derivation types (including custom `bip43Path` templates); `requireOnDeviceVerification` (default `true`) controls device confirmation.
-- Always returns an array of `{ symbol, path, address? | xpub?, accountType?, mac? }`, even for a single selection.
-
-### 3. Granular, per-coin permissions
-
-Permissions are no longer coarse read/write grants. Each method requires narrow scopes (such as `read_address`, `read_xpub`, `sign`, `sign_message`), scoped to a specific coin where relevant, and Suite groups them by coin in the approval prompt. Scopes are intentionally non-overlapping — e.g. granting `read_address` does **not** also grant `read_xpub` — so an app only ever gets access to what it actually uses.
-
-### 4. Much lighter client packages
-
-Because the Connect core now lives in Trezor Suite, the packages that third-party apps install (`@trezor/connect-web`, `-webextension`, `-mobile`) are thin clients that just route calls to Suite. They no longer bundle the core's heavy dependencies (transports, crypto, coin logic), so installs and bundles are dramatically smaller. As part of this, coin-family code has been reorganized into per-network packages (the former `@trezor/coins-*` are renamed to `@trezor/network-*`) that load their heavier dependencies on demand.
-
-### New coins & method improvements
-
-- **Tron** support (`tronGetAddress`, `tronSignTransaction`), backed by the new `@trezor/network-tron` package.
-- `solanaSignTransaction` accepts a `chunkify` flag that renders addresses on the device in 4-character chunks, matching `solanaGetAddress` and other coins' sign flows (requires firmware with chunked-address support in the Solana `SignTx` flow).
-- `ethereumSignTypedData` now computes the required hashes internally for T1B1 firmware, so callers no longer need `@trezor/connect-plugin-ethereum` to pre-compute them — passing only `data` works on all models (caller-provided hashes still take precedence).
-- The `*GetPublicKey` methods (`getPublicKey`, `ethereumGetPublicKey`, `cardanoGetPublicKey`, …) now share a **unified response shape** across coins, including a canonical `displayablePublicKey` string that any consumer can render without per-coin branching. This unification is also why the dedicated `getAccountDescriptor` method could be removed (see Breaking changes).
+- **Suite-hosted flow.** The legacy web popup/iframe is removed; Connect routes each call to Trezor Suite, which owns the core and the whole user experience. Works on desktop (direct local WebSocket, no popup), web (`suite.trezor.io`, nothing to install), and mobile (deep link to Suite Lite). Keep the default `coreMode: 'auto'`. → [architecture guide](https://connect.trezor.io/10/guides/new-connect-flow-in-trezor-suite)
+- **`selectAccount`** — a private, friendlier way to ask the user to choose one or more accounts, replacing the "call `getAccountInfo` with no path" pattern. For UTXO coins you can export just an address without ever revealing the xpub.
+- **Granular, per-coin permissions.** Methods request narrow, non-overlapping scopes (`read_address`, `read_xpub`, `sign`, `sign_message`) scoped per coin, and Suite groups them by coin in the approval prompt — an app only gets what it uses.
+- **Much lighter clients.** `@trezor/connect-web`, `-webextension` and `-mobile` no longer bundle the core's transports, crypto and coin logic, so installs and bundles shrink dramatically. Coin-family code is now split into on-demand `@trezor/network-*` packages (renamed from `@trezor/coins-*`).
+- **Tron** support (`tronGetAddress`, `tronSignTransaction`), via `@trezor/network-tron`.
+- **`ethereumSignTypedData`** computes the required T1B1 hashes internally — passing only `data` now works on all models, no `@trezor/connect-plugin-ethereum` needed.
+- **`solanaSignTransaction`** accepts `chunkify` to render addresses in 4-character chunks on device.
+- **Unified `*GetPublicKey` response** with a canonical `displayablePublicKey` any consumer can render without per-coin branching.
 
 ## Breaking changes
 
+Each item links to the step in the [migration guide](https://connect.trezor.io/10/guides/migrating-to-connect-10) with the before/after detail. Tags mark who a change hits.
+
 ### Integration & packaging
 
-- **Legacy iframe + popup integration removed.** `core-in-popup` and iframe-with-popup modes no longer exist; use the Suite-based flow above. `connect-iframe` has been removed.
-- **`manifest.appName` is now required** (see Highlights).
-- **ESM-only.** `@trezor/connect` and its dependency closure now ship ESM only. ESM consumers just `import TrezorConnect from '@trezor/connect'`; a CJS consumer that cannot migrate can use a dynamic `import()` or stay on v9.
-- **Public vs privileged API split.** The client packages now expose a public API (`TrezorConnectPublicAPI`) while `@trezor/connect` exposes the full privileged one (`TrezorConnectPrivilegedAPI`) used by Suite. The public tier drops everything that is Suite's responsibility — device-management methods (`applyFlags`, `applySettings`, `authenticateDevice`, `backupDevice`, `bleUnpair`, `changeLanguage`, `changePin`, `changeWipeCode`, `getFirmwareHash`, `getNonce`, `getSettings`, `loadDevice`, `pingDevice`, `recoveryDevice`, `resetDevice`, `setBrightness`, `setBusy`, `telemetryGet`, `thpGetCredentials`, `thpRemoveCredentials`, `wipeDevice`) are no longer callable from third-party integrations. Public `TrezorConnect` objects are now class instances, so `Object.keys(...)` enumeration and monkeypatching no longer work.
-- **Thin packages lost their event/settings API.** `on`/`off`/`removeAllListeners`, `uiResponse` and `updateConnectSettings` are removed from the public tier (they were already non-functional in v10, since the host Core does not forward them); calling them now throws `TypeError`.
-- **Type/factory renames.** The exported `TrezorConnect` type is replaced by `TrezorConnectPublicAPI` / `TrezorConnectPrivilegedAPI`, and the `factory` function by `factoryPublic` / `factoryPrivileged`. The API-schema values (`TrezorConnectCallable`, `TrezorConnectBitcoin`, …) are no longer exported as runtime values — the names remain as types only.
+- `[all]` Legacy `core-in-popup` and iframe-with-popup modes are gone; `connect-iframe` is removed. → [migration guide](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-1-required-for-every-integration)
+- `[all]` `manifest.appName` is now required. → [Step 1](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-1-required-for-every-integration)
+- `[all]` ESM-only. Use `import TrezorConnect from '@trezor/connect'`; CJS consumers use a dynamic `import()` or stay on v9. → [Step 1](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-1-required-for-every-integration)
+- `[all]` Public vs privileged API split: client packages expose `TrezorConnectPublicAPI`, `@trezor/connect` exposes `TrezorConnectPrivilegedAPI`. Device-management methods are no longer callable from third-party integrations, and `TrezorConnect` objects are now class instances (no `Object.keys` enumeration or monkeypatching). → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
+- `[all]` `on` / `off` / `removeAllListeners`, `uiResponse` and `updateConnectSettings` are removed from the public tier and throw `TypeError`. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
+- `[all]` Renames: the `TrezorConnect` type → `TrezorConnectPublicAPI` / `TrezorConnectPrivilegedAPI`; `factory` → `factoryPublic` / `factoryPrivileged`; API-schema values (`TrezorConnectCallable`, …) remain as types only. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
 
 ### Methods & parameters
 
-- **`coin` accepts the coin shortcut only** (the `CoinSymbol` set — e.g. `btc`, `bch`, `ada`), narrowed from `string`. Network **names** and **labels** (e.g. `'Bitcoin'`, `'Bitcoin Cash'`) are no longer accepted and now fail both at compile time and at runtime. The shortcut itself is still matched case-insensitively at runtime, so `coin: 'BTC'` works — but the `CoinSymbol` type lists the canonical lowercase forms, so TypeScript users should pass lowercase to type-check. Resolution is uniform across all coin families. Migrate names/labels to the shortcut: `'Bitcoin' → 'btc'`, `'Bitcoin Cash' → 'bch'`, `'cardano' → 'ada'`, etc. Path-taking methods (`getAddress`, `getPublicKey`, …) derive the network from `path` when given a former name/label; methods without a path fallback (`getAccountInfo`, `selectAccount`, `verifyMessage`, `composeTransaction`, `signTransaction`, `signMessage`, `getOwnershipId`, `getOwnershipProof`, the `blockchain*` family) throw `Method_UnknownCoin`. Full list: the [`CoinSymbol`](https://github.com/trezor/trezor-suite/blob/develop/packages/connect-common/src/types/coinInfo.ts) type.
-- **`getAccountDescriptor` removed.** The per-coin `*GetPublicKey` methods now return the same fields. Field mapping: `payload.descriptor` → Bitcoin `result.descriptor` (non-Bitcoin coins: use `result.displayablePublicKey`); `payload.path` → `result.serializedPath` on every `*GetPublicKey`; generic consumers should read `result.displayablePublicKey`.
-- **`getAccountInfo` no longer performs on-device discovery.** Calling it without `path` or `descriptor` now throws `Method_InvalidParameter` (`path or descriptor is required`) instead of opening a device-driven selection popup. Provide `path` (derive on device, then query backend) or `descriptor` (backend-only). For the old discovery behavior, use `discoverAccounts` — or `selectAccount` for user-facing selection.
-- **`cardanoGetPublicKey`:** `publicKey` is now the raw 32-byte key in hex (consistent with other coins); the Cardano extended public key moved to the new explicit `xpub` field (also available via `displayablePublicKey`).
-- **`useCardanoDerivation` removed.** Cardano session derivation is now driven by an app-level `enabledNetworks` declaration passed to `TrezorConnect.init({ enabledNetworks: [{ coin: 'ada' }] })` (or `updateConnectSettings` for in-process Core hosts). Note: `enabledNetworks` is honored only by the in-process `@trezor/connect`; on the thin packages, Cardano availability follows the host Suite wallet's enabled coins.
+- `[all]` `coin` accepts the coin shortcut only (e.g. `btc`, `bch`, `ada`); names and labels (`'Bitcoin'`) are rejected. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
+- `[all]` `getAccountDescriptor` removed — use the per-coin `*GetPublicKey`. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
+- `[all]` `getAccountInfo` without `path` or `descriptor` throws `Method_InvalidParameter`; use `discoverAccounts` or `selectAccount` for the old discovery behaviour. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
+- `[Cardano]` `cardanoGetPublicKey`: `publicKey` is now the raw 32-byte hex key; read the new `xpub` (or `displayablePublicKey`) for the extended key. → [Cardano](https://connect.trezor.io/10/guides/migrating-to-connect-10#cardano)
+- `[Cardano]` `useCardanoDerivation` removed — declare `init({ enabledNetworks: [{ coin: 'ada' }] })` instead. → [Cardano](https://connect.trezor.io/10/guides/migrating-to-connect-10#cardano)
 
 ### Transports
 
-These mostly affect apps that run their own Connect core (`@trezor/connect`); most integrations use the client packages and can skip this.
+- `[core hosts]` Pass `transports` as constructed `Transport` instances; string identifiers and classes are no longer accepted. Use `@trezor/transport-web` for WebUSB. → [Step 5](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-5-only-if-you-host-connect-core-trezorconnect)
+- `[core hosts]` `disableWebUSB()` removed — use `updateConnectSettings({ transports })` with a filtered list. → [Step 5](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-5-only-if-you-host-connect-core-trezorconnect)
+- `[core hosts]` Legacy `trezord-go` Bridge (port `21325`) is no longer supported and `TransportInfo.outdated` is removed. → [Step 5](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-5-only-if-you-host-connect-core-trezorconnect)
 
-- **Transports must be passed as instances.** `transports` no longer accepts string identifiers (`'BridgeTransport'`, …) or classes — pass fully constructed `Transport` instances, e.g. `import { BridgeTransport } from '@trezor/transport-common'; init({ transports: [new BridgeTransport({ id: 'my-app' })] })`. For WebUSB use `@trezor/transport-web`; avoid the Node-only `@trezor/transport` barrel in web/React Native bundles.
-- **`disableWebUSB()` removed** — use `updateConnectSettings({ transports })` with a filtered list instead.
-- **Legacy `trezord-go` Bridge (port `21325`) is no longer supported** and `TransportInfo.outdated` is removed; detecting an outdated Bridge is now the consumer app's job.
+### Removed
 
-## Removed & deprecated
+- `[all]` Removed coin support: EOS, NEM. → [Removed coins](https://connect.trezor.io/10/guides/migrating-to-connect-10#removed-coins)
+- `[all]` `@trezor/connect-plugin-ethereum` deprecated; its logic is inlined into `@trezor/connect`. Drop the dependency and remove `transformTypedData` calls — the 10.x plugin is a stub that throws. → [Step 2](https://connect.trezor.io/10/guides/migrating-to-connect-10#step-2-only-if-you-use-these-apis)
 
-- **Removed coin support:** EOS, NEM.
-- **`@trezor/connect-plugin-ethereum` deprecated.** Its logic is inlined into `@trezor/connect`. Drop the direct dependency and remove manual `transformTypedData` calls. The 10.x plugin is a stub that throws a deprecation error pointing at the migration.
+---
+
+Full commit history for this release: [packages/connect on GitHub](https://github.com/trezor/trezor-suite/commits/develop/packages/connect).


### PR DESCRIPTION
Stacked on top of #30252. Reworks **how we talk about Connect 10**, aimed at existing v9 integrators who need a clear upgrade path. Splits the packed `10.0.0-alpha.1` entry's three overlapping jobs (announce / changelog / migrate) into purpose-built documents.

## What changed

- **`packages/connect/CHANGELOG.md`** — reframed the entry: opens on the upgrade path rather than "the popup is gone", adds a pinned "upgrading from v9?" banner (absolute URLs so it works on GitHub/npm too), a "What's new" section, and scannable breaking-change bullets tagged by audience (`[all]` / `[Cardano]` / `[core hosts]`) that link into the migration guide instead of inlining rationale.
- **`guides/migrating-to-connect-10.mdx`** (new) — single source of truth for the upgrade: an "API changes at a glance" lookup table, an "Installing the alpha" section (install command, **Suite 26.7.2+** requirement, feedback link, v9-timeline note), and a Step 0–5 checklist.
- **`guides/new-connect-flow-in-trezor-suite.mdx`** — refreshed from the stale 9.6.0 text to the v10 Suite-hosted flow: desktop/web/mobile modes, `coreMode`, and the CSP/COOP header requirements.

## Notes

- Base is `rewrite-connect10-changelog` so the diff shows only these doc edits.
- The rendered changelog page fetches `CHANGELOG.md` from the release branch, so the reframed changelog previews on the per-branch sldev deploy, not the general explorer preview. The two guides render locally.
- Deliberately **not** filled in (need facts): a canary dist-tag beyond the pinned version, and a "known limitations / not-yet-implemented" list for the alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)