### PR TITLE
fix(connect-popup): drop malformed requestedPermissions instead of throwing

### DIFF
--- a/suite-common/connect-popup/src/permissions.test.ts
+++ b/suite-common/connect-popup/src/permissions.test.ts
@@ -34,12 +34,10 @@ describe('sanitizeRequestedPermissions', () => {
     });
 
     it('drops entries whose coin is not a known coin symbol', () => {
-        // Host-supplied input can carry arbitrary strings, so it violates the compile-time
-        // `CoinSymbol` type — cast to model the untrusted wire shape.
         const requested = [
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_address', coin: 'not-a-coin' },
-        ] as unknown as PermissionRequest[];
+        ];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
         ]);
@@ -49,7 +47,7 @@ describe('sanitizeRequestedPermissions', () => {
         const requested = [
             { permission: 'read_address', coin: 'BTC' },
             { permission: 'read_address', coin: 'tADA' },
-        ] as unknown as PermissionRequest[];
+        ];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
             { permission: 'read_address', coin: 'tada' },
@@ -57,13 +55,72 @@ describe('sanitizeRequestedPermissions', () => {
     });
 
     it('drops unknown/garbage permission values', () => {
-        const requested = [
-            { permission: 'read_address', coin: 'btc' },
-            { permission: 'nonsense' },
-        ] as unknown as PermissionRequest[];
+        const requested = [{ permission: 'read_address', coin: 'btc' }, { permission: 'nonsense' }];
         expect(sanitizeRequestedPermissions(requested, false)).toEqual([
             { permission: 'read_address', coin: 'btc' },
         ]);
+    });
+
+    // Nothing schema-validates this on the way in, and a throw here would fail every later call
+    // from that app — so every malformed shape has to be dropped instead.
+    describe('malformed host input', () => {
+        it.each([
+            ['a non-array', 'read_address'],
+            ['an object instead of an array', { permission: 'read_address' }],
+            ['null', null],
+            ['a number', 42],
+        ])('returns an empty array for %s', (_name, requested) => {
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([]);
+        });
+
+        it.each([
+            ['null entries', [null]],
+            ['undefined entries', [undefined]],
+            ['primitive entries', ['read_address', 42]],
+            ['entries with no permission', [{ coin: 'btc' }]],
+            ['entries whose permission is not a string', [{ permission: 42, coin: 'btc' }]],
+            ['entries whose coin is not a string', [{ permission: 'read_address', coin: 5 }]],
+            ['entries whose coin is null', [{ permission: 'read_address', coin: null }]],
+        ])('drops %s', (_name, requested) => {
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([]);
+        });
+
+        it('keeps valid entries alongside malformed ones', () => {
+            const requested = [
+                null,
+                { permission: 'read_address', coin: 'btc' },
+                { permission: 'read_xpub', coin: 5 },
+                'garbage',
+                { permission: 'read_features' },
+            ];
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([
+                { permission: 'read_address', coin: 'btc' },
+                { permission: 'read_features' },
+            ]);
+        });
+
+        it('does not widen a malformed coin into a device-wide coin-less grant', () => {
+            expect(
+                sanitizeRequestedPermissions([{ permission: 'sign', coin: null }], false),
+            ).toEqual([]);
+            expect(sanitizeRequestedPermissions([{ permission: 'sign' }], false)).toEqual([
+                { permission: 'sign' },
+            ]);
+        });
+
+        it('copies only whitelisted fields, dropping attacker-chosen keys', () => {
+            const requested = [
+                {
+                    permission: 'read_address',
+                    coin: 'btc',
+                    silentMode: true,
+                    origin: 'evil.example',
+                },
+            ];
+            expect(sanitizeRequestedPermissions(requested, false)).toEqual([
+                { permission: 'read_address', coin: 'btc' },
+            ]);
+        });
     });
 });
 

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -86,20 +86,39 @@ export const groupPermissionsByCoin = (permissions: PermissionRequest[]): Groupe
     return groups;
 };
 
+// Runtime guard narrowing the untrusted `permission` value against the imported grantable set,
+// mirroring `isCoinSymbol` for coins.
+const isGrantablePermission = (value: string): value is PermissionRequest['permission'] =>
+    (GRANTABLE_PERMISSIONS as readonly string[]).includes(value);
+
 // Sanitize the host-declared `requestedPermissions`: drop entries whose permission is not
 // grantable, `push_tx` on deeplinks, and unknown coins; lowercase each `coin` to its `CoinSymbol`.
+//
+// Untrusted input — nothing schema-validates it on either handshake, hence `unknown` and the shape
+// checks. Malformed input is dropped rather than thrown on, because this runs before
+// `initiateCall`: a throw there fails every later call from that app with an unactionable error.
+// Entries are never spread, so attacker-chosen keys cannot reach the consent UI or the grant.
 export const sanitizeRequestedPermissions = (
-    requested: PermissionRequest[] | undefined,
+    requested: unknown,
     isDeeplink: boolean,
 ): PermissionRequest[] =>
