### PR TITLE
test(native-trading): co-locate remaining exchange components

### DIFF
--- a/suite-native/module-trading/src/components/exchange/ExchangeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeAlert.test.tsx
@@ -6,8 +6,8 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangeAlert } from '../ExchangeAlert';
+import { ExchangeAlert } from './ExchangeAlert';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeAlert', () => {
     let form: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
@@ -9,9 +9,9 @@ import {
 import { ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
-import { createTradingPreloadedState } from '../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangeCard } from '../ExchangeCard';
+import { ExchangeCard } from './ExchangeCard';
+import { createTradingPreloadedState } from '../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeCard', () => {
     let form: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeConfirmation.test.tsx
@@ -6,21 +6,21 @@ import { getTranslation } from '@suite-native/intl';
 import { act, screen } from '@suite-native/test-utils-store';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import { CONFIRMATION_TEST_ID, ExchangeConfirmation } from './ExchangeConfirmation';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { CONFIRMATION_TEST_ID, ExchangeConfirmation } from '../ExchangeConfirmation';
+} from '../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
-jest.mock('../../../hooks/exchange/useExchangeSelectQuote', () => ({
+jest.mock('../../hooks/exchange/useExchangeSelectQuote', () => ({
     useExchangeSelectQuote: jest.fn(),
 }));
 
-jest.mock('../../../hooks/general/useTradingStellarActivateToken', () => ({
+jest.mock('../../hooks/general/useTradingStellarActivateToken', () => ({
     useTradingStellarActivateToken: jest.fn(),
 }));
 
@@ -28,9 +28,9 @@ describe('ExchangeConfirmation', () => {
     let exchangeForm: ExchangeFormType;
 
     const mockUseExchangeSelectQuote =
-        require('../../../hooks/exchange/useExchangeSelectQuote').useExchangeSelectQuote;
+        require('../../hooks/exchange/useExchangeSelectQuote').useExchangeSelectQuote;
     const mockUseTradingStellarActivateToken =
-        require('../../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
+        require('../../hooks/general/useTradingStellarActivateToken').useTradingStellarActivateToken;
 
     const baseOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
         featureFlags: createTradingFeatureFlags(),

--- a/suite-native/module-trading/src/components/exchange/ExchangeForm.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeForm.test.tsx
@@ -13,15 +13,15 @@ import {
 } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import { ExchangeForm } from './ExchangeForm';
 import {
     createTradingFeatureFlags,
     createTradingPreloadedState,
-} from '../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangeForm } from '../ExchangeForm';
+} from '../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
-jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
-    jest.requireActual('../../../hooks/general/useFocusedValueWatch'),
+jest.mock('../../hooks/general/useFocusedValueWatch', () =>
+    jest.requireActual('../../hooks/general/useFocusedValueWatch'),
 );
 
 describe('ExchangeForm', () => {

--- a/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeFormQuoteDebugView.test.tsx
@@ -5,7 +5,7 @@ import type { CryptoId, ExchangeTrade } from 'invity-api';
 import { UINT256_MAX } from '@suite-common/suite-constants';
 import { renderWithBasicProvider, screen } from '@suite-native/test-utils';
 
-import { ExchangeFormQuoteDebugView } from '../ExchangeFormQuoteDebugView';
+import { ExchangeFormQuoteDebugView } from './ExchangeFormQuoteDebugView';
 
 const USDC_CONTRACT_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const USDC_CRYPTO_ID = `ethereum--${USDC_CONTRACT_ADDRESS}` as CryptoId;
@@ -26,7 +26,7 @@ jest.mock('@suite-native/forms', () => ({
     useWatch: () => [mockQuote, mockSendAccount],
 }));
 
-jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
+jest.mock('../../hooks/exchange/useExchangeFormContext', () => ({
     useExchangeFormContext: () => ({
         control: undefined,
     }),
@@ -42,7 +42,7 @@ jest.mock('@suite-native/trading-debug', () => {
     };
 });
 
-jest.mock('../ExchangeUsdcPresetButton', () => ({
+jest.mock('./ExchangeUsdcPresetButton', () => ({
     ExchangeUsdcPresetButton: () => <Text>PRESET BUTTON MOCK</Text>,
 }));
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePickersCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePickersCard.test.tsx
@@ -4,15 +4,15 @@ import { act } from '@suite-native/test-utils-store';
 import { btcAsset, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import { ExchangePickersCard } from './ExchangePickersCard';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangePickersCard } from '../ExchangePickersCard';
+} from '../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
 const reportMock = jest.fn();
 const mockNavigate = jest.fn();

--- a/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeProviderPicker.test.tsx
@@ -3,11 +3,8 @@ import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type PreloadedStatePartial } from '@suite-native/test-utils-store';
 import { getWalletState, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { type TradingTestPreloadedState } from '../../../__tests__/tradingTestUtils';
-import {
-    ExchangeProviderPicker,
-    type ExchangeProviderPickerProps,
-} from '../ExchangeProviderPicker';
+import { ExchangeProviderPicker, type ExchangeProviderPickerProps } from './ExchangeProviderPicker';
+import { type TradingTestPreloadedState } from '../../__tests__/tradingTestUtils';
 
 describe('ExchangeProviderPicker', () => {
     let preloadedState: PreloadedStatePartial<TradingTestPreloadedState>;

--- a/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeRateAndProviderPicker.test.tsx
@@ -8,14 +8,14 @@ import { exchangeQuotes, mercuryoFixedWorstQuote } from '@suite-native/trading-f
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { getIndexOrThrow } from '@trezor/utils';
 
+import { ExchangeRateAndProviderPicker } from './ExchangeRateAndProviderPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
-import { ExchangeRateAndProviderPicker } from '../ExchangeRateAndProviderPicker';
+} from '../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {

--- a/suite-native/module-trading/src/components/exchange/ExchangeTab.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTab.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { ExchangeTab } from '../ExchangeTab';
+import { ExchangeTab } from './ExchangeTab';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 let mockIsDeviceInViewOnlyMode = false;
 let mockIsPortfolioTrackerDevice = false;
@@ -15,7 +15,7 @@ jest.mock('@suite-common/device', () => ({
     selectHasBitcoinOnlyFirmware: () => mockHasBitcoinOnlyFirmware,
 }));
 
-jest.mock('../../../hooks/exchange/useExchangeData', () => ({
+jest.mock('../../hooks/exchange/useExchangeData', () => ({
     useExchangeData: () => ({
         isLoading: false,
         lastLoadedTimestamp: 1,

--- a/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeTabContent.test.tsx
@@ -1,12 +1,12 @@
 import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { ExchangeTabContent } from '../ExchangeTabContent';
+import { ExchangeTabContent } from './ExchangeTabContent';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 let mockUseTradingExchangeData: jest.Mock;
 
-jest.mock('../../../hooks/exchange/useExchangeData', () => ({
+jest.mock('../../hooks/exchange/useExchangeData', () => ({
     useExchangeData: (...params: unknown[]) => mockUseTradingExchangeData(...params),
 }));
 

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
@@ -2,17 +2,17 @@ import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
 
+import { ExchangeUsdcPresetButton } from './ExchangeUsdcPresetButton';
 import {
     createTradingLightStore,
     createTradingPreloadedState,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { ExchangeUsdcPresetButton } from '../ExchangeUsdcPresetButton';
+} from '../../__tests__/tradingTestUtils';
 
 const mockSetValue = jest.fn();
 const mockGetValues = jest.fn();
 
-jest.mock('../../../hooks/exchange/useExchangeFormContext', () => ({
+jest.mock('../../hooks/exchange/useExchangeFormContext', () => ({
     useExchangeFormContext: () => ({ getValues: mockGetValues, setValue: mockSetValue }),
 }));
 

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountCryptoBalance.test.tsx
@@ -9,11 +9,11 @@ import {
 import { btcAsset, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
 import {
     ExchangeReceiveAccountCryptoBalance,
     RECEIVE_ACCOUNT_BALANCE_TEST_ID,
-} from '../ExchangeReceiveAccountCryptoBalance';
+} from './ExchangeReceiveAccountCryptoBalance';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeReceiveAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAccountPicker.test.tsx
@@ -9,15 +9,15 @@ import {
 } from '@suite-native/trading-types';
 import { mergeDeepObject } from '@trezor/utils';
 
+import { ExchangeReceiveAccountPicker } from './ExchangeReceiveAccountPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeReceiveAccountPicker } from '../ExchangeReceiveAccountPicker';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 const mockNavigate = jest.fn();
 const btcAccountName1 = 'BTC Account #1';

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
@@ -6,16 +6,16 @@ import { mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtur
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
 import {
+    ExchangeReceiveAmountInput,
+    type ExchangeReceiveAmountInputProps,
+} from './ExchangeReceiveAmountInput';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import {
-    ExchangeReceiveAmountInput,
-    type ExchangeReceiveAmountInputProps,
-} from '../ExchangeReceiveAmountInput';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeReceiveAmountInput', () => {
     let form: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
@@ -8,12 +8,12 @@ import {
 import { mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import { ExchangeReceiveContent } from './ExchangeReceiveContent';
 import {
     createTradingFeatureFlags,
     createTradingPreloadedState,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeReceiveContent } from '../ExchangeReceiveContent';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeReceiveContent', () => {
     let form: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeTradeableAssetPicker.test.tsx
@@ -17,13 +17,13 @@ import { exchangeActions } from '@suite-native/trading-state';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { FirmwareType } from '@trezor/connect';
 
+import { ExchangeTradeableAssetPicker } from './ExchangeTradeableAssetPicker';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeTradeableAssetPicker } from '../ExchangeTradeableAssetPicker';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAccountCryptoBalance.test.tsx
@@ -4,14 +4,14 @@ import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
 import {
-    renderHookWithTradingProvider,
-    renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import {
     ExchangeSendAccountCryptoBalance,
     SEND_ACCOUNT_BALANCE_TEST_ID,
-} from '../ExchangeSendAccountCryptoBalance';
+} from './ExchangeSendAccountCryptoBalance';
+import {
+    renderHookWithTradingProvider,
+    renderWithTradingProvider,
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeSendAccountCryptoBalance', () => {
     let exchangeForm: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountBadge.test.tsx
@@ -5,14 +5,14 @@ import { btcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
+import { ExchangeSendAmountBadge } from './ExchangeSendAmountBadge';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeSendAmountBadge } from '../ExchangeSendAmountBadge';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeSendAmountBadge', () => {
     let form: ExchangeFormType;

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAmountInput.test.tsx
@@ -10,22 +10,22 @@ import { PROTO } from '@trezor/connect';
 import { mergeDeepObject } from '@trezor/utils';
 
 import {
+    ExchangeSendAmountInput,
+    type ExchangeSendAmountInputProps,
+} from './ExchangeSendAmountInput';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import {
-    ExchangeSendAmountInput,
-    type ExchangeSendAmountInputProps,
-} from '../ExchangeSendAmountInput';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 const mockUseAmountInputDecimals = jest.fn(
     (_account?: Account, _contractAddress?: TokenAddress) => 8,
 );
 
-jest.mock('../../../../hooks/general/useAmountInputDecimals', () => ({
+jest.mock('../../../hooks/general/useAmountInputDecimals', () => ({
     useAmountInputDecimals: jest.fn((account?: Account, contractAddress?: TokenAddress) =>
         mockUseAmountInputDecimals(account, contractAddress),
     ),

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendAssetPicker.test.tsx
@@ -35,8 +35,8 @@ import {
 import { type ExchangeFormType, type MyAssetTradeable } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeSendAssetPicker } from '../ExchangeSendAssetPicker';
+import { ExchangeSendAssetPicker } from './ExchangeSendAssetPicker';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.test.tsx
@@ -8,12 +8,12 @@ import {
 import { usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
+import { ExchangeSendContent } from './ExchangeSendContent';
 import {
     createTradingFeatureFlags,
     createTradingPreloadedState,
-} from '../../../../__tests__/tradingTestUtils';
-import { useExchangeForm } from '../../../../hooks/exchange/useExchangeForm';
-import { ExchangeSendContent } from '../ExchangeSendContent';
+} from '../../../__tests__/tradingTestUtils';
+import { useExchangeForm } from '../../../hooks/exchange/useExchangeForm';
 
 describe('ExchangeSendContent', () => {
     let form: ExchangeFormType;


### PR DESCRIPTION
## Description

Moves the remaining 21 Native Trading exchange-component tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-exchange-components-2-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->