### PR TITLE
test(connect-init): co-locate thunk test

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -14,7 +14,7 @@ import {
     UI_REQUEST,
 } from '@trezor/connect';
 
-import { connectInitThunk } from '../connectInitThunks';
+import { connectInitThunk } from './connectInitThunks';
 
 describe('TrezorConnect Actions', () => {
     let store = configureMockStore();


### PR DESCRIPTION
## Description

Moves the Connect Init thunk test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is a unit test file for connect-init thunks (suite-common/connect-init/src/connectInitThunks.test.ts), which has no static E2E coverage mapping. Since this is a test file itself (not production logic), the direct risk to E2E behavior is low, but if it indicates recent changes to the underlying connectInitThunks.ts logic, the TrezorConnect popup/webextension initialization and permissions flows are the most plausible areas affected. Recommended strategy is to run the core TrezorConnect E2E tests that exercise init, permissions, and popup lifecycle as a sanity check, without running the full E2E suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/connect-init/src/connectInitThunks.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the TrezorConnect popup initialization and connection flow end-to-end (getAddress, cardanoGetAddress, cancellation, popup lifecycle), which relies on the connect initialization logic that connectInitThunks.ts implements. Changes to connect init thunks could break how the connect popup initializes or handles permissions/cancellation.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Similar to the web popup test, this covers TrezorConnect initialization and lifecycle from a webextension context, which depends on the same connect-init thunk logic for handling calls, cancellation, and popup management.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test validates the TrezorConnect permissions modal and connect app lifecycle (granting, remembering, forgetting permissions), which is directly tied to the initialization flow implemented in connectInitThunks.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — This test verifies TrezorConnect.init succeeds correctly in suite-desktop core mode before triggering an error scenario, so a regression in connect initialization thunks could surface here as an init failure.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test relies on TrezorConnect.init and the permissions/silent-mode handling logic, which is part of the connect initialization flow that could be impacted by changes to connectInitThunks.

</details>

_Updated: 2026-07-28T14:28:43.463Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-connect-init-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-connect-init-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-connect-init-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-connect-init-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-connect-init-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:31:44.804Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:30:58.797Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->