### PR TITLE
test(redux-utils): co-locate tests

### DIFF
--- a/suite-common/redux-utils/src/createSingleInstanceThunk.test.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
-import { createSingleInstanceThunk } from '../createSingleInstanceThunk';
+import { createSingleInstanceThunk } from './createSingleInstanceThunk';
 
 describe('createSingleInstanceThunk', () => {
     // Test thunk for asynchronous action

--- a/suite-common/redux-utils/src/matchLegacyActionType.type-test.ts
+++ b/suite-common/redux-utils/src/matchLegacyActionType.type-test.ts
@@ -1,6 +1,6 @@
 import { type Action } from 'redux';
 
-import { type ActionFromMatcher, createLegacyActionTypeMatcher } from '../matchLegacyActionType';
+import { type ActionFromMatcher, createLegacyActionTypeMatcher } from './matchLegacyActionType';
 
 type FirstAction = {
     type: 'first';


### PR DESCRIPTION
## Description

Moves the Redux Utils runtime and type tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit-level test files (createSingleInstanceThunk.test.ts and matchLegacyActionType.type-test.ts) within suite-common/redux-utils, which are themselves test/type-test files rather than application source code. These are low-level Redux utility helpers used broadly across the codebase, but none of the 136 candidate E2E tests reference them directly or exercise behavior that maps specifically to single-instance thunk deduplication or legacy action type matching in a way that would be observable through UI-level E2E flows. Since these changes are isolated to unit/type-level test files with no static or inferable E2E coverage, no E2E test recommendations can be made with confidence; verification should rely on the existing unit test suite (running createSingleInstanceThunk.test.ts and the type-test itself) rather than E2E tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/redux-utils/src/createSingleInstanceThunk.test.ts`
- `suite-common/redux-utils/src/matchLegacyActionType.type-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/redux-utils/src/createSingleInstanceThunk.test.ts`
- `suite-common/redux-utils/src/matchLegacyActionType.type-test.ts`

_Updated: 2026-07-28T14:46:31.258Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-redux-utils-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-redux-utils-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-redux-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-redux-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-redux-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:50:04.809Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:49:41.288Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->