### PR TITLE
test(message-system): co-locate tests

### DIFF
--- a/suite-common/message-system/src/ExperimentWrapper.test.tsx
+++ b/suite-common/message-system/src/ExperimentWrapper.test.tsx
@@ -9,10 +9,10 @@ import {
     screen,
 } from '@suite-common/test-utils';
 
-import { ExperimentWrapper } from '../ExperimentWrapper';
-import { createMessageSystemState } from '../__fixtures__/createMessageSystemState';
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { ExperimentId, type MessageSystemState } from '../messageSystemTypes';
+import { ExperimentWrapper } from './ExperimentWrapper';
+import { createMessageSystemState } from './__fixtures__/createMessageSystemState';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { ExperimentId, type MessageSystemState } from './messageSystemTypes';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 

--- a/suite-common/message-system/src/experimentUtils.test.ts
+++ b/suite-common/message-system/src/experimentUtils.test.ts
@@ -1,13 +1,13 @@
 import { getWeakRandomId } from '@trezor/utils';
 
-import { experimentTest, getArrayOfInstanceIds } from '../__fixtures__/experimentUtils';
+import { experimentTest, getArrayOfInstanceIds } from './__fixtures__/experimentUtils';
 import {
     buildExperimentGroupRanges,
     getActiveExperimentGroup,
     getExperimentGroupByInclusion,
     getInclusionFromInstanceId,
-} from '../experimentUtils';
-import { type ExperimentId } from '../messageSystemTypes';
+} from './experimentUtils';
+import { type ExperimentId } from './messageSystemTypes';
 
 jest.mock('@trezor/utils', () => ({
     ...jest.requireActual('@trezor/utils'),

--- a/suite-common/message-system/src/featureFlagUtils.test.ts
+++ b/suite-common/message-system/src/featureFlagUtils.test.ts
@@ -3,8 +3,8 @@ import { type Feature } from '@suite-common/suite-types';
 import {
     isYieldFeatureApplicableForVault,
     parseTimeoutThresholdsPerModel,
-} from '../featureFlagUtils';
-import { Feature as FeatureDefinitions } from '../messageSystemTypes';
+} from './featureFlagUtils';
+import { Feature as FeatureDefinitions } from './messageSystemTypes';
 
 describe(parseTimeoutThresholdsPerModel.name, () => {
     it('returns empty object if feature is undefined', () => {

--- a/suite-common/message-system/src/messageSystemActions.test.ts
+++ b/suite-common/message-system/src/messageSystemActions.test.ts
@@ -2,13 +2,14 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import * as fixtures from '../__fixtures__/messageSystemActions';
+import * as fixtures from './__fixtures__/messageSystemActions';
+
 import {
     type MessageSystemState,
     initMessageSystemThunk,
     messageSystemActions,
     prepareMessageSystemReducer,
-} from '../index';
+} from './index';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 
@@ -30,8 +31,8 @@ const initStore = (preloadedState: State) => {
     return store;
 };
 
-jest.mock('../../files/config.v1.ts', () => {
-    const { validJwsWithSequence10 } = require('../__fixtures__/messageSystemActions');
+jest.mock('../files/config.v1.ts', () => {
+    const { validJwsWithSequence10 } = require('./__fixtures__/messageSystemActions');
 
     return {
         __esModule: true,

--- a/suite-common/message-system/src/messageSystemReducer.test.ts
+++ b/suite-common/message-system/src/messageSystemReducer.test.ts
@@ -2,8 +2,8 @@ import { type AnyAction, combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import { fixtures, timestamp } from '../__fixtures__/messageSystemReducer';
-import { prepareMessageSystemReducer } from '../messageSystemReducer';
+import { fixtures, timestamp } from './__fixtures__/messageSystemReducer';
+import { prepareMessageSystemReducer } from './messageSystemReducer';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 

--- a/suite-common/message-system/src/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/messageSystemTypes.test.ts
@@ -5,7 +5,7 @@ import {
     type StakingNetworkSymbol,
 } from '@suite-common/wallet-config';
 
-import { Context, type GeneralContextKey, type SettingsCategory } from '../messageSystemTypes';
+import { Context, type GeneralContextKey, type SettingsCategory } from './messageSystemTypes';
 
 describe('Message system types', () => {
     describe('Context', () => {

--- a/suite-common/message-system/src/messageSystemUtils.test.ts
+++ b/suite-common/message-system/src/messageSystemUtils.test.ts
@@ -1,8 +1,8 @@
 import { getEnvironment, getOsName } from '@trezor/env-utils';
 
-import * as fixtures from '../__fixtures__/messageSystemUtils';
-import { getCachedOsVersion } from '../cachedEnvData';
-import * as messageSystem from '../messageSystemUtils';
+import * as fixtures from './__fixtures__/messageSystemUtils';
+import { getCachedOsVersion } from './cachedEnvData';
+import * as messageSystem from './messageSystemUtils';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),
@@ -10,8 +10,8 @@ jest.mock('@trezor/env-utils', () => ({
     getOsName: jest.fn(),
 }));
 
-jest.mock('../cachedEnvData', () => ({
-    ...jest.requireActual('../cachedEnvData'),
+jest.mock('./cachedEnvData', () => ({
+    ...jest.requireActual('./cachedEnvData'),
     getCachedOsVersion: jest.fn(),
 }));
 

--- a/suite-common/message-system/src/messageSystemValidation.test.ts
+++ b/suite-common/message-system/src/messageSystemValidation.test.ts
@@ -1,5 +1,5 @@
-import * as fixtures from '../__fixtures__/messageSystemValidation';
-import * as messageSystem from '../messageSystemValidation';
+import * as fixtures from './__fixtures__/messageSystemValidation';
+import * as messageSystem from './messageSystemValidation';
 
 describe('Message system validation', () => {
     describe('stripFieldFromMessage', () => {

--- a/suite-common/message-system/src/useExperiment.test.ts
+++ b/suite-common/message-system/src/useExperiment.test.ts
@@ -14,10 +14,10 @@ jest.mock('@trezor/utils', () => ({
     ),
 }));
 
-import { createMessageSystemState } from '../__fixtures__/createMessageSystemState';
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { ExperimentId, type MessageSystemState } from '../messageSystemTypes';
-import { useExperiment } from '../useExperiment';
+import { createMessageSystemState } from './__fixtures__/createMessageSystemState';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { ExperimentId, type MessageSystemState } from './messageSystemTypes';
+import { useExperiment } from './useExperiment';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 

--- a/suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts
+++ b/suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts
@@ -6,9 +6,9 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
 
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { type MessageSystemState } from '../messageSystemTypes';
-import { useMessageSystemEarnDashboard } from '../useMessageSystemEarnDashboard';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { useMessageSystemEarnDashboard } from './useMessageSystemEarnDashboard';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 

--- a/suite-common/message-system/src/useMessageSystemMessageForm.test.ts
+++ b/suite-common/message-system/src/useMessageSystemMessageForm.test.ts
@@ -8,10 +8,10 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
 
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { type MessageSystemState } from '../messageSystemTypes';
-import { getDefaultActionByCategory } from '../messageSystemUtils';
-import { useMessageSystemMessageForm } from '../useMessageSystemMessageForm';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { getDefaultActionByCategory } from './messageSystemUtils';
+import { useMessageSystemMessageForm } from './useMessageSystemMessageForm';
 
 // jsdom 20 lacks crypto.randomUUID, which getDefaultActionByCategory relies on
 if (typeof globalThis.crypto.randomUUID !== 'function') {

--- a/suite-common/message-system/src/useMessageSystemStaking.test.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.test.ts
@@ -6,9 +6,9 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
 
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { type MessageSystemState } from '../messageSystemTypes';
-import { useMessageSystemStaking } from '../useMessageSystemStaking';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { useMessageSystemStaking } from './useMessageSystemStaking';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 

--- a/suite-common/message-system/src/useMessageSystemYield.test.ts
+++ b/suite-common/message-system/src/useMessageSystemYield.test.ts
@@ -6,9 +6,9 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
 
-import { messageSystemInitialState, prepareMessageSystemReducer } from '../messageSystemReducer';
-import { type MessageSystemState } from '../messageSystemTypes';
-import { useMessageSystemYield } from '../useMessageSystemYield';
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { useMessageSystemYield } from './useMessageSystemYield';
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 


### PR DESCRIPTION
## Description

Moves the 13 Message System component, hook, reducer, validation, and utility tests beside their source files while preserving existing fixtures.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All 13 changed files are unit test files within the suite-common/message-system package (covering experiments, feature flags, message system actions/reducer/types/utils/validation, and hooks for staking/yield/earn-dashboard/message-form). Since these are unit test files themselves (not source implementation files) with no static E2E coverage mapping, the risk to E2E flows is indirect — primarily through consumers of the message-system hooks (useMessageSystemStaking, useExperiment, featureFlagUtils) that drive dashboard banners, promo content, and staking-related contextual messaging. Recommended strategy is to run a small set of E2E tests that touch staking dashboards and promo banners (where message-system hooks are known to be consumed) rather than broad regression testing, since the changes are isolated unit tests with no direct UI/behavior changes identified.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/message-system/src/ExperimentWrapper.test.tsx`
- `suite-common/message-system/src/experimentUtils.test.ts`
- `suite-common/message-system/src/featureFlagUtils.test.ts`
- `suite-common/message-system/src/messageSystemActions.test.ts`
- `suite-common/message-system/src/messageSystemReducer.test.ts`
- `suite-common/message-system/src/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemUtils.test.ts`
- `suite-common/message-system/src/messageSystemValidation.test.ts`
- `suite-common/message-system/src/useExperiment.test.ts`
- `suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts`
- `suite-common/message-system/src/useMessageSystemMessageForm.test.ts`
- `suite-common/message-system/src/useMessageSystemStaking.test.ts`
- `suite-common/message-system/src/useMessageSystemYield.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test relies on the debug mode 'Add banner' feature which surfaces promotional banners (TEX/TS7) that are typically driven by the message-system's feature flag and message rendering logic; changes to messageSystemUtils, featureFlagUtils, and messageSystemValidation could affect which banners are considered valid/active.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The useMessageSystemStaking hook changed and this test exercises the ETH staking dashboard flow (banners, instant staking banner) which is a plausible consumer of staking-related message-system content and feature-flag gating.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This first-time ETH staking flow test could be affected by changes to useMessageSystemStaking, which likely drives contextual staking messages/banners shown during the staking onboarding UI.

</details>

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking flow could indirectly surface message-system driven banners/warnings via useMessageSystemStaking or featureFlagUtils, though this test's core assertions are unrelated to messaging content.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking flow may also consume the shared useMessageSystemStaking hook for contextual banners, making it a plausible but lower-confidence regression target.
- `suite/e2e/tests/analytics/toggle.test.ts` — This test exercises onboarding/settings flows that involve feature toggles and analytics consent, which is architecturally adjacent to feature-flag driven functionality changed in featureFlagUtils; however no direct evidence ties message-system changes to this test's assertions.

</details>

⚠️ **Changes with no test coverage (10)**
- `suite-common/message-system/src/ExperimentWrapper.test.tsx`
- `suite-common/message-system/src/experimentUtils.test.ts`
- `suite-common/message-system/src/messageSystemActions.test.ts`
- `suite-common/message-system/src/messageSystemReducer.test.ts`
- `suite-common/message-system/src/messageSystemTypes.test.ts`
- `suite-common/message-system/src/messageSystemValidation.test.ts`
- `suite-common/message-system/src/useExperiment.test.ts`
- `suite-common/message-system/src/useMessageSystemEarnDashboard.test.ts`
- `suite-common/message-system/src/useMessageSystemMessageForm.test.ts`
- `suite-common/message-system/src/useMessageSystemYield.test.ts`

_Updated: 2026-07-28T14:43:12.132Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-message-system-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-message-system-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-message-system-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-message-system-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:46:28.553Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->