### PR TITLE
test(fiat-services): co-locate tests

### DIFF
--- a/suite-common/fiat-services/src/coingecko.test.ts
+++ b/suite-common/fiat-services/src/coingecko.test.ts
@@ -1,4 +1,4 @@
-import { findClosestTimestampValue } from '../src/coingecko';
+import { findClosestTimestampValue } from './coingecko';
 
 describe('findClosestTimestampValue', () => {
     test('returns the first fiat rate when timestamp is before all values', () => {

--- a/suite-common/fiat-services/src/fetch.native.test.ts
+++ b/suite-common/fiat-services/src/fetch.native.test.ts
@@ -1,4 +1,4 @@
-import { fetchUrl, requestInit } from '../src/fetch.native';
+import { fetchUrl, requestInit } from './fetch.native';
 
 // Mock fetch globally
 const mockFetch = jest.fn();

--- a/suite-common/fiat-services/src/limiter.test.ts
+++ b/suite-common/fiat-services/src/limiter.test.ts
@@ -1,4 +1,4 @@
-import { RateLimiter } from '../src/limiter';
+import { RateLimiter } from './limiter';
 
 describe('RateLimiter', () => {
     test('delay is honoured', async () => {


### PR DESCRIPTION
## Description

Moves the three Fiat Services tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests for the fiat-services package (coingecko API client, native fetch wrapper, and rate limiter) — these are internal unit tests, not application source code, and have no static E2E coverage mapping. Since these are pure unit test files for isolated logic (fetching and rate-limiting external price data), the risk to E2E flows is low and best validated by the unit tests themselves rather than full E2E runs. A couple of E2E tests that display fiat amounts on the dashboard are included at low priority as a precaution in case underlying fiat-services logic changed alongside the tests, but no strong evidence links these specific test files to E2E behavior.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/fiat-services/src/coingecko.test.ts`
- `suite-common/fiat-services/src/fetch.native.test.ts`
- `suite-common/fiat-services/src/limiter.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — This test changes fiat currency (USD to EUR) and checks that the correct currency symbol/amount is displayed on the dashboard, which relies on fiat rate/price data provided by fiat-services (coingecko fetch logic and rate limiting). A regression in the coingecko fetch or limiter logic could cause fiat values to fail to load or display incorrectly.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test asserts specific fiat amount values (e.g. '$0.00') across dashboard, asset card, portfolio, and wallet views, all of which depend on fiat price data sourced from the fiat-services package being fetched and formatted correctly.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/fiat-services/src/coingecko.test.ts`
- `suite-common/fiat-services/src/fetch.native.test.ts`
- `suite-common/fiat-services/src/limiter.test.ts`

_Updated: 2026-07-28T14:38:18.878Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-fiat-services-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-fiat-services-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-fiat-services-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-fiat-services-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-fiat-services-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:41:51.954Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->