### PR TITLE
fix(ci): exclude intentional T3W1 color-4 duplicate assets from media check

### DIFF
--- a/scripts/ci/find_duplicates.sh
+++ b/scripts/ci/find_duplicates.sh
@@ -2,8 +2,6 @@
 # this script finds duplicated files in project per provided extension
 #
 # Excluded from duplicate check (intentional duplicates):
-#   - suite-common/flags/assets/flags/*
-#     Same flags are used on purpose (e.g. overseas territories share flags with parent country).
 #   - packages/suite-data/files/videos/device/t3t1/connect_bt.webm
 #   - packages/suite-data/files/videos/device/t3t1/connect_bt_loop.webm
 #     BT connect videos are placeholders for older Trezor Suite before TS7 release.
@@ -18,7 +16,6 @@
 
 exclude_paths=(
     "**/node_modules/*"
-    "**/suite-common/flags/assets/flags/*"
     "*t3t1/connect_bt.webm"
     "*t3t1/connect_bt_loop.webm"
     "*t3w1/rotate_color_4.webm"

--- a/scripts/ci/find_duplicates.sh
+++ b/scripts/ci/find_duplicates.sh
@@ -7,6 +7,11 @@
 #   - packages/suite-data/files/videos/device/t3t1/connect_bt.webm
 #   - packages/suite-data/files/videos/device/t3t1/connect_bt_loop.webm
 #     BT connect videos are placeholders for older Trezor Suite before TS7 release.
+#   - packages/suite-data/files/**/t3w1/*_color_4*.webm and t3w1-backcolor-4.webp
+#     The T3W1 color 4 variant intentionally reuses color 1's artwork.
+#     The rotate video path is built dynamically as rotate_color_${color}.webm
+#     (DeviceAnimation.tsx), so a physical color_4 file must exist even though it
+#     is byte-identical to color_1. Remove these once real color-4 assets land.
 #
 # $1 should contain path such as ./packages/suite-data/files
 # $2 should contain file extension such as .png
@@ -16,6 +21,9 @@ exclude_paths=(
     "**/suite-common/flags/assets/flags/*"
     "*t3t1/connect_bt.webm"
     "*t3t1/connect_bt_loop.webm"
+    "*t3w1/rotate_color_4.webm"
+    "*t3w1/rotate_color_4_large.webm"
+    "*t3w1/t3w1-backcolor-4.webp"
 )
 
 find_exclude_args=()


### PR DESCRIPTION
## Description

Prerequisite for #30471. The nightly `[Test] misc` **media-duplicates** job has been failing every night since 2026-07-22, and #30471 surfaces that failure on its PR because it edits `test-misc.yml`.

### Root cause

`feat(suite): Add new color` (bbd12cffff, 2026-07-22) added the T3W1 (color `4`). Its assets are byte-identical copies of color `1`'s:

- `videos/device/t3w1/rotate_color_4.webm` == `rotate_color_1.webm`
- `videos/device/t3w1/rotate_color_4_large.webm` == `rotate_color_1_large.webm`
- `images/images/t3w1/t3w1-backcolor-4.webp` == `t3w1-backcolor-1.webp`

This is **intentional and structurally required**, not an accident:

- `models.ts` maps color `4` →  with `frontColors: { '4': '1' }` — it reuses color 1's front artwork by design (placeholder until real color-4 artwork lands).
- The rotate video src is built dynamically as `${basePath}/rotate_color_${color}${size}.webm` in `DeviceAnimation.tsx` using the raw `deviceUnitColor`, so a physical `rotate_color_4.webm` must exist even though its bytes equal color 1's — deleting it would 404 the rotate animation.
- `t3w1-backcolor-4.webp` is referenced by key `TREZOR_T3W1_BACKCOLOR_4` in `BluetoothDeviceComponent.tsx`.

### Fix

Add these three files to the existing intentional-duplicates allowlist in `scripts/ci/find_duplicates.sh`, next to the T3T1 BT-connect placeholders that are excluded for the same reason. A comment notes they should be removed once real color-4 artwork replaces the placeholders.

Verified locally: `find_duplicates.sh ./packages/suite-data/files .webm` and `.webp` now report `no duplicates`, while other extensions still scan normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-07-29T09:18:16.618Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/media-duplicates-t3w1-color4/web/](https://dev.suite.sldev.cz/suite-web/fix/media-duplicates-t3w1-color4/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/media-duplicates-t3w1-color4&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/media-duplicates-t3w1-color4&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T09:21:40.733Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T09:21:44.430Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->