### PR TITLE
fix(ci): resolve network package paths in connect release scripts

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -43,17 +43,6 @@ runs:
     - name: Publish to NPM
       shell: bash
       run: |
-        if [[ "${{ inputs.packageName }}" == network-* ]]; then
-          # e.g. "network-solana-sdk"
-          remainder="${{ inputs.packageName }}"
-          # Strip "network-" prefix -> "solana-sdk"
-          remainder="${remainder#network-}"
-          # Strip from first dash onward -> "solana"
-          network="${remainder%%-*}"
-          # Result: ./networks/solana/network-solana-sdk
-          cd "./networks/${network}/${{ inputs.packageName }}"
-        else
-          cd ./packages/${{ inputs.packageName }}
-        fi
+        cd "$(node ./scripts/ci/trezor-package-path.js "${{ inputs.packageName }}")"
         yarn build:lib
         yarn npm publish --tag ${{ inputs.deploymentType }} --access public --provenance

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -15,7 +15,7 @@ if (args.length < 2)
 const [packageName, distTag] = args;
 
 if (!['latest', 'beta', 'alpha'].includes(distTag)) {
-    throw new Error('distTag (3rd parameter) must be "alpha", "beta", or "latest"');
+    throw new Error('distTag (2nd parameter) must be "alpha", "beta", or "latest"');
 }
 
 const PACKAGE_PATH = getTrezorPackageDir(packageName);

--- a/scripts/ci/check-version.js
+++ b/scripts/ci/check-version.js
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
+import { getTrezorPackageDir } from './trezor-package-path.js';
+
 const args = process.argv.slice(2);
 
 if (args.length < 2)
@@ -16,11 +18,7 @@ if (!['latest', 'beta', 'alpha'].includes(distTag)) {
     throw new Error('distTag (3rd parameter) must be "alpha", "beta", or "latest"');
 }
 
-const ROOT = path.join(import.meta.dirname, '..', '..');
-const NETWORK_MATCH = packageName.match(/^network-([^-]+)(-(.+))?$/);
-const PACKAGE_PATH = NETWORK_MATCH
-    ? path.join(ROOT, 'networks', NETWORK_MATCH[1], packageName)
-    : path.join(ROOT, 'packages', packageName);
+const PACKAGE_PATH = getTrezorPackageDir(packageName);
 
 // read package version
 const packageJSONRaw = fs.readFileSync(path.join(PACKAGE_PATH, 'package.json'), {

--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -8,6 +8,7 @@ import {
     exec,
     getPackageDependencies,
     getTrezorPackageDir,
+    getTrezorPackageRelativePath,
     gettingNpmDistributionTags,
 } from './helpers';
 import { isPackageOnNpmRegistry } from './npm-registry.js';
@@ -53,7 +54,7 @@ const getGitCommitByPackageName = (packageName: string, maxCount = 10) =>
         `${maxCount}`,
         '--pretty=tformat:"-   %s (%h)"',
         '--',
-        `./packages/${packageName}`,
+        `./${getTrezorPackageRelativePath(packageName)}`,
     ]);
 
 const splitByNewlines = (input: string) => input.split('\n');
@@ -175,7 +176,11 @@ const bumpConnect = async () => {
             const PACKAGE_JSON_PATH = path.join(PACKAGE_PATH, 'package.json');
 
             // This uses dependency version-bump-prompt.
-            await exec('yarn', ['bump', semver, `./packages/${packageName}/package.json`]);
+            await exec('yarn', [
+                'bump',
+                semver,
+                `./${getTrezorPackageRelativePath(packageName)}/package.json`,
+            ]);
 
             const rawPackageJSON = await readFile(PACKAGE_JSON_PATH, 'utf-8');
             const packageJSON = JSON.parse(rawPackageJSON);
@@ -343,7 +348,10 @@ const bumpConnect = async () => {
             });
         }
     } catch (error) {
-        console.info('error:', error);
+        console.error('error:', error);
+        // Without this the workflow reports success even though the bump stopped half-way
+        // through, leaving some packages bumped and no release PR created.
+        process.exitCode = 1;
     }
 };
 

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -4,6 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
 
+import { getTrezorPackageDir } from './trezor-package-path.js';
+
+export { getTrezorPackageDir, getTrezorPackageRelativePath } from './trezor-package-path.js';
+
 const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const updateNeeded: string[] = [];
@@ -33,14 +37,6 @@ export const getNpmRemoteGreatestVersion = async (moduleName: string) => {
         console.error('error:', error);
         throw new Error('Not possible to get remote greatest version');
     }
