### PR TITLE
fix(suite-desktop): forward requestedPermissions from the connect-ws handshake

### DIFF
--- a/packages/suite-desktop-api/src/messages.ts
+++ b/packages/suite-desktop-api/src/messages.ts
@@ -155,6 +155,9 @@ export type ConnectPopupCall = {
         email: string;
         npmVersion?: string;
     };
+    // Mirrors connect's `PermissionRequest`, inlined to keep this package free of a
+    // `@trezor/connect` dependency — same as `manifest` above.
+    requestedPermissions?: { permission: string; coin?: string }[];
 };
 
 export type ConnectPopupCancel = {

--- a/packages/suite-desktop-core/src/libs/connect-ws.ts
+++ b/packages/suite-desktop-core/src/libs/connect-ws.ts
@@ -7,6 +7,7 @@ import {
     type CoreCallMessage,
     type Manifest,
     POPUP,
+    type PermissionRequest,
     type PopupClosedMessage,
     type PopupHandshake,
 } from '@trezor/connect';
@@ -105,6 +106,7 @@ export const exposeConnectWs = ({
 
         let manifest: Manifest | undefined;
         let version: string | undefined;
+        let requestedPermissions: PermissionRequest[] | undefined;
 
         logger.info(LOG_PREFIX, `origin: ${origin}`);
 
@@ -144,6 +146,7 @@ export const exposeConnectWs = ({
                 });
                 manifest = parseManifest(message.payload.settings.manifest);
                 version = parseVersion(message.payload.settings.version);
+                requestedPermissions = message.payload.settings.requestedPermissions;
                 ws.send(JSON.stringify({ id: message.id, type: POPUP.HANDSHAKE, payload: 'ok' }));
             } else if (message.type === POPUP.CLOSED) {
                 mainWindowProxy.getInstance()?.webContents.send('connect-popup/cancel', {
@@ -242,6 +245,7 @@ export const exposeConnectWs = ({
                             email: manifest.email,
                             npmVersion: version,
                         },
+                        requestedPermissions,
                     });
 
                     // wait for response

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -18,6 +18,7 @@ import { selectSelectedDevice } from '@suite-common/device';
 import TrezorConnect, {
     type CallMethodKeys,
     type CallMethodPayload,
+    type PermissionRequest,
     UI_REQUEST,
 } from '@trezor/connect';
 import { isMacOs } from '@trezor/env-utils';
@@ -116,6 +117,10 @@ export const useConnectPopupDesktop = () => {
                                   },
                                   origin: params.origin,
                                   manifest: params.manifest,
+                                  // Cast across the IPC boundary, same as `params.method` above.
+                                  requestedPermissions: params.requestedPermissions as
+                                      | PermissionRequest[]
+                                      | undefined,
                               },
                     }),
                 );

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -36,10 +36,8 @@ export type ConnectProcessInfo = {
 };
 export type ConnectCallSource = {
     origin: string;
-    // Permissions the host/dapp declared up front (via ConnectSettings.requestedPermissions),
-    // forwarded through the popup handshake. Sanitized in connectPopupCallThunkInner so the first
-    // consent covers the whole set. Only populated for the web/webextension handshake today;
-    // desktop-ws/mcp carry it once suite-desktop-core forwards it.
+    // Permissions the host declared up front (via ConnectSettings.requestedPermissions), carried on
+    // the handshake. Sanitized in connectPopupCallThunkInner so the first consent covers the set.
     requestedPermissions?: PermissionRequest[];
 } & (
     | {


### PR DESCRIPTION
## Description

Part of splitting #30403 into standalone PRs (follow-up to #30261; addresses items of #30401). This is fix 1 of that PR, on its own.

`CoreInSuiteDesktop` puts the host-declared `requestedPermissions` into the `POPUP.HANDSHAKE` payload, but `connect-ws.ts` read only `manifest` and `version` off `payload.settings` and discarded the rest, so `source.requestedPermissions` was always `undefined` on the desktop path. Since `TrezorConnectDynamic` resolves an unset or `'auto'` `coreMode` to `core-in-suite-desktop`, that is the default host: the same dapp build got one merged consent on Suite Web and a prompt per call on Suite Desktop.

The value is now carried on the connection state next to `manifest`/`version`, forwarded on the `connect-popup/call` IPC message, and set on the `CALL_SOURCE_DESKTOP_WS` source. The MCP source is deliberately left alone: it does not arrive through a handshake carrying settings, so the field would always be `undefined` there.

`@trezor/suite-desktop-api` inlines the permission shape rather than importing `PermissionRequest`, so the IPC-contract package stays free of a `@trezor/connect` dependency — the same treatment `manifest` already gets.

## Testing

`type-check` green on `@trezor/suite-desktop-core`, `@trezor/suite-desktop-api` and `@suite-common/connect-popup`. e2e coverage for this exact transport lives in the stacked sibling PR (see below), which asserts the declared set reaches the consent on `coreMode: 'suite-desktop'`.

## Related

Split out of #30403. Follow-up to #30261, item of #30401.

## Sibling PRs (split of #30403)

- #30489 — fix(connect-popup): drop malformed requestedPermissions instead of throwing (sanitizer hardening)
- #30486 — fix(suite-desktop): forward requestedPermissions from the connect-ws handshake
- #30488 — fix(suite): read requestedPermissions from the handshake payload on webextension
- #30487 — test(suite-e2e): cover upfront permission declaration (stacked on #30486)

Suggested merge order: #30489 first (hardens the sanitizer that #30486/#30488 expose to more transports), then #30486 and #30488 in either order, then #30487 after #30486.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the desktop TrezorConnect integration: the WebSocket bridge (connect-ws.ts), the desktop popup hook (useConnectPopupDesktop.tsx), desktop API messages (messages.ts), and shared connect-popup types. Regression risk is concentrated in desktop Connect flows. The minimal high-confidence set is the suite of desktop coreMode TrezorConnect E2E tests covering permissions, address export, account selection, message/transaction signing, error handling, and silent mode.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite-desktop-api/src/messages.ts`
- `packages/suite-desktop-core/src/libs/connect-ws.ts`
- `packages/suite/src/support/suite/useConnectPopupDesktop.tsx`
- `suite-common/connect-popup/src/connectPopupTypes.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect in suite-desktop coreMode and validates error display for invalid ethereumGetAddress paths. Directly exercises the desktop Connect popup integration built by connect-ws.ts and useConnectPopupDesktop.tsx.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — End-to-end desktop sign-message flow using TrezorConnect.init with coreMode 'suite-desktop'. Exercises permissions modal, sign-message UI, and device confirmation via the desktop WebSocket bridge.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Validates Ethereum transaction signing through the desktop Connect integration, including permissions modal and multi-step on-device prompts. Directly covers connect-ws.ts and the desktop popup hook.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo in desktop coreMode, including permissions and account selection modal. Relies on the desktop Connect popup infrastructure changed in this PR.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Core happy-path for desktop address export via TrezorConnect.getAddress, covering permissions, address confirmation, verify badge, and bundle exports. Directly exercises the desktop Connect WebSocket flow.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Specifically tests Connect permissions persistence, remember/forget logic, and the Connect settings tab in desktop mode. Permissions state is part of the connect popup types and desktop integration layer.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Tests TrezorConnect.selectAccount in desktop coreMode with multi/single selection, verification, and cancellation. Directly uses the desktop popup and account picker infrastructure.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Validates Bitcoin transaction signing via desktop Connect, including permissions and sequential device prompts. Directly covers the desktop WebSocket signing flow.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode behavior, Remember checkbox interplay, and app/focus IPC events in desktop Connect. Directly exercises messages.ts (desktop API IPC) and connect-ws.ts focus/suppression logic.

</details>

_Updated: 2026-07-30T10:46:03.982Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-forward-perms-desktop/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-forward-perms-desktop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-forward-perms-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-forward-perms-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-forward-perms-desktop&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:48:29.180Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:48:18.129Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->