### PR TITLE
test(device): co-locate tests

### DIFF
--- a/suite-common/device/src/deviceSelectors.test.ts
+++ b/suite-common/device/src/deviceSelectors.test.ts
@@ -1,9 +1,9 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { portfolioTrackerDevice } from '../src/deviceConstants';
-import { deviceReducerInitialState } from '../src/deviceReducer';
-import { selectIsDeviceAuthenticityCheckSupported } from '../src/deviceSelectors';
+import { portfolioTrackerDevice } from './deviceConstants';
+import { deviceReducerInitialState } from './deviceReducer';
+import { selectIsDeviceAuthenticityCheckSupported } from './deviceSelectors';
 
 describe(selectIsDeviceAuthenticityCheckSupported.name, () => {
     it('returns true for supported Trezor Safe devices', () => {

--- a/suite-common/device/src/services/deviceInvariabilityCheck.test.ts
+++ b/suite-common/device/src/services/deviceInvariabilityCheck.test.ts
@@ -4,7 +4,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 import {
     deviceInvariabilityCheck,
     rawDataToDeviceInvariabilityCheckDTO,
-} from '../src/services/deviceInvariabilityCheck';
+} from './deviceInvariabilityCheck';
 
 const deviceId = 'asdf1234';
 const defaultFeatures = { internal_model: DeviceModelInternal.T3B1, unit_color: 1 } as const;

--- a/suite-common/device/src/services/getIsDeviceIdValid.test.ts
+++ b/suite-common/device/src/services/getIsDeviceIdValid.test.ts
@@ -1,7 +1,7 @@
 import type { UnknownDevice } from '@suite-common/suite-types';
 import { mockConnectDevice } from '@suite-common/suite-types/mocks';
 
-import { getIsDeviceIdValid } from '../src/services/getIsDeviceIdValid';
+import { getIsDeviceIdValid } from './getIsDeviceIdValid';
 
 describe(getIsDeviceIdValid.name, () => {
     it('returns true valid acquired device', () => {

--- a/suite-common/device/src/sortDevices.test.ts
+++ b/suite-common/device/src/sortDevices.test.ts
@@ -1,7 +1,7 @@
 import type { TrezorDevice } from '@suite-common/suite-types';
 
-import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from '../src/deviceConstants';
-import { sortDevices } from '../src/sortDevices';
+import { PORTFOLIO_TRACKER_DEVICE_ID, portfolioTrackerDevice } from './deviceConstants';
+import { sortDevices } from './sortDevices';
 
 describe(sortDevices.name, () => {
     const baseAcquired: TrezorDevice = {


### PR DESCRIPTION
## Description

Moves the four Device selector, service, and utility tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit-tested internal modules in suite-common/device (device selectors, invariability checks, device ID validation, and device sorting) with no direct static E2E mapping. Since these modules underpin core device management logic used across device switching, discovery, wallet numbering, and forget-device flows, we inferred coverage from E2E tests that exercise device switcher ordering, session/device status transitions, discovery state, and device forgetting — areas most likely to surface regressions in this logic. Recommended strategy: run the unit tests for these files directly (fastest signal) plus the medium-priority E2E tests that stress device list ordering and identity resolution.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/device/src/deviceSelectors.test.ts`
- `suite-common/device/src/services/deviceInvariabilityCheck.test.ts`
- `suite-common/device/src/services/getIsDeviceIdValid.test.ts`
- `suite-common/device/src/sortDevices.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test relies heavily on device switching, session/device status logic ('Use Here'/'Connected'), and wallet list ordering which depends on device sorting and device ID validity logic in sortDevices.ts and getIsDeviceIdValid.ts. Changes to these unit-tested modules could affect how devices are displayed and reconciled across sessions.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — This test verifies wallet/device numbering and ordering in the device switcher across ejects and re-adds, which is exactly the kind of behavior governed by sortDevices and deviceInvariabilityCheck logic that was changed.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery relies on device selection and validity checks (deviceSelectors, getIsDeviceIdValid) to correctly identify and track devices through the discovery Redux state; a regression here could cause discovery to stall or misidentify devices.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgetting devices depends on correct device identity/invariability checks and device list sorting to determine which device entries to remove and how remaining ones are displayed, directly touching the changed deviceInvariabilityCheck and sortDevices logic.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Wallet ejection and standard wallet discovery involve device selection logic that could be impacted by changes to deviceSelectors, though this test's assertions are narrow (only checks BTC balance visibility).

</details>

_Updated: 2026-07-28T14:31:52.862Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-device-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-device-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-device-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:35:18.843Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:35:01.502Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->