### PR TITLE
test(earn-stablecoin): co-locate tests

### DIFF
--- a/suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts
+++ b/suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts
@@ -2,8 +2,8 @@ import {
     buildClaimCalldata,
     buildClaimTransactionReview,
     buildUnsignedClaimTransaction,
-} from '../claimSigningUtils';
-import type { ClaimReward } from '../claimSigningUtils';
+} from './claimSigningUtils';
+import type { ClaimReward } from './claimSigningUtils';
 
 const SENDER = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
 const CLAIM_CONTRACT = '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae';

--- a/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.test.ts
+++ b/suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.test.ts
@@ -1,4 +1,4 @@
-import { composeStablecoinYieldTxSimulationAction } from '../txSimulationAction';
+import { composeStablecoinYieldTxSimulationAction } from './txSimulationAction';
 
 const sourceOrigin = 'trezor-suite-native://stablecoin-yield';
 const account = {


### PR DESCRIPTION
## Description

Moves the two Stablecoin Earn signing and transaction-simulation tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests for claim signing utilities and transaction simulation logic within the earn-stablecoin package, which currently has no dedicated E2E test suite and no direct static mapping to any E2E test. No E2E tests specifically exercise 'earn-stablecoin' flows, so recommendations are inferred based on conceptual overlap with staking/claim/transaction-simulation flows in other coins (ETH, ADA) that share similar signing and simulation patterns. Given the lack of direct coverage, recommend running the unit tests themselves in CI plus a small set of related staking E2E tests as a sanity check, while flagging the stablecoin earn feature as having a real E2E coverage gap.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts`
- `suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test exercises the claim rewards flow which involves withdrawal transaction signing (device confirmation of reward address, amount, fee) — closely related to claim signing logic changes in claimSigningUtils.test.ts, even though it's for Cardano rather than the stablecoin earn feature.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test covers ETH staking transaction simulation, pending/confirmation states, and fee/amount display which parallels the tx-simulation logic being changed; a regression in transaction simulation could surface as incorrect pending amounts or fee display here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Initial ETH staking relies on transaction simulation to display amount, fee, and confirming/pending states before broadcast, which is the same category of logic (tx-simulation) being modified.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — Unstaking involves signing a deregistration transaction and displaying fee/amount details, tangentially related to claim/tx-signing utilities, but this is Cardano-specific and less directly tied to the stablecoin earn signing code.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/earn-stablecoin/src/signing/claimSigningUtils.test.ts`
- `suite-common/earn-stablecoin/src/tx-simulation/txSimulationAction.test.ts`

_Updated: 2026-07-28T14:35:00.153Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-earn-stablecoin-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-earn-stablecoin-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-earn-stablecoin-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-earn-stablecoin-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-earn-stablecoin-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:38:18.272Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:38:10.177Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->