### PR TITLE
fix(suite): reuse discovered empty tron account for trading fee estimation

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -76,8 +76,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     );
 
     useEffect(() => {
-        const currentDevice = deviceRef.current;
-        if (networkType !== 'tron' || !currentDevice || !account || !network) {
+        if (networkType !== 'tron' || !account || !network) {
             setFeeEstimationRecipient(undefined);
 
             return;
@@ -87,8 +86,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             account,
             network,
             accounts: accountsRef.current,
-            device: currentDevice,
-            chunkify,
+            device: deviceRef.current,
         }).then(recipient => {
             if (isMounted) setFeeEstimationRecipient(recipient);
         });
@@ -104,7 +102,6 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
         networkType,
         device?.state,
         network,
-        chunkify,
     ]);
 
     const composeContext = useMemo(() => {

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts
@@ -1,0 +1,210 @@
+import { getNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+
+import { deriveTronColdRecipient } from './deriveColdRecipient';
+
+jest.mock('@trezor/connect', () => ({
+    __esModule: true,
+    default: { tronGetAddress: jest.fn() },
+}));
+
+const DEVICE_STATE = 'device-a' as Account['deviceState'];
+const DERIVED_ADDRESS = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
+const network = getNetwork('trx');
+const device = { state: DEVICE_STATE } as unknown as Parameters<
+    typeof deriveTronColdRecipient
+>[0]['device'];
+
+const buildAccount = (overrides?: Partial<Account>): Account =>
+    ({
+        symbol: 'trx',
+        networkType: 'tron',
+        accountType: 'normal',
+        deviceState: DEVICE_STATE,
+        index: 0,
+        empty: false,
+        descriptor: 'TWarmAccountDescriptorAddressPlaceholder',
+        ...overrides,
+    }) as unknown as Account;
+
+const mockGetAddressSuccess = () => {
+    (TrezorConnect.tronGetAddress as jest.Mock).mockResolvedValue({
+        success: true,
+        payload: { address: DERIVED_ADDRESS },
+    });
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('deriveTronColdRecipient', () => {
+    it('reuses a discovered empty account without a device round-trip', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+        const emptyAccount = buildAccount({
+            index: 1,
+            empty: true,
+            descriptor: 'TEmptyColdAddress1111111111111111111' as Account['descriptor'],
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, emptyAccount],
+            device: undefined,
+        });
+
+        expect(result).toBe(emptyAccount.descriptor);
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('picks the highest-index empty account when several are empty', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+        const emptyLow = buildAccount({
+            index: 1,
+            empty: true,
+            descriptor: 'TEmptyLowIndexAddress1111111111111111' as Account['descriptor'],
+        });
+        const emptyHigh = buildAccount({
+            index: 3,
+            empty: true,
+            descriptor: 'TEmptyHighIndexAddress111111111111111' as Account['descriptor'],
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, emptyLow, emptyHigh],
+            device: undefined,
+        });
+
+        expect(result).toBe(emptyHigh.descriptor);
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('ignores empty accounts from another wallet and derives at highest index + 1', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+        const warmAccount = buildAccount({ index: 1, empty: false });
+        const foreignEmpty = buildAccount({
+            index: 5,
+            empty: true,
+            deviceState: 'device-b' as Account['deviceState'],
+            descriptor: 'TForeignEmptyAddress11111111111111111' as Account['descriptor'],
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, warmAccount, foreignEmpty],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect(TrezorConnect.tronGetAddress).toHaveBeenCalledTimes(1);
+        expect((TrezorConnect.tronGetAddress as jest.Mock).mock.calls[0][0]).toMatchObject({
+            path: "m/44'/195'/0'/0/2",
+        });
+    });
+
+    it('ignores failed discovery accounts flagged empty and falls back to the device', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+        const failedAccount = buildAccount({
+            index: 1,
+            empty: true,
+            failed: true,
+            error: 'discovery failed',
+            descriptor: 'failed:1:trx:normal' as Account['descriptor'],
+        });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account, failedAccount],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect((TrezorConnect.tronGetAddress as jest.Mock).mock.calls[0][0]).toMatchObject({
+            path: "m/44'/195'/0'/0/2",
+        });
+    });
+
+    it('falls back to the device when only warm accounts exist', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect(TrezorConnect.tronGetAddress).toHaveBeenCalledTimes(1);
+    });
+
+    it('derives above the source account index when the accounts list is omitted', async () => {
+        mockGetAddressSuccess();
+        const account = buildAccount({ index: 2, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            device,
+        });
+
+        expect(result).toBe(DERIVED_ADDRESS);
+        expect((TrezorConnect.tronGetAddress as jest.Mock).mock.calls[0][0]).toMatchObject({
+            path: "m/44'/195'/0'/0/3",
+        });
+    });
+
+    it('returns undefined when no empty account exists and no device is available', async () => {
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device: undefined,
+        });
+
+        expect(result).toBeUndefined();
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined for a non-tron account without touching the device', async () => {
+        const account = buildAccount({ networkType: 'ethereum', symbol: 'eth' });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBeUndefined();
+        expect(TrezorConnect.tronGetAddress).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the device derivation fails', async () => {
+        (TrezorConnect.tronGetAddress as jest.Mock).mockResolvedValue({
+            success: false,
+            payload: { error: 'device error' },
+        });
+        const account = buildAccount({ index: 0, empty: false });
+
+        const result = await deriveTronColdRecipient({
+            account,
+            network,
+            accounts: [account],
+            device,
+        });
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
@@ -9,7 +9,6 @@ type DeriveTronColdRecipientParams = {
     network: Network;
     accounts?: Account[];
     device?: TrezorDevice;
-    chunkify?: boolean;
 };
 
 export const deriveTronColdRecipient = async ({
@@ -17,23 +16,43 @@ export const deriveTronColdRecipient = async ({
     network,
     accounts,
     device,
-    chunkify,
 }: DeriveTronColdRecipientParams): Promise<string | undefined> => {
-    if (account.networkType !== 'tron' || !device) return undefined;
+    if (account.networkType !== 'tron') {
+        return undefined;
+    }
+
+    const walletAccounts = (accounts ?? []).filter(
+        a =>
+            a.deviceState === account.deviceState &&
+            a.symbol === account.symbol &&
+            a.accountType === account.accountType,
+    );
+
+    // failed discovery accounts are also flagged empty but carry a synthetic (non-address) descriptor
+    const coldAccount = walletAccounts
+        .filter(a => a.empty && !a.failed)
+        .reduce<
+            Account | undefined
+        >((best, a) => (!best || a.index > best.index ? a : best), undefined);
+
+    if (coldAccount) {
+        return coldAccount.descriptor;
+    }
+
+    if (!device) {
+        return undefined;
+    }
 
     const bip43Path = network.accountTypes[account.accountType]?.bip43Path ?? network.bip43Path;
-    // highest existing index + 1 (not count) so a gap can't hit an existing warm account
-    const nextIndex =
-        (accounts ?? [])
-            .filter(a => a.symbol === account.symbol && a.accountType === account.accountType)
-            .reduce((max, a) => Math.max(max, a.index), -1) + 1;
+    // highest existing index + 1 (not count) so a gap can't hit an existing warm account;
+    // seed with account.index so an empty/omitted accounts list can't derive index 0 over the source account
+    const nextIndex = walletAccounts.reduce((max, a) => Math.max(max, a.index), account.index) + 1;
     const path = substituteBip43Path(bip43Path, nextIndex);
 
     const result = await TrezorConnect.tronGetAddress({
         device,
         path,
         showOnTrezor: false,
-        chunkify,
     });
 
     return result.success ? result.payload.address : undefined;

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts
@@ -29,11 +29,10 @@ export const deriveTronColdRecipient = async ({
     );
 
     // failed discovery accounts are also flagged empty but carry a synthetic (non-address) descriptor
-    const coldAccount = walletAccounts
-        .filter(a => a.empty && !a.failed)
-        .reduce<
-            Account | undefined
-        >((best, a) => (!best || a.index > best.index ? a : best), undefined);
+    const coldAccount = walletAccounts.reduce<Account | undefined>(
+        (best, a) => (a.empty && !a.failed && (!best || a.index > best.index) ? a : best),
+        undefined,
+    );
 
     if (coldAccount) {
         return coldAccount.descriptor;

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts
@@ -1,0 +1,79 @@
+import { configureMockStore } from '@suite-common/test-utils';
+import { getNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
+
+import { composeTronTransactionFeeLevelsThunk } from './sendFormTronThunks';
+
+const OWNER = 'TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9';
+const COLD_RECIPIENT = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
+
+const network = getNetwork('trx');
+
+const account = {
+    symbol: 'trx',
+    networkType: 'tron',
+    accountType: 'normal',
+    index: 0,
+    deviceState: 'mock-device-state',
+    descriptor: OWNER,
+    key: 'trx-account-key',
+    path: "m/44'/195'/0'/0/0",
+    availableBalance: '1000000000',
+    tokens: [],
+    misc: {
+        tronResources: { availableStakedBandwidth: 0, availableFreeBandwidth: 5000 },
+    },
+} as unknown as Account;
+
+const formState = { outputs: [{ address: '', amount: '1' }] } as any;
+
+const composeContext = (feeEstimationRecipient?: string) =>
+    ({ account, network, feeEstimationRecipient }) as any;
+
+const dispatchCompose = (feeEstimationRecipient?: string) =>
+    configureMockStore({})
+        .dispatch(
+            composeTronTransactionFeeLevelsThunk({
+                formState,
+                composeContext: composeContext(feeEstimationRecipient),
+            }),
+        )
+        .unwrap();
+
+describe('composeTronTransactionFeeLevelsThunk – cold recipient activation fee', () => {
+    let getAccountInfo: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.spyOn(TrezorConnect, 'tronComposeTransaction').mockResolvedValue({
+            success: true,
+            payload: { bandwidth: 300 },
+        } as any);
+        getAccountInfo = jest.spyOn(TrezorConnect, 'getAccountInfo').mockResolvedValue({
+            success: true,
+            payload: { descriptor: COLD_RECIPIENT, empty: true },
+        } as any);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('estimates against the fee-estimation recipient and includes the activation fee', async () => {
+        const { normal } = await dispatchCompose(COLD_RECIPIENT);
+
+        expect(getAccountInfo).toHaveBeenCalledWith(
+            expect.objectContaining({ descriptor: COLD_RECIPIENT }),
+        );
+        expect(normal).toBeDefined();
+        expect(normal?.type).not.toBe('error');
+        expect((normal as any)?.accountActivationFee).toBeDefined();
+    });
+
+    it('does not add an activation fee when no recipient is available (falls back to own account)', async () => {
+        const { normal } = await dispatchCompose(undefined);
+
+        expect(getAccountInfo).not.toHaveBeenCalled();
+        expect(normal).toBeDefined();
+        expect(normal?.type).not.toBe('error');
+        expect((normal as any)?.accountActivationFee).toBeUndefined();
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
@@ -139,7 +139,9 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
         }
 
         const isNewAccount =
-            calldata.data === null && (await isNewTronAccount(firstComposeOutput.address, account));
+            calldata.data === null &&
+            to !== account.descriptor &&
+            (await isNewTronAccount(to, account));
 
         const feeLevel =
             calldata.data !== null


### PR DESCRIPTION
## Description

Tron trading fee estimation needs a **cold** (never-activated) recipient for the worst-case estimate (TRC20 ~2x energy; native TRX ~1 TRX activation). It was always derived via a `tronGetAddress` device round-trip — impossible for a disconnected wallet, which silently fell back to the warm address and underestimated.

`deriveTronColdRecipient` now reuses the highest-index discovered `empty` account (scoped by `deviceState`/`symbol`/`accountType`) with no device; `tronGetAddress` stays as fallback. Also fixes the compose thunk's `isNewAccount` to read the resolved recipient `to` (not the empty form output) so native-TRX estimates include the activation fee.

## Notes for QA

- Tron sell/exchange: fee estimate reflects a cold recipient even with device disconnected (remembered wallet).
- Plain send form unchanged: no address → no activation fee, no extra backend call.

Resolve #30143 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The main risk is in the trading transaction-composition hook (useTradingComposeTransaction), which affects swap and sell flows across coins, tokens, and DEX providers. I recommend a focused set of swap/sell tests that assert composedTransactionInfo, fees, and device-prompt details. The Tron send-form changes (deriveColdRecipient.ts, sendFormTronThunks.ts) are not covered by any candidate E2E test that actually exercises Tron sending, so they rely on their own unit tests and are not represented in the E2E selection.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts`
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — This test completes a SOL sell flow where the composed transaction (send amount, fee, provider address) is presented on the device prompt and in the confirmation screen. It asserts on the composed fee and send details that useTradingComposeTransaction produces for a sell trade.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — A cross-chain SOL-to-USDC swap that explicitly relies on composed transaction info for the source account, fee, and send amount shown in device prompts and confirmation screens. Regression in useTradingComposeTransaction would break these assertions.
- `suite/e2e/tests/trading/swap-coins.test.ts` — A native SOL-to-BTC swap that checks the best-offer selection, device-prompt totals/fees, and post-trade detail values. It is a representative swap flow that directly exercises the compose-transaction hook.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — A DEX ETH-to-USDC swap that asserts on composed gas limit, maximum fee, slippage, minimum received, and multi-step device prompts. It covers the DEX path of useTradingComposeTransaction.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — A cross-chain SPL token (USDT on Solana) to BTC swap that includes token approval and checks composed send amount, fee, and token symbol on the device prompt. It exercises token-specific composition logic.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test sets custom BTC fees in a swap and verifies the composed transaction info, fee rate, and total amount on the device prompt. It is a focused fee-composition scenario for Bitcoin.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test sets custom Ethereum gas parameters in a swap and asserts the composed max fee, gas limit, and priority fee values on both the UI and device emulator. It covers EVM fee composition.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — A live-environment SOL-to-USDC swap that verifies the full offer-to-broadcast flow against real providers. It serves as an end-to-end sanity check that composed transactions still work with live quotes.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts`

_Updated: 2026-07-31T18:35:27.659Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-cold-recipient-reuse/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-cold-recipient-reuse/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-cold-recipient-reuse&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-cold-recipient-reuse&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-cold-recipient-reuse&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T21:45:16.366Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T21:45:08.689Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->