### PR TITLE
test(trading): co-locate state and query tests

### DIFF
--- a/suite-common/trading/src/currency.test.ts
+++ b/suite-common/trading/src/currency.test.ts
@@ -1,4 +1,4 @@
-import { isSupportedFiatCurrency, isTradingFiatCurrencyOption } from '../currency';
+import { isSupportedFiatCurrency, isTradingFiatCurrencyOption } from './currency';
 
 describe('currency', () => {
     describe('isTradingFiatCurrencyOption', () => {

--- a/suite-common/trading/src/invityAPI.test.ts
+++ b/suite-common/trading/src/invityAPI.test.ts
@@ -1,10 +1,10 @@
 import { createHash } from 'crypto';
 import { type InfoResponse } from 'invity-api';
 
-import coins from '../__fixtures__/coins.json';
-import { invityAPIFixtures } from '../__fixtures__/invityAPI';
-import platforms from '../__fixtures__/platforms.json';
-import { invityAPI } from '../invityAPI';
+import coins from './__fixtures__/coins.json';
+import { invityAPIFixtures } from './__fixtures__/invityAPI';
+import platforms from './__fixtures__/platforms.json';
+import { invityAPI } from './invityAPI';
 
 describe('InvityAPI', () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/suite-common/trading/src/queries/useFetchOtc.test.ts
+++ b/suite-common/trading/src/queries/useFetchOtc.test.ts
@@ -1,5 +1,5 @@
-import { type TradingOTC } from '../../types';
-import { getOtcProvidersByCountry } from '../useFetchOtc';
+import { getOtcProvidersByCountry } from './useFetchOtc';
+import { type TradingOTC } from '../types';
 
 describe('getOtcProvidersByCountry', () => {
     const otcData: TradingOTC = {

--- a/suite-common/trading/src/reducers/buyReducer.test.ts
+++ b/suite-common/trading/src/reducers/buyReducer.test.ts
@@ -2,8 +2,8 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore } from '@suite-common/test-utils';
 
-import { buyTradingFixtures } from '../__fixtures__/buyTradingReducer';
-import { tradingBuyActions, tradingBuyReducer } from '../buyReducer';
+import { buyTradingFixtures } from './__fixtures__/buyTradingReducer';
+import { tradingBuyActions, tradingBuyReducer } from './buyReducer';
 
 describe('tradingBuyReducer', () => {
     buyTradingFixtures.forEach(f => {

--- a/suite-common/trading/src/reducers/exchangeReducer.test.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.test.ts
@@ -5,8 +5,8 @@ import { configureMockStore } from '@suite-common/test-utils';
 import {
     changellyExchangeQuote,
     exchangeTradingFixtures,
-} from '../__fixtures__/exchangeTradingReducer';
-import { tradingExchangeActions, tradingExchangeReducer } from '../exchangeReducer';
+} from './__fixtures__/exchangeTradingReducer';
+import { tradingExchangeActions, tradingExchangeReducer } from './exchangeReducer';
 
 describe('tradingExchangeReducer', () => {
     exchangeTradingFixtures.forEach(fixture => {

--- a/suite-common/trading/src/reducers/sellReducer.test.ts
+++ b/suite-common/trading/src/reducers/sellReducer.test.ts
@@ -2,8 +2,8 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore } from '@suite-common/test-utils';
 
-import { sellTradingFixtures } from '../__fixtures__/sellTradingReducer';
-import { tradingSellActions, tradingSellReducer } from '../sellReducer';
+import { sellTradingFixtures } from './__fixtures__/sellTradingReducer';
+import { tradingSellActions, tradingSellReducer } from './sellReducer';
 
 describe('tradingSellReducer', () => {
     sellTradingFixtures.forEach(fixture => {

--- a/suite-common/trading/src/reducers/tradingReducerExtended.test.ts
+++ b/suite-common/trading/src/reducers/tradingReducerExtended.test.ts
@@ -4,16 +4,16 @@ import type { CryptoId } from 'invity-api';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type AccountKey } from '@suite-common/wallet-types';
 
-import { buyThunks } from '../../thunks/buy';
-import { exchangeThunks } from '../../thunks/exchange';
-import { sellThunks } from '../../thunks/sell';
-import { getProviderMetadataFixture } from '../__fixtures__/providerMetadata';
-import { tradingFixtures } from '../__fixtures__/tradingReducer';
-import { buyInitialState, tradingBuyActions } from '../buyReducer';
-import { exchangeInitialState, tradingExchangeActions } from '../exchangeReducer';
-import { sellInitialState, tradingSellActions } from '../sellReducer';
-import { initialState, tradingActions } from '../tradingCommonReducer';
-import { prepareTradingReducer } from '../tradingReducer';
+import { getProviderMetadataFixture } from './__fixtures__/providerMetadata';
+import { tradingFixtures } from './__fixtures__/tradingReducer';
+import { buyInitialState, tradingBuyActions } from './buyReducer';
+import { exchangeInitialState, tradingExchangeActions } from './exchangeReducer';
+import { sellInitialState, tradingSellActions } from './sellReducer';
+import { initialState, tradingActions } from './tradingCommonReducer';
+import { prepareTradingReducer } from './tradingReducer';
+import { buyThunks } from '../thunks/buy';
+import { exchangeThunks } from '../thunks/exchange';
+import { sellThunks } from '../thunks/sell';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 

--- a/suite-common/trading/src/regional.test.ts
+++ b/suite-common/trading/src/regional.test.ts
@@ -1,4 +1,4 @@
-import { nonSanctionedRegional, regional } from '../regional';
+import { nonSanctionedRegional, regional } from './regional';
 
 describe('Regional', () => {
     describe('isInEEA', () => {

--- a/suite-common/trading/src/selectors/favouritesSelectors.test.ts
+++ b/suite-common/trading/src/selectors/favouritesSelectors.test.ts
@@ -2,14 +2,14 @@ import type { CryptoId } from 'invity-api';
 
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import type { TradingState } from '../../reducers/tradingCommonReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
-import { prepareTradingReducer } from '../../reducers/tradingReducer';
 import {
     selectIsTradingFavouriteAssetByCryptoId,
     selectTradingFavouriteAssets,
     selectTradingFavouriteAssetsArray,
-} from '../favouritesSelectors';
+} from './favouritesSelectors';
+import type { TradingState } from '../reducers/tradingCommonReducer';
+import { tradingActions } from '../reducers/tradingCommonReducer';
+import { prepareTradingReducer } from '../reducers/tradingReducer';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -14,17 +14,6 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
-import coins from '../../__fixtures__/coins.json';
-import { invityAPIFixtures } from '../../__fixtures__/invityAPI';
-import platforms from '../../__fixtures__/platforms.json';
-import { accountBtc, accountEth } from '../../__fixtures__/utils';
-import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../../constants';
-import { getProviderMetadataFixture } from '../../reducers/__fixtures__/providerMetadata';
-import { type BuyInfo, type TradingBuyState } from '../../reducers/buyReducer';
-import { type ExchangeInfo, exchangeInitialState } from '../../reducers/exchangeReducer';
-import { type SellInfo, sellInitialState } from '../../reducers/sellReducer';
-import { type TradingRootState, initialState } from '../../reducers/tradingCommonReducer';
-import type { TradingTransactionExchange, TradingTransactionSell, TradingType } from '../../types';
 import {
     type TradingRootStateWithDeviceAndAccounts,
     bestBuyQuotePerPaymentMethodProjection,
@@ -115,7 +104,18 @@ import {
     selectTradingTradesForSelectedDevice,
     selectValidTradingBuyQuotes,
     selectValidTradingSellQuotes,
-} from '../tradingSelectors';
+} from './tradingSelectors';
+import coins from '../__fixtures__/coins.json';
+import { invityAPIFixtures } from '../__fixtures__/invityAPI';
+import platforms from '../__fixtures__/platforms.json';
+import { accountBtc, accountEth } from '../__fixtures__/utils';
+import { TRADING_SLIP24_SUPPORTED_NETWORK_TYPES } from '../constants';
+import { getProviderMetadataFixture } from '../reducers/__fixtures__/providerMetadata';
+import { type BuyInfo, type TradingBuyState } from '../reducers/buyReducer';
+import { type ExchangeInfo, exchangeInitialState } from '../reducers/exchangeReducer';
+import { type SellInfo, sellInitialState } from '../reducers/sellReducer';
+import { type TradingRootState, initialState } from '../reducers/tradingCommonReducer';
+import type { TradingTransactionExchange, TradingTransactionSell, TradingType } from '../types';
 
 const supportedCoins: readonly NetworkSymbol[] = ['btc', 'eth', 'base'];
 

--- a/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.test.ts
+++ b/suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.test.ts
@@ -1,6 +1,6 @@
 import { type ExchangeTrade } from 'invity-api';
 
-import { groupTradingExchangeQuotesProjection } from '../groupTradingExchangeQuotesProjection';
+import { groupTradingExchangeQuotesProjection } from './groupTradingExchangeQuotesProjection';
 
 describe(groupTradingExchangeQuotesProjection.name, () => {
     it('groups quotes into dex, fixed and float groups', () => {

--- a/suite-common/trading/src/selectors/utils/quotePerPaymentMethodProjection.test.ts
+++ b/suite-common/trading/src/selectors/utils/quotePerPaymentMethodProjection.test.ts
@@ -1,4 +1,4 @@
-import { bestQuotePerPaymentMethodProjection } from '../quotePerPaymentMethodProjection';
+import { bestQuotePerPaymentMethodProjection } from './quotePerPaymentMethodProjection';
 
 type PaymentMethod = 'bankTransfer' | 'creditCard' | 'applePay';
 

--- a/suite-common/trading/src/utils.test.ts
+++ b/suite-common/trading/src/utils.test.ts
@@ -9,11 +9,11 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import * as BUY_FIXTURE from '../__fixtures__/buyUtils';
-import * as EXCHANGE_FIXTURE from '../__fixtures__/exchangeUtils';
-import * as SELL_FIXTURE from '../__fixtures__/sellUtils';
-import { accountBtc, accountEth } from '../__fixtures__/utils';
-import type { TradingExchangeType, TradingSellType } from '../types';
+import * as BUY_FIXTURE from './__fixtures__/buyUtils';
+import * as EXCHANGE_FIXTURE from './__fixtures__/exchangeUtils';
+import * as SELL_FIXTURE from './__fixtures__/sellUtils';
+import { accountBtc, accountEth } from './__fixtures__/utils';
+import type { TradingExchangeType, TradingSellType } from './types';
 import {
     addIdsToQuotes,
     cryptoIdToNetwork,
@@ -30,7 +30,7 @@ import {
     mapTestnetSymbol,
     testnetToProdCryptoId,
     toTokenCryptoId,
-} from '../utils';
+} from './utils';
 
 const sendAccountKey = mockAccountKey({ descriptor: 'sendAccountKey' });
 const receiveAccountKey = mockAccountKey({ descriptor: 'receiveAccountKey' });


### PR DESCRIPTION
## Description

Moves 13 Suite Common Trading reducer, selector, query, currency, regional, API, and root utility tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the suite-common/trading package's unit tests covering reducers (buy, sell, exchange, extended), selectors (trading, favourites, quote projections), currency/regional formatting, invityAPI, and general utils. Since no E2E test directly imports these unit test files, coverage is inferred from behavioral overlap: E2E tests that exercise buy/sell/swap trading flows, quote display, fee calculations, and trade status tracking are the most relevant regression surface, as they depend at runtime on the exact reducer/selector logic being modified. Recommend running the high-priority buy/sell/swap E2E flows first since they most directly exercise the changed reducers and quote projection selectors, followed by medium-priority input/navigation tests for broader confidence.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/trading/src/currency.test.ts`
- `suite-common/trading/src/invityAPI.test.ts`
- `suite-common/trading/src/queries/useFetchOtc.test.ts`
- `suite-common/trading/src/reducers/buyReducer.test.ts`
- `suite-common/trading/src/reducers/exchangeReducer.test.ts`
- `suite-common/trading/src/reducers/sellReducer.test.ts`
- `suite-common/trading/src/reducers/tradingReducerExtended.test.ts`
- `suite-common/trading/src/regional.test.ts`
- `suite-common/trading/src/selectors/favouritesSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/utils/groupTradingExchangeQuotesProjection.test.ts`
- `suite-common/trading/src/selectors/utils/quotePerPaymentMethodProjection.test.ts`
- `suite-common/trading/src/utils.test.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test exercises the buy trade flow end-to-end including quotes, best offer selection, and trade/watch payloads, which directly depend on the trading package's buyReducer, currency, invityAPI, utils, and tradingSelectors logic that were changed.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Validates min/max amount validation logic and 'no offers found' quote handling, directly exercising currency/regional formatting and quote grouping/projection logic that changed in this PR.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Exercises the sell trade flow including sellReducer state, quote selection, and payload construction, which are core areas modified in this trading package change set.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Exercises the exchange/swap trade flow directly tied to exchangeReducer and tradingReducerExtended changes, including quote confirmation and status polling logic.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test directly exercises trade history and status tracking that depends on tradingReducerExtended and tradingSelectors, both of which changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — Exercises swap asset picker, fraction buttons, provider selection and quote comparison that rely on quote grouping/payment-method projection selectors changed in this PR.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Covers sell form fraction/percentage calculations and fee-adjusted max amounts, which touch currency/regional formatting and utils logic that were modified.
- `suite/e2e/tests/trading/navigation.test.ts` — Verifies trading form navigation across buy/sell/swap entry points which rely on trading selectors and reducers state to determine preselected networks/tokens.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Buy flow for a different network exercises the same buyReducer and quote/currency logic changed here, providing cross-network regression coverage.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — Live-quote passthrough swap test touches trading reducer/selector state (composedTransactionInfo) and status polling logic, which could be impacted by exchangeReducer/tradingReducerExtended changes, but is a lower-value proof-of-concept test.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — DEX swap flow exercises quote/exchange selectors and status transitions indirectly related to the changed reducers/selectors, but is a more specialized scenario with lower likelihood of being broken by these specific unit-level changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/trading/src/queries/useFetchOtc.test.ts`
- `suite-common/trading/src/selectors/favouritesSelectors.test.ts`

_Updated: 2026-07-28T17:16:20.275Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/trading-state-query-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/trading-state-query-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/trading-state-query-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/trading-state-query-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/trading-state-query-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:19:24.026Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:19:48.054Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->