### PR TITLE
Feat/yield tasks mobile

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -134,8 +134,6 @@ export const YieldPageHeader = ({
                             >
                                 {vaultName}
                             </Text>
-                            {/* The balance aligns with the right edge of the vault name above;
-                                when the name is shorter, the gap keeps it 24px from the label. */}
                             <Row justifyContent="space-between" alignItems="center" gap={24}>
                                 <AccountLabel
                                     account={account}

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -156,4 +156,59 @@ describe('TokenIcon', () => {
             expect(getByHintText(networkIconHint)).toBeTruthy();
         });
     });
+
+    describe('wrappedTokenIcon', () => {
+        const wethContract = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as TokenAddress;
+
+        it('renders the native icon with a network badge for a wrapped-native token when set to network', async () => {
+            const { getByHintText, getByLabelText } = renderTokenIcon({
+                symbol: 'eth',
+                contractAddress: wethContract,
+                showNetworkIcon: true,
+                wrappedTokenIcon: 'network',
+            });
+
+            expect(getByHintText(networkIconHint)).toBeTruthy();
+            await waitFor(() => {
+                expect(getByHintText(tokenIconHint)).toBeTruthy();
+                expect(getByLabelText('ETH')).toBeTruthy();
+            });
+        });
+
+        it('keeps the wrapped-native token icon by default', async () => {
+            (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
+                (_symbol: string, contract: string) => Promise.resolve([contract]),
+            );
+
+            const { getByHintText, getByLabelText } = renderTokenIcon({
+                symbol: 'eth',
+                contractAddress: wethContract,
+                showNetworkIcon: true,
+            });
+
+            await waitFor(() => {
+                expect(getByLabelText(`eth:${wethContract}`)).toBeTruthy();
+                expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
+                    getTokenIconUrl(wethContract),
+                );
+            });
+        });
+
+        it('keeps the token icon for a non-wrapped token even when set to network', async () => {
+            (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
+                (_symbol: string, contract: string) => Promise.resolve([contract]),
+            );
+
+            const { getByLabelText } = renderTokenIcon({
+                symbol: 'eth',
+                contractAddress: contractA,
+                showNetworkIcon: true,
+                wrappedTokenIcon: 'network',
+            });
+
+            await waitFor(() => {
+                expect(getByLabelText(`eth:${contractA}`)).toBeTruthy();
+            });
+        });
+    });
 });

--- a/suite-native/icons/src/TokenIcon.tsx
+++ b/suite-native/icons/src/TokenIcon.tsx
@@ -11,7 +11,7 @@ import {
     getNetworkDisplaySymbol,
     isNetworkSymbol,
 } from '@suite-common/wallet-config';
