### PR TITLE
test(native-trading): co-locate exchange component tests

### DIFF
--- a/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ApprovalButton.test.tsx
@@ -4,8 +4,8 @@ import { getTranslation } from '@suite-native/intl';
 import { type TestStore, renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { ApprovalButton, type ApprovalButtonProps } from '../ApprovalButton';
+import { ApprovalButton, type ApprovalButtonProps } from './ApprovalButton';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 const mockNavigate = jest.fn();
 

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalDetails.test.tsx
@@ -2,12 +2,12 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
+import { ExchangeApprovalDetails } from './ExchangeApprovalDetails';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ExchangeApprovalDetails } from '../ExchangeApprovalDetails';
+} from '../../../__tests__/tradingTestUtils';
 
 // Mock FeeSelector to avoid deep dependency chain (useFeesManagement, etc.)
 jest.mock('@suite-native/transaction-management', () => ({

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitCard.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, renderWithBasicProvider } from '@suite-native/test-util
 import {
     ExchangeApprovalLimitCard,
     type ExchangeApprovalLimitCardProps,
-} from '../ExchangeApprovalLimitCard';
+} from './ExchangeApprovalLimitCard';
 
 const mockOnChange = jest.fn();
 

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeApprovalLimitSheet/ExchangeApprovalLimitSheet.test.tsx
@@ -2,8 +2,8 @@ import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../../__tests__/tradingTestUtils';
-import { ExchangeApprovalLimitSheet } from '../ExchangeApprovalLimitSheet';
+import { ExchangeApprovalLimitSheet } from './ExchangeApprovalLimitSheet';
+import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 
 const mockOnDismiss = jest.fn();
 const mockOnApprovalTypeSelect = jest.fn();

--- a/suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/ExchangeRevokeDetails.test.tsx
@@ -2,12 +2,12 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
+import { ExchangeRevokeDetails } from './ExchangeRevokeDetails';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { ExchangeRevokeDetails } from '../ExchangeRevokeDetails';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('ExchangeRevokeDetails', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitInfoRow.test.tsx
@@ -5,7 +5,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
 import { getWalletState, mercuryoFixedBestQuote } from '@suite-native/trading-fixtures';
 
-import { LimitInfoRow } from '../LimitInfoRow';
+import { LimitInfoRow } from './LimitInfoRow';
 
 type LimitInfoRowProps = React.ComponentProps<typeof LimitInfoRow>;
 

--- a/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/LimitPicker.test.tsx
@@ -8,8 +8,8 @@ import {
 } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { LimitPicker } from '../LimitPicker';
+import { LimitPicker } from './LimitPicker';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 describe('LimitPicker', () => {
     let store: TestStore;

--- a/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/OriginalLimit.test.tsx
@@ -4,7 +4,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
-import { OriginalLimit } from '../OriginalLimit';
+import { OriginalLimit } from './OriginalLimit';
 
 const mockSelectTradingExchangeSelectedQuote = jest.fn();
 

--- a/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Approval/RevokeLimitInfoRow.test.tsx
@@ -2,12 +2,12 @@ import { UINT256_MAX } from '@suite-common/suite-constants';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 import { BigNumber } from '@trezor/utils';
 
+import { RevokeLimitInfoRow } from './RevokeLimitInfoRow';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { RevokeLimitInfoRow } from '../RevokeLimitInfoRow';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('RevokeLimitInfoRow', () => {
     const renderRevokeLimitInfoRow = (

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationHeader.test.tsx
@@ -5,11 +5,11 @@ import { getTranslation } from '@suite-native/intl';
 import { type TestStore, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
 import {
     ExchangeConfirmationHeader,
     type ExchangeConfirmationHeaderProps,
-} from '../ExchangeConfirmationHeader';
+} from './ExchangeConfirmationHeader';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 const testQuote = exchangeQuotes[0];
 

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationInfo.test.tsx
@@ -6,11 +6,11 @@ import { type TestStore, renderWithStoreProvider, screen } from '@suite-native/t
 import { mockTransaction } from '@suite-native/tokens';
 import { exchangeQuotes } from '@suite-native/trading-fixtures';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
 import {
     ExchangeConfirmationInfo,
     type ExchangeConfirmationInfoCardProps,
-} from '../ExchangeConfirmationInfo';
+} from './ExchangeConfirmationInfo';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 const testQuote = exchangeQuotes[0];
 

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExchangeConfirmationTitle.test.tsx
@@ -4,7 +4,7 @@ import { renderWithBasicProvider } from '@suite-native/test-utils';
 import {
     ExchangeConfirmationTitle,
     type ExchangeConfirmationTitleProps,
-} from '../ExchangeConfirmationTitle';
+} from './ExchangeConfirmationTitle';
 
 describe('ExchangeConfirmationTitle', () => {
     const renderTitle = (props: ExchangeConfirmationTitleProps) =>

--- a/suite-native/module-trading/src/components/exchange/Confirmation/ExploreInBlockchainButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/Confirmation/ExploreInBlockchainButton.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider, screen, userEvent } from '@suite-native/test-utils';
 
-import { ExploreInBlockchainButton } from '../ExploreInBlockchainButton';
+import { ExploreInBlockchainButton } from './ExploreInBlockchainButton';
 
 describe('ExploreInBlockchainButton', () => {
     const getButtonByText = () =>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeEIP712Info.test.tsx
@@ -3,8 +3,8 @@ import { Text } from 'react-native';
 import { getTranslation } from '@suite-native/intl';
 import { exchangeOneInchFusion, exchangeOneInchFusionPlus } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { ExchangeEIP712Info, type ExchangeEIP712InfoProps } from '../ExchangeEIP712Info';
+import { ExchangeEIP712Info, type ExchangeEIP712InfoProps } from './ExchangeEIP712Info';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('ExchangeEIP712Info', () => {
     const renderExchangeEIP712Info = (

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFiatDeviationWarning.test.tsx
@@ -4,7 +4,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { ExchangeFiatDeviationWarning } from '../ExchangeFiatDeviationWarning';
+import { ExchangeFiatDeviationWarning } from './ExchangeFiatDeviationWarning';
 
 const mockExchangeFiatDeviation = jest.fn();
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeFromAccountTradePreviewCard.test.tsx
@@ -2,11 +2,11 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { eth1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 import {
     ExchangeFromAccountTradePreviewCard,
     type ExchangeFromAccountTradePreviewCardProps,
-} from '../ExchangeFromAccountTradePreviewCard';
+} from './ExchangeFromAccountTradePreviewCard';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('ExchangeFromAccountTradePreviewCard', () => {
     const renderExchangeFromAccountTradePreviewCard = (

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeInfo.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeInfo.test.tsx
@@ -5,8 +5,8 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { btc1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { ExchangeInfo, type ExchangeInfoProps } from '../ExchangeInfo';
+import { ExchangeInfo, type ExchangeInfoProps } from './ExchangeInfo';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 // Mock FeeSelector to avoid deep dependency chain
 jest.mock('@suite-native/transaction-management', () => ({

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewContinueButton.test.tsx
@@ -5,14 +5,14 @@ import { createPrecomposedTxFinal, mercuryoFixedWorstQuote } from '@suite-native
 import { mergeDeepObject } from '@trezor/utils';
 
 import {
+    ExchangePreviewContinueButton,
+    type ExchangePreviewContinueButtonProps,
+} from './ExchangePreviewContinueButton';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import {
-    ExchangePreviewContinueButton,
-    type ExchangePreviewContinueButtonProps,
-} from '../ExchangePreviewContinueButton';
+} from '../../../__tests__/tradingTestUtils';
 
 const mockNavigate = jest.fn();
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.test.tsx
@@ -9,8 +9,8 @@ import {
     oneInchFusionPlusWithoutEip712SignDataQuote,
 } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { ExchangePreviewView, type ExchangePreviewViewProps } from '../ExchangePreviewView';
+import { ExchangePreviewView, type ExchangePreviewViewProps } from './ExchangePreviewView';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('ExchangePreviewView', () => {
     const renderExchangePreviewView = (props: Partial<ExchangePreviewViewProps> = {}) =>

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.test.tsx
@@ -2,11 +2,11 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { btc1NormalAccount, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 import {
     ExchangeToAccountTradePreviewCard,
     type ExchangeToAccountTradePreviewCardProps,
-} from '../ExchangeToAccountTradePreviewCard';
+} from './ExchangeToAccountTradePreviewCard';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('ExchangeToAccountTradePreviewCard', () => {
     const renderExchangeToAccountTradePreviewCard = (


### PR DESCRIPTION
## Description

Moves 20 Native Trading exchange approval, confirmation, and preview component tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-exchange-components-1-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->