### PR TITLE
test(native-trading): co-locate components and hooks

### DIFF
--- a/suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeAlert.test.tsx
@@ -2,12 +2,12 @@ import { type TradingOTC, nonSanctionedRegional, type useFetchOtc } from '@suite
 import { type useFormContext } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
+import { ConciergeAlert, type ConciergeAlertFormValues } from './ConciergeAlert';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 import {
     CRYPTO_MAX_FORM_TYPE,
     CRYPTO_MIN_FORM_TYPE,
-} from '../../../utils/buy/buyFormValidationSchema';
-import { ConciergeAlert, type ConciergeAlertFormValues } from '../ConciergeAlert';
+} from '../../utils/buy/buyFormValidationSchema';
 
 type FormErrors = {
     cryptoValue?: {

--- a/suite-native/module-trading/src/components/concierge/ConciergeConfirmation.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeConfirmation.test.tsx
@@ -3,14 +3,14 @@ import { useOpenLink } from '@suite-native/link';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { TREZOR_URL } from '@trezor/urls';
 
-import { useConciergeProviders } from '../../../hooks/concierge/useConciergeProviders';
-import { ConciergeConfirmation } from '../ConciergeConfirmation';
+import { ConciergeConfirmation } from './ConciergeConfirmation';
+import { useConciergeProviders } from '../../hooks/concierge/useConciergeProviders';
 
 jest.mock('@suite-native/link', () => ({
     useOpenLink: jest.fn(),
 }));
 
-jest.mock('../../../hooks/concierge/useConciergeProviders', () => ({
+jest.mock('../../hooks/concierge/useConciergeProviders', () => ({
     useConciergeProviders: jest.fn(),
 }));
 

--- a/suite-native/module-trading/src/components/concierge/ConciergeProviderPicker.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeProviderPicker.test.tsx
@@ -10,7 +10,7 @@ import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 import { type ConciergeFormValues } from '@suite-native/trading-types';
 
-import { ConciergeProviderPicker } from '../ConciergeProviderPicker';
+import { ConciergeProviderPicker } from './ConciergeProviderPicker';
 
 const mockUseFetchOtc = jest.fn();
 jest.mock('@suite-common/trading', () => {

--- a/suite-native/module-trading/src/components/concierge/ConciergeTab.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeTab.test.tsx
@@ -1,15 +1,15 @@
 import { getTranslation } from '@suite-native/intl';
 import { selectIsTradingConciergeEnabled } from '@suite-native/trading-state';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { ConciergeTab } from '../ConciergeTab';
+import { ConciergeTab } from './ConciergeTab';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-native/trading-state', () => ({
     ...jest.requireActual('@suite-native/trading-state'),
     selectIsTradingConciergeEnabled: jest.fn(),
 }));
 
-jest.mock('../ConciergeTabContent', () => ({
+jest.mock('./ConciergeTabContent', () => ({
     ConciergeTabContent: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/concierge/ConciergeTabContent.test.tsx
+++ b/suite-native/module-trading/src/components/concierge/ConciergeTabContent.test.tsx
@@ -3,12 +3,12 @@ import { getTranslation } from '@suite-native/intl';
 import { fireEvent, screen, userEvent, waitFor } from '@suite-native/test-utils-store';
 import { residenceCheckDisabledState } from '@suite-native/trading-fixtures';
 
+import { ConciergeTabContent } from './ConciergeTabContent';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { ConciergeTabContent } from '../ConciergeTabContent';
+} from '../../__tests__/tradingTestUtils';
 
 const mockUseFetchOtc = jest.fn();
 jest.mock('@suite-common/trading', () => {

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsBody.test.tsx
@@ -2,8 +2,8 @@ import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { getTranslation } from '@suite-native/intl';
 import { oneInchFusionPlusWithEip712SignDataQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { ReviewOutputsBody, type ReviewOutputsBodyProps } from '../ReviewOutputsBody';
+import { ReviewOutputsBody, type ReviewOutputsBodyProps } from './ReviewOutputsBody';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 const defaultProps: ReviewOutputsBodyProps = {
     tradingType: 'exchange',

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsContent.test.tsx
@@ -1,8 +1,8 @@
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { renderWithTradingProvider } from '../../../__tests__/tradingTestUtils';
-import { ReviewOutputsContent, type ReviewOutputsContentProps } from '../ReviewOutputsContent';
+import { ReviewOutputsContent, type ReviewOutputsContentProps } from './ReviewOutputsContent';
+import { renderWithTradingProvider } from '../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-native/confirm-on-trezor', () => ({
     ...jest.requireActual('@suite-native/confirm-on-trezor'),
@@ -15,16 +15,16 @@ jest.mock('@suite-native/confirm-on-trezor', () => ({
 
 const mockUseTradingOutputsReviewScreenControls = jest.fn();
 
-jest.mock('../../../hooks/reviewOutputs/useTradingOutputsReviewScreenControls', () => ({
+jest.mock('../../hooks/reviewOutputs/useTradingOutputsReviewScreenControls', () => ({
     useTradingOutputsReviewScreenControls: (args: any) =>
         mockUseTradingOutputsReviewScreenControls(args),
 }));
 
-jest.mock('../../../hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag', () => ({
+jest.mock('../../hooks/reviewOutputs/useDelayedReviewOutputListDisplayFlag', () => ({
     useDelayedReviewOutputListDisplayFlag: () => true,
 }));
 
-jest.mock('../ReviewOutputsBody', () => ({
+jest.mock('./ReviewOutputsBody', () => ({
     ReviewOutputsBody: () => null,
 }));
 

--- a/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/ReviewOutputsFooter.test.tsx
@@ -1,12 +1,12 @@
 import { getTranslation } from '@suite-native/intl';
 import { userEvent } from '@suite-native/test-utils-store';
 
+import { ReviewOutputsFooter, type ReviewOutputsFooterProps } from './ReviewOutputsFooter';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { ReviewOutputsFooter, type ReviewOutputsFooterProps } from '../ReviewOutputsFooter';
+} from '../../__tests__/tradingTestUtils';
 
 describe('ReviewOutputsFooter', () => {
     const renderReviewOutputsFooter = (

--- a/suite-native/module-trading/src/components/reviewOutputs/SignDataMessageReview.test.tsx
+++ b/suite-native/module-trading/src/components/reviewOutputs/SignDataMessageReview.test.tsx
@@ -6,12 +6,12 @@ import {
     oneInchFusionPlusWithoutEip712SignDataQuote,
 } from '@suite-native/trading-fixtures';
 
+import { SignDataMessageReview } from './SignDataMessageReview';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { SignDataMessageReview } from '../SignDataMessageReview';
+} from '../../__tests__/tradingTestUtils';
 
 const ethAccount = getEthAccount();
 

--- a/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useActiveTradingTypeReaction.test.ts
@@ -16,7 +16,7 @@ import {
     tradingSlice,
 } from '@suite-native/trading-state';
 
-import { useActiveTradingTypeReaction } from '../useActiveTradingTypeReaction';
+import { useActiveTradingTypeReaction } from './useActiveTradingTypeReaction';
 
 let mockUseRouteParams: {
     tradingType?: TradingType;

--- a/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useAllTradesReloadTimer.test.ts
@@ -9,18 +9,18 @@ import {
     sol1normalAccount,
 } from '@suite-native/trading-fixtures';
 
+import { useAllTradesReloadTimer } from './useAllTradesReloadTimer';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useAllTradesReloadTimer } from '../useAllTradesReloadTimer';
+} from '../../__tests__/tradingTestUtils';
 
 // Mock the useReloadTimer hook
-jest.mock('../useReloadTimer', () => ({
+jest.mock('./useReloadTimer', () => ({
     useReloadTimer: jest.fn(),
 }));
 
-const mockUseReloadTimer = require('../useReloadTimer').useReloadTimer;
+const mockUseReloadTimer = require('./useReloadTimer').useReloadTimer;
 
 describe('useAllTradesReloadTimer', () => {
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.test.ts
@@ -3,7 +3,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { type TokensRootState } from '@suite-native/tokens';
 
-import { useAmountInputDecimals } from '../useAmountInputDecimals';
+import { useAmountInputDecimals } from './useAmountInputDecimals';
 
 const mockSelectAccountTokenDecimals = jest.fn(
     (

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.test.ts
@@ -8,8 +8,8 @@ import {
 } from '@suite-native/trading-fixtures';
 import { getFormDraftKeyByTradeType } from '@suite-native/trading-state';
 
-import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
-import { useComposeTradingTransaction } from '../useComposeTradingTransaction';
+import { useComposeTradingTransaction } from './useComposeTradingTransaction';
+import { createTradingLightStore } from '../../__tests__/tradingTestUtils';
 
 const mockComposeTradingTransactionThunk = jest.fn(
     (payload: unknown) => () =>
@@ -18,7 +18,7 @@ const mockComposeTradingTransactionThunk = jest.fn(
         }),
 );
 
-jest.mock('../../../thunks', () => ({
+jest.mock('../../thunks', () => ({
     composeTradingTransactionThunk: (payload: unknown) =>
         mockComposeTradingTransactionThunk(payload),
 }));

--- a/suite-native/module-trading/src/hooks/general/useConsent.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConsent.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@suite-native/test-utils';
 
-import { useConsent } from '../useConsent';
+import { useConsent } from './useConsent';
 
 describe('useConsent', () => {
     const renderUseConsent = () => renderHook(() => useConsent());

--- a/suite-native/module-trading/src/hooks/general/useConsentDenier.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConsentDenier.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@suite-native/test-utils';
 
-import { useConsentDenier } from '../useConsentDenier';
+import { useConsentDenier } from './useConsentDenier';
 
 describe('useConsentDenier', () => {
     const renderConsentDenierHook = <T>(

--- a/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.test.ts
@@ -2,7 +2,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { PROTO } from '@trezor/connect';
 
-import { useConvertFormValueToBaseUnit } from '../useConvertFormValueToBaseUnit';
+import { useConvertFormValueToBaseUnit } from './useConvertFormValueToBaseUnit';
 
 describe('useConvertFormValueToBaseUnit', () => {
     const renderUseConvertApiToAppAmount = (bitcoinAmountUnit: PROTO.AmountUnit) => {

--- a/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useFavouriteAssetsSectionList.test.tsx
@@ -9,8 +9,8 @@ import {
 import { adaAsset, btcAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
-import { type TradingTestPreloadedState } from '../../../__tests__/tradingTestUtils';
-import { useFavouriteAssetsSectionList } from '../useFavouriteAssetsSectionList';
+import { useFavouriteAssetsSectionList } from './useFavouriteAssetsSectionList';
+import { type TradingTestPreloadedState } from '../../__tests__/tradingTestUtils';
 
 describe('useFavouriteAssetsSectionList', () => {
     const defaultFavouriteAssets = {

--- a/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useFiatCurrencyFilteredData.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { type FiatCurrencyItem } from '@suite-native/trading-types';
 
-import { useFiatCurrencyFilteredData } from '../useFiatCurrencyFilteredData';
+import { useFiatCurrencyFilteredData } from './useFiatCurrencyFilteredData';
 
 const supportedFiatCurrencies: FiatCurrencyItem[] = [
     {

--- a/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useFocusedValueWatch.test.tsx
@@ -15,10 +15,10 @@ import { getWalletState } from '@suite-native/trading-fixtures';
 import { selectIsAmountInputActive, tradingSlice } from '@suite-native/trading-state';
 import { type BuyFormType } from '@suite-native/trading-types';
 
-import { useBuyForm } from '../../buy/useBuyForm';
-import { useFocusedValueWatch } from '../useFocusedValueWatch';
+import { useFocusedValueWatch } from './useFocusedValueWatch';
+import { useBuyForm } from '../buy/useBuyForm';
 
-jest.mock('../useFocusedValueWatch', () => jest.requireActual('../useFocusedValueWatch'));
+jest.mock('./useFocusedValueWatch', () => jest.requireActual('./useFocusedValueWatch'));
 
 describe('useFocusedValueWatch', () => {
     let form: BuyFormType;

--- a/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useGeolocationCountryCode.test.ts
@@ -14,7 +14,7 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { useGeolocationCountryCode } from '../useGeolocationCountryCode';
+import { useGeolocationCountryCode } from './useGeolocationCountryCode';
 
 jest.mock('@suite-common/geolocation', () => {
     const actual = jest.requireActual('@suite-common/geolocation');

--- a/suite-native/module-trading/src/hooks/general/useInputFieldControls.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useInputFieldControls.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@suite-native/test-utils';
 
-import { useInputFieldControls } from '../useInputFieldControls';
+import { useInputFieldControls } from './useInputFieldControls';
 
 let mockUseField: jest.Mock;
 

--- a/suite-native/module-trading/src/hooks/general/useMountedRecentlyFlag.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useMountedRecentlyFlag.test.ts
@@ -1,8 +1,8 @@
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { RECENT_DURATION, useMountedRecentlyFlag } from '../useMountedRecentlyFlag';
+import { RECENT_DURATION, useMountedRecentlyFlag } from './useMountedRecentlyFlag';
 
-jest.mock('../useMountedRecentlyFlag', () => jest.requireActual('../useMountedRecentlyFlag'));
+jest.mock('./useMountedRecentlyFlag', () => jest.requireActual('./useMountedRecentlyFlag'));
 
 describe('useMountedRecentlyFlag', () => {
     const renderUseMountedRecentlyFlag = () =>

--- a/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useMyAssetsFilteredData.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/trading-types';
 import { BigNumber } from '@trezor/utils';
 
-import { useMyAssetsFilteredData } from '../useMyAssetsFilteredData';
+import { useMyAssetsFilteredData } from './useMyAssetsFilteredData';
 
 const btcAsset: MyAssetTradeable = {
     name: 'Bitcoin',

--- a/suite-native/module-trading/src/hooks/general/useProviderFilters.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useProviderFilters.test.ts
@@ -4,7 +4,7 @@ import { EMPTY_GROUPED_TRADING_EXCHANGE_QUOTES } from '@suite-common/trading';
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { type QuotesByCategories } from '@suite-native/trading-types';
 
-import { useProviderFilters } from '../useProviderFilters';
+import { useProviderFilters } from './useProviderFilters';
 
 type UseProviderFilterProps = {
     quotes?: QuotesByCategories<ExchangeTrade>;

--- a/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useQuotesInvalidator.test.ts
@@ -3,11 +3,11 @@ import { type ActionCreatorWithoutPayload } from '@reduxjs/toolkit';
 import { type TestStore } from '@suite-native/test-utils-store';
 import { type AbortablePromise } from '@suite-native/trading-types';
 
+import { type UseQuotesInvalidatorProps, useQuotesInvalidator } from './useQuotesInvalidator';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { type UseQuotesInvalidatorProps, useQuotesInvalidator } from '../useQuotesInvalidator';
+} from '../../__tests__/tradingTestUtils';
 
 describe('useQuotesInvalidator', () => {
     let store: TestStore;

--- a/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/useReceiveAccountsListData.test.tsx
@@ -10,14 +10,14 @@ import {
 } from '@suite-native/trading-fixtures';
 
 import {
+    type ReceiveAccountsListMode,
+    useReceiveAccountsListData,
+} from './useReceiveAccountsListData';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import {
-    type ReceiveAccountsListMode,
-    useReceiveAccountsListData,
-} from '../useReceiveAccountsListData';
+} from '../../__tests__/tradingTestUtils';
 
 const ADDRESS_COMMON = { received: '0', sent: '0', transfers: 0 };
 


### PR DESCRIPTION
## Description

Moves nine Native Trading concierge and output-review component tests plus 17 general-hook tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-concierge-output-components-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->