### PR TITLE
test(suite): co-locate platform and metadata tests

### DIFF
--- a/suite/external-links/src/getTorUrlIfAvailable.test.ts
+++ b/suite/external-links/src/getTorUrlIfAvailable.test.ts
@@ -1,6 +1,6 @@
 import { TOR_URLS } from '@trezor/urls';
 
-import { getTorUrlIfAvailable } from '../getTorUrlIfAvailable';
+import { getTorUrlIfAvailable } from './getTorUrlIfAvailable';
 
 describe(getTorUrlIfAvailable.name, () => {
     beforeAll(() => {

--- a/suite/feature-feedback/src/featureFeedbackSlice.test.ts
+++ b/suite/feature-feedback/src/featureFeedbackSlice.test.ts
@@ -6,7 +6,7 @@ import {
     feedbackDismissed,
     feedbackRequested,
     initialState,
-} from '../featureFeedbackSlice';
+} from './featureFeedbackSlice';
 
 describe(featureFeedbackReducer.name, () => {
     describe(featureUsed.name, () => {

--- a/suite/flags/src/flagsSlice.test.ts
+++ b/suite/flags/src/flagsSlice.test.ts
@@ -3,7 +3,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { DEVICE } from '@trezor/connect';
 
-import { flagsInitialState, prepareFlagsReducer, selectFlags, setFlag } from '../flagsSlice';
+import { flagsInitialState, prepareFlagsReducer, selectFlags, setFlag } from './flagsSlice';
 
 const flagsReducer = prepareFlagsReducer(extraDependenciesCommonMock);
 

--- a/suite/flags/src/flagsThunks.test.ts
+++ b/suite/flags/src/flagsThunks.test.ts
@@ -1,7 +1,7 @@
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import { type FlagsState, flagsInitialState, prepareFlagsReducer } from '../flagsSlice';
-import { initialRunCompleted } from '../flagsThunks';
+import { type FlagsState, flagsInitialState, prepareFlagsReducer } from './flagsSlice';
+import { initialRunCompleted } from './flagsThunks';
 
 const flagsReducer = prepareFlagsReducer(extraDependenciesCommonMock);
 

--- a/suite/idb-migration-utils/src/createMigration.test.ts
+++ b/suite/idb-migration-utils/src/createMigration.test.ts
@@ -1,4 +1,4 @@
-import { createMigration } from '../createMigration';
+import { createMigration } from './createMigration';
 
 describe('createMigration', () => {
     it('returns correct threshold', () => {

--- a/suite/idb-migration-utils/src/encode.test.ts
+++ b/suite/idb-migration-utils/src/encode.test.ts
@@ -1,4 +1,4 @@
-import { encodeIDBVersion, idbVersionToString } from '../encode';
+import { encodeIDBVersion, idbVersionToString } from './encode';
 
 const VERSIONS = [
     '1.2.3',

--- a/suite/idb-migration-utils/src/parseIdbVersionString.test.ts
+++ b/suite/idb-migration-utils/src/parseIdbVersionString.test.ts
@@ -1,4 +1,4 @@
-import { parseIdbVersion } from '../parseIdbVersion';
+import { parseIdbVersion } from './parseIdbVersion';
 
 describe(parseIdbVersion.name, () => {
     it('parses x.y.z with revision=0', () => {

--- a/suite/labeling/src/selectIsLabelActionEnabled.test.ts
+++ b/suite/labeling/src/selectIsLabelActionEnabled.test.ts
@@ -20,7 +20,7 @@ import {
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type StaticSessionId, type UnavailableCapabilities } from '@trezor/connect';
 
-import { selectIsLabelActionEnabled } from '../selectIsLabelActionEnabled';
+import { selectIsLabelActionEnabled } from './selectIsLabelActionEnabled';
 
 /**
  * It was really hard to mock the state for metadata. So I statically mocked

--- a/suite/locks/jest.config.js
+++ b/suite/locks/jest.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    roots: ['<rootDir>/src', '<rootDir>/tests'],
+    roots: ['<rootDir>/src'],
 };

--- a/suite/locks/src/locksSlice.test.ts
+++ b/suite/locks/src/locksSlice.test.ts
@@ -13,7 +13,7 @@ import {
     selectIsDeviceOrUiLocked,
     selectIsRouterLocked,
     selectIsRouterOrUiLocked,
-} from '../src/locksSlice';
+} from './locksSlice';
 
 const getStore = (overrides: Partial<typeof locksInitialState> = {}) =>
     configureMockStore({

--- a/suite/metadata/src/fromLegacyMatadataToSearchLabels.test.ts
+++ b/suite/metadata/src/fromLegacyMatadataToSearchLabels.test.ts
@@ -3,7 +3,7 @@ import { type AccountLabels } from '@suite-common/metadata-types';
 import {
     fromLegacyMetadataToSearchAccountLabels,
     fromLegacyMetadataToSearchOutputLabels,
-} from '../fromLegacyMetadataToSearchLabels';
+} from './fromLegacyMetadataToSearchLabels';
 
 describe('fromLegacyMetadataToSearchLabels', () => {
     const accountLabelsFixture: AccountLabels = {

--- a/suite/metadata/src/metadataActions.test.ts
+++ b/suite/metadata/src/metadataActions.test.ts
@@ -7,13 +7,13 @@ import { initialWalletSettingsState, prepareAccountsReducer } from '@suite-commo
 import TrezorConnect from '@trezor/connect';
 import { asWalletDescriptor } from '@trezor/device-utils';
 
-import * as fixtures from '../__fixtures__/metadataActions';
-import * as metadataActions from '../metadataActions';
-import * as metadataLabelingActions from '../metadataLabelingActions';
-import * as metadataProviderActions from '../metadataProviderThunks';
-import { type SuiteRootStateSliceForMetadata, metadataReducer } from '../metadataReducer';
-import * as metadataThunks from '../metadataThunks';
-import { DropboxProvider } from '../providers/DropboxProvider';
+import * as fixtures from './__fixtures__/metadataActions';
+import * as metadataActions from './metadataActions';
+import * as metadataLabelingActions from './metadataLabelingActions';
+import * as metadataProviderActions from './metadataProviderThunks';
+import { type SuiteRootStateSliceForMetadata, metadataReducer } from './metadataReducer';
+import * as metadataThunks from './metadataThunks';
+import { DropboxProvider } from './providers/DropboxProvider';
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
@@ -142,7 +142,7 @@ const initStore = (state: State) => {
 
 describe('Metadata Actions', () => {
     beforeAll(() => {
-        jest.mock('../providers/DropboxProvider');
+        jest.mock('./providers/DropboxProvider');
         DropboxProvider.prototype.connect = () =>
             Promise.resolve({ success: true, payload: undefined });
         DropboxProvider.prototype.getProviderDetails = () =>
@@ -165,7 +165,7 @@ describe('Metadata Actions', () => {
                 const file = fs.readFileSync(
                     path.resolve(
                         __dirname,
-                        '../__fixtures__/828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
+                        './__fixtures__/828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85.mtdt',
                     ),
                 );
 

--- a/suite/metadata/src/metadataUtils.test.ts
+++ b/suite/metadata/src/metadataUtils.test.ts
@@ -10,7 +10,7 @@ import {
     deriveFilename,
     deriveMetadataKey,
     encrypt,
-} from '../metadataUtils';
+} from './metadataUtils';
 
 const filename = '828652b66f2e6f919fbb7fe4c9609d4891ed531c6fac4c28441e53ebe577ac85';
 // m/49'/0'/0' first segwit account

--- a/suite/metadata/src/metadataUtils.test.ts
+++ b/suite/metadata/src/metadataUtils.test.ts
@@ -41,7 +41,7 @@ const originalJson = {
 
 describe('metadata', () => {
     it('decrypt real file data from dropbox', async () => {
-        const file = fs.readFileSync(path.resolve(__dirname, `../__fixtures__/${filename}.mtdt`));
+        const file = fs.readFileSync(path.resolve(__dirname, `./__fixtures__/${filename}.mtdt`));
 
         // deriveMetadataKey
         const metadataKey = deriveMetadataKey(
@@ -94,7 +94,7 @@ describe('metadata', () => {
     });
 
     it('read file content (ArrayBuffer)', () => {
-        const file = fs.readFileSync(path.resolve(__dirname, `../__fixtures__/${filename}.mtdt`));
+        const file = fs.readFileSync(path.resolve(__dirname, `./__fixtures__/${filename}.mtdt`));
 
         function toArrayBuffer(buf: Buffer) {
             const ab = new ArrayBuffer(buf.length);

--- a/suite/metadata/src/providers/DropboxProvider.test.ts
+++ b/suite/metadata/src/providers/DropboxProvider.test.ts
@@ -1,6 +1,6 @@
 import { createDeferred } from '@trezor/utils';
 
-import { DropboxProvider } from '../DropboxProvider';
+import { DropboxProvider } from './DropboxProvider';
 
 const globalContext = globalThis as typeof globalThis & { window?: typeof globalThis };
 if (!globalContext.window) {

--- a/suite/metadata/src/random.test.ts
+++ b/suite/metadata/src/random.test.ts
@@ -1,4 +1,4 @@
-import { getCodeChallenge } from '../random';
+import { getCodeChallenge } from './random';
 
 describe('random', () => {
     describe('getCodeChallenge', () => {


### PR DESCRIPTION
## Description

Moves 14 Suite platform, state, labeling, locking, and metadata tests beside their source files.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are unit tests for shared infrastructure packages (metadata/labeling, IndexedDB migration, feature feedback, Tor links, flags, locks). The highest E2E risk lies in metadata/labeling flows and IndexedDB migrations, so the recommendation focuses on those areas. Other potentially affected areas (feature flags, app locks) have no concrete E2E coverage in the analyzed suite, so they are left uncovered.

<details><summary><b>Changed files (14)</b></summary>

- `suite/external-links/src/getTorUrlIfAvailable.test.ts`
- `suite/feature-feedback/src/featureFeedbackSlice.test.ts`
- `suite/flags/src/flagsSlice.test.ts`
- `suite/flags/src/flagsThunks.test.ts`
- `suite/idb-migration-utils/src/createMigration.test.ts`
- `suite/idb-migration-utils/src/encode.test.ts`
- `suite/idb-migration-utils/src/parseIdbVersionString.test.ts`
- `suite/labeling/src/selectIsLabelActionEnabled.test.ts`
- `suite/locks/src/locksSlice.test.ts`
- `suite/metadata/src/fromLegacyMatadataToSearchLabels.test.ts`
- `suite/metadata/src/metadataActions.test.ts`
- `suite/metadata/src/metadataUtils.test.ts`
- `suite/metadata/src/providers/DropboxProvider.test.ts`
- `suite/metadata/src/random.test.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — Directly exercises the legacy metadata/labeling flow with Dropbox provider, including account label CRUD operations. Changes to metadataActions, metadataUtils, or DropboxProvider source code would most likely surface here.
- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Specifically tests Dropbox metadata provider error handling and retry logic. A change to DropboxProvider or metadata actions/thunks would directly affect this flow.
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — Covers the new Suite Sync labeling end-to-end flow, including label creation and Evolu relay sync. Changes to metadataUtils, metadataActions, or labeling selectors could break this path.
- `suite/e2e/tests/suite/db-migration.test.ts` — Validates IndexedDB migration logic between Suite versions, which directly depends on idb-migration-utils. Changes to createMigration, encode, or parseIdbVersionString could corrupt or fail the migration.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Tests bridge/tor integration and bridge lifecycle. Changes to external-links getTorUrlIfAvailable logic could affect how Suite decides to use Tor URLs in bridge-tor contexts.
- `suite/e2e/tests/general/suite-guide.test.ts` — Exercises the in-app guide and feedback/bug-report submission flows. Changes to featureFeedbackSlice source code could affect whether feedback is sent successfully.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Tests metadata enable/disable state persistence across wallet sessions and device resets. Shared infrastructure with metadataActions/metadataUtils, so regressions are plausible.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Directly submits a bug report through the Guide panel. A change to featureFeedbackSlice could break report submission or success toast behavior.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Tests that language settings survive IndexedDB migration between Suite versions. Relies on the same idb-migration-utils machinery as db-migration.test.ts.
- `suite/e2e/tests/trading/remembered-wallet-loading.test.ts` — Loads a remembered wallet from a seeded IndexedDB dump. Changes to IndexedDB migration or encoding utilities could prevent the wallet state from being restored correctly.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite/flags/src/flagsSlice.test.ts`
- `suite/flags/src/flagsThunks.test.ts`
- `suite/locks/src/locksSlice.test.ts`
- `suite/metadata/src/random.test.ts`

_Updated: 2026-07-29T08:04:33.168Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-platform-metadata-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/suite-platform-metadata-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-platform-metadata-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-platform-metadata-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:05:57.303Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:05:39.524Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->