### PR TITLE
test(native-trading): co-locate slippage and state tests

### DIFF
--- a/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageBottomSheet.test.tsx
@@ -4,8 +4,8 @@ import { useOpenLink } from '@suite-native/link';
 import { type TestStore, act, userEvent } from '@suite-native/test-utils-store';
 import { TREZOR_TRADING_DEX_SLIPPAGE_URL } from '@trezor/urls';
 
-import { createSlippageTestStore, renderWithSlippageTestProvider } from '../../__tests__/testUtils';
-import { SlippageBottomSheet } from '../SlippageBottomSheet';
+import { SlippageBottomSheet } from './SlippageBottomSheet';
+import { createSlippageTestStore, renderWithSlippageTestProvider } from '../__tests__/testUtils';
 
 jest.mock('@suite-native/link', () => ({
     useOpenLink: jest.fn(),

--- a/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippagePicker.test.tsx
@@ -5,8 +5,8 @@ import { userEvent, within } from '@suite-native/test-utils';
 import { act } from '@suite-native/test-utils-store';
 import { mercuryoDexQuote, mercuryoFixedWorstQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithSlippageTestProvider } from '../../__tests__/testUtils';
-import { SLIPPAGE_PICKER_TEST_ID, SlippagePicker } from '../SlippagePicker';
+import { SLIPPAGE_PICKER_TEST_ID, SlippagePicker } from './SlippagePicker';
+import { renderWithSlippageTestProvider } from '../__tests__/testUtils';
 
 const mockShowSheet = jest.fn();
 const mockHideSheet = jest.fn();

--- a/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
+++ b/suite-native/trading-slippage/src/components/SlippageSummary.test.tsx
@@ -6,8 +6,8 @@ import { Form, useForm } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { mercuryoDexQuote } from '@suite-native/trading-fixtures';
 
-import { renderWithSlippageTestProvider } from '../../__tests__/testUtils';
-import { SlippageSummary } from '../SlippageSummary';
+import { SlippageSummary } from './SlippageSummary';
+import { renderWithSlippageTestProvider } from '../__tests__/testUtils';
 
 const validationSchema = yup.object({ slippage: yup.string() });
 

--- a/suite-native/trading-slippage/src/hooks/useSlippageForm.test.ts
+++ b/suite-native/trading-slippage/src/hooks/useSlippageForm.test.ts
@@ -5,8 +5,8 @@ import {
 import { getTranslation } from '@suite-native/intl';
 import { act } from '@suite-native/test-utils-store';
 
-import { renderHookWithSlippageTestProvider } from '../../__tests__/testUtils';
-import { useSlippageForm } from '../useSlippageForm';
+import { useSlippageForm } from './useSlippageForm';
+import { renderHookWithSlippageTestProvider } from '../__tests__/testUtils';
 
 describe('useSlippageForm', () => {
     const renderUseSlippageForm = async () => {

--- a/suite-native/trading-slippage/src/hooks/useSlippageLifecycle.test.ts
+++ b/suite-native/trading-slippage/src/hooks/useSlippageLifecycle.test.ts
@@ -6,11 +6,11 @@ import {
 import { act } from '@suite-native/test-utils-store';
 import { mercuryoDexQuote } from '@suite-native/trading-fixtures';
 
+import { useSlippageLifecycle } from './useSlippageLifecycle';
 import {
     createSlippageTestStore,
     renderHookWithSlippageTestProvider,
-} from '../../__tests__/testUtils';
-import { useSlippageLifecycle } from '../useSlippageLifecycle';
+} from '../__tests__/testUtils';
 
 const renderUseSlippageLifecycle = ({
     onSlippageChanged,

--- a/suite-native/trading-state/src/middlewares/tradingLastErrorSentryMiddleware.test.ts
+++ b/suite-native/trading-state/src/middlewares/tradingLastErrorSentryMiddleware.test.ts
@@ -5,7 +5,7 @@ import {
     tradingSellActions,
 } from '@suite-common/trading';
 
-import { prepareTradingLastErrorSentryMiddleware } from '../tradingLastErrorSentryMiddleware';
+import { prepareTradingLastErrorSentryMiddleware } from './tradingLastErrorSentryMiddleware';
 
 const mockCaptureSentryException = jest.fn();
 

--- a/suite-native/trading-state/src/middlewares/tradingMiddleware.test.ts
+++ b/suite-native/trading-state/src/middlewares/tradingMiddleware.test.ts
@@ -3,9 +3,9 @@ import type { ExtraDependencies } from '@suite-common/redux-utils';
 import type { TrezorDevice } from '@suite-common/suite-types';
 import { formDraftActions } from '@suite-common/wallet-core';
 
-import { buyActions, exchangeActions, sellActions, tradingActions } from '../../reducers';
-import { getFormDraftKeyByTradeType } from '../../utils';
-import { prepareTradingMiddleware } from '../tradingMiddleware';
+import { buyActions, exchangeActions, sellActions, tradingActions } from '../reducers';
+import { getFormDraftKeyByTradeType } from '../utils';
+import { prepareTradingMiddleware } from './tradingMiddleware';
 
 describe('tradingMiddleware', () => {
     const tradingMiddleware = prepareTradingMiddleware(() => ({}) as ExtraDependencies);

--- a/suite-native/trading-state/src/reducers/buySlice.test.ts
+++ b/suite-native/trading-state/src/reducers/buySlice.test.ts
@@ -10,7 +10,7 @@ import {
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
-import { buyActions, buyReducer } from '../buySlice';
+import { buyActions, buyReducer } from './buySlice';
 
 describe('buySlice', () => {
     describe('clearState', () => {

--- a/suite-native/trading-state/src/reducers/exchangeSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/exchangeSlice.test.ts
@@ -9,7 +9,7 @@ import {
     mercuryoFixedWorstQuote,
 } from '@suite-native/trading-fixtures';
 
-import { exchangeActions, exchangeReducer } from '../exchangeSlice';
+import { exchangeActions, exchangeReducer } from './exchangeSlice';
 
 describe('exchangeSlice', () => {
     it('should have correct initial state', () => {

--- a/suite-native/trading-state/src/reducers/residenceSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/residenceSlice.test.ts
@@ -1,6 +1,6 @@
 import { type TradingCountryCode } from '@suite-common/trading';
 
-import { residenceActions, residenceReducer } from '../residenceSlice';
+import { residenceActions, residenceReducer } from './residenceSlice';
 
 describe('residenceSlice', () => {
     it('should return the initial state', () => {

--- a/suite-native/trading-state/src/reducers/sellSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/sellSlice.test.ts
@@ -5,7 +5,7 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { tradingInitialState } from '@suite-native/trading-consts';
 import { banxaCreditCardSellQuote, sellQuotes } from '@suite-native/trading-fixtures';
 
-import { sellActions, sellReducer } from '../sellSlice';
+import { sellActions, sellReducer } from './sellSlice';
 
 describe('sellSlice', () => {
     describe('clearState', () => {

--- a/suite-native/trading-state/src/reducers/tradingSlice.test.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.test.ts
@@ -18,11 +18,11 @@ import {
 } from '@suite-native/trading-fixtures';
 import { type ProviderConfirmationStatus, type TradingState } from '@suite-native/trading-types';
 
-import { buyActions } from '../buySlice';
-import { exchangeActions } from '../exchangeSlice';
-import { residenceActions } from '../residenceSlice';
-import { sellActions } from '../sellSlice';
-import { tradingActions, tradingSlice } from '../tradingSlice';
+import { buyActions } from './buySlice';
+import { exchangeActions } from './exchangeSlice';
+import { residenceActions } from './residenceSlice';
+import { sellActions } from './sellSlice';
+import { tradingActions, tradingSlice } from './tradingSlice';
 
 describe('tradingSlice', () => {
     let tradingReducer: ReturnType<typeof tradingSlice.prepareReducer>;

--- a/suite-native/trading-state/src/selectors/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.test.ts
@@ -14,7 +14,7 @@ import {
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
-import { type TradingRootState } from '../../reducers';
+import { type TradingRootState } from '../reducers';
 import {
     selectBuyAmountLimits,
     selectBuyBestQuotesForAvailablePaymentMethods,
@@ -26,7 +26,7 @@ import {
     selectBuyTradeableAssets,
     selectTradingBuy,
     selectValidTradingBuyQuotesNative,
-} from '../buySelectors';
+} from './buySelectors';
 
 const supportedCoins: readonly NetworkSymbol[] = ['btc', 'eth', 'base'];
 

--- a/suite-native/trading-state/src/selectors/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.test.ts
@@ -34,7 +34,7 @@ import { type TradeableAsset } from '@suite-native/trading-types';
 import { type StaticSessionId } from '@trezor/device-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { type TradingRootState, tradingInitialState } from '../../reducers';
+import { type TradingRootState, tradingInitialState } from '../reducers';
 import {
     selectAccountLabelWithNetworkFallback,
     selectAccountsWithTokensToSellSectionCondensedListByTradingType,
@@ -55,7 +55,7 @@ import {
     selectTradingEnvironment,
     selectTradingProviderConfirmationStatus,
     selectVisibleDeviceAccountsByNetworkSymbolSorted,
-} from '../commonSelectors';
+} from './commonSelectors';
 
 const supportedCoins: readonly NetworkSymbol[] = ['btc', 'eth', 'base'];
 

--- a/suite-native/trading-state/src/selectors/exchangeSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/exchangeSelectors.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@suite-native/feature-flags';
 import { exchangeQuotes, getBtcAccount, getWalletState } from '@suite-native/trading-fixtures';
 
-import { type TradingRootState } from '../../reducers';
+import { type TradingRootState } from '../reducers';
 import {
     selectExchangeAmountLimits,
     selectExchangeBuyTradeableAssets,
@@ -20,7 +20,7 @@ import {
     selectExchangeSelectedSendAccount,
     selectGroupedExchangeQuotes,
     selectTradingExchange,
-} from '../exchangeSelectors';
+} from './exchangeSelectors';
 
 const supportedCoins: readonly NetworkSymbol[] = ['btc', 'eth', 'base'];
 

--- a/suite-native/trading-state/src/selectors/residenceSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/residenceSelectors.test.ts
@@ -18,7 +18,7 @@ import {
     selectTradingResidenceCountry,
     selectTradingResidenceCountrySubdivision,
     selectWasTradingResidenceOnboardingVisited,
-} from '../residenceSelectors';
+} from './residenceSelectors';
 
 describe('residenceSelectors', () => {
     const visitedState: TradingResidenceState = {

--- a/suite-native/trading-state/src/selectors/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.test.ts
@@ -10,7 +10,7 @@ import {
     sellQuotes,
 } from '@suite-native/trading-fixtures';
 
-import { type TradingRootState } from '../../reducers';
+import { type TradingRootState } from '../reducers';
 import {
     selectSellAmountLimits,
     selectSellBestQuotesForAvailablePaymentMethods,
@@ -20,7 +20,7 @@ import {
     selectSellSupportedFiatCurrencies,
     selectSellSupportedFiatCurrenciesList,
     selectTradingSell,
-} from '../sellSelectors';
+} from './sellSelectors';
 
 describe('sellSelectors', () => {
     let state: TradingRootState & AccountsRootState;

--- a/suite-native/trading-state/src/utils.test.ts
+++ b/suite-native/trading-state/src/utils.test.ts
@@ -9,7 +9,7 @@ import {
     usdtOnBscAsset,
 } from '@suite-native/trading-fixtures';
 
-import { getAssetByEnabledNetworksFilter, getFormDraftKeyByTradeType } from '../utils';
+import { getAssetByEnabledNetworksFilter, getFormDraftKeyByTradeType } from './utils';
 
 jest.mock('@suite-common/wallet-config', () => {
     const actual = jest.requireActual('@suite-common/wallet-config');


### PR DESCRIPTION
## Description

Moves 18 Native Trading Slippage and Trading State tests beside their source files.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-slippage-state-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->