### PR TITLE
Feat /  EarnEthBanner

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
@@ -1,0 +1,93 @@
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { selectFlags, setFlag } from '@suite/flags';
+import { Translation } from '@suite/intl';
+import { goto } from '@suite/router';
+import { events as sharedEvents } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { Banner } from '@trezor/components';
+import { PiggyBankIcon, XIcon } from '@trezor/icons';
+
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type EarnEthBannerProps = {
+    networkSymbol: NetworkSymbol;
+    apy: number | null;
+};
+
+export const EarnEthBanner = ({ networkSymbol, apy }: EarnEthBannerProps) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const dispatch = useDispatch();
+    const { earnEthBannerClosed } = useSelector(selectFlags);
+
+    const displaySymbol = getDisplaySymbol(networkSymbol);
+
+    const closeBanner = () => {
+        dispatch(setFlag({ key: 'earnEthBannerClosed', value: true }));
+
+        analytics.report({
+            type: sharedEvents.yieldNavigateEvent.name,
+            payload: {
+                action: 'cancel',
+                from: 'account-banner',
+                to: 'earn-dashboard',
+                networkSymbol,
+            },
+        });
+    };
+
+    const goToEarnDashboard = () => {
+        dispatch(goto({ routeName: 'suite-earn' }));
+
+        analytics.report({
+            type: sharedEvents.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: 'account-banner',
+                to: 'earn-dashboard',
+                networkSymbol,
+            },
+        });
+    };
+
+    if (earnEthBannerClosed) {
+        return null;
+    }
+
+    return (
+        <Banner
+            icon={PiggyBankIcon}
+            intent="brand"
+            title={
+                apy === null ? (
+                    <Translation
+                        id="TR_STAKING_BANNER_ETH_EARN_TITLE_NO_RATE"
+                        values={{ displaySymbol }}
+                    />
+                ) : (
+                    <Translation
+                        id="TR_STAKING_BANNER_ETH_EARN_TITLE"
+                        values={{ apy: formatApyValue(apy), displaySymbol }}
+                    />
+                )
+            }
+            description={
+                <Translation id="TR_STAKING_BANNER_ETH_EARN_TEXT" values={{ displaySymbol }} />
+            }
+            rightContent={
+                <>
+                    <Banner.Button onClick={goToEarnDashboard}>
+                        <Translation id="TR_STAKING_BANNER_ETH_EARN_BUTTON" />
+                    </Banner.Button>
+                    <Banner.IconButton
+                        priority="secondary"
+                        icon={XIcon}
+                        onClick={closeBanner}
+                        tooltip={{ content: <Translation id="TR_DISMISS" /> }}
+                    />
+                </>
+            }
+        />
+    );
+};

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { goto } from '@suite/router';
+import { goto, selectRouter } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
@@ -25,6 +25,9 @@ import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
 import { useStakingRate } from 'src/hooks/earn/useStakingRate';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
+import { EarnEthBanner } from './EarnEthBanner';
+import { useEarnEthBanner } from './hooks/useEarnEthBanner';
+
 type StakingBannerProps = {
     account: Account;
 };
@@ -39,9 +42,10 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
         stakeCardanoBannerClosed,
         stakeTronBannerClosed,
     } = useSelector(selectFlags);
-    const { route } = useSelector(state => state.router);
+    const { route } = useSelector(selectRouter);
     const { rate } = useStakingRate({ symbol: account.symbol, accountKey: account.key });
     const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const earnEthBanner = useEarnEthBanner(account);
 
     const displaySymbol = getDisplaySymbol(account.symbol);
     const stakingData = getStakingDataForNetwork(account);
@@ -135,13 +139,17 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
 
     const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
 
