### PR TITLE
test(thp): co-locate reducer test

### DIFF
--- a/suite-common/thp/jest.config.js
+++ b/suite-common/thp/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    roots: ['<rootDir>/src', '<rootDir>/tests', '<rootDir>/../test-utils/__mocks__'],
+    roots: ['<rootDir>/src', '<rootDir>/../test-utils/__mocks__'],
 };

--- a/suite-common/thp/src/thpReducer.test.ts
+++ b/suite-common/thp/src/thpReducer.test.ts
@@ -5,14 +5,14 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import { DEVICE, createDeviceMessage } from '@trezor/connect';
 
 import { createCredential, createDeviceThp } from '../mocks';
-import { thpActions } from '../src/thpActions';
-import { type ThpState, prepareThpReducer } from '../src/thpReducer';
+import { thpActions } from './thpActions';
+import { type ThpState, prepareThpReducer } from './thpReducer';
 import {
     selectThpAutoconnectStep,
     selectThpCredentials,
     selectThpLastCode,
     selectThpStep,
-} from '../src/thpSelectors';
+} from './thpSelectors';
 
 const thpReduce = prepareThpReducer(extraDependenciesCommonMock);
 


### PR DESCRIPTION
## Description

Moves the THP reducer test beside its source while leaving the shared package mocks in place. Removes the stale tests-directory entry from the package Jest roots so the relocated test suite can start successfully.

- THP unit tests: **0 runnable -> 8/8 passing**
- Package lint and formatting: **passing**
- Runtime behavior changes: **none**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only change is a unit test file (thpReducer.test.ts) for the THP Redux reducer in suite-common/thp. Since this is itself a test file (not application source), there is no direct static E2E coverage mapping, and the change is unlikely to affect any E2E test behavior unless the reducer logic itself was also modified alongside the test (not indicated here). We recommend running the THP-pairing-related onboarding E2E test (T3W1) as a low-priority sanity check since T3W1 onboarding uses THP pairing flows, but confidence that this change affects any E2E test is low since only a test file changed.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/thp/src/thpReducer.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🟢 <b>Low priority (2)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This is a unit test file for the THP (Trezor Host Protocol) Redux reducer, which is unrelated to WalletConnect functionality but THP pairing is used in several onboarding flows including device connection state management; there's only a loose indirect relationship via device state handling.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test exercises THP (Trezor Host Protocol) device pairing during onboarding for T3W1 devices, which likely relies on the thpReducer to manage pairing/connection state, so a reducer bug could surface as pairing failures here.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/thp/src/thpReducer.test.ts`

_Updated: 2026-07-28T15:46:23.912Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-thp-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-thp-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-thp-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-thp-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:50:06.331Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:49:33.930Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->