### PR TITLE
test(wallet-utils): co-locate A-R tests

### DIFF
--- a/suite-common/wallet-utils/src/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/accountUtils.test.ts
@@ -3,7 +3,7 @@ import { type NetworkFeature } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import * as fixtures from '../__fixtures__/accountUtils';
+import * as fixtures from './__fixtures__/accountUtils';
 import {
     accountSearchFn,
     enhanceAddresses,
@@ -18,13 +18,13 @@ import {
     sortByBIP44AddressIndex,
     sortByCoin,
     substituteBip43Path,
-} from '../accountUtils';
+} from './accountUtils';
 import {
     convertAmountSubunitsToUnits,
     convertAmountUnitsToSubunits,
     formatNetworkAmount,
     networkAmountToSmallestUnit,
-} from '../amountUtils';
+} from './amountUtils';
 
 describe('account utils', () => {
     fixtures.getUtxoFromSignedTransaction.forEach(f => {

--- a/suite-common/wallet-utils/src/allowanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/allowanceUtils.test.ts
@@ -2,7 +2,7 @@ import {
     isAllowanceUnlimited,
     shouldShowRevokeAllowanceBanner,
     tokenSupportsIncreasingAllowance,
-} from '../allowanceUtils';
+} from './allowanceUtils';
 
 // USDT requires resetting the allowance to zero before it can be changed.
 const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';

--- a/suite-common/wallet-utils/src/amountUtils.test.ts
+++ b/suite-common/wallet-utils/src/amountUtils.test.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from '@trezor/utils';
 
-import { asAmountSubunit, asAmountUnit } from '../AmountTypes';
-import { subunitsToUnits, unitsToSubunits } from '../amountUtils';
+import { asAmountSubunit, asAmountUnit } from './AmountTypes';
+import { subunitsToUnits, unitsToSubunits } from './amountUtils';
 
 describe(subunitsToUnits.name, () => {
     it('converts Sats->BTC', () => {

--- a/suite-common/wallet-utils/src/apyUtils.test.ts
+++ b/suite-common/wallet-utils/src/apyUtils.test.ts
@@ -1,4 +1,4 @@
-import { getApyPercent } from '../apyUtils';
+import { getApyPercent } from './apyUtils';
 
 describe(getApyPercent.name, () => {
     it('converts APY rate to percent with two decimal places', () => {

--- a/suite-common/wallet-utils/src/backend.test.ts
+++ b/suite-common/wallet-utils/src/backend.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultBackendType, isTrezorConnectBackendType } from '../backendUtils';
+import { getDefaultBackendType, isTrezorConnectBackendType } from './backendUtils';
 
 describe('backend utils', () => {
     test('getDefaultBackendType', () => {

--- a/suite-common/wallet-utils/src/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.test.ts
@@ -1,4 +1,4 @@
-import { formatCoinBalance } from '../balanceUtils';
+import { formatCoinBalance } from './balanceUtils';
 
 test('formatBalanceUtils', () => {
     // @ts-expect-error

--- a/suite-common/wallet-utils/src/bigNumberUtils.test.ts
+++ b/suite-common/wallet-utils/src/bigNumberUtils.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { roundToNonZeroFractionDigits } from '../bigNumberUtils';
+import { roundToNonZeroFractionDigits } from './bigNumberUtils';
 
 describe('BigNumber utils', () => {
     it('roundToNonZeroFractionDigits', () => {

--- a/suite-common/wallet-utils/src/bitcoinUtils.test.ts
+++ b/suite-common/wallet-utils/src/bitcoinUtils.test.ts
@@ -1,4 +1,4 @@
-import { datetimeToLocktime } from '../bitcoinUtils';
+import { datetimeToLocktime } from './bitcoinUtils';
 
 describe(datetimeToLocktime.name, () => {
     it('valid timestamp', () => {

--- a/suite-common/wallet-utils/src/cardanoUtils.test.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.test.ts
@@ -1,6 +1,6 @@
 import { CARDANO, PROTO } from '@trezor/connect';
 
-import * as fixtures from '../__fixtures__/cardanoUtils';
+import * as fixtures from './__fixtures__/cardanoUtils';
 import {
     formatMaxOutputAmount,
     getAddressParameters,
@@ -15,7 +15,7 @@ import {
     getVotingCertificates,
     isCardanoTx,
     transformUserOutputs,
-} from '../cardanoUtils';
+} from './cardanoUtils';
 
 describe('cardano utils', () => {
     let dateSpy: any;

--- a/suite-common/wallet-utils/src/clearSignedSwapUtils.test.ts
+++ b/suite-common/wallet-utils/src/clearSignedSwapUtils.test.ts
@@ -1,4 +1,4 @@
-import { getClearSignedSwapAmounts } from '../clearSignedSwapUtils';
+import { getClearSignedSwapAmounts } from './clearSignedSwapUtils';
 
 const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const WBTC = '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599';

--- a/suite-common/wallet-utils/src/csvParser.test.ts
+++ b/suite-common/wallet-utils/src/csvParser.test.ts
@@ -1,4 +1,4 @@
-import { parseCSV } from '../csvParserUtils';
+import { parseCSV } from './csvParserUtils';
 
 const FIXTURES = [
     {

--- a/suite-common/wallet-utils/src/earnSortUtils.test.ts
+++ b/suite-common/wallet-utils/src/earnSortUtils.test.ts
@@ -6,7 +6,7 @@ import {
     compareEarnByApyDesc,
     compareEarnByNetwork,
     compareEarnByNetworkTokenOrder,
-} from '../earnSortUtils';
+} from './earnSortUtils';
 
 type Row = {
     id: string;

--- a/suite-common/wallet-utils/src/ethConverter.test.ts
+++ b/suite-common/wallet-utils/src/ethConverter.test.ts
@@ -7,7 +7,7 @@ import {
     fromHex,
     fromIntegerString,
     fromWei,
-} from '../ethConverter';
+} from './ethConverter';
 
 // [wei, gwei, ether, hex]
 const rows = [

--- a/suite-common/wallet-utils/src/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/ethUtils.test.ts
@@ -15,7 +15,7 @@ import {
     padLeftEven,
     sanitizeHex,
     strip,
-} from '../ethUtils';
+} from './ethUtils';
 
 const VALID_CLAIM_ADDRESS = asEvmAddress('0x1111111111111111111111111111111111111111');
 

--- a/suite-common/wallet-utils/src/ethereumStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/ethereumStakingUtils.test.ts
@@ -5,13 +5,13 @@ import {
     getAccountEverstakeStakingPoolFixtures,
     getEthAccountTotalStakingBalanceFixtures,
     getUnstakeAmountByEthereumDataHexFixtures,
-} from '../__fixtures__/ethereumStakingUtils';
+} from './__fixtures__/ethereumStakingUtils';
 import {
     getAccountAutocompoundBalance,
     getAccountEverstakeStakingPool,
     getEthAccountTotalStakingBalance,
     getUnstakeAmountByEthereumDataHex,
-} from '../ethereumStakingUtils';
+} from './ethereumStakingUtils';
 
 describe('getAccountEverstakeStakingPool', () => {
     getAccountEverstakeStakingPoolFixtures.forEach(({ description, account, expected }) => {

--- a/suite-common/wallet-utils/src/fiatConverter.test.ts
+++ b/suite-common/wallet-utils/src/fiatConverter.test.ts
@@ -1,4 +1,4 @@
-import { fromBaseCurrencyToCryptoUnit, toFiatCurrency } from '../fiatConverterUtils';
+import { fromBaseCurrencyToCryptoUnit, toFiatCurrency } from './fiatConverterUtils';
 
 const rate = 3007.1079886708517;
 const rateString = '3007.1079886708517';

--- a/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
@@ -4,7 +4,7 @@ import {
     getFiatRateKey,
     getFiatRateKeyFromTicker,
     roundTimestampToNearestPastHour,
-} from '../fiatRatesUtils';
+} from './fiatRatesUtils';
 
 describe('fiat rates utils', () => {
     it('formats fiat rate key', () => {

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.test.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.test.ts
@@ -3,7 +3,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { filterReceiveAccounts, isDebugOnlyAccountType } from '../filterReceiveAccounts';
+import { filterReceiveAccounts, isDebugOnlyAccountType } from './filterReceiveAccounts';
 
 const accountsList: Account[] = [
     mockWalletAccount({ symbol: 'eth', accountType: 'legacy' }),

--- a/suite-common/wallet-utils/src/formDraftUtils.test.ts
+++ b/suite-common/wallet-utils/src/formDraftUtils.test.ts
@@ -1,7 +1,7 @@
 import { FormDraftPrefixKeyValues } from '@suite-common/wallet-constants';
 import { type FormDraftWithSendKeyPrefix } from '@suite-common/wallet-types';
 
-import { getFormDraftKey, isFormDraftKeyPrefix } from '../formDraftUtils';
+import { getFormDraftKey, isFormDraftKeyPrefix } from './formDraftUtils';
 
 describe('form draft utils', () => {
     it('getFormDraftKey', () => {

--- a/suite-common/wallet-utils/src/getMyInputsFromTransaction.test.ts
+++ b/suite-common/wallet-utils/src/getMyInputsFromTransaction.test.ts
@@ -1,7 +1,7 @@
 import {
     type GetMyInputsFromTransactionParams,
     getMyInputsFromTransaction,
-} from '../getMyInputsFromTransaction';
+} from './getMyInputsFromTransaction';
 
 describe(getMyInputsFromTransaction.name, () => {
     it("filters out utxo that doesn't belong to the account", () => {

--- a/suite-common/wallet-utils/src/localizeNumber.test.ts
+++ b/suite-common/wallet-utils/src/localizeNumber.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { localizeNumber } from '../localizeNumberUtils';
+import { localizeNumber } from './localizeNumberUtils';
 
 describe('localizeNumber', () => {
     it('formats with default locale', () => {

--- a/suite-common/wallet-utils/src/localizePercentage.test.ts
+++ b/suite-common/wallet-utils/src/localizePercentage.test.ts
@@ -1,4 +1,4 @@
-import { type FormatPercentageArgs, localizePercentage } from '../localizePercentage';
+import { type FormatPercentageArgs, localizePercentage } from './localizePercentage';
 
 const NON_BREAKING_SPACE = '\u00A0';
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -10,11 +10,11 @@ import {
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { TokenInfo } from '@trezor/connect';
 
-import { buildApprovalTransactionData } from '../ethUtils';
+import { buildApprovalTransactionData } from './ethUtils';
 import {
     constructTransactionReviewOutputs,
     isClearSignedEvmTradingSwapTransaction,
-} from '../reviewTransactionUtils';
+} from './reviewTransactionUtils';
 
 const buildPrecomposedTx = (to: string | undefined): GeneralPrecomposedTransactionFinal =>
     ({


### PR DESCRIPTION
## Description

Moves 23 Wallet Utils tests with names beginning A–R beside their source files while preserving fixture names and locations.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This PR only touches unit test files within suite-common/wallet-utils (accountUtils, ethUtils, ethConverter, ethereumStakingUtils, cardanoUtils, csvParser, balanceUtils, bigNumberUtils, fiatConverter, localizeNumber, formDraftUtils, filterReceiveAccounts, etc.) with no static E2E coverage mapping available. Since these are pure utility functions used across many wallet features (balances, fees, staking, CSV export/import, currency conversion), the safest strategy is to run a small set of E2E tests that most directly exercise the affected calculation/formatting logic — especially ETH/staking fee display, CSV import/export, and fiat/balance formatting — rather than the full suite. Many other tests were omitted because the overlap with changed utility functions is too indirect to justify inclusion given the 'omit unless concrete evidence' rule.

<details><summary><b>Changed files (23)</b></summary>

- `suite-common/wallet-utils/src/accountUtils.test.ts`
- `suite-common/wallet-utils/src/allowanceUtils.test.ts`
- `suite-common/wallet-utils/src/amountUtils.test.ts`
- `suite-common/wallet-utils/src/apyUtils.test.ts`
- `suite-common/wallet-utils/src/backend.test.ts`
- `suite-common/wallet-utils/src/balanceUtils.test.ts`
- `suite-common/wallet-utils/src/bigNumberUtils.test.ts`
- `suite-common/wallet-utils/src/bitcoinUtils.test.ts`
- `suite-common/wallet-utils/src/cardanoUtils.test.ts`
- `suite-common/wallet-utils/src/clearSignedSwapUtils.test.ts`
- `suite-common/wallet-utils/src/csvParser.test.ts`
- `suite-common/wallet-utils/src/earnSortUtils.test.ts`
- `suite-common/wallet-utils/src/ethConverter.test.ts`
- `suite-common/wallet-utils/src/ethUtils.test.ts`
- `suite-common/wallet-utils/src/ethereumStakingUtils.test.ts`
- `suite-common/wallet-utils/src/fiatConverter.test.ts`
- `suite-common/wallet-utils/src/fiatRatesUtils.test.ts`
- `suite-common/wallet-utils/src/filterReceiveAccounts.test.ts`
- `suite-common/wallet-utils/src/formDraftUtils.test.ts`
- `suite-common/wallet-utils/src/getMyInputsFromTransaction.test.ts`
- `suite-common/wallet-utils/src/localizeNumber.test.ts`
- `suite-common/wallet-utils/src/localizePercentage.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`

</details>

**Recommended tests (16)**

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test directly exercises balance calculation and display (getBigNumberFromBalance, balance truncation/ellipsis) which corresponds to changes in balanceUtils.test.ts and bigNumberUtils.test.ts unit test files; a regression in balance formatting logic would be visible here.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exporting transactions to CSV/PDF/JSON relies on CSV parsing/formatting logic covered by csvParser.test.ts changes; regressions in parsing would manifest in export correctness.
- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test imports a BTC CSV file and relies on csvToJson parsing utilities directly tied to csvParser.test.ts changes; a bug here would break CSV import into the send form.
- `suite/e2e/tests/settings/general.test.ts` — Changing fiat currency and observing dashboard values depends on fiatConverter and localizeNumber formatting utilities; changes to these could alter displayed currency values as asserted in this test.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — ETH staking flow relies heavily on ethereumStakingUtils and ethUtils/ethConverter for fee, amount, and gas calculations displayed on device prompts and toasts; these changed test files directly cover that logic.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Similar to stake-more, this test verifies ETH staking amount/fee calculations and progress states that depend on ethereumStakingUtils and ethUtils logic changed in this PR.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking and claim amount calculations depend on ethereumStakingUtils and ethUtils, which have modified unit tests in this change set.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send form fee calculations (gas limit, max fee per gas, priority fee) rely directly on ethUtils and ethConverter utilities that were modified.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base network send flow uses the same Ethereum fee calculation utilities (ethUtils, ethConverter) that were changed, risking regressions in gas/fee display.

</details>

<details><summary>🟢 <b>Low priority (7)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — Address format validation across multiple coins (BTC, ETH, SOL, TRX) touches accountUtils/bitcoinUtils address-related helpers; low confidence since receive flow mainly relies on device display rather than formatting utils changed here.
- `suite/e2e/tests/wallet/cardano.test.ts` — Cardano account details and address derivation may depend on cardanoUtils helper functions that were modified; included as low priority due to limited direct evidence of behavior overlap.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano staking reward/claim amount formatting could be affected by cardanoUtils changes, though the mapping is inferred rather than directly confirmed.
- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking deposit/fee calculations may rely on cardanoUtils helpers modified in this changeset; low confidence inferred coverage.
- `suite/e2e/tests/wallet/account-search.test.ts` — Account search/filter functionality may depend on accountUtils helpers, but the search behavior described doesn't clearly rely on formatting logic changed here.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test filters and selects receive accounts across networks, potentially touching filterReceiveAccounts logic that was modified; low confidence due to indirect relationship.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Send form draft persistence (locktime, outputs, OP_RETURN) may depend on formDraftUtils, which was modified; included at low priority due to lack of direct test evidence.

</details>

⚠️ **Changes with no test coverage (9)**
- `suite-common/wallet-utils/src/allowanceUtils.test.ts`
- `suite-common/wallet-utils/src/apyUtils.test.ts`
- `suite-common/wallet-utils/src/backend.test.ts`
- `suite-common/wallet-utils/src/clearSignedSwapUtils.test.ts`
- `suite-common/wallet-utils/src/earnSortUtils.test.ts`
- `suite-common/wallet-utils/src/getMyInputsFromTransaction.test.ts`
- `suite-common/wallet-utils/src/localizePercentage.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/amountUtils.test.ts`

_Updated: 2026-07-28T15:44:17.631Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/wallet-utils-a-r-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/wallet-utils-a-r-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/wallet-utils-a-r-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/wallet-utils-a-r-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/wallet-utils-a-r-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:47:52.637Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:47:15.389Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->