### PR TITLE
fix(connect): deliver requestedPermissions on desktop and webextension, harden the sanitizer

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -155,6 +155,9 @@ export type ConnectPopupCall = {
         email: string;
         npmVersion?: string;
     };
+    // Mirrors connect's `PermissionRequest`, inlined to keep this package free of a
+    // `@trezor/connect` dependency — same as `manifest` above.
+    requestedPermissions?: { permission: string; coin?: string }[];
 };
 
 export type ConnectPopupCancel = {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -7,6 +7,7 @@ import {
     type CoreCallMessage,
     type Manifest,
     POPUP,
+    type PermissionRequest,
     type PopupClosedMessage,
     type PopupHandshake,
 } from '@trezor/connect';
@@ -105,6 +106,7 @@ export const exposeConnectWs = ({
 
         let manifest: Manifest | undefined;
         let version: string | undefined;
+        let requestedPermissions: PermissionRequest[] | undefined;
 
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
@@ -144,6 +146,7 @@ export const exposeConnectWs = ({
                 });
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
+                requestedPermissions = message.payload.settings.requestedPermissions;
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
@@ -242,6 +245,7 @@ export const exposeConnectWs = ({
                             email: manifest.email,
                             npmVersion: version,
                         },
+                        requestedPermissions,
                     });
 
                     // wait for response

--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -29,9 +29,13 @@ export type ConnectPopupMessage =
     | {
           type: typeof POPUP.HANDSHAKE;
           id: string;
-          payload: { manifest: ManifestPartial };
-          version: string;
-          requestedPermissions?: PermissionRequest[];
+          // Same shape as the wire message from connect-web's Popup, so both links can
+          // forward it verbatim instead of remapping.
+          payload: {
+              manifest: ManifestPartial;
+              version: string;
+              requestedPermissions?: PermissionRequest[];
+          };
       }
     | { type: typeof CORE_CALL; id: string; payload: { method: string; [key: string]: unknown } }
     | { type: typeof POPUP.CLOSED; payload?: { error?: string; callId?: string } | null }
@@ -92,9 +96,9 @@ export const useConnectPopup = (
             } else if (event.type === POPUP.HANDSHAKE) {
                 manifest.current = {
                     ...event.payload.manifest,
-                    npmVersion: event.version,
+                    npmVersion: event.payload.version,
                 };
-                requestedPermissions.current = event.requestedPermissions;
+                requestedPermissions.current = event.payload.requestedPermissions;
                 setPendingHandshake(event.id);
             } else if (event.type === CORE_CALL) {
                 if (!manifest.current) {

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -18,6 +18,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import TrezorConnect, {
     type CallMethodKeys,
     type CallMethodPayload,
+    type PermissionRequest,
     UI_REQUEST,
 } from '@trezor/connect';
 import { isMacOs } from '@trezor/env-utils';
@@ -116,6 +117,10 @@ export const useConnectPopupDesktop = () => {
                                   },
                                   origin: params.origin,
                                   manifest: params.manifest,
+                                  // Cast across the IPC boundary, same as `params.method` above.
+                                  requestedPermissions: params.requestedPermissions as
+                                      | PermissionRequest[]
+                                      | undefined,
                               },
                     }),
                 );

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -137,17 +137,8 @@ export const useConnectPopupWeb = () => {
                 data.type === CORE_CALL_CANCEL ||
                 data.type === CORE_CALL
             ) {
-                const normalized: ConnectPopupMessage =
-                    data.type === POPUP.HANDSHAKE
-                        ? {
-                              type: data.type,
-                              id: data.id,
-                              payload: { manifest: data.payload?.manifest },
-                              version: data.payload?.version,
-                              requestedPermissions: data.payload?.requestedPermissions,
-                          }
-                        : data;
-                setIncomingMessages(prev => [...prev, normalized]);
+                const message: ConnectPopupMessage = data;
+                setIncomingMessages(prev => [...prev, message]);
             }
         };
 

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -163,6 +163,9 @@ const PermissionPreview = ({ permissions }: { permissions: MethodPermission[] })
     );
 };
 
