### PR TITLE
test(wallet-config): co-locate tests

### DIFF
--- a/suite-common/wallet-config/src/earnRewardsProvider.test.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.test.ts
@@ -1,8 +1,5 @@
-import {
-    getEarnYieldClaimContractAddress,
-    isEarnYieldClaimSupported,
-} from '../earnRewardsProvider';
-import { getNetworkFeatures, networkSymbolCollection } from '../utils';
+import { getEarnYieldClaimContractAddress, isEarnYieldClaimSupported } from './earnRewardsProvider';
+import { getNetworkFeatures, networkSymbolCollection } from './utils';
 
 describe(isEarnYieldClaimSupported.name, () => {
     it('has a claim contract address for every network with the claim-rewards feature', () => {

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -1,5 +1,5 @@
-import { networks } from '../networksConfig';
-import { type NetworkSymbol } from '../types';
+import { networks } from './networksConfig';
+import { type NetworkSymbol } from './types';
 import {
     filterNetworksByName,
     getMainnets,
@@ -9,7 +9,7 @@ import {
     isAccountBasedNetwork,
     isAccountOfNetwork,
     isNetworkUsingExternalBackend,
-} from '../utils';
+} from './utils';
 
 const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
 

--- a/suite-common/wallet-config/src/wrappedNativeToken.test.ts
+++ b/suite-common/wallet-config/src/wrappedNativeToken.test.ts
@@ -2,12 +2,12 @@ import { checksumAddress, isAddress } from 'viem';
 
 import { typedObjectKeys } from '@trezor/utils';
 
-import { getNetworkType } from '../utils';
+import { getNetworkType } from './utils';
 import {
     WRAPPED_NATIVE,
     getWrappedNativeAddress,
     getWrappedNativeSymbol,
-} from '../wrappedNativeToken';
+} from './wrappedNativeToken';
 
 describe(getWrappedNativeAddress.name, () => {
     it('returns the wrapped native address for a supported network', () => {


### PR DESCRIPTION
## Description

Moves the three Wallet Config tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit test files within suite-common/wallet-config covering earn rewards provider data, general utility functions, and wrapped native token mappings — these are pure unit tests with no direct static E2E coverage mapping. Since no E2E test maps directly to these files, we inferred a small set of loosely-related E2E tests (staking flows for earnRewardsProvider, and discovery/settings flows for utils) as low-priority spot checks, since a regression in these underlying config/utility functions could surface in staking eligibility or network/coin configuration behavior. Given these are unit-test-only changes with no direct UI code touched, the primary confidence should come from running the unit tests themselves; E2E coverage here is precautionary rather than required.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-config/src/earnRewardsProvider.test.ts`
- `suite-common/wallet-config/src/utils.test.ts`
- `suite-common/wallet-config/src/wrappedNativeToken.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🟢 <b>Low priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test relies on ETH staking pool/provider configuration (Everstake contract) that could be derived from wallet-config's earnRewardsProvider data; if provider mappings change, staking flows could be affected.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking relies on the same staking provider/pool configuration that earnRewardsProvider.test.ts is unit-testing; a regression in provider config could break unstake flows.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Initial ETH staking depends on staking pool/provider configuration data that earnRewardsProvider unit tests validate; changes here are a plausible but indirect risk.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking also depends on network/rewards provider configuration in wallet-config; a change to earnRewardsProvider logic could impact whether staking is offered/calculated correctly for ADA.
- `suite/e2e/tests/wallet/discovery.test.ts` — utils.test.ts likely covers general wallet-config utility functions (e.g., network lookups) used broadly during account discovery across many coins; a regression could surface as discovery failures.
- `suite/e2e/tests/settings/coins.test.ts` — Coin/network configuration and activation logic in Settings likely uses wallet-config utility functions covered by utils.test.ts, so a change there could affect which networks appear/enable correctly.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-config/src/wrappedNativeToken.test.ts`

_Updated: 2026-07-28T14:59:57.784Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-common-wallet-config-test-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-common-wallet-config-test-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-common-wallet-config-test-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/suite-common-wallet-config-test-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:04:23.670Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T15:04:17.097Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->