-};
-
-export const getTrezorPackageDir = (packageName: string) => {
-    const networkMatch = packageName.match(/^network-([^-]+)(-(.+))?$/);
-
-    return networkMatch
-        ? path.join(ROOT, 'networks', networkMatch[1]!, packageName)
-        : path.join(ROOT, 'packages', packageName);
 };
 
 export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {

--- a/scripts/ci/npm-reserve-package.js
+++ b/scripts/ci/npm-reserve-package.js
@@ -21,6 +21,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { isPackageOnNpmRegistry } from './npm-registry.js';
+import { getTrezorPackageDir } from './trezor-package-path.js';
 
 const ROOT = path.join(import.meta.dirname, '..', '..');
 
@@ -35,15 +36,6 @@ const RELEASE_ENVIRONMENT = 'production-connect';
 // `npm trust` was introduced in npm@11.15.0, which may be newer than the npm bundled with .nvmrc Node.
 const MINIMAL_NPM_MAJOR_WITH_TRUST = 11;
 const MINIMAL_NPM_MINOR_WITH_TRUST = 15;
-
-const getPackagePath = packageName => {
-    // Network packages live in ./networks/<network>/network-<network>, everything else in ./packages.
-    const networkMatch = packageName.match(/^network-([^-]+)(-(.+))?$/);
-
-    return networkMatch
-        ? path.join(ROOT, 'networks', networkMatch[1], packageName)
-        : path.join(ROOT, 'packages', packageName);
-};
 
 const run = ({ command, args, cwd = ROOT, isFatal = true }) => {
     console.log(`\n$ ${command} ${args.join(' ')}\n`);
@@ -180,7 +172,7 @@ const reserveNpmPackage = async () => {
     }
 
     const packageDirectoryName = packageNameArgument.replace('@trezor/', '');
-    const packageJSONPath = path.join(getPackagePath(packageDirectoryName), 'package.json');
+    const packageJSONPath = path.join(getTrezorPackageDir(packageDirectoryName), 'package.json');
 
     if (!fs.existsSync(packageJSONPath)) {
         throw new Error(`${packageJSONPath} not found, is "${packageDirectoryName}" correct?`);

--- a/scripts/ci/trezor-package-path.js
+++ b/scripts/ci/trezor-package-path.js
@@ -1,0 +1,44 @@
+// Locates a @trezor/* workspace package on disk. Network packages are nested a level deeper
+// (`networks/<group>/<name>`) and the group is not derivable from the name (`network-module` holds
+// `network-module-suite-types`), so resolve it from disk. Plain `.js` so it can be imported from
+// both the tsx and node scripts, and run as a CLI from `release-connect-npm/action.yml`.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const ROOT = path.join(import.meta.dirname, '..', '..');
+
+const findNetworkPackageRelativePath = packageName =>
+    fs
+        .readdirSync(path.join(ROOT, 'networks'), { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => path.posix.join('networks', entry.name, packageName))
+        .find(relativePath => fs.existsSync(path.join(ROOT, relativePath, 'package.json')));
+
+// Repo-relative path (posix slashes) for git pathspecs and `yarn bump`. Name has no `@trezor/`.
+export const getTrezorPackageRelativePath = packageName => {
+    if (!packageName.startsWith('network-')) {
+        return path.posix.join('packages', packageName);
+    }
+
+    const networkPackagePath = findNetworkPackageRelativePath(packageName);
+
+    if (!networkPackagePath) {
+        throw new Error(`Package @trezor/${packageName} not found in ./networks`);
+    }
+
+    return networkPackagePath;
+};
+
+export const getTrezorPackageDir = packageName =>
+    path.join(ROOT, getTrezorPackageRelativePath(packageName));
+
+// CLI: prints the absolute package dir, e.g. `cd "$(node trezor-package-path.js network-tron)"`.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const [packageName] = process.argv.slice(2);
+    if (!packageName) {
+        throw new Error('Usage: node ./scripts/ci/trezor-package-path.js <packageName>');
+    }
+    process.stdout.write(getTrezorPackageDir(packageName));
+}


### PR DESCRIPTION
## Description

The connect release CI scripts hardcoded `./packages/<name>`, so bumping and publishing the `@trezor/network-*` packages (now dependencies of connect) failed — and the bump workflow swallowed the error and exited green with a half-finished bump. This routes every consumer through a shared `scripts/ci/trezor-package-path.js` that resolves network packages under `networks/<group>/<name>` from disk, replacing three copies of a regex heuristic (`helpers.ts`, `check-version.js`, `npm-reserve-package.js`) and the bash equivalent in `release-connect-npm/action.yml`. The bump script now also sets a non-zero exit code on failure so a partial bump fails the workflow instead of reporting success.

## Notes for QA

CI-only change to the connect release tooling; no runtime/app surface. Exercise the "[Release] connect bump versions" and "[Release] Connect NPM" workflows and confirm the `@trezor/network-*` packages are bumped, version-checked, and published from `networks/<group>/<name>` correctly.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/warsaw/web/](https://dev.suite.sldev.cz/suite-web/warsaw/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=warsaw&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=warsaw&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:38:43.816Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:38:31.125Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->