### PR TITLE
test(native): co-locate transaction, accounts, and app tests

### DIFF
--- a/suite-native/accounts/src/components/AccountLabel.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabel.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '@suite-native/test-utils-store';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { AccountLabel, type AccountLabelPropsWithAccount } from '../AccountLabel';
+import { AccountLabel, type AccountLabelPropsWithAccount } from './AccountLabel';
 
 const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 

--- a/suite-native/accounts/src/components/AccountLabelFieldHint.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabelFieldHint.test.tsx
@@ -1,8 +1,8 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderHook, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { useAccountLabelForm } from '../../hooks/useAccountLabelForm';
-import { AccountLabelFieldHint, type AccountLabelFieldHintProps } from '../AccountLabelFieldHint';
+import { AccountLabelFieldHint, type AccountLabelFieldHintProps } from './AccountLabelFieldHint';
+import { useAccountLabelForm } from '../hooks/useAccountLabelForm';
 
 describe('AccountLabelFieldHint', () => {
     const renderComponent = (props: AccountLabelFieldHintProps) =>

--- a/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
+++ b/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
@@ -3,7 +3,7 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import type { StaticSessionId } from '@trezor/connect';
 
-import { AccountTypeBadge } from '../AccountTypeBadge';
+import { AccountTypeBadge } from './AccountTypeBadge';
 
 const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 

--- a/suite-native/accounts/src/filteredDeviceAccountsSelectors.test.ts
+++ b/suite-native/accounts/src/filteredDeviceAccountsSelectors.test.ts
@@ -12,7 +12,7 @@ import {
     selectFilteredDeviceAccountsByNetworkSymbolAndAccountType,
     selectFilteredDeviceNetworkSymbols,
     selectNetworkFilterOptions,
-} from '../selectors';
+} from './selectors';
 
 const SELECTED_WALLET_DESCRIPTOR = asWalletDescriptor('selectedWallet');
 const SELECTED_DEVICE_STATIC_SESSION_ID: StaticSessionId = 'selectedWallet@deviceId:0';

--- a/suite-native/accounts/src/selectors.test.ts
+++ b/suite-native/accounts/src/selectors.test.ts
@@ -12,8 +12,8 @@ import {
     selectFreshAccountAddressValue,
     selectHasDeviceAnyFailedAccountForNetworkSymbol,
     selectIsAccountDiscoveryFailed,
-} from '../selectors';
-import { isFilterValueMatchingAccount, sortAccountsByNetworksAndAccountTypes } from '../utils';
+} from './selectors';
+import { isFilterValueMatchingAccount, sortAccountsByNetworksAndAccountTypes } from './utils';
 
 let mockStakingBalance = '0';
 

--- a/suite-native/app/src/navigation/AppTabNavigator.test.tsx
+++ b/suite-native/app/src/navigation/AppTabNavigator.test.tsx
@@ -9,7 +9,7 @@ import {
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { AppTabNavigator } from '../AppTabNavigator';
+import { AppTabNavigator } from './AppTabNavigator';
 
 jest.mock('@suite-native/module-home', () => ({ HomeStackNavigator: () => null }));
 jest.mock('@suite-native/module-accounts-management', () => ({

--- a/suite-native/transaction-management/src/feesFormSchema.test.ts
+++ b/suite-native/transaction-management/src/feesFormSchema.test.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
-import { type FeesFormContext, feesFormValidationSchema } from '../feesFormSchema';
+import { type FeesFormContext, feesFormValidationSchema } from './feesFormSchema';
 
 describe('feesFormValidationSchema', () => {
     const createContext = (overrides: Partial<FeesFormContext> = {}): FeesFormContext => ({

--- a/suite-native/transaction-management/src/selectors.test.ts
+++ b/suite-native/transaction-management/src/selectors.test.ts
@@ -1,7 +1,7 @@
 import { type FeeLevelLabel, type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
 import { isClearSignedEvmTradingSwapTransaction } from '@suite-common/wallet-utils';
 
-import { ETH_ACCOUNT_KEY, getEthAccount, getWalletState } from '../__fixtures__/walletState';
+import { ETH_ACCOUNT_KEY, getEthAccount, getWalletState } from './__fixtures__/walletState';
 import {
     type TransactionReviewOutputsState,
     selectCustomFeeLevel,
@@ -10,8 +10,8 @@ import {
     selectFormDraftByPrefix,
     selectIsClearSignedTradingSwap,
     selectIsTransactionAlreadySigned,
-} from '../selectors';
-import { type NativeSendRootState } from '../sendFormSlice';
+} from './selectors';
+import { type NativeSendRootState } from './sendFormSlice';
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),

--- a/suite-native/transaction-management/src/sendFormSlice.test.ts
+++ b/suite-native/transaction-management/src/sendFormSlice.test.ts
@@ -2,8 +2,8 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import { createFeeLevels } from '../__fixtures__/feeLevels';
-import { prepareSendFormReducer, transactionManagementActions } from '../sendFormSlice';
+import { createFeeLevels } from './__fixtures__/feeLevels';
+import { prepareSendFormReducer, transactionManagementActions } from './sendFormSlice';
 
 describe('sendFormSlice', () => {
     // Create a test store with the prepared reducer

--- a/suite-native/transaction-management/src/utils.test.ts
+++ b/suite-native/transaction-management/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
-import { getFeeDecimals, getFeeValue } from '../utils';
+import { getFeeDecimals, getFeeValue } from './utils';
 
 describe('utils', () => {
     describe('getFeeDecimals', () => {


### PR DESCRIPTION
## Description

Moves 10 Native Transaction Management, Accounts, and non-E2E App tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-transaction-accounts-app-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->