### PR TITLE
test(connect): co-locate firmware info scenarios

### DIFF
--- a/packages/connect/src/data/getReleaseInfo.bootloader.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.bootloader.test.ts
@@ -2,7 +2,7 @@ import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
-import { getReleaseInfo } from '../firmwareInfo';
+import { getReleaseInfo } from './firmwareInfo';
 
 const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
 

--- a/packages/connect/src/data/getReleaseInfo.firmware.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.firmware.test.ts
@@ -2,7 +2,7 @@ import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
-import { getReleaseInfo } from '../firmwareInfo';
+import { getReleaseInfo } from './firmwareInfo';
 
 const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
 

--- a/packages/connect/src/data/getReleaseInfo.fresh.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.fresh.test.ts
@@ -2,7 +2,7 @@ import type { FirmwareRelease } from '@trezor/device-utils';
 import { DeviceModelInternal, FirmwareType } from '@trezor/device-utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
-import { getReleaseInfo } from '../firmwareInfo';
+import { getReleaseInfo } from './firmwareInfo';
 
 const { getDeviceFeatures, releasesT2T1 } = global.JestMocks;
 

--- a/packages/connect/src/data/getReleaseInfo.required.test.ts
+++ b/packages/connect/src/data/getReleaseInfo.required.test.ts
@@ -2,7 +2,7 @@ import type { FirmwareRelease } from '@trezor/device-utils';
 import { FirmwareType } from '@trezor/device-utils';
 import type { VersionArray } from '@trezor/utils/src/versionUtils';
 
-import { getReleaseInfo } from '../firmwareInfo';
+import { getReleaseInfo } from './firmwareInfo';
 
 const { getDeviceFeatures, releasesT1B1, releasesT2T1 } = global.JestMocks;
 


### PR DESCRIPTION
## Description

Moves the four `getReleaseInfo.*.test.ts` scenario suites out of the generic `__tests__` directory and beside `firmwareInfo.ts`, preserving each basename and test behavior. Relative imports now target the adjacent implementation.

- Colocation violations: **4 -> 0**
- Focused suites: **4 passed**
- Focused tests: **13 passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-firmware-info-tests/web/](https://dev.suite.sldev.cz/suite-web/test/connect-firmware-info-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-firmware-info-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-firmware-info-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/connect-firmware-info-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:09:07.653Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:04:20.974Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit test files for `getReleaseInfo` in `@trezor/connect`. They do not modify production source code or any behavior exercised by the Playwright E2E suite. No static coverage mapping exists, and there is no plausible path by which edits to these unit tests would affect E2E test outcomes. Therefore, no E2E tests are recommended.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/src/data/getReleaseInfo.bootloader.test.ts`
- `packages/connect/src/data/getReleaseInfo.firmware.test.ts`
- `packages/connect/src/data/getReleaseInfo.fresh.test.ts`
- `packages/connect/src/data/getReleaseInfo.required.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/connect/src/data/getReleaseInfo.bootloader.test.ts`
- `packages/connect/src/data/getReleaseInfo.firmware.test.ts`
- `packages/connect/src/data/getReleaseInfo.fresh.test.ts`
- `packages/connect/src/data/getReleaseInfo.required.test.ts`

_Updated: 2026-07-29T12:07:05.420Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->