### PR TITLE
test(native-trading): co-locate provider and residence tests

### DIFF
--- a/suite-native/trading-provider-utils/src/components/Footer.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/Footer.test.tsx
@@ -5,7 +5,7 @@ import { renderWithStoreProvider, userEvent } from '@suite-native/test-utils-sto
 import { exchangeCexdirect, getWalletState } from '@suite-native/trading-fixtures';
 import type { TradingState } from '@suite-native/trading-types';
 
-import { Footer } from '../Footer';
+import { Footer } from './Footer';
 
 const mockOpenModal = jest.fn();
 const mockCloseModal = jest.fn();

--- a/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/HowTradingWorksSheet.test.tsx
@@ -7,7 +7,7 @@ import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 import { TREZOR_SUITE_TOS_URL, TREZOR_SUPPORT_UNDERSTANDING_FEES } from '@trezor/urls';
 
-import { HowTradingWorksSheet } from '../HowTradingWorksSheet';
+import { HowTradingWorksSheet } from './HowTradingWorksSheet';
 
 const mockCloseModal = jest.fn();
 

--- a/suite-native/trading-provider-utils/src/components/KycPolicyWarning.test.tsx
+++ b/suite-native/trading-provider-utils/src/components/KycPolicyWarning.test.tsx
@@ -3,7 +3,7 @@ import type { ExchangeKYCType } from 'invity-api';
 import { Text } from '@suite-native/atoms';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { KycPolicyWarning, hasKycPolicyWarning } from '../KycPolicyWarning';
