### PR TITLE
fix(suite): export Suite Sync transaction labels

### DIFF
--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -1,5 +1,3 @@
-import { type MetadataRootState } from '@suite/metadata';
-import { type AccountLabels } from '@suite-common/metadata-types';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
 import {
     type TokenDefinitionsRootState,
@@ -11,6 +9,7 @@ import {
     TRANSACTIONS_MODULE_PREFIX,
     type TransactionsRootState,
     type WalletSettingsRootState,
+    createSimpleTargetId,
     selectAccountTransactionsMarkedAsNotScam,
     selectBaseCurrency,
     selectHistoricFiatRates,
@@ -27,12 +26,10 @@ import { formatData, getExportedFileName } from 'src/utils/wallet/exportTransact
 
 type ExportTransactionsThunkParams = {
     account: Account;
-    accountName: string;
+    defaultAccountName: string;
     type: ExportFileType;
     searchQuery: string;
 };
-
-const selectMetadataState = (state: MetadataRootState) => state.metadata;
 
 type ExportTransactionsThunkState = FiatRatesRootState &
     SelectAccountLabelsForSearchState &
@@ -50,7 +47,7 @@ export const exportTransactionsThunk = createThunk<
     { state: ExportTransactionsThunkState; extra: ExportTransactionsThunkDeps }
 >(
     `${TRANSACTIONS_MODULE_PREFIX}/exportTransactions`,
-    async ({ account, accountName, type, searchQuery }, { getState, extra }) => {
+    async ({ account, defaultAccountName, type, searchQuery }, { getState, extra }) => {
         const { services } = extra;
         // Get state of transactions
         const allTransactions = selectTransactions(getState());
@@ -62,19 +59,8 @@ export const exportTransactionsThunk = createThunk<
             account.key,
         );
 
-        // TODO: this is not nice (copy-paste)
-        // metadata reducer is still not part of trezor-common and I can not import it
-        // here. so either followup, or maybe when I have a moment I'll refactor it  before merging this
-        const provider = selectMetadataState(getState())?.providers.find(
-            p => p.clientId === selectMetadataState(getState()).selectedProvider.labels,
-        );
-        const metadataKeys = account?.metadata[1];
-        let labels: Partial<AccountLabels> = {};
-        if (!metadataKeys?.fileName || !provider?.data[metadataKeys.fileName]) {
-            labels = { outputLabels: {} };
-        } else {
-            labels = provider.data[metadataKeys.fileName] as AccountLabels;
-        }
+        const accountLabels = selectAccountLabelsForSearch(getState(), account);
+        const accountName = accountLabels.accountLabel || defaultAccountName;
 
         const transactions = getAccountTransactions(account.key, allTransactions)
             .filter(transaction => transaction.blockHeight !== -1)
@@ -82,15 +68,15 @@ export const exportTransactionsThunk = createThunk<
                 ...transaction,
                 targets: transaction.targets.map(target => ({
                     ...target,
-                    metadataLabel: labels.outputLabels?.[transaction.txid]?.[target.n],
+                    metadataLabel: accountLabels.outputLabels
+                        .get(transaction.txid)
+                        ?.get(createSimpleTargetId(target)),
                 })),
             }));
 
-        const searchLabels = selectAccountLabelsForSearch(getState(), account);
-
         const filteredTransaction =
             searchQuery.trim() !== ''
-                ? advancedSearchTransactions(transactions, searchLabels, searchQuery)
+                ? advancedSearchTransactions(transactions, accountLabels, searchQuery)
                 : transactions;
 
         // getAccountTransactions doesn't guarantee transactions will be sorted

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -68,7 +68,7 @@ export const exportTransactionsThunk = createThunk<
                 ...transaction,
                 targets: transaction.targets.map(target => ({
                     ...target,
-                    metadataLabel: accountLabels.outputLabels
+                    outputLabel: accountLabels.outputLabels
                         .get(transaction.txid)
                         ?.get(createSimpleTargetId(target)),
                 })),

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -29,7 +29,7 @@ import { type TransactionTarget } from '@trezor/connect';
 import { BigNumber, isNotNull } from '@trezor/utils';
 
 type AccountTransactionForExports = Omit<WalletAccountTransaction, 'targets'> & {
-    targets: (TransactionTarget & { metadataLabel?: string })[];
+    targets: (TransactionTarget & { outputLabel?: string })[];
 };
 
 type Data = {
@@ -203,7 +203,7 @@ const prepareContent = (
                         fee: !hasFeeBeenAlreadyUsed ? t.fee : '', // fee only once per tx
                         feeSymbol: !hasFeeBeenAlreadyUsed ? symbol : '',
                         address: target.isAddress ? (target.addresses[0] ?? '') : '', // SENT - it is destination address, RECV - it is MY address
-                        label: target.isAddress && target.metadataLabel ? target.metadataLabel : '',
+                        label: target.isAddress && target.outputLabel ? target.outputLabel : '',
                         amount: target.isAddress ? target.amount : '',
                         symbol: target.isAddress ? symbol : '',
                         fiat: target.isAddress ? getFiatAmount(target.amount, historicRate) : '',

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -2,7 +2,6 @@ import { useCallback, useState } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
-import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
 import { useServices } from '@suite-common/dependency-injection';
 import { useDispatch } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -14,7 +13,6 @@ import { Dropdown, Note } from '@trezor/components';
 import { ChecksIcon, FileArrowDownIcon, InfoIcon } from '@trezor/icons';
 
 import { exportTransactionsThunk } from 'src/actions/wallet/exportTransactionsActions';
-import { useSelector } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
 
 export interface ExportActionProps {
@@ -39,8 +37,6 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
         });
     }, [account, translationString]);
 
