### PR TITLE
fix(suite-native-29509): retry swap transaction signing after device rejection

### DIFF
--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.test.ts
@@ -13,10 +13,7 @@ import {
 } from '@suite-native/test-utils-store';
 import { getWalletState } from '@suite-native/trading-fixtures';
 import { tradingSlice } from '@suite-native/trading-state';
-import {
-    prepareSendFormReducer,
-    transactionManagementActions,
-} from '@suite-native/transaction-management';
+import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { useTradingOutputsReviewScreenControls } from './useTradingOutputsReviewScreenControls';
 import { type TradingExchangeSignAndSendTransactionProps } from '../exchange/useExchangeFlow';
@@ -200,8 +197,7 @@ describe('useTradingOutputsReviewScreenControls', () => {
             );
         });
 
-        it('should offer pop and popToTop action on thunk error', () => {
-            const dispatchSpy = jest.spyOn(store, 'dispatch');
+        it('should retry signing without leaving the outputs review', () => {
             renderUseTradingOutputsReviewScreenControls();
 
             expect(mockSignAndSendTransaction).toHaveBeenCalledWith(
@@ -229,10 +225,26 @@ describe('useTradingOutputsReviewScreenControls', () => {
                 mockShowAlert.mock.calls[0][0].onPressPrimaryButton();
             });
 
-            expect(mockPop).toHaveBeenCalledTimes(1);
-            expect(dispatchSpy).toHaveBeenCalledWith(sendFormActions.dispose());
-            expect(dispatchSpy).toHaveBeenCalledWith(transactionManagementActions.clearFeeLevels());
+            expect(mockSignAndSendTransaction).toHaveBeenCalledTimes(2);
             expect(mockReportToAnalytics).toHaveBeenCalledWith('sign-and-send', 'retry');
+        });
+
+        it('should leave the flow when error alert is canceled', () => {
+            renderUseTradingOutputsReviewScreenControls();
+
+            act(() => {
+                const { onError } = (
+                    mockSignAndSendTransaction.mock.lastCall as unknown as [
+                        TradingExchangeSignAndSendTransactionProps,
+                    ]
+                )[0];
+                onError({
+                    type: 'sign-tx-error',
+                    error: {
+                        id: 'TR_ERROR',
+                    },
+                });
+            });
 
             act(() => {
                 mockShowAlert.mock.calls[0][0].onPressSecondaryButton();

--- a/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
+++ b/suite-native/module-trading/src/hooks/reviewOutputs/useTradingOutputsReviewScreenControls.ts
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { sendFormActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { useConfirmOnTrezorController } from '@suite-native/confirm-on-trezor';
 import type {
@@ -14,7 +13,6 @@ import { tradingActions } from '@suite-native/trading-state';
 import { type TradingOutputsReviewScreenNavigationProp } from '@suite-native/trading-types';
 import {
     selectIsTransactionAlreadySigned,
-    transactionManagementActions,
     useOutputsReviewBackInterceptor,
 } from '@suite-native/transaction-management';
 
@@ -68,14 +66,15 @@ export const useTradingOutputsReviewScreenControls = ({
     }, [dispatch, navigation, orderId, reportToAnalytics]);
 
     const onError: TradingExchangeSignAndSendTransactionProps['onError'] = useCallback(
-        _error => {
+        function handleSigningError(_error) {
             if (allowAlertRef.current) {
                 showOutputsReviewErrorAlert(
                     () => {
-                        dispatch(sendFormActions.dispose());
-                        dispatch(transactionManagementActions.clearFeeLevels());
-                        navigation.pop();
                         reportToAnalytics('sign-and-send', 'retry');
+                        signAndSendTransaction({
+                            nextStep,
+                            onError: handleSigningError,
+                        });
                     },
                     () => {
                         navigation.popToTop();
@@ -84,7 +83,13 @@ export const useTradingOutputsReviewScreenControls = ({
                 );
             }
         },
-        [dispatch, navigation, showOutputsReviewErrorAlert, reportToAnalytics],
+        [
+            signAndSendTransaction,
+            nextStep,
+            navigation,
+            reportToAnalytics,
+            showOutputsReviewErrorAlert,
+        ],
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Description

- Retry transaction signing directly from the outputs review screen after a device rejection.
- Update unit tests for retry and cancellation behavior.

## Notes for QA

- Verify retrying after a rejected signing attempt keeps the user on the outputs review screen and starts signing again.
- Verify canceling the error alert exits the flow.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/29509

## Screenshots:

https://github.com/user-attachments/assets/ccac2476-2a70-480f-bbf2-8a8d64985619



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29509-swap-tx-signing-modal-shows-blank-screen-after-try-again-when-device-rejected-the-previous-attempt&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->