### PR TITLE
`TransactionComposer` and `FeeLevels` refactor

### DIFF
--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -6,6 +6,7 @@ import type {
     ComposeUtxo,
     ComposedInputs,
     DiscoveryAccount,
+    FeeLevel,
     SelectFeeLevel,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
@@ -16,7 +17,6 @@ import type {
 } from '@trezor/utxo-lib';
 import { composeTx, networks } from '@trezor/utxo-lib';
 
-import type { BitcoinFeeLevels } from '../../backend/fees/BitcoinFeeLevels';
 import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 type Options = {
@@ -25,7 +25,7 @@ type Options = {
     outputs: ComposeOutput[];
     coinInfo: BitcoinNetworkInfo;
     baseFee?: number;
-    feeLevels: BitcoinFeeLevels;
+    feeLevels: FeeLevel[];
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };
 
@@ -42,7 +42,7 @@ export class TransactionComposer {
 
     sortingStrategy: TransactionInputOutputSortingStrategy;
 
-    feeLevels: BitcoinFeeLevels;
+    feeLevels: FeeLevel[];
 
     customFee: string | undefined;
 
@@ -50,10 +50,10 @@ export class TransactionComposer {
 
     private get levels() {
         return this.customFee
-            ? this.feeLevels.levels.concat([
+            ? this.feeLevels.concat([
                   { label: 'custom' as const, feePerUnit: this.customFee, blocks: -1 },
               ])
-            : this.feeLevels.levels;
+            : this.feeLevels;
     }
 
     constructor(options: Options) {

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/TransactionComposer.js
 
+import type { Address } from '@trezor/blockchain-link-types';
 import type {
     BitcoinNetworkInfo,
     ComposeResult,
@@ -30,21 +31,16 @@ type Options = {
 };
 
 export class TransactionComposer {
-    account: DiscoveryAccount;
-
-    utxos: ComposedInputs[];
-
-    outputs: ComposeOutput[];
-
-    coinInfo: BitcoinNetworkInfo;
-
-    baseFee: number;
-
-    sortingStrategy: TransactionInputOutputSortingStrategy;
-
-    feeLevels: FeeLevel[];
-
-    customFee: string | undefined;
+    private account: DiscoveryAccount;
+    private utxos: ComposedInputs[];
+    private outputs: ComposeOutput[];
+    private coinInfo: BitcoinNetworkInfo;
+    private baseFee: number;
+    private sortingStrategy: TransactionInputOutputSortingStrategy;
+    private feeLevels: FeeLevel[];
+    private customFee: string | undefined;
+    private feePolicy: ComposeFeePolicy | undefined;
+    private changeAddress: Address | undefined;
 
     composed: { [key: string]: ComposeResult } = {};
 
@@ -64,63 +60,73 @@ export class TransactionComposer {
         this.sortingStrategy = options.sortingStrategy;
         this.feeLevels = options.feeLevels;
 
-        // map to @trezor/utxo-lib/compose format
         const { addresses } = options.account;
-        const allAddresses: string[] = !addresses
-            ? []
-            : addresses.used
-                  .concat(addresses.unused)
-                  .concat(addresses.change)
-                  .map(a => a.address);
-        this.utxos = options.utxos.flatMap(u => {
-            // exclude amounts lower than dust limit if they are NOT required
-            if (!u.required && new BigNumber(u.amount).lte(this.coinInfo.dustLimit)) return [];
+        const allAddresses = new Set(
+            addresses?.used
+                .concat(addresses.unused)
+                .concat(addresses.change)
+                .map(a => a.address),
+        );
 
-            return {
+        // find unused change address or fallback to the last in the list
+        this.changeAddress = addresses?.change.find(a => !a.transfers) ?? addresses?.change.at(-1);
+
+        // map to @trezor/utxo-lib/compose format
+        this.utxos = options.utxos
+            // exclude amounts lower than dust limit if they are NOT required
+            .filter(u => u.required || new BigNumber(u.amount).gt(this.coinInfo.dustLimit))
+            .map(u => ({
                 ...u,
                 coinbase: typeof u.coinbase === 'boolean' ? u.coinbase : false, // decide it it can be spent immediately (false) or after 100 conf (true)
-                own: allAddresses.includes(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
-            };
-        });
+                own: allAddresses.has(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
+            }));
+
+        if (networks.isNetworkType('doge', options.coinInfo.network)) {
+            this.feePolicy = 'doge';
+        } else if (networks.isNetworkType('zcash', options.coinInfo.network)) {
+            this.feePolicy = 'zcash';
+        }
     }
 
     // Composing fee levels for SelectFee view in popup
     composeAllFeeLevels() {
         const { levels } = this;
-        if (this.utxos.length < 1) return false;
 
-        this.composed = {};
-        let atLeastOneValid = false;
-        levels.forEach(level => {
-            if (level.feePerUnit !== '0') {
-                const tx = this.compose(level.feePerUnit);
-                if (tx.type === 'final') {
-                    atLeastOneValid = true;
-                }
-                this.composed[level.label] = tx;
-            }
-        });
-
-        if (!atLeastOneValid) {
-            // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const lastLevel: (typeof levels)[number] = levels[levels.length - 1];
-            let lastFee = new BigNumber(lastLevel.feePerUnit);
-            while (lastFee.gt(this.coinInfo.minFee) && this.composed.custom === undefined) {
-                lastFee = lastFee.minus(1);
-
-                const tx = this.compose(lastFee.toString());
-                if (tx.type === 'final') {
-                    this.customFee = lastFee.toString();
-                    this.composed.custom = tx;
-
-                    return true;
-                }
-            }
-
+        if (!this.utxos.length) {
             return false;
         }
 
-        return true;
+        this.composed = Object.fromEntries(
+            levels
+                .filter(({ feePerUnit }) => feePerUnit !== '0')
+                .map(({ label, feePerUnit }) => [label, this.compose(feePerUnit)]),
+        );
+
+        const atLeastOneValid = Object.values(this.composed).some(tx => tx.type === 'final');
+        if (atLeastOneValid) {
+            return true;
+        }
+
+        if (this.composed.custom) {
+            return false;
+        }
+
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        const lastLevel: (typeof levels)[number] = levels[levels.length - 1];
+        let lastFee = new BigNumber(lastLevel.feePerUnit);
+        while (lastFee.gt(this.coinInfo.minFee)) {
+            lastFee = lastFee.minus(1);
+
+            const tx = this.compose(lastFee.toString());
+            if (tx.type === 'final') {
+                this.customFee = lastFee.toString();
+                this.composed.custom = tx;
+
+                return true;
+            }
+        }
+
+        return false;
     }
 
     composeCustomFee(fee: string) {
@@ -129,48 +135,32 @@ export class TransactionComposer {
         this.customFee = tx.type === 'final' ? tx.feePerByte : fee;
     }
 
-    getFeeLevelList() {
-        const list: SelectFeeLevel[] = [];
-        this.levels.forEach(level => {
+    getFeeLevelList(): SelectFeeLevel[] {
+        return this.levels.map(level => {
             const tx = this.composed[level.label];
             if (tx?.type === 'final') {
-                list.push({
+                return {
                     name: level.label,
                     fee: tx.fee,
                     feePerByte: level.feePerUnit,
                     blocks: level.blocks,
                     minutes: level.blocks * this.coinInfo.blockTime,
                     total: tx.totalSpent,
-                });
+                };
             } else {
-                list.push({
+                return {
                     name: level.label,
                     fee: '0',
                     disabled: true,
-                });
+                };
             }
         });
-
-        return list;
     }
 
-    compose(feeRate: string): ComposeResult {
-        const { account, coinInfo, baseFee } = this;
-        const { addresses } = account;
-        if (!addresses) return { type: 'error', error: 'ADDRESSES-NOT-SET' };
-        // find not used change address or fallback to the last in the list
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const lastChange: (typeof addresses.change)[number] =
-            addresses.change[addresses.change.length - 1];
-        const changeAddress = addresses.change.find(a => !a.transfers) || lastChange;
-        // const inputAmounts = coinInfo.segwit || coinInfo.forkid !== null || coinInfo.network.consensusBranchId !== null;
+    private compose(feeRate: string): ComposeResult {
+        const { account, coinInfo, baseFee, changeAddress, feePolicy } = this;
 
-        let feePolicy: ComposeFeePolicy | undefined;
-        if (networks.isNetworkType('doge', coinInfo.network)) {
-            feePolicy = 'doge';
-        } else if (networks.isNetworkType('zcash', coinInfo.network)) {
-            feePolicy = 'zcash';
-        }
+        if (!changeAddress) return { type: 'error', error: 'ADDRESSES-NOT-SET' };
 
         return composeTx({
             txType: account.type,
@@ -186,9 +176,5 @@ export class TransactionComposer {
             baseFee,
             feePolicy,
         });
-    }
-
-    dispose() {
-        // TODO
     }
 }

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -45,7 +45,17 @@ export class TransactionComposer {
 
     feeLevels: BitcoinFeeLevels;
 
+    customFee: string | undefined;
+
     composed: { [key: string]: ComposeResult } = {};
+
+    private get levels() {
+        return this.customFee
+            ? this.feeLevels.levels.concat([
+                  { label: 'custom' as const, feePerUnit: this.customFee, blocks: -1 },
+              ])
+            : this.feeLevels.levels;
+    }
 
     constructor(options: Options) {
         this.account = options.account;
@@ -83,7 +93,7 @@ export class TransactionComposer {
 
     // Composing fee levels for SelectFee view in popup
     composeAllFeeLevels() {
-        const { levels } = this.feeLevels;
+        const { levels } = this;
         if (this.utxos.length < 1) return false;
 
         this.composed = {};
@@ -107,7 +117,7 @@ export class TransactionComposer {
 
                 const tx = this.compose(lastFee.toString());
                 if (tx.type === 'final') {
-                    this.feeLevels.updateBitcoinCustomFee(lastFee.toString());
+                    this.customFee = lastFee.toString();
                     this.composed.custom = tx;
 
                     return true;
@@ -123,17 +133,12 @@ export class TransactionComposer {
     composeCustomFee(fee: string) {
         const tx = this.compose(fee);
         this.composed.custom = tx;
-        if (tx.type === 'final') {
-            this.feeLevels.updateBitcoinCustomFee(tx.feePerByte);
-        } else {
-            this.feeLevels.updateBitcoinCustomFee(fee);
-        }
+        this.customFee = tx.type === 'final' ? tx.feePerByte : fee;
     }
 
     getFeeLevelList() {
         const list: SelectFeeLevel[] = [];
-        const { levels } = this.feeLevels;
-        levels.forEach(level => {
+        this.levels.forEach(level => {
             const tx = this.composed[level.label];
             if (tx?.type === 'final') {
                 list.push({

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -16,8 +16,6 @@ import type {
 } from '@trezor/utxo-lib';
 import { composeTx, networks } from '@trezor/utxo-lib';
 
-import type { Blockchain } from '../../backend/BlockchainLink';
-import { getOrInitBitcoinFeeLevels } from '../../backend/fees';
 import type { BitcoinFeeLevels } from '../../backend/fees/BitcoinFeeLevels';
 import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
@@ -27,6 +25,7 @@ type Options = {
     outputs: ComposeOutput[];
     coinInfo: BitcoinNetworkInfo;
     baseFee?: number;
+    feeLevels: BitcoinFeeLevels;
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };
 
@@ -63,7 +62,7 @@ export class TransactionComposer {
         this.coinInfo = options.coinInfo;
         this.baseFee = options.baseFee || 0;
         this.sortingStrategy = options.sortingStrategy;
-        this.feeLevels = getOrInitBitcoinFeeLevels(options.coinInfo);
+        this.feeLevels = options.feeLevels;
 
         // map to @trezor/utxo-lib/compose format
         const { addresses } = options.account;
@@ -83,12 +82,6 @@ export class TransactionComposer {
                 own: allAddresses.includes(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
             };
         });
-    }
-
-    async init(blockchain: Blockchain) {
-        if (!this.feeLevels.wasFetchedSuccessfully) {
-            await this.feeLevels.load(blockchain);
-        }
     }
 
     // Composing fee levels for SelectFee view in popup

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -38,8 +38,6 @@ export class TransactionComposer {
 
     coinInfo: BitcoinNetworkInfo;
 
-    blockHeight = 0;
-
     baseFee: number;
 
     sortingStrategy: TransactionInputOutputSortingStrategy;
@@ -52,7 +50,6 @@ export class TransactionComposer {
         this.account = options.account;
         this.outputs = options.outputs;
         this.coinInfo = options.coinInfo;
-        this.blockHeight = 0;
         this.baseFee = options.baseFee || 0;
         this.sortingStrategy = options.sortingStrategy;
         this.feeLevels = getOrInitBitcoinFeeLevels(options.coinInfo);
@@ -78,9 +75,6 @@ export class TransactionComposer {
     }
 
     async init(blockchain: Blockchain) {
-        const { blockHeight } = await blockchain.getNetworkInfo();
-        this.blockHeight = blockHeight;
-
         if (!this.feeLevels.wasFetchedSuccessfully) {
             await this.feeLevels.load(blockchain);
         }

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -19,6 +19,7 @@ import { composeTx, networks } from '@trezor/utxo-lib';
 import type { Blockchain } from '../../backend/BlockchainLink';
 import { getOrInitBitcoinFeeLevels } from '../../backend/fees';
 import type { BitcoinFeeLevels } from '../../backend/fees/BitcoinFeeLevels';
+import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 type Options = {
     account: DiscoveryAccount;
@@ -178,7 +179,8 @@ export class TransactionComposer {
             utxos: this.utxos,
             outputs: this.outputs,
             feeRate,
-            longTermFeeRate: this.feeLevels.longTermFeeRate,
+            // TODO https://github.com/trezor/trezor-suite/issues/18483 rewrite with response from a new planned blockbook API
+            longTermFeeRate: DEFAULT_BITCOIN_LONGTERM_FEE_RATE,
             sortingStrategy: this.sortingStrategy,
             network: coinInfo.network,
             changeAddress,

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -390,9 +390,8 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         // get backend instance (it should be initialized before)
         const blockchain = await this.getBlockchain(context.sendCoreMessage);
         const feeLevels = getOrInitFeeLevels(coinInfo);
-        if (!feeLevels.wasFetchedSuccessfully) {
-            await feeLevels.load(blockchain);
-        }
+        await feeLevels.load(blockchain);
+
         const composer = new TransactionComposer({
             account,
             utxos,

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -44,6 +44,7 @@ import { signTxLegacy } from './bitcoin/signtxLegacy';
 import { deriveOutputScript, verifyTx } from './bitcoin/signtxVerify';
 import { Discovery } from './common/Discovery';
 import { validateParams } from './common/paramsValidator';
+import { getOrInitBitcoinFeeLevels } from '../backend/fees';
 
 type Params = {
     outputs: ComposeOutput[];
@@ -158,6 +159,15 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
     ): Promise<PrecomposedResult[]> {
         const { coinInfo, outputs, baseFee, sortingStrategy } = this.params;
         const address_n = pathUtils.validatePath(account.path);
+
+        // This is mandatory, @trezor/utxo-lib/compose expects current block height
+        // TODO: make it possible without it (offline composing)
+        const blockchain = await this.getBlockchain(sendCoreMessage);
+        const bitcoinFeeLevels = getOrInitBitcoinFeeLevels(coinInfo);
+        if (!bitcoinFeeLevels.wasFetchedSuccessfully) {
+            await bitcoinFeeLevels.load(blockchain);
+        }
+
         const composer = new TransactionComposer({
             account: {
                 type: pathUtils.getAccountType(address_n),
@@ -170,13 +180,9 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             coinInfo,
             outputs,
             baseFee,
+            feeLevels: bitcoinFeeLevels,
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
-
-        // This is mandatory, @trezor/utxo-lib/compose expects current block height
-        // TODO: make it possible without it (offline composing)
-        const blockchain = await this.getBlockchain(sendCoreMessage);
-        await composer.init(blockchain);
 
         return feeLevels.map(level => {
             composer.composeCustomFee(level.feePerUnit);
@@ -394,14 +400,18 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         // get backend instance (it should be initialized before)
         const blockchain = await this.getBlockchain(context.sendCoreMessage);
+        const feeLevels = getOrInitBitcoinFeeLevels(coinInfo);
+        if (!feeLevels.wasFetchedSuccessfully) {
+            await feeLevels.load(blockchain);
+        }
         const composer = new TransactionComposer({
             account,
             utxos,
             coinInfo,
             outputs,
+            feeLevels,
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
-        await composer.init(blockchain);
 
         // try to compose multiple transactions with different fee levels
         // check if any of composed transactions is valid

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -1,7 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/ComposeTransaction.js
 
 import {
-    type AccountUtxo,
     type BitcoinNetworkInfo,
     type ComposeResult,
     DEFAULT_SORTING_STRATEGY,
@@ -211,21 +210,95 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
     private async interactiveFlow(context: MethodContext): Promise<SignedTransaction> {
         // discover accounts and wait for user action
-        const { account, utxo } = await this.selectAccount(context);
+        const { account, utxo: utxos } = await this.selectAccount(context);
 
-        // wait for fee selection
-        const response = await this.selectFee(account, utxo, context);
-        // check for interruption
-        if (this.disposed) {
-            throw ERRORS.TypedError(
-                'Runtime',
-                'ComposeTransaction: selectFee response received after dispose',
-            );
+        const { coinInfo, outputs, sortingStrategy, push } = this.params;
+
+        // get backend instance (it should be initialized before)
+        const blockchain = await this.getBlockchain(context.sendCoreMessage);
+        const feeLevels = getOrInitFeeLevels(coinInfo);
+        await feeLevels.load(blockchain);
+
+        const composer = new TransactionComposer({
+            account,
+            utxos,
+            coinInfo,
+            outputs,
+            feeLevels: feeLevels.levels,
+            sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
+        });
+
+        // try to compose multiple transactions with different fee levels
+        // check if any of composed transactions is valid
+        const hasFunds = composer.composeAllFeeLevels();
+        if (!hasFunds) {
+            // show error view
+            context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
+            // wait few seconds...
+            await resolveAfter(2000);
+
+            // and go back to discovery
+            return this.interactiveFlow(context);
         }
 
-        if (typeof response === 'string') {
+        // set select account view
+        // this view will be updated from discovery events
+        context.sendCoreMessage(
+            createUiMessage(UI_REQUEST.SELECT_FEE, {
+                feeLevels: composer.getFeeLevelList(),
+                coinInfo: this.params.coinInfo,
+            }),
+        );
+
+        // wait for fee selection
+        let resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice()).promise;
+
+        while (resp.payload.type === 'compose-custom') {
+            // recompose custom fee level with requested value
+            composer.composeCustomFee(resp.payload.value);
+            context.sendCoreMessage(
+                createUiMessage(
+                    UI_REQUEST.UPDATE_CUSTOM_FEE,
+                    {
+                        feeLevels: composer.getFeeLevelList(),
+                        coinInfo: this.params.coinInfo,
+                    },
+                    { requestId: resp.requestId },
+                ),
+            );
+
+            // wait for user action
+            resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice()).promise;
+        }
+
+        if (resp.payload.type === 'change-account') {
+            // check for interruption
+            if (this.disposed) {
+                throw ERRORS.TypedError(
+                    'Runtime',
+                    'ComposeTransaction: selectFee response received after dispose',
+                );
+            }
+
             // back to account selection
             return this.interactiveFlow(context);
+        }
+
+        const { composed } = composer;
+        const composedKey = resp.payload.value;
+        // @ts-expect-error: noUncheckedIndexedAccess
+        const tx: ComposeResult = composed[composedKey];
+
+        const response = await this._sign(tx, context.sendCoreMessage);
+
+        if (push) {
+            const blockchain2 = await this.getBlockchain(context.sendCoreMessage);
+            const txid = await blockchain2.pushTransaction(response.serializedTx);
+
+            return {
+                ...response,
+                txid,
+            };
         }
 
         return response;
@@ -384,91 +457,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         return { account, utxo };
     }
 
-    private async selectFee(
-        account: DiscoveryAccount,
-        utxos: AccountUtxo[],
-        context: MethodContext,
-    ) {
-        const { coinInfo, outputs, sortingStrategy } = this.params;
-
-        // get backend instance (it should be initialized before)
-        const blockchain = await this.getBlockchain(context.sendCoreMessage);
-        const feeLevels = getOrInitFeeLevels(coinInfo);
-        await feeLevels.load(blockchain);
-
-        const composer = new TransactionComposer({
-            account,
-            utxos,
-            coinInfo,
-            outputs,
-            feeLevels: feeLevels.levels,
-            sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
-        });
-
-        // try to compose multiple transactions with different fee levels
-        // check if any of composed transactions is valid
-        const hasFunds = composer.composeAllFeeLevels();
-        if (!hasFunds) {
-            // show error view
-            context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
-            // wait few seconds...
-            await resolveAfter(2000);
-
-            // and go back to discovery
-            return 'change-account';
-        }
-
-        // set select account view
-        // this view will be updated from discovery events
-        context.sendCoreMessage(
-            createUiMessage(UI_REQUEST.SELECT_FEE, {
-                feeLevels: composer.getFeeLevelList(),
-                coinInfo: this.params.coinInfo,
-            }),
-        );
-
-        // wait for user action
-        return this._selectFeeUiResponse(composer, context);
-    }
-
-    private async _selectFeeUiResponse(
-        composer: TransactionComposer,
-        context: MethodContext,
-    ): Promise<SignedTransaction | 'change-account'> {
-        const resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice())
-            .promise;
-        switch (resp.payload.type) {
-            case 'compose-custom':
-                // recompose custom fee level with requested value
-                composer.composeCustomFee(resp.payload.value);
-                context.sendCoreMessage(
-                    createUiMessage(
-                        UI_REQUEST.UPDATE_CUSTOM_FEE,
-                        {
-                            feeLevels: composer.getFeeLevelList(),
-                            coinInfo: this.params.coinInfo,
-                        },
-                        { requestId: resp.requestId },
-                    ),
-                );
-
-                // wait for user action
-                return this._selectFeeUiResponse(composer, context);
-
-            case 'send': {
-                const { composed } = composer;
-                const composedKey = resp.payload.value;
-                // @ts-expect-error: noUncheckedIndexedAccess
-                const tx: ComposeResult = composed[composedKey];
-
-                return this._sign(tx, context.sendCoreMessage);
-            }
-
-            default:
-                return 'change-account';
-        }
-    }
-
     private async _sign(tx: ComposeResult, sendCoreMessage: MethodContext['sendCoreMessage']) {
         const device = this.getDevice();
         const { params } = this;
@@ -519,16 +507,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             outputScripts,
             network: coinInfo.network,
         });
-
-        if (params.push) {
-            const blockchain = await this.getBlockchain(sendCoreMessage);
-            const txid = await blockchain.pushTransaction(response.serializedTx);
-
-            return {
-                ...response,
-                txid,
-            };
-        }
 
         return response;
     }

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -201,11 +201,15 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         return Promise.resolve(levels);
     }
 
-    async run(context: MethodContext): Promise<SignedTransaction | PrecomposedResult[]> {
+    run(context: MethodContext) {
         if (this.params.account && this.params.feeLevels) {
             return this.precompose(this.params.account, this.params.feeLevels);
+        } else {
+            return this.interactiveFlow(context);
         }
+    }
 
+    private async interactiveFlow(context: MethodContext): Promise<SignedTransaction> {
         // discover accounts and wait for user action
         const { account, utxo } = await this.selectAccount(context);
 
@@ -221,7 +225,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         if (typeof response === 'string') {
             // back to account selection
-            return this.run(context);
+            return this.interactiveFlow(context);
         }
 
         return response;

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -44,7 +44,7 @@ import { signTxLegacy } from './bitcoin/signtxLegacy';
 import { deriveOutputScript, verifyTx } from './bitcoin/signtxVerify';
 import { Discovery } from './common/Discovery';
 import { validateParams } from './common/paramsValidator';
-import { getOrInitBitcoinFeeLevels } from '../backend/fees';
+import { getOrInitFeeLevels } from '../backend/fees';
 
 type Params = {
     outputs: ComposeOutput[];
@@ -163,7 +163,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         // This is mandatory, @trezor/utxo-lib/compose expects current block height
         // TODO: make it possible without it (offline composing)
         const blockchain = await this.getBlockchain(sendCoreMessage);
-        const bitcoinFeeLevels = getOrInitBitcoinFeeLevels(coinInfo);
+        const bitcoinFeeLevels = getOrInitFeeLevels(coinInfo);
         if (!bitcoinFeeLevels.wasFetchedSuccessfully) {
             await bitcoinFeeLevels.load(blockchain);
         }
@@ -400,7 +400,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         // get backend instance (it should be initialized before)
         const blockchain = await this.getBlockchain(context.sendCoreMessage);
-        const feeLevels = getOrInitBitcoinFeeLevels(coinInfo);
+        const feeLevels = getOrInitFeeLevels(coinInfo);
         if (!feeLevels.wasFetchedSuccessfully) {
             await feeLevels.load(blockchain);
         }

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -152,21 +152,12 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         return initBlockchain(this.params.coinInfo, sendCoreMessage, this.params.identity);
     }
 
-    private async precompose(
+    private precompose(
         account: PrecomposeParams['account'],
         feeLevels: PrecomposeParams['feeLevels'],
-        sendCoreMessage: MethodContext['sendCoreMessage'],
     ): Promise<PrecomposedResult[]> {
         const { coinInfo, outputs, baseFee, sortingStrategy } = this.params;
         const address_n = pathUtils.validatePath(account.path);
-
-        // This is mandatory, @trezor/utxo-lib/compose expects current block height
-        // TODO: make it possible without it (offline composing)
-        const blockchain = await this.getBlockchain(sendCoreMessage);
-        const bitcoinFeeLevels = getOrInitFeeLevels(coinInfo);
-        if (!bitcoinFeeLevels.wasFetchedSuccessfully) {
-            await bitcoinFeeLevels.load(blockchain);
-        }
 
         const composer = new TransactionComposer({
             account: {
@@ -180,11 +171,11 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             coinInfo,
             outputs,
             baseFee,
-            feeLevels: bitcoinFeeLevels.levels,
+            feeLevels: [], // Not needed for composeCustomFee
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 
-        return feeLevels.map(level => {
+        const levels = feeLevels.map(level => {
             composer.composeCustomFee(level.feePerUnit);
             const { composed } = composer;
             // @ts-expect-error: noUncheckedIndexedAccess
@@ -206,15 +197,13 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
             return tx;
         });
+
+        return Promise.resolve(levels);
     }
 
     async run(context: MethodContext): Promise<SignedTransaction | PrecomposedResult[]> {
         if (this.params.account && this.params.feeLevels) {
-            return this.precompose(
-                this.params.account,
-                this.params.feeLevels,
-                context.sendCoreMessage,
-            );
+            return this.precompose(this.params.account, this.params.feeLevels);
         }
 
         // discover accounts and wait for user action

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -180,7 +180,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             coinInfo,
             outputs,
             baseFee,
-            feeLevels: bitcoinFeeLevels,
+            feeLevels: bitcoinFeeLevels.levels,
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 
@@ -409,7 +409,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             utxos,
             coinInfo,
             outputs,
-            feeLevels,
+            feeLevels: feeLevels.levels,
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts
@@ -74,33 +74,6 @@ describe('BitcoinFeeLevels', () => {
         expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '22']);
     });
 
-    it('fetches Bitcoin smart FeeLevels with custom fee level', async () => {
-        const coinInfo = getBitcoinNetwork('btc');
-        if (!coinInfo) throw new Error('coinInfo is missing');
-        const coinInfoMock = { ...coinInfo, defaultFees: defaultFeesMock };
-
-        const spy = jest
-            .spyOn(BlockchainLink.prototype, 'estimateFee')
-            .mockImplementation(estimateFeeMockOK);
-
-        const backend = await initBlockchain(coinInfoMock, () => {});
-        const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
-
-        // 'custom' level is appended at the end
-        feeLevelsInstance.updateBitcoinCustomFee('7.6');
-        expect(feeLevelsInstance.levels.at(-1)).toMatchObject({
-            label: 'custom',
-            feePerUnit: '7.6',
-        });
-
-        const result = await feeLevelsInstance.load(backend);
-        // 'custom' level is excluded from the query
-        expect(spy).toHaveBeenCalledWith({ blocks: [1, 10, 40, 80] });
-
-        // but the 'custom' level is still present, unchanged
-        expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2', '7.6']);
-    });
-
     it('fetches Testnet smart FeeLevels with some unknown results in response', async () => {
         const coinInfo = getBitcoinNetwork('test');
         if (!coinInfo) throw new Error('coinInfo is missing');

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts
@@ -52,7 +52,8 @@ describe('BitcoinFeeLevels', () => {
         // returns preloaded values from coins.json
         expect(feeLevelsInstance.levels.map(l => l.feePerUnit)).toEqual(['222', '111', '77', '22']);
 
-        const result = await feeLevelsInstance.load(backend);
+        await feeLevelsInstance.load(backend);
+        const result = feeLevelsInstance.levels;
         // linear mock of requested blocks
         expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '2']);
     });
@@ -69,7 +70,8 @@ describe('BitcoinFeeLevels', () => {
         const backend = await initBlockchain(coinInfoMock, () => {});
         const feeLevelsInstance = new BitcoinFeeLevels(coinInfoMock);
 
-        const result = await feeLevelsInstance.load(backend);
+        await feeLevelsInstance.load(backend);
+        const result = feeLevelsInstance.levels;
         // linear mock of requested blocks, or preloaded values if not fetched successfully
         expect(result.map(l => l.feePerUnit)).toEqual(['9.9', '9', '6', '22']);
     });
@@ -93,7 +95,8 @@ describe('BitcoinFeeLevels', () => {
         // returns preloaded values from coins.json
         expect(feeLevelsInstance.levels.map(l => l.feePerUnit)).toEqual(['111']);
 
-        const result = await feeLevelsInstance.load(backend);
+        await feeLevelsInstance.load(backend);
+        const result = feeLevelsInstance.levels;
         expect(result?.map(l => l.feePerUnit)).toEqual(['9']);
     });
 });

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -35,7 +35,6 @@ export class BitcoinFeeLevels extends MiscFeeLevels {
                 const level: (typeof this.levels)[number] = this.levels[index];
                 level.feePerUnit = trimmedFeePerUnit.toString();
             });
-            this.wasFetchedSuccessfully = true;
         } catch {
             // do not throw, just keep current fee levels
         }

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -1,26 +1,32 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/Fees.js
 
-import type { BitcoinNetworkInfo } from '@trezor/connect-common';
+import type { BitcoinNetworkInfo, FeeLevel } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { cloneObject } from '@trezor/utils/src/cloneObject';
 import { clamp } from '@trezor/utils/src/number';
 
 import type { Blockchain } from '../Blockchain';
-import { MiscFeeLevels } from './MiscFeeLevels';
+import type { FeeLevels } from './feeLevelsBase';
 
-export class BitcoinFeeLevels extends MiscFeeLevels {
-    coinInfo: BitcoinNetworkInfo;
+export class BitcoinFeeLevels implements FeeLevels {
+    private coinInfo: BitcoinNetworkInfo;
+    private feeLevels: FeeLevel[];
+
+    get levels() {
+        return this.feeLevels;
+    }
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: BitcoinNetworkInfo) {
-        super(coinInfo);
         this.coinInfo = coinInfo;
+        this.feeLevels = cloneObject(coinInfo.defaultFees);
     }
 
     async load(blockchain: Blockchain) {
         try {
             const { minFee, maxFee } = this.coinInfo;
-            // get numbers of blocks to be requested, filter out 'custom' if present (the last one)
-            const blocks = this.levels.map(level => level.blocks).filter(b => b > 0);
+            // get numbers of blocks to be requested
+            const blocks = this.feeLevels.map(level => level.blocks);
             const response = await blockchain.estimateFee({ blocks });
 
             response.forEach(({ feePerUnit: feePerKB }, index) => {
@@ -32,13 +38,11 @@ export class BitcoinFeeLevels extends MiscFeeLevels {
 
                 const trimmedFeePerUnit = clamp(feePerB, minFee, maxFee);
                 // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                const level: (typeof this.levels)[number] = this.levels[index];
+                const level: (typeof this.feeLevels)[number] = this.feeLevels[index];
                 level.feePerUnit = trimmedFeePerUnit.toString();
             });
         } catch {
             // do not throw, just keep current fee levels
         }
-
-        return this.levels;
     }
 }

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -6,18 +6,14 @@ import { clamp } from '@trezor/utils/src/number';
 
 import type { Blockchain } from '../Blockchain';
 import { MiscFeeLevels } from './MiscFeeLevels';
-import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 export class BitcoinFeeLevels extends MiscFeeLevels {
     coinInfo: BitcoinNetworkInfo;
-    longTermFeeRate: string; // long term fee rate is used by @trezor/utxo-lib composeTx module
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: BitcoinNetworkInfo) {
         super(coinInfo);
         this.coinInfo = coinInfo;
-        // TODO https://github.com/trezor/trezor-suite/issues/18483 rewrite with response from a new planned blockbook API
-        this.longTermFeeRate = DEFAULT_BITCOIN_LONGTERM_FEE_RATE;
     }
 
     async load(blockchain: Blockchain) {

--- a/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
+++ b/packages/connect/src/backend/fees/BitcoinFeeLevels.ts
@@ -42,18 +42,4 @@ export class BitcoinFeeLevels extends MiscFeeLevels {
 
         return this.levels;
     }
-
-    updateBitcoinCustomFee(feePerUnit: string) {
-        this.levels = this.levels.filter(l => l.label !== 'custom');
-        this.levels.push({
-            label: 'custom',
-            feePerUnit,
-            /*
-             We do not estimate confirmation time for custom fees. It could be interpolated if we had
-             an array of historical fee rates, but not with the mempool.space API that blockbook provides.
-             That data, although great for estimating low/normal/high fees, means something completely different.
-            */
-            blocks: -1,
-        });
-    }
 }

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.test.ts
@@ -247,12 +247,9 @@ describe('api/ethereum/Fees', () => {
         const backend = await initBlockchain(coinInfo, () => {});
         const feeLevels = new EthereumFeeLevels(coinInfo);
 
-        expect(feeLevels.wasFetchedSuccessfully).toBeFalsy();
-
         const levelsAfterError = await feeLevels.load(backend, ETH_REQUEST);
 
         expect(levelsAfterError).toEqual(feeLevels.levels);
-        expect(feeLevels.wasFetchedSuccessfully).toBeFalsy();
 
         backend.disconnect();
         spy.mockRestore();

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.test.ts
@@ -54,7 +54,8 @@ describe('api/ethereum/Fees', () => {
 
         expect(feeLevels.levels).toHaveLength(1);
 
-        const smartLevels = await feeLevels.load(backend, ETH_REQUEST);
+        await feeLevels.load(backend, ETH_REQUEST);
+        const smartLevels = feeLevels.levels;
 
         expect(smartLevels).toHaveLength(3);
         expect(smartLevels?.map(l => l.label)).toEqual(['low', 'normal', 'high']);
@@ -78,9 +79,9 @@ describe('api/ethereum/Fees', () => {
             const backend = await initBlockchain(coinInfo, () => {});
             const feeLevels = new EthereumFeeLevels(coinInfo);
 
-            const levels = await feeLevels.load(backend, ETH_REQUEST);
+            await feeLevels.load(backend, ETH_REQUEST);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const [level]: [FeeLevel] = levels;
+            const [level]: [FeeLevel] = feeLevels.levels;
 
             // 0.001 Gwei → 0.001 × 1e9 = 1 000 000 wei
             expect(level.feePerUnit).toBe('1000000');
@@ -98,9 +99,9 @@ describe('api/ethereum/Fees', () => {
             const backend = await initBlockchain(coinInfo, () => {});
             const feeLevels = new EthereumFeeLevels(coinInfo);
 
-            const levels = await feeLevels.load(backend, ETH_REQUEST);
+            await feeLevels.load(backend, ETH_REQUEST);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const [level]: [FeeLevel] = levels;
+            const [level]: [FeeLevel] = feeLevels.levels;
 
             // must be an integer wei string — fromWei("1500000000.7", 'gwei') would crash
             expect(level.feePerUnit).toMatch(/^\d+$/);
@@ -127,7 +128,8 @@ describe('api/ethereum/Fees', () => {
             const backend = await initBlockchain(coinInfo, () => {});
             const feeLevels = new EthereumFeeLevels(coinInfo);
 
-            const levels = await feeLevels.load(backend, ETH_REQUEST);
+            await feeLevels.load(backend, ETH_REQUEST);
+            const { levels } = feeLevels;
 
             // minFee for eth = 0.001 Gwei → 0.001 × 1e9 = 1 000 000 wei
             // maxFeePerGas must be an integer wei string, never a decimal gwei string like "0.001"
@@ -150,9 +152,9 @@ describe('api/ethereum/Fees', () => {
             const backend = await initBlockchain(coinInfo, () => {});
             const feeLevels = new EthereumFeeLevels(coinInfo);
 
-            const levels = await feeLevels.load(backend, ETH_REQUEST);
+            await feeLevels.load(backend, ETH_REQUEST);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const [level]: [FeeLevel] = levels;
+            const [level]: [FeeLevel] = feeLevels.levels;
 
             // maxFee = 10 000 Gwei → 10 000 × 1e9 = 10 000 000 000 000 wei
             expect(level.feePerUnit).toBe('10000000000000');
@@ -175,7 +177,8 @@ describe('api/ethereum/Fees', () => {
         const backend = await initBlockchain(coinInfo, () => {});
         const feeLevels = new EthereumFeeLevels(coinInfo);
 
-        const smartLevels = await feeLevels.load(backend, ETH_REQUEST);
+        await feeLevels.load(backend, ETH_REQUEST);
+        const smartLevels = feeLevels.levels;
 
         expect(smartLevels).toHaveLength(1);
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -226,7 +229,8 @@ describe('api/ethereum/Fees', () => {
         const backend = await initBlockchain(coinInfo, () => {});
         const feeLevels = new EthereumFeeLevels(coinInfo);
 
-        const smart = await feeLevels.load(backend, ETH_REQUEST);
+        await feeLevels.load(backend, ETH_REQUEST);
+        const smart = feeLevels.levels;
 
         smart.forEach(lvl => {
             expect(Number(lvl.maxPriorityFeePerGas)).toBe(30e9);
@@ -247,7 +251,8 @@ describe('api/ethereum/Fees', () => {
         const backend = await initBlockchain(coinInfo, () => {});
         const feeLevels = new EthereumFeeLevels(coinInfo);
 
-        const levelsAfterError = await feeLevels.load(backend, ETH_REQUEST);
+        await feeLevels.load(backend, ETH_REQUEST);
+        const levelsAfterError = feeLevels.levels;
 
         expect(levelsAfterError).toEqual(feeLevels.levels);
 

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -85,7 +85,6 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                     feePerUnit,
                 };
             }
-            this.wasFetchedSuccessfully = true;
         } catch {
             // silent
         }

--- a/packages/connect/src/backend/fees/EthereumFeeLevels.ts
+++ b/packages/connect/src/backend/fees/EthereumFeeLevels.ts
@@ -1,20 +1,29 @@
 import type { EthereumNetworkInfo, FeeLevel } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
+import { cloneObject } from '@trezor/utils/src/cloneObject';
+import { isNotNull } from '@trezor/utils/src/isNotNull';
 import { clamp } from '@trezor/utils/src/number';
 
 import type { Blockchain } from '../Blockchain';
-import { MiscFeeLevels } from './MiscFeeLevels';
+import type { FeeLevels } from './feeLevelsBase';
 
-export class EthereumFeeLevels extends MiscFeeLevels {
-    coinInfo: EthereumNetworkInfo;
+export class EthereumFeeLevels implements FeeLevels {
+    private coinInfo: EthereumNetworkInfo;
+    private level: FeeLevel;
+    private eip1559levels?: FeeLevel[];
+
+    get levels() {
+        return this.eip1559levels ?? [this.level];
+    }
 
     // override only to narrow down the coinInfo type
     constructor(coinInfo: EthereumNetworkInfo) {
-        super(coinInfo);
         this.coinInfo = coinInfo;
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        this.level = cloneObject(coinInfo.defaultFees[0]);
     }
 
-    async load(blockchain: Blockchain, request: Parameters<typeof blockchain.estimateFee>[0]) {
+    async load(blockchain: Blockchain, request: Parameters<Blockchain['estimateFee']>[0]) {
         try {
             const estimateResult = await blockchain.estimateFee(request);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -42,7 +51,7 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                 const levels = (['low', 'medium', 'high'] as const).map(levelKey => {
                     const level = eip1559[levelKey];
 
-                    const label = levelKey === 'medium' ? 'normal' : levelKey;
+                    const label: FeeLevel['label'] = levelKey === 'medium' ? 'normal' : levelKey;
 
                     if (!level?.maxFeePerGas || !level?.maxPriorityFeePerGas) {
                         return null;
@@ -74,21 +83,13 @@ export class EthereumFeeLevels extends MiscFeeLevels {
                     };
                 });
 
-                this.levels = levels.filter(level => level) as FeeLevel[];
+                this.eip1559levels = levels.filter(isNotNull);
             } else {
-                const { levels } = this;
-                // @ts-expect-error: indexing with noUncheckedIndexedAccess
-                const currentLevel: (typeof levels)[number] = levels[0];
-                this.levels[0] = {
-                    ...currentLevel,
-                    ...response,
-                    feePerUnit,
-                };
+                this.eip1559levels = undefined;
+                this.level = { ...this.level, ...response, feePerUnit };
             }
         } catch {
             // silent
         }
-
-        return this.levels;
     }
 }

--- a/packages/connect/src/backend/fees/MiscFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.test.ts
@@ -50,7 +50,6 @@ describe('MiscFeeLevels – Solana', () => {
             feePerUnit: '8000',
             feeLimit: '1234',
         });
-        expect(feeLevels.wasFetchedSuccessfully).toBe(true);
         expect(backend.estimateFee).toHaveBeenCalledWith(REQUEST);
     });
 
@@ -83,6 +82,5 @@ describe('MiscFeeLevels – Solana', () => {
         const after = await feeLevels.load(backend, REQUEST);
 
         expect(after).toEqual(original);
-        expect(feeLevels.wasFetchedSuccessfully).toBe(false);
     });
 });

--- a/packages/connect/src/backend/fees/MiscFeeLevels.test.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.test.ts
@@ -40,7 +40,8 @@ describe('MiscFeeLevels – Solana', () => {
         const feeLevels = new MiscFeeLevels(SOL_COIN_INFO);
         const backend = makeBackend(HAPPY_RESPONSE);
 
-        const levels = await feeLevels.load(backend, REQUEST);
+        await feeLevels.load(backend, REQUEST);
+        const { levels } = feeLevels;
 
         expect(levels).toHaveLength(1);
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -79,8 +80,8 @@ describe('MiscFeeLevels – Solana', () => {
         const feeLevels = new MiscFeeLevels(SOL_COIN_INFO);
         const original = [...feeLevels.levels];
 
-        const after = await feeLevels.load(backend, REQUEST);
+        await feeLevels.load(backend, REQUEST);
 
-        expect(after).toEqual(original);
+        expect(feeLevels.levels).toEqual(original);
     });
 });

--- a/packages/connect/src/backend/fees/MiscFeeLevels.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.ts
@@ -5,17 +5,23 @@ import { BigNumber } from '@trezor/utils/src/bigNumber';
 import { cloneObject } from '@trezor/utils/src/cloneObject';
 
 import type { Blockchain } from '../Blockchain';
+import type { FeeLevels } from './feeLevelsBase';
 
-export class MiscFeeLevels {
-    coinInfo: CoinInfo;
-    levels: FeeLevel[];
+export class MiscFeeLevels implements FeeLevels {
+    private coinInfo: CoinInfo;
+    private level: FeeLevel;
+
+    get levels() {
+        return [this.level];
+    }
 
     constructor(coinInfo: CoinInfo) {
         this.coinInfo = coinInfo;
-        this.levels = cloneObject(coinInfo.defaultFees);
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess - misc coins should have only one FeeLevel (normal)
+        this.level = cloneObject(coinInfo.defaultFees[0]);
     }
 
-    async load(blockchain: Blockchain, request: Parameters<typeof blockchain.estimateFee>[0] = {}) {
+    async load(blockchain: Blockchain, request: Parameters<Blockchain['estimateFee']>[0]) {
         try {
             const estimateResult = await blockchain.estimateFee(request);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -32,19 +38,9 @@ export class MiscFeeLevels {
                 Math.max(this.coinInfo.minFee, fee),
             ).toString();
 
-            // misc coins should have only one FeeLevel (normal)
-            const { levels } = this;
-            // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const currentLevel: (typeof levels)[number] = levels[0];
-            this.levels[0] = {
-                ...currentLevel,
-                ...response,
-                feePerUnit,
-            };
+            this.level = { ...this.level, ...response, feePerUnit };
         } catch {
             // silent
         }
-
-        return this.levels;
     }
 }

--- a/packages/connect/src/backend/fees/MiscFeeLevels.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.ts
@@ -9,8 +9,6 @@ import type { Blockchain } from '../Blockchain';
 export class MiscFeeLevels {
     coinInfo: CoinInfo;
     levels: FeeLevel[];
-    // indicates that this.levels are current rates from backend, otherwise they are only the default values from jsons
-    wasFetchedSuccessfully: boolean = false;
 
     constructor(coinInfo: CoinInfo) {
         this.coinInfo = coinInfo;
@@ -43,7 +41,6 @@ export class MiscFeeLevels {
                 ...response,
                 feePerUnit,
             };
-            this.wasFetchedSuccessfully = true;
         } catch {
             // silent
         }

--- a/packages/connect/src/backend/fees/MiscFeeLevels.ts
+++ b/packages/connect/src/backend/fees/MiscFeeLevels.ts
@@ -17,7 +17,7 @@ export class MiscFeeLevels {
         this.levels = cloneObject(coinInfo.defaultFees);
     }
 
-    async load(blockchain: Blockchain, request: Parameters<typeof blockchain.estimateFee>[0]) {
+    async load(blockchain: Blockchain, request: Parameters<typeof blockchain.estimateFee>[0] = {}) {
         try {
             const estimateResult = await blockchain.estimateFee(request);
             // @ts-expect-error: indexing with noUncheckedIndexedAccess

--- a/packages/connect/src/backend/fees/feeLevelsBase.ts
+++ b/packages/connect/src/backend/fees/feeLevelsBase.ts
@@ -1,0 +1,8 @@
+import type { FeeLevel } from '@trezor/connect-common';
+
+import type { Blockchain } from '../Blockchain';
+
+export interface FeeLevels {
+    levels: FeeLevel[];
+    load(blockchain: Blockchain, request?: Parameters<Blockchain['estimateFee']>[0]): Promise<void>;
+}

--- a/packages/connect/src/backend/fees/index.ts
+++ b/packages/connect/src/backend/fees/index.ts
@@ -1,4 +1,4 @@
-import type { BitcoinNetworkInfo, CoinInfo } from '@trezor/connect-common';
+import type { CoinInfo } from '@trezor/connect-common';
 import { exhaustive } from '@trezor/type-utils';
 
 import { BitcoinFeeLevels } from './BitcoinFeeLevels';
@@ -25,17 +25,5 @@ const feeLevelsPerTypeFactory = (coinInfo: CoinInfo): MiscFeeLevels => {
 /**
  * Helper to keep a single instance of FeeLevels for each coin
  */
-export const getOrInitFeeLevels = (coinInfo: CoinInfo): MiscFeeLevels => {
-    const { shortcut } = coinInfo;
-    if (!Object.prototype.hasOwnProperty.call(instancesPerCoin, shortcut)) {
-        instancesPerCoin[shortcut] = feeLevelsPerTypeFactory(coinInfo);
-    }
-
-    // @ts-expect-error: indexing with noUncheckedIndexedAccess
-    const instance: MiscFeeLevels = instancesPerCoin[shortcut];
-
-    return instance;
-};
-
-export const getOrInitBitcoinFeeLevels = (coinInfo: BitcoinNetworkInfo) =>
-    getOrInitFeeLevels(coinInfo) as BitcoinFeeLevels;
+export const getOrInitFeeLevels = (coinInfo: CoinInfo) =>
+    (instancesPerCoin[coinInfo.shortcut] ??= feeLevelsPerTypeFactory(coinInfo));

--- a/packages/connect/src/backend/fees/index.ts
+++ b/packages/connect/src/backend/fees/index.ts
@@ -4,10 +4,11 @@ import { exhaustive } from '@trezor/type-utils';
 import { BitcoinFeeLevels } from './BitcoinFeeLevels';
 import { EthereumFeeLevels } from './EthereumFeeLevels';
 import { MiscFeeLevels } from './MiscFeeLevels';
+import type { FeeLevels } from './feeLevelsBase';
 
-const instancesPerCoin: { [shortcut: CoinInfo['shortcut']]: MiscFeeLevels } = {};
+const instancesPerCoin: { [shortcut: CoinInfo['shortcut']]: FeeLevels } = {};
 
-const feeLevelsPerTypeFactory = (coinInfo: CoinInfo): MiscFeeLevels => {
+const feeLevelsPerTypeFactory = (coinInfo: CoinInfo): FeeLevels => {
     const { type } = coinInfo;
 
     switch (type) {


### PR DESCRIPTION
## Description

Prerequisite for #30253 (extracting interactive flow from `composeTransaction` to new `sendTransaction` method). This one cleans up the `composeTransaction` method and related code `TransactionComposer` and `FeeLevels` in `@trezor/connect` package. This shouldn't introduce any meaningful changes for users or 3rd parties.

## Commits

- unused `blockHeight` field removed from `TransactionComposer`
  - this will later help to decouple `BitcoinFeeLevels` and `TransactionComposer`
- `longTermFeeRate` moved from `BitcoinFeeLevels` directly to `TransactionComposer`
  - it was constant anyway, and it will again help with decoupling
- custom fee moved from `BitcoinFeeLevels` to `TransactionComposer`
  - **last custom fee is now not persisted in Connect** (it wasn't always real custom fee but sometimes also last calculated fee anyway, see `composeTransaction`'s non-interactive flow)
  - `composeTransaction` should behave same as before
  - **`blockchainEstimateFee` response now won't contain custom fee level if previously set**
    - consequently, custom fee level is never stored in Suite's `feesReducer`, as it seems it was always filtered out anyway
- loading fees from backend was moved outside `TransactionComposer`
  - `TransactionComposer` is now fully synchronous and deterministic
- instead of `BitcoinFeeLevels`, only resulting levels are now passed to `TransactionComposer`
  - `BitcoinFeeLevels` are now decoupled from `TransactionComposer`
- `BitcoinFeeLevels` are now handled the same as any other fee levels
  - special treatment isn't needed anymore as there is no custom level or long term fee rate
- fee levels are now **not** loaded in non-interactive (= Suite) `composeTransaction` flow
  - in this flow, only custom fees were used anyway and they don't need to be loaded
- `wasFetchedSuccessfully` flag removed from fee levels
  - in `blockchainEstimateFee` it was unused
  - in non-interactive `composeTransaction` flow, loading fees was removed
  - in interactive `composeTransaction` flow it's probably fine to always fetch the current fees
- `TransactionComposer` code polished
  - no behavioral changes expected
- `BitcoinFeeLevels`/`EthereumFeeLevels`/`MiscFeeLevels` decoupled 
  - instead of inheriting `MiscFeeLevels`, classes now implement common interface
  - this allows e.g. not to store fee levels as an array where only one level is ever expected
  - no behavioral changes expected
- separate interactive and non-interactive `composeTransaction` flow
  - in interactive flow, only the interactive flow is now recursively executed instead of whole `run` method
- interactive `composeTransaction` flow was spaghettified
  - it allows cleaner control flow instead of e.g. returning payloads **or** arbitrary control strings from subroutines
  - no behavioral changes expected

## Followup

Separation of interactive `composeTransaction` flow into a new `sendTransaction` method (#30253).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on Connect transaction composition (Bitcoin UTXO composer) and fee-level calculation for Bitcoin, Ethereum, and miscellaneous chains. The highest risk is incorrect fee computation or broken transaction composition, which is user-visible at device confirmation and broadcast time. The recommended strategy prioritizes send/swap/staking flows that exercise custom fees and transaction composition across BTC, ETH, Base, and SOL, while avoiding broad coverage from the heavily-shared fees/index.ts barrel.

<details><summary><b>Changed files (10)</b></summary>

- `packages/connect/src/api/bitcoin/TransactionComposer.ts`
- `packages/connect/src/api/composeTransaction.ts`
- `packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts`
- `packages/connect/src/backend/fees/BitcoinFeeLevels.ts`
- `packages/connect/src/backend/fees/EthereumFeeLevels.test.ts`
- `packages/connect/src/backend/fees/EthereumFeeLevels.ts`
- `packages/connect/src/backend/fees/MiscFeeLevels.test.ts`
- `packages/connect/src/backend/fees/MiscFeeLevels.ts`
- `packages/connect/src/backend/fees/feeLevelsBase.ts`
- `packages/connect/src/backend/fees/index.ts`

</details>

**Recommended tests (15)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Directly exercises custom EVM gas fees (gas limit, max fee per gas, max priority fee per gas) on the Base network and verifies device prompt fee breakdowns, making it a strong regression detector for EthereumFeeLevels changes.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Validates the full Dogecoin send flow including fee calculation and device prompt total/fee display; uses composeTransaction paths for UTXO chains with large amounts near MAX_SAFE_INTEGER.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Covers the Ethereum send flow with custom gas parameters and asserts max fee, fee rate, and gas limit values on both the Suite prompt and hardware device display.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Exercises the LTC send flow with set-max amount and mocked blockbook backend, directly touching composeTransaction/TransactionComposer for a Bitcoin-like network.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Directly tests Bitcoin transaction composition with multiple outputs, locktime, OP_RETURN, amount unit switching, and fee handling; this is one of the most comprehensive covers of TransactionComposer and BitcoinFeeLevels.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Validates Solana fee calculation, max sendable amount (balance minus fees and reserve), and device prompt fee display, directly exercising MiscFeeLevels.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers Ethereum staking transaction composition with device prompt amount/fee display and relies on correct Ethereum fee estimation for the staking contract call.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Specifically tests Bitcoin swap with custom fee rate and verifies total amount equals send amount plus fee on the device prompt; directly hits TransactionComposer and BitcoinFeeLevels.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap with custom gas limit, max fee per gas, and max priority fee per gas, asserting calculated maximum fee on device prompt and emulator fee info screen.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Covers the Bitcoin sell flow including fee calculation on the sell form and send transaction confirmation, sharing the same composeTransaction/fee infrastructure.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Exercises Ethereum sell flow with custom gas fee settings and confirmation screen fee display, sharing EthereumFeeLevels logic with send-eth and swap-fees-ethereum.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests Bitcoin sell form custom fee switching and max amount calculation, which depends on fee estimation and composeTransaction behavior for BTC and SOL.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Continues Ethereum staking fee validation and transaction confirmation flow; a regression in Ethereum fee levels would likely also surface here.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Covers Ethereum unstake and claim transactions with device fee displays, relying on the same Ethereum fee estimation path.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Tests a DEX Ethereum swap with a 1.25 gas limit buffer and network fee display; would catch regressions in Ethereum gas estimation logic used by DEX trades.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect/src/backend/fees/BitcoinFeeLevels.test.ts`
- `packages/connect/src/backend/fees/EthereumFeeLevels.test.ts`
- `packages/connect/src/backend/fees/MiscFeeLevels.test.ts`

_Updated: 2026-07-29T10:44:54.017Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/send-transaction-prerequisite/web/](https://dev.suite.sldev.cz/suite-web/refactor/send-transaction-prerequisite/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/send-transaction-prerequisite&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/send-transaction-prerequisite&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/send-transaction-prerequisite&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T10:44:56.261Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T10:44:51.440Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->