-    const { accountLabel } = useSelector(selectLabelingDataForSelectedAccount);
-
     const runExport = useCallback(
         async (type: ExportFileType) => {
             if (isExportRunning) {
@@ -63,11 +59,10 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
                         noLoading: true,
                     }),
                 );
-                const accountName = accountLabel || getAccountTitle();
                 await dispatch(
                     exportTransactionsThunk({
                         account,
-                        accountName,
+                        defaultAccountName: getAccountTitle(),
                         type,
                         searchQuery,
                     }),
@@ -89,7 +84,6 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
             analytics,
             account,
             dispatch,
-            accountLabel,
             getAccountTitle,
             searchQuery,
             translationString,

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 import { mnemonic12Fixtures } from '@suite-common/e2e-evolu-client';
 
 import { AccountLabelId } from '../../../support/enums/accountLabelId';
@@ -31,7 +33,13 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
         await metadataPage.enableSuiteSync();
     });
 
-    test('Create new labels', async ({ evoluClient, dashboardPage, walletPage, metadataPage }) => {
+    test('Create new labels', async ({
+        evoluClient,
+        dashboardPage,
+        walletPage,
+        metadataPage,
+        page,
+    }) => {
         await test.step('Change account label', async () => {
             await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
             await metadataPage.account.changeLabel({
@@ -81,6 +89,21 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
                     Number(expectedOutput.outputIndex),
                 ),
             ).toHaveText(expectedOutput.label);
+        });
+
+        await test.step('Export account and output labels', async () => {
+            const downloadPromise = page.waitForEvent('download');
+            await walletPage.exportTransactions('csv');
+            const download = await downloadPromise;
+
+            expect(download.suggestedFilename()).toContain(
+                expectedAccount.label.replaceAll(' ', '_'),
+            );
+
+            const downloadPath = await download.path();
+            const exportedTransactions = fs.readFileSync(downloadPath, 'utf8');
+
+            expect(exportedTransactions).toContain(expectedOutput.label);
         });
 
         await test.step('Verify data are sync to Relay', async () => {

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -117,14 +117,25 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await walletPage.exportTransactions('csv');
                 const download = await downloadPromise;
 
-                expect(download.suggestedFilename()).toContain(
-                    expectedAccount.label.replaceAll(' ', '_'),
+                expect(download.suggestedFilename()).toMatch(
+                    new RegExp(
+                        `^${expectedAccount.label.replaceAll(' ', '_')}_\\d{8}T\\d{6}\\.csv$`,
+                    ),
                 );
 
                 const downloadPath = await download.path();
                 const exportedTransactions = fs.readFileSync(downloadPath, 'utf8');
+                const [header, ...rows] = exportedTransactions
+                    .split('\n')
+                    .map(row => row.split(','));
+                const transactionIdColumnIndex = header?.indexOf('Transaction ID') ?? -1;
+                const labelColumnIndex = header?.indexOf('Label') ?? -1;
+                const exportedOutputLabels = rows
+                    .filter(row => row[transactionIdColumnIndex] === expectedOutput.txId)
+                    .map(row => row[labelColumnIndex])
+                    .filter(label => label !== '');
 
-                expect(exportedTransactions).toContain(expectedOutput.label);
+                expect(exportedOutputLabels).toEqual([expectedOutput.label]);
             });
         },
     );

--- a/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts
@@ -33,13 +33,7 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
         await metadataPage.enableSuiteSync();
     });
 
-    test('Create new labels', async ({
-        evoluClient,
-        dashboardPage,
-        walletPage,
-        metadataPage,
-        page,
-    }) => {
+    test('Create new labels', async ({ evoluClient, dashboardPage, walletPage, metadataPage }) => {
         await test.step('Change account label', async () => {
             await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
             await metadataPage.account.changeLabel({
@@ -91,21 +85,6 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
             ).toHaveText(expectedOutput.label);
         });
 
-        await test.step('Export account and output labels', async () => {
-            const downloadPromise = page.waitForEvent('download');
-            await walletPage.exportTransactions('csv');
-            const download = await downloadPromise;
-
-            expect(download.suggestedFilename()).toContain(
-                expectedAccount.label.replaceAll(' ', '_'),
-            );
-
-            const downloadPath = await download.path();
-            const exportedTransactions = fs.readFileSync(downloadPath, 'utf8');
-
-            expect(exportedTransactions).toContain(expectedOutput.label);
-        });
-
         await test.step('Verify data are sync to Relay', async () => {
             await evoluClient.init({ ownerSecret: mnemonic12Fixtures.ownerSecret });
             await evoluClient.expectInTable('account', [expectedAccount], { softExpect: true });
@@ -114,4 +93,39 @@ test.describe('Suite Sync - Labelling', { tag: ['@T3W1', '@T3T1'] }, () => {
             await evoluClient.expectInTable('output', [expectedOutput], { softExpect: true });
         });
     });
+
+    test(
+        'Export account and output labels',
+        { tag: ['@webOnly'] },
+        async ({ walletPage, metadataPage, page }) => {
+            await test.step('Create labels to export', async () => {
+                await walletPage.openAccount({ symbol: 'btc', type: 'normal', atIndex: 0 });
+                await metadataPage.account.changeLabel({
+                    accountId: AccountLabelId.BitcoinDefault1,
+                    label: expectedAccount.label,
+                    confirmSuiteSync: true,
+                });
+                await metadataPage.output.changeLabel({
+                    outputId: expectedOutput.txId,
+                    txNumber: Number(expectedOutput.outputIndex),
+                    label: expectedOutput.label,
+                });
+            });
+
+            await test.step('Export and verify labels', async () => {
+                const downloadPromise = page.waitForEvent('download');
+                await walletPage.exportTransactions('csv');
+                const download = await downloadPromise;
+
+                expect(download.suggestedFilename()).toContain(
+                    expectedAccount.label.replaceAll(' ', '_'),
+                );
+
+                const downloadPath = await download.path();
+                const exportedTransactions = fs.readFileSync(downloadPath, 'utf8');
+
+                expect(exportedTransactions).toContain(expectedOutput.label);
+            });
+        },
+    );
 });


### PR DESCRIPTION
## Description

Resolves https://github.com/trezor/trezor-suite/issues/27953. Transaction exports previously read labels directly from the deprecated legacy metadata provider, leaving Suite Sync output-label columns empty and filenames on default account names. The export now uses the provider-aware account label selector and normalized output IDs; its download-content E2E is web-only because Playwright does not emit Electron download events, while the original cross-platform labeling coverage remains on desktop.

- Suite Web T3W1 export E2E: **1 passed in 2.7 minutes**
- Suite Desktop T3W1 labeling E2E: **1 passed in 2.7 minutes**
- E2E lint and type-check: **passed**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily modifies the transaction export pipeline (action, utility, and UI trigger) plus one suite-sync test file. The highest-risk regressions would be broken or malformed transaction exports. Run the dedicated export test and the CSV export-with-labels test for coverage of the source changes, and run the modified test file to validate its own changes.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/actions/wallet/exportTransactionsActions.ts`
- `packages/suite/src/utils/wallet/exportTransactionsUtils.ts`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx`
- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/create-new-labels.test.ts` — This test file itself was modified in the change set, so it must be executed to verify the test changes are valid and the suite-sync label creation flow still passes.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Directly validates the transaction export feature across PDF, CSV, and JSON formats for BTC, LTC, ETH, and ADA networks. Changes to exportTransactionsActions.ts, exportTransactionsUtils.ts, and ExportAction.tsx directly impact the code paths this test exercises.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test includes a CSV transaction export assertion that verifies output labels are preserved in exported files. Changes to export utilities could alter CSV formatting and affect label inclusion.

</details>

_Updated: 2026-09-02T11:24:20.253Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-sync-transaction-export/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-sync-transaction-export/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-sync-transaction-export&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-sync-transaction-export&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-02T11:26:59.476Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-09-02T11:26:40.175Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->