### PR TITLE
test(wallet-utils): co-locate S-Z tests

### DIFF
--- a/suite-common/wallet-utils/src/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.test.ts
@@ -7,7 +7,7 @@ import {
 import { type FeeLevel } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
-import * as fixtures from '../__fixtures__/sendFormUtils';
+import * as fixtures from './__fixtures__/sendFormUtils';
 import {
     calculateMax,
     calculateTotal,
@@ -22,7 +22,7 @@ import {
     isAmountWithinNetworkReserve,
     prepareEthereumTransaction,
     restoreOrigOutputsOrder,
-} from '../sendFormUtils';
+} from './sendFormUtils';
 
 describe('sendForm utils', () => {
     fixtures.prepareEthereumTransaction.forEach(f => {

--- a/suite-common/wallet-utils/src/solanaStakingLimitUtils.test.ts
+++ b/suite-common/wallet-utils/src/solanaStakingLimitUtils.test.ts
@@ -1,4 +1,4 @@
-import { resolveSolanaStakingLimit } from '../solanaStakingLimitUtils';
+import { resolveSolanaStakingLimit } from './solanaStakingLimitUtils';
 
 describe('resolveSolanaStakingLimit', () => {
     describe('unstake', () => {

--- a/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/solanaStakingUtils.test.ts
@@ -2,7 +2,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';
 
-import { getSolanaUnstakeAmountBounds } from '../solanaStakingUtils';
+import { getSolanaUnstakeAmountBounds } from './solanaStakingUtils';
 
 const SOL = 1_000_000_000;
 

--- a/suite-common/wallet-utils/src/stakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.test.ts
@@ -1,5 +1,5 @@
-import { getUnstakingPeriodInDaysFixture } from '../__fixtures__/stakingUtils';
-import { getUnstakingPeriodInDays } from '../stakingUtils';
+import { getUnstakingPeriodInDaysFixture } from './__fixtures__/stakingUtils';
+import { getUnstakingPeriodInDays } from './stakingUtils';
 
 describe('getUnstakingPeriodInDays', () => {
     getUnstakingPeriodInDaysFixture.forEach(test => {

--- a/suite-common/wallet-utils/src/stellarTokens.test.ts
+++ b/suite-common/wallet-utils/src/stellarTokens.test.ts
@@ -1,7 +1,7 @@
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
 
-import { getStellarInactiveTokens } from '../stellarTokens';
+import { getStellarInactiveTokens } from './stellarTokens';
 
 jest.mock('@trezor/blockchain-link-utils/src/stellar', () => ({
     STELLAR_DECIMALS: 7,

--- a/suite-common/wallet-utils/src/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.test.ts
@@ -1,13 +1,13 @@
 import type { TokenInfo } from '@trezor/blockchain-link-types';
 
-import { getContractAddressForNetworkSymbolFixtures } from '../__fixtures__/tokenUtils';
+import { getContractAddressForNetworkSymbolFixtures } from './__fixtures__/tokenUtils';
 import {
     getAssetLogoContractAddresses,
     getContractAddressForNetworkSymbol,
     getErc4626Contracts,
     isWrappedNativeToken,
     sortTokensByName,
-} from '../tokenUtils';
+} from './tokenUtils';
 
 describe('getContractAddressForNetworkSymbol', () => {
     getContractAddressForNetworkSymbolFixtures.forEach(

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -1,7 +1,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 
-import * as fixtures from '../__fixtures__/transactionUtils';
+import * as fixtures from './__fixtures__/transactionUtils';
 import {
     type MonthKey,
     analyzeTransactions,
@@ -23,7 +23,7 @@ import {
     isTransactionCancellable,
     parseTransactionDateKey,
     parseTransactionMonthKey,
-} from '../transactionUtils';
+} from './transactionUtils';
 
 const { getWalletTransaction } = testMocks;
 

--- a/suite-common/wallet-utils/src/tronStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.test.ts
@@ -29,7 +29,7 @@ import {
     isTronClaimSupported,
     isTronRewardClaimOnCooldown,
     isTronStakingActive,
-} from '../tronStakingUtils';
+} from './tronStakingUtils';
 
 const TRX = 1_000_000;
 const NOW_SECONDS = 1_700_000_000;

--- a/suite-common/wallet-utils/src/tronUtils.test.ts
+++ b/suite-common/wallet-utils/src/tronUtils.test.ts
@@ -1,7 +1,7 @@
 import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
 
-import { calculateTronFeeBreakdown, computeBandwidthFeeLevel } from '../tronUtils';
+import { calculateTronFeeBreakdown, computeBandwidthFeeLevel } from './tronUtils';
 
 const makeTrc20Tx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
     ({

--- a/suite-common/wallet-utils/src/validation.test.ts
+++ b/suite-common/wallet-utils/src/validation.test.ts
@@ -1,4 +1,4 @@
-import { isDecimalsValid, isHexValid, isInteger } from '../validationUtils';
+import { isDecimalsValid, isHexValid, isInteger } from './validationUtils';
 
 describe('validation', () => {
     it('isDecimalsValid', () => {


### PR DESCRIPTION
## Description

Moves 10 Wallet Utils tests with names beginning S–Z beside their source files while preserving fixture names and locations.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit tests within suite-common/wallet-utils covering staking (SOL/general), send-form, transaction, token, Tron, Stellar, and validation utilities—core shared logic used across staking and send/trading E2E flows. Since there's no static mapping, recommendations are inferred from LLM behavior descriptions: prioritize Solana and general staking E2E tests (highest overlap with solanaStakingUtils/solanaStakingLimitUtils/stakingUtils), ETH/ADA staking flows, and send-form E2E tests across BTC/ETH/SOL/Base/LTC networks (sendFormUtils/transactionUtils/validation). Medium priority covers transaction list/export/pagination tests relying on transactionUtils, and swap-fee tests relying on fee computation utils. No E2E tests were found that specifically exercise Tron or Stellar token utilities, so those changed files remain uncovered by any existing E2E test.

<details><summary><b>Changed files (10)</b></summary>

- `suite-common/wallet-utils/src/sendFormUtils.test.ts`
- `suite-common/wallet-utils/src/solanaStakingLimitUtils.test.ts`
- `suite-common/wallet-utils/src/solanaStakingUtils.test.ts`
- `suite-common/wallet-utils/src/stakingUtils.test.ts`
- `suite-common/wallet-utils/src/stellarTokens.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/tronStakingUtils.test.ts`
- `suite-common/wallet-utils/src/tronUtils.test.ts`
- `suite-common/wallet-utils/src/validation.test.ts`

</details>

**Recommended tests (25)**

<details><summary>🔴 <b>High priority (15)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Directly exercises Solana staking flows (stake amount calculation, rent, fee handling) which are covered by unit tests in solanaStakingUtils.test.ts and solanaStakingLimitUtils.test.ts. Changes to these utils could break stake amount computation or limit validation shown in this E2E test.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Exercises Solana stake-more flow including balance/fee/rent calculations that depend on solanaStakingUtils and solanaStakingLimitUtils logic being changed.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Covers Solana unstake/claim amount calculations that rely on the same staking utility functions being modified in solanaStakingUtils.test.ts and stakingUtils.test.ts.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Tests Solana staking rewards calculation and display, directly tied to solanaStakingUtils logic that was changed.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking flow (amount, fee, pending/confirmed transitions) depends on shared stakingUtils logic that was changed, risking regressions in staking amount/status computation.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — ETH stake-more flow relies on staking utility calculations (amounts, pending/staked transitions) covered by stakingUtils.test.ts changes.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake/claim flow depends on staking utility functions for amount and status calculations that were modified.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking flow (deposit, fee, delegation) uses shared staking utility logic; a regression in stakingUtils could break ADA stake amount/fee calculations verified here.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstake flow depends on staking utility calculations (deposit return, fee) that could be affected by changes in stakingUtils.test.ts.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Cardano reward claiming logic (fee vs reward comparison, balance updates) relies on staking utility functions covered by stakingUtils.test.ts changes.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests staking form validation logic (min/max amounts, decimals, fraction calculations, fiat/crypto conversion) which directly exercises validation.test.ts and stakingUtils.test.ts logic.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Ethereum send flow validates recipient/amount/fee computations that depend on sendFormUtils and transactionUtils, both changed in this PR.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base network send flow with custom EVM fees exercises sendFormUtils and transactionUtils logic that was changed, risking fee/amount display regressions.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana send flow with max-amount, fee, and reserve calculations exercises sendFormUtils logic directly, and changes there could break amount computation shown here.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Covers multiple send form behaviors (outputs, locktime, satoshi units, OP_RETURN) that depend heavily on sendFormUtils and transactionUtils, both modified in this change set.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests validation of amounts exceeding MAX_SAFE_INTEGER during send, touching validation.test.ts and transactionUtils.test.ts logic for transaction signing error paths.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC send flow with MimbleWimble peg-out spending and max amount setting depends on sendFormUtils logic that was modified.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Swap flow with custom BTC fee calculation depends on transactionUtils/sendFormUtils fee computation logic that was changed.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Swap flow with custom Ethereum gas fee calculations relies on transactionUtils/sendFormUtils fee logic potentially impacted by these changes.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Tests pending/confirmed transaction labeling and grouping, which relies on transactionUtils logic (transaction categorization, self-send detection) that was modified.
- `suite/e2e/tests/wallet/transactions.test.ts` — Transaction search and time-range filtering depends on transactionUtils for processing/formatting transactions, which was changed in this PR.
- `suite/e2e/tests/wallet/pagination.test.ts` — Transaction list pagination display depends on transactionUtils formatting/processing logic that was changed.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export (CSV/PDF/JSON) depends on transactionUtils formatting logic across multiple networks including token-based ones, which was modified.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Output labeling on transactions with multiple outputs and CSV export relies on transactionUtils output processing, which could be indirectly affected by the change.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Ethereum message signing indirectly touches shared wallet-utils validation/address logic, though the direct link to changed files is not conclusive.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-utils/src/tronStakingUtils.test.ts`
- `suite-common/wallet-utils/src/tronUtils.test.ts`
- `suite-common/wallet-utils/src/stellarTokens.test.ts`

_Updated: 2026-07-28T12:58:32.790Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/wallet-utils-s-z-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/wallet-utils-s-z-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/wallet-utils-s-z-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/wallet-utils-s-z-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/wallet-utils-s-z-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:01:48.024Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:00:51.413Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->