### PR TITLE
Feat / Yield APY CTA

### DIFF
--- a/packages/components/src/components/Badge/Badge.tsx
+++ b/packages/components/src/components/Badge/Badge.tsx
@@ -16,7 +16,7 @@ import {
 import { Box } from '../Box/Box';
 import { Row } from '../Flex/Flex';
 import { Icon, type IconComponent } from '../Icon/Icon';
-import { Text } from '../typography/Text/Text';
+import { Text, type TextPriority } from '../typography/Text/Text';
 
 export const allowedBadgeFrameProps = ['margin', 'cursor'] as const satisfies FramePropsKeys[];
 type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number]>;
@@ -24,6 +24,8 @@ type AllowedFrameProps = Pick<FrameProps, (typeof allowedBadgeFrameProps)[number
 export type BadgeProps = AllowedFrameProps & {
     size?: BadgeSize;
     intent?: BadgeIntent;
+    /** Text emphasis. Defaults to full strength, dimmed for the `neutral` intent. */
+    priority?: TextPriority;
     iconLeft?: IconComponent;
     iconRight?: IconComponent;
     children?: React.ReactNode;
@@ -33,6 +35,7 @@ export type BadgeProps = AllowedFrameProps & {
 export const Badge = ({
     size = 'medium',
     intent = 'neutral',
+    priority = intent === 'neutral' ? 'secondary' : 'primary',
     iconLeft,
     iconRight,
     children,
@@ -40,7 +43,6 @@ export const Badge = ({
     ...rest
 }: BadgeProps) => {
     const frameProps = pickAndPrepareFrameProps(rest, allowedBadgeFrameProps, false);
-    const textPriority = intent === 'neutral' ? 'secondary' : 'primary';
 
     const iconProps = {
         color: mapIntentToIconColor(intent),
@@ -61,7 +63,7 @@ export const Badge = ({
                     as="div"
                     typographyStyle={mapSizeToTypographyStyle(size)}
                     intent={intent}
-                    priority={textPriority}
+                    priority={priority}
                     textWrap="nowrap"
                 >
                     {children}

--- a/packages/components/src/components/Table/TableRow.tsx
+++ b/packages/components/src/components/Table/TableRow.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, type Ref } from 'react';
 
 import styled, { css } from 'styled-components';
 
@@ -8,6 +8,7 @@ import { useTableHeader } from './TableHeader';
 export const Row = styled.tr<{
     $isCollapsed: boolean;
     $verticalAlign?: string;
+    $isHighlightedOnHover: boolean;
     $isHighlighted: boolean;
     $isHeader: boolean;
     $hasBorderTop: boolean;
@@ -28,13 +29,22 @@ export const Row = styled.tr<{
 
     ${({ $verticalAlign }) => `vertical-align: ${$verticalAlign};`}
 
-    ${({ $isHighlighted, theme, $isHeader }) =>
-        $isHighlighted &&
+    ${({ $isHighlightedOnHover, theme, $isHeader, $isHighlighted }) =>
+        $isHighlightedOnHover &&
         !$isHeader &&
+        !$isHighlighted &&
         css`
             &:hover {
                 background-color: ${theme.elementFillGhostHovered};
             }
+        `}
+
+    ${({ $isHighlighted, theme }) =>
+        $isHighlighted &&
+        css`
+            background-color: ${theme.elementFillWarningSofter};
+            outline: solid 2px ${theme.elementBorderWarningSofter};
+            outline-offset: -2px;
         `}
 
     ${({ $isCollapsed }) =>
@@ -59,9 +69,12 @@ export interface TableRowProps {
     isCollapsed?: boolean;
     verticalAlign?: string;
     isHighlightedOnHover?: boolean;
+    /** Keeps the row highlighted, e.g. while it is the target of an anchor navigation. */
+    isHighlighted?: boolean;
     onClick?: () => void;
     onHover?: (isHovering: boolean) => void;
     hasBorderTop?: boolean;
+    ref?: Ref<HTMLTableRowElement>;
     'data-testid'?: string;
 }
 
@@ -72,7 +85,9 @@ export const TableRow = ({
     onHover,
     verticalAlign,
     isHighlightedOnHover,
+    isHighlighted = false,
     hasBorderTop,
+    ref,
     'data-testid': dataTestId,
 }: TableRowProps) => {
     const isHeader = useTableHeader();
@@ -82,9 +97,11 @@ export const TableRow = ({
         <Row
             $verticalAlign={verticalAlign}
             $isCollapsed={isCollapsed}
-            $isHighlighted={isHighlightedOnHover ?? isRowHighlightedOnHover}
+            $isHighlightedOnHover={isHighlightedOnHover ?? isRowHighlightedOnHover}
+            $isHighlighted={isHighlighted}
             $isHeader={isHeader}
             $hasBorderTop={hasBorderTop ?? hasBorders}
+            ref={ref}
             onClick={onClick}
             onMouseEnter={() => onHover?.(true)}
             onMouseLeave={() => onHover?.(false)}

--- a/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
+++ b/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { Translation, type TranslationKey } from '@suite/intl';
+import { EarnAnchor, goto } from '@suite/router';
+import { events as sharedEvents } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol } from '@suite-common/networks';
+import { Badge, type BadgeProps, commonFocusStyles } from '@trezor/components';
+import { TrendUpIcon } from '@trezor/icons';
+import { getBorderRadiusCssValue } from '@trezor/theme';
+
+import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
+import { useDispatch } from 'src/hooks/suite';
+
+// The badge itself is not interactive, so a button carries the click and the focus ring.
+const BadgeButton = styled.button`
+    display: inline-flex;
+    padding: 0;
+    border: none;
+    border-radius: ${getBorderRadiusCssValue('full')};
+    background: none;
+    cursor: pointer;
+
+    &:focus-visible {
+        ${commonFocusStyles}
+    }
+`;
+
+type YieldBadgeVariant = 'inactive' | 'active' | 'promo';
+
+type YieldBadgeVariantConfig = {
+    translationId: TranslationKey;
+    priority: NonNullable<BadgeProps['priority']>;
+    iconLeft?: BadgeProps['iconLeft'];
+};
+
+const variantConfigMap: Record<YieldBadgeVariant, YieldBadgeVariantConfig> = {
+    inactive: {
+        translationId: 'TR_EARN_YIELD_BADGE_UP_TO_RATE',
+        priority: 'secondary',
+    },
+    active: {
+        translationId: 'TR_EARN_YIELD_BADGE_RATE',
+        priority: 'primary',
+    },
+    promo: {
+        translationId: 'TR_EARN_YIELD_BADGE_UP_TO_RATE',
+        priority: 'primary',
+        iconLeft: TrendUpIcon,
+    },
+};
+
+type YieldBadgeProps = {
+    apy: number;
+    /** `inactive` = eligible but not yielding, `active` = already yielding, `promo` = trade box teaser. */
+    variant: YieldBadgeVariant;
+    networkSymbol: NetworkSymbol;
+    analyticsFrom: 'account-tokens' | 'account-defi-tokens' | 'account-tradebox';
+    vaultId?: string;
+};
+
+export const YieldBadge = ({
+    apy,
+    variant,
+    networkSymbol,
+    analyticsFrom,
+    vaultId,
+}: YieldBadgeProps) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const dispatch = useDispatch();
+
+    const { translationId, priority, iconLeft } = variantConfigMap[variant];
+
+    const goToEarnYield = () => {
+        dispatch(goto({ routeName: 'suite-earn', anchor: EarnAnchor.Yield }));
+
+        analytics.report({
+            type: sharedEvents.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: analyticsFrom,
+                to: 'earn-dashboard',
+                networkSymbol,
+                vaultId,
+            },
+        });
+    };
+
+    return (
+        <BadgeButton type="button" onClick={goToEarnYield} data-testid="@earn/yield-badge">
+            <Badge intent="brand" size="small" priority={priority} iconLeft={iconLeft}>
+                <Translation id={translationId} values={{ apy: formatApyValue(apy) }} />
+            </Badge>
+        </BadgeButton>
+    );
+};

--- a/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
+++ b/packages/suite/src/components/earn/YieldBadge/YieldBadge.tsx
@@ -5,12 +5,13 @@ import { Translation, type TranslationKey } from '@suite/intl';
 import { EarnAnchor, goto } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { type NetworkSymbol } from '@suite-common/networks';
+import { type Account } from '@suite-common/wallet-types';
 import { Badge, type BadgeProps, commonFocusStyles } from '@trezor/components';
 import { TrendUpIcon } from '@trezor/icons';
 import { getBorderRadiusCssValue } from '@trezor/theme';
 
 import { formatApyValue } from 'src/components/earn/utils/earnApyUtils';
+import { getYieldOpportunityAnchor } from 'src/components/earn/utils/getYieldOpportunityAnchor';
 import { useDispatch } from 'src/hooks/suite';
 
 // The badge itself is not interactive, so a button carries the click and the focus ring.
@@ -31,23 +32,29 @@ type YieldBadgeVariant = 'inactive' | 'active' | 'promo';
 
 type YieldBadgeVariantConfig = {
     translationId: TranslationKey;
-    priority: NonNullable<BadgeProps['priority']>;
+    priority?: BadgeProps['priority'];
     iconLeft?: BadgeProps['iconLeft'];
+    /**
+     * Token badges point at the vault row of their account, the trade box teaser covers
+     * staking too, so it opens the Earn page plain — no anchor, nothing highlighted.
+     */
+    shouldAnchorAtVaultRow: boolean;
 };
 
 const variantConfigMap: Record<YieldBadgeVariant, YieldBadgeVariantConfig> = {
     inactive: {
         translationId: 'TR_EARN_YIELD_BADGE_UP_TO_RATE',
         priority: 'secondary',
+        shouldAnchorAtVaultRow: true,
     },
     active: {
         translationId: 'TR_EARN_YIELD_BADGE_RATE',
-        priority: 'primary',
+        shouldAnchorAtVaultRow: true,
     },
     promo: {
         translationId: 'TR_EARN_YIELD_BADGE_UP_TO_RATE',
-        priority: 'primary',
         iconLeft: TrendUpIcon,
+        shouldAnchorAtVaultRow: false,
     },
 };
 
@@ -55,25 +62,25 @@ type YieldBadgeProps = {
     apy: number;
     /** `inactive` = eligible but not yielding, `active` = already yielding, `promo` = trade box teaser. */
     variant: YieldBadgeVariant;
-    networkSymbol: NetworkSymbol;
+    account: Account;
+    vaultId: string;
     analyticsFrom: 'account-tokens' | 'account-defi-tokens' | 'account-tradebox';
-    vaultId?: string;
 };
 
-export const YieldBadge = ({
-    apy,
-    variant,
-    networkSymbol,
-    analyticsFrom,
-    vaultId,
-}: YieldBadgeProps) => {
+export const YieldBadge = ({ apy, variant, account, vaultId, analyticsFrom }: YieldBadgeProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
 
-    const { translationId, priority, iconLeft } = variantConfigMap[variant];
+    const { translationId, iconLeft, priority, shouldAnchorAtVaultRow } = variantConfigMap[variant];
 
     const goToEarnYield = () => {
-        dispatch(goto({ routeName: 'suite-earn', anchor: EarnAnchor.Yield }));
+        // The row anchor scrolls to and highlights the vault row of this very account; the
+        // Earn page falls back to scrolling the yield section when that row is not rendered.
+        const anchor = shouldAnchorAtVaultRow
+            ? (getYieldOpportunityAnchor({ account, vaultId }) ?? EarnAnchor.Yield)
+            : undefined;
+
+        dispatch(goto({ routeName: 'suite-earn', anchor }));
 
         analytics.report({
             type: sharedEvents.yieldNavigateEvent.name,
@@ -81,7 +88,7 @@ export const YieldBadge = ({
                 action: 'continue',
                 from: analyticsFrom,
                 to: 'earn-dashboard',
-                networkSymbol,
+                networkSymbol: account.symbol,
                 vaultId,
             },
         });

--- a/packages/suite/src/components/earn/dashboard/common/EarnDashboardDisabledSection.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnDashboardDisabledSection.tsx
@@ -1,8 +1,9 @@
 import { Translation, type TranslationKey } from '@suite/intl';
-import { EarnAnchor, useAnchor } from '@suite/router';
+import { EarnAnchor, isEarnYieldRowAnchor, selectRouterAnchor, useAnchor } from '@suite/router';
 import { Banner } from '@trezor/components';
 
 import { DashboardSection } from 'src/components/dashboard';
+import { useSelector } from 'src/hooks/suite';
 import {
     type EarnDashboardType,
     useMessageSystemEarnDashboard,
@@ -26,7 +27,13 @@ const SECTION_CONFIG: Record<EarnDashboardType, { anchor: string; titleId: Trans
 export const EarnDashboardDisabledSection = ({ type }: EarnDashboardDisabledSectionProps) => {
     const { content, variant } = useMessageSystemEarnDashboard(type);
     const { anchor, titleId } = SECTION_CONFIG[type];
-    const { anchorRef } = useAnchor(anchor);
+
+    // Yield badges anchor at a single dashboard row. With the section disabled no row
+    // exists, so it answers for the row anchor itself and scrolls the explanation into
+    // view — without a highlight, same as the fallback in EarnYieldTable.
+    const routerAnchor = useSelector(selectRouterAnchor);
+    const shouldClaimRowAnchor = type === 'yield' && isEarnYieldRowAnchor(routerAnchor);
+    const { anchorRef } = useAnchor(shouldClaimRowAnchor && routerAnchor ? routerAnchor : anchor);
 
     return (
         <DashboardSection heading={<Translation id={titleId} />} ref={anchorRef}>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -37,6 +37,7 @@ import { EarnYieldYearlyRewards } from './EarnYieldYearlyRewards';
 import { type YieldAccountOpportunity } from './types';
 import { getEarnRouteParams } from '../../utils/getEarnRouteParams';
 import { EarnAccountCell } from '../common/EarnAccountCell';
+import { useYieldAccountOpportunityAnchor } from './hooks/useYieldAccountOpportunityAnchor';
 
 type EarnYieldAccountOpportunityProps = {
     opportunity: YieldAccountOpportunity;
@@ -56,6 +57,8 @@ export const EarnYieldAccountOpportunity = ({
     const isFirmwareOutdated = !isStablecoinYieldSupported(selectedDevice);
     const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
         useFirmwareUpgradeModal();
+
+    const { setAnchorElement, shouldHighlight } = useYieldAccountOpportunityAnchor(opportunity);
 
     const vaultContractAddress = getYieldVaultContractAddress(opportunity.vault);
     const depositMessageSystem = useMessageSystemYield('deposit', { vaultContractAddress });
@@ -418,7 +421,11 @@ export const EarnYieldAccountOpportunity = ({
     return (
         <>
             {firmwareModal}
-            <Table.Row data-testid={`@earn/dashboard/row/${opportunity.vault.id}`}>
+            <Table.Row
+                ref={setAnchorElement}
+                isHighlighted={shouldHighlight}
+                data-testid={`@earn/dashboard/row/${opportunity.vault.id}`}
+            >
                 <Table.Cell>{accountCell}</Table.Cell>
 
                 <Table.Cell>{apyCell}</Table.Cell>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -3,7 +3,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { ContextMessage } from '@suite/message-system';
-import { EarnAnchor, goto, useAnchor } from '@suite/router';
+import {
+    EarnAnchor,
+    goto,
+    isEarnYieldRowAnchor,
+    selectRouterAnchor,
+    useAnchor,
+} from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import {
@@ -15,7 +21,6 @@ import { Context } from '@suite-common/message-system';
 import { NORMAL_ACCOUNT_TYPE } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { Button, Card, Column, Table } from '@trezor/components';
-import { OutlineHighlight } from '@trezor/product-components';
 
 import { DashboardSection } from 'src/components/dashboard';
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -28,13 +33,13 @@ import { EarnYieldTableBody } from './EarnYieldTableBody';
 import { useYieldAccountsVisibility } from './hooks/useYieldAccountsVisibility';
 import { useYieldTableData } from './hooks/useYieldTableData';
 import { PoweredByBadge } from '../../providers/PoweredByBadge';
+import { getYieldOpportunityAnchor } from '../../utils/getYieldOpportunityAnchor';
 import { useMerklRewards } from '../../yield/claim/hooks';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
 
 const emptyVaults: YieldDtoV2[] = [];
 
 export const EarnYieldTable = () => {
-    const { anchorRef, shouldHighlight } = useAnchor(EarnAnchor.Yield);
     const { isBelowLaptop } = useLayoutSize();
     const isCardLayout = isBelowLaptop;
     const dispatch = useDispatch();
@@ -76,6 +81,27 @@ export const EarnYieldTable = () => {
         isExpanded,
         toggleIsExpanded,
     } = useYieldAccountsVisibility({ yieldAccountOpportunities });
+
+    // Yield badges anchor at a single row, which scrolls and highlights itself. Take over
+    // the anchor to scroll the whole section when that row is not rendered — it may sit
+    // behind "show more" or belong to another device.
+    const routerAnchor = useSelector(selectRouterAnchor);
+    // The body swaps rows for a loading or error state, so a matching opportunity only
+    // means a mounted row when neither is showing.
+    const hasAnchoredRow =
+        !isYieldOpportunitiesError &&
+        displayedYieldAccountOpportunities.some(
+            opportunity =>
+                getYieldOpportunityAnchor({
+                    account: opportunity.account,
+                    vaultId: opportunity.vault.id,
+                }) === routerAnchor,
+        );
+    const shouldScrollWholeSection =
+        isEarnYieldRowAnchor(routerAnchor) && !isYieldOpportunitiesLoading && !hasAnchoredRow;
+    const { anchorRef } = useAnchor(
+        shouldScrollWholeSection && routerAnchor ? routerAnchor : EarnAnchor.Yield,
+    );
 
     const { merklRewardsQuery, missingRateTickersQuery } = useMerklRewards(yieldAccounts);
     const { accountsRewards } = merklRewardsQuery.data;
@@ -147,40 +173,55 @@ export const EarnYieldTable = () => {
         <Column data-testid="@earn/dashboard" gap={16}>
             <ContextMessage context={Context.getEarnDashboard('yield')} />
 
-            <OutlineHighlight shouldHighlight={shouldHighlight}>
-                <DashboardSection
-                    heading={<Translation id="TR_EARN_DEFI_YIELD_TITLE" />}
-                    subheading={<Translation id="TR_EARN_DEFI_YIELD_DASHBOARD_TEXT" />}
-                    actions={<PoweredByBadge provider="morpho" />}
-                    ref={anchorRef}
-                >
-                    <Column gap={16} alignItems="center">
-                        {(isYieldActive || accountsRewards.length > 0) && (
-                            <>
-                                <EarnYieldClaimRewardsBanner
-                                    value={merklRewardsQuery.data.totalRewardsToClaim.value}
-                                    currency={merklRewardsQuery.data.totalRewardsToClaim.currency}
-                                    isValueLoading={merklRewardsQuery.isLoading}
-                                    isClaimDisabled={isClaimDisabled}
-                                    claimDisabledTooltip={
-                                        claimMessageSystem.isDisabled
-                                            ? claimMessageSystem.content
-                                            : undefined
-                                    }
-                                    onClaim={() => setIsClaimModalOpen(true)}
+            <DashboardSection
+                heading={<Translation id="TR_EARN_DEFI_YIELD_TITLE" />}
+                subheading={<Translation id="TR_EARN_DEFI_YIELD_DASHBOARD_TEXT" />}
+                actions={<PoweredByBadge provider="morpho" />}
+                ref={anchorRef}
+            >
+                <Column gap={16} alignItems="center">
+                    {(isYieldActive || accountsRewards.length > 0) && (
+                        <>
+                            <EarnYieldClaimRewardsBanner
+                                value={merklRewardsQuery.data.totalRewardsToClaim.value}
+                                currency={merklRewardsQuery.data.totalRewardsToClaim.currency}
+                                isValueLoading={merklRewardsQuery.isLoading}
+                                isClaimDisabled={isClaimDisabled}
+                                claimDisabledTooltip={
+                                    claimMessageSystem.isDisabled
+                                        ? claimMessageSystem.content
+                                        : undefined
+                                }
+                                onClaim={() => setIsClaimModalOpen(true)}
+                            />
+                            {isClaimModalOpen && (
+                                <EarnYieldClaimSelectAccountModal
+                                    accountsRewards={accountsRewards}
+                                    onSelect={handleClaimableAccountSelect}
+                                    onClose={() => setIsClaimModalOpen(false)}
                                 />
-                                {isClaimModalOpen && (
-                                    <EarnYieldClaimSelectAccountModal
-                                        accountsRewards={accountsRewards}
-                                        onSelect={handleClaimableAccountSelect}
-                                        onClose={() => setIsClaimModalOpen(false)}
-                                    />
-                                )}
-                            </>
-                        )}
+                            )}
+                        </>
+                    )}
 
-                        {isCardLayout ? (
-                            <Column gap={8} width="100%">
+                    {isCardLayout ? (
+                        <Column gap={8} width="100%">
+                            <EarnYieldTableBody
+                                isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
+                                isYieldOpportunitiesError={isYieldOpportunitiesError}
+                                onRetry={refetchYieldOpportunities}
+                                yieldAccountOpportunities={displayedYieldAccountOpportunities}
+                                yieldInactiveVaultOpportunities={yieldInactiveVaultOpportunities}
+                                isCardLayout={isCardLayout}
+                            />
+                        </Column>
+                    ) : (
+                        <Card paddingType="none">
+                            <Table isRowHighlightedOnHover margin={{ top: 8 }}>
+                                <EarnDashboardTableHeader
+                                    accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_VAULT"
+                                    showRewardsColumns={hasAnyRewardsData}
+                                />
                                 <EarnYieldTableBody
                                     isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
                                     isYieldOpportunitiesError={isYieldOpportunitiesError}
@@ -191,42 +232,21 @@ export const EarnYieldTable = () => {
                                     }
                                     isCardLayout={isCardLayout}
                                 />
-                            </Column>
-                        ) : (
-                            <Card paddingType="none">
-                                <Table isRowHighlightedOnHover margin={{ top: 8 }}>
-                                    <EarnDashboardTableHeader
-                                        accountColumnTranslationId="TR_EARN_DASHBOARD_TABLE_ACCOUNT_VAULT"
-                                        showRewardsColumns={hasAnyRewardsData}
-                                    />
-                                    <EarnYieldTableBody
-                                        isYieldOpportunitiesLoading={isYieldOpportunitiesLoading}
-                                        isYieldOpportunitiesError={isYieldOpportunitiesError}
-                                        onRetry={refetchYieldOpportunities}
-                                        yieldAccountOpportunities={
-                                            displayedYieldAccountOpportunities
-                                        }
-                                        yieldInactiveVaultOpportunities={
-                                            yieldInactiveVaultOpportunities
-                                        }
-                                        isCardLayout={isCardLayout}
-                                    />
-                                </Table>
-                            </Card>
-                        )}
+                            </Table>
+                        </Card>
+                    )}
 
-                        {hasHiddenYieldAccountOpportunities && (
-                            <Button
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={handleToggleShowMore}
-                            >
-                                <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
-                            </Button>
-                        )}
-                    </Column>
-                </DashboardSection>
-            </OutlineHighlight>
+                    {hasHiddenYieldAccountOpportunities && (
+                        <Button
+                            intent="neutral"
+                            priority="secondary"
+                            onClick={handleToggleShowMore}
+                        >
+                            <Translation id={isExpanded ? 'TR_SHOW_LESS' : 'TR_SHOW_MORE'} />
+                        </Button>
+                    )}
+                </Column>
+            </DashboardSection>
         </Column>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountOpportunityAnchor.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountOpportunityAnchor.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react';
+
+import { useAnchor } from '@suite/router';
+
+import { getYieldOpportunityAnchor } from 'src/components/earn/utils/getYieldOpportunityAnchor';
+
+import type { YieldAccountOpportunity } from '../types';
+
+export function useYieldAccountOpportunityAnchor(opportunity: YieldAccountOpportunity) {
+    // Anchored from the yield badges on the account screens — scrolls to and highlights
+    // this row only.
+    const rowAnchor =
+        getYieldOpportunityAnchor({
+            account: opportunity.account,
+            vaultId: opportunity.vault.id,
+        }) ?? '';
+    const { anchorRef, shouldHighlight } = useAnchor<HTMLElement>(rowAnchor);
+    // The row is a table row in one layout and a card in the other, so the anchor element
+    // is attached by callback instead of a single typed ref.
+    const setAnchorElement = useCallback(
+        (element: HTMLElement | null) => {
+            anchorRef.current = element;
+        },
+        [anchorRef],
+    );
+
+    return {
+        setAnchorElement,
+        shouldHighlight,
+    };
+}

--- a/packages/suite/src/components/earn/utils/getYieldOpportunityAnchor.ts
+++ b/packages/suite/src/components/earn/utils/getYieldOpportunityAnchor.ts
@@ -1,0 +1,20 @@
+import { type AnchorType, getEarnYieldRowAnchor } from '@suite/router';
+import { type Account } from '@suite-common/wallet-types';
+
+type GetYieldOpportunityAnchorProps = {
+    account?: Account;
+    vaultId: string;
+};
+
+/** Anchor of the Earn yield dashboard row holding the given vault for the given account. */
+export const getYieldOpportunityAnchor = ({
+    account,
+    vaultId,
+}: GetYieldOpportunityAnchorProps): AnchorType | undefined =>
+    account &&
+    getEarnYieldRowAnchor({
+        symbol: account.symbol,
+        accountIndex: account.index,
+        accountType: account.accountType,
+        vaultId,
+    });

--- a/packages/suite/src/components/earn/utils/yieldVaultUtils.ts
+++ b/packages/suite/src/components/earn/utils/yieldVaultUtils.ts
@@ -1,0 +1,47 @@
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsYieldFeatureDisabled,
+} from '@suite-common/message-system';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
+import { getApyPercent, isApyAvailable } from '@suite-common/wallet-utils';
+
+// Each vault can be remotely killed on its own via the message system — a killed vault
+// must not be advertised.
+export const isYieldVaultDepositEnabled = (
+    state: MessageSystemRootState,
+    vault: Pick<YieldDtoV2, 'id' | 'outputToken'>,
+) =>
+    !selectIsYieldFeatureDisabled(
+        state,
+        Feature.earn.yield.deposit,
+        getYieldVaultContractAddress(vault),
+    );
+
+/**
+ * Picks the not-killed vault with the highest available APY. Returns one of the passed
+ * vault objects, so when used in a selector its identity is stable across unrelated
+ * store updates.
+ */
+export const getBestEnabledYieldVault = (
+    state: MessageSystemRootState,
+    vaults: YieldDtoV2[],
+): YieldDtoV2 | null =>
+    vaults.reduce<YieldDtoV2 | null>((best, vault) => {
+        if (!isYieldVaultDepositEnabled(state, vault)) {
+            return best;
+        }
+
+        const vaultApy = getApyPercent(vault.rewardRate.total);
+
+        if (vaultApy === null || !isApyAvailable(vaultApy)) {
+            return best;
+        }
+
+        if (!best) {
+            return vault;
+        }
+
+        return (getApyPercent(best.rewardRate.total) ?? 0) >= vaultApy ? best : vault;
+    }, null);

--- a/packages/suite/src/hooks/earn/useNativeYieldVault.ts
+++ b/packages/suite/src/hooks/earn/useNativeYieldVault.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import { getNetworkByYieldXyzId, isWrappedNativeToken } from '@suite-common/wallet-config';
+import { isYieldVaultOperational } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getApyPercent } from '@suite-common/wallet-utils';
+
+import {
+    getBestEnabledYieldVault,
+    isYieldVaultDepositEnabled,
+} from 'src/components/earn/utils/yieldVaultUtils';
+import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
+
+const emptyVaults: YieldDtoV2[] = [];
+
+/**
+ * Yield options for an account's native coin — deposit-open vaults taking the
+ * wrapped-native token (the native balance can be wrapped on the way into the vault).
+ */
+export const useNativeYieldVault = (account: Account) => {
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldOptionRelevant =
+        account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+    const {
+        data: availableVaults,
+        isSuccess: hasLoadedVaults,
+        isError: hasVaultsError,
+    } = useAllYieldOpportunities({ enabled: isYieldOptionRelevant });
+
+    const wrappedNativeVaults = useMemo(
+        () =>
+            isYieldOptionRelevant
+                ? (availableVaults ?? emptyVaults).filter(
+                      vault =>
+                          isYieldVaultOperational(vault) &&
+                          vault.status.enter &&
+                          getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                          isWrappedNativeToken(account.symbol, vault.token.address),
+                  )
+                : emptyVaults,
+        [isYieldOptionRelevant, availableVaults, account.symbol],
+    );
+
+    const hasYieldOption = useSelector(state =>
+        wrappedNativeVaults.some(vault => isYieldVaultDepositEnabled(state, vault)),
+    );
+    const bestVault = useSelector(state => getBestEnabledYieldVault(state, wrappedNativeVaults));
+
+    // Hold rendering until the vaults query settles so dependent UI does not flash
+    // from a yield-less to a yield-aware variant underneath the user.
+    const isResolving = isYieldOptionRelevant && !hasLoadedVaults && !hasVaultsError;
+
+    return {
+        isResolving,
+        hasYieldOption,
+        bestVaultApy: bestVault ? getApyPercent(bestVault.rewardRate.total) : null,
+        bestVaultId: bestVault?.id ?? null,
+    };
+};

--- a/packages/suite/src/hooks/earn/useNativeYieldVault.ts
+++ b/packages/suite/src/hooks/earn/useNativeYieldVault.ts
@@ -23,11 +23,9 @@ export const useNativeYieldVault = (account: Account) => {
     const yieldDepositMessageSystem = useMessageSystemYield('deposit');
     const isYieldOptionRelevant =
         account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
-    const {
-        data: availableVaults,
-        isSuccess: hasLoadedVaults,
-        isError: hasVaultsError,
-    } = useAllYieldOpportunities({ enabled: isYieldOptionRelevant });
+    const { data: availableVaults } = useAllYieldOpportunities({
+        enabled: isYieldOptionRelevant,
+    });
 
     const wrappedNativeVaults = useMemo(
         () =>
@@ -47,15 +45,11 @@ export const useNativeYieldVault = (account: Account) => {
         wrappedNativeVaults.some(vault => isYieldVaultDepositEnabled(state, vault)),
     );
     const bestVault = useSelector(state => getBestEnabledYieldVault(state, wrappedNativeVaults));
-
-    // Hold rendering until the vaults query settles so dependent UI does not flash
-    // from a yield-less to a yield-aware variant underneath the user.
-    const isResolving = isYieldOptionRelevant && !hasLoadedVaults && !hasVaultsError;
+    const bestVaultApy = bestVault ? getApyPercent(bestVault.rewardRate.total) : null;
 
     return {
-        isResolving,
         hasYieldOption,
-        bestVaultApy: bestVault ? getApyPercent(bestVault.rewardRate.total) : null,
-        bestVaultId: bestVault?.id ?? null,
+        bestVault:
+            bestVault && bestVaultApy !== null ? { id: bestVault.id, apy: bestVaultApy } : null,
     };
 };

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -42,11 +42,7 @@ import { BigNumber } from '@trezor/utils';
 import { SUITE } from 'src/actions/suite/constants';
 import { COINJOIN } from 'src/actions/wallet/constants';
 import { type Action, type AppState } from 'src/types/suite';
-import {
-    getSuiteReadyPayload,
-    redactRouterUrl,
-    redactTransactionIdFromAnchor,
-} from 'src/utils/suite/analytics';
+import { getSuiteReadyPayload, redactAnchor, redactRouterUrl } from 'src/utils/suite/analytics';
 import { hasVisibleTokens } from 'src/utils/wallet/tokenUtils';
 
 /*
@@ -237,7 +233,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                         payload: {
                             prevRouterUrl: redactRouterUrl(prevRouterUrl),
                             nextRouterUrl: redactRouterUrl(selectRouterUrl(state)),
-                            anchor: redactTransactionIdFromAnchor(action.payload.anchor),
+                            anchor: redactAnchor(action.payload.anchor),
                         },
                     });
 
@@ -257,7 +253,7 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                         payload: {
                             prevRouterUrl: redactRouterUrl(prevRouterUrl),
                             nextRouterUrl: redactRouterUrl(prevRouterUrl),
-                            anchor: redactTransactionIdFromAnchor(action.payload),
+                            anchor: redactAnchor(action.payload),
                         },
                     });
                 }

--- a/packages/suite/src/middlewares/suite/logsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/logsMiddleware.ts
@@ -12,7 +12,7 @@ import { redactUserPathFromString } from '@trezor/utils';
 
 import { PROTOCOL, SUITE } from 'src/actions/suite/constants';
 import { type Action, type AppState, type Dispatch } from 'src/types/suite';
-import { redactTransactionIdFromAnchor } from 'src/utils/suite/analytics';
+import { redactAnchor } from 'src/utils/suite/analytics';
 
 const log =
     (api: MiddlewareAPI<Dispatch, AppState>) =>
@@ -74,7 +74,7 @@ const log =
                         payload: {
                             pathname: action.payload.pathname,
                             app: action.payload.app,
-                            anchor: redactTransactionIdFromAnchor(action.payload.anchor),
+                            anchor: redactAnchor(action.payload.anchor),
                         },
                     }),
                 );

--- a/packages/suite/src/utils/suite/analytics.ts
+++ b/packages/suite/src/utils/suite/analytics.ts
@@ -1,6 +1,6 @@
 import type { SuiteReadyPayload } from '@suite/analytics';
 import { selectIsLegacyLabelingVisible } from '@suite/metadata';
-import { AccountTransactionBaseAnchor } from '@suite/router';
+import { AccountTransactionBaseAnchor, EarnAnchor, isEarnYieldRowAnchor } from '@suite/router';
 import {
     selectAutodetectLanguage,
     selectAutodetectTheme,
@@ -51,13 +51,22 @@ const resolveLabelingType = (
     return state.suiteSync.settings.isSuiteSyncEnabled ? 'suite-sync' : 'off';
 };
 
-// redact transaction id from account transaction anchor
-export const redactTransactionIdFromAnchor = (anchor?: string) => {
+// Collapses the per-item part of anchors (transaction id, earn yield row) — anchors reach
+// analytics and logs, so they must never carry account-identifying data.
+export const redactAnchor = (anchor?: string) => {
     if (!anchor) {
         return undefined;
     }
 
-    return anchor.startsWith(AccountTransactionBaseAnchor) ? AccountTransactionBaseAnchor : anchor;
+    if (anchor.startsWith(AccountTransactionBaseAnchor)) {
+        return AccountTransactionBaseAnchor;
+    }
+
+    if (isEarnYieldRowAnchor(anchor)) {
+        return EarnAnchor.Yield;
+    }
+
+    return anchor;
 };
 
 // 1. replace coinjoin by taproot

--- a/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isErc4626, isTestnet, sortTokensByName } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
+import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 import {
     enhanceTokensWithRates,
     getTokens,
@@ -28,6 +30,15 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
     const { account, network } = selectedAccount;
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
+
+    // The yield badge only makes sense where vaults can exist; the per-vault kill switch
+    // is checked down in the row hook, this global one just gates the query.
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldBadgeRelevant =
+        account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+    const { data: yieldOpportunities } = useAllYieldOpportunities({
+        enabled: isYieldBadgeRelevant,
+    });
 
     const enhancedTokens = useMemo(() => {
         const accountTokens = account.tokens?.filter(token => !isErc4626(token));
@@ -71,6 +82,7 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
             tokensWithoutBalance={tokens.shownWithoutBalance}
             network={network}
             searchQuery={searchQuery}
+            yieldOpportunities={isYieldBadgeRelevant ? yieldOpportunities : undefined}
         />
     ) : (
         <NoTokens

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -13,6 +13,7 @@ import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { Column, Row, Table, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
 
+import { YieldBadge } from 'src/components/earn/YieldBadge/YieldBadge';
 import {
     BaseCurrencyValue,
     FormattedCryptoAmount,
@@ -24,6 +25,7 @@ import { useSelector } from 'src/hooks/suite';
 
 import { BlurUrls } from '../BlurUrls';
 import { TokenRowActions } from './TokenRowActions';
+import { useTokenYieldBadge } from './hooks/useTokenYieldBadge';
 import type { TokensTableType } from './types';
 
 type TokenRowProps = {
@@ -53,6 +55,12 @@ export const TokenRow = ({
     const isTokenKnown = useSelector(state =>
         selectIsSpecificCoinDefinitionKnown(state, account.symbol, token.contract as TokenAddress),
     );
+    const yieldBadge = useTokenYieldBadge({
+        networkSymbol: account.symbol,
+        token,
+        type,
+        yieldOpportunities,
+    });
 
     const [showDeactivateModal, setShowDeactivateModal] = useState(false);
 
@@ -73,6 +81,17 @@ export const TokenRow = ({
                             shouldTryToFetch={isTokenKnown}
                         />
                         {isTokenKnown ? token.name : <BlurUrls text={token.name} />}
+                        {yieldBadge && (
+                            <YieldBadge
+                                apy={yieldBadge.apy}
+                                variant={type === 'defi' ? 'active' : 'inactive'}
+                                networkSymbol={account.symbol}
+                                analyticsFrom={
+                                    type === 'defi' ? 'account-defi-tokens' : 'account-tokens'
+                                }
+                                vaultId={yieldBadge.vaultId}
+                            />
+                        )}
                     </Row>
                 </Table.Cell>
 

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -58,6 +58,7 @@ export const TokenRow = ({
     const yieldBadge = useTokenYieldBadge({
         networkSymbol: account.symbol,
         token,
+        accountTokens: account.tokens,
         type,
         yieldOpportunities,
     });
@@ -84,12 +85,12 @@ export const TokenRow = ({
                         {yieldBadge && (
                             <YieldBadge
                                 apy={yieldBadge.apy}
-                                variant={type === 'defi' ? 'active' : 'inactive'}
-                                networkSymbol={account.symbol}
+                                variant={yieldBadge.hasVaultPosition ? 'active' : 'inactive'}
+                                account={account}
+                                vaultId={yieldBadge.vaultId}
                                 analyticsFrom={
                                     type === 'defi' ? 'account-defi-tokens' : 'account-tokens'
                                 }
-                                vaultId={yieldBadge.vaultId}
                             />
                         )}
                     </Row>

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 
 import { Address, copyAddressToClipboard, showCopyAddressModal } from '@suite/address';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
@@ -29,7 +29,11 @@ import {
     tradingActions,
 } from '@suite-common/trading';
 import { type Explorer, type Network } from '@suite-common/wallet-config';
-import { selectExplorer, sendFormActions } from '@suite-common/wallet-core';
+import {
+    getYieldVaultForOutputToken,
+    selectExplorer,
+    sendFormActions,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
     getContractAddressForNetworkSymbol,
@@ -120,13 +124,18 @@ const TokenRowBasicActions = ({
     const canSellToken = !!tokenTradingOptions && tokenTradingOptions.sell;
     const canReceiveToken = !isDeviceLocked && !isDeviceCompromised;
 
-    const availableVault = yieldOpportunities?.find(
-        vault =>
-            !vault.metadata.underMaintenance &&
-            !vault.metadata.deprecated &&
-            vault.outputToken?.address !== undefined &&
-            getContractAddressForNetworkSymbol(account.symbol, vault.outputToken.address) ===
-                getContractAddressForNetworkSymbol(account.symbol, token.contract),
+    const availableVault = useMemo(
+        () =>
+            getYieldVaultForOutputToken({
+                vaults: yieldOpportunities,
+                networkSymbol: account.symbol,
+                token: {
+                    address: token.contract,
+                    symbol: token.symbol ?? '',
+                    decimals: token.decimals,
+                },
+            }),
+        [yieldOpportunities, account.symbol, token.contract, token.symbol, token.decimals],
     );
 
     const isDepositButtonDisabled = !availableVault?.status.enter;

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
@@ -6,8 +6,10 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     getYieldVaultForOutputToken,
     getYieldVaultsForInputToken,
+    hasYieldVaultPosition,
 } from '@suite-common/wallet-core';
 import { getApyPercent } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { exhaustive } from '@trezor/type-utils';
 
 import { getBestEnabledYieldVault } from 'src/components/earn/utils/yieldVaultUtils';
@@ -18,6 +20,7 @@ import type { TokensTableType } from '../types';
 type UseTokenYieldBadgeParams = {
     networkSymbol: NetworkSymbol;
     token: EnhancedTokenInfo;
+    accountTokens: TokenInfo[] | undefined;
     type: TokensTableType;
     yieldOpportunities?: YieldDtoV2[];
 };
@@ -25,11 +28,14 @@ type UseTokenYieldBadgeParams = {
 type TokenYieldBadgeData = {
     apy: number;
     vaultId: string;
+    /** The account holds the vault's receipt token, so it already earns this rate. */
+    hasVaultPosition: boolean;
 };
 
 export const useTokenYieldBadge = ({
     networkSymbol,
     token,
+    accountTokens,
     type,
     yieldOpportunities,
 }: UseTokenYieldBadgeParams): TokenYieldBadgeData | null => {
@@ -66,7 +72,22 @@ export const useTokenYieldBadge = ({
         }
     }, [yieldOpportunities, networkSymbol, token.contract, token.symbol, token.decimals, type]);
 
-    const bestEnabledVault = useSelector(state => getBestEnabledYieldVault(state, matchedVaults));
+    const vaultsWithPosition = useMemo(
+        () =>
+            matchedVaults.filter(vault =>
+                hasYieldVaultPosition({ networkSymbol, vault, accountTokens }),
+            ),
+        [matchedVaults, networkSymbol, accountTokens],
+    );
+
+    // A vault the user already deposited into states the rate they actually earn, so it
+    // outranks a higher-paying one they have not touched.
+    const bestEnabledVault = useSelector(state =>
+        getBestEnabledYieldVault(
+            state,
+            vaultsWithPosition.length > 0 ? vaultsWithPosition : matchedVaults,
+        ),
+    );
 
     if (!bestEnabledVault) {
         return null;
@@ -78,5 +99,9 @@ export const useTokenYieldBadge = ({
         return null;
     }
 
-    return { apy, vaultId: bestEnabledVault.id };
+    return {
+        apy,
+        vaultId: bestEnabledVault.id,
+        hasVaultPosition: vaultsWithPosition.includes(bestEnabledVault),
+    };
 };

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    getYieldVaultForOutputToken,
+    getYieldVaultsForInputToken,
+} from '@suite-common/wallet-core';
+import { getApyPercent } from '@suite-common/wallet-utils';
+import { exhaustive } from '@trezor/type-utils';
+
+import { getBestEnabledYieldVault } from 'src/components/earn/utils/yieldVaultUtils';
+import { useSelector } from 'src/hooks/suite';
+
+import type { TokensTableType } from '../types';
+
+type UseTokenYieldBadgeParams = {
+    networkSymbol: NetworkSymbol;
+    token: EnhancedTokenInfo;
+    type: TokensTableType;
+    yieldOpportunities?: YieldDtoV2[];
+};
+
+type TokenYieldBadgeData = {
+    apy: number;
+    vaultId: string;
+};
+
+export const useTokenYieldBadge = ({
+    networkSymbol,
+    token,
+    type,
+    yieldOpportunities,
+}: UseTokenYieldBadgeParams): TokenYieldBadgeData | null => {
+    const matchedVaults = useMemo(() => {
+        const heldToken = {
+            address: token.contract,
+            symbol: token.symbol ?? '',
+            decimals: token.decimals,
+        };
+
+        // On the DeFi tab the row is a vault receipt token, on the Tokens tab it is a
+        // potential vault deposit. The unverified table never advertises yield; the
+        // hidden-tokens tables stay badge-free because they pass no yield opportunities.
+        switch (type) {
+            case 'defi': {
+                const vault = getYieldVaultForOutputToken({
+                    vaults: yieldOpportunities,
+                    networkSymbol,
+                    token: heldToken,
+                });
+
+                return vault ? [vault] : [];
+            }
+            case 'default':
+                return getYieldVaultsForInputToken({
+                    vaults: yieldOpportunities,
+                    networkSymbol,
+                    token: heldToken,
+                });
+            case 'hidden':
+                return [];
+            default:
+                return exhaustive(type);
+        }
+    }, [yieldOpportunities, networkSymbol, token.contract, token.symbol, token.decimals, type]);
+
+    const bestEnabledVault = useSelector(state => getBestEnabledYieldVault(state, matchedVaults));
+
+    if (!bestEnabledVault) {
+        return null;
+    }
+
+    const apy = getApyPercent(bestEnabledVault.rewardRate.total);
+
+    if (apy === null) {
+        return null;
+    }
+
+    return { apy, vaultId: bestEnabledVault.id };
+};

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -2,7 +2,6 @@ import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { getNetworkDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
-import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Card, Flex, InfoItem, Row, Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { TokenIcon } from '@trezor/product-components';
@@ -10,12 +9,12 @@ import { TokenIcon } from '@trezor/product-components';
 import { DashboardSection } from 'src/components/dashboard';
 import { YieldBadge } from 'src/components/earn/YieldBadge/YieldBadge';
 import { PriceTicker, TrendTicker } from 'src/components/suite';
-import { useNativeYieldVault } from 'src/hooks/earn/useNativeYieldVault';
 import { useLayoutSize } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
 import { TradeBoxActionButton } from './TradeBoxActionButton';
 import { WrapNativeTokenButton } from './WrapNativeTokenButton';
+import { useTradeBoxEarnOptions } from './hooks/useTradeBoxEarnOptions';
 
 type TradeBoxProps = {
     account: Account;
@@ -25,9 +24,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
     const { isBelowTablet, isBelowMobile } = useLayoutSize();
     const { device } = useDevice();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
-    const { hasYieldOption, bestVaultApy, bestVaultId } = useNativeYieldVault(account);
-
-    const hasEarnOption = hasNetworkFeatures(account, 'staking') || hasYieldOption;
+    const { hasEarnOption, yieldBadge } = useTradeBoxEarnOptions(account);
 
     return (
         <DashboardSection>
@@ -83,14 +80,14 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                                 </InfoItem>
                             </>
                         ) : null}
-                        {bestVaultApy !== null && (
+                        {yieldBadge && (
                             <Row alignItems="center">
                                 <YieldBadge
-                                    apy={bestVaultApy}
+                                    apy={yieldBadge.apy}
                                     variant="promo"
-                                    networkSymbol={account.symbol}
+                                    account={account}
+                                    vaultId={yieldBadge.vaultId}
                                     analyticsFrom="account-tradebox"
-                                    vaultId={bestVaultId ?? undefined}
                                 />
                             </Row>
                         )}

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -1,119 +1,33 @@
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
-import { type Route, goto } from '@suite/router';
-import { useServices } from '@suite-common/dependency-injection';
-import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { getNetworkDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
-import { Button, Card, Flex, InfoItem, Row, Text } from '@trezor/components';
+import { Card, Flex, InfoItem, Row, Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { TokenIcon } from '@trezor/product-components';
-import { exhaustive } from '@trezor/type-utils';
 
 import { DashboardSection } from 'src/components/dashboard';
+import { YieldBadge } from 'src/components/earn/YieldBadge/YieldBadge';
 import { PriceTicker, TrendTicker } from 'src/components/suite';
-import { useDispatch, useLayoutSize } from 'src/hooks/suite';
+import { useNativeYieldVault } from 'src/hooks/earn/useNativeYieldVault';
+import { useLayoutSize } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
+import { TradeBoxActionButton } from './TradeBoxActionButton';
 import { WrapNativeTokenButton } from './WrapNativeTokenButton';
 
 type TradeBoxProps = {
     account: Account;
 };
 
-type ActionType = 'buy' | 'sell' | 'exchange' | 'stake';
-
 export const TradeBox = ({ account }: TradeBoxProps) => {
     const { isBelowTablet, isBelowMobile } = useLayoutSize();
-    const dispatch = useDispatch();
     const { device } = useDevice();
-    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
+    const { hasYieldOption, bestVaultApy, bestVaultId } = useNativeYieldVault(account);
 
-    const isStakeNetwork = hasNetworkFeatures(account, 'staking');
-
-    const ActionButton = ({
-        type,
-        children,
-        isDisabled = false,
-    }: {
-        type: ActionType;
-        children: React.ReactNode;
-        isDisabled?: boolean;
-    }) => {
-        const gotoRouteName: Route['name'] =
-            type === 'stake' ? 'wallet-staking' : `wallet-trading-${type}`;
-        const gotoProps =
-            type === 'stake'
-                ? {
-                      routeName: gotoRouteName,
-                      preserveParams: true,
-                      params: {
-                          symbol: account.symbol,
-                          accountIndex: account.index,
-                          accountType: account.accountType,
-                      },
-                  }
-                : { routeName: gotoRouteName };
-        const dataTestId = type === 'stake' ? undefined : `@trading/menu/wallet-trading-${type}`;
-
-        const handleOnClick = () => {
-            dispatch(
-                tradingActions.setTradingFromPrefilledAccount(
-                    getTradingPrefilledFromAccountData(account),
-                ),
-            );
-
-            dispatch(goto(gotoProps));
-
-            switch (type) {
-                case 'buy':
-                case 'sell':
-                case 'exchange': {
-                    analytics.report({
-                        type: events.tradeNavigateEvent.name,
-                        payload: {
-                            action: 'navigate',
-                            type,
-                            from: 'account/tradebox',
-                            networkSymbol: account.symbol,
-                        },
-                    });
-
-                    break;
-                }
-                case 'stake': {
-                    analytics.report({
-                        type: events.stakingNavigateEvent.name,
-                        payload: {
-                            action: 'navigate',
-                            from: 'account/tradebox',
-                            networkSymbol: account.symbol,
-                        },
-                    });
-
-                    break;
-                }
-                default:
-                    exhaustive(type);
-            }
-        };
-
-        return (
-            <Button
-                intent="neutral"
-                priority="secondary"
-                size="small"
-                onClick={handleOnClick}
-                data-testid={dataTestId}
-                isDisabled={isDisabled}
-            >
-                {children}
-            </Button>
-        );
-    };
+    const hasEarnOption = hasNetworkFeatures(account, 'staking') || hasYieldOption;
 
     return (
         <DashboardSection>
@@ -169,23 +83,42 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                                 </InfoItem>
                             </>
                         ) : null}
+                        {bestVaultApy !== null && (
+                            <Row alignItems="center">
+                                <YieldBadge
+                                    apy={bestVaultApy}
+                                    variant="promo"
+                                    networkSymbol={account.symbol}
+                                    analyticsFrom="account-tradebox"
+                                    vaultId={bestVaultId ?? undefined}
+                                />
+                            </Row>
+                        )}
                     </Flex>
                     <Row gap={12}>
-                        {isStakeNetwork && (
-                            <ActionButton type="stake">
-                                <Translation id="TR_STAKE_STAKE" />
-                            </ActionButton>
+                        {hasEarnOption && (
+                            <TradeBoxActionButton account={account} type="earn">
+                                <Translation id="TR_EARN" />
+                            </TradeBoxActionButton>
                         )}
-                        <ActionButton type="buy">
+                        <TradeBoxActionButton account={account} type="buy">
                             <Translation id="TR_NAV_BUY" />
-                        </ActionButton>
-                        <ActionButton type="sell" isDisabled={account.empty}>
+                        </TradeBoxActionButton>
+                        <TradeBoxActionButton
+                            account={account}
+                            type="sell"
+                            isDisabled={account.empty}
+                        >
                             <Translation id="TR_NAV_SELL" />
-                        </ActionButton>
+                        </TradeBoxActionButton>
                         {!hasBitcoinOnlyFirmware(device) && (
-                            <ActionButton type="exchange" isDisabled={account.empty}>
+                            <TradeBoxActionButton
+                                account={account}
+                                type="exchange"
+                                isDisabled={account.empty}
+                            >
                                 <Translation id="TR_TRADING_SWAP" />
-                            </ActionButton>
+                            </TradeBoxActionButton>
                         )}
                         <WrapNativeTokenButton account={account} />
                     </Row>

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
@@ -1,0 +1,99 @@
+import { type ReactNode } from 'react';
+
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { type Route, goto } from '@suite/router';
+import { events as sharedEvents } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
+import { Button } from '@trezor/components';
+import { exhaustive } from '@trezor/type-utils';
+
+import { useDispatch } from 'src/hooks/suite';
+import { type Account } from 'src/types/wallet';
+
+// All action buttons share a fixed minimum so the row reads as a uniform group.
+const ACTION_BUTTON_MIN_WIDTH = 76;
+
+type TradeBoxActionType = 'buy' | 'sell' | 'exchange' | 'earn';
+
+type TradeBoxActionButtonProps = {
+    account: Account;
+    type: TradeBoxActionType;
+    children: ReactNode;
+    isDisabled?: boolean;
+};
+
+/** Navigates from the account TradeBox to the trading flow or the earn dashboard. */
+export const TradeBoxActionButton = ({
+    account,
+    type,
+    children,
+    isDisabled = false,
+}: TradeBoxActionButtonProps) => {
+    const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+
+    const dataTestId =
+        type === 'earn' ? '@account/tradebox/earn' : `@trading/menu/wallet-trading-${type}`;
+
+    const handleOnClick = () => {
+        switch (type) {
+            case 'buy':
+            case 'sell':
+            case 'exchange': {
+                const gotoRouteName: Route['name'] = `wallet-trading-${type}`;
+
+                dispatch(
+                    tradingActions.setTradingFromPrefilledAccount(
+                        getTradingPrefilledFromAccountData(account),
+                    ),
+                );
+
+                dispatch(goto({ routeName: gotoRouteName }));
+
+                analytics.report({
+                    type: events.tradeNavigateEvent.name,
+                    payload: {
+                        action: 'navigate',
+                        type,
+                        from: 'account/tradebox',
+                        networkSymbol: account.symbol,
+                    },
+                });
+
+                break;
+            }
+            case 'earn': {
+                dispatch(goto({ routeName: 'suite-earn' }));
+
+                analytics.report({
+                    type: sharedEvents.yieldNavigateEvent.name,
+                    payload: {
+                        action: 'continue',
+                        from: 'account-tradebox',
+                        to: 'earn-dashboard',
+                        networkSymbol: account.symbol,
+                    },
+                });
+
+                break;
+            }
+            default:
+                exhaustive(type);
+        }
+    };
+
+    return (
+        <Button
+            intent="neutral"
+            priority="secondary"
+            size="small"
+            minWidth={ACTION_BUTTON_MIN_WIDTH}
+            onClick={handleOnClick}
+            data-testid={dataTestId}
+            isDisabled={isDisabled}
+        >
+            {children}
+        </Button>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TradeBox/hooks/useTradeBoxEarnOptions.ts
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/hooks/useTradeBoxEarnOptions.ts
@@ -1,0 +1,40 @@
+import { hasNetworkFeatures, isApyAvailable } from '@suite-common/wallet-utils';
+
+import { useNativeYieldVault } from 'src/hooks/earn/useNativeYieldVault';
+import { useStakingRate } from 'src/hooks/earn/useStakingRate';
+import { type Account } from 'src/types/wallet';
+
+type TradeBoxYieldBadge = {
+    apy: number;
+    vaultId: string;
+};
+
+type TradeBoxEarnOptions = {
+    hasEarnOption: boolean;
+    yieldBadge: TradeBoxYieldBadge | null;
+};
+
+export const useTradeBoxEarnOptions = (account: Account): TradeBoxEarnOptions => {
+    const { hasYieldOption, bestVault } = useNativeYieldVault(account);
+    const { rate: stakingRate } = useStakingRate({
+        symbol: account.symbol,
+        accountKey: account.key,
+    });
+
+    // The token list badges advertise a single vault, while the trade box teases every way
+    // to earn on the account — so it shows the better of the vault and staking rates.
+    const yieldBadge = bestVault
+        ? {
+              apy:
+                  stakingRate !== null && isApyAvailable(stakingRate)
+                      ? Math.max(bestVault.apy, stakingRate)
+                      : bestVault.apy,
+              vaultId: bestVault.id,
+          }
+        : null;
+
+    return {
+        hasEarnOption: hasNetworkFeatures(account, 'staking') || hasYieldOption,
+        yieldBadge,
+    };
+};

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -8,7 +8,9 @@ type Attributes = {
     from: AttributeDef<
         | 'earn-dashboard'
         | 'account-banner'
+        | 'account-tokens'
         | 'account-defi-tokens'
+        | 'account-tradebox'
         | 'deposit-in-a-nutshell-modal'
         | 'deposit-legal-modal'
         | 'claim-select-account-modal'
@@ -51,14 +53,17 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         from: {
             description:
-                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens` and `claim-select-account-modal` are desktop-only; `account-banner` = in-account earn promo banner',
+                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens` and `claim-select-account-modal` are desktop-only; `account-tokens` = yield badge on the account Tokens tab, `account-defi-tokens` also covers the yield badge on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
                     version: '26.7.1',
                     notes: 'added `choose-account-sheet`, `account-detail`, `insufficient-balance-screen` values (mobile)',
                 },
-                { version: '26.8.0', notes: 'added `account-banner` value' },
+                {
+                    version: '26.8.0',
+                    notes: 'added `account-tokens`, `account-tradebox` values',
+                },
             ],
         },
         to: {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -1,4 +1,5 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
+import type { YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 
 import type { YieldPendingTransactionState } from './stablecoinYieldTypes';
 import {
@@ -12,7 +13,10 @@ import {
     getWrappableNativeBalance,
     getYieldDepositableBalance,
     getYieldFlowStepSequence,
+    getYieldVaultForOutputToken,
+    getYieldVaultsForInputToken,
     getYieldWrapAmount,
+    isYieldVaultOperational,
     splitYieldPendingTransaction,
 } from './stablecoinYieldUtils';
 
@@ -419,6 +423,243 @@ describe('stablecoinYieldUtils', () => {
             expect(getYieldWrapAmount({ totalAmount: '1', matchedWethBalance: undefined })).toBe(
                 '1',
             );
+        });
+    });
+
+    describe('vault token matching', () => {
+        const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+        const USDT_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+        const RECEIPT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+
+        const createVaultFixture = ({
+            network = 'ethereum',
+            tokenAddress,
+            tokenSymbol = 'USDC',
+            tokenDecimals = 6,
+            outputTokenAddress,
+            underMaintenance = false,
+            deprecated = false,
+            enter = true,
+        }: {
+            network?: YieldDtoV2['network'];
+            tokenAddress?: string;
+            tokenSymbol?: string;
+            tokenDecimals?: number;
+            outputTokenAddress?: string;
+            underMaintenance?: boolean;
+            deprecated?: boolean;
+            enter?: boolean;
+        }) =>
+            ({
+                metadata: { name: 'Vault', underMaintenance, deprecated },
+                network,
+                status: { enter, exit: true },
+                token: {
+                    symbol: tokenSymbol,
+                    network,
+                    name: tokenSymbol,
+                    decimals: tokenDecimals,
+                    address: tokenAddress,
+                },
+                outputToken: outputTokenAddress
+                    ? {
+                          symbol: `tr${tokenSymbol}`,
+                          network,
+                          name: `Vault ${tokenSymbol}`,
+                          decimals: 18,
+                          address: outputTokenAddress,
+                      }
+                    : undefined,
+            }) satisfies Pick<
+                YieldDtoV2,
+                'metadata' | 'network' | 'status' | 'token' | 'outputToken'
+            >;
+
+        const heldUsdc = { address: USDC_ADDRESS, symbol: 'USDC', decimals: 6 };
+
+        describe('isYieldVaultOperational', () => {
+            it('accepts a vault that is neither under maintenance nor deprecated', () => {
+                expect(isYieldVaultOperational(createVaultFixture({}))).toBe(true);
+            });
+
+            it('rejects a vault under maintenance', () => {
+                expect(
+                    isYieldVaultOperational(createVaultFixture({ underMaintenance: true })),
+                ).toBe(false);
+            });
+
+            it('rejects a deprecated vault', () => {
+                expect(isYieldVaultOperational(createVaultFixture({ deprecated: true }))).toBe(
+                    false,
+                );
+            });
+        });
+
+        describe('getYieldVaultsForInputToken', () => {
+            it('returns vaults whose input token matches the held token regardless of address case', () => {
+                const usdcVault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS.toLowerCase(),
+                });
+                const usdtVault = createVaultFixture({
+                    tokenAddress: USDT_ADDRESS,
+                    tokenSymbol: 'USDT',
+                });
+
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: [usdcVault, usdtVault],
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toEqual([usdcVault]);
+            });
+
+            it('filters out vaults on other networks', () => {
+                const polygonVault = createVaultFixture({
+                    network: 'polygon',
+                    tokenAddress: USDC_ADDRESS,
+                });
+
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: [polygonVault],
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toEqual([]);
+            });
+
+            it('filters out vaults under maintenance or deprecated', () => {
+                const maintainedVault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    underMaintenance: true,
+                });
+                const deprecatedVault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    deprecated: true,
+                });
+
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: [maintainedVault, deprecatedVault],
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toEqual([]);
+            });
+
+            it('filters out vaults with deposits closed', () => {
+                const closedVault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    enter: false,
+                });
+
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: [closedVault],
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toEqual([]);
+            });
+
+            it('matches by symbol and decimals when the vault token has no address', () => {
+                const addresslessVault = createVaultFixture({});
+
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: [addresslessVault],
+                        networkSymbol: 'eth',
+                        token: { address: USDC_ADDRESS, symbol: 'usdc', decimals: 6 },
+                    }),
+                ).toEqual([addresslessVault]);
+            });
+
+            it('returns an empty array when vaults are not loaded', () => {
+                expect(
+                    getYieldVaultsForInputToken({
+                        vaults: undefined,
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toEqual([]);
+            });
+        });
+
+        describe('getYieldVaultForOutputToken', () => {
+            const heldReceiptToken = { address: RECEIPT_ADDRESS, symbol: 'trUSDC', decimals: 18 };
+
+            it('finds the vault whose receipt token matches the held token', () => {
+                const vault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    outputTokenAddress: RECEIPT_ADDRESS.toUpperCase().replace('0X', '0x'),
+                });
+
+                expect(
+                    getYieldVaultForOutputToken({
+                        vaults: [vault],
+                        networkSymbol: 'eth',
+                        token: heldReceiptToken,
+                    }),
+                ).toBe(vault);
+            });
+
+            it('does not match a vault by its input token', () => {
+                const vault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    outputTokenAddress: RECEIPT_ADDRESS,
+                });
+
+                expect(
+                    getYieldVaultForOutputToken({
+                        vaults: [vault],
+                        networkSymbol: 'eth',
+                        token: heldUsdc,
+                    }),
+                ).toBeUndefined();
+            });
+
+            it('ignores vaults under maintenance', () => {
+                const vault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    outputTokenAddress: RECEIPT_ADDRESS,
+                    underMaintenance: true,
+                });
+
+                expect(
+                    getYieldVaultForOutputToken({
+                        vaults: [vault],
+                        networkSymbol: 'eth',
+                        token: heldReceiptToken,
+                    }),
+                ).toBeUndefined();
+            });
+
+            it('still matches a vault with deposits closed — it describes an existing position', () => {
+                const closedVault = createVaultFixture({
+                    tokenAddress: USDC_ADDRESS,
+                    outputTokenAddress: RECEIPT_ADDRESS,
+                    enter: false,
+                });
+
+                expect(
+                    getYieldVaultForOutputToken({
+                        vaults: [closedVault],
+                        networkSymbol: 'eth',
+                        token: heldReceiptToken,
+                    }),
+                ).toBe(closedVault);
+            });
+
+            it('returns undefined when vaults are not loaded', () => {
+                expect(
+                    getYieldVaultForOutputToken({
+                        vaults: undefined,
+                        networkSymbol: 'eth',
+                        token: heldReceiptToken,
+                    }),
+                ).toBeUndefined();
+            });
         });
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -16,6 +16,7 @@ import {
     getYieldVaultForOutputToken,
     getYieldVaultsForInputToken,
     getYieldWrapAmount,
+    hasYieldVaultPosition,
     isYieldVaultOperational,
     splitYieldPendingTransaction,
 } from './stablecoinYieldUtils';
@@ -583,6 +584,102 @@ describe('stablecoinYieldUtils', () => {
                         token: heldUsdc,
                     }),
                 ).toEqual([]);
+            });
+        });
+
+        describe('hasYieldVaultPosition', () => {
+            const vaultWithReceiptToken = createVaultFixture({
+                tokenAddress: USDC_ADDRESS,
+                outputTokenAddress: RECEIPT_ADDRESS,
+            });
+
+            const createHeldReceiptToken = (address: string, balance?: string) => ({
+                contract: address,
+                symbol: 'trUSDC',
+                decimals: 18,
+                balance,
+            });
+
+            it('reports a position when the receipt token is held with a balance', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '1.5')],
+                    }),
+                ).toBe(true);
+            });
+
+            it('matches the receipt token regardless of address case', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: [
+                            createHeldReceiptToken(
+                                RECEIPT_ADDRESS.toUpperCase().replace('0X', '0x'),
+                                '2',
+                            ),
+                        ],
+                    }),
+                ).toBe(true);
+            });
+
+            it('reports no position when the receipt token balance is zero', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '0')],
+                    }),
+                ).toBe(false);
+            });
+
+            it('reports no position when the receipt token has no balance yet', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, undefined)],
+                    }),
+                ).toBe(false);
+            });
+
+            it('does not treat holding the deposit token as a position', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: [
+                            {
+                                contract: USDC_ADDRESS,
+                                symbol: 'USDC',
+                                decimals: 6,
+                                balance: '500',
+                            },
+                        ],
+                    }),
+                ).toBe(false);
+            });
+
+            it('reports no position for a vault without a receipt token', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: createVaultFixture({ tokenAddress: USDC_ADDRESS }),
+                        accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '1')],
+                    }),
+                ).toBe(false);
+            });
+
+            it('reports no position when the account has no tokens', () => {
+                expect(
+                    hasYieldVaultPosition({
+                        networkSymbol: 'eth',
+                        vault: vaultWithReceiptToken,
+                        accountTokens: undefined,
+                    }),
+                ).toBe(false);
             });
         });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -11,6 +11,7 @@ import {
     isWrappedNativeToken,
     unitsToSubunits,
 } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
 
 import { YIELD_FLOW_AVAILABLE_STEPS } from './stablecoinYieldConstants';
