### PR TITLE
test(wallet-core): co-locate earn tests

### DIFF
--- a/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts
+++ b/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts
@@ -5,7 +5,7 @@ import {
     type EarnStablecoinYieldDepositFiatInput,
     calculateEarnDepositsFiatData,
     getEarnDepositsFiatStatus,
-} from '../earnDepositsFiatUtils';
+} from './earnDepositsFiatUtils';
 
 const USDC_CONTRACT_CHECKSUMMED = toTokenAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
 const USDC_CONTRACT_LOWERCASE = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts
@@ -5,22 +5,22 @@ import { type FeeInfo, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
 
-import { fetchAllowance } from '../../allowance/fetchAllowance';
-import { feesReducer } from '../../fees/feesReducer';
-import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
-import { composeYieldDepositTransactionThunk } from '../stablecoinYieldDepositThunks';
-import { estimateYieldFeeLevel } from '../stablecoinYieldFeeEstimation';
-import { type YieldFlowResolvedData } from '../stablecoinYieldTypes';
+import { composeYieldDepositTransactionThunk } from './stablecoinYieldDepositThunks';
+import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
+import { type YieldFlowResolvedData } from './stablecoinYieldTypes';
+import { fetchAllowance } from '../allowance/fetchAllowance';
+import { feesReducer } from '../fees/feesReducer';
+import { ethereumGetCurrentNonceThunk } from '../send/sendFormEthereumThunks';
 
-jest.mock('../../allowance/fetchAllowance', () => ({
+jest.mock('../allowance/fetchAllowance', () => ({
     fetchAllowance: jest.fn(),
 }));
 
-jest.mock('../stablecoinYieldFeeEstimation', () => ({
+jest.mock('./stablecoinYieldFeeEstimation', () => ({
     estimateYieldFeeLevel: jest.fn(),
 }));
 
-jest.mock('../../send/sendFormEthereumThunks', () => ({
+jest.mock('../send/sendFormEthereumThunks', () => ({
     ethereumGetCurrentNonceThunk: jest.fn(() => () => {
         const result = { nonce: '5', confirmedNonce: '5' };
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts
@@ -3,7 +3,7 @@ import { testMocks } from '@suite-common/test-utils';
 import { type Features } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { isStablecoinYieldSupported } from '../stablecoinYieldDeviceUtils';
+import { isStablecoinYieldSupported } from './stablecoinYieldDeviceUtils';
 
 const createDevice = (features: Partial<Features>): TrezorDevice =>
     ({

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts
@@ -1,6 +1,6 @@
 import TrezorConnect from '@trezor/connect';
 
-import { estimateYieldFeeLevel } from '../stablecoinYieldFeeEstimation';
+import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
 
 jest.mock('@trezor/connect', () => ({
     __esModule: true,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -7,8 +7,8 @@ import {
     initialStablecoinYieldState,
     stablecoinYieldActions,
     stablecoinYieldReducer,
-} from '../stablecoinYieldReducer';
-import type { YieldFlowType, YieldPendingTransactionState } from '../stablecoinYieldTypes';
+} from './stablecoinYieldReducer';
+import type { YieldFlowType, YieldPendingTransactionState } from './stablecoinYieldTypes';
 
 const FLOW_KEY = 'account-key:yield-id:0xtoken';
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -1,6 +1,6 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 
-import type { YieldPendingTransactionState } from '../stablecoinYieldTypes';
+import type { YieldPendingTransactionState } from './stablecoinYieldTypes';
 import {
     buildEvmSelectedFee,
     buildYieldDepositCalldata,
@@ -14,7 +14,7 @@ import {
     getYieldFlowStepSequence,
     getYieldWrapAmount,
     splitYieldPendingTransaction,
-} from '../stablecoinYieldUtils';
+} from './stablecoinYieldUtils';
 
 const ACCOUNT_DESCRIPTOR = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const VAULT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';

--- a/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeSelectors.test.ts
@@ -1,7 +1,7 @@
-import { type StakeDataState, stakeDataInitialState } from '../stakeDataSlice';
-import { stakeInitialState } from '../stakeReducer';
-import type { StakeRootState } from '../stakeReducerTypes';
-import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from '../stakeSelectors';
+import { type StakeDataState, stakeDataInitialState } from './stakeDataSlice';
+import { stakeInitialState } from './stakeReducer';
+import type { StakeRootState } from './stakeReducerTypes';
+import { selectCardanoPoolsInfo, selectEthNextRewardPayout } from './stakeSelectors';
 
 const buildStakeState = (data: Partial<StakeDataState['data']>): StakeRootState => ({
     wallet: {

--- a/suite-common/wallet-core/src/stake/stakeThunks.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.test.ts
@@ -6,10 +6,10 @@ import {
 import { configureMockStore } from '@suite-common/test-utils';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
-import { stakeDataActions, stakeDataInitialState } from '../stakeDataSlice';
-import { stakeInitialState } from '../stakeReducer';
-import type { StakeState } from '../stakeReducerTypes';
-import { initStakeDataThunk } from '../stakeThunks';
+import { stakeDataActions, stakeDataInitialState } from './stakeDataSlice';
+import { stakeInitialState } from './stakeReducer';
+import type { StakeState } from './stakeReducerTypes';
+import { initStakeDataThunk } from './stakeThunks';
 
 jest.mock('@suite-common/earn-staking-api', () => ({
     getStakingBatch: jest.fn(),

--- a/suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts
@@ -1,6 +1,6 @@
 import { type AccountKey, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
-import { initialTronStakeTxReview, tronStakeActions, tronStakeReducer } from '../tronStakeReducer';
+import { initialTronStakeTxReview, tronStakeActions, tronStakeReducer } from './tronStakeReducer';
 
 const KEY = 'account-1' as AccountKey;
 const FLOW = 'stake' as const;


### PR DESCRIPTION
## Description

Moves nine Wallet Core earn, stablecoin-yield, and staking tests beside their source files without relocating shared support code or changing behavior. The rebase preserves the latest native-token wrap and unwrap test coverage and adjusts only relocation-dependent imports.

- Relocated test suites: **9**
- Focused unit tests: **114/114 passing**
- Wallet Core lint and formatting: **passing**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests for wallet-core staking (stake reducer/thunks/selectors, Tron stake reducer) and stablecoin-yield / earn-deposit-fiat modules, none of which have direct E2E static coverage mappings. Since no E2E test file explicitly imports these wallet-core modules, recommendations are inferred from behavioral overlap: E2E staking tests (ETH, ADA, SOL) exercise the same core staking state management (stake, thunks, selectors) that was modified, making them the best proxy for regression detection. No E2E tests were found that plausibly exercise the stablecoin-yield feature, Tron staking, or earn-deposits-fiat utilities, so these remain uncovered by E2E and should rely on their own unit test suites plus manual verification if a UI surface exists.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stake/stakeSelectors.test.ts`
- `suite-common/wallet-core/src/stake/stakeThunks.test.ts`
- `suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test exercises the ETH staking flow end-to-end (stake dashboard, staking transaction, pending/confirmed states), which directly depends on stake reducer/thunk/selector logic changed in stakeSelectors.test.ts and stakeThunks.test.ts. Unit test changes in the stake module suggest underlying staking state management logic was modified, and this E2E test is the most direct behavioral check of that logic for ETH.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstaking and claiming ETH rewards rely on the same stake selectors/thunks that were modified; this test validates unstake/claim transitions and reward/balance calculations that would break if stake state logic regressed.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test covers first-time ETH staking including staking dashboard empty states and progress phase transitions, which are governed by the stake reducer/selector logic that was changed; a regression here would be immediately user-visible.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking uses shared staking state infrastructure (thunks/selectors) that was changed; while ADA has its own staking mechanics (stake key registration, delegation), the core stake state transitions are likely shared with the modified stakeThunks/stakeSelectors.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking relies on the same shared stake reducer/thunk infrastructure as ETH staking; a regression in core stake logic could affect ADA's unstake flow status displays and balance calculations.
- `suite/e2e/tests/staking/ada/claim.test.ts` — ADA reward claiming depends on staking reward calculations that likely flow through the same stake selectors that were modified, making this a plausible regression target.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking flows (pending/staked amount computation, progress phases) likely share the core stake state module that was changed; verifying SOL's initial stake flow provides cross-network confidence in the modified stake logic.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstake/claim behavior depends on the shared staking state module (reducer/selectors/thunks) that was changed, so this test provides additional coverage for staking status transitions across networks.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Stake-more for an existing SOL stake exercises incremental staking state updates that may be affected by changes to stake thunks/selectors, though this is a secondary path relative to initial staking tests.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Reward display and caching logic for SOL staking could be impacted if selectors computing reward totals were changed, but this is a more peripheral aspect of the staking feature.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts`

_Updated: 2026-07-28T15:55:34.283Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/wallet-core-earn-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/wallet-core-earn-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/wallet-core-earn-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/wallet-core-earn-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/wallet-core-earn-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:58:58.862Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:58:42.934Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->