### PR TITLE
test(dependency-injection): co-locate tests

### DIFF
--- a/suite-common/dependency-injection/src/selectServices.test.ts
+++ b/suite-common/dependency-injection/src/selectServices.test.ts
@@ -1,4 +1,4 @@
-import { selectServices } from '../useServices';
+import { selectServices } from './useServices';
 
 const services = {
     a: jest.fn(),

--- a/suite-common/dependency-injection/src/toGetter.test.ts
+++ b/suite-common/dependency-injection/src/toGetter.test.ts
@@ -1,4 +1,4 @@
-import { toGetter } from '../toGetter';
+import { toGetter } from './toGetter';
 
 type TestState = {
     relayUrl: string;

--- a/suite-common/dependency-injection/src/useServices.test.tsx
+++ b/suite-common/dependency-injection/src/useServices.test.tsx
@@ -2,7 +2,7 @@ import React, { type PropsWithChildren } from 'react';
 
 import { renderHook } from '@testing-library/react';
 
-import { ServicesProvider, useServices } from '../useServices';
+import { ServicesProvider, useServices } from './useServices';
 
 type ADep = { a: () => void };
 type BDep = { b: () => void };

--- a/suite-common/dependency-injection/src/useServices.type-test.ts
+++ b/suite-common/dependency-injection/src/useServices.type-test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-import { useServices } from '../useServices';
+import { useServices } from './useServices';
 
 type ADep = { a: () => void };
 type BDep = { b: () => void };


### PR DESCRIPTION
## Description

Moves the four Dependency Injection runtime and type tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit/type test files within suite-common/dependency-injection (selectServices.test.ts, toGetter.test.ts, useServices.test.tsx, useServices.type-test.ts). These are internal unit tests for a dependency-injection utility package, not part of the E2E Playwright test suite, and none of the 119 candidate E2E tests reference or exercise this module based on their documented behaviors, entry points, or source hints. There is no evidence in the LLM analysis that any E2E test flow depends on this dependency-injection package's runtime behavior. Given this, no E2E tests are recommended to run for this change; verification should rely on the unit test suite itself (running the modified test files directly) rather than the E2E suite.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/dependency-injection/src/selectServices.test.ts`
- `suite-common/dependency-injection/src/toGetter.test.ts`
- `suite-common/dependency-injection/src/useServices.test.tsx`
- `suite-common/dependency-injection/src/useServices.type-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-common/dependency-injection/src/selectServices.test.ts`
- `suite-common/dependency-injection/src/toGetter.test.ts`
- `suite-common/dependency-injection/src/useServices.test.tsx`
- `suite-common/dependency-injection/src/useServices.type-test.ts`

_Updated: 2026-07-28T14:30:25.475Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-dependency-injection-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-dependency-injection-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-dependency-injection-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-dependency-injection-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-dependency-injection-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:34:06.075Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:33:59.775Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->