### PR TITLE
ci(connect): guard npm release against unreserved package names

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -4,39 +4,9 @@ inputs:
   deploymentType:
     description: "Specifies the deployment type for the npm package. Use 'alpha' for early prereleases, 'beta' for prereleases close to production, and 'latest' for stable versions intended for end-users."
     required: true
-    type: choice
-    options:
-      - alpha
-      - beta
-      - latest
   packageName:
-    description: "The name of the package to be deployed. Select from the predefined list of packages."
+    description: "The name of the package to be deployed, without the @trezor/ scope (e.g. 'connect-web' or 'network-solana')."
     required: true
-    type: choice
-    options:
-      - blockchain-link-types
-      - blockchain-link-utils
-      - blockchain-link
-      - connect-common
-      - connect-data
-      - transport
-      - utils
-      - utxo-lib
-      - connect-plugin-stellar
-      - connect-plugin-ethereum
-      - type-utils
-      - env-utils
-      - protocol
-      - protobuf
-      - schema-utils
-      - crypto-utils
-      - device-utils
-      - device-authenticity
-      - network-solana
-      - connect
-      - connect-web
-      - connect-webextension
-      - connect-mobile
 
 runs:
   using: "composite"

--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -89,9 +89,36 @@ jobs:
         run: |
           yarn tsx ./scripts/ci/check-packages-same-deployment-type.ts '${{ env.PACKAGES }}' "${{ env.DEPLOYMENT_TYPE }}"
 
+  # CI cannot publish a package name that does not exist on npm yet, because npm requires the package
+  # to exist before a trusted publisher (OIDC) can be configured for it. We check all packages
+  # upfront so that a missing reservation does not leave the release half-published.
+  check-packages-reserved:
+    name: Check npm package names are reserved
+    runs-on: ubuntu-latest
+    needs: [identify-release-packages]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Setup node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Check packages exist on the npm registry
+        env:
+          PACKAGES: ${{ needs.identify-release-packages.outputs.packagesNeedRelease }}
+        run: node ./scripts/ci/check-npm-packages-reserved.js "$PACKAGES"
+
   deploy-npm-connect-dependencies:
     name: Deploy NPM ${{ needs.identify-release-packages.outputs.deploymentType }} ${{ matrix.package }}
-    needs: [extract-version, sanity-check-version-match, identify-release-packages]
+    needs:
+      [
+        extract-version,
+        sanity-check-version-match,
+        identify-release-packages,
+        check-packages-reserved,
+      ]
     environment: production-connect
     runs-on: ubuntu-latest
     strategy:

--- a/docs/packages/creating-packages.md
+++ b/docs/packages/creating-packages.md
@@ -7,3 +7,25 @@
 1. Place this package to dependency field of package.json in package where you want to use it.
 1. Run `yarn refs` to generate tsconfig refs.
 1. Run `yarn` to let yarn symlink this package.
