### PR TITLE
test(bluetooth): co-locate tests

### DIFF
--- a/suite-common/bluetooth/jest.config.js
+++ b/suite-common/bluetooth/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    roots: ['<rootDir>/src', '<rootDir>/tests', '<rootDir>/../test-utils/__mocks__'],
+    roots: ['<rootDir>/src', '<rootDir>/../test-utils/__mocks__'],
 };

--- a/suite-common/bluetooth/src/bluetoothReducer.test.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.test.ts
@@ -6,9 +6,9 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { type Device, asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { bluetoothActions } from '../src/bluetoothActions';
-import { prepareBluetoothReducerCreator, prepareInitialState } from '../src/bluetoothReducer';
-import type { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
+import { bluetoothActions } from './bluetoothActions';
+import { prepareBluetoothReducerCreator, prepareInitialState } from './bluetoothReducer';
+import type { BluetoothDeviceCommon, BluetoothManufacturerData } from './types';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/src/bluetoothSelectors.test.ts
+++ b/suite-common/bluetooth/src/bluetoothSelectors.test.ts
@@ -1,13 +1,9 @@
 import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import {
-    type BluetoothManufacturerData,
-    prepareInitialState,
-    prepareSelectAllDevices,
-} from '../src';
-import type { WithBluetoothState } from '../src/bluetoothSelectors';
-import type { BluetoothDeviceCommon } from '../src/types';
+import { prepareInitialState } from './bluetoothReducer';
+import { type WithBluetoothState, prepareSelectAllDevices } from './bluetoothSelectors';
+import type { BluetoothDeviceCommon, BluetoothManufacturerData } from './types';
 
 const manufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/src/filterOutOldDuplicates.test.ts
+++ b/suite-common/bluetooth/src/filterOutOldDuplicates.test.ts
@@ -2,8 +2,8 @@ import { asBluetoothDeviceId } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { createBluetoothDeviceCommon } from '../mocks';
-import { filterOutOldDuplicates } from '../src/filterOutOldDuplicates';
-import type { BluetoothDeviceCommon, BluetoothManufacturerData } from '../src/types';
+import { filterOutOldDuplicates } from './filterOutOldDuplicates';
+import type { BluetoothDeviceCommon, BluetoothManufacturerData } from './types';
 
 const mockedManufacturerData: BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal.T3W1,

--- a/suite-common/bluetooth/src/manufacturerDataUtils.test.ts
+++ b/suite-common/bluetooth/src/manufacturerDataUtils.test.ts
@@ -1,6 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { parseManufacturerData, serializeManufacturerData } from '../src';
+import { parseManufacturerData, serializeManufacturerData } from './manufacturerDataUtils';
 
 const filterPolicy = {
     pairing: false,


### PR DESCRIPTION
## Description

Moves the four Bluetooth tests beside their source files while leaving shared mocks in place.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files within the suite-common/bluetooth package (reducer, selectors, duplicate filtering, and manufacturer data parsing). These are isolated unit tests with no direct static E2E coverage mapping. The only plausible E2E overlap is with tests that exercise Bluetooth-capable device (TS7/T3W1) state transitions such as forget-device flows; other suggested tests are speculative at best. Since these are pure unit-test changes to internal Bluetooth logic modules, running the associated unit tests themselves (not shown here) plus a light smoke check via forget-device.test.ts is the recommended minimal strategy — broad E2E coverage is not warranted.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/bluetooth/src/bluetoothReducer.test.ts`
- `suite-common/bluetooth/src/bluetoothSelectors.test.ts`
- `suite-common/bluetooth/src/filterOutOldDuplicates.test.ts`
- `suite-common/bluetooth/src/manufacturerDataUtils.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test covers Bluetooth pairing/unpairing and device state mocking (mockDeviceBluetoothState, expectDeviceState) for TS7/T3W1 devices, which directly relies on Bluetooth reducer/selector logic and device-state derivation that these unit tests cover. A regression in bluetoothReducer or bluetoothSelectors logic could break the forget/unpair flows tested here.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test involves enabling BTC network and interacting with device switching for a TS7 (Bluetooth-capable) device via debug mode, touching some Bluetooth-related device state, though it does not directly test Bluetooth pairing logic.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/bluetooth/src/filterOutOldDuplicates.test.ts`
- `suite-common/bluetooth/src/manufacturerDataUtils.test.ts`

_Updated: 2026-07-28T14:46:01.029Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-bluetooth-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-bluetooth-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-bluetooth-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-bluetooth-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-bluetooth-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:49:34.024Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:49:10.136Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->