### PR TITLE
test(staking): co-locate Ethereum staking test

### DIFF
--- a/suite-common/staking/src/utils/__fixtures__/ethereumStaking.ts
+++ b/suite-common/staking/src/utils/__fixtures__/ethereumStaking.ts
@@ -1,7 +1,7 @@
 import { type EthValidatorsQueue } from '@suite-common/earn-staking-api';
 import { DAYS_TO_ADD_TO_POOL_DEFAULT } from '@suite-common/wallet-constants';
 
-import { ETH_NETWORK_ADDRESSES } from '../constants/ethereumNetworkAddresses';
+import { ETH_NETWORK_ADDRESSES } from '../../constants/ethereumNetworkAddresses';
 
 export const transformTxFixtures = [
     {

--- a/suite-common/staking/src/utils/ethereumStaking.test.ts
+++ b/suite-common/staking/src/utils/ethereumStaking.test.ts
@@ -13,6 +13,11 @@ import {
 import { type Err, type Ok, type Result } from '@trezor/type-utils';
 
 import {
+    type GetStakeFormsDefaultValuesParams,
+    type GetStakeTxGasLimitParams,
+    type StakeTxBaseArgs,
+} from '../types';
+import {
     claimFailedFixture,
     claimFixture,
     getAdjustedGasLimitConsumptionFixture,
@@ -30,12 +35,7 @@ import {
     transformTxFixtures,
     unstakeFailedFixture,
     unstakeFixture,
-} from '../__fixtures__/ethereumStaking';
-import {
-    type GetStakeFormsDefaultValuesParams,
-    type GetStakeTxGasLimitParams,
-    type StakeTxBaseArgs,
-} from '../types';
+} from './__fixtures__/ethereumStaking';
 import {
     claimWithdrawRequest,
     getAdjustedGasLimitConsumption,
@@ -51,7 +51,7 @@ import {
     stake,
     transformTx,
     unstake,
-} from '../utils/ethereumStaking';
+} from './ethereumStaking';
 
 describe('transformTx', () => {
     transformTxFixtures.forEach(test => {


### PR DESCRIPTION
## Description

Moves the Ethereum Staking utility test beside its source and keeps its fixture in the adjacent __fixtures__ directory.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-staking-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-staking-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-staking-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:51:28.490Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:50:48.451Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-staking-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-staking-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->