+
+## How to publish this new package to npm?
+
+Only needed for packages with `publishConfig` that end up in the `@trezor/connect` dependency tree,
+those are published by the `[Release] Connect NPM` workflow.
+
+The workflow authenticates to npm with OIDC ([trusted publishing](https://docs.npmjs.com/trusted-publishers/)),
+and npm can only configure a trusted publisher for a package that already exists on the registry. So a
+brand-new name has to be reserved once, locally, by a maintainer with npm publish rights:
+
+```bash
+yarn reserve-npm-package network-tron
+```
+
+That publishes a `0.0.0-reserved` placeholder (uninstallable, published under the `reserved` dist tag)
+and configures GitHub Actions as the trusted publisher. Afterwards the release workflow publishes the
+package like any other one. Add `--dry-run` to preview both steps without touching the registry.
+
+Skipping this fails the release in the `Check npm package names are reserved` job, and if it were
+skipped there it would fail mid-release with `YN0033: No authentication configured for request`. The
+same reservation is also listed as a checklist item in the version bump PR comment. Renaming an
+already published package counts as a new name and needs a new reservation.

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "update-project-references": "yarn tsx ./scripts/updateProjectReferences.ts",
         "generate-icons": "yarn workspace @suite-common/icons generate-icons && yarn workspace @trezor/icons generate-icons",
         "generate-package": "yarn workspace @trezor/scripts generate-package",
+        "reserve-npm-package": "node ./scripts/ci/npm-reserve-package.js",
         "deps": "rimraf **/node_modules && yarn",
         "list-outdated": "./scripts/list-outdated-dependencies/list-outdated-dependencies.sh",
         "message-system-sign-config": "yarn workspace @suite-common/message-system sign-config",

--- a/scripts/ci/check-npm-packages-reserved.js
+++ b/scripts/ci/check-npm-packages-reserved.js
@@ -1,0 +1,73 @@
+// Fails the connect NPM release before anything is published if any package that is about to be
+// released does not exist on the npm registry yet.
+//
+// CI cannot publish a brand-new package name: npm requires the package to exist before a trusted
+// publisher (OIDC) can be configured for it, so `yarn npm publish` fails with "YN0033: No
+// authentication configured for request". Since packages are published in dependency order, hitting
+// this in the middle of a release leaves it half-published (dependencies out, connect not).
+//
+// Usage: node ./scripts/ci/check-npm-packages-reserved.js '["utils","transport"]'
+
+import { isPackageOnNpmRegistry } from './npm-registry.js';
+
+// Kept in sync with the `deploy-npm-connect` matrix in .github/workflows/release-connect-npm.yml.
+const CONNECT_PACKAGES = ['connect', 'connect-web', 'connect-webextension', 'connect-mobile'];
+
+// What `identify-release-packages` passes instead of an empty array.
+const NO_PACKAGES_TO_RELEASE = 'no-packages-to-release';
+
+const [packagesToReleaseJSON] = process.argv.slice(2);
+
+if (!packagesToReleaseJSON) {
+    throw new Error(
+        'Reserved packages check requires 1 parameter: JSON array of package names to release',
+    );
+}
+
+const packagesToRelease = JSON.parse(packagesToReleaseJSON);
+
+if (!Array.isArray(packagesToRelease)) {
+    throw new Error(`Expected a JSON array of package names, got ${packagesToReleaseJSON}`);
+}
+
+const packagesToCheck = [
+    ...new Set([
+        ...packagesToRelease.filter(packageName => packageName !== NO_PACKAGES_TO_RELEASE),
+        ...CONNECT_PACKAGES,
+    ]),
+];
+
+const results = await Promise.all(
+    packagesToCheck.map(async packageName => ({
+        packageName,
+        isReserved: await isPackageOnNpmRegistry(`@trezor/${packageName}`),
+    })),
+);
+
+const unreservedPackages = results
+    .filter(({ isReserved }) => !isReserved)
+    .map(({ packageName }) => packageName);
+
+if (!unreservedPackages.length) {
+    console.log(`All ${packagesToCheck.length} packages to release exist on the npm registry.`);
+    process.exit(0);
+}
+
+console.log(
+    `::error title=Unreserved npm package names::${unreservedPackages.join(', ')} - reserve the names before releasing, see the job log`,
+);
+console.error(
+    [
+        '',
+        `These packages are not on the npm registry yet, so CI cannot publish them:`,
+        ...unreservedPackages.map(packageName => `  - @trezor/${packageName}`),
+        '',
+        'A maintainer with npm publish rights has to reserve each name once, locally:',
+        ...unreservedPackages.map(packageName => `  yarn reserve-npm-package ${packageName}`),
+        '',
+        'Then re-run this workflow. See docs/packages/creating-packages.md for details.',
+        '',
+    ].join('\n'),
+);
+
+process.exit(1);

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -10,6 +10,7 @@ import {
     getTrezorPackageDir,
     gettingNpmDistributionTags,
 } from './helpers';
+import { isPackageOnNpmRegistry } from './npm-registry.js';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -118,6 +119,17 @@ const updateConnectChangelog = async (
     } catch (error) {
         console.error('Error updating CHANGELOG.md:', error);
     }
+};
+
+const getUnreservedNpmPackages = async (packageNames: string[]) => {
+    const packages = await Promise.all(
+        packageNames.map(async packageName => ({
+            packageName,
+            isReserved: await isPackageOnNpmRegistry(`@trezor/${packageName}`),
+        })),
+    );
+
+    return packages.filter(({ isReserved }) => !isReserved).map(({ packageName }) => packageName);
 };
 
 const bumpConnect = async () => {
@@ -274,10 +286,27 @@ const bumpConnect = async () => {
             '',
         );
 
+        // The release workflow publishes over OIDC, which npm cannot set up for a package that does
+        // not exist yet. Warning here gives us time to reserve the names before the release runs.
+        const unreservedPackages = await getUnreservedNpmPackages(allUniquePackagesToUpdate);
+        const unreservedPackagesWarning = unreservedPackages.length
+            ? [
+                  '',
+                  '',
+                  '> [!WARNING]',
+                  '> These packages are not on the npm registry yet, so the release workflow cannot publish them.',
+                  '> Reserve each name locally before releasing (needs npm publish rights):',
+                  '>',
+                  ...unreservedPackages.map(
+                      packageName => `> - [ ] \`yarn reserve-npm-package ${packageName}\``,
+                  ),
+              ].join('\n')
+            : '';
+
         if (depsChecklist) {
             await comment({
                 prNumber,
-                body: depsChecklist,
+                body: `${depsChecklist}${unreservedPackagesWarning}`,
             });
         }
 

--- a/scripts/ci/npm-registry.js
+++ b/scripts/ci/npm-registry.js
@@ -1,0 +1,27 @@
+const REGISTRY_URL = 'https://registry.npmjs.org';
+
+// Abbreviated metadata, we only care about the package existing, not about its (potentially huge) packument.
+const ABBREVIATED_METADATA_ACCEPT_HEADER = 'application/vnd.npm.install-v1+json';
+
+/**
+ * A package name is "reserved" once it exists on the registry. Until then npm refuses to configure
+ * a trusted publisher (OIDC) for it, which is how all @trezor/* packages are published from CI.
+ *
+ * @param {string} packageName Full package name, including the scope, e.g. `@trezor/connect`.
+ * @returns {Promise<boolean>}
+ */
+export const isPackageOnNpmRegistry = async packageName => {
+    const response = await fetch(`${REGISTRY_URL}/${packageName}`, {
+        headers: { accept: ABBREVIATED_METADATA_ACCEPT_HEADER },
+    });
+
+    if (response.status === 404) {
+        return false;
+    }
+
+    if (!response.ok) {
+        throw new Error(`npm registry returned ${response.status} for ${packageName}`);
+    }
+
+    return true;
+};

--- a/scripts/ci/npm-reserve-package.js
+++ b/scripts/ci/npm-reserve-package.js
@@ -1,0 +1,264 @@
+// Reserves a new @trezor/* package name on the npm registry and configures GitHub Actions as its
+// trusted publisher, so that "[Release] Connect NPM" can publish it over OIDC.
+//
+// This has to be run once per new package, locally, by a maintainer with npm publish rights:
+//
+//     yarn reserve-npm-package network-tron
+//
+// Pass --dry-run to see what would be published and which trusted publisher would be configured,
+// without touching the registry.
+//
+// It cannot be automated in CI: npm refuses to configure a trusted publisher for a package that
+// does not exist yet, and `npm trust` requires account-level 2FA (it rejects tokens with 2FA
+// bypass), so a human has to be in the loop either way.
+//
+// The placeholder is published as 0.0.0-reserved under the `reserved` dist tag, which keeps the
+// package uninstallable until the release workflow publishes the first real version.
+
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { isPackageOnNpmRegistry } from './npm-registry.js';
+
+const ROOT = path.join(import.meta.dirname, '..', '..');
+
+const PLACEHOLDER_VERSION = '0.0.0-reserved';
+const PLACEHOLDER_DIST_TAG = 'reserved';
+
+// Trusted publisher of every @trezor/* package released from the connect release workflow.
+const GITHUB_REPOSITORY = 'trezor/trezor-suite';
+const RELEASE_WORKFLOW_FILE = 'release-connect-npm.yml';
+const RELEASE_ENVIRONMENT = 'production-connect';
+
+// `npm trust` was introduced in npm@11.15.0, which may be newer than the npm bundled with .nvmrc Node.
+const MINIMAL_NPM_MAJOR_WITH_TRUST = 11;
+const MINIMAL_NPM_MINOR_WITH_TRUST = 15;
+
+const getPackagePath = packageName => {
+    // Network packages live in ./networks/<network>/network-<network>, everything else in ./packages.
+    const networkMatch = packageName.match(/^network-([^-]+)(-(.+))?$/);
+
+    return networkMatch
+        ? path.join(ROOT, 'networks', networkMatch[1], packageName)
+        : path.join(ROOT, 'packages', packageName);
+};
+
+const run = ({ command, args, cwd = ROOT, isFatal = true }) => {
+    console.log(`\n$ ${command} ${args.join(' ')}\n`);
+
+    const { status, error } = child_process.spawnSync(command, args, { cwd, stdio: 'inherit' });
+
+    if (error) {
+        throw error;
+    }
+
+    if (status !== 0 && isFatal) {
+        throw new Error(`"${command} ${args.join(' ')}" failed with exit code ${status}`);
+    }
+
+    return status === 0;
+};
+
+// `npm trust` lives in a newer npm than the one bundled with our Node version, in which case we run
+// it through npx instead of asking the maintainer to upgrade their global npm.
+const getNpmCommandWithTrust = () => {
+    const { stdout } = child_process.spawnSync('npm', ['--version'], { encoding: 'utf-8' });
+    const npmVersion = stdout.trim();
+    const [major, minor] = npmVersion.split('.').map(Number);
+    const hasTrustCommand =
+        major > MINIMAL_NPM_MAJOR_WITH_TRUST ||
+        (major === MINIMAL_NPM_MAJOR_WITH_TRUST && minor >= MINIMAL_NPM_MINOR_WITH_TRUST);
+
+    if (hasTrustCommand) {
+        return { command: 'npm', args: [] };
+    }
+
+    console.log(
+        `Local npm ${npmVersion} has no "trust" command (npm@${MINIMAL_NPM_MAJOR_WITH_TRUST}.${MINIMAL_NPM_MINOR_WITH_TRUST}.0+ needed), running it through npx.`,
+    );
+
+    return { command: 'npx', args: ['-y', 'npm@latest'] };
+};
+
+const getNpmUsername = () => {
+    const { status, stdout } = child_process.spawnSync('npm', ['whoami'], { encoding: 'utf-8' });
+
+    return status === 0 ? stdout.trim() : undefined;
+};
+
+const getTrustArgs = packageName => [
+    'trust',
+    'github',
+    packageName,
+    '--repository',
+    GITHUB_REPOSITORY,
+    '--file',
+    RELEASE_WORKFLOW_FILE,
+    '--environment',
+    RELEASE_ENVIRONMENT,
+    '--allow-publish',
+];
+
+const createPlaceholderPackage = ({ packageName, homepage }) => {
+    const placeholderPath = fs.mkdtempSync(path.join(os.tmpdir(), 'trezor-reserve-npm-'));
+
+    const placeholderPackageJSON = {
+        name: packageName,
+        version: PLACEHOLDER_VERSION,
+        description: `Placeholder reserving the ${packageName} name on npm. Not meant to be installed.`,
+        license: 'SEE LICENSE IN LICENSE.md',
+        repository: { type: 'git', url: `git://github.com/${GITHUB_REPOSITORY}.git` },
+        homepage,
+        publishConfig: { access: 'public' },
+    };
+
+    fs.writeFileSync(
+        path.join(placeholderPath, 'package.json'),
+        `${JSON.stringify(placeholderPackageJSON, null, 4)}\n`,
+    );
+    fs.writeFileSync(
+        path.join(placeholderPath, 'README.md'),
+        [
+            `# ${packageName}`,
+            '',
+            `Placeholder reserving the \`${packageName}\` name so that it can be published from CI`,
+            `over OIDC. The first real version is published from ${GITHUB_REPOSITORY}.`,
+            '',
+        ].join('\n'),
+    );
+    fs.copyFileSync(path.join(ROOT, 'LICENSE.md'), path.join(placeholderPath, 'LICENSE.md'));
+
+    return placeholderPath;
+};
+
+// A first publish may set the `latest` dist tag even though we publish under a different one. We
+// remove it so that `npm install` of the package keeps failing until the first real release.
+const removeLatestDistTag = packageName => {
+    const { stdout } = child_process.spawnSync(
+        'npm',
+        ['view', packageName, 'dist-tags', '--json'],
+        { encoding: 'utf-8' },
+    );
+
+    let distTags = {};
+    try {
+        distTags = JSON.parse(stdout);
+    } catch {
+        console.warn(`Could not read dist tags of ${packageName}, skipping the "latest" cleanup.`);
+
+        return;
+    }
+
+    if (!distTags.latest) {
+        return;
+    }
+
+    const isRemoved = run({
+        command: 'npm',
+        args: ['dist-tag', 'rm', packageName, 'latest'],
+        isFatal: false,
+    });
+
+    if (!isRemoved) {
+        console.warn(
+            `Could not remove the "latest" dist tag, do it manually: npm dist-tag rm ${packageName} latest`,
+        );
+    }
+};
+
+const reserveNpmPackage = async () => {
+    const scriptArguments = process.argv.slice(2);
+    const isDryRun = scriptArguments.includes('--dry-run');
+    const [packageNameArgument] = scriptArguments.filter(argument => argument !== '--dry-run');
+
+    if (!packageNameArgument) {
+        throw new Error(
+            'Reserve script requires 1 parameter: package name, e.g. "yarn reserve-npm-package network-tron"',
+        );
+    }
+
+    const packageDirectoryName = packageNameArgument.replace('@trezor/', '');
+    const packageJSONPath = path.join(getPackagePath(packageDirectoryName), 'package.json');
+
+    if (!fs.existsSync(packageJSONPath)) {
+        throw new Error(`${packageJSONPath} not found, is "${packageDirectoryName}" correct?`);
+    }
+
+    const {
+        name: packageName,
+        homepage,
+        publishConfig,
+        private: isPrivate,
+    } = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));
+
+    if (isPrivate || !publishConfig) {
+        throw new Error(`${packageName} is not published to npm, there is nothing to reserve.`);
+    }
+
+    const { command, args } = getNpmCommandWithTrust();
+    const trustCommand = [command, ...args, ...getTrustArgs(packageName)].join(' ');
+
+    if (await isPackageOnNpmRegistry(packageName)) {
+        console.log(`${packageName} already exists on npm, no reservation needed.`);
+        console.log(
+            `\nIf the release still fails with "No authentication configured for request", its trusted publisher is missing:\n\n    ${trustCommand}\n`,
+        );
+
+        return;
+    }
+
+    const npmUsername = getNpmUsername();
+
+    if (!npmUsername && !isDryRun) {
+        throw new Error('Not logged in to npm, run "npm login" first.');
+    }
+
+    const npmAccount = npmUsername ? ` as npm user ${npmUsername}` : '';
+
+    console.log(`Reserving ${packageName} on npm as ${PLACEHOLDER_VERSION}${npmAccount}.`);
+
+    const placeholderPath = createPlaceholderPackage({ packageName, homepage });
+
+    try {
+        run({
+            command: 'npm',
+            args: [
+                'publish',
+                '--tag',
+                PLACEHOLDER_DIST_TAG,
+                '--access',
+                'public',
+                ...(isDryRun ? ['--dry-run'] : []),
+            ],
+            cwd: placeholderPath,
+        });
+    } finally {
+        fs.rmSync(placeholderPath, { recursive: true, force: true });
+    }
+
+    if (isDryRun) {
+        console.log(`\nWould configure the trusted publisher with:\n\n    ${trustCommand}\n`);
+
+        return;
+    }
+
+    removeLatestDistTag(packageName);
+
+    console.log('\nConfiguring GitHub Actions as the trusted publisher.');
+    run({ command, args: [...args, ...getTrustArgs(packageName)] });
+
+    console.log(
+        [
+            '',
+            `${packageName} is reserved and can now be published by "[Release] Connect NPM".`,
+            '',
+            'Verify with:',
+            `    ${[command, ...args, 'trust', 'list', packageName].join(' ')}`,
+            '',
+        ].join('\n'),
+    );
+};
+
+reserveNpmPackage();


