### PR TITLE
test(bip329): co-locate tests

### DIFF
--- a/suite-common/bip329/src/legacy/slip15ToBip329.test.ts
+++ b/suite-common/bip329/src/legacy/slip15ToBip329.test.ts
@@ -1,6 +1,6 @@
 import { type AccountLabels } from '@suite-common/metadata-types';
 
-import { slip15ToBip329 } from '../legacy/slip15ToBip329';
+import { slip15ToBip329 } from './slip15ToBip329';
 
 describe(slip15ToBip329.name, () => {
     it('transforms legacy labels to bip329 labels', () => {

--- a/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.test.ts
+++ b/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.test.ts
@@ -1,7 +1,7 @@
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { err, ok } from '@trezor/type-utils';
 
-import { createBip329ToSuiteSync } from '../suiteSync/createBip329ToSuiteSync';
+import { createBip329ToSuiteSync } from './createBip329ToSuiteSync';
 
 const account = mockWalletAccount({
     symbol: 'btc',

--- a/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.test.ts
+++ b/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.test.ts
@@ -5,7 +5,7 @@ import {
 import { asTxTargetId } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { createSuiteSyncToBip329 } from '../suiteSync/createSuiteSyncToBip329';
+import { createSuiteSyncToBip329 } from './createSuiteSyncToBip329';
 
 const account = mockWalletAccount({
     symbol: 'btc',

--- a/suite-common/bip329/src/suiteSync/suiteSyncToBip329.test.ts
+++ b/suite-common/bip329/src/suiteSync/suiteSyncToBip329.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@suite-common/suite-sync-storage';
 import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 
-import { suiteSyncToBip329 } from '../suiteSync/suiteSyncToBip329';
+import { suiteSyncToBip329 } from './suiteSyncToBip329';
 
 describe(suiteSyncToBip329.name, () => {
     it('transforms suite sync labels to bip329 labels', () => {


### PR DESCRIPTION
## Description

Moves the four BIP-329 tests beside their legacy and Suite Sync source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files live in suite-common/bip329, the library responsible for converting labels between the legacy BIP329/SLIP15 format and the newer Suite Sync (Evolu) format. No static E2E coverage mapping exists for these unit-test files, so recommendations are inferred from E2E tests whose described behaviors directly involve legacy-to-SuiteSync label migration or SuiteSync label sync with the Evolu relay. Highest priority is given to explicit migration tests since they most directly exercise the conversion functions; lower-priority tests provide incidental round-trip coverage of the sync logic through relay verification.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/bip329/src/legacy/slip15ToBip329.test.ts`
- `suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.test.ts`
- `suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.test.ts`
- `suite-common/bip329/src/suiteSync/suiteSyncToBip329.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test explicitly exercises migration of legacy Dropbox labels to Suite Sync, which is exactly the BIP329 legacy-to-suiteSync conversion logic being changed (slip15ToBip329, createBip329ToSuiteSync). A regression in the conversion functions would directly break this migration flow.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This test specifically validates migrating local legacy file labels (account, output, address) to Suite Sync with verification against the Evolu relay, directly covering the createBip329ToSuiteSync conversion logic that was changed.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Creating labels via Suite Sync and syncing them to the Evolu relay tables (account, wallet, address, output) exercises the createSuiteSyncToBip329/suiteSyncToBip329 conversion paths that were modified, verifying label data is correctly transformed for storage.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test syncs labels FROM the Evolu relay to Suite Sync and displays them, which relies on the suiteSyncToBip329/createSuiteSyncToBip329 conversion functions to correctly parse relay data back into displayable labels.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test updates and removes labels (account, wallet, address, output) and verifies both directions of sync with the Evolu relay, covering the round-trip conversion logic (createSuiteSyncToBip329 and createBip329ToSuiteSync) that was changed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Removing labels and syncing null values to the relay touches the same BIP329-to-SuiteSync conversion path, but this test is more narrowly focused on removal semantics rather than the core conversion logic itself.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test involves multiple passphrase wallets syncing labels via Suite Sync to Evolu relay, providing incidental coverage of the label conversion logic across different wallet contexts.

</details>

_Updated: 2026-07-28T13:08:44.991Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-bip329-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-bip329-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-bip329-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-bip329-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-bip329-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:11:43.169Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T13:11:11.529Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->