### PR TITLE
test(native-trading): co-locate buy components

### DIFF
--- a/suite-native/module-trading/src/components/buy/BuyAlert.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyAlert.test.tsx
@@ -5,8 +5,8 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
 
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyAlert } from '../BuyAlert';
+import { BuyAlert } from './BuyAlert';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyAlert', () => {
     let form: BuyFormType;

--- a/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
@@ -3,13 +3,13 @@ import { getTranslation } from '@suite-native/intl';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
 
+import { BuyCard } from './BuyCard';
 import {
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyCard } from '../BuyCard';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyCard', () => {
     let form: BuyFormType;

--- a/suite-native/module-trading/src/components/buy/BuyConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyConfirmation.test.tsx
@@ -3,11 +3,11 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
-import { BuyConfirmation } from '../BuyConfirmation';
+import { BuyConfirmation } from './BuyConfirmation';
 
 const CTA_TEXT = getTranslation('moduleTrading.tradingScreen.buttons.continue');
 
-jest.mock('../../../hooks/buy/useBuyFlow', () => ({
+jest.mock('../../hooks/buy/useBuyFlow', () => ({
     useBuyFlow: jest.fn(),
 }));
 
@@ -16,20 +16,20 @@ jest.mock('@suite-native/forms', () => ({
     useWatch: () => [undefined, undefined],
 }));
 
-jest.mock('../../../hooks/buy/useBuyFormContext', () => ({
+jest.mock('../../hooks/buy/useBuyFormContext', () => ({
     useBuyFormContext: () => ({
         control: undefined,
     }),
 }));
 
-jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
+jest.mock('../../hooks/general/useTradingStellarActivateToken', () => ({
     useTradingStellarActivateToken: jest.fn(),
 }));
 
 describe('BuyConfirmation', () => {
-    const mockUseBuyFlow = require('../../../hooks/buy/useBuyFlow').useBuyFlow;
+    const mockUseBuyFlow = require('../../hooks/buy/useBuyFlow').useBuyFlow;
     const mockUseTradingStellarActivateToken =
-        require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
+        require('../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
     const renderConfirmation = () =>
         renderWithStoreProvider(<BuyConfirmation />, {

--- a/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCryptoAmountInput.test.tsx
@@ -5,14 +5,14 @@ import { btcAsset } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
+import { BuyCryptoAmountInput, type CryptoAmountInputProps } from './BuyCryptoAmountInput';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyCryptoAmountInput, type CryptoAmountInputProps } from '../BuyCryptoAmountInput';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyCryptoAmountInput', () => {
     const renderCryptoAmountInput = (

--- a/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatAmountInput.test.tsx
@@ -3,14 +3,14 @@ import { getTranslation } from '@suite-native/intl';
 import { act, userEvent } from '@suite-native/test-utils-store';
 import { type BuyFormType } from '@suite-native/trading-types';
 
+import { BuyFiatAmountInput } from './BuyFiatAmountInput';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyFiatAmountInput } from '../BuyFiatAmountInput';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyFiatAmountInput', () => {
     const renderFiatAmountInput = (

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencyPicker.test.tsx
@@ -14,9 +14,9 @@ import {
 import { buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 
-import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyFiatCurrencyPicker } from '../BuyFiatCurrencyPicker';
+import { BuyFiatCurrencyPicker } from './BuyFiatCurrencyPicker';
+import { createTradingLightStore } from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 let mockUseListDataFilter: typeof useListDataFilter;
 const reportMock = jest.fn();

--- a/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFiatCurrencySheet.test.tsx
@@ -1,7 +1,7 @@
 import { renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
-import { BuyFiatCurrencySheet } from '../BuyFiatCurrencySheet';
+import { BuyFiatCurrencySheet } from './BuyFiatCurrencySheet';
 
 describe('BuyFiatCurrencySheet', () => {
     const renderBuyFiatCurrencySheet = () =>

--- a/suite-native/module-trading/src/components/buy/BuyForm.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyForm.test.tsx
@@ -4,21 +4,21 @@ import { act, screen } from '@suite-native/test-utils-store';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
 
+import { BuyForm } from './BuyForm';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyForm } from '../BuyForm';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
-jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
-    jest.requireActual('../../../hooks/general/useFocusedValueWatch'),
+jest.mock('../../hooks/general/useFocusedValueWatch', () =>
+    jest.requireActual('../../hooks/general/useFocusedValueWatch'),
 );
 
-jest.mock('../../concierge/ConciergeAlert', () => ({
+jest.mock('../concierge/ConciergeAlert', () => ({
     ConciergeAlert: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyFormFieldErrorBadge.test.tsx
@@ -8,17 +8,14 @@ import { btcAsset, getInitializedTradingStateWithQuotes } from '@suite-native/tr
 import { type BuyFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
+import { BuyFormFieldErrorBadge, type BuyFormFieldErrorBadgeProps } from './BuyFormFieldErrorBadge';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import {
-    BuyFormFieldErrorBadge,
-    type BuyFormFieldErrorBadgeProps,
-} from '../BuyFormFieldErrorBadge';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyFormFieldErrorBadge', () => {
     let tradingForm: BuyFormType;

--- a/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPaymentMethodPicker.test.tsx
@@ -29,8 +29,8 @@ import { tradingSlice } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { mergeDeepObject } from '@trezor/utils';
 
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyPaymentMethodPicker } from '../BuyPaymentMethodPicker';
+import { BuyPaymentMethodPicker } from './BuyPaymentMethodPicker';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 const reportMock = jest.fn();
 const creditCardPaymentMethodTranslation = getTranslation(

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyGeneralErrorScreen.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyGeneralErrorScreen.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { BuyGeneralErrorScreen } from '../BuyGeneralErrorScreen';
+import { BuyGeneralErrorScreen } from './BuyGeneralErrorScreen';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewContinueButton.test.tsx
@@ -1,11 +1,11 @@
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { useBuyPreviewFlow } from '../../../../hooks/buy/useBuyPreviewFlow';
-import { BuyPreviewContinueButton } from '../BuyPreviewContinueButton';
+import { BuyPreviewContinueButton } from './BuyPreviewContinueButton';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
+import { useBuyPreviewFlow } from '../../../hooks/buy/useBuyPreviewFlow';
 
-jest.mock('../../../../hooks/buy/useBuyPreviewFlow', () => ({
+jest.mock('../../../hooks/buy/useBuyPreviewFlow', () => ({
     useBuyPreviewFlow: jest.fn(),
 }));
 

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewInfoCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewInfoCard.test.tsx
@@ -1,8 +1,8 @@
 import { getTranslation } from '@suite-native/intl';
 import { mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { BuyPreviewInfoCard } from '../BuyPreviewInfoCard';
+import { BuyPreviewInfoCard } from './BuyPreviewInfoCard';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('BuyPreviewInfoCard', () => {
     const renderCard = (quote = mercuryoApplePayBuyQuote) =>

--- a/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewReceiveCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyPreview/BuyPreviewReceiveCard.test.tsx
@@ -2,8 +2,8 @@ import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils-store';
 import { btc1NormalAccount, mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { BuyPreviewReceiveCard } from '../BuyPreviewReceiveCard';
+import { BuyPreviewReceiveCard } from './BuyPreviewReceiveCard';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('BuyPreviewReceiveCard', () => {
     const withReceiveAccount = {

--- a/suite-native/module-trading/src/components/buy/BuyProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyProviderPicker.test.tsx
@@ -13,14 +13,14 @@ import {
 import { type BuyFormType } from '@suite-native/trading-types';
 import { getIndexOrThrow, mergeDeepObject } from '@trezor/utils';
 
+import { BuyProviderPicker } from './BuyProviderPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyProviderPicker } from '../BuyProviderPicker';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountCryptoBalance.test.tsx
@@ -8,11 +8,11 @@ import {
 import { btcAsset, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
 
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
 import {
     BuyReceiveAccountCryptoBalance,
     RECEIVE_ACCOUNT_BALANCE_TEST_ID,
-} from '../BuyReceiveAccountCryptoBalance';
+} from './BuyReceiveAccountCryptoBalance';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 describe('BuyReceiveAccountCryptoBalance', () => {
     let buyForm: BuyFormType;

--- a/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyReceiveAccountPicker.test.tsx
@@ -8,14 +8,14 @@ import {
     type TradeableAsset,
 } from '@suite-native/trading-types';
 
+import { BuyReceiveAccountPicker } from './BuyReceiveAccountPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyReceiveAccountPicker } from '../BuyReceiveAccountPicker';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 const mockNavigate = jest.fn();
 const btcAccountName1 = 'BTC Account #1';

--- a/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTab.test.tsx
@@ -2,16 +2,16 @@ import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 import { selectIsTradingBuyEnabled } from '@suite-native/trading-state';
 
+import { BuyTab } from './BuyTab';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { BuyTab } from '../BuyTab';
+} from '../../__tests__/tradingTestUtils';
 
 let mockUseTradingBuyData: jest.Mock;
 
-jest.mock('../../../hooks/buy/useBuyData', () => ({
+jest.mock('../../hooks/buy/useBuyData', () => ({
     useBuyData: (...params: unknown[]) => mockUseTradingBuyData(...params),
 }));
 
@@ -20,7 +20,7 @@ jest.mock('@suite-native/trading-state', () => ({
     selectIsTradingBuyEnabled: jest.fn(),
 }));
 
-jest.mock('../../concierge/ConciergeAlert', () => ({
+jest.mock('../concierge/ConciergeAlert', () => ({
     ConciergeAlert: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyTradeableAssetPicker.test.tsx
@@ -15,13 +15,13 @@ import { buyActions } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
+import { BuyTradeableAssetPicker } from './BuyTradeableAssetPicker';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useBuyForm } from '../../../hooks/buy/useBuyForm';
-import { BuyTradeableAssetPicker } from '../BuyTradeableAssetPicker';
+} from '../../__tests__/tradingTestUtils';
+import { useBuyForm } from '../../hooks/buy/useBuyForm';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {


### PR DESCRIPTION
## Description

Moves 19 Native Trading buy-component tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-buy-components-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->