### PR TITLE
test(suite-sync-evolu): co-locate storage test

### DIFF
--- a/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
@@ -14,9 +14,9 @@ import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { asWalletDescriptor } from '@trezor/device-utils';
 import { createDeferred } from '@trezor/utils';
 
+import { createEvoluInstanceFactory } from './createEvoluInstance';
+import { createEvoluStorageFactory } from './evoluStorage';
 import { testCreateRunWithEvoluDeps } from '../mocks/testCreateRunWithEvoluDeps';
-import { createEvoluInstanceFactory } from '../src/createEvoluInstance';
-import { createEvoluStorageFactory } from '../src/evoluStorage';
 
 const suiteSyncOwner: SuiteSyncOwner = {
     ownerId: asSuiteSyncOwnerId('yg0UgROParTpm60ltI3hDw'),


### PR DESCRIPTION
## Description

Moves the Suite Sync Evolu storage test beside its source file while leaving the shared package mock in place.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is to evoluStorage.test.ts within suite-common/suite-sync-evolu, which underlies the Suite Sync labeling feature (Evolu-based relay storage for account/wallet/address/output labels). Since there is no static coverage mapping, recommendations are inferred from E2E tests that directly exercise Suite Sync's Evolu relay read/write/remove/sync behavior. Priority is given to tests that explicitly assert against Evolu relay table contents (create, remove, sync, update) since these most directly reflect the storage module's behavior; tests that merely enable Suite Sync incidentally (e.g., banner/UI-focused tests) are lower priority.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/suite-sync-evolu/src/evoluStorage.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test directly exercises Suite Sync's Evolu-based storage layer (creating account, wallet, address, and output labels and verifying they land correctly in the Evolu relay tables), which is the exact functionality area of the changed evoluStorage module.
- `suite/e2e/tests/metadata/suite-sync/remove-labels.test.ts` — Removing labels and verifying null values sync to the Evolu relay directly tests evoluStorage's read/write/delete paths, which are the storage primitives most likely affected by changes to evoluStorage.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — This test seeds data directly into the Evolu relay and verifies Suite correctly reads/syncs it back, exercising the evoluStorage read/sync logic that was changed.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — This test covers the full update and removal lifecycle of labels via Suite Sync/Evolu, directly touching the storage read/write/update code paths that evoluStorage implements.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — Multiple passphrase wallets each get their own Evolu owner secret and independent label storage; a regression in evoluStorage's owner/key-scoped storage logic would likely surface here.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — This test migrates labels from legacy Dropbox storage into Suite Sync/Evolu, exercising the evoluStorage write path used during migration, though it's less focused on evoluStorage internals than direct create/remove tests.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — This migration test verifies that legacy local labels are written into Evolu relay tables (account, output, address), touching the same storage write paths evoluStorage implements.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — This test enables Suite Sync and interacts with banners rather than directly verifying evoluStorage data persistence, so it has only tangential exposure to the changed storage code.

</details>

_Updated: 2026-07-28T14:49:18.569Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-sync-evolu-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-sync-evolu-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-suite-sync-evolu-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-suite-sync-evolu-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:52:59.364Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:52:52.960Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->