@@ -599,6 +600,33 @@ export const getYieldVaultForOutputToken = <TVault extends YieldVaultMatchFields
             isYieldVaultOperational(vault) &&
             isYieldVaultOnNetwork(vault, networkSymbol) &&
             doTokensMatch({ networkSymbol, firstToken: token, secondToken: vault.outputToken }),
+    );
+
+type YieldVaultPositionParams = {
+    networkSymbol: NetworkSymbol;
+    vault: Pick<YieldDtoV2, 'outputToken'>;
+    accountTokens: Pick<TokenInfo, 'contract' | 'symbol' | 'decimals' | 'balance'>[] | undefined;
+};
+
+/** Whether the account already holds the vault's receipt token, i.e. has deposited into it. */
+export const hasYieldVaultPosition = ({
+    networkSymbol,
+    vault,
+    accountTokens,
+}: YieldVaultPositionParams): boolean =>
+    (accountTokens ?? []).some(
+        accountToken =>
+            accountToken.symbol !== undefined &&
+            doTokensMatch({
+                networkSymbol,
+                firstToken: {
+                    address: accountToken.contract,
+                    symbol: accountToken.symbol,
+                    decimals: accountToken.decimals,
+                },
+                secondToken: vault.outputToken,
+            }) &&
+            new BigNumber(accountToken.balance ?? '0').gt(0),
     );
 
 export const getAllowanceSpender = (flowData: YieldFlowResolvedData) =>

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -1,6 +1,6 @@
 import { Calldata, type EvmAddress } from '@suite-common/calldata';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetworkByYieldXyzId } from '@suite-common/wallet-config';
 import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import { type AccountKey, type EvmSelectedFee } from '@suite-common/wallet-types';
 import {
@@ -557,6 +557,49 @@ const getVaultAddressFromYieldId = (yieldId: string) =>
 
 export const getYieldVaultContractAddress = (vault: Pick<YieldDtoV2, 'id' | 'outputToken'>) =>
     vault.outputToken?.address ?? getVaultAddressFromYieldId(vault.id);
+
+export const isYieldVaultOperational = (vault: Pick<YieldDtoV2, 'metadata'>): boolean =>
+    !vault.metadata.underMaintenance && !vault.metadata.deprecated;
+
+type YieldVaultMatchFields = Pick<
+    YieldDtoV2,
+    'metadata' | 'network' | 'status' | 'token' | 'outputToken'
+>;
+
+type GetYieldVaultsForTokenParams<TVault extends YieldVaultMatchFields> = {
+    vaults: TVault[] | undefined;
+    networkSymbol: NetworkSymbol;
+    token: TokenLike;
+};
+
+const isYieldVaultOnNetwork = (vault: YieldVaultMatchFields, networkSymbol: NetworkSymbol) =>
+    getNetworkByYieldXyzId(vault.network)?.symbol === networkSymbol;
+
+// Input-token matching invites a deposit, so it also requires deposits to be open.
+export const getYieldVaultsForInputToken = <TVault extends YieldVaultMatchFields>({
+    vaults,
+    networkSymbol,
+    token,
+}: GetYieldVaultsForTokenParams<TVault>): TVault[] =>
+    (vaults ?? []).filter(
+        vault =>
+            isYieldVaultOperational(vault) &&
+            vault.status.enter &&
+            isYieldVaultOnNetwork(vault, networkSymbol) &&
+            doTokensMatch({ networkSymbol, firstToken: token, secondToken: vault.token }),
+    );
+
+export const getYieldVaultForOutputToken = <TVault extends YieldVaultMatchFields>({
+    vaults,
+    networkSymbol,
+    token,
+}: GetYieldVaultsForTokenParams<TVault>): TVault | undefined =>
+    vaults?.find(
+        vault =>
+            isYieldVaultOperational(vault) &&
+            isYieldVaultOnNetwork(vault, networkSymbol) &&
+            doTokensMatch({ networkSymbol, firstToken: token, secondToken: vault.outputToken }),
+    );
 
 export const getAllowanceSpender = (flowData: YieldFlowResolvedData) =>
     flowData.receiptToken.contractAddress ?? getYieldVaultContractAddress(flowData.vault);

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10153,6 +10153,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_DEPOSIT',
         defaultMessage: 'Deposit',
     },
