### PR TITLE
test(native-trading): co-locate browser auth tests

### DIFF
--- a/suite-native/trading-browser-auth/src/components/ConfirmationFailed.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ConfirmationFailed.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { ConfirmationFailed } from '../ConfirmationFailed';
+import { ConfirmationFailed } from './ConfirmationFailed';
 
 const mockNavigateBack = jest.fn();
 

--- a/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderConfirmationStatusInfo.test.tsx
@@ -2,11 +2,11 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { type ProviderConfirmationStatus } from '@suite-native/trading-types';
 
-import { ProviderConfirmationStatusInfo } from '../ProviderConfirmationStatusInfo';
+import { ProviderConfirmationStatusInfo } from './ProviderConfirmationStatusInfo';
 
 let mockUseProviderConfirmationStatus: ProviderConfirmationStatus;
 
-jest.mock('../../hooks/useProviderConfirmationStatus', () => ({
+jest.mock('../hooks/useProviderConfirmationStatus', () => ({
     useProviderConfirmationStatus: () => mockUseProviderConfirmationStatus,
 }));
 

--- a/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
+++ b/suite-native/trading-browser-auth/src/components/ProviderStatusDevButtons.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
 
-import { ProviderStatusDevButtons } from '../ProviderStatusDevButtons';
+import { ProviderStatusDevButtons } from './ProviderStatusDevButtons';
 
 describe('ProviderStatusDevButtons', () => {
     let store: TestStore;

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserAuth.test.ts
@@ -21,8 +21,8 @@ import {
     tradingSlice,
 } from '@suite-native/trading-state';
 
-import { TRADING_URL_DEFAULT_BACK } from '../../consts';
-import { useBrowserAuth } from '../useBrowserAuth';
+import { TRADING_URL_DEFAULT_BACK } from '../consts';
+import { useBrowserAuth } from './useBrowserAuth';
 
 const mockOpenBrowserAsync = jest.fn();
 const mockDismissBrowser = jest.fn();
@@ -51,7 +51,7 @@ jest.mock('@suite-native/sentry', () => ({
 
 const mockSetShouldWatchForForeground = jest.fn();
 
-jest.mock('../useOnForegroundCallback', () => ({
+jest.mock('./useOnForegroundCallback', () => ({
     useOnForegroundCallback: (_: () => void) => ({
         setShouldWatchForForeground: mockSetShouldWatchForForeground,
     }),

--- a/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useBrowserStateChangeCallbacks.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
 
-import { useBrowserStateChangeCallbacks } from '../useBrowserStateChangeCallbacks';
+import { useBrowserStateChangeCallbacks } from './useBrowserStateChangeCallbacks';
 
 const mockReportToAnalytics = jest.fn();
 

--- a/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useDispatchProviderConfirmationStatus.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { selectTradingProviderConfirmationStatus, tradingSlice } from '@suite-native/trading-state';
 
-import { useDispatchProviderConfirmationStatus } from '../useDispatchProviderConfirmationStatus';
+import { useDispatchProviderConfirmationStatus } from './useDispatchProviderConfirmationStatus';
 
 describe('useDispatchProviderConfirmationStatus', () => {
     let store: TestStore;

--- a/suite-native/trading-browser-auth/src/hooks/useOnForegroundCallback.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useOnForegroundCallback.test.ts
@@ -2,7 +2,7 @@ import { AppState } from 'react-native';
 
 import { act, renderHookWithBasicProvider, screen } from '@suite-native/test-utils';
 
-import { useOnForegroundCallback } from '../useOnForegroundCallback';
+import { useOnForegroundCallback } from './useOnForegroundCallback';
 
 const mockCaptureSentryException = jest.fn();
 

--- a/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
+++ b/suite-native/trading-browser-auth/src/hooks/useProviderConfirmationStatus.test.ts
@@ -17,7 +17,7 @@ import {
 } from '@suite-native/trading-state';
 import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
-import { useProviderConfirmationStatus } from '../useProviderConfirmationStatus';
+import { useProviderConfirmationStatus } from './useProviderConfirmationStatus';
 
 describe('useProviderConfirmationStatus', () => {
     let store: TestStore;

--- a/suite-native/trading-browser-auth/src/utils/formUtils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/formUtils.test.ts
@@ -5,7 +5,7 @@ import {
     buildTradingUrl,
     getRequestFormSource,
     getSourceForForm,
-} from '../formUtils';
+} from './formUtils';
 
 describe('formUtils', () => {
     describe('applyHtmlTemplate', () => {

--- a/suite-native/trading-browser-auth/src/utils/utils.test.ts
+++ b/suite-native/trading-browser-auth/src/utils/utils.test.ts
@@ -1,5 +1,5 @@
-import { TRADING_URL_DEFAULT_BACK } from '../../consts';
-import { doesUrlContainCloseCallbackUrl } from '../utils';
+import { TRADING_URL_DEFAULT_BACK } from '../consts';
+import { doesUrlContainCloseCallbackUrl } from './utils';
 
 describe('utils', () => {
     describe('doesUrlContainCloseCallbackUrl', () => {


### PR DESCRIPTION
## Description

Moves 10 Native Trading Browser Auth tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-browser-auth-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->