### PR TITLE
test(mev): co-locate settings test

### DIFF
--- a/suite-common/mev/src/mevProtectionSettings.test.ts
+++ b/suite-common/mev/src/mevProtectionSettings.test.ts
@@ -3,7 +3,7 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { FirmwareType } from '@trezor/device-utils';
 
-import { selectIsMevProtectionSettingsVisible } from '../mevProtectionSettings';
+import { selectIsMevProtectionSettingsVisible } from './mevProtectionSettings';
 
 describe('selectIsMevProtectionSettingsVisible', () => {
     const getState = (firmwareType: FirmwareType) => ({


### PR DESCRIPTION
## Description

Moves the MEV protection settings test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file itself (suite-common/mev/src/mevProtectionSettings.test.ts), which is a Jest/unit-level test for MEV protection settings logic, not a Playwright E2E test. None of the 103 candidate E2E tests reference MEV protection, swap DEX/LI.FI slippage settings, or any MEV-related configuration in their behaviors or source hints, so there is no plausible E2E coverage overlap. Since this change is isolated to a unit test file with no corresponding E2E-visible feature change described in the candidate list, no E2E tests are recommended to run for this change set; standard unit test execution (e.g., via Jest) should suffice for verification.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/mev/src/mevProtectionSettings.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/mev/src/mevProtectionSettings.test.ts`

_Updated: 2026-07-28T14:44:15.437Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-mev-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-mev-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-mev-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-mev-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:47:31.670Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->