### PR TITLE
test(native-trading): co-locate remaining general hooks

### DIFF
--- a/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useContextForTradingForm.test.ts
@@ -1,12 +1,12 @@
 import { type TradingAmountLimitProps } from '@suite-common/trading';
 import { act } from '@suite-native/test-utils-store';
 
+import { useContextForTradingForm } from './useContextForTradingForm';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useContextForTradingForm } from '../useContextForTradingForm';
+} from '../../../__tests__/tradingTestUtils';
 
 describe('useContextForTradingForm', () => {
     const renderUseContextForTradingForm = (

--- a/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
+++ b/suite-native/module-trading/src/hooks/general/form/useCountryChangeEffect.test.tsx
@@ -23,7 +23,7 @@ import {
     tradingSlice,
 } from '@suite-native/trading-state';
 
-import { useCountryChangeEffect } from '../useCountryChangeEffect';
+import { useCountryChangeEffect } from './useCountryChangeEffect';
 
 type CountryFormValues = {
     country: TradingCountryOption | undefined;

--- a/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useProviderMetadataChangeEffect.test.ts
@@ -4,11 +4,11 @@ import { useForm } from '@suite-native/forms';
 import { type TestStore } from '@suite-native/test-utils-store';
 import { buyMercuryo } from '@suite-native/trading-fixtures';
 
+import { useProviderMetadataChangeEffect } from './useProviderMetadataChangeEffect';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../../__tests__/tradingTestUtils';
-import { useProviderMetadataChangeEffect } from '../useProviderMetadataChangeEffect';
+} from '../../../__tests__/tradingTestUtils';
 
 type ProviderFormValues = {
     quote: {

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountChangeEffect.test.ts
@@ -15,7 +15,7 @@ import {
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedReceiveAccount, tradingSlice } from '@suite-native/trading-state';
 
-import { useReceiveAccountChangeEffect } from '../useReceiveAccountChangeEffect';
+import { useReceiveAccountChangeEffect } from './useReceiveAccountChangeEffect';
 
 describe('useReceiveAccountChangeEffect', () => {
     let store: TestStore;

--- a/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useReceiveAccountPreselectionEffect.test.ts
@@ -13,8 +13,8 @@ import {
 } from '@suite-native/trading-state';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { useReceiveAccountPreselectionEffect } from '../useReceiveAccountPreselectionEffect';
+import { useReceiveAccountPreselectionEffect } from './useReceiveAccountPreselectionEffect';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 const btc1AccountKey = btc1NormalAccount.key;
 

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountAssetBalance.test.ts
@@ -5,7 +5,7 @@ import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { btcAsset, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { type SellFormValues, type TradeableAsset } from '@suite-native/trading-types';
 
-import { useSendAccountAssetBalance } from '../useSendAccountAssetBalance';
+import { useSendAccountAssetBalance } from './useSendAccountAssetBalance';
 
 type HookProps = {
     sendAccount: Account | undefined;

--- a/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useSendAccountChangeEffect.test.ts
@@ -15,7 +15,7 @@ import {
 import { getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 import { selectExchangeSelectedSendAccount, tradingSlice } from '@suite-native/trading-state';
 
-import { useSendAccountChangeEffect } from '../useSendAccountChangeEffect';
+import { useSendAccountChangeEffect } from './useSendAccountChangeEffect';
 
 const btc1Account = getBtcAccount({ descriptor: asAccountDescriptor('btc1normal') });
 const btc2Account = getBtcAccount({ descriptor: asAccountDescriptor('btc2legacy') });

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.test.ts
@@ -6,8 +6,8 @@ import { type TestStore, renderHookWithStoreProvider } from '@suite-native/test-
 import { btcAsset, ethAsset, getBtcAccount, usdcAsset } from '@suite-native/trading-fixtures';
 import { buyActions, exchangeActions } from '@suite-native/trading-state';
 
-import { createTradingLightStore } from '../../../../__tests__/tradingTestUtils';
-import { useTradeableAssetChange } from '../useTradeableAssetChange';
+import { useTradeableAssetChange } from './useTradeableAssetChange';
+import { createTradingLightStore } from '../../../__tests__/tradingTestUtils';
 
 const reportMock = jest.fn();
 const services: NativeAnalyticsDep = {

--- a/suite-native/module-trading/src/hooks/general/useReloadTimer.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useReloadTimer.test.ts
@@ -2,7 +2,7 @@ import { INVITY_API_RELOAD_QUOTES_AFTER_SECONDS } from '@suite-common/trading';
 import { renderHook } from '@suite-native/test-utils';
 import { type useTimer } from '@trezor/react-utils';
 
-import { MAX_RESET_COUNT, useReloadTimer } from '../useReloadTimer';
+import { MAX_RESET_COUNT, useReloadTimer } from './useReloadTimer';
 
 let mockTimerReturn: ReturnType<typeof useTimer>;
 

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.test.ts
@@ -15,7 +15,7 @@ import {
 } from '@suite-native/trading-fixtures';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
-import { useTradeableAssetsFilteredData } from '../useTradeableAssetsFilteredData';
+import { useTradeableAssetsFilteredData } from './useTradeableAssetsFilteredData';
 
 const mockAssets: TradeableAsset[] = [
     btcAsset,

--- a/suite-native/module-trading/src/hooks/general/useTradingFiatValues.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingFiatValues.test.ts
@@ -17,7 +17,7 @@ import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
+} from '../../__tests__/tradingTestUtils';
 
 jest.mock('@suite-common/fiat-services', () => ({
     ...jest.requireActual('@suite-common/fiat-services'),

--- a/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingStellarActivateToken.test.ts
@@ -2,7 +2,7 @@ import type { BuyTrade, CryptoId, ExchangeTrade } from 'invity-api';
 
 import { act, renderHook, waitFor } from '@suite-native/test-utils';
 
-import { useTradingStellarActivateToken } from '../useTradingStellarActivateToken';
+import { useTradingStellarActivateToken } from './useTradingStellarActivateToken';
 
 const mockDispatch = jest.fn();
 const mockUseSelector = jest.fn();

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.test.ts
@@ -6,11 +6,11 @@ import {
     getInitializedTradingStateWithQuotes,
 } from '@suite-native/trading-fixtures';
 
+import { useTradingTransaction } from './useTradingTransaction';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useTradingTransaction } from '../useTradingTransaction';
+} from '../../__tests__/tradingTestUtils';
 
 const mockComposeTradingTransaction = jest.fn();
 
@@ -40,7 +40,7 @@ jest.mock('@suite-common/trading', () => ({
 }));
 
 // Mock the thunks
-jest.mock('../../../thunks', () => ({
+jest.mock('../../thunks', () => ({
     signAndPushSendFormTransactionThunk: (payload: unknown) => ({
         type: 'signAndPushSendFormTransactionThunkMock',
         payload,
@@ -48,7 +48,7 @@ jest.mock('../../../thunks', () => ({
     }),
 }));
 
-jest.mock('../useComposeTradingTransaction', () => ({
+jest.mock('./useComposeTradingTransaction', () => ({
     useComposeTradingTransaction: () => ({
         composeTradingTransaction: mockComposeTradingTransaction,
     }),

--- a/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useTransactionStateChangeAnalyticsReporting.test.ts
@@ -6,7 +6,7 @@ import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { renderHook, renderHookWithBasicProvider } from '@suite-native/test-utils';
 import { getBuyTrade, getExchangeTrade } from '@suite-native/trading-fixtures';
 
-import { useTransactionStateChangeAnalyticsReporting } from '../useTransactionStateChangeAnalyticsReporting';
+import { useTransactionStateChangeAnalyticsReporting } from './useTransactionStateChangeAnalyticsReporting';
 
 type Props = { trades: TradingTransaction[] };
 type ReportSpy = jest.SpyInstance;

--- a/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchAllTrades.test.ts
@@ -9,23 +9,23 @@ import {
     sol1normalAccount,
 } from '@suite-native/trading-fixtures';
 
+import { useWatchAllTrades } from './useWatchAllTrades';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useWatchAllTrades } from '../useWatchAllTrades';
+} from '../../__tests__/tradingTestUtils';
 
 // Mock the useAllTradesReloadTimer hook
-jest.mock('../useAllTradesReloadTimer', () => ({
+jest.mock('./useAllTradesReloadTimer', () => ({
     useAllTradesReloadTimer: jest.fn(),
 }));
 
 // Mock the useTransactionStateChangeAnalyticsReporting hook
-jest.mock('../useTransactionStateChangeAnalyticsReporting', () => ({
+jest.mock('./useTransactionStateChangeAnalyticsReporting', () => ({
     useTransactionStateChangeAnalyticsReporting: jest.fn(),
 }));
 
-const mockUseAllTradesReloadTimer = require('../useAllTradesReloadTimer').useAllTradesReloadTimer;
+const mockUseAllTradesReloadTimer = require('./useAllTradesReloadTimer').useAllTradesReloadTimer;
 
 describe('useWatchAllTrades', () => {
     beforeEach(() => {

--- a/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
+++ b/suite-native/module-trading/src/hooks/general/useWatchTrade.test.ts
@@ -7,13 +7,13 @@ import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type TestStore } from '@suite-native/test-utils-store';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
+import { useWatchTrade } from './useWatchTrade';
 import {
     createTradingLightStore,
     renderHookWithTradingProvider,
-} from '../../../__tests__/tradingTestUtils';
-import { useWatchTrade } from '../useWatchTrade';
+} from '../../__tests__/tradingTestUtils';
 
-jest.mock('../useReloadTimer', () => ({
+jest.mock('./useReloadTimer', () => ({
     useReloadTimer: jest.fn(),
 }));
 
@@ -26,7 +26,7 @@ jest.mock('@suite-common/trading', () => ({
 
 const mockWatchTradeThunk = require('@suite-common/trading').tradingThunks.watchTradeThunk;
 
-const mockUseReloadTimer = require('../useReloadTimer').useReloadTimer;
+const mockUseReloadTimer = require('./useReloadTimer').useReloadTimer;
 
 type ReportSpy = jest.SpyInstance;
 


### PR DESCRIPTION
## Description

Moves the remaining 16 Native Trading general-hook tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-general-hooks-2-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->