### PR TITLE
test(native-transaction): co-locate component tests

### DIFF
--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItem.test.tsx
@@ -3,11 +3,11 @@ import { getTranslation } from '@suite-native/intl';
 import { within } from '@suite-native/test-utils';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { ETH_ACCOUNT_KEY } from '../../../__fixtures__/walletState';
-import { type StatefulReviewOutput } from '../../../types';
-import { ReviewOutputItem, type ReviewOutputItemProps } from '../ReviewOutputItem';
+import { ReviewOutputItem, type ReviewOutputItemProps } from './ReviewOutputItem';
+import { ETH_ACCOUNT_KEY } from '../../__fixtures__/walletState';
+import { type StatefulReviewOutput } from '../../types';
 
-jest.mock('../ReviewOutputItemValues', () => ({
+jest.mock('./ReviewOutputItemValues', () => ({
     ReviewOutputItemValues: ({
         translationKey,
         value,

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
@@ -2,18 +2,14 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import {
-    ETH_ACCOUNT_KEY,
-    SOL_ACCOUNT_KEY,
-    getWalletState,
-} from '../../../__fixtures__/walletState';
-import { type ReviewSummaryOutput, type StatefulReviewOutput } from '../../../types';
-import { ReviewOutputItemList, type ReviewOutputItemListProps } from '../ReviewOutputItemList';
+import { ReviewOutputItemList, type ReviewOutputItemListProps } from './ReviewOutputItemList';
+import { ETH_ACCOUNT_KEY, SOL_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
+import { type ReviewSummaryOutput, type StatefulReviewOutput } from '../../types';
 
 let mockSelectTransactionReviewOutputsFromDraftReturnValue: StatefulReviewOutput[] | null;
 let mockSelectIsTransactionAlreadySignedValue: boolean;
 
-jest.mock('../../../selectors', () => {
+jest.mock('../../selectors', () => {
     const selectReviewSummaryOutputReturnValue = {
         state: 'active',
         totalSpent: '1200000000000000000', // 1.2 ETH in wei

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemValues.test.tsx
@@ -2,11 +2,8 @@ import { type TokenAddress } from '@suite-common/wallet-types';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
-import {
-    ReviewOutputItemValues,
-    type ReviewOutputItemValuesProps,
-} from '../ReviewOutputItemValues';
+import { ReviewOutputItemValues, type ReviewOutputItemValuesProps } from './ReviewOutputItemValues';
+import { ETH_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 
 const oneUsdc = '1000000'; // 1 USDC in smallest unit
 

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
@@ -3,20 +3,20 @@ import { Text as MockText } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { ETH_ACCOUNT_KEY } from '../../../__fixtures__/walletState';
 import {
     ReviewOutputSummaryItem,
     type ReviewOutputSummaryItemProps,
-} from '../ReviewOutputSummaryItem';
+} from './ReviewOutputSummaryItem';
+import { ETH_ACCOUNT_KEY } from '../../__fixtures__/walletState';
 
 const mockSelectIsClearSignedTradingSwap = jest.fn();
-jest.mock('../../../selectors', () => ({
-    ...jest.requireActual('../../../selectors'),
+jest.mock('../../selectors', () => ({
+    ...jest.requireActual('../../selectors'),
     selectIsClearSignedTradingSwap: (...args: unknown[]) =>
         mockSelectIsClearSignedTradingSwap(...args),
 }));
 
-jest.mock('../ReviewOutputItemValues', () => ({
+jest.mock('./ReviewOutputItemValues', () => ({
     ReviewOutputItemValues: ({
         translationKey,
         value,

--- a/suite-native/transaction-management/src/components/SlidingFooterOverlay.test.tsx
+++ b/suite-native/transaction-management/src/components/SlidingFooterOverlay.test.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { SlidingFooterOverlay } from '../SlidingFooterOverlay';
+import { SlidingFooterOverlay } from './SlidingFooterOverlay';
 
 describe('SlidingFooterOverlay', () => {
     it('should render children', () => {

--- a/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/components/TxValidityTimer.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { TxValidityTimer } from '../TxValidityTimer';
+import { TxValidityTimer } from './TxValidityTimer';
 
 const tryAgainLabel = getTranslation('generic.buttons.tryAgain');
 const confirmingLabel = getTranslation('transactionManagement.txValidityTimer.confirming');

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.test.tsx
@@ -9,18 +9,18 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
+import { CustomFee } from './CustomFee';
 import {
     BTC_ACCOUNT_KEY,
     ETH_ACCOUNT_KEY,
     getWalletState,
-} from '../../../../__fixtures__/walletState';
-import { type FeesFormType } from '../../../../feesFormSchema';
-import { type CustomFeeParams, useFeesForm } from '../../../../hooks';
-import { useCustomFee } from '../../../../hooks/fees/useCustomFee';
-import { CustomFee } from '../CustomFee';
+} from '../../../__fixtures__/walletState';
+import { type FeesFormType } from '../../../feesFormSchema';
+import { type CustomFeeParams, useFeesForm } from '../../../hooks';
+import { useCustomFee } from '../../../hooks/fees/useCustomFee';
 
 // Mock the useCustomFee hook
-jest.mock('../../../../hooks/fees/useCustomFee', () => ({
+jest.mock('../../../hooks/fees/useCustomFee', () => ({
     useCustomFee: jest.fn(),
 }));
 

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.test.tsx
@@ -8,14 +8,14 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
+import { CustomFeeCard, type CustomFeeCardProps } from './CustomFeeCard';
 import {
     BTC_ACCOUNT_KEY,
     ETH_ACCOUNT_KEY,
     getWalletState,
-} from '../../../../__fixtures__/walletState';
-import { type FeesFormType } from '../../../../feesFormSchema';
-import { useFeesForm } from '../../../../hooks';
-import { CustomFeeCard, type CustomFeeCardProps } from '../CustomFeeCard';
+} from '../../../__fixtures__/walletState';
+import { type FeesFormType } from '../../../feesFormSchema';
+import { useFeesForm } from '../../../hooks';
 
 describe('CustomFeeCard', () => {
     const defaultProps = {

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
@@ -9,10 +9,10 @@ import {
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { type FeesFormType } from '../../../..';
-import { ETH_ACCOUNT_KEY, getWalletState } from '../../../../__fixtures__/walletState';
-import { useFeesForm } from '../../../../hooks';
-import { CustomFeeInputs, type CustomFeeInputsProps } from '../CustomFeeInputs';
+import { CustomFeeInputs, type CustomFeeInputsProps } from './CustomFeeInputs';
+import { type FeesFormType } from '../../..';
+import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
+import { useFeesForm } from '../../../hooks';
 
 // Mock the selectors
 jest.mock('@suite-common/wallet-core', () => ({

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeLabel.test.tsx
@@ -7,10 +7,10 @@ import {
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../../__fixtures__/walletState';
-import { type FeesFormType } from '../../../../feesFormSchema';
-import { useFeesForm } from '../../../../hooks';
-import { CustomFeeLabel } from '../CustomFeeLabel';
+import { CustomFeeLabel } from './CustomFeeLabel';
+import { getWalletState } from '../../../__fixtures__/walletState';
+import { type FeesFormType } from '../../../feesFormSchema';
+import { useFeesForm } from '../../../hooks';
 
 describe('CustomFeeLabel', () => {
     const defaultState = {

--- a/suite-native/transaction-management/src/components/fees/FeeLabelTranslation.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeLabelTranslation.test.tsx
@@ -3,7 +3,7 @@ import { Text } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { FeeLabelTranslation } from '../FeeLabelTranslation';
+import { FeeLabelTranslation } from './FeeLabelTranslation';
 
 describe('FeeLabelTranslation', () => {
     const renderFeeLabelTranslation = (networkType: NetworkType) =>

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.test.tsx
@@ -8,10 +8,10 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
-import { createFeeLevel } from '../../../../__fixtures__/feeLevels';
-import { getWalletState } from '../../../../__fixtures__/walletState';
-import { type NativeSupportedPredefinedFeeLevel } from '../../../../types';
-import { FeeOption } from '../FeeOption';
+import { FeeOption } from './FeeOption';
+import { createFeeLevel } from '../../../__fixtures__/feeLevels';
+import { getWalletState } from '../../../__fixtures__/walletState';
+import { type NativeSupportedPredefinedFeeLevel } from '../../../types';
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionErrorMessage.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionErrorMessage.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { FeeOptionErrorMessage } from '../FeeOptionErrorMessage';
+import { FeeOptionErrorMessage } from './FeeOptionErrorMessage';
 
 describe('FeeOptionErrorMessage', () => {
     const renderFeeOptionErrorMessage = (isVisible: boolean) =>

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
@@ -14,10 +14,10 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
-import { createFeeLevel, createFeeLevels } from '../../../../__fixtures__/feeLevels';
-import { ETH_ACCOUNT_KEY, getWalletState } from '../../../../__fixtures__/walletState';
-import { useFeesForm } from '../../../../hooks/fees/useFeesForm';
-import { FeeOptionsList, type FeeOptionsListProps } from '../FeeOptionsList';
+import { FeeOptionsList, type FeeOptionsListProps } from './FeeOptionsList';
+import { createFeeLevel, createFeeLevels } from '../../../__fixtures__/feeLevels';
+import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
+import { useFeesForm } from '../../../hooks/fees/useFeesForm';
 
 // Mock the fee-related selectors
 jest.mock('@suite-common/wallet-core', () => ({

--- a/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
@@ -2,8 +2,8 @@ import { type FormState } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { BTC_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
-import { FeeSelectorRow } from '../FeeSelectorRow';
+import { FeeSelectorRow } from './FeeSelectorRow';
+import { BTC_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 
 const noopThunk = jest.fn();
 

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
@@ -1,8 +1,8 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../__fixtures__/walletState';
-import { FeeSummaryCard, type FeeSummaryCardProps } from '../FeeSummaryCard';
+import { FeeSummaryCard, type FeeSummaryCardProps } from './FeeSummaryCard';
+import { getWalletState } from '../../__fixtures__/walletState';
 
 const defaultProps: FeeSummaryCardProps = {
     fee: '1000',

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
@@ -1,8 +1,8 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../__fixtures__/walletState';
-import { FeeSummaryRow, type FeeSummaryRowProps } from '../FeeSummaryRow';
+import { FeeSummaryRow, type FeeSummaryRowProps } from './FeeSummaryRow';
+import { getWalletState } from '../../__fixtures__/walletState';
 
 const defaultProps: FeeSummaryRowProps = {
     fee: '1000',

--- a/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
@@ -5,9 +5,9 @@ import { Form, useForm } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { createFeeLevels } from '../../../__fixtures__/feeLevels';
-import { getWalletState } from '../../../__fixtures__/walletState';
-import { FeesContent, type FeesContentProps } from '../FeesContent';
+import { FeesContent, type FeesContentProps } from './FeesContent';
+import { createFeeLevels } from '../../__fixtures__/feeLevels';
+import { getWalletState } from '../../__fixtures__/walletState';
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({

--- a/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesFooter.test.tsx
@@ -11,8 +11,8 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../__fixtures__/walletState';
-import { FeesFooter } from '../FeesFooter';
+import { FeesFooter } from './FeesFooter';
+import { getWalletState } from '../../__fixtures__/walletState';
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({

--- a/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
@@ -1,8 +1,8 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../../__fixtures__/walletState';
-import { TronFeeSummaryRow, type TronFeeSummaryRowProps } from '../TronFeeSummaryRow';
+import { TronFeeSummaryRow, type TronFeeSummaryRowProps } from './TronFeeSummaryRow';
+import { getWalletState } from '../../../__fixtures__/walletState';
 
 const defaultProps: TronFeeSummaryRowProps = {
     symbol: 'trx',


### PR DESCRIPTION
## Description

Moves 20 Native Transaction Management component tests beside their source files while leaving the qualified-basename case for its dedicated migration.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-transaction-components-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->