### PR TITLE
test(native): co-locate home, onboarding, and transfer tests

### DIFF
--- a/suite-native/module-home/src/screens/HomeScreen/selectHomeScreenState.test.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/selectHomeScreenState.test.ts
@@ -2,7 +2,7 @@ import { PORTFOLIO_TRACKER_DEVICE_ID, PORTFOLIO_TRACKER_DEVICE_STATE } from '@su
 import { createStoreFromPreloadedState } from '@suite-native/test-utils-store';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { selectHomeScreenState } from '../homescreenSelectors';
+import { selectHomeScreenState } from './homescreenSelectors';
 
 const TEST_SESSION_ID = 'address@hash:0' as const;
 

--- a/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
+++ b/suite-native/module-onboarding/src/hooks/useExitOnboardingFlow.test.ts
@@ -8,7 +8,7 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { useExitOnboardingFlow } from '../useExitOnboardingFlow';
+import { useExitOnboardingFlow } from './useExitOnboardingFlow';
 
 const mockNavigationDispatch = jest.fn();
 

--- a/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/BiometricsScreen.test.tsx
@@ -10,7 +10,7 @@ import {
     userEvent,
 } from '@suite-native/test-utils-store';
 
-import { BiometricsScreen, type BiometricsScreenProps } from '../BiometricsScreen';
+import { BiometricsScreen, type BiometricsScreenProps } from './BiometricsScreen';
 
 const mockNavigate = jest.fn();
 const mockNavigationDispatch = jest.fn();

--- a/suite-native/module-onboarding/src/screens/TradingLocationScreen.test.tsx
+++ b/suite-native/module-onboarding/src/screens/TradingLocationScreen.test.tsx
@@ -6,7 +6,7 @@ import { getTranslation } from '@suite-native/intl';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 import { renderWithStoreProvider, screen, userEvent } from '@suite-native/test-utils-store';
 
-import { TradingLocationScreen } from '../TradingLocationScreen';
+import { TradingLocationScreen } from './TradingLocationScreen';
 
 const mockExitOnboardingFlow = jest.fn();
 const reportMock = jest.fn();
@@ -23,7 +23,7 @@ jest.mock('@react-navigation/native', () => ({
         }) as RouteProp<RootStackParamList, RootStackRoutes.TradingHistory>,
 }));
 
