### PR TITLE
fix(suite): read requestedPermissions from the handshake payload on webextension

### DIFF
--- a/packages/suite/src/support/suite/useConnectPopup.tsx
+++ b/packages/suite/src/support/suite/useConnectPopup.tsx
@@ -29,9 +29,13 @@ export type ConnectPopupMessage =
     | {
           type: typeof POPUP.HANDSHAKE;
           id: string;
-          payload: { manifest: ManifestPartial };
-          version: string;
-          requestedPermissions?: PermissionRequest[];
+          // Same shape as the wire message from connect-web's Popup, so both links can
+          // forward it verbatim instead of remapping.
+          payload: {
+              manifest: ManifestPartial;
+              version: string;
+              requestedPermissions?: PermissionRequest[];
+          };
       }
     | { type: typeof CORE_CALL; id: string; payload: { method: string; [key: string]: unknown } }
     | { type: typeof POPUP.CLOSED; payload?: { error?: string; callId?: string } | null }
@@ -92,9 +96,9 @@ export const useConnectPopup = (
             } else if (event.type === POPUP.HANDSHAKE) {
                 manifest.current = {
                     ...event.payload.manifest,
-                    npmVersion: event.version,
+                    npmVersion: event.payload.version,
                 };
-                requestedPermissions.current = event.requestedPermissions;
+                requestedPermissions.current = event.payload.requestedPermissions;
                 setPendingHandshake(event.id);
             } else if (event.type === CORE_CALL) {
                 if (!manifest.current) {

--- a/packages/suite/src/support/suite/useConnectPopupWeb.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupWeb.tsx
@@ -137,17 +137,8 @@ export const useConnectPopupWeb = () => {
                 data.type === CORE_CALL_CANCEL ||
                 data.type === CORE_CALL
             ) {
-                const normalized: ConnectPopupMessage =
-                    data.type === POPUP.HANDSHAKE
-                        ? {
-                              type: data.type,
-                              id: data.id,
-                              payload: { manifest: data.payload?.manifest },
-                              version: data.payload?.version,
-                              requestedPermissions: data.payload?.requestedPermissions,
-                          }
-                        : data;
-                setIncomingMessages(prev => [...prev, normalized]);
+                const message: ConnectPopupMessage = data;
+                setIncomingMessages(prev => [...prev, message]);
             }
         };
 


### PR DESCRIPTION
## Description

Part of splitting #30403 into standalone PRs (follow-up to #30261; addresses items of #30401). This is fix 2 of that PR, on its own.

The wire message emitted by the connect-web `Popup` nests `manifest`, `version` and `requestedPermissions` under `payload`, and `WebExtensionPopup extends Popup`, so both links receive that shape. `ConnectPopupMessage` however declared `version` and `requestedPermissions` as siblings of `payload`, and only the web link remapped the incoming message to match; the webextension link forwards the parsed message verbatim, so both fields read as `undefined` there.

`ConnectPopupMessage` now mirrors the wire shape so both links forward verbatim, and the web-only remap is gone. This also fixes a pre-existing bug that fell out of the same mismatch: `npmVersion` has been silently `undefined` in the connect-popup analytics event on webextension for as long as the remap has existed.

The top-level `id` (assigned by `AbstractMessageChannel.postMessage`) survives the reshape on both transports, so the `POPUP.HANDSHAKE` reply is unaffected. No other consumer reads the old flat shape and no producer builds it.

## Testing

`type-check` green on `@trezor/suite`. The webextension half has no e2e (the connect-ws harness the specs use is desktop-only), so worth a manual check on a webextension build that `init({ requestedPermissions })` surfaces the declared set in the first consent and that `npmVersion` is populated.

## Related

Split out of #30403. Follow-up to #30261, item of #30401.

## Sibling PRs (split of #30403)

- #30489 — fix(connect-popup): drop malformed requestedPermissions instead of throwing (sanitizer hardening)
- #30486 — fix(suite-desktop): forward requestedPermissions from the connect-ws handshake
- #30488 — fix(suite): read requestedPermissions from the handshake payload on webextension
- #30487 — test(suite-e2e): cover upfront permission declaration (stacked on #30486)

Suggested merge order: #30489 first (hardens the sanitizer that #30486/#30488 expose to more transports), then #30486 and #30488 in either order, then #30487 after #30486.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are broad, globally-imported hooks for Trezor Connect popup handling, so the static coverage list of 133 tests is largely transitive. The highest-confidence tests are those that directly cover the /connect-popup route and the WebUSB/Bridge connect-device flow. A small number of medium-priority tests covering Bridge session management and disconnected-device connection modals provide additional safety without inflating the run.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/support/suite/useConnectPopup.tsx`
- `packages/suite/src/support/suite/useConnectPopupWeb.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test explicitly navigates to and validates the /connect-popup route. Since the changed files are useConnectPopup and useConnectPopupWeb, which directly render or manage the Connect popup route, this is the most targeted regression check available.
- `suite/e2e/tests/suite/bridge.test.ts` — The test exercises the Bridge page, WebUSB transport selection, and the connect-device prompt flow. These are core web-specific responsibilities of useConnectPopupWeb, so changes to that hook could break this flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session takeover and reclamation across tabs, which relies on the same Connect/Bridge integration layer managed by the changed hooks. A regression in popup session handling could affect device status transitions.
- `suite/e2e/tests/wallet/without-device.test.ts` — Covers the connection modal and disconnected-device state in send/settings flows. The changed hooks are involved in device availability checks for Connect calls, so a regression could alter when the connection modal appears.

</details>

_Updated: 2026-07-29T08:41:04.415Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-perms-webext-shape/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-perms-webext-shape/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-perms-webext-shape&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-perms-webext-shape&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:42:57.041Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T08:42:35.421Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->