### PR TITLE
test(firmware-upgrade): co-locate firmware utils test

### DIFF
--- a/suite/firmware-upgrade/jest.config.js
+++ b/suite/firmware-upgrade/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite/firmware-upgrade/package.json
+++ b/suite/firmware-upgrade/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {

--- a/suite/firmware-upgrade/src/firmwareUtils.test.ts
+++ b/suite/firmware-upgrade/src/firmwareUtils.test.ts
@@ -1,6 +1,7 @@
-import { getFormattedFingerprint, validateFirmware } from '@suite/firmware-upgrade';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { getFormattedFingerprint, validateFirmware } from './firmwareUtils';
 
 describe('getFormattedFingerprint', () => {
     it('should return a formatted fingerprint', () => {


### PR DESCRIPTION
## Description

Moves the firmware utility suite out of the Suite application and beside `suite/firmware-upgrade/src/firmwareUtils.ts`, with a matching basename and local implementation import. A package-local Jest target makes the utility tests independently runnable.

- Suite-owned utility violations: **1 -> 0**
- Firmware utility tests: **6 passed**
- Package-local test suites: **0 -> 1**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is confined to the firmware-upgrade package (package.json and its unit tests), so the main E2E risk is concentrated in firmware installation and update-modal flows. No static coverage mapping was available, so recommendations are inferred from the LLM test descriptions. The custom-firmware test is the highest-value single test; the two device-settings tests add lower-risk coverage of the firmware update modal. Onboarding firmware-setup tests were omitted because they focus on readiness checks rather than the upgrade package itself.

<details><summary><b>Changed files (2)</b></summary>

- `suite/firmware-upgrade/package.json`
- `suite/firmware-upgrade/src/firmwareUtils.test.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — This test directly exercises custom firmware installation through Settings > Device, which is the core functionality of the changed suite/firmware-upgrade package. A dependency or utility change there could break the install flow or the 'reconnect device' completion state it asserts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test opens and closes the firmware update modal from device settings, so it touches UI/components provided by the firmware-upgrade package. A regression in the package's modal or version-check logic could be surfaced here.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Like the T2T1 variant, this test opens the firmware update modal on a T3B1 device and therefore exercises firmware-upgrade package UI/components from another device path.

</details>

_Updated: 2026-07-29T12:29:56.037Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/firmware-utils-colocation/web/](https://dev.suite.sldev.cz/suite-web/test/firmware-utils-colocation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/firmware-utils-colocation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/firmware-utils-colocation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:32:37.175Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:32:16.838Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->