### PR TITLE
test(modal): co-locate reducer tests

### DIFF
--- a/suite/modal/jest.config.js
+++ b/suite/modal/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite/modal/package.json
+++ b/suite/modal/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite/modal/src/__fixtures__/modalReducer.ts
+++ b/suite/modal/src/__fixtures__/modalReducer.ts
@@ -1,3 +1,6 @@
+import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { DEVICE, UI_REQUEST } from '@trezor/connect';
+
 import {
     MODAL_CLOSE,
     MODAL_CONTEXT_DEVICE,
@@ -5,9 +8,7 @@ import {
     MODAL_CONTEXT_NONE,
     MODAL_CONTEXT_USER,
     MODAL_OPEN_USER_CONTEXT,
-} from '@suite/modal';
-import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { DEVICE, UI_REQUEST } from '@trezor/connect';
+} from '../constants';
 
 // Default devices
 const CONNECT_DEVICE = mockConnectDevice({

--- a/suite/modal/src/modalReducer.test.ts
+++ b/suite/modal/src/modalReducer.test.ts
@@ -1,15 +1,12 @@
-import { type State, modalReducer } from '@suite/modal';
-
-import { type Action } from 'src/types/suite';
-
-import fixtures from '../__fixtures__/modalReducer';
+import fixtures from './__fixtures__/modalReducer';
+import { type State, modalReducer } from './modalReducer';
 
 describe('modalReducer', () => {
     fixtures.forEach(f => {
         it(f.description, () => {
             let state: State = f.initialState as State;
             f.actions.forEach(a => {
-                state = modalReducer(state, a as Action);
+                state = modalReducer(state, a);
             });
             expect(state).toEqual(f.result);
         });


### PR DESCRIPTION
## Description

Moves `modalReducer.test.ts` and its single-use fixture into `suite/modal`, beside the reducer they exercise. The test now passes the fixture actions directly to the reducer and no longer imports or casts through the Suite-wide `Action` type; a package-local Jest target makes the suite independently runnable.

- Suite action-type dependencies: **1 -> 0**
- Modal reducer cases: **17 passed**
- Package-local test suites: **0 -> 1**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the suite/modal package—test fixtures and the modal reducer unit test—with no static e2e coverage. The main runtime risk is a regression in modal state management, which is best caught by modal-heavy Trezor Connect flows and the Suite Guide panel. The recommended set is small and targeted at user-visible modal behavior rather than broad regression coverage.

<details><summary><b>Changed files (3)</b></summary>

- `suite/modal/package.json`
- `suite/modal/src/__fixtures__/modalReducer.ts`
- `suite/modal/src/modalReducer.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test directly exercises the Connect permissions modal lifecycle—granting, remembering, forgetting, and re-triggering the permissions modal. Because the change touches the modal reducer and its fixtures, any regression in modal open/close state or payload handling would surface here immediately.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Inferred coverage: this test repeatedly opens and closes Connect permission and address-confirmation modals, and verifies modal behavior across cancellation and popup reuse. It exercises the same modal state machinery that the reducer change targets, though less specifically than permissions.test.ts.
- `suite/e2e/tests/suite/guide.test.ts` — Inferred coverage: the Suite Guide panel behaves as a modal overlay that must open, close, and remain usable over other UI surfaces. A modal reducer regression could break its visibility or dismissal, so this provides a quick user-facing sanity check.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/modal/src/modalReducer.test.ts`

_Updated: 2026-07-29T12:22:06.211Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/modal-reducer-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/modal-reducer-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/modal-reducer-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/modal-reducer-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:24:27.576Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->