### PR TITLE
fix(transport-bluetooth): throttle `transport-interface-change` event

### DIFF
--- a/packages/transport-bluetooth/src/client/bluetooth-api.ts
+++ b/packages/transport-bluetooth/src/client/bluetooth-api.ts
@@ -12,7 +12,11 @@ import {
 } from '@trezor/transport-common';
 
 import { TrezorBluetooth } from './trezor-bluetooth';
-import { type BluetoothDevice, type TrezorBluetoothSettings } from './types';
+import {
+    type BluetoothAdapterState,
+    type BluetoothDevice,
+    type TrezorBluetoothSettings,
+} from './types';
 
 // implementation of @trezor/transport/src/api/abstract
 
@@ -22,6 +26,7 @@ export class BluetoothApi extends AbstractApi {
     chunkSize = 244;
     api: TrezorBluetooth;
 
+    private adapterState?: BluetoothAdapterState;
     private readBuffer = readMessageBuffer();
     private readSubscription: Record<string, boolean> = {}; // [device.id]: true
 
@@ -85,9 +90,11 @@ export class BluetoothApi extends AbstractApi {
             }
         });
         api.on('adapter_state_changed', ({ state }) => {
+            if (this.adapterState === state) return;
             if (state !== 'enabled') {
                 transportApiEvent({ devices: [] });
             }
+            this.adapterState = state;
         });
         api.on('disconnected', () => {
             this.emit('transport-interface-error', { error: ERRORS.API_DISCONNECTED });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Minor issue on linux and disabled bluetooth (disabled via systemctl)

If BT adapter is not found then `adapter_state_changed` === 'disabled' is emitted periodically (until adapter is found) - this leads to unnecessary `transport-interface-change` event overflow:

<img width="1824" height="932" alt="Screenshot from 2026-07-28 13-55-42" src="https://github.com/user-attachments/assets/a11b3833-162b-48b9-a3f3-3f332e239f8f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is the Bluetooth transport client API (packages/transport-bluetooth/src/client/bluetooth-api.ts), which has no static test coverage mapping. Among the candidate tests, only forget-device.test.ts explicitly exercises Bluetooth-specific device state, pairing, and unpairing flows, making it the most relevant inferred test. multiple-sessions.test.ts is included at low priority since it touches transport/session reconnection logic conceptually related to transport clients, but it targets Bridge transport, not Bluetooth. Recommend running forget-device.test.ts as a priority check and multiple-sessions.test.ts as a secondary sanity check.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport-bluetooth/src/client/bluetooth-api.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This changed file is the Bluetooth client API for transport-bluetooth, and this test exercises Bluetooth device state mocking, pairing/unpairing, and forget-device flows for TS7 devices with Bluetooth history, directly touching Bluetooth client behavior.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test covers transport/session management (Bridge session takeover and reconnection) which is adjacent to transport client logic, though it targets Bridge transport rather than Bluetooth specifically.

</details>

_Updated: 2026-07-28T12:24:08.463Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/transport-bluetooth-emit-changes/web/](https://dev.suite.sldev.cz/suite-web/fix/transport-bluetooth-emit-changes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/transport-bluetooth-emit-changes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/transport-bluetooth-emit-changes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:26:36.654Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:26:14.450Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->