### PR TITLE
test(trading): co-locate hook tests

### DIFF
--- a/suite-common/trading/src/hooks/resolveAssetTokenOption.test.ts
+++ b/suite-common/trading/src/hooks/resolveAssetTokenOption.test.ts
@@ -1,8 +1,8 @@
 import { type Coins, type CryptoId } from 'invity-api';
 
-import coins from '../../__fixtures__/coins.json';
-import { createTradingTestState, renderHookWithTradingStore } from '../../__tests__/testUtils';
-import { useTradingAssets } from '../useTradingAssets';
+import { useTradingAssets } from './useTradingAssets';
+import coins from '../__fixtures__/coins.json';
+import { createTradingTestState, renderHookWithTradingStore } from '../__tests__/testUtils';
 
 const AUSDC_CONTRACT = '0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c';
 const UNKNOWN_TOKEN_CONTRACT = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';

--- a/suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts
+++ b/suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts
@@ -9,7 +9,7 @@ import {
 import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { useAllowanceTxTracking } from '../useAllowanceTxTracking';
+import { useAllowanceTxTracking } from './useAllowanceTxTracking';
 
 const ACCOUNT_KEY = mockAccountKey({ descriptor: 'testAccountKey' });
 const TXID = 'test-txid-abc123';

--- a/suite-common/trading/src/hooks/useCountryFilteredData.test.ts
+++ b/suite-common/trading/src/hooks/useCountryFilteredData.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useCountryFilteredData } from '../useCountryFilteredData';
+import { useCountryFilteredData } from './useCountryFilteredData';
 
 describe('useCountryFilteredData', () => {
     const renderUseCountryFilteredData = () => renderHook(() => useCountryFilteredData());

--- a/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.test.ts
+++ b/suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useCountrySubdivisionFilteredData } from '../useCountrySubdivisionFilteredData';
+import { useCountrySubdivisionFilteredData } from './useCountrySubdivisionFilteredData';
 
 describe('useCountrySubdivisionFilteredData', () => {
     it('should return empty data when countryCode is undefined', () => {

--- a/suite-common/trading/src/hooks/useDexExchangeTxSimulation.test.ts
+++ b/suite-common/trading/src/hooks/useDexExchangeTxSimulation.test.ts
@@ -5,16 +5,16 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { type TxSimulationAction } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { createTradingTestState, renderHookWithTradingStore } from '../../__tests__/testUtils';
-import { initialState } from '../../reducers/tradingCommonReducer';
-import { composeDexTxSimulationAction } from '../../utils/exchange/composeDexTxSimulationAction';
-import { useDexExchangeTxSimulation } from '../useDexExchangeTxSimulation';
+import { useDexExchangeTxSimulation } from './useDexExchangeTxSimulation';
+import { createTradingTestState, renderHookWithTradingStore } from '../__tests__/testUtils';
+import { initialState } from '../reducers/tradingCommonReducer';
+import { composeDexTxSimulationAction } from '../utils/exchange/composeDexTxSimulationAction';
 
 jest.mock('@suite-common/tx-simulation', () => ({
     useTxSimulation: jest.fn(),
 }));
 
-jest.mock('../../utils/exchange/composeDexTxSimulationAction', () => ({
+jest.mock('../utils/exchange/composeDexTxSimulationAction', () => ({
     composeDexTxSimulationAction: jest.fn(),
 }));
 

--- a/suite-common/trading/src/hooks/useExchangeFiatDeviation.test.ts
+++ b/suite-common/trading/src/hooks/useExchangeFiatDeviation.test.ts
@@ -3,10 +3,10 @@ import { type CryptoId } from 'invity-api';
 
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { useExchangeFiatDeviation } from '../useExchangeFiatDeviation';
-import { type TradingFiatRatesReturn, useTradingFiatValues } from '../useTradingFiatValues';
+import { useExchangeFiatDeviation } from './useExchangeFiatDeviation';
+import { type TradingFiatRatesReturn, useTradingFiatValues } from './useTradingFiatValues';
 
-jest.mock('../useTradingFiatValues', () => ({
+jest.mock('./useTradingFiatValues', () => ({
     useTradingFiatValues: jest.fn(),
 }));
 

--- a/suite-common/trading/src/hooks/useListDataFilter.test.ts
+++ b/suite-common/trading/src/hooks/useListDataFilter.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useListDataFilter } from '../useListDataFilter';
+import { useListDataFilter } from './useListDataFilter';
 
 type ItemShape = {
     id: string;

--- a/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.test.tsx
+++ b/suite-common/trading/src/hooks/useProviderMetadataChangeEffect.test.tsx
@@ -4,11 +4,11 @@ import {
     createSellInfoState,
     createTradingTestState,
     renderHookWithTradingStore,
-} from '../../__tests__/testUtils';
-import { getProviderMetadataFixture } from '../../reducers/__fixtures__/providerMetadata';
-import { initialState } from '../../reducers/tradingCommonReducer';
-import { type TradingType } from '../../types';
-import { useProviderMetadataChangeEffect } from '../useProviderMetadataChangeEffect';
+} from '../__tests__/testUtils';
+import { getProviderMetadataFixture } from '../reducers/__fixtures__/providerMetadata';
+import { initialState } from '../reducers/tradingCommonReducer';
+import { type TradingType } from '../types';
+import { useProviderMetadataChangeEffect } from './useProviderMetadataChangeEffect';
 
 const mockProviderMetadataChangeNow = getProviderMetadataFixture();
 const mockProviderMetadataSideShift = getProviderMetadataFixture('sideshift');

--- a/suite-common/trading/src/hooks/useSectionDataFilter.test.ts
+++ b/suite-common/trading/src/hooks/useSectionDataFilter.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { useSectionDataFilter } from '../useSectionDataFilter';
+import { useSectionDataFilter } from './useSectionDataFilter';
 
 type ItemShape = {
     id: string;

--- a/suite-common/trading/src/hooks/useTradingAssets.test.ts
+++ b/suite-common/trading/src/hooks/useTradingAssets.test.ts
@@ -1,8 +1,8 @@
 import { type CryptoId } from 'invity-api';
 
-import coins from '../../__fixtures__/coins.json';
-import platforms from '../../__fixtures__/platforms.json';
-import { createAssetOption } from '../useTradingAssets';
+import { createAssetOption } from './useTradingAssets';
+import coins from '../__fixtures__/coins.json';
+import platforms from '../__fixtures__/platforms.json';
 
 describe('createAssetOption', () => {
     it('should return correct data for Bitcoin', () => {

--- a/suite-common/trading/src/hooks/useTradingFiatValues.test.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.test.ts
@@ -6,15 +6,15 @@ import { type Rate, type Timestamp } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 
 import {
-    type TradingTestStateWithWalletSettings,
-    createTestStateWithWalletSettings,
-    renderHookWithTradingStore,
-} from '../../__tests__/testUtils';
-import {
     type TradingFiatRatesProps,
     type TradingFiatRatesReturn,
     useTradingFiatValues,
-} from '../useTradingFiatValues';
+} from './useTradingFiatValues';
+import {
+    type TradingTestStateWithWalletSettings,
+    createTestStateWithWalletSettings,
+    renderHookWithTradingStore,
+} from '../__tests__/testUtils';
 
 // Mock crypto IDs for testing
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;

--- a/suite-common/trading/src/hooks/useTradingRefetchScheduler.test.ts
+++ b/suite-common/trading/src/hooks/useTradingRefetchScheduler.test.ts
@@ -1,8 +1,8 @@
 import { act } from 'react';
 
-import { renderHookWithTradingStore } from '../../__tests__/testUtils';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
-import { useTradingRefetchScheduler } from '../useTradingRefetchScheduler';
+import { useTradingRefetchScheduler } from './useTradingRefetchScheduler';
+import { renderHookWithTradingStore } from '../__tests__/testUtils';
+import { tradingActions } from '../reducers/tradingCommonReducer';
 
 describe('useTradingRefetchScheduler', () => {
     it('should verify that timestapp is set and cleared on unmount', () => {


### PR DESCRIPTION
## Description

Moves 12 Suite Common Trading hook tests beside their source files while preserving shared test utilities and fixtures.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies unit-tested hooks within suite-common/trading (asset/token resolution, country/fiat filtering, fiat value calculation, DEX transaction simulation, provider metadata effects, and refetch scheduling) that underpin the Buy/Sell/Swap trading UI across the Suite E2E suite. Since there is no static coverage mapping, tests were inferred from LLM behavior descriptions that closely align with each hook's responsibility (e.g., asset picker/token selection ↔ resolveAssetTokenOption, form validation limits ↔ useCountryFilteredData/useExchangeFiatDeviation, fee/quote refresh ↔ useTradingRefetchScheduler). Recommended strategy: run the high-priority Buy/Sell/Swap form and DEX tests first as they most directly exercise the changed logic, followed by medium-priority token-specific swap/sell tests to catch asset-resolution regressions.

<details><summary><b>Changed files (12)</b></summary>

- `suite-common/trading/src/hooks/resolveAssetTokenOption.test.ts`
- `suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts`
- `suite-common/trading/src/hooks/useCountryFilteredData.test.ts`
- `suite-common/trading/src/hooks/useCountrySubdivisionFilteredData.test.ts`
- `suite-common/trading/src/hooks/useDexExchangeTxSimulation.test.ts`
- `suite-common/trading/src/hooks/useExchangeFiatDeviation.test.ts`
- `suite-common/trading/src/hooks/useListDataFilter.test.ts`
- `suite-common/trading/src/hooks/useProviderMetadataChangeEffect.test.tsx`
- `suite-common/trading/src/hooks/useSectionDataFilter.test.ts`
- `suite-common/trading/src/hooks/useTradingAssets.test.ts`
- `suite-common/trading/src/hooks/useTradingFiatValues.test.ts`
- `suite-common/trading/src/hooks/useTradingRefetchScheduler.test.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test exercises the swap asset picker, crypto/fiat amount filling, fraction/max buttons, and provider selection, which directly correspond to the hooks changed (useTradingAssets, useListDataFilter, useSectionDataFilter, useTradingFiatValues, resolveAssetTokenOption) that drive filtering, asset resolution, and fiat/crypto conversion logic in the swap form.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Sell form fraction buttons, custom fee, decimal/insufficient-fund validation, country selector, and fiat currency change map closely to useCountryFilteredData, useCountrySubdivisionFilteredData, useTradingFiatValues, and useTradingAssets hooks that were changed.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Buy form min/max validation and 'no offers found' behavior depend on fiat value calculations and asset/country filtering logic (useExchangeFiatDeviation, useTradingFiatValues, useCountryFilteredData) that were modified.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This DEX swap test involves slippage, minimum-received calculations, and DEX transaction simulation/confirmation flows directly tied to useDexExchangeTxSimulation and useTradingFiatValues, both of which were changed.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buying a specific SPL token relies on asset/token resolution logic (resolveAssetTokenOption) and country/fiat selection, both changed, making this a plausible regression surface for token-specific buy flows.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Token-to-coin swap navigation and quote refresh depend on asset resolution and refetch scheduling logic (resolveAssetTokenOption, useTradingRefetchScheduler) which were both modified.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — SPL token-to-token swap flow uses asset resolution and periodic quote refresh mechanisms tied to resolveAssetTokenOption and useTradingRefetchScheduler.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — This test's core assertion is that provider info still displays for token/disabled-network buy assets, directly exercising asset resolution logic (resolveAssetTokenOption) that was changed.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Custom fee handling and quote refresh (composedTransactionInfo) during a live swap likely interacts with useTradingRefetchScheduler and useTradingFiatValues logic that changed.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH swap with custom gas fees and quote-based fee calculation likely depends on the modified fiat value and refetch scheduler hooks used to keep quotes and fee estimates current.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) requires asset/token resolution logic tied to resolveAssetTokenOption, which was directly changed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Cross-network coin-to-token swap touches asset resolution logic, but this test is more focused on live device/transaction flow than the changed hook's specific behavior.
- `suite/e2e/tests/trading/swap-history.test.ts` — Trade history relies on periodic status polling that could be affected by refetch scheduler changes, though the test intercepts status endpoints directly, reducing risk exposure.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/trading/src/hooks/useAllowanceTxTracking.test.ts`
- `suite-common/trading/src/hooks/useProviderMetadataChangeEffect.test.tsx`

_Updated: 2026-07-28T12:39:03.465Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/trading-hooks-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/trading-hooks-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/trading-hooks-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/trading-hooks-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/trading-hooks-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:42:30.872Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:41:54.836Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->