### PR TITLE
test(device): co-locate reducer tests

### DIFF
--- a/suite-common/device/package.json
+++ b/suite-common/device/package.json
@@ -26,5 +26,8 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
+    },
+    "devDependencies": {
+        "@suite-common/test-utils": "workspace:*"
     }
 }

--- a/suite-common/device/src/__fixtures__/deviceReducer.ts
+++ b/suite-common/device/src/__fixtures__/deviceReducer.ts
@@ -1,12 +1,10 @@
-import {
-    type DeviceReducerState,
-    deviceActions,
-    deviceReducerInitialState,
-} from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { DEVICE } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
+
+import { deviceActions } from '../deviceActions';
+import { type DeviceReducerState, deviceReducerInitialState } from '../deviceReducer';
 
 // Default devices
 const CONNECT_DEVICE = mockConnectDevice();

--- a/suite-common/device/src/deviceReducer.test.ts
+++ b/suite-common/device/src/deviceReducer.test.ts
@@ -1,10 +1,9 @@
-import { prepareDeviceReducer } from '@suite-common/device';
+import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 
-import { extraDependencies } from 'src/support/extraDependencies';
+import fixtures from './__fixtures__/deviceReducer';
+import { prepareDeviceReducer } from './deviceReducer';
 
-import fixtures from '../__fixtures__/deviceReducer';
-
-const deviceReducer = prepareDeviceReducer(extraDependencies);
+const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 
 type State = ReturnType<typeof deviceReducer>;
 

--- a/suite-common/device/tsconfig.json
+++ b/suite-common/device/tsconfig.json
@@ -13,6 +13,7 @@
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
         { "path": "../../packages/type-utils" },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/utils" },
+        { "path": "../test-utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10355,6 +10355,7 @@ __metadata:
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/test-utils": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     "@trezor/device-utils": "workspace:*"


### PR DESCRIPTION
## Description

Moves `deviceReducer.test.ts` beside the reducer in `suite-common/device` and places its single-use fixture in the adjacent `__fixtures__` directory. The reducer uses `extraDependenciesCommonMock` instead of Suite application dependencies, keeping the common package isolated from the desktop/web composition root. The package project references are regenerated in canonical dependency order so Validation’s `verify-project-references` check passes.

- Suite-owned reducer violations: **2 files -> 0**
- Reducer cases: **37 passed**
- Device package: **5 suites, 55 tests passed**
- `verify-project-references`, package lint, package type-check, and formatting: **passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/device-reducer-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/device-reducer-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are confined to the suite-common/device package's tests, fixtures, and build config, suggesting the device reducer or its exports were modified. The highest-confidence E2E coverage is the entropy-check-failure test, which directly exercises @suite-common/device actions. Complement it with a small set of tests that stress device state transitions (forget, reconnect, session takeover). Skip broad onboarding/wallet discovery suites because they do not specifically target device reducer behavior.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/device/package.json`
- `suite-common/device/src/__fixtures__/deviceReducer.ts`
- `suite-common/device/src/deviceReducer.test.ts`
- `suite-common/device/tsconfig.json`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test explicitly imports deviceActions from @suite-common/device and dispatches setSimulatedEntropyCheckFail directly to the Redux store, so any change to the device reducer or its action creators could break this flow.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — This test validates that cached passphrase wallets survive device disconnect/reconnect, which depends on device state persistence in the reducer.
- `suite/e2e/tests/settings/forget-device.test.ts` — The forget-device flow mutates device state in the Redux store (unpair, forget, Bluetooth state); changes to the device reducer could alter how remembered/disconnected devices are represented.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Bridge session takeover and reclaim flows rely on device connection state being correctly reflected in the UI; device reducer changes could affect status transitions.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/device/package.json`
- `suite-common/device/tsconfig.json`

_Updated: 2026-07-29T14:42:54.134Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/device-reducer-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/device-reducer-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/device-reducer-colocation&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T14:44:07.390Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T14:43:49.926Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->