### PR TITLE
fix(suite-native): remove stale firmware depcheck ignore

### DIFF
--- a/suite-native/firmware/.depcheckrc.json
+++ b/suite-native/firmware/.depcheckrc.json
@@ -1,7 +1,3 @@
 {
-    "ignore-patterns": ["libDev", "lib"],
-    "ignores": [
-        "// Todo: This need so be solved. See: https://github.com/trezor/trezor-suite/issues/21559",
-        "@suite-native/device"
-    ]
+    "ignore-patterns": ["libDev", "lib"]
 }


### PR DESCRIPTION
## Description

The firmware depcheck config continued suppressing `@suite-native/device` after the Confirm on Trezor code moved into a standalone package and broke the cycle. Remove the obsolete exception while retaining generated-output exclusions; the focused firmware depcheck passes without it. Closes #21559.

- Ignored package dependencies: **1 -> 0**
- Depcheck config lines: **7 -> 3**

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-firmware-depcheck&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->