### PR TITLE
Memoize some selectors

### DIFF
--- a/suite/desktop-update/package.json
+++ b/suite/desktop-update/package.json
@@ -16,6 +16,7 @@
         "@suite-common/device": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite/analytics": "workspace:*",

--- a/suite/desktop-update/src/quickActions/selectUpdateStatus.ts
+++ b/suite/desktop-update/src/quickActions/selectUpdateStatus.ts
@@ -1,4 +1,6 @@
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+import type { TrezorDevice } from '@suite-common/suite-types';
 import { getSuiteVersion } from '@trezor/env-utils';
 import { versionUtils } from '@trezor/utils';
 
@@ -74,12 +76,10 @@ const getDeviceStatus = ({
     return 'up-to-date';
 };
 
-export const selectUpdateStatus = (
-    state: DesktopUpdateRootState & DeviceRootState,
+const getUpdateStatus = (
+    device: TrezorDevice | undefined,
+    desktopUpdate: DesktopUpdateState,
 ): UpdateStatusData => {
-    const device = selectSelectedDevice(state);
-    const desktopUpdate = selectDesktopUpdate(state);
-
     const isDeviceDisconnected = device?.connected !== true;
 
     // If firmware is outdated and suite update download/check is in progress,
@@ -136,3 +136,12 @@ export const selectUpdateStatus = (
 
     return { updateStatus: 'up-to-date', ...common };
 };
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<
+    DesktopUpdateRootState & DeviceRootState
+>();
+
+export const selectUpdateStatus = createMemoizedSelector(
+    [selectSelectedDevice, selectDesktopUpdate],
+    getUpdateStatus,
+);

--- a/suite/desktop-update/tsconfig.json
+++ b/suite/desktop-update/tsconfig.json
@@ -10,6 +10,9 @@
             "path": "../../suite-common/suite-constants"
         },
         {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/toast-notifications"
         },
         {

--- a/suite/tor/package.json
+++ b/suite/tor/package.json
@@ -13,6 +13,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/redux-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
     },
     "devDependencies": {

--- a/suite/tor/src/torSelectors.ts
+++ b/suite/tor/src/torSelectors.ts
@@ -1,20 +1,23 @@
+import { createWeakMapSelector } from '@suite-common/redux-utils';
+
 import { type TorRootState, TorStatus } from './torSlice';
 import { getIsTorEnabled, getIsTorLoading } from './torUtils';
+
+const createMemoizedSelector = createWeakMapSelector.withTypes<TorRootState>();
 
 export const selectIsTorEnabled = (state: TorRootState) =>
     state.tor.torStatus === TorStatus.Enabled || state.tor.torStatus === TorStatus.Slow;
 
-export const selectTorState = (state: TorRootState) => {
-    const { torStatus, torBootstrap } = state.tor;
-
-    return {
+export const selectTorState = createMemoizedSelector(
+    [(state: TorRootState) => state.tor],
+    ({ torStatus, torBootstrap }) => ({
         torStatus,
+        torBootstrap,
         isTorEnabled: getIsTorEnabled(torStatus),
         isTorLoading: getIsTorLoading(torStatus),
         isTorError: torStatus === TorStatus.Error,
         isTorDisabling: torStatus === TorStatus.Disabling,
         isTorDisabled: torStatus === TorStatus.Disabled,
         isTorEnabling: torStatus === TorStatus.Enabling,
-        torBootstrap,
-    };
-};
+    }),
+);

--- a/suite/tor/tsconfig.json
+++ b/suite/tor/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/redux-utils"
+        },
         { "path": "../../packages/utils" },
         { "path": "../../packages/urls" }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -15296,6 +15296,7 @@ __metadata:
   resolution: "@suite/tor@workspace:suite/tor"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/redux-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
     "@trezor/utils": "workspace:*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -14707,6 +14707,7 @@ __metadata:
     "@suite-common/device": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite/analytics": "workspace:*"


### PR DESCRIPTION
## Description

Memoize `selectTorState` and `selectUpdateStatus` selectors in order to resolve most frequent `Selector ... returned a different result when called with the same parameters.` console warnings.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all in the desktop-update and tor packages. None of the 98 candidate E2E tests reference these modules in their source hints or behaviors, and there is no static coverage mapping available. Therefore the existing Playwright E2E suite provides no targeted coverage for this change set. The recommended strategy is to rely on unit/integration tests for suite/desktop-update and suite/tor and to run a minimal smoke build of the desktop app if needed, rather than running unrelated E2E tests.

<details><summary><b>Changed files (6)</b></summary>

- `suite/desktop-update/package.json`
- `suite/desktop-update/src/quickActions/selectUpdateStatus.ts`
- `suite/desktop-update/tsconfig.json`
- `suite/tor/package.json`
- `suite/tor/src/torSelectors.ts`
- `suite/tor/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `suite/desktop-update/package.json`
- `suite/desktop-update/src/quickActions/selectUpdateStatus.ts`
- `suite/desktop-update/tsconfig.json`
- `suite/tor/package.json`
- `suite/tor/src/torSelectors.ts`
- `suite/tor/tsconfig.json`

_Updated: 2026-07-29T12:49:40.580Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/memoize-selectors/web/](https://dev.suite.sldev.cz/suite-web/chore/memoize-selectors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/memoize-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/memoize-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:53:06.203Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:52:58.538Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->