### PR TITLE
test(address): co-locate tests

### DIFF
--- a/suite-common/address/src/autocorrectAddress.test.ts
+++ b/suite-common/address/src/autocorrectAddress.test.ts
@@ -3,8 +3,8 @@ import {
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
 
-import { createAddressValidator } from '../AddressValidator';
-import { autocorrectAddress } from '../autocorrectAddress';
+import { createAddressValidator } from './AddressValidator';
+import { autocorrectAddress } from './autocorrectAddress';
 
 describe('autocorrectAddress', () => {
     const networkModules = createNetworksCompositionRoot();

--- a/suite-common/address/src/evmChecksumUtils.test.ts
+++ b/suite-common/address/src/evmChecksumUtils.test.ts
@@ -1,4 +1,4 @@
-import { areEvmAddressesEqual, checkAddressChecksum, toChecksumAddress } from '../evmChecksumUtils';
+import { areEvmAddressesEqual, checkAddressChecksum, toChecksumAddress } from './evmChecksumUtils';
 
 // Test cases from https://eips.ethereum.org/EIPS/eip-55
 // [checksummed, lowercase, uppercase]

--- a/suite-common/address/src/getFirstFreshAddress.test.ts
+++ b/suite-common/address/src/getFirstFreshAddress.test.ts
@@ -1,7 +1,7 @@
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { getFirstFreshAddress, getFreshAddresses } from '../getFirstFreshAddress';
+import { getFirstFreshAddress, getFreshAddresses } from './getFirstFreshAddress';
 
 describe(getFirstFreshAddress.name, () => {
     it('returns all unrevealed unused addresses for utxo-based accounts in order', () => {

--- a/suite-common/address/src/getUsedAddressesList.test.ts
+++ b/suite-common/address/src/getUsedAddressesList.test.ts
@@ -1,7 +1,7 @@
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
 
-import { getUsedAddressesList } from '../getUsedAddressesList';
+import { getUsedAddressesList } from './getUsedAddressesList';
 
 type AccountAddress = NonNullable<Account['addresses']>['used'][number];
 

--- a/suite-common/address/src/hasBitcoinCashAddressPrefix.test.ts
+++ b/suite-common/address/src/hasBitcoinCashAddressPrefix.test.ts
@@ -1,4 +1,4 @@
-import { hasBitcoinCashAddressPrefix } from '../hasBitcoinCashAddressPrefix';
+import { hasBitcoinCashAddressPrefix } from './hasBitcoinCashAddressPrefix';
 
 describe('hasBitcoinCashAddressPrefix', () => {
     it.each([

--- a/suite-common/address/src/isAddressDeprecated.test.ts
+++ b/suite-common/address/src/isAddressDeprecated.test.ts
@@ -3,8 +3,8 @@ import {
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
 
-import { createAddressValidator } from '../AddressValidator';
-import { isAddressDeprecated } from '../isAddressDeprecated';
+import { createAddressValidator } from './AddressValidator';
+import { isAddressDeprecated } from './isAddressDeprecated';
 
 // https://litecoin-project.github.io/p2sh-convert/
 // https://cashaddr.bitcoincash.org/

--- a/suite-common/address/src/isBech32AddressUppercase.test.ts
+++ b/suite-common/address/src/isBech32AddressUppercase.test.ts
@@ -1,4 +1,4 @@
-import { isBech32AddressUppercase } from '../isBech32AddressUppercase';
+import { isBech32AddressUppercase } from './isBech32AddressUppercase';
 
 describe('isBech32AddressUppercase', () => {
     it('returns false for empty string', () => {

--- a/suite-common/address/src/isBitcoinCashAddressUppercase.test.ts
+++ b/suite-common/address/src/isBitcoinCashAddressUppercase.test.ts
@@ -1,4 +1,4 @@
-import { isBitcoinCashAddressUppercase } from '../isBitcoinCashAddressUppercase';
+import { isBitcoinCashAddressUppercase } from './isBitcoinCashAddressUppercase';
 
 describe('isBitcoinCashAddressUppercase', () => {
     it.each([

--- a/suite-common/address/src/isTaprootAddress.test.ts
+++ b/suite-common/address/src/isTaprootAddress.test.ts
@@ -3,8 +3,8 @@ import {
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
 
-import { createAddressValidator } from '../AddressValidator';
-import { isTaprootAddress } from '../isTaprootAddress';
+import { createAddressValidator } from './AddressValidator';
+import { isTaprootAddress } from './isTaprootAddress';
 
 describe('isTaprootAddress', () => {
     const networkModules = createNetworksCompositionRoot();


### PR DESCRIPTION
## Description

Moves nine Address tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests for pure address utility functions (checksum, deprecation, prefix/uppercase detection, taproot detection, used-address list, fresh address lookup) in suite-common/address. There is no static E2E coverage mapping for these files since they are unit-level; however, several E2E tests exercise address display/verification flows (receive, send, passphrase reconnection) that could surface regressions if the underlying address utilities were altered. Recommended strategy is to run the address utility's own unit tests (out of scope here) plus a small set of E2E tests that reveal/verify addresses across BTC, ETH, and Cardano to catch any integration-level regressions in address formatting or checksum validation.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/address/src/autocorrectAddress.test.ts`
- `suite-common/address/src/evmChecksumUtils.test.ts`
- `suite-common/address/src/getFirstFreshAddress.test.ts`
- `suite-common/address/src/getUsedAddressesList.test.ts`
- `suite-common/address/src/hasBitcoinCashAddressPrefix.test.ts`
- `suite-common/address/src/isAddressDeprecated.test.ts`
- `suite-common/address/src/isBech32AddressUppercase.test.ts`
- `suite-common/address/src/isBitcoinCashAddressUppercase.test.ts`
- `suite-common/address/src/isTaprootAddress.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test verifies receive address display/format and clipboard copy across BTC, ETH, SOL, and TRX, directly exercising address formatting/validation logic (e.g. regex checks per coin, EVM checksum display) that overlaps with changes to evmChecksumUtils, isTaprootAddress, isBech32AddressUppercase, and isBitcoinCashAddressUppercase.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test checks Ethereum and Bitcoin address reveal/verification (checksum comparison, whitespace-stripped address matching device display) which is inferred to depend on address utility functions such as evmChecksumUtils and getFirstFreshAddress logic used to derive/display the correct receive address.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Involves address formatting and verification logic (formatAddress, cardanoTetragrams) and passphrase-derived address correctness, which could be impacted by shared address utility changes, though Cardano address format is less directly covered by the changed BTC/EVM-specific utils.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests BTC address reveal, verification, and used-address list behavior after reconnection, which touches getUsedAddressesList and address formatting utilities that were changed.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Exercises used-address table display across multiple hidden wallets, which relates to getUsedAddressesList and address formatting/verification changes, though the primary focus of the test is passphrase flows rather than address utilities.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/address/src/autocorrectAddress.test.ts`
- `suite-common/address/src/hasBitcoinCashAddressPrefix.test.ts`
- `suite-common/address/src/isAddressDeprecated.test.ts`

_Updated: 2026-07-28T12:59:40.914Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-address-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-address-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-address-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-address-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-address-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:03:17.776Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:02:55.432Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->