### PR TITLE
test(receive): co-locate slice test

### DIFF
--- a/suite-common/receive/src/receiveSlice.test.ts
+++ b/suite-common/receive/src/receiveSlice.test.ts
@@ -13,7 +13,7 @@ import {
     receiveActions,
     selectCurrentFreshAddress,
     selectTouchedAddresses,
-} from '../receiveSlice';
+} from './receiveSlice';
 
 const bitcoinAccount = mockWalletAccount({ symbol: 'btc' });
 const ethereumAccount = mockWalletAccount({ symbol: 'eth' }, networkSpecificDefaultEthereum);


### PR DESCRIPTION
## Description

Moves the Receive slice test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is a unit test file for the receive Redux slice (suite-common/receive/src/receiveSlice.test.ts), which has no static E2E coverage mapping. Since this slice underpins address reveal, verification, and caching behavior across the wallet, the recommended E2E tests focus on receive-address flows (standard, global, and passphrase-protected) where regressions in receive state management would be most visible. Given this is primarily a unit-test change with no direct behavioral source modification indicated, risk is likely low, but targeted E2E receive-flow tests provide a reasonable confidence check.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/receive/src/receiveSlice.test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/receive.test.ts` — This test directly exercises the receive address reveal/copy flow across multiple coins (BTC, ETH, SOL, TRX), which is the primary user-facing behavior backed by the receive Redux slice being changed. A regression in receiveSlice logic (address generation/state tracking) would likely surface as incorrect or missing addresses here.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test verifies the global receive flow including address reveal and verification against the device display, directly depending on receive state management logic that the changed slice test covers.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test relies heavily on receive address caching and re-confirmation behavior after device disconnect/reconnect, which is state managed by the receive slice; changes here could affect passphrase-cached address handling.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — This test covers Cardano address reveal/verification under passphrase wallets and device restarts, exercising the receive slice's address/state persistence across sessions.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Includes a Cardano receive address reveal and confirmation flow that touches the same receive state logic, though it's a smaller part of this broader account-details test.

</details>

_Updated: 2026-07-28T14:45:42.399Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-receive-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-receive-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-receive-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-receive-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-receive-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:49:00.126Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:48:27.027Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->