### PR DESCRIPTION
## Description

New `@trezor/*` packages cannot be published from CI: npm requires a package to exist before a trusted publisher (OIDC) can be configured for it, so `yarn npm publish` fails with `YN0033: No authentication configured for request` — which is what left [10.0.0-alpha.1](https://github.com/trezor/trezor-suite/actions/runs/25914546385) half-published in May (20 dependencies out, `connect` skipped). This adds a `check-packages-reserved` job that fails the release *before* anything is published, a `yarn reserve-npm-package <name>` command that publishes an uninstallable `0.0.0-reserved` placeholder and configures GitHub Actions as the trusted publisher in one step, and a warning in the version bump PR comment so names get reserved before the release branch even exists. The reservation itself stays manual on purpose: `npm trust` requires account-level 2FA and rejects tokens with 2FA bypass, so a token in CI would not remove the manual step — it would only re-add a long-lived write credential that the npm CLI silently prefers as an OIDC fallback. It also drops the hand-maintained (and already stale) `packageName` option list from the composite action, which GitHub ignores for composite actions anyway.

## Notes for QA

No app/runtime code is touched — this is release tooling only. Worth knowing before the next connect release: seven packages in the current `@trezor/connect` dependency closure are not on npm yet (`transport-common`, `transport-web`, `network-cardano`, `network-ripple`, `network-solana`, `network-stellar`, `network-tron`), so `[Release] Connect NPM` will now stop in the new job until someone with npm publish rights runs `yarn reserve-npm-package <name>` for each (`--dry-run` previews it without touching the registry).

Verified locally: lint, type-check and prettier pass; the preflight script was run against the live registry (exit 1 with the instructions for unreserved names, exit 0 when all exist, `no-packages-to-release` sentinel handled), and the reserve script end-to-end in `--dry-run` plus its error paths (not logged in, private package, typo'd name, missing argument).

## Related Issue

Resolve N/A

## Screenshots:

Output of the new gate:

```
::error title=Unreserved npm package names::transport-web - reserve the names before releasing, see the job log

These packages are not on the npm registry yet, so CI cannot publish them:
  - @trezor/transport-web

A maintainer with npm publish rights has to reserve each name once, locally:
  yarn reserve-npm-package transport-web

Then re-run this workflow. See docs/packages/creating-packages.md for details.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/los-angeles/web/](https://dev.suite.sldev.cz/suite-web/los-angeles/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=los-angeles&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=los-angeles&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T10:49:45.804Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T10:49:41.932Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->