### PR TITLE
test(wallet-core): co-locate foundation tests

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
@@ -5,8 +5,8 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { type Bip43Path } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
-import { accountsActions } from '../accountsActions';
-import { type AccountsRootState, prepareAccountsReducer } from '../accountsReducer';
+import { accountsActions } from './accountsActions';
+import { type AccountsRootState, prepareAccountsReducer } from './accountsReducer';
 
 const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
 

--- a/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts
@@ -1,13 +1,13 @@
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { accountsActions } from '../accountsActions';
+import { accountsActions } from './accountsActions';
 import {
     type AccountsRefreshTimeState,
     accountRefreshed,
     accountsRefreshTimeReducer,
     selectAccountRefreshTime,
-} from '../accountsRefreshTimeReducer';
+} from './accountsRefreshTimeReducer';
 
 const account = mockWalletAccount({
     symbol: 'btc',

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.test.ts
@@ -5,12 +5,12 @@ import { networks } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { type AccountsRootState } from '../accountsReducer';
+import { type AccountsRootState } from './accountsReducer';
 import {
     selectAddressByNetworkAndPath,
     selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex,
     selectVisibleDeviceAccountsMap,
-} from '../accountsSelectors';
+} from './accountsSelectors';
 
 const BTC_DEVICE_SSID: `${string}@${string}:${number}` =
     'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@AC94BB9C1B08FE73BE1E3322:0';

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.test.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.test.ts
@@ -1,8 +1,8 @@
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type BackendSettings } from '@suite-common/wallet-types';
 
-import { type SetBackendPayload, blockchainActions } from '../blockchainActions';
-import { blockchainInitialState, prepareBlockchainReducer } from '../blockchainReducer';
+import { type SetBackendPayload, blockchainActions } from './blockchainActions';
+import { blockchainInitialState, prepareBlockchainReducer } from './blockchainReducer';
 
 const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
 

--- a/suite-common/wallet-core/src/device/deviceThunks.test.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.test.ts
@@ -8,8 +8,8 @@ import { prepareDeviceReducer } from '@suite-common/device';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { prepareThpReducer } from '@suite-common/thp';
 
-import { forgetPersistentDataPreloadedStateFixture } from '../__fixtures__/forgetPersistentDataPreloadedState';
-import { forgetDevicePersistentDataThunk } from '../deviceThunks';
+import { forgetPersistentDataPreloadedStateFixture } from './__fixtures__/forgetPersistentDataPreloadedState';
+import { forgetDevicePersistentDataThunk } from './deviceThunks';
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const bluetoothReducer = prepareBluetoothReducerCreator<BluetoothDeviceCommon>()(

--- a/suite-common/wallet-core/src/discovery/discoveryReducer.test.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryReducer.test.ts
@@ -3,8 +3,8 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type DeviceUniquePath } from '@trezor/connect';
 
-import { discoveryActions } from '../discoveryActions';
-import { type DiscoveryRootState, prepareDiscoveryReducer } from '../discoveryReducer';
+import { discoveryActions } from './discoveryActions';
+import { type DiscoveryRootState, prepareDiscoveryReducer } from './discoveryReducer';
 
 const discoveryReducer = prepareDiscoveryReducer(extraDependenciesCommonMock);
 

--- a/suite-common/wallet-core/src/fees/feesThunks.test.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.test.ts
@@ -3,13 +3,10 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type FeeInfo } from '@suite-common/wallet-types';
 
-import {
-    blockchainInitialState,
-    prepareBlockchainReducer,
-} from '../../blockchain/blockchainReducer';
-import { DEFAULT_FEE_INFO } from '../feesConstants';
-import { feesReducer } from '../feesReducer';
-import { updateFeeInfoThunk } from '../feesThunks';
+import { DEFAULT_FEE_INFO } from './feesConstants';
+import { feesReducer } from './feesReducer';
+import { updateFeeInfoThunk } from './feesThunks';
+import { blockchainInitialState, prepareBlockchainReducer } from '../blockchain/blockchainReducer';
 
 const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
 

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.test.ts
@@ -9,12 +9,9 @@ import {
     type TokenAddress,
 } from '@suite-common/wallet-types';
 
