### PR TITLE
test(suite-sync-quota-manager): co-locate tests

### DIFF
--- a/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/challenge/createPrepareChallengeSessionFetch.test.ts
@@ -1,7 +1,7 @@
 import { ok } from '@trezor/type-utils';
 
-import { createPrepareChallengeSessionFetch } from '../createPrepareChallengeSessionFetch';
-import { createPrepareChallengeSessionDepsMock } from '../mocks/createPrepareChallengeSessionDepsMock';
+import { createPrepareChallengeSessionFetch } from './createPrepareChallengeSessionFetch';
+import { createPrepareChallengeSessionDepsMock } from './mocks/createPrepareChallengeSessionDepsMock';
 
 describe(createPrepareChallengeSessionFetch.name, () => {
     it('should prepare challenge unique for each session', async () => {

--- a/suite-common/suite-sync-quota-manager/src/createEnsureQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/createEnsureQuota.test.ts
@@ -9,10 +9,10 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
 
-import { type EnsureQuotaDeps, createEnsureQuota } from '../createEnsureQuota';
-import { createEnsureDeviceHasQuotaMock } from '../device/mocks/createEnsureDeviceHasQuotaMock';
-import { QuotaManagerCommunicationFailed } from '../errors';
-import { createEnsureOwnerHasAllocatedQuotaMock } from '../owner/mocks/createEnsureOwnerHasAllocatedQuotaMock';
+import { type EnsureQuotaDeps, createEnsureQuota } from './createEnsureQuota';
+import { createEnsureDeviceHasQuotaMock } from './device/mocks/createEnsureDeviceHasQuotaMock';
+import { QuotaManagerCommunicationFailed } from './errors';
+import { createEnsureOwnerHasAllocatedQuotaMock } from './owner/mocks/createEnsureOwnerHasAllocatedQuotaMock';
 
 const OWNER_ABCD: SuiteSyncOwner = {
     ownerId: asSuiteSyncOwnerId('owner-id-abcd'),

--- a/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createEnsureDeviceHasQuota.test.ts
@@ -4,8 +4,8 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { err, ok } from '@trezor/type-utils';
 
-import { createEnsureDeviceHasQuota } from '../createEnsureDeviceHasQuota';
-import { createEnsureDeviceHasQuotaDepsMock } from '../mocks/createEnsureDeviceHasQuotaDepsMock';
+import { createEnsureDeviceHasQuota } from './createEnsureDeviceHasQuota';
+import { createEnsureDeviceHasQuotaDepsMock } from './mocks/createEnsureDeviceHasQuotaDepsMock';
 
 const device = mockSuiteDevice(
     { id: 'device-id' },

--- a/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/device/createRegisterDevice.test.ts
@@ -5,8 +5,8 @@ import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { err, ok } from '@trezor/type-utils';
 
-import { DEFAULT_DEVICE_SIZE_QUOTA } from '../../quotaManagerQuotaSize';
-import { type RegisterDeviceDeps, createRegisterDevice } from '../createRegisterDevice';
+import { DEFAULT_DEVICE_SIZE_QUOTA } from '../quotaManagerQuotaSize';
+import { type RegisterDeviceDeps, createRegisterDevice } from './createRegisterDevice';
 
 const deviceWithLegacyRegistrationRequest = mockSuiteDevice(
     { id: 'device-id-v1' },

--- a/suite-common/suite-sync-quota-manager/src/owner/createAllocateOwnerQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createAllocateOwnerQuota.test.ts
@@ -4,8 +4,8 @@ import { asSuiteSyncOwnerId } from '@suite-common/suite-sync-storage';
 import { type WalletDescriptor, asWalletDescriptor } from '@trezor/device-utils';
 import { err, ok } from '@trezor/type-utils';
 
-import { DEFAULT_ACCOUNT_SIZE_QUOTA } from '../../quotaManagerQuotaSize';
-import { type AllocateOwnerQuotaDeps, createAllocateOwnerQuota } from '../createAllocateOwnerQuota';
+import { DEFAULT_ACCOUNT_SIZE_QUOTA } from '../quotaManagerQuotaSize';
+import { type AllocateOwnerQuotaDeps, createAllocateOwnerQuota } from './createAllocateOwnerQuota';
 
 const ownerId = asSuiteSyncOwnerId('owner-id');
 const walletDescriptor: WalletDescriptor = asWalletDescriptor('descriptor');

--- a/suite-common/suite-sync-quota-manager/src/owner/createEnsureOwnerHasAllocatedQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/createEnsureOwnerHasAllocatedQuota.test.ts
@@ -7,8 +7,8 @@ import { err, ok } from '@trezor/type-utils';
 
 import { createEnsureOwnerHasAllocatedQuotaDepsMock } from '../device/mocks/createEnsureOwnerHasAllocatedQuotaDepsMock';
 import { QuotaManagerCommunicationFailed } from '../errors';
-import { type AllocateOwnerQuota } from '../owner/createAllocateOwnerQuota';
-import { createEnsureOwnerHasAllocatedQuota } from '../owner/createEnsureOwnerHasAllocatedQuota';
+import { type AllocateOwnerQuota } from './createAllocateOwnerQuota';
+import { createEnsureOwnerHasAllocatedQuota } from './createEnsureOwnerHasAllocatedQuota';
 
 const ownerId = asSuiteSyncOwnerId('owner-id');
 const walletDescriptor: WalletDescriptor = asWalletDescriptor('descriptor');

--- a/suite-common/suite-sync-quota-manager/src/owner/getAccountIncrementSizeQuota.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/owner/getAccountIncrementSizeQuota.test.ts
@@ -1,8 +1,8 @@
 import {
     DEFAULT_ACCOUNT_INCREMENT_SIZE_QUOTA,
     DEFAULT_DEVICE_SIZE_QUOTA,
-} from '../../quotaManagerQuotaSize';
-import { getAccountIncrementSizeQuota } from '../getAccountIncrementSizeQuota';
+} from '../quotaManagerQuotaSize';
+import { getAccountIncrementSizeQuota } from './getAccountIncrementSizeQuota';
 
 describe(getAccountIncrementSizeQuota.name, () => {
     it('return default account size quota if unspent storage is bigger than default', () => {

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerFetch.test.ts
@@ -1,4 +1,4 @@
-import { createQuotaManagerFetch } from '../quotaManagerFetch';
+import { createQuotaManagerFetch } from './quotaManagerFetch';
 
 jest.mock('@trezor/env-utils', () => {
     const actual = jest.requireActual('@trezor/env-utils');

--- a/suite-common/suite-sync-quota-manager/src/quotaManagerUrl.test.ts
+++ b/suite-common/suite-sync-quota-manager/src/quotaManagerUrl.test.ts
@@ -1,12 +1,12 @@
 import { isCodesignBuild } from '@trezor/env-utils';
 
-import { type WithSuiteSyncQuotaManagerState } from '../quotaManagerSelectors';
+import { type WithSuiteSyncQuotaManagerState } from './quotaManagerSelectors';
 import {
     getQuotaManagerDefaultUrl,
     getQuotaManagerUrl,
     selectQuotaManagerCustomUrl,
     selectQuotaManagerUrl,
-} from '../quotaManagerUrl';
+} from './quotaManagerUrl';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),


### PR DESCRIPTION
## Description

Moves the nine Suite Sync Quota Manager tests beside their source files while leaving existing dependency mocks in place.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-sync-quota-manager-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-sync-quota-manager-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-suite-sync-quota-manager-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-suite-sync-quota-manager-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-suite-sync-quota-manager-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:55:44.801Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:54:05.127Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->