### PR TITLE
test(trading): co-locate utility tests

### DIFF
--- a/suite-common/trading/src/utils/apiKeyUtils.test.ts
+++ b/suite-common/trading/src/utils/apiKeyUtils.test.ts
@@ -1,4 +1,4 @@
-import { getRandomAccountDescriptor } from '../apiKeyUtils';
+import { getRandomAccountDescriptor } from './apiKeyUtils';
 
 describe('getRandomAccountDescriptor', () => {
     it('should return 20 characters', () => {

--- a/suite-common/trading/src/utils/buy/buyUtils.test.ts
+++ b/suite-common/trading/src/utils/buy/buyUtils.test.ts
@@ -1,5 +1,5 @@
-import * as fixtures from '../__fixtures__/buyUtils';
-import { buyUtils } from '../buyUtils';
+import * as fixtures from './__fixtures__/buyUtils';
+import { buyUtils } from './buyUtils';
 
 describe('getAmountLimits', () => {
     const currency = 'bitcoin';

--- a/suite-common/trading/src/utils/countryUtils.test.ts
+++ b/suite-common/trading/src/utils/countryUtils.test.ts
@@ -8,7 +8,7 @@ import {
     isCountrySubdivisionEmpty,
     isCountrySubdivisionRequired,
     toTradingCountryCode,
-} from '../countryUtils';
+} from './countryUtils';
 
 describe('countryUtils', () => {
     describe('isCountryCode', () => {

--- a/suite-common/trading/src/utils/currencyUtils.test.ts
+++ b/suite-common/trading/src/utils/currencyUtils.test.ts
@@ -4,7 +4,7 @@ import {
     getCurrencyLabel,
     getSupportedFiatCurrencyWithFallback,
     mapFiatCurrencyCodeToBaseCurrencyCode,
-} from '../currencyUtils';
+} from './currencyUtils';
 
 describe('currencyUtils', () => {
     describe('buildTradingFiatOption', () => {

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.test.ts
@@ -11,7 +11,7 @@ import {
     hasEip712SignDataType,
     requiresTokenApproval,
     tokenSupportsIncreasingAllowance,
-} from '../exchangeUtils';
+} from './exchangeUtils';
 
 const USDT_CRYPTO_ID = 'ethereum--0xdac17f958d2ee523a2206206994597c13d831ec7' as CryptoId;
 const DAI_CRYPTO_ID = 'ethereum--0x6b175474e89094c44da98b954eedeac495271d0f' as CryptoId;

--- a/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
+++ b/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
@@ -2,7 +2,7 @@ import type { CryptoId } from 'invity-api';
 
 import { type NetworkTxSimulationResult } from '@suite-common/tx-simulation';
 
-import { getSimulatedReceiveAmount } from '../getSimulatedReceiveAmount';
+import { getSimulatedReceiveAmount } from './getSimulatedReceiveAmount';
 
 const USDC_CONTRACT = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 

--- a/suite-common/trading/src/utils/exchange/receiveAddressCoherence.test.ts
+++ b/suite-common/trading/src/utils/exchange/receiveAddressCoherence.test.ts
@@ -2,7 +2,7 @@ import { type CryptoId } from 'invity-api';
 
 import { type AddressValidator } from '@suite-common/address';
 
-import { isReceiveAddressCoherent, isReceiveAddressValid } from '../receiveAddressCoherence';
+import { isReceiveAddressCoherent, isReceiveAddressValid } from './receiveAddressCoherence';
 
 // Vitalik's address, all lowercase so no EIP-55 checksum is required.
 const VALID_ETH_ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.test.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.test.ts
@@ -4,7 +4,7 @@ import {
     getTradingErrorDisplay,
     isResolvedTradeError,
     resolveExchangeTradeError,
-} from '../resolveExchangeTradeError';
+} from './resolveExchangeTradeError';
 
 const coinSymbols: Record<string, string> = {
     bitcoin: 'BTC',

--- a/suite-common/trading/src/utils/exchange/signDataUtils.test.ts
+++ b/suite-common/trading/src/utils/exchange/signDataUtils.test.ts
@@ -1,7 +1,7 @@
 import { type Account } from '@suite-common/wallet-types';
 
-import { accountEth } from '../../../__fixtures__/utils';
-import { formatMessageValue, getSignerAddress, simplifyJSON } from '../signDataUtils';
+import { formatMessageValue, getSignerAddress, simplifyJSON } from './signDataUtils';
+import { accountEth } from '../../__fixtures__/utils';
 
 describe('simplifyJSON', () => {
     it('returns empty string for nullish input', () => {

--- a/suite-common/trading/src/utils/infoUtils.test.ts
+++ b/suite-common/trading/src/utils/infoUtils.test.ts
@@ -1,14 +1,14 @@
 import { type CryptoId } from 'invity-api';
 
-import coins from '../../__fixtures__/coins.json';
-import platforms from '../../__fixtures__/platforms.json';
 import {
     getTradingCoinInfoByCryptoId,
     getTradingCoinSymbolByCryptoId,
     getTradingNativeCoinSymbolByCryptoId,
     getTradingPlatformsInfoByCryptoId,
     getTradingSymbolAndContractAddressByCryptoId,
-} from '../infoUtils';
+} from './infoUtils';
+import coins from '../__fixtures__/coins.json';
+import platforms from '../__fixtures__/platforms.json';
 
 describe('infoUtils', () => {
     it('getTradingCoinInfoByCryptoId should select coin', () => {

--- a/suite-common/trading/src/utils/numberUtils.test.ts
+++ b/suite-common/trading/src/utils/numberUtils.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { formatExchangeRate } from '../numberUtils';
+import { formatExchangeRate } from './numberUtils';
 
 describe('formatExchangeRate', () => {
     it('rate >= 1 uses 3 decimal places', () => {

--- a/suite-common/trading/src/utils/receiveAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.test.ts
@@ -1,7 +1,7 @@
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { getReceiveAccountPreselection } from '../receiveAccountUtils';
+import { getReceiveAccountPreselection } from './receiveAccountUtils';
 
 const btcUnusedAddress = 'bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz';
 

--- a/suite-common/trading/src/utils/sell/sellUtils.test.ts
+++ b/suite-common/trading/src/utils/sell/sellUtils.test.ts
@@ -1,8 +1,8 @@
 import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
-import { type TradingSellInfoSelector } from '../../../selectors/tradingSelectors';
-import { sellUtilsFixtures } from '../__fixtures__/sellUtils';
-import { sellUtils } from '../sellUtils';
+import { sellUtilsFixtures } from './__fixtures__/sellUtils';
+import { sellUtils } from './sellUtils';
+import { type TradingSellInfoSelector } from '../../selectors/tradingSelectors';
 
 describe('sellUtils', () => {
     describe('getAmountLimits', () => {

--- a/suite-common/trading/src/utils/signature/signatureUtils.test.ts
+++ b/suite-common/trading/src/utils/signature/signatureUtils.test.ts
@@ -6,10 +6,10 @@ import {
     formatSlip24AddressByNetwork,
     tradingExchangeCreatePaymentRequest,
     tradingSellCreatePaymentRequest,
-} from '../signatureUtils';
+} from './signatureUtils';
 
 // Mock external dependencies
-jest.mock('../../../utils', () => ({
+jest.mock('../../utils', () => ({
     cryptoIdToNetworkAndContractAddress: jest
         .fn()
         .mockImplementation((cryptoId: CryptoId | undefined) => {

--- a/suite-common/trading/src/utils/signature/validatePaymentRequest.test.ts
+++ b/suite-common/trading/src/utils/signature/validatePaymentRequest.test.ts
@@ -6,7 +6,7 @@ import {
     type Slip24Output,
     computePaymentRequestPayload,
     validatePaymentRequestSignature,
-} from '../validatePaymentRequest';
+} from './validatePaymentRequest';
 
 // Fixture taken from trezor-trade-api PaymentRequestSigner tests: the signature was
 // produced by the API implementation with the debug key (m/0h of "all all ... all" seed),
@@ -177,7 +177,7 @@ describe(validatePaymentRequestSignature.name, () => {
                 const { validatePaymentRequestSignature: validateInProduction } =
                     jest.requireActual<{
                         validatePaymentRequestSignature: typeof validatePaymentRequestSignature;
-                    }>('../validatePaymentRequest');
+                    }>('./validatePaymentRequest');
 
                 const isValid = validateInProduction({
                     paymentRequest: createFixturePaymentRequest(),

--- a/suite-common/trading/src/utils/slippageFormValidationSchema.test.ts
+++ b/suite-common/trading/src/utils/slippageFormValidationSchema.test.ts
@@ -1,6 +1,6 @@
 import { yup } from '@suite-common/validators';
 
-import { getSlippageFormValidationSchema } from '../slippageFormValidationSchema';
+import { getSlippageFormValidationSchema } from './slippageFormValidationSchema';
 
 const messages = {
     required: 'REQUIRED',

--- a/suite-common/trading/src/utils/tradeOperationUtils.test.ts
+++ b/suite-common/trading/src/utils/tradeOperationUtils.test.ts
@@ -8,7 +8,7 @@ import type {
     SellTradeStatus,
 } from 'invity-api';
 
-import { getTradeOperationData } from '../tradeOperationUtils';
+import { getTradeOperationData } from './tradeOperationUtils';
 
 const buildBuyTrade = (status: BuyTradeStatus | undefined): BuyTrade =>
     ({

--- a/suite-common/trading/src/utils/tradingAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/tradingAccountUtils.test.ts
@@ -2,7 +2,7 @@ import { type CryptoId } from 'invity-api';
 
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { isAccountEligibleForTrade } from '../tradingAccountUtils';
+import { isAccountEligibleForTrade } from './tradingAccountUtils';
 
 const TOKEN_CRYPTO_ID = 'ethereum--0xTokenContract' as CryptoId;
 

--- a/suite-common/trading/src/utils/typeGuards.test.ts
+++ b/suite-common/trading/src/utils/typeGuards.test.ts
@@ -1,4 +1,4 @@
-import { isSendRejectedError } from '../typeGuards';
+import { isSendRejectedError } from './typeGuards';
 
 describe('typeGuards', () => {
     describe('isSendRejectedError', () => {


### PR DESCRIPTION
## Description

Moves 19 Suite Common Trading utility tests beside their source files while preserving shared fixture locations.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies unit-level utility logic in suite-common/trading (buy/sell amount handling, currency/country resolution, exchange rate simulation, signature/payment-request validation, slippage validation, trade operation and account resolution, and type guards). No E2E test file statically imports these unit test files, so all recommendations are inferred from behavioral overlap: the changed utilities underpin amount validation, quote/offer calculation, and trade payload construction across the buy/sell/swap E2E flows. We recommend prioritizing the core buy/sell/swap happy-path and input-validation E2E tests (which exercise numberUtils, buyUtils, sellUtils, exchangeUtils, and tradeOperationUtils most directly), with medium priority given to swap history, navigation, and live/passthrough swap tests that touch adjacent utilities (tradingAccountUtils, receiveAccountUtils, typeGuards, resolveExchangeTradeError). Signature/payment-request validation (signDataUtils, signatureUtils, validatePaymentRequest) and apiKeyUtils have no clear E2E-level behavioral coverage identified and should be exercised primarily via their own unit tests.

<details><summary><b>Changed files (19)</b></summary>

- `suite-common/trading/src/utils/apiKeyUtils.test.ts`
- `suite-common/trading/src/utils/buy/buyUtils.test.ts`
- `suite-common/trading/src/utils/countryUtils.test.ts`
- `suite-common/trading/src/utils/currencyUtils.test.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/src/utils/exchange/receiveAddressCoherence.test.ts`
- `suite-common/trading/src/utils/exchange/resolveExchangeTradeError.test.ts`
- `suite-common/trading/src/utils/exchange/signDataUtils.test.ts`
- `suite-common/trading/src/utils/infoUtils.test.ts`
- `suite-common/trading/src/utils/numberUtils.test.ts`
- `suite-common/trading/src/utils/receiveAccountUtils.test.ts`
- `suite-common/trading/src/utils/sell/sellUtils.test.ts`
- `suite-common/trading/src/utils/signature/signatureUtils.test.ts`
- `suite-common/trading/src/utils/signature/validatePaymentRequest.test.ts`
- `suite-common/trading/src/utils/slippageFormValidationSchema.test.ts`
- `suite-common/trading/src/utils/tradeOperationUtils.test.ts`
- `suite-common/trading/src/utils/tradingAccountUtils.test.ts`
- `suite-common/trading/src/utils/typeGuards.test.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the buy flow end-to-end (quotes, offer comparison, trade request payload, watch/status transitions), directly relying on buyUtils, currencyUtils, countryUtils, numberUtils and tradeOperationUtils logic that were changed. Any regression in buy amount/currency/country calculation would surface as incorrect quote or payload assertions here.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Covers the sell flow (quotes, fee calculation, trade payload, confirmation) which directly depends on sellUtils, receiveAddressCoherence, and numberUtils changes; a regression in sell amount/address validation would be caught by the payload and confirmation assertions.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Exercises the swap/exchange flow which relies heavily on exchangeUtils, getSimulatedReceiveAmount, tradeOperationUtils, and receiveAccountUtils — all changed — validating fee/amount calculations and status transitions end-to-end.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Validates DEX-specific swap details including slippage and minimum received calculations, directly tied to changed slippageFormValidationSchema and exchangeUtils logic, plus tradeOperationUtils for offer/quote handling.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Specifically tests min/max amount validation errors and disabled states for the buy form, directly exercising numberUtils and buyUtils validation logic that changed.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly tests input validation (decimals, exceeds-balance), fraction/Max calculations, and custom fee logic in the sell form, which are governed by sellUtils and numberUtils changes.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form input validation, fraction buttons, and exceeds-balance errors — behavior driven by numberUtils and tradeOperationUtils, both changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/swap-history.test.ts` — Displays trade history with statuses, amounts, and provider info derived from tradingAccountUtils and infoUtils, both changed; a regression in trade record formatting or status resolution could surface here.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Exercises cross-chain token swap quote/confirmation logic tied to exchangeUtils and receiveAccountUtils changes, verifying amount and account resolution correctness.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Tests provider display for a disabled-network buy asset, which touches receiveAccountUtils and typeGuards logic used to resolve valid receive assets across enabled/disabled networks.
- `suite/e2e/tests/trading/navigation.test.ts` — Verifies correct asset/network preselection when navigating to buy/sell/swap forms from various entry points, which depends on typeGuards and receiveAccountUtils resolving correct crypto/network types.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — Live-quote swap flow relying on getSimulatedReceiveAmount and exchangeUtils calculations for real-time amount display, plus resolveExchangeTradeError for handling trade failures.
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — Similar to the ETH-to-BTC passthrough test, this exercises live swap quote/amount computation and trade error resolution paths affected by the exchange utility changes.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-common/trading/src/utils/apiKeyUtils.test.ts`
- `suite-common/trading/src/utils/signature/signDataUtils.test.ts`
- `suite-common/trading/src/utils/signature/signatureUtils.test.ts`
- `suite-common/trading/src/utils/signature/validatePaymentRequest.test.ts`

_Updated: 2026-07-28T15:52:12.115Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/trading-utils-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/trading-utils-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/trading-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/trading-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/trading-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:57:30.190Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:57:21.804Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->