### PR TITLE
fix(suite): keep a TRX reserve for the Tron voting fee

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/TronStakeFees.tsx
+++ b/packages/suite/src/components/earn/staking/tron/TronStakeFees.tsx
@@ -3,11 +3,10 @@ import { Card, Column } from '@trezor/components';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 
 import { useTronStakeContext } from './TronStakeContext';
-import { useTronStakeFees } from './hooks/useTronStakeFees';
 
 export const TronStakeFees = () => {
-    const { account } = useTronStakeContext();
-    const { feeInfo, composedLevels } = useTronStakeFees();
+    const { account, fees } = useTronStakeContext();
+    const { feeInfo, composedLevels } = fees;
 
     return (
         <Card paddingType="none">

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useFormState } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
 import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { TRON_STAKING_RESERVE } from '@suite-common/wallet-constants';
 import { composeTronFreezeFeeLevelsThunk } from '@suite-common/wallet-core';
 import {
     asAmountSubunit,
@@ -37,6 +38,8 @@ export const TronFreezeAmount = () => {
     const { errors } = useFormState({ control });
     const isDisabled = !!actions.pendingTxid;
 
+    const [isMaxActive, setIsMaxActive] = useState(false);
+
     const {
         currency,
         setCurrency,
@@ -56,16 +59,21 @@ export const TronFreezeAmount = () => {
 
     const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
 
+    const amount = form.methods.watch('amount');
     const resourceType = form.methods.watch('resourceType');
 
     const maxFreezeAmount = useMemo(async () => {
-        const availableBalance = subunitsToUnits({
+        const availableBalanceUnits = subunitsToUnits({
             value: asAmountSubunit(new BigNumber(account.availableBalance)),
             symbol: account.symbol,
         }).toString();
 
         const levels = await dispatch(
-            composeTronFreezeFeeLevelsThunk({ account, amount: availableBalance, resourceType }),
+            composeTronFreezeFeeLevelsThunk({
+                account,
+                amount: availableBalanceUnits,
+                resourceType,
+            }),
         )
             .unwrap()
             .catch(() => undefined);
@@ -73,12 +81,10 @@ export const TronFreezeAmount = () => {
         const feeInSun = levels?.normal?.type === 'final' ? levels.normal.fee : '0';
         const maxInSun = BigNumber.max(new BigNumber(account.availableBalance).minus(feeInSun), 0);
 
-        const maxAmount = subunitsToUnits({
+        return subunitsToUnits({
             value: asAmountSubunit(maxInSun),
             symbol: account.symbol,
         }).toString();
-
-        return maxAmount;
     }, [account, resourceType, dispatch]);
 
     const cryptoInputRules = {
@@ -111,7 +117,9 @@ export const TronFreezeAmount = () => {
                     maxFreezeAmountInUnits &&
                     new BigNumber(value).isGreaterThan(maxFreezeAmountInUnits)
                 ) {
-                    return translationString('AMOUNT_IS_NOT_ENOUGH');
+                    return translationString('AMOUNT_NOT_ENOUGH_CURRENCY_FEE', {
+                        networkDisplaySymbol,
+                    });
                 }
             },
         },
@@ -154,16 +162,33 @@ export const TronFreezeAmount = () => {
                     maxFreezeAmountInFiat &&
                     new BigNumber(value).isGreaterThan(maxFreezeAmountInFiat)
                 ) {
-                    return translationString('AMOUNT_IS_NOT_ENOUGH');
+                    return translationString('AMOUNT_NOT_ENOUGH_CURRENCY_FEE', {
+                        networkDisplaySymbol,
+                    });
                 }
             },
         },
     };
 
+    const handleCryptoAmountChange = (value: string) => {
+        setIsMaxActive(false);
+        onCryptoAmountChange(value);
+    };
+
+    const handleFiatAmountChange = (value: string) => {
+        setIsMaxActive(false);
+        onFiatAmountChange(value);
+    };
+
     const handleSetMax = async () => {
         form.methods.clearErrors(['amount', 'fiatAmount']);
+        setIsMaxActive(true);
 
-        const maxAmount = await maxFreezeAmount;
+        const maxFreezeAmountInUnits = await maxFreezeAmount;
+        const maxAmount = BigNumber.max(
+            new BigNumber(maxFreezeAmountInUnits).minus(TRON_STAKING_RESERVE),
+            0,
+        ).toString();
 
         form.methods.setValue('amount', maxAmount, { shouldValidate: true });
 
@@ -180,6 +205,17 @@ export const TronFreezeAmount = () => {
     const hasError = !!errors.amount || !!errors.fiatAmount;
     const errorMessage = errors.amount?.message ?? errors.fiatAmount?.message;
 
+    const amountBn = new BigNumber(amount || '0');
+
+    const showLeftReserveBanner = isMaxActive && amountBn.isGreaterThan(0);
+
+    const showRecommendedReserveBanner =
+        !isMaxActive &&
+        !hasError &&
+        !!minStakingAmount &&
+        amountBn.isGreaterThanOrEqualTo(minStakingAmount) &&
+        new BigNumber(availableBalance).minus(amountBn).isLessThan(TRON_STAKING_RESERVE);
+
     const numberInputProps = {
         name: currency === 'crypto' ? 'amount' : 'fiatAmount',
         locale,
@@ -188,7 +224,7 @@ export const TronFreezeAmount = () => {
         maxLength: currency === 'crypto' ? formInputsMaxLength.amount : formInputsMaxLength.fiat,
         isDisabled,
         hasError,
-        onChange: currency === 'crypto' ? onCryptoAmountChange : onFiatAmountChange,
+        onChange: currency === 'crypto' ? handleCryptoAmountChange : handleFiatAmountChange,
         rightContent: (
             <Text typographyStyle="body-md" intent="neutral" priority="secondary">
                 {currency === 'crypto' ? networkDisplaySymbol : baseCurrencyCode.toUpperCase()}
@@ -243,6 +279,36 @@ export const TronFreezeAmount = () => {
 
             {!!errorMessage && (
                 <Banner intent="warning" description={<Text>{errorMessage}</Text>} />
+            )}
+
+            {showLeftReserveBanner && (
+                <Banner
+                    intent="info"
+                    description={
+                        <Translation
+                            id="TR_EARN_TRON_RESERVE_LEFT_FOR_VOTING"
+                            values={{
+                                amount: TRON_STAKING_RESERVE.toString(),
+                                networkDisplaySymbol,
+                            }}
+                        />
+                    }
+                />
+            )}
+
+            {showRecommendedReserveBanner && (
+                <Banner
+                    intent="info"
+                    description={
+                        <Translation
+                            id="TR_EARN_TRON_RESERVE_RECOMMENDED_FOR_VOTING"
+                            values={{
+                                amount: TRON_STAKING_RESERVE.toString(),
+                                networkDisplaySymbol,
+                            }}
+                        />
+                    }
+                />
             )}
         </Column>
     );

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import {
+    type TronStakeStepId,
     composeTronClaimFeeLevelsThunk,
     composeTronFreezeFeeLevelsThunk,
     composeTronUnstakeFeeLevelsThunk,
@@ -8,24 +9,28 @@ import {
     composeTronWithdrawFeeLevelsThunk,
     selectRawNetworkFeeInfo,
 } from '@suite-common/wallet-core';
-import { type FeeInfo, type PrecomposedLevels } from '@suite-common/wallet-types';
+import { type Account, type FeeInfo, type PrecomposedLevels } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { exhaustive } from '@trezor/type-utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-import { useTronStakeContext } from '../TronStakeContext';
 import { resolveVotedRepresentativeAddress } from '../voteUtils';
+import { type useTronStakeForm } from './useTronStakeForm';
 
 interface TronStakeFees {
     feeInfo: FeeInfo;
     composedLevels: PrecomposedLevels | undefined;
 }
 
-export const useTronStakeFees = (): TronStakeFees => {
+interface UseTronStakeFeesProps {
+    account: Account;
+    form: ReturnType<typeof useTronStakeForm>;
+    step: TronStakeStepId;
+}
+
+export const useTronStakeFees = ({ account, form, step }: UseTronStakeFeesProps): TronStakeFees => {
     const dispatch = useDispatch();
-    const { account, form, actions } = useTronStakeContext();
-    const { step } = actions;
 
     const amount = form.methods.watch('amount');
     const resourceType = form.methods.watch('resourceType');

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts
@@ -9,6 +9,7 @@ import { useDispatch } from 'src/hooks/suite';
 
 import { useTronAmountInput } from './useTronAmountInput';
 import { type TronStakeActions, useTronStakeActions } from './useTronStakeActions';
+import { useTronStakeFees } from './useTronStakeFees';
 import { useTronStakeForm } from './useTronStakeForm';
 import { useTronStakePendingTransactionTracking } from './useTronStakePendingTransactionTracking';
 
@@ -18,6 +19,7 @@ export interface TronStakeContextValues {
     form: ReturnType<typeof useTronStakeForm>;
     actions: TronStakeActions;
     amountInput: ReturnType<typeof useTronAmountInput>;
+    fees: ReturnType<typeof useTronStakeFees>;
 }
 
 interface UseTronStakeFlowProps {
@@ -34,6 +36,7 @@ export const useTronStakeFlow = ({
 
     const form = useTronStakeForm({ account, flow });
     const actions = useTronStakeActions({ account, form, flow });
+    const fees = useTronStakeFees({ account, form, step: actions.step });
 
     const { methods } = form;
 
@@ -56,5 +59,6 @@ export const useTronStakeFlow = ({
         form,
         actions,
         amountInput,
+        fees,
     };
 };

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
@@ -1,6 +1,7 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Banner, Card, Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -15,10 +16,12 @@ import { TronVoteRepresentativeSelect } from './TronVoteRepresentativeSelect';
 import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteForm = () => {
-    const { account, form, actions } = useTronStakeContext();
+    const { account, form, actions, fees } = useTronStakeContext();
     const { error } = actions;
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
+
+    const hasInsufficientFunds = fees.composedLevels?.normal?.type === 'error';
 
     const totalVotingPower =
         account.networkType === 'tron'
@@ -46,6 +49,20 @@ export const TronVoteForm = () => {
                 <TronVoteApr />
 
                 <TronStakeFees />
+
+                {hasInsufficientFunds && (
+                    <Banner
+                        intent="warning"
+                        description={
+                            <Translation
+                                id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
+                                values={{
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                }}
+                            />
+                        }
+                    />
+                )}
 
                 {error && (
                     <Banner

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
@@ -1,6 +1,7 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { Banner, Column } from '@trezor/components';
 
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
@@ -13,10 +14,12 @@ import { TronVoteRepresentativeSelect } from './TronVoteRepresentativeSelect';
 import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteStep = () => {
-    const { form, actions, account } = useTronStakeContext();
+    const { form, actions, account, fees } = useTronStakeContext();
     const { error } = actions;
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
+
+    const hasInsufficientFunds = fees.composedLevels?.normal?.type === 'error';
 
     return (
         <FormProvider {...form.methods}>
@@ -28,6 +31,20 @@ export const TronVoteStep = () => {
                 <TronVoteApr />
 
                 <TronStakeFees />
+
+                {hasInsufficientFunds && (
+                    <Banner
+                        intent="warning"
+                        description={
+                            <Translation
+                                id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
+                                values={{
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                }}
+                            />
+                        }
+                    />
+                )}
 
                 {error && (
                     <Banner

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx
@@ -17,11 +17,13 @@ export const TronVoteSubmitButton = () => {
     const { device, isLocked } = useDevice();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
-    const { account, form, actions } = useTronStakeContext();
+    const { account, form, actions, fees } = useTronStakeContext();
     const { isSubmitting, pendingTxid, submitAction } = actions;
     const { control } = form.methods;
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
+
+    const hasInsufficientFunds = fees.composedLevels?.normal?.type === 'error';
 
     const representative = useWatch({ control, name: 'representative' });
     const customRepresentativeAddress = useWatch({ control, name: 'customRepresentativeAddress' });
@@ -67,6 +69,7 @@ export const TronVoteSubmitButton = () => {
                     !isRepresentativeSelected ||
                     isSubmitting ||
                     isDeviceLocked ||
+                    hasInsufficientFunds ||
                     !!pendingTxid
                 }
                 isLoading={isSubmitting || isDiscoveryRunning}

--- a/suite-common/wallet-constants/src/tronStakingConstants.ts
+++ b/suite-common/wallet-constants/src/tronStakingConstants.ts
@@ -4,6 +4,7 @@ export const MIN_TRON_AMOUNT_FOR_STAKING = new BigNumber(1);
 export const MAX_TRON_AMOUNT_FOR_STAKING = new BigNumber(1_000_000_000);
 export const MIN_TRON_FOR_WITHDRAWALS = new BigNumber(0.01);
 export const MIN_TRON_BALANCE_FOR_FEE_BUFFER = new BigNumber(5);
+export const TRON_STAKING_RESERVE = new BigNumber(0.5);
 export const MIN_TRON_BALANCE_FOR_STAKING =
     MIN_TRON_AMOUNT_FOR_STAKING.plus(MIN_TRON_FOR_WITHDRAWALS);
 

--- a/suite-common/wallet-core/src/stake/tron/actions/vote/composeVote.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/vote/composeVote.ts
@@ -6,6 +6,7 @@ import {
 } from '@suite-common/wallet-types';
 import { computeBandwidthFeeLevel } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
 
 import { buildVoteContract } from './voteContract';
 import {
@@ -59,6 +60,10 @@ export const composeTronVoteFeeLevelsThunk = createThunk<
         });
 
         const feeInSun = feeLevel.feePerTx || '0';
+
+        if (new BigNumber(account.availableBalance).lt(feeInSun)) {
+            return { normal: { type: 'error', error: 'AMOUNT_IS_NOT_ENOUGH' } };
+        }
 
         const tx: PrecomposedTransactionFinal = {
             type: 'final',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10863,6 +10863,16 @@ export const messages = defineMessages({
         id: 'TR_EARN_TRON_WITHDRAW_TITLE',
         defaultMessage: 'Withdraw',
     },
+    TR_EARN_TRON_RESERVE_LEFT_FOR_VOTING: {
+        id: 'TR_EARN_TRON_RESERVE_LEFT_FOR_VOTING',
+        defaultMessage:
+            "We've left {amount} {networkDisplaySymbol} in your account so you can pay for voting fees.",
+    },
+    TR_EARN_TRON_RESERVE_RECOMMENDED_FOR_VOTING: {
+        id: 'TR_EARN_TRON_RESERVE_RECOMMENDED_FOR_VOTING',
+        defaultMessage:
+            "It's recommended to leave {amount} {networkDisplaySymbol} so you can pay for voting fees.",
+    },
     TR_EARN_TRON_CLAIM_ADDRESS: {
         id: 'TR_EARN_TRON_CLAIM_ADDRESS',
         defaultMessage: 'Claim address',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements network reserve for Tron staking. 0.5 TRX is left when freezing max. If user freezes more, recommendation is show to keep 0.5 TRX.

Also added fee check in voting step - now we don't allow tx submit when user doesn't have enough for a fee

## Notes for QA


## Related Issue

Resolve #30484

## Screenshots:
<img width="716" height="866" alt="image" src="https://github.com/user-attachments/assets/2bd17041-6480-4f71-95d0-2b54e735518a" />

<img width="659" height="874" alt="image" src="https://github.com/user-attachments/assets/e8743cc2-5827-4d47-98c6-2a802bcb343e" />

<img width="664" height="571" alt="image" src="https://github.com/user-attachments/assets/e1590de9-38c3-4269-a6ce-d40562ae1cf0" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly scoped to Tron staking UI components, hooks, constants, and vote composition logic. No dedicated Tron staking end-to-end tests exist in the candidate set; the broad static coverage mapping of 133 tests per file is best explained by transitive imports through shared layout/routing rather than meaningful functional coverage. The only candidate that actually visits the affected Tron earn routes is check-links, which should be run to catch render crashes or broken links. Relying solely on e2e here is risky—consider supplementing with unit/integration tests for Tron freeze, stake, and vote flows.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/components/earn/staking/tron/TronStakeFees.tsx`
- `packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFees.ts`
- `packages/suite/src/components/earn/staking/tron/hooks/useTronStakeFlow.ts`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteSubmitButton.tsx`
- `suite-common/wallet-constants/src/tronStakingConstants.ts`
- `suite-common/wallet-core/src/stake/tron/actions/vote/composeVote.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to all /earn/tron/* routes (/earn/tron/stake, /earn/tron/vote, /earn/tron/unstake, /earn/tron/withdraw, /earn/tron/claim) and verifies the page loads and links are reachable. Since the changed files are Tron staking UI components, hooks, constants, and vote composition logic, a render-time crash or broken route on these pages would likely cause this test to fail. No other candidate test visits Tron staking routes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-07-29T10:22:47.453Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-stake-reserve/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-stake-reserve/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-stake-reserve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-stake-reserve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-stake-reserve&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T10:25:47.605Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T10:25:18.497Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->