+// The e2e testID convention allows no underscores; connectPermissionsModal.ts mirrors this.
+const permissionTestId = (permission: MethodPermission) => permission.replace(/_/g, '-');
+
 type PermissionGroupProps = {
     coin?: CoinSymbol;
     permissions: MethodPermission[];
@@ -180,7 +183,7 @@ const PermissionGroup = ({
     const [isOpen, setIsOpen] = useState(defaultIsOpen);
 
     return (
-        <Collapsible isOpen={isOpen}>
+        <Collapsible isOpen={isOpen} data-testid={`@connect-permissions/group/${coin ?? 'device'}`}>
             <Collapsible.Toggle onClick={() => setIsOpen(!isOpen)}>
                 <Row justifyContent="space-between" gap={12} padding={{ vertical: 8 }}>
                     <Row gap={16}>
@@ -198,7 +201,10 @@ const PermissionGroup = ({
             <Collapsible.Content>
                 <Column gap={8} margin={{ top: 4, bottom: 8 }}>
                     {permissions.map(permission => (
-                        <PermissionRow key={permission}>
+                        <PermissionRow
+                            key={permission}
+                            data-testid={`@connect-permissions/permission/${permissionTestId(permission)}`}
+                        >
                             <Row gap={12}>
                                 <PermissionIcon permission={permission} />
                                 <Text typographyStyle="body-sm">

--- a/suite-common/connect-popup/src/__tests__/permissions.test.ts
+++ b/suite-common/connect-popup/src/__tests__/permissions.test.ts
@@ -34,12 +34,10 @@ describe('sanitizeRequestedPermissions', () => {
     });
 
     it('drops entries whose coin is not a known coin symbol', () => {
-        // Host-supplied input can carry arbitrary strings, so it violates the compile-time
-        // `CoinSymbol` type — cast to model the untrusted wire shape.
         const requested = [
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_address', coin: 'not-a-coin' },
-        ] as unknown as PermissionRequest[];
+        ];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
         ]);
@@ -49,7 +47,7 @@ describe('sanitizeRequestedPermissions', () => {
         const requested = [
             { permission: 'read_address', coin: 'BTC' },
             { permission: 'read_address', coin: 'tADA' },
-        ] as unknown as PermissionRequest[];
+        ];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_address', coin: 'tada' },
@@ -57,13 +55,72 @@ describe('sanitizeRequestedPermissions', () => {
     });
 
     it('drops unknown/garbage permission values', () => {
-        const requested = [
-            { permission: 'read_address', coin: 'btc' },
-            { permission: 'nonsense' },
-        ] as unknown as PermissionRequest[];
+        const requested = [{ permission: 'read_address', coin: 'btc' }, { permission: 'nonsense' }];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
         ]);
+    });
+
+    // Nothing schema-validates this on the way in, and a throw here would fail every later call
+    // from that app — so every malformed shape has to be dropped instead.
+    describe('malformed host input', () => {
+        it.each([
+            ['a non-array', 'read_address'],
+            ['an object instead of an array', { permission: 'read_address' }],
+            ['null', null],
+            ['a number', 42],
+        ])('returns an empty array for %s', (_name, requested) => {
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([]);
+        });
+
+        it.each([
+            ['null entries', [null]],
+            ['undefined entries', [undefined]],
+            ['primitive entries', ['read_address', 42]],
+            ['entries with no permission', [{ coin: 'btc' }]],
+            ['entries whose permission is not a string', [{ permission: 42, coin: 'btc' }]],
+            ['entries whose coin is not a string', [{ permission: 'read_address', coin: 5 }]],
+            ['entries whose coin is null', [{ permission: 'read_address', coin: null }]],
+        ])('drops %s', (_name, requested) => {
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([]);
+        });
+
+        it('keeps valid entries alongside malformed ones', () => {
+            const requested = [
+                null,
+                { permission: 'read_address', coin: 'btc' },
+                { permission: 'read_xpub', coin: 5 },
+                'garbage',
+                { permission: 'read_features' },
+            ];
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([
+                { permission: 'read_address', coin: 'btc' },
+                { permission: 'read_features' },
+            ]);
+        });
+
+        it('does not widen a malformed coin into a device-wide coin-less grant', () => {
+            expect(
+                sanitizeRequestedPermissions([{ permission: 'sign', coin: null }], false),
+            ).toEqual([]);
+            expect(sanitizeRequestedPermissions([{ permission: 'sign' }], false)).toEqual([
+                { permission: 'sign' },
+            ]);
+        });
+
+        it('copies only whitelisted fields, dropping attacker-chosen keys', () => {
+            const requested = [
+                {
+                    permission: 'read_address',
+                    coin: 'btc',
+                    silentMode: true,
+                    origin: 'evil.example',
+                },
+            ];
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([
+                { permission: 'read_address', coin: 'btc' },
+            ]);
+        });
     });
 });
 

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -36,10 +36,8 @@ export type ConnectProcessInfo = {
 };
 export type ConnectCallSource = {
     origin: string;
-    // Permissions the host/dapp declared up front (via ConnectSettings.requestedPermissions),
-    // forwarded through the popup handshake. Sanitized in connectPopupCallThunkInner so the first
-    // consent covers the whole set. Only populated for the web/webextension handshake today;
-    // desktop-ws/mcp carry it once suite-desktop-core forwards it.
+    // Permissions the host declared up front (via ConnectSettings.requestedPermissions), carried on
+    // the handshake. Sanitized in connectPopupCallThunkInner so the first consent covers the set.
     requestedPermissions?: PermissionRequest[];
 } & (
     | {

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -88,7 +88,7 @@ export const groupPermissionsByCoin = (permissions: PermissionRequest[]): Groupe
 // grantable to a dapp, and `push_tx` is additionally excluded on deeplink sources — mirrors the
 // hard block in connectPopupCallThunkInner. Everything else (including unknown/garbage values from
 // untrusted host input, and coins that are not a known `CoinSymbol`) is dropped.
-const GRANTABLE_PERMISSIONS: ReadonlySet<PermissionRequest['permission']> = new Set([
+const GRANTABLE_PERMISSIONS: ReadonlySet<string> = new Set<PermissionRequest['permission']>([
     'read_address',
     'read_xpub',
     'read_account_info',
@@ -99,20 +99,38 @@ const GRANTABLE_PERMISSIONS: ReadonlySet<PermissionRequest['permission']> = new 
     'push_tx',
 ]);
 
+// Runtime guard for the untrusted `permission` value, mirroring `isCoinSymbol` for coins.
+const isGrantablePermission = (value: string): value is PermissionRequest['permission'] =>
+    GRANTABLE_PERMISSIONS.has(value);
+
 // Sanitize the host-declared `requestedPermissions`: drop entries whose permission is not
 // grantable, `push_tx` on deeplinks, and unknown coins; lowercase each `coin` to its `CoinSymbol`.
+//
+// Untrusted input — nothing schema-validates it on either handshake, hence `unknown` and the shape
+// checks. Malformed input is dropped rather than thrown on, because this runs before
+// `initiateCall`: a throw there fails every later call from that app with an unactionable error.
+// Entries are never spread, so attacker-chosen keys cannot reach the consent UI or the grant.
 export const sanitizeRequestedPermissions = (
-    requested: PermissionRequest[] | undefined,
+    requested: unknown,
     isDeeplink: boolean,
 ): PermissionRequest[] =>
-    (requested ?? []).flatMap(({ permission, coin }) => {
-        if (!GRANTABLE_PERMISSIONS.has(permission)) return [];
-        if (permission === 'push_tx' && isDeeplink) return [];
-        if (coin === undefined) return [{ permission }];
-        const symbol = coin.toLowerCase();
+    Array.isArray(requested)
+        ? requested.flatMap((entry): PermissionRequest[] => {
+              const { permission, coin } = (entry ?? {}) as {
+                  permission?: unknown;
+                  coin?: unknown;
+              };
+              if (typeof permission !== 'string' || !isGrantablePermission(permission)) return [];
+              if (permission === 'push_tx' && isDeeplink) return [];
+              // Only an absent coin means coin-less. A malformed one is dropped, not widened —
+              // a coin-less grant is device-wide, so widening would fail open.
+              if (coin === undefined) return [{ permission }];
+              if (typeof coin !== 'string') return [];
+              const symbol = coin.toLowerCase();
 
-        return isCoinSymbol(symbol) ? [{ permission, coin: symbol }] : [];
-    });
+              return isCoinSymbol(symbol) ? [{ permission, coin: symbol }] : [];
+          })
+        : [];
 
 // Lowercase each permission's `coin` to its `CoinSymbol`. Normalizes grants persisted before coins
 // were canonicalized at the source.

--- a/suite/e2e/support/pageObjects/connectPermissionsModal.ts
+++ b/suite/e2e/support/pageObjects/connectPermissionsModal.ts
@@ -8,6 +8,10 @@ export class ConnectPermissionsModal {
     readonly silentModeCheckbox: Locator;
     readonly confirmButton: Locator;
     readonly cancelButton: Locator;
+    /** Lowercase `CoinSymbol` (`btc`), or `device` for the coin-less group. */
+    readonly permissionGroup: (coin: string) => Locator;
+    /** `permission` as used in code (`read_address`); the testID dash-cases it. */
+    readonly groupPermission: (coin: string, permission: string) => Locator;
 
     constructor(page: Page) {
         this.loadingHeader = page
@@ -21,5 +25,10 @@ export class ConnectPermissionsModal {
         );
         this.confirmButton = page.getByTestId('@connect-permissions-modal/confirm-button');
         this.cancelButton = page.getByTestId('@connect-permissions-modal/cancel-button');
+        this.permissionGroup = coin => page.getByTestId(`@connect-permissions/group/${coin}`);
+        this.groupPermission = (coin, permission) =>
+            this.permissionGroup(coin).getByTestId(
+                `@connect-permissions/permission/${permission.replace(/_/g, '-')}`,
+            );
     }
 }

--- a/suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts
+++ b/suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts
@@ -1,0 +1,82 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+// Separate from permissions.test.ts because the declaration is part of `TrezorConnect.init`, and
+// every connect-ws spec in this folder initializes exactly once per file.
+const DECLARED_PERMISSIONS = [
+    { permission: 'read_address', coin: 'btc' },
+    { permission: 'read_address', coin: 'ltc' },
+] as const;
+
+test.describe(
+    'TrezorConnect upfront permissions',
+    { tag: ['@T3T1', '@T3W1', '@desktopOnly'] },
+    () => {
+        test.use({ electronConf: { exposeConnectWs: true } });
+
+        test.beforeEach(async ({ onboardingPage }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Initialize TrezorConnect with declared permissions', async () => {
+                await TrezorConnect.init({
+                    manifest: {
+                        appUrl: 'http://localhost:8080',
+                        email: '',
+                        appName: 'Tester',
+                    },
+                    coreMode: 'suite-desktop',
+                    debug: true,
+                    requestedPermissions: [...DECLARED_PERMISSIONS],
+                });
+            });
+        });
+
+        test(
+            'Permissions - a declared set is approved in a single consent',
+            {
+                annotation: createTestAnnotation({
+                    testCase:
+                        'Suite Connect: permissions declared at init are shown in the first consent and cover later calls.',
+                }),
+            },
+            async ({ connectPermissionsModal, page }) => {
+                await test.step('the consent lists the declared coins, not just the one being called', async () => {
+                    TrezorConnect.getAddress({
+                        path: "m/44'/0'/0'/0/0",
+                        coin: 'btc',
+                    });
+
+                    await expect(
+                        connectPermissionsModal.groupPermission('btc', 'read_address'),
+                    ).toBeVisible();
+                    // The call only needs btc, so the ltc group can only come from the declaration.
+                    await expect(
+                        connectPermissionsModal.groupPermission('ltc', 'read_address'),
+                    ).toBeVisible();
+                });
+
+                await test.step('approving once remembers the whole declared set', async () => {
+                    await connectPermissionsModal.rememberCheckbox.click();
+                    await connectPermissionsModal.confirmButton.click();
+                    await page.getByTestId('@connect-address-confirmation/confirm-button').click();
+                    await page.getByTestId('@connect-address-confirmation/close-button').click();
+                });
+
+                await test.step('a declared coin the user never called is already granted', async () => {
+                    TrezorConnect.getAddress({
+                        path: "m/44'/2'/0'/0/0",
+                        coin: 'ltc',
+                    });
+
+                    // Reaching the address confirmation at all means no consent was requested.
+                    await expect(
+                        page.getByTestId('@connect-address-confirmation/confirm-button'),
+                    ).toBeVisible();
+                    await expect(connectPermissionsModal.confirmButton).toBeHidden();
+                });
+            },
+        );
+    },
+);


### PR DESCRIPTION
## Description

Items 1–3 of #30401, the follow-up list from the review of #30261 (upfront permission declaration). After #30261 merged, `ConnectSettings.requestedPermissions` actually reached the consent dialog on **Suite Web only** — two transports dropped it on the way, and the sanitizer at the end of the path threw on malformed input.

Three independent fixes, one per commit.

### 1. Suite Desktop dropped the field — and it is the default host

`CoreInSuiteDesktop` puts `requestedPermissions` into the `POPUP.HANDSHAKE` payload, but [`connect-ws.ts`](https://github.com/trezor/trezor-suite/blob/e7fb1529de55ff18583fb7e4f633b7c9047b6ecf/packages/suite-desktop-core/src/libs/connect-ws.ts#L145-L146) read only `manifest` and `version` off `payload.settings` and discarded the rest, so `source.requestedPermissions` was always `undefined` there. `TrezorConnectDynamic` resolves an unset or `'auto'` `coreMode` to `core-in-suite-desktop`, so this is the default path — the same dapp build got one merged consent on Suite Web and a prompt per call on Suite Desktop.

The value is now carried on the connection state next to `manifest`/`version`, forwarded on the `connect-popup/call` IPC message, and set on the `CALL_SOURCE_DESKTOP_WS` source. The MCP source is deliberately left alone: it does not arrive through a handshake carrying settings, so the field would always be `undefined` there.

`@trezor/suite-desktop-api` inlines the permission shape rather than importing `PermissionRequest`, so the IPC-contract package stays free of a `@trezor/connect` dependency — the same treatment `manifest` already gets.

### 2. Webextension dropped it too, because of a message-shape mismatch

The wire message emitted by the connect-web `Popup` nests `manifest`, `version` and `requestedPermissions` under `payload`, and `WebExtensionPopup extends Popup`, so both links receive that shape. `ConnectPopupMessage` however declared `version` and `requestedPermissions` as siblings of `payload`, and only the web link remapped the incoming message to match; the webextension link forwards the parsed message verbatim.

`ConnectPopupMessage` now mirrors the wire shape so both links forward verbatim, and the web-only remap is gone. This also fixes a pre-existing bug that fell out of the same mismatch: `npmVersion` has been silently `undefined` in the connect-popup analytics event on webextension for as long as the remap has existed.

### 3. The sanitizer threw on malformed host input

`sanitizeRequestedPermissions` validated values but never shape, while its parameter type claimed the input was already a `PermissionRequest[]`. Nothing schema-validates this value on the way in — neither handshake does — so a non-array, a `null` entry or a non-string `coin` threw a raw `TypeError`. That happens before `initiateCall`, so there is no `activeCall` to attach the error to: the popup renders its bare error screen and the dapp gets `Failure_UnknownCode` carrying a JS message, for **every** subsequent call from that app, not just the malformed one.

The parameter is now `unknown` and each entry is shape-checked, mirroring `enabledNetworksStore.sanitize` — guard the array, guard each field, drop what does not fit. Entries are still never spread, so attacker-chosen keys cannot reach the consent UI or the persisted grant.

One deliberate asymmetry: a malformed `coin` is **dropped**, not treated as coin-less. A coin-less grant is device-wide and broader than any coin-scoped one, so widening on garbage input would fail open.

Note that fixes 1 and 2 are what make fix 3 load-bearing — while the field was being dropped, the sanitizer never saw hostile input at all.

### 4. e2e coverage

`suite/e2e/tests/trezor-connect/permissions.test.ts` already covers the grant lifecycle (consent → remember → silent reuse → forget → re-prompt) over `coreMode: 'suite-desktop'`, so it exercises the very transport fix 1 touches. It stayed green through the bug because it only ever asserts that the consent modal *appears*, never what it *lists* — and a declared set that never arrives looks identical to one that does if you only check for the modal.

The new `upfrontPermissions.test.ts` closes that: it declares two coins at `init()`, calls a method needing only one of them, and asserts the consent lists both. The group for the coin that was never called can only come from the declaration, so this fails on `develop` today. It then calls that second coin and requires the address confirmation to appear with no consent prompt — the behaviour the feature exists to provide.

Asserting modal contents needed locators the permission list did not have, so `PermissionGroup` gains a testID per coin group and per permission row. That component is shared with Settings → Connected apps, so both surfaces become assertable — which also unblocks testing items 4 and 6 of #30401 later.

**Not covered here:** the webextension half of fix 2 has no equivalent spec, because the connect-ws harness these specs use is desktop-only. `connectPopupWebextension.test.ts` drives the connect-explorer in a browser instead and would need a different setup to declare permissions.

## Notes for QA

Worth exercising on **Suite Desktop** and **the webextension build** specifically, since those are the two paths that were inert before:

- A dapp that calls `TrezorConnect.init({ requestedPermissions: [...] })` and then makes a call should see a single consent dialog listing the whole declared set, on desktop and webextension as well as web — not one prompt per call.
- Regression check on Suite Web, which already worked: the consent contents should be unchanged.
- Declaring nothing (`requestedPermissions` omitted) must behave exactly as before: consent shows only what the call itself needs.
- A dapp sending a malformed declaration (e.g. `requestedPermissions: 'nonsense'`) should now be treated as if it declared nothing, and its calls should work normally — previously every call from it failed with `Failure_UnknownCode`.
- MCP calls are untouched and should keep prompting per call as before.

## Related Issue

Follow-up to #30261. Addresses items 1, 2 and 3 of #30401.

Remaining items from that issue (coin-less blanket grants, raw persisted declaration, docs, identity key, native migration, `enabledNetworks` widening, exhaustiveness, tests/CHANGELOG) are not touched here.

## Testing

- New e2e spec `upfrontPermissions.test.ts`; `type-check` and `lint:js` green on `@trezor/suite-e2e`. **I could not execute it here** — the connect-ws specs need a desktop build plus trezor-user-env, so it needs a CI run (or a reviewer with the harness) to confirm it goes green.
- `@suite-common/connect-popup` unit tests: 33 passed, up from 19 — the new `malformed host input` block covers 4 whole-value shapes, 7 entry shapes, mixed valid/invalid input, the coin-less-widening guard, and the whitelist-copy behaviour.
- `lint:js` green on `@suite-common/connect-popup`, `@trezor/suite-desktop-api`, `@trezor/suite-desktop-core`; prettier clean.
- `type-check` green on `@suite-common/connect-popup` and `@trezor/suite-desktop-api`. `packages/suite` currently reports 51 errors on `develop` in unrelated areas (earn / staking / wrapNativeToken) from in-flight cross-package work; none of them are in the files this PR touches.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is tightly scoped to the TrezorConnect popup/permissions infrastructure: the shared connect-popup permissions logic and types, the useConnectPopup hooks (web and desktop), the desktop connect WebSocket bridge, and the desktop API message contract. Although useConnectPopup.tsx, useConnectPopupWeb.tsx, and connectPopupTypes.ts statically map to 133 tests, nearly all of those are unrelated wallet/staking/onboarding flows that only transitively import shared app bootstrap code — the actual functional surface of this change (permission granting, remembering, silent mode, popup cancellation, cross-context connect init) is almost exclusively exercised by the suite/e2e/tests/trezor-connect/* suite. Recommend running the full trezor-connect test folder, with connectPopupWeb/webextension, permissions, and silentMode as highest priority since they test the exact modified logic, and the remaining trezor-connect method tests (getAddress, getAccountInfo, sign*, selectAccount, error) at medium priority since they pass through the same modified init/permission code paths.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite-desktop-api/src/messages.ts`
- `packages/suite-desktop-core/src/libs/connect-ws.ts`
- `packages/suite/src/support/suite/useConnectPopup.tsx`
- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx`
- `packages/suite/src/support/suite/useConnectPopupWeb.tsx`
- `suite-common/connect-popup/src/__tests__/permissions.test.ts`
- `suite-common/connect-popup/src/connectPopupTypes.ts`
- `suite-common/connect-popup/src/permissions.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly exercises the TrezorConnect popup web flow (getAddress, cardanoGetAddress, permissions modal, cancellation, popup lifecycle) which is precisely what useConnectPopup.tsx, useConnectPopupWeb.tsx, and the connect-popup permissions/types module implement. Changes to permissions.ts and connectPopupTypes.ts directly affect the Grant Permissions modal and cancellation flows tested here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test covers the webextension variant of the same popup permissions and cancellation flows (Grant Permissions modal, Method_Interrupted errors, popup focus/close behavior) that are implemented by useConnectPopup.tsx/useConnectPopupWeb.tsx and the shared permissions logic being changed.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test explicitly validates the permissions remembering/forgetting behavior, the 'Remember' checkbox, and the Connect settings connected-apps list — directly matching the changed permissions.ts module and connectPopupTypes.ts.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test verifies silent mode permission state (connectPopup.permissions[0].silentMode), the Remember/silent-mode checkboxes in the permissions modal, and app-focus IPC suppression via suite-desktop-api/connect-ws — all directly tied to the changed permissions.ts, connectPopupTypes.ts, messages.ts, and connect-ws.ts files.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — getAddress relies on the connect permissions modal (grant permissions, confirm) exercised via useConnectPopup/useConnectPopupDesktop and the shared permissions module, making it a direct regression target for this change set.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test initializes TrezorConnect in suite-desktop core mode via the WebSocket connection (connect-ws.ts) and validates popup error surfacing; changes to connect-ws.ts and messages.ts (desktop API) could affect this initialization path.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses TrezorConnect via suite-desktop core mode and the connect permissions modal confirm flow, both touched by the connect-ws.ts and useConnectPopupDesktop.tsx changes.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Relies on TrezorConnect.init with suite-desktop core mode (connect-ws.ts) and the connect permissions modal confirm button, both implicated by the changed desktop connect infrastructure.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Exercises the connect permissions modal ('Proceed to account selection') and TrezorConnect.init in suite-desktop core mode, both directly touched by the changed permissions and connect-ws modules.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Uses the connect permissions modal confirm flow and desktop TrezorConnect WebSocket initialization, which are within the blast radius of the connect-ws.ts and permissions.ts changes.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Exercises the connect permissions modal confirmation step prior to account selection, directly using the shared permissions logic and desktop connect popup hook that were changed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/__tests__/permissions.test.ts`

_Updated: 2026-07-28T14:18:06.382Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/upfront-permissions-desktop-webext/web/](https://dev.suite.sldev.cz/suite-web/fix/upfront-permissions-desktop-webext/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/upfront-permissions-desktop-webext&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/upfront-permissions-desktop-webext&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/upfront-permissions-desktop-webext&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:38:09.909Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:38:41.832Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
