### PR TITLE
test(device-authenticity): co-locate thunk test

### DIFF
--- a/suite-common/device-authenticity/jest.config.js
+++ b/suite-common/device-authenticity/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    roots: ['<rootDir>/src', '<rootDir>/tests', '<rootDir>/../test-utils/__mocks__'],
+    roots: ['<rootDir>/src', '<rootDir>/../test-utils/__mocks__'],
 };

--- a/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.test.ts
+++ b/suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.test.ts
@@ -5,9 +5,9 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
 import { type ToastPayload, notificationsActions } from '@suite-common/toast-notifications';
 import type { AuthenticateDeviceResult, Response } from '@trezor/connect';
-import { Err, Ok } from '@trezor/type-utils';
+import type { Err, Ok } from '@trezor/type-utils';
 
-import { checkDeviceAuthenticityThunk } from '../src/checkDeviceAuthenticityThunk';
+import { checkDeviceAuthenticityThunk } from './checkDeviceAuthenticityThunk';
 
 const initStore = (device?: TrezorDevice) =>
     configureMockStore({


### PR DESCRIPTION
## Description

Moves the Device Authenticity thunk test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test for checkDeviceAuthenticityThunk, which underlies the device authenticity check feature exercised during onboarding. Since no static E2E coverage mapping exists for this file, we infer relevance based on functional overlap: the dedicated authenticity-check E2E test is the most direct and reliable signal for regressions in this logic. Other onboarding flows that pass through authenticity checks are included at low priority as secondary coverage. Recommended strategy is to run the authenticity-check test as a mandatory gate and optionally the T3B1 wallet creation test for broader onboarding confidence.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/device-authenticity/src/checkDeviceAuthenticityThunk.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test directly exercises the device authenticity check flow during onboarding, which is the exact functionality implemented in checkDeviceAuthenticityThunk. A change to the thunk's unit test file suggests underlying logic changes that this E2E test would validate end-to-end.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts` — Onboarding wallet creation flows may invoke device authenticity checks as part of the onboarding sequence, so a regression in the authenticity thunk could surface here, though this test's primary focus is wallet creation rather than authenticity verification.

</details>

_Updated: 2026-07-28T14:49:31.599Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-device-authenticity-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-device-authenticity-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-device-authenticity-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-device-authenticity-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-device-authenticity-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:53:04.361Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:53:05.603Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->