### PR TITLE
test(formatters): co-locate tests

### DIFF
--- a/suite-common/formatters/src/formatters/AddressFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/AddressFormatter.test.ts
@@ -1,4 +1,4 @@
-import { AddressFormatter } from '../AddressFormatter';
+import { AddressFormatter } from './AddressFormatter';
 
 const EVM_ADDRESS = '0xde0B295669a9FD93d5F28D9Ec85E40f4cb697BAe';
 const BTC_ADDRESS = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';

--- a/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.test.ts
@@ -4,7 +4,7 @@ import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { PROTO } from '@trezor/connect';
 import { BigNumber } from '@trezor/utils';
 
-import { prepareBaseCurrencyAmountFormatter } from '../prepareBaseCurrencyAmountFormatter';
+import { prepareBaseCurrencyAmountFormatter } from './prepareBaseCurrencyAmountFormatter';
 
 const intl = createIntl({
     locale: 'en',

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
@@ -2,7 +2,7 @@ import { createIntl } from 'react-intl';
 
 import { PROTO } from '@trezor/connect';
 
-import { prepareCryptoAmountFormatter } from '../prepareCryptoAmountFormatter';
+import { prepareCryptoAmountFormatter } from './prepareCryptoAmountFormatter';
 
 const intl = createIntl({ locale: 'en-US' });
 

--- a/suite-common/formatters/src/formatters/prepareDisplaySymbolFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/prepareDisplaySymbolFormatter.test.ts
@@ -1,7 +1,7 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
-import { prepareDisplaySymbolFormatter } from '../prepareDisplaySymbolFormatter';
+import { prepareDisplaySymbolFormatter } from './prepareDisplaySymbolFormatter';
 
 describe('prepareDisplaySymbolFormatter', () => {
     let displaySymbolFormatter: ReturnType<typeof prepareDisplaySymbolFormatter>;

--- a/suite-common/formatters/src/makeFormatter.test.ts
+++ b/suite-common/formatters/src/makeFormatter.test.ts
@@ -1,4 +1,4 @@
-import { makeFormatter } from '../makeFormatter';
+import { makeFormatter } from './makeFormatter';
 
 const toUpperCase = (string: string) => string.toUpperCase();
 

--- a/suite-common/formatters/src/utils/clearAddressPrefix.test.ts
+++ b/suite-common/formatters/src/utils/clearAddressPrefix.test.ts
@@ -1,4 +1,4 @@
-import { clearAddressPrefix } from '../clearAddressPrefix';
+import { clearAddressPrefix } from './clearAddressPrefix';
 
 describe('clearAddressPrefix', () => {
     test.each([

--- a/suite-common/formatters/src/utils/convert.test.ts
+++ b/suite-common/formatters/src/utils/convert.test.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@trezor/utils';
 
-import { convertCryptoToFiatAmount } from '../convert';
+import { convertCryptoToFiatAmount } from './convert';
 
 describe('convertCryptoToFiatAmount', () => {
     test.each([


### PR DESCRIPTION
## Description

Moves the seven Formatter and utility tests beside their source files while leaving the shared test provider in place.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to unit tests for shared formatting utilities (address formatting, currency/crypto amount formatting, display symbol formatting, and generic formatter creation) in suite-common/formatters. No static E2E coverage mapping exists since these are unit-level test files, but several E2E tests exercise UI flows that display formatted addresses and monetary amounts, making them the most likely to surface regressions if formatter output changes. Recommended strategy: run the unit tests for the changed formatter files directly (fastest, most precise), and additionally run a small set of E2E tests that render addresses and fiat/crypto amounts to catch integration-level formatting regressions.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/formatters/src/formatters/AddressFormatter.test.ts`
- `suite-common/formatters/src/formatters/prepareBaseCurrencyAmountFormatter.test.ts`
- `suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts`
- `suite-common/formatters/src/formatters/prepareDisplaySymbolFormatter.test.ts`
- `suite-common/formatters/src/makeFormatter.test.ts`
- `suite-common/formatters/src/utils/clearAddressPrefix.test.ts`
- `suite-common/formatters/src/utils/convert.test.ts`

</details>

**Recommended tests (7)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test asserts exact regex formats for receive addresses across BTC, ETH, SOL, and TRX, and relies on address formatting/prefix-clearing logic to match device-displayed addresses with clipboard values. Changes to AddressFormatter or clearAddressPrefix directly affect how addresses are rendered and compared here.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies that displayed addresses (with whitespace/prefix handling) match expected Ethereum and Bitcoin addresses exactly, which depends on address formatting utilities that were changed.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test validates balance display formatting including ellipsis truncation logic, which is likely powered by crypto/base currency amount formatters that were changed.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test checks fiat and crypto amount formatting across multiple dashboard components (asset card, portfolio, wallet value), directly exercising currency/crypto amount formatter output that was modified.
- `suite/e2e/tests/settings/general.test.ts` — This test verifies fiat currency changes reflect correctly in displayed amounts (e.g. $0.00 to €0.00), which is a direct consumer of base currency amount formatting logic that changed.

</details>

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test displays formatted amounts (with localizeNumber) and symbols for ETH sends, and could be indirectly affected by crypto amount or display symbol formatter changes, though it primarily relies on other localization utilities.
- `suite/e2e/tests/wallet/public-keys.test.ts` — This test strips whitespace from displayed public keys for comparison, which shares logic patterns with address formatting utilities that changed, though public keys are not addresses.

</details>

_Updated: 2026-07-28T14:39:12.024Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-formatters-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-formatters-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-formatters-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-formatters-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-formatters-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:42:22.347Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:41:54.826Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->