### PR TITLE
test(analytics-redux): co-locate reducer test

### DIFF
--- a/suite-common/analytics-redux/src/redux/analyticsReducer.test.ts
+++ b/suite-common/analytics-redux/src/redux/analyticsReducer.test.ts
@@ -1,5 +1,5 @@
-import { selectHasUserAllowedTracking, selectIsAnalyticsEnabled } from '../analyticsReducer';
-import type { AnalyticsState } from '../analyticsReducer';
+import { selectHasUserAllowedTracking, selectIsAnalyticsEnabled } from './analyticsReducer';
+import type { AnalyticsState } from './analyticsReducer';
 
 type RootState = {
     analytics: AnalyticsState;


### PR DESCRIPTION
## Description

Moves the Analytics Redux reducer test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is a unit test file for the analytics Redux reducer (analyticsReducer.test.ts), which itself has no static E2E coverage mapping since it's a unit test, not application source. However, since this indicates recent work/changes around analytics reducer logic (likely reflecting underlying reducer behavior changes being tested), we infer that E2E tests exercising analytics state (enable/disable, session/instance IDs, event firing tied to settings) are the most relevant to validate. Recommended strategy: run the analytics-specific E2E suites (toggle, events) as high priority, with settings/general and initial-run as secondary checks since they touch overlapping analytics state paths.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/analytics-redux/src/redux/analyticsReducer.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — This test directly exercises the analytics enable/disable reducer logic (session ID/instance ID persistence, dispose events, re-enabling) which is the core state managed by analyticsReducer.test.ts's unit under test. A regression in the reducer's state transitions would likely surface here.
- `suite/e2e/tests/analytics/events.test.ts` — This E2E test validates the full analytics event pipeline (SuiteReady, DeviceConnect, SettingsAnalytics, etc.) that depends on the analytics reducer's state (enabled/disabled, instance/session IDs, settings snapshot), making it a direct check of reducer behavior end-to-end.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test verifies analytics events fired on settings changes (fiat, theme, language, analytics toggle), which depend on the analytics reducer correctly tracking enabled state and settings updates.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — This test covers the analytics consent toggle during onboarding's initial run flow, which interacts with the same analytics enabled/disabled state managed by the reducer, though the primary flow tested is onboarding persistence rather than reducer logic itself.

</details>

_Updated: 2026-07-28T13:02:20.744Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-analytics-redux-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-analytics-redux-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-analytics-redux-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-analytics-redux-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-analytics-redux-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:05:44.045Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:05:24.441Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->