### PR TITLE
[nit] refactor(suite-desktop): derive MCP EVM chain doc list from network config

### DIFF
--- a/packages/suite-desktop-core/src/modules/mcp-server.ts
+++ b/packages/suite-desktop-core/src/modules/mcp-server.ts
@@ -10,7 +10,7 @@ import * as crypto from 'crypto';
 import * as http from 'http';
 
 import { CALL_SOURCE_MCP, type ConnectProcessInfo } from '@suite-common/connect-popup';
-import { getNetworkOptional } from '@suite-common/wallet-config';
+import { getMainnets, getNetworkOptional } from '@suite-common/wallet-config';
 import { convertAmountUnitsToSubunits, substituteBip43Path } from '@suite-common/wallet-utils';
 import { validateIpcMessage } from '@trezor/ipc-proxy';
 import { findProcessFromIncomingPort } from '@trezor/node-utils';
@@ -40,6 +40,16 @@ const getNetworkTypeForCoin = (coin: string) => getNetworkOptional(coin.toLowerC
 const isEvmCoin = (coin: string) => getNetworkTypeForCoin(coin) === 'ethereum';
 const isXrpCoin = (coin: string) => getNetworkTypeForCoin(coin) === 'ripple';
 const isUtxoCoin = (coin: string) => getNetworkTypeForCoin(coin) === 'bitcoin';
+
+// Comma-separated EVM mainnet symbols for MCP tool documentation, derived from the
+// network config so new EVM chains appear automatically. `etc` (Ethereum Classic) is
+// excluded from the derived list and appended as a literal so the prose reads
+// "…, avax, etc" (et cetera) instead of rendering the symbol twice.
+const EVM_CHAINS_DOC =
+    getMainnets()
+        .filter(network => network.networkType === 'ethereum' && network.symbol !== 'etc')
+        .map(network => network.symbol)
+        .join(', ') + ', etc';
 
 /**
  * Convert a human-readable coin value to the smallest unit as a string.
@@ -71,8 +81,8 @@ const MCP_TOOLS = [
         description:
             'Get a receive address from the Trezor device for a given cryptocurrency. ' +
             'The address can optionally be displayed on the Trezor screen for verification. ' +
-            'Supports Bitcoin/UTXO coins via getAddress and all EVM chains (eth, pol, bsc, arb, ' +
-            'base, op, avax, rhc, etc) via ethereumGetAddress.',
+            'Supports Bitcoin/UTXO coins via getAddress and all EVM chains ' +
+            `(${EVM_CHAINS_DOC}) via ethereumGetAddress.`,
         inputSchema: {
             type: 'object' as const,
             properties: {
@@ -360,7 +370,7 @@ const MCP_TOOLS = [
             'Just provide "to" address, "value", and "coin" — everything else is automatic. ' +
             'For Bitcoin/UTXO chains (btc, ltc, bch, doge, zec): ' +
             'handled by composeTransaction — account, UTXOs, and fees are resolved by Suite. ' +
-            'For Ethereum/EVM chains (eth, pol, bsc, arb, base, op, avax, rhc, etc): ' +
+            `For Ethereum/EVM chains (${EVM_CHAINS_DOC}): ` +
             'nonce and EIP-1559 gas fees are auto-filled; use "accountIndex" to select account. ' +
             'For ERC-20 token transfers: set "tokenContract" and "tokenDecimals" — the server encodes the transfer calldata automatically. ' +
             'For XRP: sequence and fee are auto-filled. ' +
@@ -372,8 +382,8 @@ const MCP_TOOLS = [
                 coin: {
                     type: 'string',
                     description:
-                        'Coin symbol. Supported: eth, pol, bsc, arb, base, op, avax, rhc, etc, ' +
-                        'tsep, thod (EVM); xrp, txrp (Ripple); btc, ltc, bch, doge, zec (UTXO).',
+                        `Coin symbol. Supported: ${EVM_CHAINS_DOC}, tsep, thod (EVM); ` +
+                        'xrp, txrp (Ripple); btc, ltc, bch, doge, zec (UTXO).',
                 },
                 to: {
                     type: 'string',


### PR DESCRIPTION
## Description

Second recommendation (R2) from the "Adding an EVM Chain" centralization audit: derive the MCP tool-description EVM chain list instead of hand-maintaining it.

`packages/suite-desktop-core/src/modules/mcp-server.ts` hardcoded the set of supported EVM chains in three separate prose strings inside the MCP tool definitions. Every new EVM chain required editing all three by hand — one more forgettable touch point on the per-chain checklist.

This derives the list once from `getMainnets()` (the file already imports from `@suite-common/wallet-config`, so no new layer edge), interpolates it into the three descriptions, and resolves the standing `TODO` above `MCP_TOOLS`.

Ethereum Classic (`etc`) is filtered out of the derived list and appended as a literal `, etc`, so the prose still reads "…, avax, etc" (et cetera) rather than rendering the symbol twice — the regression a naive `.map(symbol).join(', ')` would introduce.

## Related

Part of the EVM-chain onboarding simplification series. Sibling: #30471 (R1 — icon drift gate).

## Screenshots

N/A — internal MCP tool documentation strings only; no behaviour or UI change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file, packages/suite-desktop-core/src/modules/mcp-server.ts, implements an MCP (Model Context Protocol) server module within the desktop core package. None of the 99 candidate E2E tests reference this file statically, and none of the described test behaviors (onboarding, staking, trading, metadata sync, analytics, wallet operations, browser compatibility, bridge daemon, etc.) exercise an MCP server integration point. This suggests the mcp-server module is either a new/experimental feature not yet covered by E2E tests, or it operates through a channel (e.g., a separate MCP client protocol) that isn't exercised by any existing Playwright suite. Given the lack of any direct or inferable coverage, no specific test can be confidently recommended; this change should be validated through manual testing, targeted unit/integration tests for the MCP module itself, or new E2E coverage should be authored if this functionality is user-facing.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/modules/mcp-server.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/modules/mcp-server.ts`

_Updated: 2026-07-28T17:42:56.059Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/mcp-evm-chain-doc-derive/web/](https://dev.suite.sldev.cz/suite-web/mroz22/mcp-evm-chain-doc-derive/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/mcp-evm-chain-doc-derive&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/mcp-evm-chain-doc-derive&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:46:23.271Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T17:45:25.921Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->