### PR TITLE
test(native): co-locate onboarding and earn tests

### DIFF
--- a/suite-native/module-device-onboarding/src/hooks/useReportOnboardingStepViewedAnalytics.test.tsx
+++ b/suite-native/module-device-onboarding/src/hooks/useReportOnboardingStepViewedAnalytics.test.tsx
@@ -4,7 +4,7 @@ import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { DeviceOnboardingStackRoutes } from '@suite-native/navigation';
 import { act, renderHook } from '@suite-native/test-utils-store';
 
-import { useReportOnboardingStepViewedAnalytics } from '../useReportOnboardingStepViewedAnalytics';
+import { useReportOnboardingStepViewedAnalytics } from './useReportOnboardingStepViewedAnalytics';
 
 const renderUseReportStepViewed = () => {
     const services: NativeAnalyticsDep = {

--- a/suite-native/module-device-onboarding/src/onboardingAnalyticsSteps.test.ts
+++ b/suite-native/module-device-onboarding/src/onboardingAnalyticsSteps.test.ts
@@ -3,7 +3,7 @@ import { DeviceOnboardingStackRoutes } from '@suite-native/navigation';
 import {
     getDeviceOnboardingAnalyticsStepIndex,
     screenToAnalyticsStepMap,
-} from '../onboardingAnalyticsSteps';
+} from './onboardingAnalyticsSteps';
 
 describe('onboardingAnalyticsSteps', () => {
     it('maps every device-onboarding route (exhaustiveness guard)', () => {

--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.test.tsx
@@ -3,21 +3,20 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
 
-import { UnstakeTransactionDataReviewStepList } from '../UnstakeTransactionDataReviewStepList';
+import { ClaimTransactionDataReviewStepList } from './ClaimTransactionDataReviewStepList';
 
-const mockUnstakeOutputItem = jest.fn();
+const mockClaimOutputItem = jest.fn();
 const mockEarnSummaryOutputItem = jest.fn();
 
 let mockIsTransactionAlreadySigned: boolean;
 let mockSummaryOutput: ReviewSummaryOutput | null;
 let mockAccountNetworkSymbol: string | null;
-let mockPrecomposed: { fee: string; solanaTxMeta?: { deviceAmountLamports: string } };
 
 const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
-    useRoute: () => ({ params: { accountKey, amount: '1' } }),
+    useRoute: () => ({ params: { accountKey } }),
 }));
 
 jest.mock('@suite-native/transaction-management', () => ({
@@ -31,15 +30,20 @@ jest.mock('@suite-common/wallet-core', () => ({
     selectAccountNetworkSymbol: () => mockAccountNetworkSymbol,
 }));
 
-jest.mock('../UnstakeOutputItem', () => ({
-    UnstakeOutputItem: (props: { outputState?: string }) => {
-        mockUnstakeOutputItem(props);
+jest.mock('@suite-native/staking', () => ({
+    ...jest.requireActual('@suite-native/staking'),
+    selectClaimableAmountByAccountKey: () => '5',
+}));
+
+jest.mock('./ClaimOutputItem', () => ({
+    ClaimOutputItem: (props: { outputState?: string }) => {
+        mockClaimOutputItem(props);
 
         return null;
     },
 }));
 
-jest.mock('../EarnSummaryOutputItem', () => ({
+jest.mock('./EarnSummaryOutputItem', () => ({
     EarnSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
         mockEarnSummaryOutputItem(props);
 
@@ -47,45 +51,35 @@ jest.mock('../EarnSummaryOutputItem', () => ({
     },
 }));
 
-jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
-    useEarnSelectedPrecomposedTransaction: () => mockPrecomposed,
+jest.mock('../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000', totalSpent: '5' }),
 }));
 
-const renderStepList = () => renderWithStoreProvider(<UnstakeTransactionDataReviewStepList />);
+const renderStepList = () => renderWithStoreProvider(<ClaimTransactionDataReviewStepList />);
 
-describe('UnstakeTransactionDataReviewStepList', () => {
+describe('ClaimTransactionDataReviewStepList', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockIsTransactionAlreadySigned = false;
         mockSummaryOutput = null;
         mockAccountNetworkSymbol = 'eth';
-        mockPrecomposed = { fee: '21000' };
     });
 
-    it('renders nothing until the account network symbol is known', () => {
-        mockAccountNetworkSymbol = null;
-
-        renderStepList();
-
-        expect(mockUnstakeOutputItem).not.toHaveBeenCalled();
-        expect(mockEarnSummaryOutputItem).not.toHaveBeenCalled();
-    });
-
-    it('renders the unstake and summary cards without a Next button', () => {
+    it('renders the claim and summary cards without a Next button', () => {
         const { queryByText, queryByTestId } = renderStepList();
 
-        expect(mockUnstakeOutputItem).toHaveBeenCalledTimes(1);
+        expect(mockClaimOutputItem).toHaveBeenCalledTimes(1);
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledTimes(1);
         expect(queryByText(getTranslation('generic.buttons.next'))).toBeNull();
-        expect(queryByTestId('@earn/unstake-review-continue')).toBeNull();
+        expect(queryByTestId('@earn/claim-review-continue')).toBeNull();
     });
 
-    it('keeps the unstake step active and the summary hidden until the device confirms the outputs', () => {
+    it('keeps the claim step active and the summary hidden until the device confirms the outputs', () => {
         mockSummaryOutput = null;
 
         renderStepList();
 
-        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'active' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -93,12 +87,12 @@ describe('UnstakeTransactionDataReviewStepList', () => {
         );
     });
 
-    it('marks the unstake step done and activates the summary once all device outputs are confirmed', () => {
-        mockSummaryOutput = { state: 'active', totalSpent: '1', fee: '21000' };
+    it('marks the claim step done and activates the summary once all device outputs are confirmed', () => {
+        mockSummaryOutput = { state: 'active', totalSpent: '5', fee: '21000' };
 
         renderStepList();
 
-        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'success' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -108,11 +102,11 @@ describe('UnstakeTransactionDataReviewStepList', () => {
 
     it('marks both steps done and hides the sliding footer once the transaction is signed', () => {
         mockIsTransactionAlreadySigned = true;
-        mockSummaryOutput = { state: 'success', totalSpent: '1', fee: '21000' };
+        mockSummaryOutput = { state: 'success', totalSpent: '5', fee: '21000' };
 
         const { queryByTestId } = renderStepList();
 
-        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
+        expect(mockClaimOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'success' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -125,14 +119,5 @@ describe('UnstakeTransactionDataReviewStepList', () => {
         const { getByTestId } = renderStepList();
 
         expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
-    });
-
-    it('passes the amount in base units and the unstake stake type to the summary', () => {
-        renderStepList();
-
-        // Route amount '1' ETH -> 1e18 wei. The summary decides itself whether to show it.
-        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
-            expect.objectContaining({ amount: '1000000000000000000', stakeType: 'unstake' }),
-        );
     });
 });

--- a/suite-native/module-earn/src/components/EarnSummaryOutputItem.test.tsx
+++ b/suite-native/module-earn/src/components/EarnSummaryOutputItem.test.tsx
@@ -1,8 +1,8 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { type EarnFormDraftPrefix } from '../../types';
-import { EarnSummaryOutputItem } from '../EarnSummaryOutputItem';
+import { type EarnFormDraftPrefix } from '../types';
+import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 
 const mockReviewOutputItemValues = jest.fn();
 

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.test.tsx
@@ -3,7 +3,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
 
-import { EarnTransactionDataReviewStepList } from '../EarnTransactionDataReviewStepList';
+import { EarnTransactionDataReviewStepList } from './EarnTransactionDataReviewStepList';
 
 const mockEarnStakeOutputItem = jest.fn();
 const mockEarnSummaryOutputItem = jest.fn();
@@ -17,7 +17,7 @@ jest.mock('@suite-native/transaction-management', () => ({
     selectReviewSummaryOutput: () => mockSummaryOutput,
 }));
 
-jest.mock('../EarnStakeOutputItem', () => ({
+jest.mock('./EarnStakeOutputItem', () => ({
     EarnStakeOutputItem: (props: { outputState?: string }) => {
         mockEarnStakeOutputItem(props);
 
@@ -25,7 +25,7 @@ jest.mock('../EarnStakeOutputItem', () => ({
     },
 }));
 
-jest.mock('../EarnSummaryOutputItem', () => ({
+jest.mock('./EarnSummaryOutputItem', () => ({
     EarnSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
         mockEarnSummaryOutputItem(props);
 
@@ -33,7 +33,7 @@ jest.mock('../EarnSummaryOutputItem', () => ({
     },
 }));
 
-jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+jest.mock('../hooks/useEarnSelectedPrecomposedTransaction', () => ({
     useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000' }),
 }));
 

--- a/suite-native/module-earn/src/components/SolanaUnstakeAmountBoundsAlert.test.tsx
+++ b/suite-native/module-earn/src/components/SolanaUnstakeAmountBoundsAlert.test.tsx
@@ -8,9 +8,9 @@ import {
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';
 
-import { type EarnFormValues } from '../../earnFormSchema';
-import { type UnstakeFormContext, unstakeFormValidationSchema } from '../../unstakeFormSchema';
-import { SolanaUnstakeAmountBoundsAlert } from '../SolanaUnstakeAmountBoundsAlert';
+import { type EarnFormValues } from '../earnFormSchema';
+import { type UnstakeFormContext, unstakeFormValidationSchema } from '../unstakeFormSchema';
+import { SolanaUnstakeAmountBoundsAlert } from './SolanaUnstakeAmountBoundsAlert';
 
 const SOL = 1_000_000_000;
 

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.test.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.test.tsx
@@ -3,20 +3,21 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { type ReviewSummaryOutput } from '@suite-native/transaction-management';
 
-import { ClaimTransactionDataReviewStepList } from '../ClaimTransactionDataReviewStepList';
+import { UnstakeTransactionDataReviewStepList } from './UnstakeTransactionDataReviewStepList';
 
-const mockClaimOutputItem = jest.fn();
+const mockUnstakeOutputItem = jest.fn();
 const mockEarnSummaryOutputItem = jest.fn();
 
 let mockIsTransactionAlreadySigned: boolean;
 let mockSummaryOutput: ReviewSummaryOutput | null;
 let mockAccountNetworkSymbol: string | null;
+let mockPrecomposed: { fee: string; solanaTxMeta?: { deviceAmountLamports: string } };
 
 const accountKey = mockAccountKey({ symbol: 'eth', descriptor: 'ethAccount' });
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
-    useRoute: () => ({ params: { accountKey } }),
+    useRoute: () => ({ params: { accountKey, amount: '1' } }),
 }));
 
 jest.mock('@suite-native/transaction-management', () => ({
@@ -30,20 +31,15 @@ jest.mock('@suite-common/wallet-core', () => ({
     selectAccountNetworkSymbol: () => mockAccountNetworkSymbol,
 }));
 
-jest.mock('@suite-native/staking', () => ({
-    ...jest.requireActual('@suite-native/staking'),
-    selectClaimableAmountByAccountKey: () => '5',
-}));
-
-jest.mock('../ClaimOutputItem', () => ({
-    ClaimOutputItem: (props: { outputState?: string }) => {
-        mockClaimOutputItem(props);
+jest.mock('./UnstakeOutputItem', () => ({
+    UnstakeOutputItem: (props: { outputState?: string }) => {
+        mockUnstakeOutputItem(props);
 
         return null;
     },
 }));
 
-jest.mock('../EarnSummaryOutputItem', () => ({
+jest.mock('./EarnSummaryOutputItem', () => ({
     EarnSummaryOutputItem: (props: { outputState?: string; fee?: string }) => {
         mockEarnSummaryOutputItem(props);
 
@@ -51,35 +47,45 @@ jest.mock('../EarnSummaryOutputItem', () => ({
     },
 }));
 
-jest.mock('../../hooks/useEarnSelectedPrecomposedTransaction', () => ({
-    useEarnSelectedPrecomposedTransaction: () => ({ fee: '21000', totalSpent: '5' }),
+jest.mock('../hooks/useEarnSelectedPrecomposedTransaction', () => ({
+    useEarnSelectedPrecomposedTransaction: () => mockPrecomposed,
 }));
 
-const renderStepList = () => renderWithStoreProvider(<ClaimTransactionDataReviewStepList />);
+const renderStepList = () => renderWithStoreProvider(<UnstakeTransactionDataReviewStepList />);
 
-describe('ClaimTransactionDataReviewStepList', () => {
+describe('UnstakeTransactionDataReviewStepList', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockIsTransactionAlreadySigned = false;
         mockSummaryOutput = null;
         mockAccountNetworkSymbol = 'eth';
+        mockPrecomposed = { fee: '21000' };
     });
 
-    it('renders the claim and summary cards without a Next button', () => {
+    it('renders nothing until the account network symbol is known', () => {
+        mockAccountNetworkSymbol = null;
+
+        renderStepList();
+
+        expect(mockUnstakeOutputItem).not.toHaveBeenCalled();
+        expect(mockEarnSummaryOutputItem).not.toHaveBeenCalled();
+    });
+
+    it('renders the unstake and summary cards without a Next button', () => {
         const { queryByText, queryByTestId } = renderStepList();
 
-        expect(mockClaimOutputItem).toHaveBeenCalledTimes(1);
+        expect(mockUnstakeOutputItem).toHaveBeenCalledTimes(1);
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledTimes(1);
         expect(queryByText(getTranslation('generic.buttons.next'))).toBeNull();
-        expect(queryByTestId('@earn/claim-review-continue')).toBeNull();
+        expect(queryByTestId('@earn/unstake-review-continue')).toBeNull();
     });
 
-    it('keeps the claim step active and the summary hidden until the device confirms the outputs', () => {
+    it('keeps the unstake step active and the summary hidden until the device confirms the outputs', () => {
         mockSummaryOutput = null;
 
         renderStepList();
 
-        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'active' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -87,12 +93,12 @@ describe('ClaimTransactionDataReviewStepList', () => {
         );
     });
 
-    it('marks the claim step done and activates the summary once all device outputs are confirmed', () => {
-        mockSummaryOutput = { state: 'active', totalSpent: '5', fee: '21000' };
+    it('marks the unstake step done and activates the summary once all device outputs are confirmed', () => {
+        mockSummaryOutput = { state: 'active', totalSpent: '1', fee: '21000' };
 
         renderStepList();
 
-        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'success' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -102,11 +108,11 @@ describe('ClaimTransactionDataReviewStepList', () => {
 
     it('marks both steps done and hides the sliding footer once the transaction is signed', () => {
         mockIsTransactionAlreadySigned = true;
-        mockSummaryOutput = { state: 'success', totalSpent: '5', fee: '21000' };
+        mockSummaryOutput = { state: 'success', totalSpent: '1', fee: '21000' };
 
         const { queryByTestId } = renderStepList();
 
-        expect(mockClaimOutputItem).toHaveBeenCalledWith(
+        expect(mockUnstakeOutputItem).toHaveBeenCalledWith(
             expect.objectContaining({ outputState: 'success' }),
         );
         expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
@@ -119,5 +125,14 @@ describe('ClaimTransactionDataReviewStepList', () => {
         const { getByTestId } = renderStepList();
 
         expect(getByTestId('sliding-footer-overlay')).toBeOnTheScreen();
+    });
+
+    it('passes the amount in base units and the unstake stake type to the summary', () => {
+        renderStepList();
+
+        // Route amount '1' ETH -> 1e18 wei. The summary decides itself whether to show it.
+        expect(mockEarnSummaryOutputItem).toHaveBeenCalledWith(
+            expect.objectContaining({ amount: '1000000000000000000', stakeType: 'unstake' }),
+        );
     });
 });

--- a/suite-native/module-earn/src/hooks/useAutoStartReview.test.tsx
+++ b/suite-native/module-earn/src/hooks/useAutoStartReview.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@suite-native/test-utils';
 
-import { type ReviewAutoStartControls, useAutoStartReview } from '../useAutoStartReview';
+import { type ReviewAutoStartControls, useAutoStartReview } from './useAutoStartReview';
 
 const mockWaitForDeviceReview = jest.fn();
 

--- a/suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts
+++ b/suite-native/module-earn/src/hooks/useEarnDepositsCardData.test.ts
@@ -4,8 +4,8 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../../types';
-import { useEarnDepositsCardData } from '../useEarnDepositsCardData';
+import { type StablecoinYieldEarnItem, type StakingEarnItem } from '../types';
+import { useEarnDepositsCardData } from './useEarnDepositsCardData';
 
 jest.mock('@suite-common/wallet-core', () => ({
     ...jest.requireActual('@suite-common/wallet-core'),

--- a/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.test.tsx
+++ b/suite-native/module-earn/src/hooks/useEarnReviewAutoStart.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@suite-native/test-utils';
 
-import { useEarnReviewAutoStart } from '../useEarnReviewAutoStart';
+import { useEarnReviewAutoStart } from './useEarnReviewAutoStart';
 
 const mockWaitForDeviceReview = jest.fn();
 

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.test.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.test.ts
@@ -2,7 +2,7 @@ import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
 
-import { resolveYieldFlowData } from '../useResolvedYieldFlowData';
+import { resolveYieldFlowData } from './useResolvedYieldFlowData';
 
 const accountKey = 'eth-account-key' as AccountKey;
 const underlyingTokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';

--- a/suite-native/module-earn/src/hooks/useStakingDetailNavigation.test.tsx
+++ b/suite-native/module-earn/src/hooks/useStakingDetailNavigation.test.tsx
@@ -2,7 +2,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { RootStackRoutes } from '@suite-native/navigation';
 import { renderHook } from '@suite-native/test-utils';
 
-import { useStakingDetailNavigation } from '../useStakingDetailNavigation';
+import { useStakingDetailNavigation } from './useStakingDetailNavigation';
 
 const mockNavigate = jest.fn();
 

--- a/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
+++ b/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { BigNumber } from '@trezor/utils';
 
-import { useStartYieldDepositFlow } from '../useStartYieldDepositFlow';
+import { useStartYieldDepositFlow } from './useStartYieldDepositFlow';
 
 const mockNavigate = jest.fn();
 

--- a/suite-native/module-earn/src/hooks/useYieldDepositSubmit.test.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositSubmit.test.ts
@@ -1,10 +1,10 @@
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { useShowYieldAlert } from '../useShowYieldAlert';
-import { type PreparedYieldDepositAction } from '../useYieldDepositFees';
-import { useYieldDepositSubmit } from '../useYieldDepositSubmit';
+import { useShowYieldAlert } from './useShowYieldAlert';
+import { type PreparedYieldDepositAction } from './useYieldDepositFees';
+import { useYieldDepositSubmit } from './useYieldDepositSubmit';
 
-jest.mock('../useShowYieldAlert');
+jest.mock('./useShowYieldAlert');
 
 const mockUseShowYieldAlert = jest.mocked(useShowYieldAlert);
 

--- a/suite-native/module-earn/src/unstakeFormSchema.test.ts
+++ b/suite-native/module-earn/src/unstakeFormSchema.test.ts
@@ -2,7 +2,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { type SolanaStakingAccount } from '@trezor/blockchain-link-types';
 import { StakeState } from '@trezor/network-solana/constants';
 
-import { type UnstakeFormContext, unstakeFormValidationSchema } from '../unstakeFormSchema';
+import { type UnstakeFormContext, unstakeFormValidationSchema } from './unstakeFormSchema';
 
 const SOL = 1_000_000_000;
 

--- a/suite-native/module-earn/src/utils.test.ts
+++ b/suite-native/module-earn/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { handleEarnReviewError } from '../utils';
+import { handleEarnReviewError } from './utils';
 
 const buildHandlers = () => ({
     navigation: { pop: jest.fn() },

--- a/suite-native/module-earn/src/utils/isBalanceBelowStakingMinimum.test.ts
+++ b/suite-native/module-earn/src/utils/isBalanceBelowStakingMinimum.test.ts
@@ -1,6 +1,6 @@
 import { type Account } from '@suite-common/wallet-types';
 
-import { isBalanceBelowStakingMinimum } from '../isBalanceBelowStakingMinimum';
+import { isBalanceBelowStakingMinimum } from './isBalanceBelowStakingMinimum';
 
 const createMockAccount = (symbol: Account['symbol'], availableBalance: string): Account =>
     ({ symbol, availableBalance }) as Account;

--- a/suite-native/module-earn/src/utils/navigateByAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/navigateByAccountState.test.ts
@@ -3,7 +3,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
 import { RootStackRoutes } from '@suite-native/navigation';
 
-import { navigateByAccountState } from '../navigateByAccountState';
+import { navigateByAccountState } from './navigateByAccountState';
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),

--- a/suite-native/module-earn/src/utils/resolveStakingHomeRoute.test.ts
+++ b/suite-native/module-earn/src/utils/resolveStakingHomeRoute.test.ts
@@ -3,7 +3,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
 import { RootStackRoutes } from '@suite-native/navigation';
 
-import { resolveStakingHomeRoute } from '../resolveStakingHomeRoute';
+import { resolveStakingHomeRoute } from './resolveStakingHomeRoute';
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),

--- a/suite-native/module-earn/src/utils/resolveStakingTargetRoute.test.ts
+++ b/suite-native/module-earn/src/utils/resolveStakingTargetRoute.test.ts
@@ -1,6 +1,6 @@
 import { RootStackRoutes } from '@suite-native/navigation';
 
-import { resolveStakingTargetRoute } from '../resolveStakingTargetRoute';
+import { resolveStakingTargetRoute } from './resolveStakingTargetRoute';
 
 describe('resolveStakingTargetRoute', () => {
     it('routes Ethereum accounts to StakingManagement', () => {

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -13,7 +13,7 @@ import {
     getStablecoinYieldAccountRewards,
     getStablecoinYieldClaimRewardsSnapshot,
     getTotalFiatClaimableAmount,
-} from '../stablecoinYieldClaimSummaryUtils';
+} from './stablecoinYieldClaimSummaryUtils';
 
 const receiptTokenContract = toTokenAddress('0x0000000000000000000000000000000000000002');
 

--- a/suite-native/module-earn/src/utils/yieldClaimFeeUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimFeeUtils.test.ts
@@ -1,6 +1,6 @@
 import { type FeeInfo, isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
 
-import { buildYieldClaimFeeLevels, getYieldClaimFee } from '../yieldClaimFeeUtils';
+import { buildYieldClaimFeeLevels, getYieldClaimFee } from './yieldClaimFeeUtils';
 
 const feeInfo = {
     blockHeight: 1,

--- a/suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimFeeWarningUtils.test.ts
@@ -1,7 +1,7 @@
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
-import { getClaimFeeWarning } from '../yieldClaimFeeWarningUtils';
+import { getClaimFeeWarning } from './yieldClaimFeeWarningUtils';
 
 const fiatAmount = (amount: string) => asBaseCurrencyAmount(new BigNumber(amount));
 

--- a/suite-native/module-earn/src/utils/yieldClaimReviewUtils.test.ts
+++ b/suite-native/module-earn/src/utils/yieldClaimReviewUtils.test.ts
@@ -1,6 +1,6 @@
 import { type StablecoinYieldActionReviewState } from '@suite-common/wallet-core';
 
-import { buildYieldClaimRewards } from '../yieldClaimReviewUtils';
+import { buildYieldClaimRewards } from './yieldClaimReviewUtils';
 
 type YieldClaimReview = Extract<StablecoinYieldActionReviewState, { type: 'claim' }>;
 

--- a/suite-native/module-earn/src/yieldClaimThunks.test.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.test.ts
@@ -20,7 +20,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import TrezorConnect from '@trezor/connect';
 import { type StaticSessionId } from '@trezor/device-utils';
 
-import { pushYieldClaimReviewThunk } from '../yieldClaimThunks';
+import { pushYieldClaimReviewThunk } from './yieldClaimThunks';
 
 jest.mock('@trezor/connect', () => ({
     __esModule: true,

--- a/suite-native/module-earn/src/yieldDepositFeeUtils.test.ts
+++ b/suite-native/module-earn/src/yieldDepositFeeUtils.test.ts
@@ -7,7 +7,7 @@ import {
     buildYieldDepositFeeLevels,
     buildYieldDepositFeePreview,
     buildYieldDepositSelectedFeeUnsignedTransaction,
-} from '../yieldDepositFeeUtils';
+} from './yieldDepositFeeUtils';
 
 const baseUnsignedTransaction = {
     from: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',

--- a/suite-native/module-earn/src/yieldTransactionThunks.test.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.test.ts
@@ -20,7 +20,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import TrezorConnect from '@trezor/connect';
 import { type StaticSessionId } from '@trezor/device-utils';
 
-import { pushYieldActionReviewThunk } from '../yieldTransactionThunks';
+import { pushYieldActionReviewThunk } from './yieldTransactionThunks';
 
 jest.mock('@trezor/connect', () => ({
     __esModule: true,


### PR DESCRIPTION
## Description

Moves 27 Native Device Onboarding and Earn tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-device-onboarding-earn-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->