### PR TITLE
fix(components): reset border property in Box component to prevent unintended styles

### DIFF
--- a/packages/components/src/components/Box/Box.tsx
+++ b/packages/components/src/components/Box/Box.tsx
@@ -52,6 +52,7 @@ const Container = styled.div<
     background: unset;
     box-shadow: unset;
     outline: ${({ $borderColor, theme }) => theme[$borderColor ?? 'borderNeutral']} solid 0;
+    border: 0;
     transition: 0.2s ease-in-out;
 
     ${({ $borderWidth }) =>


### PR DESCRIPTION
## Notes for QA
Fixed unintended borders on some interactive elements.

## Screenshots:
<img width="1584" height="1298" alt="image" src="https://github.com/user-attachments/assets/31c2b8d7-8524-462a-b0c8-a4b8fbc93506" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a shared Box layout primitive that maps to 133 tests, indicating it is a broad global component. Because the actual diff is not available, the safest minimal strategy is to run a representative cross-section of high-impact UI flows that exercise Box-based containers in different contexts: dashboard, onboarding, settings, trading, and wallet send. These tests will catch regressions that affect layout, visibility, or clickability of core UI elements. No source files are completely uncovered.

<details><summary><b>Changed files (1)</b></summary>

- `packages/components/src/components/Box/Box.tsx`

</details>

**Recommended tests (6)**

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test exercises the dashboard Assets section in both grid and table views, including asset cards and the activate-assets modal. Box is a foundational layout primitive used for these card and modal containers, so a regression in Box could hide asset contents or break the Buy button layout.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The test asserts that portfolio, asset, and wallet-switcher balances are hidden and revealed on hover. These values are rendered inside dashboard card and row containers that rely on Box, so a Box layout change could disrupt value masking or visibility.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Onboarding screens, including analytics consent, firmware checks, wallet creation, backup, and PIN setup, are composed of stacked layout containers. A Box regression could push elements out of view or break click targets during this critical first-run flow.
- `suite/e2e/tests/settings/general.test.ts` — The test interacts with settings options for fiat, theme, language, and analytics toggle. These option groups are laid out in Box containers, so a change to Box could obscure labels or make toggles/selects unclickable.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy flow renders quote cards, a preview panel, and transaction detail screens. Box is commonly used for these card and panel layouts; a regression could hide the best offer, preview button, or KYC warning.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test covers the ETH send form, custom fee panel, and the device confirmation modal. Box is used to group form sections and modal content, so a change could misalign or hide recipient, amount, or fee information.

</details>

_Updated: 2026-07-29T07:57:20.337Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/box-borders/web/](https://dev.suite.sldev.cz/suite-web/fix/box-borders/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/box-borders&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/box-borders&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:00:05.455Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T07:59:05.169Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->