### PR TITLE
test(toast-notifications): co-locate reducer test

### DIFF
--- a/suite-common/toast-notifications/src/notificationsReducer.test.ts
+++ b/suite-common/toast-notifications/src/notificationsReducer.test.ts
@@ -1,10 +1,10 @@
 import { configureMockStore } from '@suite-common/test-utils';
 
-import { notificationsActions } from '../notificationsActions';
-import { createNotificationsReducer } from '../notificationsReducer';
-import { selectNotifications } from '../notificationsSelectors';
-import { removeAccountEventsThunk } from '../notificationsThunks';
-import { type NotificationsRootState, type NotificationsState } from '../types';
+import { notificationsActions } from './notificationsActions';
+import { createNotificationsReducer } from './notificationsReducer';
+import { selectNotifications } from './notificationsSelectors';
+import { removeAccountEventsThunk } from './notificationsThunks';
+import { type NotificationsRootState, type NotificationsState } from './types';
 
 const { reducer: notificationsReducer } = createNotificationsReducer();
 


### PR DESCRIPTION
## Description

Moves the Toast Notifications reducer test beside its source file.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a unit test file for the toast-notifications reducer (notificationsReducer.test.ts), which is itself a unit test rather than application source code — it has no static E2E coverage mapping since unit test changes don't get referenced by E2E specs. Since this is a self-contained unit test change with no accompanying source code modification, the risk to E2E behavior is minimal; however, as a precaution, a small set of E2E tests that heavily rely on toast notification appearance/disappearance timing were selected as low-priority sanity checks. The primary recommendation is to run the unit test suite itself (not shown here since only E2E tests were requested) rather than extensive E2E runs.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/toast-notifications/src/notificationsReducer.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🟢 <b>Low priority (3)</b></summary>

- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test asserts toast notification behaviors (e.g., backup close button, toast for errors) which rely on the toast-notifications reducer to correctly track notification state; a regression in notificationsReducer could cause toast visibility issues here.
- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test explicitly checks a toast notification ('@toast/backup-failed') and an error banner, both of which depend on the toast-notifications state management being correct.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test verifies a 'settings applied' toast appears and then automatically disappears, directly exercising the notification lifecycle (add/remove) that the changed reducer manages.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/toast-notifications/src/notificationsReducer.test.ts`

_Updated: 2026-07-28T14:54:19.394Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-toast-notifications-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-toast-notifications-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-toast-notifications-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-toast-notifications-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-toast-notifications-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:57:48.838Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| All routes are covered by SECTIONS | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T14:57:23.048Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->