### PR TITLE
fix(suite-native): ensure that custom network backends are persisted

### DIFF
--- a/suite-native/state/package.json
+++ b/suite-native/state/package.json
@@ -33,6 +33,7 @@
         "@suite-common/thp": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/token-definitions": "workspace:*",
+        "@suite-common/wallet-config": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/walletconnect": "workspace:*",
         "@suite-native/analytics": "workspace:*",

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -17,6 +17,7 @@ import { suiteSyncQuotaManagerReducer } from '@suite-common/suite-sync-quota-man
 import { prepareThpReducer } from '@suite-common/thp';
 import { createNotificationsReducer } from '@suite-common/toast-notifications';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
+import { networkSymbolCollection } from '@suite-common/wallet-config';
 import {
     accountsRefreshTimeReducer,
     feesReducer,
@@ -118,7 +119,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
 
     const blockchainPersistedReducer = preparePersistReducer({
         reducer: blockchainReducer,
-        persistedKeys: ['btc'],
+        persistedKeys: networkSymbolCollection,
         key: 'blockchain',
         version: 1,
         transforms: [blockchainPersistTransform],

--- a/suite-native/state/tsconfig.json
+++ b/suite-native/state/tsconfig.json
@@ -52,6 +52,9 @@
             "path": "../../suite-common/token-definitions"
         },
         {
+            "path": "../../suite-common/wallet-config"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/storage/src/transforms/blockchainTransforms.ts
+++ b/suite-native/storage/src/transforms/blockchainTransforms.ts
@@ -2,14 +2,16 @@ import { createTransform } from 'redux-persist';
 
 import { type Blockchain } from '@suite-common/wallet-types';
 
-export const blockchainPersistTransform = createTransform<Blockchain, Pick<Blockchain, 'backends'>>(
-    inboundState => ({ backends: inboundState.backends }),
+export const blockchainPersistTransform = createTransform<
+    Blockchain,
+    Pick<Blockchain, 'backends'> | undefined
+>(
+    ({ backends }) => (backends && Object.keys(backends).length > 0 ? { backends } : undefined),
     outboundState => ({
         connected: false,
         blockHash: '0',
         blockHeight: 0,
         version: '0',
-        backends: outboundState.backends,
+        backends: outboundState ? outboundState.backends : {},
     }),
-    { whitelist: ['btc'] },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13772,6 +13772,7 @@ __metadata:
     "@suite-common/thp": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/token-definitions": "workspace:*"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/walletconnect": "workspace:*"
     "@suite-native/analytics": "workspace:*"


### PR DESCRIPTION
## Description

Only non-empty `backends` configuration objects are persisted, default `{}` is ignored.

## Related Issue

Resolve #30399

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/network-backends-persist&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/network-backends-persist&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/network-backends-persist&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files all belong to `suite-native` (the mobile application): state package configuration, Redux reducers, and mobile storage transforms. None of the 117 candidate tests cover `suite-native`; they are all `suite/e2e` tests for the web/desktop Suite application. Therefore no test in the provided list can provide meaningful coverage or regression detection for these changes. A mobile-native test suite would be required to validate this change set.

<details><summary><b>Changed files (4)</b></summary>

- `suite-native/state/package.json`
- `suite-native/state/src/reducers.ts`
- `suite-native/state/tsconfig.json`
- `suite-native/storage/src/transforms/blockchainTransforms.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `suite-native/state/package.json`
- `suite-native/state/src/reducers.ts`
- `suite-native/state/tsconfig.json`
- `suite-native/storage/src/transforms/blockchainTransforms.ts`

_Updated: 2026-07-29T12:21:36.192Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/network-backends-persist/web/](https://dev.suite.sldev.cz/suite-web/fix/native/network-backends-persist/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:25:06.030Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:24:30.598Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->