+    TR_EARN_YIELD_BADGE_RATE: {
+        id: 'TR_EARN_YIELD_BADGE_RATE',
+        defaultMessage: '{apy}% Yield',
+    },
+    TR_EARN_YIELD_BADGE_UP_TO_RATE: {
+        id: 'TR_EARN_YIELD_BADGE_UP_TO_RATE',
+        defaultMessage: 'up to {apy}% Yield',
+    },
     TR_EARN_YIELD_APY_SOURCE_LENDING_INTEREST: {
         id: 'TR_EARN_YIELD_APY_SOURCE_LENDING_INTEREST',
         defaultMessage: 'Automatically added and compounded.',

--- a/suite/router/src/anchor.test.ts
+++ b/suite/router/src/anchor.test.ts
@@ -6,6 +6,53 @@ describe('anchor utils', () => {
         expect(anchorUtils.getTxAnchor('txid')).toBe('@account/transaction/txid');
     });
 
+    describe('getEarnYieldRowAnchor', () => {
+        it('identifies the row by network, account type and index — never by account key', () => {
+            expect(
+                anchorUtils.getEarnYieldRowAnchor({
+                    symbol: 'eth',
+                    accountType: 'normal',
+                    accountIndex: 0,
+                    vaultId: 'ethereum:1:0x58d97b57bb95320f9a05dc918aef65434969c2b2',
+                }),
+            ).toBe(
+                '@earn/yield/eth-normal-0/ethereum:1:0x58d97b57bb95320f9a05dc918aef65434969c2b2',
+            );
+        });
+
+        it('distinguishes accounts of the same network holding the same vault', () => {
+            const vaultId = 'ethereum:1:0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+
+            expect(
+                anchorUtils.getEarnYieldRowAnchor({
+                    symbol: 'eth',
+                    accountType: 'normal',
+                    accountIndex: 0,
+                    vaultId,
+                }),
+            ).not.toBe(
+                anchorUtils.getEarnYieldRowAnchor({
+                    symbol: 'eth',
+                    accountType: 'normal',
+                    accountIndex: 1,
+                    vaultId,
+                }),
+            );
+        });
+    });
+
+    describe('isEarnYieldRowAnchor', () => {
+        it.each([
+            ['@earn/yield/eth-normal-0/ethereum:1:0xabc', true],
+            ['@earn/yield', false],
+            ['@earn/staking', false],
+            ['@account/transaction/txid', false],
+            [undefined, false],
+        ])('%s -> %s', (anchor, expected) => {
+            expect(anchorUtils.isEarnYieldRowAnchor(anchor)).toBe(expected);
+        });
+    });
+
     fixtures.findAnchorTransactionPage.forEach(f => {
         it(`findAnchorTransactionPage ${f.testName}`, () => {
             expect(

--- a/suite/router/src/anchorUtils.ts
+++ b/suite/router/src/anchorUtils.ts
@@ -1,11 +1,35 @@
+import type { AccountType, NetworkSymbol } from '@suite-common/wallet-config';
 import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 
-import { AccountTransactionBaseAnchor, type AnchorType } from './anchors';
+import { AccountTransactionBaseAnchor, type AnchorType, EarnAnchor } from './anchors';
+
+type EarnYieldRowAnchorParams = {
+    symbol: NetworkSymbol;
+    accountIndex: number;
+    accountType: NonNullable<AccountType>;
+    vaultId: string;
+};
 
 const getTxIdFromAnchor = (anchor?: string): string => anchor?.split('/').pop() || '';
 
 export const getTxAnchor = (txId?: string): AnchorType | undefined =>
     txId ? `${AccountTransactionBaseAnchor}/${txId}` : undefined;
+
+/**
+ * Anchor of a single (account, vault) row of the Earn yield dashboard. The account is
+ * identified the way routes identify it, never by its account key — that one embeds the
+ * account descriptor and the device session id, and anchors are reported to analytics.
+ */
+export const getEarnYieldRowAnchor = ({
+    symbol,
+    accountIndex,
+    accountType,
+    vaultId,
+}: EarnYieldRowAnchorParams): AnchorType =>
+    `${EarnAnchor.Yield}/${symbol}-${accountType}-${accountIndex}/${vaultId}`;
+
+export const isEarnYieldRowAnchor = (anchor?: string): boolean =>
+    anchor?.startsWith(`${EarnAnchor.Yield}/`) ?? false;
 
 export const findAnchorTransactionPage = (
     transactions: WalletAccountTransaction[],

--- a/suite/router/src/useAnchor.ts
+++ b/suite/router/src/useAnchor.ts
@@ -4,34 +4,56 @@ import { useSelector } from 'react-redux';
 import { selectRouterAnchor } from './routerReducer';
 import { ScrollContext } from './scrollContext';
 
-export const useAnchor = (anchorId: string) => {
+export const useAnchor = <TElement extends HTMLElement = HTMLDivElement>(anchorId: string) => {
     const { scrollRef, topOffset } = useContext(ScrollContext);
-    const anchorRef = useRef<HTMLDivElement>(null);
+    const anchorRef = useRef<TElement>(null);
     const anchor = useSelector(selectRouterAnchor);
+    const isAnchored = anchorId === anchor;
 
     useEffect(() => {
-        if (anchorId === anchor && anchorRef.current) {
-            const scrollContainer = scrollRef.current;
+        const element = anchorRef.current;
+        const scrollContainer = scrollRef.current;
 
-            if (!scrollContainer) {
-                return;
-            }
-
-            const element = anchorRef.current;
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const elementRect = element.getBoundingClientRect();
-            const relativeTop = elementRect.top - containerRect.top + scrollContainer.scrollTop;
-            const offsetPosition = relativeTop - topOffset;
-
-            scrollContainer.scrollTo({
-                top: offsetPosition,
-                behavior: 'smooth',
-            });
+        if (!isAnchored || !element || !scrollContainer) {
+            return;
         }
-    }, [anchor, anchorId, scrollRef, topOffset]);
+
+        // An IntersectionObserver hands over geometry the browser has already computed,
+        // unlike getBoundingClientRect which forces a synchronous layout. It reports once
+        // right after observation starts, which is all the anchor needs — and that first
+        // report also covers elements that mount after the anchor was set.
+        const observer = new IntersectionObserver(
+            entries => {
+                const lastEntry = entries.at(-1);
+
+                observer.disconnect();
+
+                if (!lastEntry?.rootBounds) {
+                    return;
+                }
+
+                const relativeTop =
+                    lastEntry.boundingClientRect.top -
+                    lastEntry.rootBounds.top +
+                    scrollContainer.scrollTop;
+
+                window.requestAnimationFrame(() => {
+                    scrollContainer.scrollTo({
+                        top: relativeTop - topOffset,
+                        behavior: 'smooth',
+                    });
+                });
+            },
+            { root: scrollContainer },
+        );
+
+        observer.observe(element);
+
+        return () => observer.disconnect();
+    }, [isAnchored, scrollRef, topOffset]);
 
     return {
         anchorRef,
-        shouldHighlight: anchorId === anchor,
+        shouldHighlight: isAnchored,
     };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Introduce YieldBadge component and related utilities. There 3 different occurrences:

1. As part of `TradeBox` component. Here, it shows best APY across staking / vaults and redirects only to Earn page (no anchor, or highlighting)
<img width="1452" height="431" alt="Snímek obrazovky 2026-07-30 v 11 55 42" src="https://github.com/user-attachments/assets/c0ca6b6f-99b7-4da5-ad9c-a9c9669be718" />


2. As part of `Tokens` tab. It shows best stablecoin Yield APY, redirects to Earn with anchor directly at given vault.
<img width="1455" height="611" alt="Snímek obrazovky 2026-07-30 v 11 55 51" src="https://github.com/user-attachments/assets/6951dd33-f0aa-4198-9608-080731d89481" />
 

3. As part of `DeFi` tab. Basically same as the 2. point
<img width="1455" height="665" alt="Snímek obrazovky 2026-07-30 v 11 55 56" src="https://github.com/user-attachments/assets/fae9ecfc-a7e1-439c-afbf-a718c57bd20c" />


- Also, fix layout trashing (improve perf.) of `useAnchor`: use observer API instead of JS methods causing sync. layout calc, usually prolonging given frame over its time budget, thus making the transition look not smooth. 

## Notes for QA


## Related Issue

Resolve #27898




<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/27898-yield-apy-at-tokens/web/](https://dev.suite.sldev.cz/suite-web/feat/27898-yield-apy-at-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/27898-yield-apy-at-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/27898-yield-apy-at-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/27898-yield-apy-at-tokens&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:15:41.665Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:15:43.369Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->