-    (requested ?? []).flatMap(({ permission, coin }) => {
-        if (!GRANTABLE_PERMISSIONS.includes(permission)) return [];
-        if (permission === 'push_tx' && isDeeplink) return [];
-        if (coin === undefined) return [{ permission }];
-        const symbol = coin.toLowerCase();
+    Array.isArray(requested)
+        ? requested.flatMap((entry): PermissionRequest[] => {
+              const { permission, coin } = (entry ?? {}) as {
+                  permission?: unknown;
+                  coin?: unknown;
+              };
+              if (typeof permission !== 'string' || !isGrantablePermission(permission)) return [];
+              if (permission === 'push_tx' && isDeeplink) return [];
+              // Only an absent coin means coin-less. A malformed one is dropped, not widened —
+              // a coin-less grant is device-wide, so widening would fail open.
+              if (coin === undefined) return [{ permission }];
+              if (typeof coin !== 'string') return [];
+              const symbol = coin.toLowerCase();
 
-        return isCoinSymbol(symbol) ? [{ permission, coin: symbol }] : [];
-    });
+              return isCoinSymbol(symbol) ? [{ permission, coin: symbol }] : [];
+          })
+        : [];
 
 // Lowercase each permission's `coin` to its `CoinSymbol`. Normalizes grants persisted before coins
 // were canonicalized at the source.


### PR DESCRIPTION
## Description

Part of splitting #30403 into standalone PRs (follow-up to #30261; addresses items of #30401). This is fix 3 of that PR, on its own.

`sanitizeRequestedPermissions` validated values but never shape, while its parameter type claimed the input was already a `PermissionRequest[]`. Nothing schema-validates this host-controlled value on the way in — neither handshake does — so a non-array, a `null` entry or a non-string `coin` threw a raw `TypeError`. That happens before `initiateCall`, so there is no `activeCall` to attach the error to: the popup renders its bare error screen and the dapp gets `Failure_UnknownCode` carrying a JS message, for **every** subsequent call from that app, not just the malformed one.

The parameter is now `unknown` and each entry is shape-checked, mirroring `enabledNetworksStore.sanitize` — guard the array, guard each field, drop what does not fit. Entries are still never spread, so attacker-chosen keys cannot reach the consent UI or the persisted grant.

One deliberate asymmetry: a malformed `coin` is **dropped**, not treated as coin-less. A coin-less grant is device-wide and broader than any coin-scoped one, so widening on garbage input would fail open.

This hardens a sanitizer that is already reachable on `develop` through the Suite Web path, so it stands on its own; it ideally lands before the desktop and webextension delivery PRs, which extend that exposure to the other two transports.

## Testing

`@suite-common/connect-popup` unit tests: 33 passed, up from 19 — the new `malformed host input` block covers 4 whole-value shapes, 7 entry shapes, mixed valid/invalid input, the coin-less-widening guard, and the whitelist-copy behaviour. `type-check` green on `@suite-common/connect-popup`.

## Related

Split out of #30403. Follow-up to #30261, item of #30401.

## Sibling PRs (split of #30403)

- #30489 — fix(connect-popup): drop malformed requestedPermissions instead of throwing (sanitizer hardening)
- #30486 — fix(suite-desktop): forward requestedPermissions from the connect-ws handshake
- #30488 — fix(suite): read requestedPermissions from the handshake payload on webextension
- #30487 — test(suite-e2e): cover upfront permission declaration (stacked on #30486)

Suggested merge order: #30489 first (hardens the sanitizer that #30486/#30488 expose to more transports), then #30486 and #30488 in either order, then #30487 after #30486.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are localized to the Connect popup permissions module, so the highest-value tests are the ones that explicitly interact with the Grant Permissions modal, remembered/connected apps, and silent mode. Running the targeted trezor-connect permissions and popup tests will catch regressions in permission grant, cancellation, persistence, and silent mode without needing the broad set of 134 transitively mapped tests.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/connect-popup/src/permissions.test.ts`
- `suite-common/connect-popup/src/permissions.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises the Grant Permissions modal in a web Connect flow, including granting permissions, cancellation at the permissions step, and multiple method types (getAddress / cardanoGetAddress). A change to the permissions module would very likely break this test first.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Exercises the same Grant Permissions modal but from a webextension context, which uses the same permissions logic and is a distinct integration surface for Connect. Regressions in permission grant/cancellation would surface here.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Dedicated test for remembering, revoking, and listing connected app permissions in Settings, including the Remember checkbox and the 'no apps' state. This is the closest end-to-end coverage to the permissions module itself.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests the silent-mode permission option inside the permissions modal and its effect on subsequent Connect calls, plus the connected-apps dropdown in Settings. Silent mode is part of the permissions grant UI/state.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Requires confirming the Connect permissions modal before exporting addresses, and covers both single and bundled address exports. It acts as a representative happy-path check that the permission grant step works for a common read-only Connect method.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Requires confirming the Connect permissions modal before signing a Bitcoin transaction. It verifies that permission grant transitions correctly into the signing flow and that device prompts render after the modal is accepted.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/permissions.test.ts`

_Updated: 2026-08-05T05:49:11.277Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-harden-perms-sanitizer/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-harden-perms-sanitizer/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-harden-perms-sanitizer&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-harden-perms-sanitizer&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-harden-perms-sanitizer&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T05:50:19.153Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T05:51:13.291Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->