### PR TITLE
test(suite-utils): co-locate tests

### DIFF
--- a/suite-common/suite-utils/src/build.test.ts
+++ b/suite-common/suite-utils/src/build.test.ts
@@ -12,28 +12,28 @@ describe('build', () => {
 
         it('dev false when NODE_ENV is production', () => {
             process.env.NODE_ENV = 'production';
-            const { isDevEnv } = require('../build');
+            const { isDevEnv } = require('./build');
 
             expect(isDevEnv).toEqual(false);
         });
 
         it('dev true when NODE_ENV is development', () => {
             process.env.NODE_ENV = 'development';
-            const { isDevEnv } = require('../build');
+            const { isDevEnv } = require('./build');
 
             expect(isDevEnv).toEqual(true);
         });
 
         it('dev true when NODE_ENV is anything excluding production', () => {
             process.env.NODE_ENV = 'anything';
-            const { isDevEnv } = require('../build');
+            const { isDevEnv } = require('./build');
 
             expect(isDevEnv).toEqual(true);
         });
 
         it('dev true when NODE_ENV is not set', () => {
             process.env.NODE_ENV = undefined;
-            const { isDevEnv } = require('../build');
+            const { isDevEnv } = require('./build');
 
             expect(isDevEnv).toEqual(true);
         });

--- a/suite-common/suite-utils/src/date.test.ts
+++ b/suite-common/suite-utils/src/date.test.ts
@@ -1,4 +1,4 @@
-import { formatDurationStrict, parseUTCdatetime } from '../date';
+import { formatDurationStrict, parseUTCdatetime } from './date';
 
 describe('Date utils', () => {
     test('format duration strict', () => {

--- a/suite-common/suite-utils/src/device.test.ts
+++ b/suite-common/suite-utils/src/device.test.ts
@@ -2,7 +2,7 @@ import { type AcquiredDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import fixtures from '../__fixtures__/device';
+import fixtures from './__fixtures__/device';
 import {
     findInstanceIndex,
     getChangelogUrl,
@@ -26,7 +26,7 @@ import {
     isSelectedDevice,
     isSelectedInstance,
     sortByTimestamp,
-} from '../device';
+} from './device';
 
 describe(getStatus.name, () => {
     fixtures.getStatus.forEach(f => {

--- a/suite-common/suite-utils/src/features.test.ts
+++ b/suite-common/suite-utils/src/features.test.ts
@@ -1,4 +1,4 @@
-import * as features from '../features';
+import * as features from './features';
 
 const MOCK_FLAGS = {
     FLAG: false,

--- a/suite-common/suite-utils/src/invariant.test.ts
+++ b/suite-common/suite-utils/src/invariant.test.ts
@@ -1,4 +1,4 @@
-import { invariant } from '../invariant';
+import { invariant } from './invariant';
 
 describe('invariant', () => {
     it('should throw error when condition is not met', () => {

--- a/suite-common/suite-utils/src/listFilterUtils.test.ts
+++ b/suite-common/suite-utils/src/listFilterUtils.test.ts
@@ -1,4 +1,4 @@
-import { normalizeForSearch } from '../listFilterUtils';
+import { normalizeForSearch } from './listFilterUtils';
 
 describe('normalizeForSearch', () => {
     it.each([

--- a/suite-common/suite-utils/src/parseFirmwareChangelog.test.ts
+++ b/suite-common/suite-utils/src/parseFirmwareChangelog.test.ts
@@ -4,7 +4,7 @@ import {
     type ParseFirmwareChangelogParams,
     type ParseFirmwareChangelogResult,
     parseFirmwareChangelog,
-} from '../parseFirmwareChangelog';
+} from './parseFirmwareChangelog';
 
 const CHANGELOG_STRING =
     '* Replacement transaction signing for replace-by-fee.\n* Support for Output Descriptors export.\n* Show Ypub/Zpub correctly for multisig GetAddress.\n* Show amounts in mBTC, uBTC and sat denominations.';

--- a/suite-common/suite-utils/src/protocol.test.ts
+++ b/suite-common/suite-utils/src/protocol.test.ts
@@ -1,7 +1,7 @@
 import { type Protocol } from '@suite-common/suite-constants';
 
-import * as fixtures from '../__fixtures__/protocol';
-import { getNetworkSymbolForProtocol } from '../protocol';
+import * as fixtures from './__fixtures__/protocol';
+import { getNetworkSymbolForProtocol } from './protocol';
 
 describe('getNetworkSymbolForProtocol', () => {
     fixtures.getNetworkSymbolForProtocol.forEach(f => {


### PR DESCRIPTION
## Description

Moves the eight Suite Utils tests beside their source files while preserving the adjacent fixture directory.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-suite-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-suite-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-suite-utils-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:55:37.326Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:55:14.550Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-utils-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-suite-utils-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->