-    if (
-        route?.name !== 'wallet-index' ||
-        isStakingBannerClosed(account.networkType) ||
-        !account ||
-        isStakingActive ||
-        !stakingLimits
-    ) {
+    if (route?.name !== 'wallet-index' || !account || earnEthBanner.isResolving) {
+        return null;
+    }
+
+    // The earn promo has its own dismissal flag and is shown even to users who
+    // already stake or closed the staking banner before the promo existed.
+    if (earnEthBanner.hasYieldOption) {
+        return <EarnEthBanner networkSymbol={account.symbol} apy={earnEthBanner.apy} />;
+    }
+
+    if (isStakingBannerClosed(account.networkType) || isStakingActive || !stakingLimits) {
         return null;
     }
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsYieldFeatureDisabled,
+} from '@suite-common/message-system';
+import { getNetworkByYieldXyzId, isWrappedNativeToken } from '@suite-common/wallet-config';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getApyPercent, isApyAvailable } from '@suite-common/wallet-utils';
+
+import { useStakingRate } from 'src/hooks/earn/useStakingRate';
+import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
+
+const emptyVaults: YieldDtoV2[] = [];
+
+// Each vault can be remotely killed on its own via the message system — a killed vault
+// must not be advertised.
+const isVaultDepositEnabled = (state: MessageSystemRootState, vault: YieldDtoV2) =>
+    !selectIsYieldFeatureDisabled(
+        state,
+        Feature.earn.yield.deposit,
+        getYieldVaultContractAddress(vault),
+    );
+
+export const useEarnEthBanner = (account: Account) => {
+    const { rate: stakingRate } = useStakingRate({
+        symbol: account.symbol,
+        accountKey: account.key,
+    });
+
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldOptionRelevant =
+        account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+    const {
+        data: availableVaults,
+        isSuccess: hasLoadedVaults,
+        isError: hasVaultsError,
+    } = useAllYieldOpportunities({ enabled: isYieldOptionRelevant });
+
+    // The native coin can also earn yield via a wrapped-native vault — promote both options.
+    const wrappedNativeVaults = useMemo(
+        () =>
+            isYieldOptionRelevant
+                ? (availableVaults ?? emptyVaults).filter(
+                      vault =>
+                          !vault.metadata.underMaintenance &&
+                          !vault.metadata.deprecated &&
+                          getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                          isWrappedNativeToken(account.symbol, vault.token.address),
+                  )
+                : emptyVaults,
+        [isYieldOptionRelevant, availableVaults, account.symbol],
+    );
+
+    const hasYieldOption = useSelector(state =>
+        wrappedNativeVaults.some(vault => isVaultDepositEnabled(state, vault)),
+    );
+    const bestVaultApy = useSelector(state => {
+        const enabledVaultApys = wrappedNativeVaults
+            .filter(vault => isVaultDepositEnabled(state, vault))
+            .map(vault => getApyPercent(vault.rewardRate.total))
+            .filter((vaultApy): vaultApy is number => isApyAvailable(vaultApy));
+
+        return enabledVaultApys.length > 0 ? Math.max(...enabledVaultApys) : null;
+    });
+
+    // Hold rendering until the vaults query settles so the banner variant does not
+    // flash from staking-only to staking+yield underneath the user.
+    const isResolving = isYieldOptionRelevant && !hasLoadedVaults && !hasVaultsError;
+
+    const apyCandidates = [stakingRate, bestVaultApy].filter(
+        (apyCandidate): apyCandidate is number => isApyAvailable(apyCandidate),
+    );
+    const apy = apyCandidates.length > 0 ? Math.max(...apyCandidates) : null;
+
+    return { isResolving, hasYieldOption, apy };
+};

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -7,6 +7,7 @@ type Attributes = {
     action: AttributeDef<EarnModalAction>;
     from: AttributeDef<
         | 'earn-dashboard'
+        | 'account-banner'
         | 'account-defi-tokens'
         | 'deposit-in-a-nutshell-modal'
         | 'deposit-legal-modal'
@@ -50,13 +51,14 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         from: {
             description:
-                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens` and `claim-select-account-modal` are desktop-only',
+                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens` and `claim-select-account-modal` are desktop-only; `account-banner` = in-account earn promo banner',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
                     version: '26.7.1',
                     notes: 'added `choose-account-sheet`, `account-detail`, `insufficient-balance-screen` values (mobile)',
                 },
+                { version: '26.8.0', notes: 'added `account-banner` value' },
             ],
         },
         to: {

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -18,6 +18,7 @@ export type FlagsState = {
     showSettingsDesktopAppPromoBanner: boolean;
     activateAssetsBannerClosed: boolean;
     stakeEthBannerClosed: boolean;
+    earnEthBannerClosed: boolean;
     stakeSolBannerClosed: boolean;
     stakeCardanoBannerClosed: boolean;
     stakeTronBannerClosed: boolean;
@@ -51,6 +52,7 @@ export const flagsInitialState: FlagsState = {
     showSettingsDesktopAppPromoBanner: true,
     activateAssetsBannerClosed: false,
     stakeEthBannerClosed: false,
+    earnEthBannerClosed: false,
     stakeSolBannerClosed: false,
     stakeCardanoBannerClosed: false,
     stakeTronBannerClosed: false,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10486,6 +10486,23 @@ export const messages = defineMessages({
         id: 'TR_STAKING_BANNER_DETAIL_EXPLORE_STAKING',
         defaultMessage: 'Explore staking',
     },
+    TR_STAKING_BANNER_ETH_EARN_TITLE: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_TITLE',
+        defaultMessage: 'Earn up to {apy}% on your {displaySymbol}',
+    },
+    TR_STAKING_BANNER_ETH_EARN_TITLE_NO_RATE: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_TITLE_NO_RATE',
+        defaultMessage: 'Earn on your {displaySymbol}: stake it or earn yield',
+    },
+    TR_STAKING_BANNER_ETH_EARN_TEXT: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_TEXT',
+        defaultMessage:
+            'Stake {displaySymbol} for network rewards, or deposit it in a yield vault.',
+    },
+    TR_STAKING_BANNER_ETH_EARN_BUTTON: {
+        id: 'TR_STAKING_BANNER_ETH_EARN_BUTTON',
+        defaultMessage: 'Explore',
+    },
     TR_STAKING_CARD_TITLE: {
         id: 'TR_STAKING_CARD_TITLE',
         defaultMessage: 'Earn ~{apy}% APY by staking your {displaySymbol}',


### PR DESCRIPTION
## Description

Add `EarnEthBanner` component and integrate yield options into `StakingBanner`

## Notes for QA

A CTA for Earn page in form of a simple banner to staking page.

## Related Issue

Resolve #29873

## Screenshots:

<img width="1757" height="804" alt="Snímek obrazovky 2026-07-28 v 16 44 19" src="https://github.com/user-attachments/assets/156702a5-1cfe-4a8b-aaa6-cf757d89ef9c" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on staking/earn account banners (EarnEthBanner, StakingBanner, useEarnEthBanner), the yield navigation analytics event, and broad shared utilities (flags, intl). The highest risk is that banner rendering, navigation, or analytics firing breaks for ETH and other staking-enabled networks. The recommended tests target the analytics event directly and the main staking entry-point flows, with a few cross-network staking tests for regression confidence. No low-priority tests are warranted because the broad-utility files (flags, messages) do not give specific evidence that unrelated suites are affected.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts`
- `suite-common/analytics/src/events/yieldNavigateEvent.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — Directly exercises the StakingNavigate analytics event that corresponds to the changed yieldNavigateEvent.ts. A regression in event payload, firing condition, or EventType mapping would be caught here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests the first-time ETH staking flow starting from an inactive Ethereum account, which is exactly the context where EarnEthBanner, useEarnEthBanner, and StakingBanner are rendered. Validates that the banner-driven entry point into staking still works.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Tests the inactive Cardano staking account state where the shared StakingBanner component may be shown. Provides cross-network coverage that banner-related navigation into staking still functions.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Exercises the ETH staking dashboard and shared staking infrastructure after an initial stake. While the banner is less likely to appear here, changes to StakingBanner or yield navigation could affect dashboard continuity.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Tests the Solana staking empty-state flow, exercising the shared StakingBanner component and the transition from banner/dashboard into the staking form on a non-ETH network.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite/flags/src/flagsSlice.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-30T08:25:12.796Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29873-earn-banner/web/](https://dev.suite.sldev.cz/suite-web/feat/29873-earn-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29873-earn-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29873-earn-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/29873-earn-banner&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T08:26:49.672Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T08:26:43.624Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->