### PR TITLE
test(connect-common): co-locate API type tests

### DIFF
--- a/packages/connect-common/src/types/api/bitcoin.type-test.ts
+++ b/packages/connect-common/src/types/api/bitcoin.type-test.ts
@@ -1,5 +1,5 @@
-import type { PrecomposedResult, TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { PrecomposedResult, TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 export const getAddress = async (api: TrezorConnect) => {
     // regular

--- a/packages/connect-common/src/types/api/blockchain.type-test.ts
+++ b/packages/connect-common/src/types/api/blockchain.type-test.ts
@@ -1,4 +1,4 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
 
 export const blockchainEstimateFee = async (api: TrezorConnect) => {
     const simple = await api.blockchainEstimateFee({ coin: 'btc' });

--- a/packages/connect-common/src/types/api/cardano.type-test.ts
+++ b/packages/connect-common/src/types/api/cardano.type-test.ts
@@ -1,7 +1,7 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 const {
     CardanoAddressType,

--- a/packages/connect-common/src/types/api/ethereum.type-test.ts
+++ b/packages/connect-common/src/types/api/ethereum.type-test.ts
@@ -1,5 +1,5 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 export const ethereumGetAddress = async (api: TrezorConnect) => {
     // regular

--- a/packages/connect-common/src/types/api/events.type-test.ts
+++ b/packages/connect-common/src/types/api/events.type-test.ts
@@ -1,6 +1,6 @@
 import { ThpPairingMethod } from '@trezor/protocol';
 
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
 import {
     BLOCKCHAIN,
     BLOCKCHAIN_EVENT,
@@ -8,7 +8,7 @@ import {
     TRANSPORT_EVENT,
     UI_EVENT,
     UI_REQUEST,
-} from '../../..';
+} from '../../index';
 
 export const events = (api: TrezorConnect) => {
     api.on(DEVICE_EVENT, event => {

--- a/packages/connect-common/src/types/api/index.type-test.ts
+++ b/packages/connect-common/src/types/api/index.type-test.ts
@@ -3,7 +3,7 @@
 import type {
     TrezorConnectPrivilegedAPI as TrezorConnect,
     // Exported types // TODO: breaking change missing ex: EthereumAddress
-} from '../../..';
+} from '../../index';
 
 export const init = async (api: TrezorConnect) => {
     const settings = await api.getSettings();

--- a/packages/connect-common/src/types/api/management.type-test.ts
+++ b/packages/connect-common/src/types/api/management.type-test.ts
@@ -1,6 +1,6 @@
 import { MessagesSchema as PROTO } from '@trezor/protobuf';
 
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
 
 export const management = async (api: TrezorConnect) => {
     const reset = await api.resetDevice({

--- a/packages/connect-common/src/types/api/misc.type-test.ts
+++ b/packages/connect-common/src/types/api/misc.type-test.ts
@@ -1,4 +1,4 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
 
 export const cipherKeyValue = async (api: TrezorConnect) => {
     const kv = await api.cipherKeyValue({

--- a/packages/connect-common/src/types/api/ripple.type-test.ts
+++ b/packages/connect-common/src/types/api/ripple.type-test.ts
@@ -1,5 +1,5 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 export const rippleGetAddress = async (api: TrezorConnect) => {
     // regular

--- a/packages/connect-common/src/types/api/stellar.type-test.ts
+++ b/packages/connect-common/src/types/api/stellar.type-test.ts
@@ -1,5 +1,5 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 export const stellarGetAddress = async (api: TrezorConnect) => {
     // regular

--- a/packages/connect-common/src/types/api/tezos.type-test.ts
+++ b/packages/connect-common/src/types/api/tezos.type-test.ts
@@ -1,5 +1,5 @@
-import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../..';
-import { asDeviceUniquePath } from '../../..';
+import type { TrezorConnectPrivilegedAPI as TrezorConnect } from '../../index';
+import { asDeviceUniquePath } from '../../index';
 
 export const tezosGetAddress = async (api: TrezorConnect) => {
     // regular


### PR DESCRIPTION
## Description

Reclassifies the 11 Connect API compile-time modules from an excluded `__tests__` directory as adjacent `.type-test.ts` files. Their public-API imports now use the explicit package index, so lint accepts the colocated paths and the package type-check actively validates them.

- Hidden compile-time modules: **11 -> 0**
- Active colocated type tests: **11**
- Emitted type-test files in `lib/`: **0**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are `.type-test.ts` files under `packages/connect-common/src/types/api/`. These are compile-time type assertions for the @trezor/connect public API and do not contain any runtime code. Playwright E2E tests exercise runtime behavior, so no E2E test can provide meaningful signal for this change set. The appropriate validation is TypeScript type-checking / tsd-style unit tests, not end-to-end tests. Running E2E tests here would waste CI resources without improving confidence.

<details><summary><b>Changed files (11)</b></summary>

- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect-common/src/types/api/blockchain.type-test.ts`
- `packages/connect-common/src/types/api/cardano.type-test.ts`
- `packages/connect-common/src/types/api/ethereum.type-test.ts`
- `packages/connect-common/src/types/api/events.type-test.ts`
- `packages/connect-common/src/types/api/index.type-test.ts`
- `packages/connect-common/src/types/api/management.type-test.ts`
- `packages/connect-common/src/types/api/misc.type-test.ts`
- `packages/connect-common/src/types/api/ripple.type-test.ts`
- `packages/connect-common/src/types/api/stellar.type-test.ts`
- `packages/connect-common/src/types/api/tezos.type-test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (11)**
- `packages/connect-common/src/types/api/bitcoin.type-test.ts`
- `packages/connect-common/src/types/api/blockchain.type-test.ts`
- `packages/connect-common/src/types/api/cardano.type-test.ts`
- `packages/connect-common/src/types/api/ethereum.type-test.ts`
- `packages/connect-common/src/types/api/events.type-test.ts`
- `packages/connect-common/src/types/api/index.type-test.ts`
- `packages/connect-common/src/types/api/management.type-test.ts`
- `packages/connect-common/src/types/api/misc.type-test.ts`
- `packages/connect-common/src/types/api/ripple.type-test.ts`
- `packages/connect-common/src/types/api/stellar.type-test.ts`
- `packages/connect-common/src/types/api/tezos.type-test.ts`

_Updated: 2026-07-29T12:05:25.751Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-common-api-type-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-common-api-type-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:08:04.066Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:06:51.138Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-common-api-type-tests/web/](https://dev.suite.sldev.cz/suite-web/test/connect-common-api-type-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->