### PR TITLE
test(delegated-identity-key): co-locate tests

### DIFF
--- a/suite-common/delegated-identity-key/src/ensureDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/ensureDelegatedIdentityKey.test.ts
@@ -6,7 +6,7 @@ import { ok } from '@trezor/type-utils';
 import {
     type EnsureDelegatedIdentityKeyDeps,
     createEnsureDelegatedIdentityKey,
-} from '../ensureDelegatedIdentityKey';
+} from './ensureDelegatedIdentityKey';
 
 const deps: EnsureDelegatedIdentityKeyDeps = {
     loadDelegatedIdentityKeyFromState: () =>

--- a/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.test.ts
+++ b/suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.test.ts
@@ -1,6 +1,6 @@
 import { DELEGATED_IDENTITY_KEY } from '@suite-common/delegated-identity-key-types/mocks';
 
-import { getProofOfDelegatedIdentity } from '../getProofOfDelegatedIdentity';
+import { getProofOfDelegatedIdentity } from './getProofOfDelegatedIdentity';
 
 describe(getProofOfDelegatedIdentity.name, () => {
     it('calculates the proof', () => {

--- a/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.test.ts
+++ b/suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@suite-common/platform-encryption';
 import { err, ok } from '@trezor/type-utils';
 
-import { createLoadDelegatedIdentityKeyFromState } from '../loadDelegatedIdentityKeyFromState';
+import { createLoadDelegatedIdentityKeyFromState } from './loadDelegatedIdentityKeyFromState';
 
 describe(createLoadDelegatedIdentityKeyFromState.name, () => {
     it('gets the encrypted key', async () => {

--- a/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts
+++ b/suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts
@@ -4,7 +4,7 @@ import {
     type RetrieveDelegatedIdentityKeyFromDeviceDeps,
     type RetrieveDelegatedIdentityKeyParams,
     createRetrieveDelegatedIdentityKeyFromDevice,
-} from '../retrieveDelegatedIdentityKeyFromDevice';
+} from './retrieveDelegatedIdentityKeyFromDevice';
 
 const device123: RetrieveDelegatedIdentityKeyParams['device'] = {
     path: asDeviceUniquePath('1/2/3'),

--- a/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.test.ts
+++ b/suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.test.ts
@@ -4,7 +4,7 @@ import { type EncryptableBranded, asEncryptedHex } from '@suite-common/platform-
 import { asDelegatedIdentityKey } from '@suite-common/suite-types';
 import { ok } from '@trezor/type-utils';
 
-import { createSaveDelegatedIdentityKey } from '../saveDelegatedIdentityKey';
+import { createSaveDelegatedIdentityKey } from './saveDelegatedIdentityKey';
 
 describe(createSaveDelegatedIdentityKey.name, () => {
     it('saves the encrypted value to the store', async () => {


### PR DESCRIPTION
## Description

Moves the five Delegated Identity Key tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit tests for the suite-common/delegated-identity-key package, which underpins Suite Sync's ability to derive, prove, retrieve, load, and persist a per-wallet identity key used to authenticate with the Evolu relay server. No E2E test statically imports these files, but several Suite Sync E2E tests (create/sync/remove/update labels, multi-wallet, legacy migration) functionally depend on this key-derivation flow succeeding, so a regression here would most likely surface as label sync/authentication failures in those flows. Recommended strategy: run the Suite Sync E2E suite (especially create-new-labels, sync-from-relay, and multi-wallet, which most directly exercise key derivation/proof/device retrieval) at medium priority, with the remaining Suite Sync and migration tests at low priority since their core behavior is less directly coupled to key derivation logic. Since there is no direct/static coverage, confidence in this mapping is inferred rather than guaranteed — a unit-test-level regression could still slip past E2E if the failure mode is subtle (e.g., wrong key value that still authenticates).

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/delegated-identity-key/src/ensureDelegatedIdentityKey.test.ts`
- `suite-common/delegated-identity-key/src/getProofOfDelegatedIdentity.test.ts`
- `suite-common/delegated-identity-key/src/loadDelegatedIdentityKeyFromState.test.ts`
- `suite-common/delegated-identity-key/src/retrieveDelegatedIdentityKeyFromDevice.test.ts`
- `suite-common/delegated-identity-key/src/saveDelegatedIdentityKey.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Suite Sync relies on Evolu relay authentication which is derived from a delegated identity key (owner secret derivation). Changes to how the delegated identity key is ensured, proven, loaded, retrieved, or saved could break the ability to authenticate/sync labels to the Evolu relay in this test.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test explicitly requires device confirmation to set up Suite Sync (initiateSuiteSyncSetup, quota manager), which likely depends on retrieving/deriving a delegated identity key from the device — directly related to retrieveDelegatedIdentityKeyFromDevice.test.ts and getProofOfDelegatedIdentity.test.ts changes.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test enables Suite Sync across multiple passphrase wallets, each requiring its own owner secret derived per-wallet — a scenario directly exercising loadDelegatedIdentityKeyFromState and ensureDelegatedIdentityKey logic for maintaining distinct keys per hidden wallet.

</details>

<details><summary>🟢 <b>Low priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Also depends on Suite Sync's identity key infrastructure for authenticating with the Evolu relay, but the core behavior under test (label removal) is less directly tied to key derivation logic than sync/creation tests.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Involves enabling Suite Sync and downloading labels which requires the delegated identity key to authenticate against the relay; a regression in key persistence/loading could cause label sync failures here.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This migration test switches from legacy Dropbox labeling to Suite Sync, which requires establishing a delegated identity key for the first time — a scenario that would surface bugs in ensureDelegatedIdentityKey or saveDelegatedIdentityKey.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Similar to the other legacy-to-SuiteSync migration test, this exercises first-time delegated identity key establishment and Evolu relay sync during migration, which is the core purpose of the changed unit tests.

</details>

_Updated: 2026-07-28T14:29:46.868Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-delegated-identity-key-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-delegated-identity-key-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-delegated-identity-key-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-delegated-identity-key-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-delegated-identity-key-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:33:01.841Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:32:45.685Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->