### PR TITLE
test(native-trading): co-locate sell components

### DIFF
--- a/suite-native/module-trading/src/components/sell/SellAlert.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellAlert.test.tsx
@@ -4,8 +4,8 @@ import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 
-import { useSellForm } from '../../../hooks/sell/useSellForm';
-import { SellAlert } from '../SellAlert';
+import { SellAlert } from './SellAlert';
+import { useSellForm } from '../../hooks/sell/useSellForm';
 
 describe('SellAlert', () => {
     let form: SellFormType;

--- a/suite-native/module-trading/src/components/sell/SellCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.test.tsx
@@ -9,9 +9,9 @@ import {
 import { sellQuotes, usdcAsset } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 
-import { createTradingPreloadedState } from '../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../hooks/sell/useSellForm';
-import { SellCard } from '../SellCard';
+import { SellCard } from './SellCard';
+import { createTradingPreloadedState } from '../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../hooks/sell/useSellForm';
 
 describe('SellCard', () => {
     let form: SellFormType;

--- a/suite-native/module-trading/src/components/sell/SellConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellConfirmation.test.tsx
@@ -2,14 +2,14 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingStateWithQuotes } from '@suite-native/trading-fixtures';
 
-import { SellConfirmation } from '../SellConfirmation';
+import { SellConfirmation } from './SellConfirmation';
 
 const EXCHANGE_NAME = 'test-provider';
 const CTA_TEXT = getTranslation('moduleTrading.tradingScreen.buttons.sellVia', {
     providerName: EXCHANGE_NAME,
 });
 
-jest.mock('../../../hooks/sell/useSellSelectQuote', () => ({
+jest.mock('../../hooks/sell/useSellSelectQuote', () => ({
     useSellSelectQuote: jest.fn(),
 }));
 
@@ -18,7 +18,7 @@ jest.mock('@suite-native/forms', () => ({
     useWatch: () => ({ exchange: 'test-provider' }),
 }));
 
-jest.mock('../../../hooks/sell/useSellFormContext', () => ({
+jest.mock('../../hooks/sell/useSellFormContext', () => ({
     useSellFormContext: () => ({
         control: undefined,
     }),
@@ -26,7 +26,7 @@ jest.mock('../../../hooks/sell/useSellFormContext', () => ({
 
 describe('SellConfirmation', () => {
     const mockUseSellSelectQuote =
-        require('../../../hooks/sell/useSellSelectQuote').useSellSelectQuote;
+        require('../../hooks/sell/useSellSelectQuote').useSellSelectQuote;
 
     const renderConfirmation = () =>
         renderWithStoreProvider(<SellConfirmation />, {

--- a/suite-native/module-trading/src/components/sell/SellForm.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellForm.test.tsx
@@ -12,20 +12,20 @@ import {
 } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 
+import { SellForm } from './SellForm';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../hooks/sell/useSellForm';
-import { SellForm } from '../SellForm';
+} from '../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../hooks/sell/useSellForm';
 
-jest.mock('../../../hooks/general/useFocusedValueWatch', () =>
-    jest.requireActual('../../../hooks/general/useFocusedValueWatch'),
+jest.mock('../../hooks/general/useFocusedValueWatch', () =>
+    jest.requireActual('../../hooks/general/useFocusedValueWatch'),
 );
 
-jest.mock('../../concierge/ConciergeAlert', () => ({
+jest.mock('../concierge/ConciergeAlert', () => ({
     ConciergeAlert: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellFormFieldErrorBadge.test.tsx
@@ -6,16 +6,16 @@ import { type SellFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
 import {
+    SellFormFieldErrorBadge,
+    type SellFormFieldErrorBadgeProps,
+} from './SellFormFieldErrorBadge';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../hooks/sell/useSellForm';
-import {
-    SellFormFieldErrorBadge,
-    type SellFormFieldErrorBadgeProps,
-} from '../SellFormFieldErrorBadge';
+} from '../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../hooks/sell/useSellForm';
 
 describe('SellFormFieldErrorBadge', () => {
     let tradingForm: SellFormType;

--- a/suite-native/module-trading/src/components/sell/SellKYCWarning.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellKYCWarning.test.tsx
@@ -2,12 +2,12 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { sellQuotes } from '@suite-native/trading-fixtures';
 
+import { SellKYCWarning } from './SellKYCWarning';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingPreloadedState,
-} from '../../../__tests__/tradingTestUtils';
-import { SellKYCWarning } from '../SellKYCWarning';
+} from '../../__tests__/tradingTestUtils';
 
 describe('SellKYCWarning', () => {
     const KYC_REQUIRED_TEXT = getTranslation('moduleTrading.tradingScreen.kycRequired');

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountItem.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountItem.test.tsx
@@ -4,7 +4,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { unverifiedBankAccount, verifiedBankAccount } from '@suite-native/trading-fixtures';
 
-import { BANK_ACCOUNT_ITEM_TEST_ID, SellBankAccountItem } from '../SellBankAccountItem';
+import { BANK_ACCOUNT_ITEM_TEST_ID, SellBankAccountItem } from './SellBankAccountItem';
 
 describe('SellBankAccountItem', () => {
     const renderSellBankAccountItem = (props = {}) =>

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountPicker.test.tsx
@@ -7,15 +7,15 @@ import {
     verifiedBankAccount,
 } from '@suite-native/trading-fixtures';
 
+import { SellBankAccountPicker } from './SellBankAccountPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../../__tests__/tradingTestUtils';
-import { SellBankAccountPicker } from '../SellBankAccountPicker';
+} from '../../../../__tests__/tradingTestUtils';
 
 // Mock the SellBankAccountSheet component to isolate the picker component
-jest.mock('../SellBankAccountSheet', () => ({
+jest.mock('./SellBankAccountSheet', () => ({
     SellBankAccountSheet: jest.fn().mockImplementation(() => <div>Bank Account Sheet</div>),
 }));
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountSheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/BankAccount/SellBankAccountSheet.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { bankAccounts, verifiedBankAccount } from '@suite-native/trading-fixtures';
 
-import { SellBankAccountSheet } from '../SellBankAccountSheet';
+import { SellBankAccountSheet } from './SellBankAccountSheet';
 
 describe('SellBankAccountSheet', () => {
     const mockOnBankAccountSelect = jest.fn();

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellFromAccountTradePreviewCard.test.tsx
@@ -2,11 +2,11 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { banxaCreditCardSellQuote, eth1NormalAccount } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
 import {
     SellFromAccountTradePreviewCard,
     type SellFromAccountTradePreviewCardProps,
-} from '../SellFromAccountTradePreviewCard';
+} from './SellFromAccountTradePreviewCard';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 describe('SellFromAccountTradePreviewCard', () => {
     const renderSellFromAccountTradePreviewCard = (

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellInfo.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellInfo.test.tsx
@@ -4,8 +4,8 @@ import { getTranslation } from '@suite-native/intl';
 import { banxaCreditCardSellQuote, eth1NormalAccount } from '@suite-native/trading-fixtures';
 import type { ProviderConfirmationStatus } from '@suite-native/trading-types';
 
-import { renderWithTradingProvider } from '../../../../__tests__/tradingTestUtils';
-import { SellInfo, type SellInfoProps } from '../SellInfo';
+import { SellInfo, type SellInfoProps } from './SellInfo';
+import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
 
 // Mock FeeSelector to avoid deep dependency chain
 jest.mock('@suite-native/transaction-management', () => ({

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewContinueButton.test.tsx
@@ -5,14 +5,14 @@ import { banxaCreditCardSellQuote, createPrecomposedTxFinal } from '@suite-nativ
 import { mergeDeepObject } from '@trezor/utils';
 
 import {
+    SellPreviewContinueButton,
+    type SellPreviewContinueButtonProps,
+} from './SellPreviewContinueButton';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import {
-    SellPreviewContinueButton,
-    type SellPreviewContinueButtonProps,
-} from '../SellPreviewContinueButton';
+} from '../../../__tests__/tradingTestUtils';
 
 const mockNavigate = jest.fn();
 

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewScreenHeader.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { SellPreviewScreenHeader } from '../SellPreviewScreenHeader';
+import { SellPreviewScreenHeader } from './SellPreviewScreenHeader';
 
 describe('SellPreviewScreenHeader', () => {
     const renderSellPreviewScreenHeader = () =>

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellPreviewView.test.tsx
@@ -7,13 +7,13 @@ import {
     getSellTrade,
 } from '@suite-native/trading-fixtures';
 
+import { BANK_ACCOUNT_ITEM_TEST_ID } from './BankAccount/SellBankAccountItem';
+import { SellPreviewView, type SellPreviewViewProps } from './SellPreviewView';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { BANK_ACCOUNT_ITEM_TEST_ID } from '../BankAccount/SellBankAccountItem';
-import { SellPreviewView, type SellPreviewViewProps } from '../SellPreviewView';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('SellPreviewView', () => {
     const getSellTradeWithBankAccounts = () => ({

--- a/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellPreview/SellToFiatTradePreviewCard.test.tsx
@@ -9,7 +9,7 @@ import {
 import {
     SellToFiatTradePreviewCard,
     type SellToFiatTradePreviewCardProps,
-} from '../SellToFiatTradePreviewCard';
+} from './SellToFiatTradePreviewCard';
 
 describe('SellToFiatTradePreviewCard', () => {
     const renderSellToFiatTradePreviewCard = (

--- a/suite-native/module-trading/src/components/sell/SellTab.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTab.test.tsx
@@ -2,8 +2,8 @@ import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-sy
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils-store';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { SellTab } from '../SellTab';
+import { SellTab } from './SellTab';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 let mockIsDeviceInViewOnlyMode = false;
 let mockIsPortfolioTrackerDevice = false;
@@ -14,7 +14,7 @@ jest.mock('@suite-common/device', () => ({
     selectIsPortfolioTrackerDevice: () => mockIsPortfolioTrackerDevice,
 }));
 
-jest.mock('../../../hooks/sell/useSellData', () => ({
+jest.mock('../../hooks/sell/useSellData', () => ({
     useSellData: () => ({
         isLoading: false,
         lastLoadedTimestamp: 1,
@@ -22,7 +22,7 @@ jest.mock('../../../hooks/sell/useSellData', () => ({
     }),
 }));
 
-jest.mock('../../concierge/ConciergeAlert', () => ({
+jest.mock('../concierge/ConciergeAlert', () => ({
     ConciergeAlert: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/sell/SellTabContent.test.tsx
@@ -1,12 +1,12 @@
 import { getTranslation } from '@suite-native/intl';
 import { act, screen, userEvent } from '@suite-native/test-utils-store';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { SellTabContent } from '../SellTabContent';
+import { SellTabContent } from './SellTabContent';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 let mockUseSellData: jest.Mock;
 
-jest.mock('../../../hooks/sell/useSellData', () => ({
+jest.mock('../../hooks/sell/useSellData', () => ({
     useSellData: (...params: unknown[]) => mockUseSellData(...params),
 }));
 jest.mock('@suite-native/trading-state', () => ({
@@ -14,7 +14,7 @@ jest.mock('@suite-native/trading-state', () => ({
     selectIsTradingSellEnabled: () => true,
 }));
 
-jest.mock('../../concierge/ConciergeAlert', () => ({
+jest.mock('../concierge/ConciergeAlert', () => ({
     ConciergeAlert: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatAmountInput.test.tsx
@@ -3,12 +3,12 @@ import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 import { type SellFormType } from '@suite-native/trading-types';
 
+import { SellFiatAmountInput } from './SellFiatAmountInput';
 import {
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellFiatAmountInput } from '../SellFiatAmountInput';
+} from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 describe('SellFiatAmountInput', () => {
     const renderFiatAmountInput = (form: SellFormType) =>

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencyPicker.test.tsx
@@ -14,9 +14,9 @@ import {
 import { sellActions } from '@suite-native/trading-state';
 import { type SellFormType } from '@suite-native/trading-types';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellFiatCurrencyPicker } from '../SellFiatCurrencyPicker';
+import { SellFiatCurrencyPicker } from './SellFiatCurrencyPicker';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 let mockUseListDataFilter: typeof useListDataFilter;
 const reportMock = jest.fn();

--- a/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellFiatCurrencySheet.test.tsx
@@ -1,7 +1,7 @@
 import { renderWithStoreProvider, screen } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 
-import { SellFiatCurrencySheet } from '../SellFiatCurrencySheet';
+import { SellFiatCurrencySheet } from './SellFiatCurrencySheet';
 
 describe('SellFiatCurrencySheet', () => {
     const renderSellFiatCurrencySheet = () =>

--- a/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/fiat/SellReceiveMethodPicker.test.tsx
@@ -14,13 +14,13 @@ import { banxaBankTransferSellQuote, sellQuotes } from '@suite-native/trading-fi
 import { type SellFormType } from '@suite-native/trading-types';
 import { getIndexOrThrow } from '@trezor/utils';
 
+import { SellReceiveMethodPicker } from './SellReceiveMethodPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingPreloadedState,
-} from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellReceiveMethodPicker } from '../SellReceiveMethodPicker';
+} from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 const reportMock = jest.fn();
 const creditCardPaymentMethodTranslation = getTranslation(

--- a/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/payment/SellProviderPicker.test.tsx
@@ -13,13 +13,13 @@ import { banxaCreditCardSellQuote, sellQuotes } from '@suite-native/trading-fixt
 import { type SellFormType } from '@suite-native/trading-types';
 import { getIndexOrThrow } from '@trezor/utils';
 
+import { SellProviderPicker } from './SellProviderPicker';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     createTradingPreloadedState,
-} from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellProviderPicker } from '../SellProviderPicker';
+} from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {

--- a/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAccountCryptoBalance.test.tsx
@@ -4,14 +4,14 @@ import { btcAsset, getBtcAccount } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 
 import {
-    renderHookWithTradingProvider,
-    renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import {
     SEND_ACCOUNT_BALANCE_TEST_ID,
     SellSendAccountCryptoBalance,
-} from '../SellSendAccountCryptoBalance';
+} from './SellSendAccountCryptoBalance';
+import {
+    renderHookWithTradingProvider,
+    renderWithTradingProvider,
+} from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 describe('SellSendAccountCryptoBalance', () => {
     let sellForm: SellFormType;

--- a/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAmountInput.test.tsx
@@ -7,20 +7,20 @@ import { btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type SellFormType } from '@suite-native/trading-types';
 import { PROTO } from '@trezor/connect';
 
+import { SellSendAmountInput, type SellSendAmountInputProps } from './SellSendAmountInput';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellSendAmountInput, type SellSendAmountInputProps } from '../SellSendAmountInput';
+} from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 const mockUseAmountInputDecimals = jest.fn(
     (_account?: Account, _contractAddress?: TokenAddress) => 8,
 );
 
-jest.mock('../../../../hooks/general/useAmountInputDecimals', () => ({
+jest.mock('../../../hooks/general/useAmountInputDecimals', () => ({
     useAmountInputDecimals: jest.fn((account?: Account, contractAddress?: TokenAddress) =>
         mockUseAmountInputDecimals(account, contractAddress),
     ),

--- a/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
+++ b/suite-native/module-trading/src/components/sell/send/SellSendAssetPicker.test.tsx
@@ -22,9 +22,9 @@ import {
 import { type MyAssetTradeable, type SellFormType } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { useSellForm } from '../../../../hooks/sell/useSellForm';
-import { SellSendAssetPicker } from '../SellSendAssetPicker';
+import { SellSendAssetPicker } from './SellSendAssetPicker';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
+import { useSellForm } from '../../../hooks/sell/useSellForm';
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),


### PR DESCRIPTION
## Description

Moves 25 Native Trading sell-component tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-sell-components-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->