### PR TITLE
test(suite-e2e): cover upfront permission declaration

### DIFF
--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -163,6 +163,9 @@ const PermissionPreview = ({ permissions }: { permissions: MethodPermission[] })
     );
 };
 
+// The e2e testID convention allows no underscores; connectPermissionsModal.ts mirrors this.
+const permissionTestId = (permission: MethodPermission) => permission.replace(/_/g, '-');
+
 type PermissionGroupProps = {
     coin?: CoinSymbol;
     permissions: MethodPermission[];
@@ -180,7 +183,7 @@ const PermissionGroup = ({
     const [isOpen, setIsOpen] = useState(defaultIsOpen);
 
     return (
-        <Collapsible isOpen={isOpen}>
+        <Collapsible isOpen={isOpen} data-testid={`@connect-permissions/group/${coin ?? 'device'}`}>
             <Collapsible.Toggle onClick={() => setIsOpen(!isOpen)}>
                 <Row justifyContent="space-between" gap={12} padding={{ vertical: 8 }}>
                     <Row gap={16}>
@@ -198,7 +201,10 @@ const PermissionGroup = ({
             <Collapsible.Content>
                 <Column gap={8} margin={{ top: 4, bottom: 8 }}>
                     {permissions.map(permission => (
-                        <PermissionRow key={permission}>
+                        <PermissionRow
+                            key={permission}
+                            data-testid={`@connect-permissions/permission/${permissionTestId(permission)}`}
+                        >
                             <Row gap={12}>
                                 <PermissionIcon permission={permission} />
                                 <Text typographyStyle="body-sm">

--- a/suite/e2e/support/pageObjects/connectPermissionsModal.ts
+++ b/suite/e2e/support/pageObjects/connectPermissionsModal.ts
@@ -8,6 +8,10 @@ export class ConnectPermissionsModal {
     readonly silentModeCheckbox: Locator;
     readonly confirmButton: Locator;
     readonly cancelButton: Locator;
+    /** Lowercase `CoinSymbol` (`btc`), or `device` for the coin-less group. */
+    readonly permissionGroup: (coin: string) => Locator;
+    /** `permission` as used in code (`read_address`); the testID dash-cases it. */
+    readonly groupPermission: (coin: string, permission: string) => Locator;
 
     constructor(page: Page) {
         this.loadingHeader = page
@@ -21,5 +25,10 @@ export class ConnectPermissionsModal {
         );
         this.confirmButton = page.getByTestId('@connect-permissions-modal/confirm-button');
         this.cancelButton = page.getByTestId('@connect-permissions-modal/cancel-button');
+        this.permissionGroup = coin => page.getByTestId(`@connect-permissions/group/${coin}`);
+        this.groupPermission = (coin, permission) =>
+            this.permissionGroup(coin).getByTestId(
+                `@connect-permissions/permission/${permission.replace(/_/g, '-')}`,
+            );
     }
 }

--- a/suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts
+++ b/suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts
@@ -1,0 +1,82 @@
+import TrezorConnect from '@trezor/connect-web';
+
+import { expect, test } from '../../support/fixtures';
+import { createTestAnnotation } from '../../support/reporters/annotations';
+
+// Separate from permissions.test.ts because the declaration is part of `TrezorConnect.init`, and
+// every connect-ws spec in this folder initializes exactly once per file.
+const DECLARED_PERMISSIONS = [
+    { permission: 'read_address', coin: 'btc' },
+    { permission: 'read_address', coin: 'ltc' },
+] as const;
+
+test.describe(
+    'TrezorConnect upfront permissions',
+    { tag: ['@T3T1', '@T3W1', '@desktopOnly'] },
+    () => {
+        test.use({ electronConf: { exposeConnectWs: true } });
+
+        test.beforeEach(async ({ onboardingPage }) => {
+            await onboardingPage.completeOnboarding();
+
+            await test.step('Initialize TrezorConnect with declared permissions', async () => {
+                await TrezorConnect.init({
+                    manifest: {
+                        appUrl: 'http://localhost:8080',
+                        email: '',
+                        appName: 'Tester',
+                    },
+                    coreMode: 'suite-desktop',
+                    debug: true,
+                    requestedPermissions: [...DECLARED_PERMISSIONS],
+                });
+            });
+        });
+
+        test(
+            'Permissions - a declared set is approved in a single consent',
+            {
+                annotation: createTestAnnotation({
+                    testCase:
+                        'Suite Connect: permissions declared at init are shown in the first consent and cover later calls.',
+                }),
+            },
+            async ({ connectPermissionsModal, page }) => {
+                await test.step('the consent lists the declared coins, not just the one being called', async () => {
+                    TrezorConnect.getAddress({
+                        path: "m/44'/0'/0'/0/0",
+                        coin: 'btc',
+                    });
+
+                    await expect(
+                        connectPermissionsModal.groupPermission('btc', 'read_address'),
+                    ).toBeVisible();
+                    // The call only needs btc, so the ltc group can only come from the declaration.
+                    await expect(
+                        connectPermissionsModal.groupPermission('ltc', 'read_address'),
+                    ).toBeVisible();
+                });
+
+                await test.step('approving once remembers the whole declared set', async () => {
+                    await connectPermissionsModal.rememberCheckbox.click();
+                    await connectPermissionsModal.confirmButton.click();
+                    await page.getByTestId('@connect-address-confirmation/confirm-button').click();
+                    await page.getByTestId('@connect-address-confirmation/close-button').click();
+                });
+
+                await test.step('a declared coin the user never called is already granted', async () => {
+                    TrezorConnect.getAddress({
+                        path: "m/44'/2'/0'/0/0",
+                        coin: 'ltc',
+                    });
+
+                    // Reaching the address confirmation at all means no consent was requested.
+                    await expect(
+                        page.getByTestId('@connect-address-confirmation/confirm-button'),
+                    ).toBeVisible();
+                    await expect(connectPermissionsModal.confirmButton).toBeHidden();
+                });
+            },
+        );
+    },
+);


### PR DESCRIPTION
## Description

Part of splitting #30403 into standalone PRs. This is the e2e coverage (fix 4 of that PR), **stacked on top of the desktop-forwarding PR** because it exercises exactly the transport that fix repairs and is red on `develop` without it.

The existing `permissions.test.ts` covers the grant lifecycle (consent, remember, reuse, forget) but only ever asserts that the consent modal *appears* — never what it *lists*. That is why it stayed green while `requestedPermissions` was being dropped on two of three transports: a declared set that never arrives is indistinguishable from one that does, if you only check that a modal showed up.

`upfrontPermissions.test.ts` declares two coins at `init()`, calls a method needing only one of them, and asserts the consent lists both — the group for the coin that was never called can only come from the declaration. It then calls that second coin and requires the address confirmation to appear with no consent prompt, which is the behaviour the feature exists to provide.

Asserting modal contents needed locators the permission list did not have, so `PermissionGroup` gains a testID per coin group and per permission row. That component is shared with Settings → Connected apps, so both surfaces become assertable. Permission values carry underscores, which the testID convention does not allow, so they are dash-cased; the page object mirrors that conversion.

## Testing

`type-check` and `lint:js` green on `@trezor/suite-e2e`. The spec needs a desktop build plus trezor-user-env to execute, so it needs a CI run (or a reviewer with the harness) to confirm green.

## Related

Split out of #30403. Stacked on the desktop-forwarding PR (see below); must merge after it. Item of #30401.

## Sibling PRs (split of #30403)

- #30489 — fix(connect-popup): drop malformed requestedPermissions instead of throwing (sanitizer hardening)
- #30486 — fix(suite-desktop): forward requestedPermissions from the connect-ws handshake
- #30488 — fix(suite): read requestedPermissions from the handshake payload on webextension
- #30487 — test(suite-e2e): cover upfront permission declaration (stacked on #30486)

Suggested merge order: #30489 first (hardens the sanitizer that #30486/#30488 expose to more transports), then #30486 and #30488 in either order, then #30487 after #30486.
