### PR TITLE
fix(suite-native): preserve TrezorConnect cancel context

### DIFF
--- a/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
+++ b/suite-native/module-device-settings/src/screens/WipeDeviceContinueOnTrezorScreen.tsx
@@ -12,14 +12,13 @@ import TrezorConnect from '@trezor/connect';
 
 export const WipeDeviceContinueOnTrezorScreen = () => {
     const shouldFactoryResetBeVisible = useSelector(selectShouldFactoryResetBeVisible);
-
-    useInterceptNativeNavigation({ onPress: TrezorConnect.cancel });
-
     const device = useSelector(selectSelectedDevice);
 
     const closeAction = useCallback(() => {
         TrezorConnect.cancel();
     }, []);
+
+    useInterceptNativeNavigation({ onPress: closeAction });
 
     if (!device) {
         return null;

--- a/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import {
@@ -17,7 +19,11 @@ export const ReceiveAddressVerificationScreen = () => {
         params: { source },
     } = useRoute<RouteProp<ReceiveStackParamList, ReceiveStackRoutes.ReceiveAddressVerification>>();
 
-    useInterceptNativeNavigation({ onPress: TrezorConnect.cancel });
+    const handleCancel = useCallback(() => {
+        TrezorConnect.cancel();
+    }, []);
+
+    useInterceptNativeNavigation({ onPress: handleCancel });
 
     const titleTxKey =
         source === ReceiveAddressVerificationSource.Shared


### PR DESCRIPTION
## Description

Preserves the `TrezorConnect` method context when native back navigation cancels device flows. Passing `TrezorConnect.cancel` directly to `useInterceptNativeNavigation` detached the method from its instance, so the hook later called it with `this` as `undefined` and crashed inside `CoreInModule.cancel`.

This wraps the cancel call in callbacks for receive address verification and wipe-device continue-on-Trezor screens.

## Notes for QA

Verify Android hardware back navigation on Receive address verification while waiting for confirmation on Trezor.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29734

## Screenshots:


https://github.com/user-attachments/assets/e86b8ac9-c053-4e52-a341-66a358a86ca9


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/onpress-this-loss&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->