### PR TITLE
feat(suite-desktop): add learning materials for eth vaults

### DIFF
--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -9,9 +9,14 @@ import {
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type YieldFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { getApyPercent, isStakingNetworkType } from '@suite-common/wallet-utils';
+import {
+    getApyPercent,
+    isStakingNetworkType,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-utils';
 import { Divider } from '@trezor/components';
 
 import { EarnInANutshellModalLayout } from './components/EarnInANutshellModalLayout';
@@ -62,12 +67,23 @@ export const YieldEarnInANutshellModal = ({
     const yieldApy =
         vault?.rewardRate?.total != null ? getApyPercent(vault.rewardRate.total) : null;
 
+    // Wrapped-native vaults (e.g. an ETH vault holding WETH) get extra wrap/unwrap education:
+    // an intro highlight plus a wrap step on deposit and an unwrap step on withdrawal.
+    const isWrappedNativeVault =
+        vault !== undefined && isWrappedNativeToken(account.symbol, vault.token.address);
+    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+
     const processes: EarnInANutshellProcess[] = [
         {
             processType: 'deposit',
             'data-testid': '@modal/earn-in-a-nutshell/deposit-process',
             heading: <Translation id="TR_EARN_DEPOSITING_PROCESS" />,
-            badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 2 }} />,
+            badge: (
+                <Translation
+                    id="TR_TX_FEE_COUNT"
+                    values={{ count: isWrappedNativeVault ? 3 : 2 }}
+                />
+            ),
             content: (
                 <YieldDepositingInfo
                     apy={yieldApy}
@@ -75,6 +91,8 @@ export const YieldEarnInANutshellModal = ({
                     networkSymbol={account.symbol}
                     depositSymbol={depositSymbol}
                     vaultSymbol={vaultSymbol}
+                    isWrappedNativeVault={isWrappedNativeVault}
+                    nativeSymbol={nativeSymbol}
                 />
             ),
         },
@@ -82,8 +100,19 @@ export const YieldEarnInANutshellModal = ({
             processType: 'withdraw',
             'data-testid': '@modal/earn-in-a-nutshell/withdraw-process',
             heading: <Translation id="TR_EARN_WITHDRAWING_PROCESS" />,
-            badge: <Translation id="TR_TX_FEE_COUNT" values={{ count: 1 }} />,
-            content: <YieldWithdrawingInfo depositSymbol={depositSymbol} />,
+            badge: (
+                <Translation
+                    id="TR_TX_FEE_COUNT"
+                    values={{ count: isWrappedNativeVault ? 2 : 1 }}
+                />
+            ),
+            content: (
+                <YieldWithdrawingInfo
+                    depositSymbol={depositSymbol}
+                    isWrappedNativeVault={isWrappedNativeVault}
+                    nativeSymbol={nativeSymbol}
+                />
+            ),
         },
         ...(rewardsSymbols !== undefined && rewardsSymbols.length > 0
             ? [
@@ -148,11 +177,14 @@ export const YieldEarnInANutshellModal = ({
             onCancel={handleOnCancel}
             actionType={actionType}
             onAction={handleOnAction}
+            hasCancelButton={actionType !== 'close'}
         >
             <YieldEarnInANutshellHighlights
                 depositSymbol={depositSymbol}
                 vaultSymbol={vaultSymbol}
                 rewardsSymbols={rewardsSymbols}
+                isWrappedNativeVault={isWrappedNativeVault}
+                nativeSymbol={nativeSymbol}
             />
             <Divider margin={{ top: 24, bottom: 16 }} />
             <EarnInANutshellProcesses items={processes} onItemToggle={handleProcessToggle} />

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellModalLayout.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellModalLayout.tsx
@@ -9,6 +9,7 @@ type EarnInANutshellModalLayoutProps = {
     onCancel: () => void;
     actionType?: EarnModalAction;
     onAction: () => void;
+    hasCancelButton?: boolean;
     children: ReactNode;
 };
 
@@ -17,6 +18,7 @@ export const EarnInANutshellModalLayout = ({
     onCancel,
     actionType = 'continue',
     onAction,
+    hasCancelButton = false,
     children,
 }: EarnInANutshellModalLayoutProps) => (
     <Modal
@@ -25,9 +27,21 @@ export const EarnInANutshellModalLayout = ({
         width={400}
         onCancel={onCancel}
         bottomContent={
-            <Modal.Button onClick={onAction} data-testid="@modal/staking/continue-button">
-                <Translation id={actionType === 'close' ? 'TR_GOT_IT' : 'TR_CONTINUE'} />
-            </Modal.Button>
+            <>
+                <Modal.Button onClick={onAction} data-testid="@modal/staking/continue-button">
+                    <Translation id={actionType === 'close' ? 'TR_GOT_IT' : 'TR_CONTINUE'} />
+                </Modal.Button>
+                {hasCancelButton && (
+                    <Modal.Button
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={onCancel}
+                        data-testid="@modal/staking/cancel-button"
+                    >
+                        <Translation id="TR_CANCEL" />
+                    </Modal.Button>
+                )}
+            </>
         }
     >
         {children}

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx
@@ -14,6 +14,8 @@ type YieldDepositingInfoProps = {
     networkSymbol: NetworkSymbol;
     depositSymbol: string;
     vaultSymbol: string | undefined;
+    isWrappedNativeVault?: boolean;
+    nativeSymbol?: string;
 };
 
 export const YieldDepositingInfo = ({
@@ -22,8 +24,21 @@ export const YieldDepositingInfo = ({
     networkSymbol,
     depositSymbol,
     vaultSymbol,
+    isWrappedNativeVault = false,
+    nativeSymbol,
 }: YieldDepositingInfoProps) => (
     <StepList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
+        {isWrappedNativeVault && nativeSymbol && (
+            <EarnInfoRow
+                heading={
+                    <Translation
+                        id="TR_EARN_YIELD_WRAP_TITLE"
+                        values={{ nativeSymbol, tokenSymbol: depositSymbol }}
+                    />
+                }
+                content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+            />
+        )}
         <EarnInfoRow
             heading={
                 <Translation

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx
@@ -1,7 +1,13 @@
 import { FormattedList } from 'react-intl';
 
 import { Translation } from '@suite/intl';
-import { CoinsIcon, HandCoinsIcon, LockSimpleIcon, PlusCircleIcon } from '@trezor/icons';
+import {
+    CoinVerticalIcon,
+    CoinsIcon,
+    HandCoinsIcon,
+    LockSimpleIcon,
+    PlusCircleIcon,
+} from '@trezor/icons';
 
 import {
     type EarnInANutshellHighlight,
@@ -12,20 +18,41 @@ interface YieldEarnInANutshellHighlightsProps {
     depositSymbol: string;
     vaultSymbol?: string;
     rewardsSymbols?: string[];
+    isWrappedNativeVault?: boolean;
+    nativeSymbol?: string;
 }
 
 export const YieldEarnInANutshellHighlights = ({
     depositSymbol,
     vaultSymbol,
     rewardsSymbols,
+    isWrappedNativeVault = false,
+    nativeSymbol,
 }: YieldEarnInANutshellHighlightsProps) => {
+    // For a wrapped-native vault the user perceives their asset as the native coin (e.g. ETH),
+    // while `depositSymbol` is the wrapped token the vault holds (e.g. WETH).
+    const supplySymbol = isWrappedNativeVault && nativeSymbol ? nativeSymbol : depositSymbol;
+
     const highlights: EarnInANutshellHighlight[] = [
+        ...(isWrappedNativeVault && nativeSymbol
+            ? [
+                  {
+                      icon: CoinVerticalIcon,
+                      content: (
+                          <Translation
+                              id="TR_EARN_WETH_NUTSHELL_WRAP"
+                              values={{ nativeSymbol, wrappedSymbol: depositSymbol }}
+                          />
+                      ),
+                  },
+              ]
+            : []),
         {
             icon: LockSimpleIcon,
             content: (
                 <Translation
                     id="TR_EARN_YIELD_NUTSHELL_DEPOSITED_AMOUNT"
-                    values={{ supplySymbol: depositSymbol }}
+                    values={{ supplySymbol }}
                 />
             ),
         },
@@ -34,7 +61,7 @@ export const YieldEarnInANutshellHighlights = ({
             content: (
                 <Translation
                     id="TR_EARN_YIELD_NUTSHELL_COMPOUND_INTEREST"
-                    values={{ supplySymbol: depositSymbol }}
+                    values={{ supplySymbol }}
                 />
             ),
         },
@@ -45,7 +72,7 @@ export const YieldEarnInANutshellHighlights = ({
                       content: (
                           <Translation
                               id="TR_EARN_YIELD_NUTSHELL_VAULT_TOKENS"
-                              values={{ supplySymbol: depositSymbol, vaultSymbol }}
+                              values={{ supplySymbol, vaultSymbol }}
                           />
                       ),
                   },

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx
@@ -5,28 +5,51 @@ import { EarnInfoRow } from './EarnInfoRow';
 
 interface YieldWithdrawingInfoProps {
     depositSymbol: string;
+    isWrappedNativeVault?: boolean;
+    nativeSymbol?: string;
 }
 
-export const YieldWithdrawingInfo = ({ depositSymbol }: YieldWithdrawingInfoProps) => (
-    <StepList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
-        <EarnInfoRow
-            heading={<Translation id="TR_EARN_SIGN_WITHDRAWAL_TRANSACTION" />}
-            subheading={
-                <Translation
-                    id="TR_EARN_YIELD_WITHDRAW_USES_VAULT_TOKENS_SUB"
-                    values={{ supplySymbol: depositSymbol }}
+export const YieldWithdrawingInfo = ({
+    depositSymbol,
+    isWrappedNativeVault = false,
+    nativeSymbol,
+}: YieldWithdrawingInfoProps) => {
+    // The user's account receives the native coin (e.g. ETH); `depositSymbol` is the wrapped
+    // token the vault redeems into (e.g. WETH), which the unwrap step then converts back.
+    const receiveSymbol = isWrappedNativeVault && nativeSymbol ? nativeSymbol : depositSymbol;
+
+    return (
+        <StepList bulletGap={12} gap={16} bulletSize="small" titleGap={2}>
+            <EarnInfoRow
+                heading={<Translation id="TR_EARN_SIGN_WITHDRAWAL_TRANSACTION" />}
+                subheading={
+                    <Translation
+                        id="TR_EARN_YIELD_WITHDRAW_USES_VAULT_TOKENS_SUB"
+                        values={{ supplySymbol: depositSymbol }}
+                    />
+                }
+                content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
+            />
+            {isWrappedNativeVault && nativeSymbol && (
+                <EarnInfoRow
+                    heading={
+                        <Translation
+                            id="TR_EARN_YIELD_UNWRAP_TITLE"
+                            values={{ tokenSymbol: depositSymbol, nativeSymbol }}
+                        />
+                    }
+                    content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
                 />
-            }
-            content={{ text: <Translation id="TR_TRADING_NETWORK_FEE" />, isBadge: true }}
-        />
-        <EarnInfoRow
-            heading={
-                <Translation
-                    id="TR_EARN_YIELD_RECEIVE_IN_ACCOUNT"
-                    values={{ supplySymbol: depositSymbol }}
-                />
-            }
-            content={{ text: <Translation id="TR_EARN_INSTANTLY" /> }}
-        />
-    </StepList>
-);
+            )}
+            <EarnInfoRow
+                heading={
+                    <Translation
+                        id="TR_EARN_YIELD_RECEIVE_IN_ACCOUNT"
+                        values={{ supplySymbol: receiveSymbol }}
+                    />
+                }
+                content={{ text: <Translation id="TR_EARN_INSTANTLY" /> }}
+            />
+        </StepList>
+    );
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11091,6 +11091,11 @@ export const messages = defineMessages({
         defaultMessage:
             "You'll earn {rewardsSymbol} as rewards. They may only be offered for a limited time, but once earned, you can claim them in the Earn tab.",
     },
+    TR_EARN_WETH_NUTSHELL_WRAP: {
+        id: 'TR_EARN_WETH_NUTSHELL_WRAP',
+        defaultMessage:
+            'This vault accepts {nativeSymbol} as a wrapped token called {wrappedSymbol}. You can wrap your {nativeSymbol} during the deposit.',
+    },
     TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION: {
         id: 'TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION',
         defaultMessage: 'Approve spending transaction',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implements described in the future points about ETH Vaults

## Notes for QA

1) navigate to deposit yield flow
2) click how it works on the top right
3) assert that texts are matching the ones described in issue
4) part about extra rewards and claiming is backend-enabled 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29879

## Screenshots:

| WETH | USDC |
|--------|--------|
| <img width="501" height="945" alt="Screenshot 2026-07-28 at 16 51 46" src="https://github.com/user-attachments/assets/9c6be5a3-a6b7-4fc8-97b4-a19846fdd98e" /> | <img width="481" height="906" alt="Screenshot 2026-07-28 at 16 51 35" src="https://github.com/user-attachments/assets/bb86dfb3-81f4-4eff-b84a-b728570592cf" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is tightly scoped to the Earn in a Nutshell staking onboarding modal and its sub-components, plus related translations. Risk is concentrated in first-time staking flows across networks. The three recommended tests directly exercise the modal for ETH, SOL, and ADA and assert the key translation keys it displays, providing high confidence with minimal runtime.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnInANutshellModalLayout.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldDepositingInfo.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldEarnInANutshellHighlights.tsx`
- `packages/suite/src/components/earn/modals/EarnInANutshell/components/YieldWithdrawingInfo.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test directly exercises the Cardano staking flow through the 'staking nutshell modal' and asserts the TR_EARN_STAKING_IN_A_NUTSHELL header, which is rendered by the changed EarnInANutshell components. Any layout, content, or translation change in these modal files would be immediately visible here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The test opens the Ethereum first-time staking flow and verifies the TR_EARN_STAKING_IN_A_NUTSHELL modal header and acknowledgement step, which are implemented by the changed components. This is the primary user path affected by the change set.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test starts Solana staking from an empty account and asserts the 'Staking in a Nutshell' modal (TR_EARN_STAKING_IN_A_NUTSHELL) rendered by the changed components, covering another network path through the same shared modal.

</details>

_Updated: 2026-07-29T06:51:06.183Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-edu/web/](https://dev.suite.sldev.cz/suite-web/feat/wrapped-native-edu/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrapped-native-edu&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrapped-native-edu&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T06:52:03.172Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T06:51:17.906Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->