### PR TITLE
test(earn-stablecoin-api): co-locate tests

### DIFF
--- a/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts
@@ -4,7 +4,7 @@ import {
     networkSpecificDefaultEthereum,
 } from '@suite-common/wallet-types/mocks';
 
-import { getMerklRewardsQueryEntriesForAccounts } from '../useGetMerklRewardsQueryEntries';
+import { getMerklRewardsQueryEntriesForAccounts } from './useGetMerklRewardsQueryEntries';
 
 const emptyEthereumAccount = mockWalletAccount(
     {

--- a/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.test.ts
+++ b/suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.test.ts
@@ -1,6 +1,6 @@
 import { type RewardDtoV2, type TokenDtoV2 } from '@suite-common/earn-stablecoin-defs';
 
-import { sortRewardsByUnderlyingToken } from '../../utils/sortRewardsByUnderlyingToken';
+import { sortRewardsByUnderlyingToken } from './sortRewardsByUnderlyingToken';
 
 const USDC: TokenDtoV2 = {
     symbol: 'USDC',

--- a/suite-common/earn-stablecoin-api/src/verification/schema.test.ts
+++ b/suite-common/earn-stablecoin-api/src/verification/schema.test.ts
@@ -1,4 +1,4 @@
-import { parseUnsignedEvmTransaction } from '../../verification/schema';
+import { parseUnsignedEvmTransaction } from './schema';
 
 const APPROVAL_UNSIGNED_TX =
     '{"from":"0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3","gasLimit":"0xe563","to":"0xdac17f958d2ee523a2206206994597c13d831ec7","data":"0x095ea7b3000000000000000000000000beef047a543e45807105e51a8bbefcc5950fcfba00000000000000000000000000000000000000000000000000000000000f4240","nonce":664,"type":2,"maxFeePerGas":"0x0ee6b280","maxPriorityFeePerGas":"0x054e0840","chainId":1}';


### PR DESCRIPTION
## Description

Moves the three Stablecoin Earn API hook, utility, and verification tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files themselves (Jest/Vitest-style unit tests for merkl rewards query hooks, reward sorting utilities, and schema verification) located in suite-common/earn-stablecoin-api. These are not part of the Playwright E2E test suite catalog provided, and none of the 112 candidate E2E tests reference or exercise this stablecoin-earn API package (no staking tests in the catalog cover 'stablecoin'/'merkl' functionality specifically - the staking tests cover ADA, ETH, and SOL native staking flows, not a stablecoin/Merkl rewards feature). Since these changes are isolated unit tests for a package with no corresponding E2E UI flow represented in the candidate set, no E2E tests can be confidently recommended; the appropriate verification is running the unit tests themselves, not E2E tests.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts`
- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.test.ts`
- `suite-common/earn-stablecoin-api/src/verification/schema.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts`
- `suite-common/earn-stablecoin-api/src/utils/sortRewardsByUnderlyingToken.test.ts`
- `suite-common/earn-stablecoin-api/src/verification/schema.test.ts`

_Updated: 2026-07-28T14:35:38.159Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-earn-stablecoin-api-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-earn-stablecoin-api-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-earn-stablecoin-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-earn-stablecoin-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-earn-stablecoin-api-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:39:47.988Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:38:48.828Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->