-import { type AccountsRootState } from '../../accounts/accountsReducer';
-import {
-    selectHistoricFiatRatesByTimestamp,
-    selectTickerFromAccounts,
-} from '../fiatRatesSelectors';
-import { type FiatRatesRootState } from '../fiatRatesTypes';
+import { selectHistoricFiatRatesByTimestamp, selectTickerFromAccounts } from './fiatRatesSelectors';
+import { type FiatRatesRootState } from './fiatRatesTypes';
+import { type AccountsRootState } from '../accounts/accountsReducer';
 
 const STANDARD_WALLET_SSID = 'standardWallet@device_id:0' as const;
 const STANDARD_WALLET = mockSuiteDevice({ state: { staticSessionId: STANDARD_WALLET_SSID } });

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts
@@ -9,8 +9,8 @@ import {
 } from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
-import { blockchainInitialState } from '../../blockchain/blockchainReducer';
-import { updateTxsFiatRatesThunk } from '../fiatRatesThunks';
+import { updateTxsFiatRatesThunk } from './fiatRatesThunks';
+import { blockchainInitialState } from '../blockchain/blockchainReducer';
 
 jest.mock('@suite-common/fiat-services', () => ({
     getFiatRatesForTimestamps: jest.fn(),

--- a/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
@@ -3,8 +3,8 @@ import { useDispatch } from 'react-redux';
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 import { type TickerId, toTokenAddress } from '@suite-common/wallet-types';
 
-import { updateFiatRatesThunk } from '../fiatRatesThunks';
-import { useMissingRateTickersQuery } from '../useMissingRateTickersQuery';
+import { updateFiatRatesThunk } from './fiatRatesThunks';
+import { useMissingRateTickersQuery } from './useMissingRateTickersQuery';
 
 jest.mock('react-redux', () => ({
     useDispatch: jest.fn(),
@@ -21,7 +21,7 @@ jest.mock('@suite-common/react-query', () => ({
     useQuery: jest.fn(query => query),
 }));
 
-jest.mock('../fiatRatesThunks', () => ({
+jest.mock('./fiatRatesThunks', () => ({
     updateFiatRatesThunk: jest.fn(payload => ({
         type: 'updateFiatRatesThunk',
         payload,

--- a/suite-common/wallet-core/src/tokens/tokenUtils.test.ts
+++ b/suite-common/wallet-core/src/tokens/tokenUtils.test.ts
@@ -1,7 +1,7 @@
 import { type TokenDefinition } from '@suite-common/token-definitions';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { getAccountAnalyticsTokenSymbols } from '../tokenUtils';
+import { getAccountAnalyticsTokenSymbols } from './tokenUtils';
 
 const legitContract = '0x' + 'a'.repeat(40);
 const spamContract = '0x' + 'b'.repeat(40);

--- a/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.test.ts
+++ b/suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.test.ts
@@ -4,7 +4,7 @@ import { UI_REQUEST } from '@trezor/connect';
 import { createUiMessage } from '@trezor/connect-common';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 
-import { defaultTrezorUIEventHandlerThunk } from '../defaultTrezorUIEventHandlerThunk';
+import { defaultTrezorUIEventHandlerThunk } from './defaultTrezorUIEventHandlerThunk';
 
 const device = mockSuiteDevice();
 


### PR DESCRIPTION
## Description

Moves 12 Wallet Core account, blockchain, device, discovery, fee, fiat-rate, token, and UI-event tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set consists entirely of unit test files for suite-common/wallet-core reducers, selectors, and thunks (accounts, discovery, blockchain, device, fees, fiat-rates, tokens, uiEvent). Since these are core state-management modules with no static E2E coverage mapping, recommendations are inferred from the LLM analysis of E2E test behaviors that exercise the corresponding runtime logic (discovery flows, account balances, custom backends, fee calculations, fiat conversions, and device connect/disconnect handling). Recommended strategy: prioritize E2E tests touching discovery/account/balance flows and custom backend configuration (highest risk of regression), followed by fee-calculation and device-connection related tests; tokenUtils.test.ts and useMissingRateTickersQuery.test.ts have no clear E2E analog and remain uncovered.

<details><summary><b>Changed files (12)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsReducer.test.ts`
- `suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts`
- `suite-common/wallet-core/src/accounts/accountsSelectors.test.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.test.ts`
- `suite-common/wallet-core/src/device/deviceThunks.test.ts`
- `suite-common/wallet-core/src/discovery/discoveryReducer.test.ts`
- `suite-common/wallet-core/src/fees/feesThunks.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesSelectors.test.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.test.ts`
- `suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts`
- `suite-common/wallet-core/src/tokens/tokenUtils.test.ts`
- `suite-common/wallet-core/src/uiEvent/defaultTrezorUIEventHandlerThunk.test.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — This test directly exercises the wallet discovery flow and Redux 'wallet.discovery' state transitions (starting/complete), which is the core behavior covered by discoveryReducer.test.ts and accountsReducer.test.ts unit tests. A regression in discovery or account reducer logic would be immediately visible as accounts failing to appear or discovery hanging.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Covers ejecting/adding a standard wallet and verifying account balance visibility, which relies directly on accountsReducer/accountsSelectors and discoveryReducer logic changed in this PR.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Explicitly tests that discovery completes and accounts/balances render correctly against a custom backend, directly exercising discoveryReducer and accountsReducer/accountsSelectors logic that was modified.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Exercises discovery success/error states with custom backends (blockchain connection), directly related to blockchainReducer and discoveryReducer changes; validates account-empty vs discovery-error UI states driven by these reducers.
- `suite/e2e/tests/settings/electrum.test.ts` — Verifies discovery via an Electrum backend and resulting balance/fiat display, directly touching blockchainReducer (backend/blockchain connection state), discoveryReducer, and fiatRatesSelectors/Thunks logic that were all changed.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Tests account balance updates after receiving funds on regtest, directly exercising accountsReducer/accountsSelectors balance computation and blockchainReducer state updates that changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (10)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Exercises asset activation and discovery completion after enabling new networks, which depends on accountsReducer/discoveryReducer state and fiatRatesSelectors for displayed values.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Displays fiat and crypto balances across account/asset/portfolio/wallet views, which depend on fiatRatesSelectors and accountsSelectors computations changed in this PR.
- `suite/e2e/tests/settings/general.test.ts` — Changes fiat currency and verifies dashboard fiat display updates accordingly, directly exercising fiatRatesSelectors/fiatRatesThunks logic that was modified.
- `suite/e2e/tests/settings/coins.test.ts` — Tests network activation/deactivation and custom backend configuration, which relies on accountsReducer, discoveryReducer, and blockchainReducer state management that changed.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises fee estimation and transaction sending on a Bitcoin regtest network, touching feesThunks (fee calculation) logic that was changed in this PR.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Involves custom Ethereum fee calculations (gas limit, max fee per gas) which is directly tied to feesThunks logic changed in this PR.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Exercises custom Ethereum gas fee inputs and fee calculation display on send form, directly related to feesThunks changes.
- `suite/e2e/tests/onboarding/initial-run.test.ts` — Covers THP device pairing flow and connection status which relates to deviceThunks and uiEvent handler thunk changes governing device connect/disconnect UI event handling.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect behavior and passphrase re-caching, which is closely tied to deviceThunks logic (device connect/disconnect handling) that was modified.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests device disconnect detection and reconnection prompts in the send flow, directly related to deviceThunks changes governing device connection state management.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Involves account balance/transaction state tracking on regtest, touching accountsReducer and blockchainReducer logic, but is a broader integration test with many moving parts unrelated to the core changed logic.
- `suite/e2e/tests/wallet/receive.test.ts` — Covers device connect/reveal address flow across multiple coins, tangentially related to deviceThunks and uiEvent handler changes for confirmation prompts, but not a direct exercise of the modified reducer logic.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/tokens/tokenUtils.test.ts`
- `suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts`
- `suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts`

_Updated: 2026-07-28T12:45:22.239Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/wallet-core-foundation-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/wallet-core-foundation-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/wallet-core-foundation-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/wallet-core-foundation-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/wallet-core-foundation-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:48:11.811Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T12:47:45.507Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->