### PR TITLE
test(native-trading): co-locate general component tests

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountList.test.tsx
@@ -29,7 +29,7 @@ import {
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type Address } from '@trezor/blockchain-link-types';
 
-import { AccountList, type AccountsListProps, keyExtractor } from '../AccountList';
+import { AccountList, type AccountsListProps, keyExtractor } from './AccountList';
 
 const defaultPreloadedState = {
     device: {

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
@@ -4,8 +4,8 @@ import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 import { type ReceiveAccount } from '@suite-native/trading-types';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { AccountListAddressItem } from '../AccountListAddressItem';
+import { AccountListAddressItem } from './AccountListAddressItem';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-common/wallet-core', () => {
     const fiatRate = { rate: 1e8 };

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListFooter.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListFooter.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { AccountListFooter, type AccountsListFooterProps } from '../AccountListFooter';
+import { AccountListFooter, type AccountsListFooterProps } from './AccountListFooter';
 
 describe('AccountListFooter', () => {
     const renderAccountsListFooter = (props: Partial<AccountsListFooterProps>) =>

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
@@ -5,8 +5,8 @@ import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-nativ
 import { type ReceiveAccount } from '@suite-native/trading-types';
 import { type StaticSessionId } from '@trezor/connect';
 
-import { createTradingTestStore } from '../../../../__tests__/tradingTestUtils';
-import { AccountListItem } from '../AccountListItem';
+import { AccountListItem } from './AccountListItem';
+import { createTradingTestStore } from '../../../__tests__/tradingTestUtils';
 
 const DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 

--- a/suite-native/module-trading/src/components/general/AccountList/NoAccountsComponent.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/NoAccountsComponent.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { NoAccountsComponent } from '../NoAccountsComponent';
+import { NoAccountsComponent } from './NoAccountsComponent';
 
 describe('NoAccountsComponent', () => {
     const renderNoAccountsComponent = ({

--- a/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/LastErrorMessage.test.tsx
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { tradingSlice } from '@suite-native/trading-state';
 
-import { LastErrorMessage, type LastErrorMessageProps } from '../LastErrorMessage';
+import { LastErrorMessage, type LastErrorMessageProps } from './LastErrorMessage';
 
 describe('LastErrorMessage', () => {
     let store: TestStore;

--- a/suite-native/module-trading/src/components/general/Error/TradingTypeDisabled.test.tsx
+++ b/suite-native/module-trading/src/components/general/Error/TradingTypeDisabled.test.tsx
@@ -1,7 +1,7 @@
 import { type TradingType } from '@suite-common/trading';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { TradingTypeDisabled, type TradingTypeDisabledProps } from '../TradingTypeDisabled';
+import { TradingTypeDisabled, type TradingTypeDisabledProps } from './TradingTypeDisabled';
 
 describe('TradingTypeDisabled', () => {
     const renderTradingTypeDisabled = (props: TradingTypeDisabledProps) =>

--- a/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/FiatCurrencySheet/FiatCurrencyListItem.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { FiatCurrencyListItem, type FiatCurrencyListItemProps } from '../FiatCurrencyListItem';
+import { FiatCurrencyListItem, type FiatCurrencyListItemProps } from './FiatCurrencyListItem';
 
 describe('FiatCurrencyListItem', () => {
     const renderFiatCurrencyListItem = (props: Partial<FiatCurrencyListItemProps>) =>

--- a/suite-native/module-trading/src/components/general/Header/Header.test.tsx
+++ b/suite-native/module-trading/src/components/general/Header/Header.test.tsx
@@ -5,13 +5,13 @@ import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-fla
 import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent } from '@suite-native/test-utils-store';
 
+import { Header } from './Header';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingLightStore,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { Header } from '../Header';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('Header', () => {
     const getFFOverrides = (): PreloadedStatePartial<TradingTestPreloadedState> => ({

--- a/suite-native/module-trading/src/components/general/Input/AmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/general/Input/AmountInput.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { paletteV2 } from '@trezor/theme';
 
-import { AMOUNT_INPUT_TEST_ID, AmountInput, type AmountInputProps } from '../AmountInput';
+import { AMOUNT_INPUT_TEST_ID, AmountInput, type AmountInputProps } from './AmountInput';
 
 describe('AmountInput', () => {
     const renderAmountInput = (props: Partial<AmountInputProps>) =>

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.test.tsx
@@ -2,7 +2,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { MyAssetFilterTabs } from '../MyAssetFilterTabs';
+import { MyAssetFilterTabs } from './MyAssetFilterTabs';
 
 const availableNetworks: NetworkSymbol[] = ['btc', 'eth'];
 

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetListItem.test.tsx
@@ -12,7 +12,7 @@ import { base1NormalAccount, getBtcAccount, getEthAccount } from '@suite-native/
 import { type MyAsset } from '@suite-native/trading-types';
 import { BigNumber, getIndexOrThrow } from '@trezor/utils';
 
-import { MyAssetListItem, type MyAssetListItemProps } from '../MyAssetListItem';
+import { MyAssetListItem, type MyAssetListItemProps } from './MyAssetListItem';
 
 describe('MyAssetListItem', () => {
     const mockBtcAsset: MyAsset = {

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheet.test.tsx
@@ -13,9 +13,9 @@ import { selectAccountsWithTokensToSellSectionCondensedListByTradingType } from 
 import { type MyAssetTradeable } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { TEST_ID_ACCOUNT_TYPE_BADGE } from '../MyAssetListSectionHeader';
-import { MyAssetSheet, type MyAssetSheetProps } from '../MyAssetSheet';
+import { TEST_ID_ACCOUNT_TYPE_BADGE } from './MyAssetListSectionHeader';
+import { MyAssetSheet, type MyAssetSheetProps } from './MyAssetSheet';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.test.tsx
@@ -2,7 +2,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { MyAssetSheetHeader } from '../MyAssetSheetHeader';
+import { MyAssetSheetHeader } from './MyAssetSheetHeader';
 
 jest.mock('@trezor/react-utils', () => ({
     ...jest.requireActual('@trezor/react-utils'),

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetsDisabledListItem.test.tsx
@@ -3,7 +3,7 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import {
     MyAssetsDisabledListItem,
     type MyAssetsDisabledListItemProps,
-} from '../MyAssetsDisabledListItem';
+} from './MyAssetsDisabledListItem';
 
 describe('MyAssetsDisabledListItem', () => {
     const renderMyAssetsDisabledListItem = (props: MyAssetsDisabledListItemProps) =>

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
@@ -6,7 +6,7 @@ import {
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
-import { PaymentMethodListItem, type PaymentMethodListItemProps } from '../PaymentMethodListItem';
+import { PaymentMethodListItem, type PaymentMethodListItemProps } from './PaymentMethodListItem';
 
 describe('PaymentMethodListItem', () => {
     const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });

--- a/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/NoProvidersPlaceholder.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { NoProvidersPlaceholder } from '../NoProvidersPlaceholder';
+import { NoProvidersPlaceholder } from './NoProvidersPlaceholder';
 
 describe('NoProvidersPlaceholder', () => {
     const renderNoProvidersPlaceholder = () => renderWithBasicProvider(<NoProvidersPlaceholder />);

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
@@ -9,12 +9,12 @@ import {
     mockWalletFiatRatesAndSettings,
 } from '@suite-native/trading-fixtures';
 
+import { ProviderListItem, type ProviderListItemProps } from './ProviderListItem';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ProviderListItem, type ProviderListItemProps } from '../ProviderListItem';
+} from '../../../__tests__/tradingTestUtils';
 
 const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
     wallet: {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemValueRow.test.tsx
@@ -6,12 +6,12 @@ import {
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
+import { ProviderListItemValueRow } from './ProviderListItemValueRow';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ProviderListItemValueRow } from '../ProviderListItemValueRow';
+} from '../../../__tests__/tradingTestUtils';
 
 const overridesWithQuotes: PreloadedStatePartial<TradingTestPreloadedState> = {
     wallet: { trading: getInitializedTradingStateWithQuotes() },

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheet.test.tsx
@@ -7,12 +7,12 @@ import { getTranslation } from '@suite-native/intl';
 import { screen } from '@suite-native/test-utils-store';
 import { cexdirectFloatingQuote, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
+import { ProviderSheet, type ProviderSheetProps } from './ProviderSheet';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ProviderSheet, type ProviderSheetProps } from '../ProviderSheet';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('ProviderSheet', () => {
     const renderProviderSheet = (

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetHandle.test.tsx
@@ -1,12 +1,12 @@
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 
+import { ProviderSheetHandle, type ProviderSheetHandleProps } from './ProviderSheetHandle';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ProviderSheetHandle, type ProviderSheetHandleProps } from '../ProviderSheetHandle';
+} from '../../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-common/message-system', () => {
     const messages: Record<string, unknown> = {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderSheetSectionHeader.test.tsx
@@ -1,10 +1,10 @@
 import { type QuotesCategory } from '@suite-native/trading-types';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 import {
     ProviderSheetSectionHeader,
     type ProviderSheetSectionHeaderProps,
-} from '../ProviderSheetSectionHeader';
+} from './ProviderSheetSectionHeader';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('ProviderSheetSectionHeader', () => {
     const renderProviderSheetSectionHeader = (props: ProviderSheetSectionHeaderProps) =>

--- a/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/general/ReceiveAccount/ReceiveAccountPicker.test.tsx
@@ -2,8 +2,8 @@ import { getTranslation } from '@suite-native/intl';
 import { type TestStore, fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { btc1NormalAccount } from '@suite-native/trading-fixtures';
 
-import { createTradingTestStore } from '../../../../__tests__/tradingTestUtils';
-import { ReceiveAccountPicker, type ReceiveAccountPickerProps } from '../ReceiveAccountPicker';
+import { ReceiveAccountPicker, type ReceiveAccountPickerProps } from './ReceiveAccountPicker';
+import { createTradingTestStore } from '../../../__tests__/tradingTestUtils';
 
 const defaultOverrides = {
     device: {

--- a/suite-native/module-trading/src/components/general/TradeInfo/ProviderInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/ProviderInfoRow.test.tsx
@@ -2,7 +2,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
-import { ProviderInfoRow, type ProviderInfoRowProps } from '../ProviderInfoRow';
+import { ProviderInfoRow, type ProviderInfoRowProps } from './ProviderInfoRow';
 
 describe('ProviderInfoRow', () => {
     const renderProviderInfoRow = (props: Partial<ProviderInfoRowProps> = {}) => {

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeFiatSideCard.test.tsx
@@ -2,7 +2,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import type { ExtendedSellCryptoPaymentMethod } from '@suite-native/trading-types';
 
-import { TradeFiatSideCard, type TradeFiatSideCardProps } from '../TradeFiatSideCard';
+import { TradeFiatSideCard, type TradeFiatSideCardProps } from './TradeFiatSideCard';
 
 describe('TradeFiatSideCard', () => {
     const renderTradeFiatSideCard = (props: TradeFiatSideCardProps) =>

--- a/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeInfo/TradeInfo.test.tsx
@@ -6,8 +6,8 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { mercuryoDexQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { TradeInfo } from '../TradeInfo';
+import { TradeInfo } from './TradeInfo';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 const btc1AccountKey = mockAccountKey({ symbol: 'btc', descriptor: 'btc1' });
 


### PR DESCRIPTION
## Description

Moves 26 Native Trading general-component tests from Account List through Trade Info beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-general-components-1-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->