### PR TITLE
test(native): co-locate shared UI and account tests

### DIFF
--- a/suite-native/graph/src/selectors.test.ts
+++ b/suite-native/graph/src/selectors.test.ts
@@ -13,7 +13,7 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import {
     selectDeviceHistoryIgnoredNetworkSymbols,
     selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning,
-} from '../selectors';
+} from './selectors';
 
 // Mock the dependencies
 jest.mock('@suite-common/wallet-core', () => ({

--- a/suite-native/graph/src/utils.test.ts
+++ b/suite-native/graph/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { type FiatGraphPoint } from '@suite-common/graph';
 
-import { getExtremaFromGraphPoints, omitErrorMessageSensitiveData } from '../utils';
+import { getExtremaFromGraphPoints, omitErrorMessageSensitiveData } from './utils';
 
 describe('Suite native graph utils', () => {
     test('getExtremaFromGraphPoints', () => {

--- a/suite-native/helpers/src/hooks/useAmountInputTransformers.test.ts
+++ b/suite-native/helpers/src/hooks/useAmountInputTransformers.test.ts
@@ -2,7 +2,7 @@ import { type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { PROTO } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
 
-import { useAmountInputTransformers } from '../useAmountInputTransformers';
+import { useAmountInputTransformers } from './useAmountInputTransformers';
 
 let mockState: DeepPartial<WalletSettingsRootState> | undefined;
 

--- a/suite-native/helpers/src/hooks/useUpdateEffect.test.ts
+++ b/suite-native/helpers/src/hooks/useUpdateEffect.test.ts
@@ -2,7 +2,7 @@ import { type EffectCallback } from 'react';
 
 import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { useUpdateEffect } from '../useUpdateEffect';
+import { useUpdateEffect } from './useUpdateEffect';
 
 describe('useUpdateEffect', () => {
     const renderUseUpdateEffect = (initialEffect: EffectCallback) =>

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -7,7 +7,7 @@ import { act, fireEvent, renderWithBasicProvider, waitFor } from '@suite-native/
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { createDeferred } from '@trezor/utils';
 
-import { TokenIcon } from '../TokenIcon';
+import { TokenIcon } from './TokenIcon';
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),

--- a/suite-native/intl/src/localeSlice.test.ts
+++ b/suite-native/intl/src/localeSlice.test.ts
@@ -1,11 +1,11 @@
-import { DEFAULT_LOCALE, type LocaleCode } from '../languages';
+import { DEFAULT_LOCALE, type LocaleCode } from './languages';
 import {
     type LocaleSliceRootState,
     type LocaleState,
     selectLocale,
     selectSupportedLanguageLocale,
-} from '../localeSlice';
-import { type SupportedLocaleCode } from '../types';
+} from './localeSlice';
+import { type SupportedLocaleCode } from './types';
 
 describe('selectSupportedLanguageLocale', () => {
     const testCases = [

--- a/suite-native/intl/src/utils.test.ts
+++ b/suite-native/intl/src/utils.test.ts
@@ -3,7 +3,7 @@ import {
     findTranslationStructureCollisions,
     flatten,
     unflatten,
-} from '../utils';
+} from './utils';
 
 describe('flatten', () => {
     it('should flatten nested translation object to dot notation', () => {

--- a/suite-native/message-system/src/components/ContextMessage.test.tsx
+++ b/suite-native/message-system/src/components/ContextMessage.test.tsx
@@ -2,7 +2,7 @@ import { Context, type ContextDomain } from '@suite-common/message-system';
 import { type Action, type Message } from '@suite-common/suite-types';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { ContextMessage } from '../ContextMessage';
+import { ContextMessage } from './ContextMessage';
 
 const contextActionId = 'ContextActionId_1';
 const contentText = 'Content Text';

--- a/suite-native/module-accounts-import/src/components/SelectableNetworkList.test.tsx
+++ b/suite-native/module-accounts-import/src/components/SelectableNetworkList.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { SelectableNetworkList } from '../SelectableNetworkList';
+import { SelectableNetworkList } from './SelectableNetworkList';
 
 const getMockPreloadedState = (areTestnetsEnabled: boolean) => ({
     appSettings: {

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@suite-native/navigation';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { AccountSettingsScreen } from '../AccountSettingsScreen';
+import { AccountSettingsScreen } from './AccountSettingsScreen';
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),


### PR DESCRIPTION
## Description

Moves 10 Native shared UI, internationalization, messaging, and account module tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-shared-ui-accounts-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->