-import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
+import { getAssetLogoContractAddresses, isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { useAsyncMemo } from '@trezor/react-utils';
@@ -97,6 +97,10 @@ interface TokenIconProps {
     contractAddress?: string;
     showNetworkIcon?: boolean;
     size?: TokenIconSize | number;
+    /**
+     * If the token is a wrapped native token (e.g. WETH), this prop determines whether to show the icon of the token itself or its network icon.
+     */
+    wrappedTokenIcon?: 'token' | 'network';
 }
 
 const TokenIconComponent = ({ symbol, contractAddress, size = 'small' }: TokenIconProps) => {
@@ -194,8 +198,17 @@ export const TokenIcon = ({
     contractAddress,
     showNetworkIcon = false,
     size = 'small',
+    wrappedTokenIcon = 'token',
 }: TokenIconProps) => {
     const { applyStyle } = useNativeStyles();
+
+    if (
+        wrappedTokenIcon === 'network' &&
+        isNetworkSymbol(symbol) &&
+        isWrappedNativeToken(symbol, contractAddress)
+    ) {
+        contractAddress = undefined;
+    }
 
     if (!showNetworkIcon || !isNetworkSymbol(symbol)) {
         return <TokenIconComponent symbol={symbol} contractAddress={contractAddress} size={size} />;
@@ -203,7 +216,8 @@ export const TokenIcon = ({
 
     const displaySymbol = getNetworkDisplaySymbol(symbol) as NetworkDisplaySymbol;
     const showForNativeToken = displaySymbol === 'ETH' && symbol !== 'eth';
-    const shouldShowNetwork = showForNativeToken || contractAddress;
+    const shouldShowNetwork =
+        showForNativeToken || contractAddress || wrappedTokenIcon === 'network';
 
     const iconSymbol = contractAddress ? symbol : displaySymbol;
     const iconSize = typeof size === 'number' ? size : tokenIconSizes[size];

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -140,6 +140,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                         contractAddress={contractAddress}
                         size="extraSmall"
                         showNetworkIcon
+                        wrappedTokenIcon={isStablecoinYieldItem ? 'network' : 'token'}
                     />
                 </Box>
 

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -24,10 +24,10 @@ import {
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { CRYPTO_BALANCE_DECIMALS } from '../constants';
-import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
-import { type EarnDepositsCardActiveItem } from '../types';
 import { EarnClaimAlert } from './EarnClaimAlert';
 import { EarnTronVotingAlert } from './EarnTronVotingAlert';
+import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
+import { type EarnDepositsCardActiveItem } from '../types';
 
 const itemCardStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.sp16,
@@ -72,7 +72,7 @@ type EarnAccountCardProps = {
 export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCardProps) => {
     const { applyStyle } = useNativeStyles();
     const isStakingItem = item.type === 'staking';
-    const isStablecoinYieldItem = item.type === 'stablecoin-yield';
+    const isDefiYieldItem = item.type === 'stablecoin-yield';
     const isSupportedStaking = isStakingItem && isSupportedStakingNetworkSymbol(item.symbol);
     const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
 
@@ -126,8 +126,8 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
     const showTronVotingAlert =
         isStakingItem && item.symbol === 'trx' && availableTronVotingPower !== '0';
 
-    const contractAddress = isStablecoinYieldItem ? item.tokenContractAddress : undefined;
-    const secondaryDescription = isStablecoinYieldItem
+    const contractAddress = isDefiYieldItem ? item.tokenContractAddress : undefined;
+    const secondaryDescription = isDefiYieldItem
         ? item.accountLabel || getNetworkDisplaySymbolName(item.networkSymbol)
         : null;
 
@@ -140,7 +140,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                         contractAddress={contractAddress}
                         size="extraSmall"
                         showNetworkIcon
-                        wrappedTokenIcon={isStablecoinYieldItem ? 'network' : 'token'}
+                        wrappedTokenIcon={isDefiYieldItem ? 'network' : 'token'}
                     />
                 </Box>
 

--- a/suite-native/module-earn/src/components/EarnDepositsCardRow.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCardRow.tsx
@@ -85,6 +85,9 @@ export const EarnDepositsCardRow = React.memo(({ row, onPress }: EarnDepositsCar
                                     }
                                     size="extraSmall"
                                     showNetworkIcon
+                                    wrappedTokenIcon={
+                                        item.type === 'stablecoin-yield' ? 'network' : 'token'
+                                    }
                                 />
                             </Box>
                         ))}

--- a/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
+++ b/suite-native/module-earn/src/components/EarnItemOverviewSection.tsx
@@ -101,7 +101,11 @@ export const EarnItemOverviewSection = (item: EarnPromoItem) => {
     const iconProps =
         item.type === 'staking'
             ? { symbol: item.symbol }
-            : { symbol: item.networkSymbol, contractAddress: item.tokenContractAddress };
+            : {
+                  symbol: item.networkSymbol,
+                  contractAddress: item.tokenContractAddress,
+                  wrappedTokenIcon: 'network' as const,
+              };
 
     return (
         <HStack

--- a/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
@@ -1,7 +1,11 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { useSelector } from 'react-redux';
+
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
-import { HStack, IconButton, Text, VStack } from '@suite-native/atoms';
+import { formatCoinBalance } from '@suite-common/wallet-utils';
+import { Box, DiscreetText, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
 import { TokenIcon } from '@suite-native/icons';
+import { selectSupportedLanguageLocale } from '@suite-native/intl';
 import { ScreenHeader } from '@suite-native/navigation';
 
 type YieldDepositFlowScreenHeaderProps = {
@@ -19,7 +23,11 @@ export const YieldDepositFlowScreenHeader = ({
     tokenContract,
     vaultName,
 }: YieldDepositFlowScreenHeaderProps) => {
+    const locale = useSelector(selectSupportedLanguageLocale);
     const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    // Same format as the desktop yield page header: `formatCoinBalance` keeps the leading
+    // significant digits and appends an ellipsis (…) once the fractional part gets too long.
+    const formattedBalance = `${formatCoinBalance(account.formattedBalance, locale)} ${getNetworkDisplaySymbol(account.symbol)}`;
 
     return (
         <ScreenHeader
@@ -38,14 +46,26 @@ export const YieldDepositFlowScreenHeader = ({
                         <Text variant="body-md" numberOfLines={1} ellipsizeMode="tail">
                             {vaultName}
                         </Text>
-                        <Text
-                            variant="body-xs"
-                            color="contentSecondary"
-                            numberOfLines={1}
-                            ellipsizeMode="tail"
-                        >
-                            {accountLabel}
-                        </Text>
+                        <HStack spacing="sp24" justifyContent="space-between" alignItems="center">
+                            <Box flexShrink={1}>
+                                <Text
+                                    variant="body-xs"
+                                    color="contentSecondary"
+                                    numberOfLines={1}
+                                    ellipsizeMode="tail"
+                                >
+                                    {accountLabel}
+                                </Text>
+                            </Box>
+                            <DiscreetText
+                                variant="body-xs"
+                                color="contentSecondary"
+                                numberOfLines={1}
+                                testID="@yield/flow-header/balance"
+                            >
+                                {formattedBalance}
+                            </DiscreetText>
+                        </HStack>
                     </VStack>
                 </HStack>
             }

--- a/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
@@ -32,6 +32,7 @@ export const YieldDepositFlowScreenHeader = ({
                         contractAddress={tokenContract}
                         size="small"
                         showNetworkIcon
+                        wrappedTokenIcon="network"
                     />
                     <VStack spacing={0} flexShrink={1}>
                         <Text variant="body-md" numberOfLines={1} ellipsizeMode="tail">

--- a/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
+++ b/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
@@ -210,6 +210,7 @@ export const YieldPendingTransactionModal = ({
                                     symbol={accountSymbol}
                                     contractAddress={vaultTokenContract}
                                     size="extraSmall"
+                                    wrappedTokenIcon="network"
                                 />
                                 <Text
                                     variant="body-sm"

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
@@ -1,0 +1,70 @@
+import { toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { getChooseAccountBalanceData } from './chooseAccountBalanceUtils';
+
+const WETH_ADDRESS = toTokenAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+const USDC_ADDRESS = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+
+describe(getChooseAccountBalanceData.name, () => {
+    it('returns the account balance when no token balance is requested', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1.5' });
+
+        expect(getChooseAccountBalanceData(account)).toEqual({
+            type: 'account',
+            value: '1.5',
+        });
+    });
+
+    it('combines the token and wrappable native balance for a wrapped-native vault, denominated as native', () => {
+        const account = mockWalletAccount({
+            symbol: 'eth',
+            formattedBalance: '1',
+            tokens: [mockAccountToken({ contract: WETH_ADDRESS, balance: '0.5' })],
+        });
+
+        expect(
+            getChooseAccountBalanceData(account, {
+                tokenContractAddress: WETH_ADDRESS,
+                tokenSymbol: toTokenSymbol('WETH'),
+            }),
+        ).toEqual({
+            type: 'account',
+            value: '1.495',
+        });
+    });
+
+    it('counts a native-only account (no WETH token) as depositable for a wrapped-native vault', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+
+        expect(
+            getChooseAccountBalanceData(account, {
+                tokenContractAddress: WETH_ADDRESS,
+                tokenSymbol: toTokenSymbol('WETH'),
+            }),
+        ).toEqual({
+            type: 'account',
+            value: '0.995',
+        });
+    });
+
+    it('keeps the token denomination for a non-wrapped-native vault', () => {
+        const account = mockWalletAccount({
+            symbol: 'eth',
+            formattedBalance: '1',
+            tokens: [mockAccountToken({ contract: USDC_ADDRESS, balance: '100' })],
+        });
+
+        expect(
+            getChooseAccountBalanceData(account, {
+                tokenContractAddress: USDC_ADDRESS,
+                tokenSymbol: toTokenSymbol('USDC'),
+            }),
+        ).toEqual({
+            type: 'token',
+            value: '100',
+            tokenContractAddress: USDC_ADDRESS,
+            tokenSymbol: 'USDC',
+        });
+    });
+});

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
@@ -16,7 +16,7 @@ describe(getChooseAccountBalanceData.name, () => {
         });
     });
 
-    it('combines the token and wrappable native balance for a wrapped-native vault, denominated as native', () => {
+    it('combines the token balance with the full native balance for a wrapped-native vault, denominated as native', () => {
         const account = mockWalletAccount({
             symbol: 'eth',
             formattedBalance: '1',
@@ -30,7 +30,7 @@ describe(getChooseAccountBalanceData.name, () => {
             }),
         ).toEqual({
             type: 'account',
-            value: '1.495',
+            value: '1.5',
         });
     });
 
@@ -44,7 +44,7 @@ describe(getChooseAccountBalanceData.name, () => {
             }),
         ).toEqual({
             type: 'account',
-            value: '0.995',
+            value: '1',
         });
     });
 

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
@@ -30,9 +30,9 @@ export const getChooseAccountBalanceData = (
         };
     }
 
-    // A wrapped-native (WETH) vault can also spend the wrappable native balance (minus the fee
-    // reserve), so the depositable amount is denominated as the native asset — which also makes
-    // the fiat conversion use the native rate.
+    // A wrapped-native (WETH) vault can also spend the wrappable native balance, so the
+    // depositable amount is denominated as the native asset — which also makes the fiat
+    // conversion use the native rate.
     if (isWrappedNativeToken(account.symbol, tokenBalance.tokenContractAddress)) {
         return {
             type: 'account',

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts
@@ -1,7 +1,11 @@
 import { type Account, toTokenAddress } from '@suite-common/wallet-types';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 
 import { type ChooseAccountTokenBalance } from '../types';
-import { getAccountTokenByContract } from './contractTokenBalanceUtils';
+import {
+    getAccountTokenByContract,
+    getYieldVaultDepositableBalance,
+} from './contractTokenBalanceUtils';
 
 export type ChooseAccountBalanceData =
     | {
@@ -23,6 +27,16 @@ export const getChooseAccountBalanceData = (
         return {
             type: 'account',
             value: account.formattedBalance,
+        };
+    }
+
+    // A wrapped-native (WETH) vault can also spend the wrappable native balance (minus the fee
+    // reserve), so the depositable amount is denominated as the native asset — which also makes
+    // the fiat conversion use the native rate.
+    if (isWrappedNativeToken(account.symbol, tokenBalance.tokenContractAddress)) {
+        return {
+            type: 'account',
+            value: getYieldVaultDepositableBalance(account, tokenBalance.tokenContractAddress),
         };
     }
 

--- a/suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts
+++ b/suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts
@@ -1,3 +1,4 @@
+import { getYieldDepositableBalance } from '@suite-common/wallet-core';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -33,6 +34,24 @@ export const getAccountTokenByContract = (
         ) ?? null
     );
 };
+
+/**
+ * Balance a yield vault deposit can spend from the account. For a wrapped-native (WETH) vault
+ * the wrappable native balance counts in too, minus the fee reserve kept for the follow-up
+ * wrap + approve + deposit fees.
+ */
+export const getYieldVaultDepositableBalance = (
+    account: Account,
+    vaultTokenContract: TokenAddress | null,
+): string =>
+    getYieldDepositableBalance({
+        networkSymbol: account.symbol,
+        nativeFormattedBalance: account.formattedBalance,
+        vaultTokenAddress: vaultTokenContract,
+        matchedTokenBalance: vaultTokenContract
+            ? getAccountTokenByContract(account, vaultTokenContract)?.balance
+            : null,
+    });
 
 export const hasPositiveContractTokenBalance = (
     account: Account,

--- a/suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts
+++ b/suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts
@@ -36,9 +36,9 @@ export const getAccountTokenByContract = (
 };
 
 /**
- * Balance a yield vault deposit can spend from the account. For a wrapped-native (WETH) vault
- * the wrappable native balance counts in too, minus the fee reserve kept for the follow-up
- * wrap + approve + deposit fees.
+ * Balance a yield vault deposit can spend from the account. For a wrapped-native (WETH) vault the
+ * native balance can be wrapped, so it counts in too; the fee reserve is deducted later, by the
+ * wrap step's available-to-wrap amount.
  */
 export const getYieldVaultDepositableBalance = (
     account: Account,

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
@@ -1,0 +1,105 @@
+import { toTokenAddress } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { RootStackRoutes, YieldStackRoutes } from '@suite-native/navigation';
+
+import { type StablecoinYieldNavigationItem } from '../types';
+import { navigateByYieldAccountState } from './navigateByYieldAccountState';
+
+const WETH_ADDRESS = toTokenAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
+const USDC_ADDRESS = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+const RECEIPT_ADDRESS = toTokenAddress('0xde6c23e561f3e55846207ec45a91b777e0f7c889');
+
+const createMockItem = (
+    underlyingTokenContract: StablecoinYieldNavigationItem['underlyingTokenContract'],
+): StablecoinYieldNavigationItem => ({
+    yieldId: 'ethereum-vault',
+    underlyingTokenContract,
+    receiptTokenContract: RECEIPT_ADDRESS,
+});
+
+const mockNavigate = jest.fn();
+const isFirmwareSupported = jest.fn().mockReturnValue(true);
+const showFirmwareUpdateAlert = jest.fn();
+
+const navigate = (
+    account: Parameters<typeof navigateByYieldAccountState>[0],
+    item = createMockItem(WETH_ADDRESS),
+) =>
+    navigateByYieldAccountState(
+        account,
+        item,
+        mockNavigate,
+        isFirmwareSupported,
+        showFirmwareUpdateAlert,
+    );
+
+describe(navigateByYieldAccountState.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        isFirmwareSupported.mockReturnValue(true);
+    });
+
+    it('navigates to the account detail when the account holds the receipt token', () => {
+        const account = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [mockAccountToken({ contract: RECEIPT_ADDRESS, balance: '1' })],
+        });
+
+        expect(navigate(account)).toBe('account-detail');
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.AccountDetail, {
+            accountKey: account.key,
+            tokenContract: RECEIPT_ADDRESS,
+            closeActionType: 'back',
+        });
+    });
+
+    it('prefers the account detail over the deposit flow when the account holds both a receipt position and a depositable balance', () => {
+        const account = mockWalletAccount({
+            symbol: 'eth',
+            formattedBalance: '1',
+            tokens: [mockAccountToken({ contract: RECEIPT_ADDRESS, balance: '1' })],
+        });
+
+        expect(navigate(account)).toBe('account-detail');
+    });
+
+    it('routes a native-only account into the deposit flow for a wrapped-native vault', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+
+        expect(navigate(account)).toBe('deposit-in-a-nutshell-modal');
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.YieldNavigator, {
+            screen: YieldStackRoutes.HowYieldWorks,
+            params: {
+                accountKey: account.key,
+                tokenContract: WETH_ADDRESS,
+                yieldId: 'ethereum-vault',
+            },
+        });
+    });
+
+    it('routes to the insufficient-balance screen when the native balance is below the gas reserve', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
+
+        expect(navigate(account)).toBe('insufficient-balance-screen');
+        expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.YieldInsufficientBalance, {
+            accountKey: account.key,
+            tokenContract: WETH_ADDRESS,
+            yieldId: 'ethereum-vault',
+        });
+    });
+
+    it('does not count the native balance for a non-wrapped-native vault', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
+
+        expect(navigate(account, createMockItem(USDC_ADDRESS))).toBe('insufficient-balance-screen');
+    });
+
+    it('shows the firmware update alert for a depositable account with unsupported firmware', () => {
+        isFirmwareSupported.mockReturnValue(false);
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+
+        expect(navigate(account)).toBe('firmware-update-alert');
+        expect(showFirmwareUpdateAlert).toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
@@ -77,8 +77,14 @@ describe(navigateByYieldAccountState.name, () => {
         });
     });
 
-    it('routes to the insufficient-balance screen when the native balance is below the gas reserve', () => {
+    it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {
         const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
+
+        expect(navigate(account)).toBe('deposit-in-a-nutshell-modal');
+    });
+
+    it('routes to the insufficient-balance screen when the account is empty', () => {
+        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0' });
 
         expect(navigate(account)).toBe('insufficient-balance-screen');
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.YieldInsufficientBalance, {

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.ts
@@ -6,9 +6,13 @@ import {
     type StackNavigationProps,
     YieldStackRoutes,
 } from '@suite-native/navigation';
+import { BigNumber } from '@trezor/utils';
 
 import { type StablecoinYieldNavigationItem } from '../types';
-import { hasPositiveContractTokenBalance } from './contractTokenBalanceUtils';
+import {
+    getYieldVaultDepositableBalance,
+    hasPositiveContractTokenBalance,
+} from './contractTokenBalanceUtils';
 
 type YieldNavigateFn = StackNavigationProps<
     RootStackParamList,
@@ -40,7 +44,13 @@ export const navigateByYieldAccountState = (
         return 'account-detail';
     }
 
-    if (hasPositiveContractTokenBalance(account, underlyingTokenContract)) {
+    // For a wrapped-native (WETH) vault the wrappable native balance counts in as depositable
+    // too, so an account holding only the native asset still routes into the deposit flow.
+    const hasDepositableBalance = new BigNumber(
+        getYieldVaultDepositableBalance(account, underlyingTokenContract),
+    ).gt(0);
+
+    if (hasDepositableBalance) {
         if (!isFirmwareSupported('deposit')) {
             showFirmwareUpdateAlert();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow-up on [the desktop counterpart](https://github.com/trezor/trezor-suite/pull/30299):

- display WETH vault icon as ETH one
- count native balance as depositable for wrapped-native vaults on earn dashboard
- show account balance in yield flow screen header

## Related Issue

Resolve #29882
Resolve #29886
Resolve #29871

## Screenshots:

<img width="375" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-27 at 17 25 56" src="https://github.com/user-attachments/assets/f8cd5cb2-fd0b-448f-87ef-984c49901bf6" />

<img width="375" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 14 16 31" src="https://github.com/user-attachments/assets/c1ddc36f-0eb3-4fd3-b655-1c1dc7f5a0b2" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by suite-native/mobile earn components and utilities, which are outside the scope of the suite/e2e Playwright tests and therefore have no relevant coverage here. The only desktop file, YieldPageHeader.tsx, affects the earn/yield pages, and the closest existing safeguard is the general link/routing smoke test that visits those routes. Running that single test gives a lightweight check for gross regressions; otherwise, mobile changes rely on native/mobile test suites not represented in this list.

<details><summary><b>Changed files (13)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `suite-native/icons/src/TokenIcon.test.tsx`
- `suite-native/icons/src/TokenIcon.tsx`
- `suite-native/module-earn/src/components/EarnAccountCard.tsx`
- `suite-native/module-earn/src/components/EarnDepositsCardRow.tsx`
- `suite-native/module-earn/src/components/EarnItemOverviewSection.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx`
- `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx`
- `suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts`
- `suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts`
- `suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to every /earn/yield/* route (deposit, withdraw, claim, wrap, unwrap, etc.), so a regression in YieldPageHeader that crashes or prevents those pages from rendering would be caught by the page-load and content-attachment assertions.

</details>

⚠️ **Changes with no test coverage (12)**
- `suite-native/icons/src/TokenIcon.test.tsx`
- `suite-native/icons/src/TokenIcon.tsx`
- `suite-native/module-earn/src/components/EarnAccountCard.tsx`
- `suite-native/module-earn/src/components/EarnDepositsCardRow.tsx`
- `suite-native/module-earn/src/components/EarnItemOverviewSection.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx`
- `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx`
- `suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts`
- `suite-native/module-earn/src/utils/chooseAccountBalanceUtils.ts`
- `suite-native/module-earn/src/utils/contractTokenBalanceUtils.ts`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.ts`

_Updated: 2026-08-04T15:03:48.034Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/weth-tasks-mobile/web/](https://dev.suite.sldev.cz/suite-web/feat/weth-tasks-mobile/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/weth-tasks-mobile&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/weth-tasks-mobile&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/weth-tasks-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:06:37.317Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T15:06:09.733Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->