+import { KycPolicyWarning, hasKycPolicyWarning } from './KycPolicyWarning';
 
 describe('KycPolicyWarning', () => {
     it.each([

--- a/suite-native/trading-quote-utils/src/QuoteError.test.ts
+++ b/suite-native/trading-quote-utils/src/QuoteError.test.ts
@@ -5,7 +5,7 @@ import {
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
-import { QuoteError } from '../QuoteError';
+import { QuoteError } from './QuoteError';
 
 describe('QuoteError', () => {
     it('is an instance of Error', () => {

--- a/suite-native/trading-quote-utils/src/components/CryptoToFiatValueBadge.test.tsx
+++ b/suite-native/trading-quote-utils/src/components/CryptoToFiatValueBadge.test.tsx
@@ -1,17 +1,14 @@
 import { act, renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { btcAsset, ethAsset, mockWalletFiatRatesAndSettings } from '@suite-native/trading-fixtures';
 
-import {
-    CryptoToFiatValueBadge,
-    type CryptoToFiatValueBadgeProps,
-} from '../CryptoToFiatValueBadge';
+import { CryptoToFiatValueBadge, type CryptoToFiatValueBadgeProps } from './CryptoToFiatValueBadge';
 
 jest.mock('@suite-common/fiat-services', () => ({
     ...jest.requireActual('@suite-common/fiat-services'),
     fetchCurrentFiatRates: () => Promise.resolve(null),
 }));
 
-jest.mock('../CryptoToFiatValueBadge', () => jest.requireActual('../CryptoToFiatValueBadge'));
+jest.mock('./CryptoToFiatValueBadge', () => jest.requireActual('./CryptoToFiatValueBadge'));
 
 describe('CryptoToFiatValueBadge', () => {
     const getPreloadedState = () => ({

--- a/suite-native/trading-quote-utils/src/hooks/useChangeStringsExtractor.test.ts
+++ b/suite-native/trading-quote-utils/src/hooks/useChangeStringsExtractor.test.ts
@@ -7,7 +7,7 @@ import {
     getSellTrade,
 } from '@suite-native/trading-fixtures';
 
-import { useChangeStringsExtractor } from '../useChangeStringsExtractor';
+import { useChangeStringsExtractor } from './useChangeStringsExtractor';
 
 describe('useChangeStringsExtractor', () => {
     const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });

--- a/suite-native/trading-quote-utils/src/hooks/useReceiveAmountMultiplier.test.ts
+++ b/suite-native/trading-quote-utils/src/hooks/useReceiveAmountMultiplier.test.ts
@@ -1,7 +1,7 @@
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { getInitializedTradingState, mercuryoDexQuote } from '@suite-native/trading-fixtures';
 
-import { useReceiveAmountMultiplier } from '../useReceiveAmountMultiplier';
+import { useReceiveAmountMultiplier } from './useReceiveAmountMultiplier';
 
 const getPreloadedState = (swapSlippage: string | undefined) => {
     const trading = getInitializedTradingState();

--- a/suite-native/trading-quote-utils/src/utils/utils.test.ts
+++ b/suite-native/trading-quote-utils/src/utils/utils.test.ts
@@ -12,7 +12,7 @@ import {
     getTradeOperationData,
     getTradeStatusStep,
     getTradeTitle,
-} from '../utils';
+} from './utils';
 
 describe('utils', () => {
     describe('getTradeOperationData', () => {

--- a/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
+++ b/suite-native/trading-residence/src/components/ConfirmLocationButton.test.tsx
@@ -19,15 +19,15 @@ import {
     selectTradingResidenceCountrySubdivision,
 } from '@suite-native/trading-state';
 
-import { type TradingLocationFormValues } from '../../types/tradingLocationForm';
-import { ConfirmLocationButton, type ConfirmLocationButtonProps } from '../ConfirmLocationButton';
-import { CountrySubdivisionPicker } from '../CountrySheet/CountrySubdivisionPicker';
-import { CountrySubdivisionPickerControlsContext } from '../CountrySheet/CountrySubdivisionPickerControlsContext';
-import { LocationForm } from '../LocationForm';
+import { ConfirmLocationButton, type ConfirmLocationButtonProps } from './ConfirmLocationButton';
+import { type TradingLocationFormValues } from '../types/tradingLocationForm';
+import { CountrySubdivisionPicker } from './CountrySheet/CountrySubdivisionPicker';
+import { CountrySubdivisionPickerControlsContext } from './CountrySheet/CountrySubdivisionPickerControlsContext';
+import { LocationForm } from './LocationForm';
 
 const mockAnalyticsReport = jest.fn();
 
-jest.mock('../../hooks/useCountrySelectionAnalyticsReport', () => ({
+jest.mock('../hooks/useCountrySelectionAnalyticsReport', () => ({
     useCountrySelectionAnalyticsReport: () => mockAnalyticsReport,
 }));
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryListItem.test.tsx
@@ -1,7 +1,7 @@
 import { nonSanctionedRegional } from '@suite-common/trading';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { CountryListItem, type CountryListItemProps } from '../CountryListItem';
+import { CountryListItem, type CountryListItemProps } from './CountryListItem';
 
 describe('CountryListItem', () => {
     const usData = nonSanctionedRegional.countriesOptionsMap.get('US')!;

--- a/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountryOfResidencePicker.test.tsx
@@ -16,13 +16,13 @@ import {
 } from '@suite-native/test-utils-store';
 import { residenceReducer } from '@suite-native/trading-state';
 
-import { useLocationForm } from '../../../hooks/useLocationForm';
-import { type TradingLocationFormValues } from '../../../types/tradingLocationForm';
-import { locationFormValidationSchema } from '../../../utils/locationFormValidationSchema';
 import {
     CountryOfResidencePicker,
     type CountryOfResidencePickerProps,
-} from '../CountryOfResidencePicker';
+} from './CountryOfResidencePicker';
+import { useLocationForm } from '../../hooks/useLocationForm';
+import { type TradingLocationFormValues } from '../../types/tradingLocationForm';
+import { locationFormValidationSchema } from '../../utils/locationFormValidationSchema';
 
 let mockUseCountryFilteredData: jest.Mock;
 

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionListItem.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionListItem.test.tsx
@@ -5,7 +5,7 @@ import { userEvent } from '@suite-native/test-utils-store';
 import {
     CountrySubdivisionListItem,
     type CountrySubdivisionListItemProps,
-} from '../CountrySubdivisionListItem';
+} from './CountrySubdivisionListItem';
 
 describe('CountrySubdivisionListItem', () => {
     const subdivisionData = {

--- a/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.test.tsx
+++ b/suite-native/trading-residence/src/components/CountrySheet/CountrySubdivisionPicker.test.tsx
@@ -5,10 +5,10 @@ import { getTranslation } from '@suite-native/intl';
 import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-native/test-utils';
 import { screen, userEvent } from '@suite-native/test-utils-store';
 
-import { type TradingLocationFormValues } from '../../../types/tradingLocationForm';
-import { locationFormValidationSchema } from '../../../utils/locationFormValidationSchema';
-import { CountrySubdivisionPicker } from '../CountrySubdivisionPicker';
-import { CountrySubdivisionPickerControlsContext } from '../CountrySubdivisionPickerControlsContext';
+import { CountrySubdivisionPicker } from './CountrySubdivisionPicker';
+import { CountrySubdivisionPickerControlsContext } from './CountrySubdivisionPickerControlsContext';
+import { type TradingLocationFormValues } from '../../types/tradingLocationForm';
+import { locationFormValidationSchema } from '../../utils/locationFormValidationSchema';
 
 const usaCountry = {
     value: 'US',

--- a/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
+++ b/suite-native/trading-residence/src/components/OnboardingButtons.test.tsx
@@ -15,8 +15,8 @@ import {
     selectWasTradingResidenceOnboardingVisited,
 } from '@suite-native/trading-state';
 
-import { LocationForm } from '../LocationForm';
-import { OnboardingButtons, type OnboardingButtonsProps } from '../OnboardingButtons';
+import { LocationForm } from './LocationForm';
+import { OnboardingButtons, type OnboardingButtonsProps } from './OnboardingButtons';
 
 describe('OnboardingButtons', () => {
     let store: TestStore;

--- a/suite-native/trading-residence/src/components/SkipButton.test.tsx
+++ b/suite-native/trading-residence/src/components/SkipButton.test.tsx
@@ -1,11 +1,11 @@
 import { getTranslation } from '@suite-native/intl';
 import { fireEvent, renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { SkipButton, type SkipButtonProps } from '../SkipButton';
+import { SkipButton, type SkipButtonProps } from './SkipButton';
 
 const mockAnalyticsReport = jest.fn();
 
-jest.mock('../../hooks/useCountrySelectionAnalyticsReport', () => ({
+jest.mock('../hooks/useCountrySelectionAnalyticsReport', () => ({
     useCountrySelectionAnalyticsReport: () => mockAnalyticsReport,
 }));
 

--- a/suite-native/trading-residence/src/components/TradingAvailability.test.tsx
+++ b/suite-native/trading-residence/src/components/TradingAvailability.test.tsx
@@ -1,11 +1,11 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider } from '@suite-native/test-utils';
 
-import { TradingAvailability } from '../TradingAvailability';
+import { TradingAvailability } from './TradingAvailability';
 
 let mockIsTradingAvailableForForm: boolean;
 
-jest.mock('../../hooks/useIsTradingAvailableForForm', () => ({
+jest.mock('../hooks/useIsTradingAvailableForForm', () => ({
     useIsTradingAvailableForForm: () => mockIsTradingAvailableForForm,
 }));
 

--- a/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
+++ b/suite-native/trading-residence/src/components/TradingLocationSettings.test.tsx
@@ -15,7 +15,7 @@ import { residenceReducer } from '@suite-native/trading-state';
 import {
     TradingLocationSettings,
     type TradingLocationSettingsProps,
-} from '../TradingLocationSettings';
+} from './TradingLocationSettings';
 
 describe('TradingLocationSettings', () => {
     let store: TestStore;

--- a/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.test.ts
+++ b/suite-native/trading-residence/src/hooks/useAvailableScreenSquare.test.ts
@@ -6,7 +6,7 @@ import {
     HEADER_HEIGHT,
     HORIZONTAL_MARGIN,
     useAvailableScreenSquare,
-} from '../useAvailableScreenSquare';
+} from './useAvailableScreenSquare';
 
 // useWindowDimensions returns { width: 750, height: 1334 } by default in jest-expo
 const MOCKED_SCREEN_HEIGHT = 1334;

--- a/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.test.ts
+++ b/suite-native/trading-residence/src/hooks/useCountrySelectionAnalyticsReport.test.ts
@@ -2,7 +2,7 @@ import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { useCountrySelectionAnalyticsReport } from '../useCountrySelectionAnalyticsReport';
+import { useCountrySelectionAnalyticsReport } from './useCountrySelectionAnalyticsReport';
 
 describe('useCountrySelectionAnalyticsReport', () => {
     const reportMock = jest.fn();

--- a/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
+++ b/suite-native/trading-residence/src/hooks/useFormCountryCode.test.tsx
@@ -13,9 +13,9 @@ import {
 } from '@suite-native/test-utils-store';
 import { residenceReducer } from '@suite-native/trading-state';
 
-import { type TradingLocationFormType } from '../../types/tradingLocationForm';
-import { useFormCountryCode } from '../useFormCountryCode';
-import { useLocationForm } from '../useLocationForm';
+import { useFormCountryCode } from './useFormCountryCode';
+import { useLocationForm } from './useLocationForm';
+import { type TradingLocationFormType } from '../types/tradingLocationForm';
 
 describe('useFormCountryCode', () => {
     const renderLocationForm = () =>

--- a/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.test.tsx
+++ b/suite-native/trading-residence/src/hooks/useIsTradingAvailableForForm.test.tsx
@@ -1,8 +1,8 @@
 import { type TradingCountryCode } from '@suite-common/trading';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { LocationForm } from '../../components/LocationForm';
-import { useIsTradingAvailableForForm } from '../useIsTradingAvailableForForm';
+import { useIsTradingAvailableForForm } from './useIsTradingAvailableForForm';
+import { LocationForm } from '../components/LocationForm';
 
 describe('useIsTradingAvailableForForm', () => {
     const renderUseIsTradingAvailableForForm = (preloadedState: Record<string, unknown>) =>

--- a/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
+++ b/suite-native/trading-residence/src/hooks/useLocationForm.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { residenceActions, residenceReducer } from '@suite-native/trading-state';
 
-import { useLocationForm } from '../useLocationForm';
+import { useLocationForm } from './useLocationForm';
 
 describe('useLocationForm', () => {
     let store: TestStore;

--- a/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/SettingsTradingLocationScreen.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { residenceReducer } from '@suite-native/trading-state';
 
-import { SettingsTradingLocationScreen } from '../SettingsTradingLocationScreen';
+import { SettingsTradingLocationScreen } from './SettingsTradingLocationScreen';
 
 const mockNavigationGoBack = jest.fn();
 const reportMock = jest.fn();

--- a/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
+++ b/suite-native/trading-residence/src/screens/TradingLocationModalScreen.test.tsx
@@ -19,7 +19,7 @@ import { residenceReducer } from '@suite-native/trading-state';
 import {
     TradingLocationModalScreen,
     type TradingLocationModalScreenProps,
-} from '../TradingLocationModalScreen';
+} from './TradingLocationModalScreen';
 
 const mockNavigationDispatch = jest.fn();
 const reportMock = jest.fn();

--- a/suite-native/trading-residence/src/utils/getPreferredCountryOption.test.ts
+++ b/suite-native/trading-residence/src/utils/getPreferredCountryOption.test.ts
@@ -1,6 +1,6 @@
 import Localization, { type Locale } from 'expo-localization';
 
-import { getPreferredCountryOption } from '../getPreferredCountryOption';
+import { getPreferredCountryOption } from './getPreferredCountryOption';
 
 describe('getPreferredCountryOption()', () => {
     it('should use value from expo-localization when country is not set in store', () => {


### PR DESCRIPTION
## Description

Moves 25 Native Trading Provider, Quote, and Residence tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-provider-residence-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->