### PR TITLE
chore(suite-desktop): code commentary on useless code-splitting

### DIFF
--- a/packages/suite-desktop-ui/src/support/desktopComponents.ts
+++ b/packages/suite-desktop-ui/src/support/desktopComponents.ts
@@ -47,6 +47,15 @@ import { TradingSellForm } from 'src/views/wallet/trading/sell/TradingSellForm';
 import { TradingTransactions } from 'src/views/wallet/trading/transactions/TradingTransactions';
 import { Transactions } from 'src/views/wallet/transactions/Transactions';
 
+/*
+ Note 1: Currently, this list contains the same components as webComponents.ts, but there could be Desktop-specific
+ pages to avoid bundling Desktop code into @trezor/suite, which ends up in Web too.
+
+ Note 2: Unlike Web, we don't use code-splitting with dynamic JS bundle loading – on Desktop it'd be useless.
+ There's an idea that on weak CPU, parsing & interpreting the JS bundle could be a limiting factor (code-splitting could help).
+ But it was tested that this is negligible time. On weak CPU, code execution is the limiting factor (unaffected by code-splitting).
+*/
+
 export const desktopComponents: Record<PageName, ComponentType> = {
     'suite-index': Dashboard,
     'suite-earn': Earn,


### PR DESCRIPTION
## Description

This is the right place for code commentary, so devs in future understand why code-splitting is / isn't used.

### Test setup

Windows 11 laptop with 8th gen intel i5, throttled to 30 %.
Tested A) develop build B) build with code splitting in `desktopComponents.ts`:
open Suite, press ctrl+R, measure time from ctrl+R press to appearance of dashboard graph skeleton.
I made ~ 5 attempts for each, but the difference of avg times is much less than stddev → totally inconclusive :shrug: 

:information_source: TIL you can arbitrarily throttle CPU in :window:, FYI you can do that in:
Control Panel → Power Options → (your current power plan) → Advanced power settings → Processor power management → Maximum processor state

## Related Issue

Research as part of #28882