### PR TITLE
test(transaction-search): co-locate tests

### DIFF
--- a/suite-common/transaction-search/src/advancedSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/advancedSearchTransactions.test.ts
@@ -1,10 +1,10 @@
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { typedObjectEntries } from '@trezor/utils';
 
-import { searchTransactionsFixture } from '../__fixtures__/searchTransactions.fixture';
-import stMock from '../__fixtures__/searchTransactions.json';
-import { advancedSearchTransactions } from '../advancedSearchTransactions';
-import { type SearchAccountLabels, type SearchOutputLabels } from '../searchLabels';
+import { searchTransactionsFixture } from './__fixtures__/searchTransactions.fixture';
+import stMock from './__fixtures__/searchTransactions.json';
+import { advancedSearchTransactions } from './advancedSearchTransactions';
+import { type SearchAccountLabels, type SearchOutputLabels } from './searchLabels';
 
 // Original Fixtures were create with legacy metadata structure,
 // so we need to transform them to fit the new SearchAccountLabels structure used in the tests

--- a/suite-common/transaction-search/src/filterAndCategorizeUtxos.test.ts
+++ b/suite-common/transaction-search/src/filterAndCategorizeUtxos.test.ts
@@ -1,8 +1,8 @@
 import {
     baseUtxo,
     filterAndCategorizeUtxosFixtures,
-} from '../__fixtures__/filterAndCategorizeUtxosFixtures';
-import { filterAndCategorizeUtxos } from '../filterAndCategorizeUtxos';
+} from './__fixtures__/filterAndCategorizeUtxosFixtures';
+import { filterAndCategorizeUtxos } from './filterAndCategorizeUtxos';
 
 describe(filterAndCategorizeUtxos.name, () => {
     it('filters and categorizes correctly while searching by address', () => {

--- a/suite-common/transaction-search/src/getExcludedUtxos.test.ts
+++ b/suite-common/transaction-search/src/getExcludedUtxos.test.ts
@@ -1,7 +1,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import { getUtxoOutpoint } from '@suite-common/wallet-utils';
 
-import { getExcludedUtxos } from '../getExcludedUtxos';
+import { getExcludedUtxos } from './getExcludedUtxos';
 const { getUtxo } = testMocks;
 
 describe(getExcludedUtxos.name, () => {

--- a/suite-common/transaction-search/src/getTargetAmounts.test.ts
+++ b/suite-common/transaction-search/src/getTargetAmounts.test.ts
@@ -1,7 +1,7 @@
 import { testMocks } from '@suite-common/test-utils';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 
-import { getTargetAmounts } from '../getTargetAmounts';
+import { getTargetAmounts } from './getTargetAmounts';
 
 const { getWalletTransaction } = testMocks;
 


### PR DESCRIPTION
## Description

Moves the four Transaction Search tests beside their source files while preserving the adjacent fixtures.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files for transaction-search utilities (advanced search, UTXO filtering/categorization, excluded UTXOs, and target amount calculation) with no static E2E coverage mapping. Since these are pure unit tests for shared transaction/UTXO logic, risk to E2E flows is indirect; we inferred a small set of wallet-related E2E tests (transaction listing, pending/confirmed categorization, and send form with multiple outputs) that plausibly exercise the same underlying transaction/UTXO processing logic. Recommend running these as a light smoke check alongside the existing unit tests, rather than a broad E2E sweep, since the core validation for these changes should come from the unit tests themselves.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/transaction-search/src/advancedSearchTransactions.test.ts`
- `suite-common/transaction-search/src/filterAndCategorizeUtxos.test.ts`
- `suite-common/transaction-search/src/getExcludedUtxos.test.ts`
- `suite-common/transaction-search/src/getTargetAmounts.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test exercises transaction list categorization (pending vs confirmed, sending/receiving/self labels), which is closely related to the filterAndCategorizeUtxos and getExcludedUtxos logic changed in suite-common/transaction-search; a regression in UTXO/transaction categorization could surface as incorrect pending/confirmed grouping or labels here.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches for transactions by address and filters by time range, which depends on transaction search/filtering behavior; changes to advancedSearchTransactions or target amount calculations could affect which transactions are surfaced or matched.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test involves multiple outputs, OP_RETURN handling, and UTXO-driven send behavior on regtest; changes to UTXO filtering/categorization or target amount computation could indirectly affect coin selection or output rendering, though no direct code path evidence was found.

</details>

_Updated: 2026-07-28T14:57:03.406Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-transaction-search-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-transaction-search-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-transaction-search-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-transaction-search-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-transaction-search-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:00:50.218Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:00:24.080Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->