### PR TITLE
fix(suite): reuse discovered empty tron account for trading fee estimation

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -76,8 +76,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     );
 
     useEffect(() => {
-        const currentDevice = deviceRef.current;
-        if (networkType !== 'tron' || !currentDevice || !account || !network) {
+        if (networkType !== 'tron' || !account || !network) {
             setFeeEstimationRecipient(undefined);
 
             return;
@@ -87,8 +86,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             account,
             network,
             accounts: accountsRef.current,
-            device: currentDevice,
-            chunkify,
+            device: deviceRef.current,
         }).then(recipient => {
             if (isMounted) setFeeEstimationRecipient(recipient);
         });
@@ -104,7 +102,6 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         networkType,
         device?.state,
         network,
-        chunkify,
     ]);
 
     const composeContext = useMemo(() => {

--- a/suite-common/wallet-core/src/send/tron/__tests__/deriveColdRecipient.test.ts
+++ b/suite-common/wallet-core/src/send/tron/__tests__/deriveColdRecipient.test.ts
@@ -1,0 +1,194 @@
+import { getNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+
+import { deriveTronColdRecipient } from '../deriveColdRecipient';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: { tronGetAddress: jest.fn() },
+}));
+
+const DEVICE_STATE = 'device-a' as Account['deviceState'];
+const DERIVED_ADDRESS = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
+const network = getNetwork('trx');
+const device = { state: DEVICE_STATE } as unknown as Parameters<
+    typeof deriveTronColdRecipient
+>[0]['device'];
+
+const buildAccount = (overrides?: Partial<Account>): Account =>
+    ({
+        symbol: 'trx',
+        networkType: 'tron',
+        accountType: 'normal',
+        deviceState: DEVICE_STATE,
+        index: 0,
+        empty: false,
+        descriptor: 'TWarmAccountDescriptorAddressPlaceholder',
+        ...overrides,
+    }) as unknown as Account;
+
+const mockGetAddressSuccess = () => {
+    (TrezorConnect.tronGetAddress as jest.Mock).mockResolvedValue({
+        success: true,
+        payload: { address: DERIVED_ADDRESS },
+    });
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('deriveTronColdRecipient', () => {
+    it('reuses a discovered empty account without a device round-trip', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+        const emptyAccount = buildAccount({
+            index: 1,
+            empty: true,
+            descriptor: 'TEmptyColdAddress1111111111111111111',
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, emptyAccount],
+            device: undefined,
+        });
+
+        expect(result).toBe(emptyAccount.descriptor);
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('picks the highest-index empty account when several are empty', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+        const emptyLow = buildAccount({
+            index: 1,
+            empty: true,
+            descriptor: 'TEmptyLowIndexAddress1111111111111111',
+        });
+        const emptyHigh = buildAccount({
+            index: 3,
+            empty: true,
+            descriptor: 'TEmptyHighIndexAddress111111111111111',
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, emptyLow, emptyHigh],
+            device: undefined,
+        });
+
+        expect(result).toBe(emptyHigh.descriptor);
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('ignores empty accounts from another wallet and derives at highest index + 1', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+        const warmAccount = buildAccount({ index: 1, empty: false });
+        const foreignEmpty = buildAccount({
+            index: 5,
+            empty: true,
+            deviceState: 'device-b' as Account['deviceState'],
+            descriptor: 'TForeignEmptyAddress11111111111111111',
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, warmAccount, foreignEmpty],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect(TrezorConnect.tronGetAddress).toHaveBeenCalledTimes(1);
+        expect((TrezorConnect.tronGetAddress as jest.Mock).mock.calls[0][0]).toMatchObject({
+            path: "m/44'/195'/0'/0/2",
+        });
+    });
+
+    it('ignores failed discovery accounts flagged empty and falls back to the device', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+        const failedAccount = buildAccount({
+            index: 1,
+            empty: true,
+            failed: true,
+            error: 'discovery failed',
+            descriptor: 'failed:1:trx:normal' as Account['descriptor'],
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, failedAccount],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect((TrezorConnect.tronGetAddress as jest.Mock).mock.calls[0][0]).toMatchObject({
+            path: "m/44'/195'/0'/0/2",
+        });
+    });
+
+    it('falls back to the device when only warm accounts exist', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect(TrezorConnect.tronGetAddress).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined when no empty account exists and no device is available', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device: undefined,
+        });
+
+        expect(result).toBeUndefined();
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined for a non-tron account without touching the device', async () => {
+        const account = buildAccount({ networkType: 'ethereum', symbol: 'eth' });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBeUndefined();
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the device derivation fails', async () => {
+        (TrezorConnect.tronGetAddress as jest.Mock).mockResolvedValue({
+            success: false,
+            payload: { error: 'device error' },
+        });
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
@@ -9,7 +9,6 @@ type DeriveTronColdRecipientParams = {
     network: Network;
     accounts?: Account[];
     device?: TrezorDevice;
-    chunkify?: boolean;
 };
 
 export const deriveTronColdRecipient = async ({
@@ -17,23 +16,43 @@ export const deriveTronColdRecipient = async ({
     network,
     accounts,
     device,
-    chunkify,
 }: DeriveTronColdRecipientParams): Promise<string | undefined> => {
-    if (account.networkType !== 'tron' || !device) return undefined;
+    if (account.networkType !== 'tron') {
+        return undefined;
+    }
+
+    const walletAccounts = (accounts ?? []).filter(
+        a =>
+            a.deviceState === account.deviceState &&
+            a.symbol === account.symbol &&
+            a.accountType === account.accountType,
+    );
+
+    // failed discovery accounts are also flagged empty but carry a synthetic (non-address) descriptor
+    const coldAccount = walletAccounts
+        .filter(a => a.empty && !a.failed)
+        .reduce<Account | undefined>(
+            (best, a) => (!best || a.index > best.index ? a : best),
+            undefined,
+        );
+
+    if (coldAccount) {
+        return coldAccount.descriptor;
+    }
+
+    if (!device) {
+        return undefined;
+    }
 
     const bip43Path = network.accountTypes[account.accountType]?.bip43Path ?? network.bip43Path;
     // highest existing index + 1 (not count) so a gap can't hit an existing warm account
-    const nextIndex =
-        (accounts ?? [])
-            .filter(a => a.symbol === account.symbol && a.accountType === account.accountType)
-            .reduce((max, a) => Math.max(max, a.index), -1) + 1;
+    const nextIndex = walletAccounts.reduce((max, a) => Math.max(max, a.index), -1) + 1;
     const path = substituteBip43Path(bip43Path, nextIndex);
 
     const result = await TrezorConnect.tronGetAddress({
         device,
         path,
         showOnTrezor: false,
-        chunkify,
     });
 
     return result.success ? result.payload.address : undefined;

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
@@ -139,7 +139,9 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
         }
 
         const isNewAccount =
-            calldata.data === null && (await isNewTronAccount(firstComposeOutput.address, account));
+            calldata.data === null &&
+            to !== account.descriptor &&
+            (await isNewTronAccount(to, account));
 
         const feeLevel =
             calldata.data !== null


### PR DESCRIPTION
## Description

Tron trading fee estimation needs a **cold** (never-activated) recipient for the worst-case estimate (TRC20 ~2x energy; native TRX ~1 TRX activation). It was always derived via a `tronGetAddress` device round-trip — impossible for a disconnected wallet, which silently fell back to the warm address and underestimated.

`deriveTronColdRecipient` now reuses the highest-index discovered `empty` account (scoped by `deviceState`/`symbol`/`accountType`) with no device; `tronGetAddress` stays as fallback. Also fixes the compose thunk's `isNewAccount` to read the resolved recipient `to` (not the empty form output) so native-TRX estimates include the activation fee.

## Notes for QA

- Tron sell/exchange: fee estimate reflects a cold recipient even with device disconnected (remembered wallet).
- Plain send form unchanged: no address → no activation fee, no extra backend call.

Resolve #30143 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set updates the trading swap transaction composition hook and Tron send-form logic. The biggest regression risk is in swap flows that rely on `wallet.trading.composedTransactionInfo` and fee calculation, so run the two direct swap-fees tests plus a representative set of full swap flows. The Tron changes have no targeted e2e coverage in this candidate set and depend on the included unit test and code review.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`
- `suite-common/wallet-core/src/send/tron/__tests__/deriveColdRecipient.test.ts`
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test directly asserts that `wallet.trading.composedTransactionInfo` is populated and that the total amount/fee rate are correct on the device prompt after selecting a swap offer. That state is the core output of `useTradingComposeTransaction`, so a regression here would be immediately visible.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Analogous to the BTC swap-fees test but for Ethereum custom gas parameters. It verifies composed transaction info, gas limit, max fee per gas, and max priority fee per gas on both the UI and the device, all of which flow through the compose-transaction hook.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — A full SOL→USDC swap flow that selects a receive account, confirms the best offer, and verifies device prompt amounts. It exercises the compose-transaction path end-to-end for a coin-to-token scenario.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Cross-chain native-coin swap (SOL→BTC) with status polling and provider support link checks. It depends on correct transaction composition before broadcasting, making it a good representative full-swap regression test.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — DEX swap via LI.FI involves slippage, minimum received, and a 1.25× gas limit buffer on Ethereum. These DEX-specific compose/fee details are sensitive to changes in transaction composition logic.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — SPL token (USDT) to BTC cross-chain swap. Token sends have different compose/fee behavior than native coins, so this complements the other swap flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/send/tron/__tests__/deriveColdRecipient.test.ts`

_Updated: 2026-07-28T23:47:11.819Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/buffalo/web/](https://dev.suite.sldev.cz/suite-web/buffalo/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=buffalo&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=buffalo&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=buffalo&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T23:49:17.669Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-28T23:49:13.150Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->