### PR TITLE
chore(wallet-core): enable Robinhood EIP1559

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -283,7 +283,7 @@ export const networks = {
         decimals: 18,
         testnet: false,
         explorer: getExplorerUrls('https://robinscan.io', 'ethereum'),
-        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'coin-definitions', 'graph'],
+        features: ['rbf', 'sign-verify', 'tokens', 'nfts', 'coin-definitions', 'eip1559', 'graph'],
         backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
         accountTypes: {
             ledger: {

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -15,32 +15,6 @@ const { btc: bitcoin, eth: ethereum, test: testnet, regtest } = networks;
 
 const mockNetworks = [bitcoin, ethereum, testnet, regtest];
 
-describe('Robinhood Chain network', () => {
-    it('uses the expected mainnet identity and production configuration', () => {
-        expect(networks.rhc).toMatchObject({
-            symbol: 'rhc',
-            settlementLayer: 'eth',
-            chainId: 4663,
-            caipId: 'eip155:4663',
-            coingeckoId: 'robinhood',
-            tradeCryptoId: 'robinhood--0x0000000000000000000000000000000000000000',
-            displaySymbolName: 'Robinhood Ethereum',
-            nativeTokenReserve: '0.0002',
-            backendOptions: [{ type: 'blockbook', isExternalBackend: true }, { type: 'evm-rpc' }],
-        });
-        expect(networks.rhc.explorer.base).toBe('https://robinscan.io');
-        expect(networks.rhc.features).not.toContain('eip1559');
-        expect(networks.rhc).not.toHaveProperty('isDebugOnlyNetwork');
-        expect(getMainnets({ allNetworks: [networks.rhc] })).toEqual([networks.rhc]);
-    });
-});
-
-describe('HyperEVM network', () => {
-    it('supports NFTs and NFT definitions', () => {
-        expect(networks.hype.features).toEqual(expect.arrayContaining(['nfts', 'nft-definitions']));
-    });
-});
-
 describe(getMainnets.name, () => {
     it('returns non-testnet, non-debug-only networks when debug is false', () => {
         const result = getMainnets({


### PR DESCRIPTION
## Description

- enable eip1559 for Robinhood

Will start working when https://github.com/trezor/blockbook/issues/1678 done

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** suite-common/wallet-config/src/networksConfig.ts is a broad dependency referenced by many tests, so the recommendation focuses on a small, representative set. High-priority tests cover network enablement/backend configuration and account-type definitions, while medium-priority tests provide regression coverage for multi-coin discovery, addresses, public keys, and trading navigation. The unit test suite-common/wallet-config/src/utils.test.ts has no E2E coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`
- `suite-common/wallet-config/src/utils.test.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises enabling BTC/ETH networks and configuring custom Blockbook backends, which relies on network definitions, backend types, and discovery behavior from networksConfig.ts.
- `suite/e2e/tests/settings/coins.test.ts` — Activates mainnet/testnet assets and configures an ETH custom backend, making it sensitive to the network list, testnet flags, and backend configuration in networksConfig.ts.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adds different account types for BTC/LTC and non-BTC coins (ETH, Base, ADA), verifying expected symbols, paths, and analytics events tied to accountTypes and NetworkSymbol in networksConfig.ts.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Enables BTC, ETH, POL, BSC, and ARB via the Activate Assets modal; would regress if any of those network symbols or activation flags changed.
- `suite/e2e/tests/trading/navigation.test.ts` — Opens buy/sell/swap forms for BTC, LTC, ETH, and specific tokens, so it depends on correct network identifiers and trading support in the config.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates eight different coins and runs discovery, providing broad coverage of network configuration without being tied to a single specialized flow.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Displays XPUBs for BTC, LTC, and ADA, which are influenced by coin-type and network definitions in networksConfig.ts.
- `suite/e2e/tests/wallet/receive.test.ts` — Reveals and validates addresses for BTC, ETH, SOL, and TRX; address formats and supported networks are defined in networksConfig.ts.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-config/src/utils.test.ts`

_Updated: 2026-07-29T08:47:24.983Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/rhc-enable-eip1559/web/](https://dev.suite.sldev.cz/suite-web/chore/rhc-enable-eip1559/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/rhc-enable-eip1559&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/rhc-enable-eip1559&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/rhc-enable-eip1559&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:49:21.932Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:49:00.981Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->