### PR TITLE
test(native-trading): co-locate debug and history tests

### DIFF
--- a/suite-native/trading-debug/src/components/CopyableText.test.tsx
+++ b/suite-native/trading-debug/src/components/CopyableText.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { CopyableText, type CopyableTextProps } from '../CopyableText';
+import { CopyableText, type CopyableTextProps } from './CopyableText';
 
 const mockCopyToClipboard = jest.fn();
 

--- a/suite-native/trading-debug/src/components/DebugModeView.test.tsx
+++ b/suite-native/trading-debug/src/components/DebugModeView.test.tsx
@@ -1,11 +1,11 @@
 import { Text } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { DebugModeView } from '../DebugModeView';
+import { DebugModeView } from './DebugModeView';
 
 let mockDebugMode: boolean;
 
-jest.mock('../../hooks/useTradingDebugModeFlag', () => ({
+jest.mock('../hooks/useTradingDebugModeFlag', () => ({
     useTradingDebugModeFlag: () => mockDebugMode,
 }));
 

--- a/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
+++ b/suite-native/trading-debug/src/components/TradingEnvironmentWarning.test.tsx
@@ -11,7 +11,7 @@ import {
 import { tradingInitialState } from '@suite-native/trading-consts';
 import type { TradingState } from '@suite-native/trading-types';
 
-import { TradingEnvironmentWarning } from '../TradingEnvironmentWarning';
+import { TradingEnvironmentWarning } from './TradingEnvironmentWarning';
 
 describe('TradingEnvironmentWarning', () => {
     const reducer = {

--- a/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.test.ts
+++ b/suite-native/trading-debug/src/hooks/useTradingDebugModeFlag.test.ts
@@ -1,7 +1,7 @@
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { useTradingDebugModeFlag } from '../useTradingDebugModeFlag';
+import { useTradingDebugModeFlag } from './useTradingDebugModeFlag';
 
 describe('useTradingDebugModeFlag', () => {
     const renderUseDebugModeFlag = (preloadedState = {}) =>

--- a/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.test.ts
+++ b/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.test.ts
@@ -3,11 +3,11 @@ import { act } from 'react';
 import type { TransactionStatus } from '@suite-common/trading';
 import { renderHook } from '@suite-native/test-utils';
 
-import { useTransactionStatusOverride } from '../useTransactionStatusOverride';
+import { useTransactionStatusOverride } from './useTransactionStatusOverride';
 
 let mockIsDebugMode: boolean;
 
-jest.mock('../useTradingDebugModeFlag', () => ({
+jest.mock('./useTradingDebugModeFlag', () => ({
     useTradingDebugModeFlag: () => mockIsDebugMode,
 }));
 

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAlert.test.tsx
@@ -9,7 +9,7 @@ import {
 } from '@suite-native/trading-fixtures';
 import { type TradeStatusStep } from '@suite-native/trading-quote-utils';
 
-import { TradeDetailAlert } from '../TradeDetailAlert';
+import { TradeDetailAlert } from './TradeDetailAlert';
 
 const mockOpenBrowser = jest.fn();
 

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAmountStack.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailAmountStack.test.tsx
@@ -1,7 +1,7 @@
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 import { btcAsset } from '@suite-native/trading-fixtures';
 
-import { TradeDetailAmountStack } from '../TradeDetailAmountStack';
+import { TradeDetailAmountStack } from './TradeDetailAmountStack';
 
 describe('TradeDetailAmountStack', () => {
     it('should render fiat amount without crypto icon and fiat badge', () => {

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailFooter.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailFooter.test.tsx
@@ -3,7 +3,7 @@ import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingState, getSellTrade } from '@suite-native/trading-fixtures';
 
-import { TradeDetailFooter } from '../TradeDetailFooter';
+import { TradeDetailFooter } from './TradeDetailFooter';
 
 const mockCopyToClipboard = jest.fn();
 

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailHeader.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailHeader.test.tsx
@@ -7,8 +7,8 @@ import {
     getSellTrade,
 } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingHistoryProvider } from '../../../__tests__/tradingHistoryTestUtils';
-import { TradeDetailHeader } from '../TradeDetailHeader';
+import { TradeDetailHeader } from './TradeDetailHeader';
+import { renderWithTradingHistoryProvider } from '../../__tests__/tradingHistoryTestUtils';
 
 const createOverrides = (trades: TradingTransaction[]) => ({
     wallet: {

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailInfo.test.tsx
@@ -7,7 +7,7 @@ import {
     getInitializedTradingState,
 } from '@suite-native/trading-fixtures';
 
-import { TradeDetailInfo } from '../TradeDetailInfo';
+import { TradeDetailInfo } from './TradeDetailInfo';
 
 const getPreloadedState = (trades: TradingTransaction[]) => ({
     wallet: {

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailProviderCard.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailProviderCard.test.tsx
@@ -9,7 +9,7 @@ import {
     getInitializedTradingState,
 } from '@suite-native/trading-fixtures';
 
-import { TradeDetailProviderCard } from '../TradeDetailProviderCard';
+import { TradeDetailProviderCard } from './TradeDetailProviderCard';
 
 const statusUrl = 'https://checkout.mercuryo.io/trade-history';
 

--- a/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailTransactionInfo.test.tsx
+++ b/suite-native/trading-history/src/components/TradeDetailSheet/TradeDetailTransactionInfo.test.tsx
@@ -10,14 +10,14 @@ import {
 } from '@suite-native/trading-fixtures';
 
 import {
+    TradeDetailTransactionInfo,
+    type TradeDetailTransactionInfoProps,
+} from './TradeDetailTransactionInfo';
+import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingHistoryProvider,
-} from '../../../__tests__/tradingHistoryTestUtils';
-import {
-    TradeDetailTransactionInfo,
-    type TradeDetailTransactionInfoProps,
-} from '../TradeDetailTransactionInfo';
+} from '../../__tests__/tradingHistoryTestUtils';
 
 jest.mock('@suite-native/trading-state', () => {
     const actual = jest.requireActual('@suite-native/trading-state');

--- a/suite-native/trading-history/src/components/TradeHistoryListItem/TradeHistoryListItem.test.tsx
+++ b/suite-native/trading-history/src/components/TradeHistoryListItem/TradeHistoryListItem.test.tsx
@@ -2,8 +2,8 @@ import { type TradingTransaction } from '@suite-common/trading';
 import { getTranslation } from '@suite-native/intl';
 import { getBuyTrade } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingHistoryProvider } from '../../../__tests__/tradingHistoryTestUtils';
-import { TradeHistoryListItem } from '../TradeHistoryListItem';
+import { TradeHistoryListItem } from './TradeHistoryListItem';
+import { renderWithTradingHistoryProvider } from '../../__tests__/tradingHistoryTestUtils';
 
 describe('TradeHistoryListItem', () => {
     const renderTradeHistoryListItem = (transaction: TradingTransaction) =>

--- a/suite-native/trading-history/src/components/TradeStatusBadge.test.tsx
+++ b/suite-native/trading-history/src/components/TradeStatusBadge.test.tsx
@@ -3,8 +3,8 @@ import { type BadgeIntent } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
 import { getBuyTrade, getExchangeTrade, getSellTrade } from '@suite-native/trading-fixtures';
 
-import { renderWithTradingHistoryProvider } from '../../__tests__/tradingHistoryTestUtils';
-import { TradeStatusBadge, getBadgeIconName, getBadgeVariant } from '../TradeStatusBadge';
+import { TradeStatusBadge, getBadgeIconName, getBadgeVariant } from './TradeStatusBadge';
+import { renderWithTradingHistoryProvider } from '../__tests__/tradingHistoryTestUtils';
 
 describe('TradeStatusBadge', () => {
     it('should render nothing when status is undefined', () => {

--- a/suite-native/trading-history/src/components/TradingHistory.test.tsx
+++ b/suite-native/trading-history/src/components/TradingHistory.test.tsx
@@ -2,12 +2,12 @@ import { getTranslation } from '@suite-native/intl';
 import { fireEvent } from '@suite-native/test-utils-store';
 import { accounts, getBuyTrade } from '@suite-native/trading-fixtures';
 
+import { TradingHistory } from './TradingHistory';
 import {
     type PreloadedStatePartial,
     type TradingTestPreloadedState,
     renderWithTradingHistoryProvider,
-} from '../../__tests__/tradingHistoryTestUtils';
-import { TradingHistory } from '../TradingHistory';
+} from '../__tests__/tradingHistoryTestUtils';
 
 const mockShowSheet = jest.fn();
 

--- a/suite-native/trading-history/src/hooks/useSymbolExtractor.test.ts
+++ b/suite-native/trading-history/src/hooks/useSymbolExtractor.test.ts
@@ -3,7 +3,7 @@ import type { CryptoId } from 'invity-api';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingState } from '@suite-native/trading-fixtures';
 
-import { useSymbolExtractor } from '../useSymbolExtractor';
+import { useSymbolExtractor } from './useSymbolExtractor';
 
 describe('useSymbolExtractor', () => {
     it('should return symbol for known cryptoId', () => {


### PR DESCRIPTION
## Description

Moves 16 Native Trading Debug and Trading History tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-debug-history-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->