### PR TITLE
test(transfer-uri): co-locate tests

### DIFF
--- a/suite-common/transfer-uri/src/parseBip321Uri.test.ts
+++ b/suite-common/transfer-uri/src/parseBip321Uri.test.ts
@@ -1,6 +1,6 @@
 import { type Result, err, ok } from '@trezor/type-utils';
 
-import { parseBip321Uri } from '../parseBip321Uri';
+import { parseBip321Uri } from './parseBip321Uri';
 
 const cases: { description: string; uri: string; expected: Result<unknown, unknown> }[] = [
     {

--- a/suite-common/transfer-uri/src/parseErc681TransferUri.test.ts
+++ b/suite-common/transfer-uri/src/parseErc681TransferUri.test.ts
@@ -1,5 +1,5 @@
-import * as fixtures from '../__fixtures__/parseErc681TransferUri';
-import { parseErc681TransferUri } from '../parseErc681TransferUri';
+import * as fixtures from './__fixtures__/parseErc681TransferUri';
+import { parseErc681TransferUri } from './parseErc681TransferUri';
 
 describe(parseErc681TransferUri.name, () => {
     fixtures.parseErc681TransferUri.forEach(f => {

--- a/suite-common/transfer-uri/src/parseTransferUri.test.ts
+++ b/suite-common/transfer-uri/src/parseTransferUri.test.ts
@@ -1,6 +1,6 @@
 import { err, ok } from '@trezor/type-utils';
 
-import { parseTransferUri } from '../parseTransferUri';
+import { parseTransferUri } from './parseTransferUri';
 
 describe(parseTransferUri.name, () => {
     // --- ERC-681 dispatch ---


### PR DESCRIPTION
## Description

Moves the three Transfer URI parser tests beside their source files while preserving the adjacent fixture.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files themselves (parseBip321Uri.test.ts, parseErc681TransferUri.test.ts, parseTransferUri.test.ts) within suite-common/transfer-uri, which are unit-level Jest/Vitest tests for URI parsing logic (BIP321 Bitcoin payment URIs, ERC-681 Ethereum transfer URIs, and generic transfer URI parsing). None of the 103 candidate E2E tests in the provided catalog reference these files via static coverage mapping, and reviewing the E2E test behaviors/entry_points/source_hints, none of them exercise URI-based payment/transfer link parsing (e.g., clicking a bitcoin: or ethereum: link to pre-fill a send form) — the E2E suite focuses on onboarding, staking, trading, metadata sync, settings, and device flows using manually filled forms rather than URI deep-linking. Since these are self-contained unit tests for a parsing utility with no evidence of E2E flows depending on URI-triggered send/receive forms, no E2E test can be confidently recommended; the appropriate verification is running the affected unit tests themselves (outside the E2E suite) rather than any Playwright E2E test.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/transfer-uri/src/parseBip321Uri.test.ts`
- `suite-common/transfer-uri/src/parseErc681TransferUri.test.ts`
- `suite-common/transfer-uri/src/parseTransferUri.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/transfer-uri/src/parseBip321Uri.test.ts`
- `suite-common/transfer-uri/src/parseErc681TransferUri.test.ts`
- `suite-common/transfer-uri/src/parseTransferUri.test.ts`

_Updated: 2026-07-28T14:57:53.598Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-transfer-uri-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-transfer-uri-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-transfer-uri-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-common-transfer-uri-test-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-transfer-uri-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:01:20.564Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:00:56.043Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->