-jest.mock('../../hooks/useExitOnboardingFlow', () => ({
+jest.mock('../hooks/useExitOnboardingFlow', () => ({
     useExitOnboardingFlow: () => mockExitOnboardingFlow,
 }));
 

--- a/suite-native/module-receive/src/addressVerification.test.ts
+++ b/suite-native/module-receive/src/addressVerification.test.ts
@@ -1,6 +1,6 @@
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
 
-import { AddressVerificationResultType, verifyReceiveAddress } from '../addressVerification';
+import { AddressVerificationResultType, verifyReceiveAddress } from './addressVerification';
 
 jest.mock('@suite-native/device-mutex', () => ({
     requestPrioritizedDeviceAccess: jest.fn(),

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
@@ -6,7 +6,7 @@ import { getTranslation } from '@suite-native/intl';
 import { ReceiveAddressVerificationSource, ReceiveStackRoutes } from '@suite-native/navigation';
 import { renderWithBasicProvider, userEvent, waitFor } from '@suite-native/test-utils';
 
-import { ReceiveAddressActions } from '../ReceiveAddressActions';
+import { ReceiveAddressActions } from './ReceiveAddressActions';
 
 const mockCopyToClipboard = jest.fn();
 const mockOpenCopiedAddressBottomSheet = jest.fn();

--- a/suite-native/module-receive/src/components/ReceiveAddressVerificationBottomSheet.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressVerificationBottomSheet.test.tsx
@@ -2,7 +2,7 @@ import { getTranslation } from '@suite-native/intl';
 import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 
-import { ReceiveAddressVerificationBottomSheet } from '../ReceiveAddressVerificationBottomSheet';
+import { ReceiveAddressVerificationBottomSheet } from './ReceiveAddressVerificationBottomSheet';
 
 describe('ReceiveAddressVerificationBottomSheet', () => {
     const onVerifyAddress = jest.fn();

--- a/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
@@ -6,7 +6,7 @@ import { useRoute } from '@react-navigation/native';
 import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { ReceiveAddressVerificationScreen } from '../ReceiveAddressVerificationScreen';
+import { ReceiveAddressVerificationScreen } from './ReceiveAddressVerificationScreen';
 
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),

--- a/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxoScreenFooter.test.tsx
@@ -1,9 +1,9 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { SendUtxoScreenFooter } from '../SendUtxoScreenFooter';
+import { SendUtxoScreenFooter } from './SendUtxoScreenFooter';
 
-jest.mock('../../../hooks/useUtxoSelection', () => ({
+jest.mock('../../hooks/useUtxoSelection', () => ({
     useUtxoSelection: jest.fn(),
 }));
 

--- a/suite-native/module-send/src/components/CoinControl/SendUtxosScreenHeader.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SendUtxosScreenHeader.test.tsx
@@ -1,12 +1,12 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { useUtxoSelection } from '../../../hooks/useUtxoSelection';
-import { SendUtxoScreenHeader } from '../SendUtxoScreenHeader';
+import { SendUtxoScreenHeader } from './SendUtxoScreenHeader';
+import { useUtxoSelection } from '../../hooks/useUtxoSelection';
 
 const accountKey = mockAccountKey({ descriptor: 'testAccKey' });
 
-jest.mock('../../../hooks/useUtxoSelection', () => ({
+jest.mock('../../hooks/useUtxoSelection', () => ({
     useUtxoSelection: jest.fn(),
 }));
 

--- a/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.test.tsx
+++ b/suite-native/module-send/src/components/CoinControl/SwitchCoinControlButton.test.tsx
@@ -7,10 +7,10 @@ import {
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
 
-import { useUtxoSelection } from '../../../hooks/useUtxoSelection';
-import { SwitchCoinControlButton } from '../SwitchCoinControlButton';
+import { SwitchCoinControlButton } from './SwitchCoinControlButton';
+import { useUtxoSelection } from '../../hooks/useUtxoSelection';
 
-jest.mock('../../../hooks/useUtxoSelection', () => ({
+jest.mock('../../hooks/useUtxoSelection', () => ({
     useUtxoSelection: jest.fn(),
 }));
 

--- a/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.test.tsx
+++ b/suite-native/module-send/src/hooks/useAddressValidationAlerts/useAddressValidationAlerts.test.tsx
@@ -5,7 +5,7 @@ import { Form, useWatch } from '@suite-native/forms';
 import { act, renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 import TrezorConnect from '@trezor/connect';
 
-import { useAddressValidationAlerts } from '../useAddressValidationAlerts';
+import { useAddressValidationAlerts } from './useAddressValidationAlerts';
 
 const mockAccountInfoResponses = {
     unusedAddress: {

--- a/suite-native/module-send/src/hooks/useRequestDelayedNavigationToOutputsReview.test.ts
+++ b/suite-native/module-send/src/hooks/useRequestDelayedNavigationToOutputsReview.test.ts
@@ -2,7 +2,7 @@ import { type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { useRequestDelayedNavigationToOutputsReview } from '../useRequestDelayedNavigationToOutputsReview';
+import { useRequestDelayedNavigationToOutputsReview } from './useRequestDelayedNavigationToOutputsReview';
 
 const mockSelectDeviceButtonRequestsCodes = jest.fn().mockReturnValue([]);
 const mockNavigate = jest.fn();

--- a/suite-native/module-send/src/hooks/useUtxoSelection.test.ts
+++ b/suite-native/module-send/src/hooks/useUtxoSelection.test.ts
@@ -3,8 +3,8 @@ import { useAtom } from 'jotai';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderHook } from '@suite-native/test-utils';
 
-import { type SelectedUtxos } from '../../types';
-import { useUtxoSelection } from '../useUtxoSelection';
+import { type SelectedUtxos } from '../types';
+import { useUtxoSelection } from './useUtxoSelection';
 
 const accountKey = mockAccountKey({ descriptor: 'testAccKey' });
 

--- a/suite-native/module-send/src/selectors.test.ts
+++ b/suite-native/module-send/src/selectors.test.ts
@@ -2,7 +2,7 @@ import { type FormState, type TokenAddress } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type NativeSendRootState } from '@suite-native/transaction-management';
 
-import { selectDestinationTagFromDraft } from '../selectors';
+import { selectDestinationTagFromDraft } from './selectors';
 
 const createMockState = (
     overrides: Partial<NativeSendRootState['wallet']['send']> = {},


### PR DESCRIPTION
## Description

Moves 15 Native Home, Onboarding, Receive, and Send tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-home-onboarding-send-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->