### PR TITLE
Respect message-system claim flag on Cardano StakingCard

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -110,8 +110,10 @@ export const StakingCard = ({
     const {
         isStakingDisabled,
         isUnstakingDisabled,
+        isClaimingDisabled,
         stakingMessageContent,
         unstakingMessageContent,
+        claimingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
     const {
@@ -185,7 +187,7 @@ export const StakingCard = ({
     };
 
     const openClaimModal = () => {
-        if (canClaimRewards) {
+        if (canClaimRewards && !isClaimingDisabled) {
             dispatch(openModal({ type: 'claim', account }));
 
             analytics.report({
@@ -392,14 +394,17 @@ export const StakingCard = ({
                             </Button>
                         </Tooltip>
                     ) : (
-                        <Button
-                            onClick={openClaimModal}
-                            isDisabled={!canClaimRewards}
-                            intent="brand"
-                            data-testid="@account/staking/claim-rewards-button"
-                        >
-                            <Translation id="TR_EARN_CLAIM_REWARDS" />
-                        </Button>
+                        <Tooltip content={claimingMessageContent}>
+                            <Button
+                                onClick={openClaimModal}
+                                isDisabled={!canClaimRewards || isClaimingDisabled}
+                                iconLeft={isClaimingDisabled ? InfoIcon : undefined}
+                                intent="brand"
+                                data-testid="@account/staking/claim-rewards-button"
+                            >
+                                <Translation id="TR_EARN_CLAIM_REWARDS" />
+                            </Button>
+                        </Tooltip>
                     )}
                     <Tooltip content={unstakingMessageContent}>
                         <Button


### PR DESCRIPTION
## Description

The Cardano Claim rewards button ignored the message-system claim kill-switch. It now respects `isClaimingDisabled`, disabling the button and showing a tooltip, like Stake/Unstake already do.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30043

## Screenshots:
<img width="687" height="217" alt="Screenshot 2026-07-28 at 23 38 16" src="https://github.com/user-attachments/assets/0bf30a31-421f-43f9-9f44-0e6d089cdbb5" />
