### PR TITLE
test(feedback): co-locate tests

### DIFF
--- a/suite-common/feedback/src/getFeedbackUrl.test.ts
+++ b/suite-common/feedback/src/getFeedbackUrl.test.ts
@@ -1,7 +1,7 @@
 import { isCodesignBuild } from '@trezor/env-utils';
 
-import type { FeedbackType } from '../src';
-import { FEEDBACK_ENDPOINT, getFeedbackUrl } from '../src/getFeedbackUrl';
+import type { FeedbackType } from './feedback';
+import { FEEDBACK_ENDPOINT, getFeedbackUrl } from './getFeedbackUrl';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),

--- a/suite-common/feedback/src/userData.test.ts
+++ b/suite-common/feedback/src/userData.test.ts
@@ -10,7 +10,7 @@ import {
     getWindowWidth,
 } from '@trezor/env-utils';
 
-import { buildUserFeedbackData } from '../src/userData';
+import { buildUserFeedbackData } from './userData';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),


### PR DESCRIPTION
## Description

Moves the two Feedback URL and user-data tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests within suite-common/feedback covering getFeedbackUrl and userData logic, which underpin the bug-report/feedback submission feature exposed through the Suite Guide panel. No static E2E coverage mapping exists, so recommendations are inferred from LLM behavior analysis: tests that exercise bug report and feedback form submission (which depend on feedback URL construction and user data payloads) are the most relevant to validate end-to-end. Since these are isolated unit test files for a small utility module, risk of broad regression is low, and a small, targeted set of E2E tests touching the feedback/guide flow should suffice.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/feedback/src/getFeedbackUrl.test.ts`
- `suite-common/feedback/src/userData.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test exercises the bug report submission flow via the Guide panel's Support and Feedback section, which relies on the @suite-common/feedback package (FeedbackCategory type and feedback form/API logic). Changes to getFeedbackUrl or userData in that package could affect the URL construction or user data payload used when submitting feedback.
- `suite/e2e/tests/general/suite-guide.test.ts` — This test covers sending bug reports and feedback (with rating/message) through the Guide panel, which is the primary user-facing consumer of the feedback module's URL/user-data generation logic that was changed.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/suite/guide.test.ts` — This test includes a feedback form submission scenario (suggestion rating, text input, success toast) that also depends on the feedback module, though it's a secondary/broader guide test rather than a focused feedback test.

</details>

_Updated: 2026-07-28T14:37:05.169Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-feedback-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-feedback-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-feedback-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-feedback-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-feedback-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:40:52.733Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:40:33.484Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->