### PR TITLE
test(suite): co-locate quote hook tests

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
@@ -1,33 +1,33 @@
 import { type Resolver, useForm } from 'react-hook-form';
 
 import { act, waitFor } from '@testing-library/react';
-import { type CryptoId, type SellFiatTrade } from 'invity-api';
+import type { BuyTrade, CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
-    type TradingAssetSellOption,
-    type TradingSellFormProps,
-    sellInitialState,
+    type TradingAssetOption,
+    type TradingBuyFormProps,
+    type TradingCountryOption,
+    buyInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { type Network, getNetwork } from '@suite-common/wallet-config';
-import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { getNetwork } from '@suite-common/wallet-config';
 
-import { DEBOUNCE_DELAY_MS } from '../../common/useTradingQuoteRequest';
-import { useSellQuotes } from '../useSellQuotes';
+import { useBuyQuotes } from './useBuyQuotes';
+import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
 
-const QUOTES: SellFiatTrade[] = [
-    {
-        paymentMethod: 'bankTransfer',
-        paymentMethodName: 'Bank transfer',
-        exchange: 'provider-1',
-        rate: 2,
-    },
+const QUOTES: BuyTrade[] = [
     {
         paymentMethod: 'creditCard',
         paymentMethodName: 'Credit card',
-        exchange: 'provider-2',
+        exchange: 'provider-1',
         rate: 1,
+    },
+    {
+        paymentMethod: 'bankTransfer',
+        paymentMethodName: 'Bank transfer',
+        exchange: 'provider-2',
+        rate: 2,
     },
 ];
 
@@ -37,7 +37,6 @@ const mockHandleRequest = jest.fn((payload: unknown) => {
 
     return Object.assign(thunk, { payload });
 });
-const mockClearQuotes = jest.fn();
 
 jest.mock('@suite-common/dependency-injection', () => ({
     ...jest.requireActual('@suite-common/dependency-injection'),
@@ -49,70 +48,24 @@ jest.mock('@suite-common/trading', () => {
 
     return {
         ...actual,
-        sellThunks: {
-            ...actual.sellThunks,
+        buyThunks: {
+            ...actual.buyThunks,
             handleRequestThunk: (payload: unknown) => mockHandleRequest(payload),
-        },
-        tradingSellActions: {
-            ...actual.tradingSellActions,
-            clearQuotes: () => {
-                mockClearQuotes();
-
-                return actual.tradingSellActions.clearQuotes();
-            },
         },
     };
 });
 
-const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
-    id: 'bitcoin' as CryptoId,
-    isNativeToken: true,
-    name: 'Bitcoin',
-    coingeckoId: 'bitcoin',
-    contractAddress: null,
-    symbol: 'btc',
-    displaySymbol: 'BTC',
-    networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
-};
-
-const VALID_DEFAULTS: TradingSellFormProps = {
-    outputs: [
-        {
-            type: 'payment',
-            address: 'address',
-            amount: '0.0015',
-            fiat: '50',
-            currency: { value: 'usd', label: 'USD' },
-            token: null,
-            label: '',
-        },
-    ],
-    countrySelect: {
-        value: 'CZ' as const,
-        codeAlpha3: 'CZE',
-        flag: '🇨🇿',
-        name: 'Czechia',
-        label: '🇨🇿 Czechia',
-        shortLabel: '🇨🇿 CZE',
-    },
-    sendCryptoSelect: SEND_CRYPTO_SELECT,
-    amountInCrypto: true,
+const VALID_DEFAULTS: TradingBuyFormProps = {
+    fiatInput: '100',
+    cryptoInput: '',
+    currencySelect: { value: 'eur', label: 'EUR' },
+    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: 'btc' } as TradingAssetOption,
+    countrySelect: { value: 'DE', label: 'Germany' } as TradingCountryOption,
+    countrySubdivisionSelect: undefined,
     paymentMethod: undefined,
     provider: undefined,
-    feePerUnit: '',
-    feeLimit: '',
-    options: ['broadcast'],
-    bitcoinLocktimeBlockHeight: '',
-    bitcoinLocktimeDatetime: '',
-    ethereumNonce: '',
-    transactionData: '',
-    destinationTag: '',
-    isCoinControlEnabled: false,
-    hasCoinControlBeenOpened: false,
-    utxoSorting: 'newestFirst',
-    selectedUtxos: [],
+    amountInCrypto: false,
+    receiveAddress: 'bc1qreceive',
 };
 
 const NO_REFETCH_WAIT_MS = DEBOUNCE_DELAY_MS + 200;
@@ -125,55 +78,45 @@ const wait = (ms: number) =>
             }),
     );
 
-const renderSellQuotes = (
-    defaultValues: TradingSellFormProps,
-    options: { resolver?: Resolver<TradingSellFormProps> } = {},
+const renderBuyQuotes = (
+    defaultValues: TradingBuyFormProps,
+    options: { resolver?: Resolver<TradingBuyFormProps> } = {},
 ) => {
     const { resolver } = options;
-    const initialProps: { currentNetwork: Network | undefined } = {
-        currentNetwork: getNetwork('btc'),
-    };
-
     const store = configureMockStore({
         preloadedState: {
             wallet: {
                 trading: {
                     ...tradingInitialState,
-                    sell: { ...sellInitialState, quotes: QUOTES },
+                    buy: { ...buyInitialState, quotes: QUOTES },
                 },
             },
         },
     });
 
     return renderHookWithStoreProvider(
-        ({ currentNetwork }) => {
-            const methods = useForm<TradingSellFormProps>({
+        () => {
+            const methods = useForm<TradingBuyFormProps>({
                 mode: 'onChange',
                 defaultValues,
                 resolver,
             });
-            useSellQuotes({
-                methods,
-                network: currentNetwork,
-                shouldSendInSats: false,
-                composeRequestCallback: jest.fn(),
-            });
+            useBuyQuotes({ methods, network: getNetwork('btc'), shouldSendInSats: false });
 
             return methods;
         },
-        { store, initialProps },
+        { store },
     );
 };
 
-describe('useSellQuotes', () => {
+describe('useBuyQuotes', () => {
     beforeEach(() => {
         mockHandleRequest.mockClear();
         mockAbort.mockClear();
-        mockClearQuotes.mockClear();
     });
 
     it('dispatches a quotes request after the debounce when the form is valid', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
+        const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -183,6 +126,7 @@ describe('useSellQuotes', () => {
 
         expect(mockHandleRequest).toHaveBeenCalledWith(
             expect.objectContaining({
+                formValues: expect.objectContaining({ fiatInput: '100' }),
                 network: expect.objectContaining({ symbol: 'btc' }),
                 shouldSendInSats: false,
             }),
@@ -190,7 +134,7 @@ describe('useSellQuotes', () => {
     });
 
     it('auto-selects the best quote payment method when none is selected', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
+        const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -199,14 +143,14 @@ describe('useSellQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
         await waitFor(() =>
             expect(result.current.getValues('paymentMethod')).toEqual({
-                value: 'bankTransfer',
-                label: 'Bank transfer',
+                value: 'creditCard',
+                label: 'Credit card',
             }),
         );
     });
 
     it('refetches immediately (without the debounce) when a select field changes', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
+        const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -214,15 +158,15 @@ describe('useSellQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
 
         await act(async () => {
-            result.current.setValue('outputs.0.currency', { value: 'eur', label: 'EUR' });
+            result.current.setValue('currencySelect', { value: 'usd', label: 'USD' });
             await result.current.trigger();
         });
 
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 200 });
     });
 
-    it('does not refetch on an output-fiat edit but does on the synced output-amount edit', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
+    it('debounces the refetch when an amount field changes', async () => {
+        const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -230,21 +174,18 @@ describe('useSellQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
 
         await act(async () => {
-            result.current.setValue('outputs.0.fiat', '99');
+            result.current.setValue('fiatInput', '200');
             await result.current.trigger();
         });
-        await wait(NO_REFETCH_WAIT_MS);
+
+        await wait(150);
         expect(mockHandleRequest).toHaveBeenCalledTimes(1);
 
-        await act(async () => {
-            result.current.setValue('outputs.0.amount', '0.003');
-            await result.current.trigger();
-        });
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
     });
 
     it('does not refetch when only a non-key field (provider) changes', async () => {
-        const { result } = renderSellQuotes(VALID_DEFAULTS);
+        const { result } = renderBuyQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -261,11 +202,11 @@ describe('useSellQuotes', () => {
     });
 
     it('does not fetch while the form is invalid', async () => {
-        const invalidResolver: Resolver<TradingSellFormProps> = () => ({
+        const invalidResolver: Resolver<TradingBuyFormProps> = () => ({
             values: {},
-            errors: { feePerUnit: { type: 'manual', message: 'invalid' } },
+            errors: { fiatInput: { type: 'manual', message: 'invalid' } },
         });
-        const { result } = renderSellQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
+        const { result } = renderBuyQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
 
         await act(async () => {
             await result.current.trigger();
@@ -273,16 +214,5 @@ describe('useSellQuotes', () => {
         await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).not.toHaveBeenCalled();
-    });
-
-    it('clears quotes eagerly when the network becomes undefined', async () => {
-        const { rerender } = renderSellQuotes(VALID_DEFAULTS);
-
-        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
-        expect(mockClearQuotes).not.toHaveBeenCalled();
-
-        rerender({ currentNetwork: undefined });
-
-        await waitFor(() => expect(mockClearQuotes).toHaveBeenCalled());
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
@@ -1,33 +1,33 @@
 import { type Resolver, useForm } from 'react-hook-form';
 
 import { act, waitFor } from '@testing-library/react';
-import type { BuyTrade, CryptoId } from 'invity-api';
+import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import {
-    type TradingAssetOption,
-    type TradingBuyFormProps,
-    type TradingCountryOption,
-    buyInitialState,
+    type TradingAssetSellOption,
+    type TradingSellFormProps,
+    sellInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type Network, getNetwork } from '@suite-common/wallet-config';
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
-import { DEBOUNCE_DELAY_MS } from '../../common/useTradingQuoteRequest';
-import { useBuyQuotes } from '../useBuyQuotes';
+import { useSellQuotes } from './useSellQuotes';
+import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
 
-const QUOTES: BuyTrade[] = [
-    {
-        paymentMethod: 'creditCard',
-        paymentMethodName: 'Credit card',
-        exchange: 'provider-1',
-        rate: 1,
-    },
+const QUOTES: SellFiatTrade[] = [
     {
         paymentMethod: 'bankTransfer',
         paymentMethodName: 'Bank transfer',
-        exchange: 'provider-2',
+        exchange: 'provider-1',
         rate: 2,
+    },
+    {
+        paymentMethod: 'creditCard',
+        paymentMethodName: 'Credit card',
+        exchange: 'provider-2',
+        rate: 1,
     },
 ];
 
@@ -37,6 +37,7 @@ const mockHandleRequest = jest.fn((payload: unknown) => {
 
     return Object.assign(thunk, { payload });
 });
+const mockClearQuotes = jest.fn();
 
 jest.mock('@suite-common/dependency-injection', () => ({
     ...jest.requireActual('@suite-common/dependency-injection'),
@@ -48,24 +49,70 @@ jest.mock('@suite-common/trading', () => {
 
     return {
         ...actual,
-        buyThunks: {
-            ...actual.buyThunks,
+        sellThunks: {
+            ...actual.sellThunks,
             handleRequestThunk: (payload: unknown) => mockHandleRequest(payload),
+        },
+        tradingSellActions: {
+            ...actual.tradingSellActions,
+            clearQuotes: () => {
+                mockClearQuotes();
+
+                return actual.tradingSellActions.clearQuotes();
+            },
         },
     };
 });
 
-const VALID_DEFAULTS: TradingBuyFormProps = {
-    fiatInput: '100',
-    cryptoInput: '',
-    currencySelect: { value: 'eur', label: 'EUR' },
-    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: 'btc' } as TradingAssetOption,
-    countrySelect: { value: 'DE', label: 'Germany' } as TradingCountryOption,
-    countrySubdivisionSelect: undefined,
+const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
+    id: 'bitcoin' as CryptoId,
+    isNativeToken: true,
+    name: 'Bitcoin',
+    coingeckoId: 'bitcoin',
+    contractAddress: null,
+    symbol: 'btc',
+    displaySymbol: 'BTC',
+    networkName: 'Bitcoin',
+    networkSymbol: 'btc',
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+};
+
+const VALID_DEFAULTS: TradingSellFormProps = {
+    outputs: [
+        {
+            type: 'payment',
+            address: 'address',
+            amount: '0.0015',
+            fiat: '50',
+            currency: { value: 'usd', label: 'USD' },
+            token: null,
+            label: '',
+        },
+    ],
+    countrySelect: {
+        value: 'CZ' as const,
+        codeAlpha3: 'CZE',
+        flag: '🇨🇿',
+        name: 'Czechia',
+        label: '🇨🇿 Czechia',
+        shortLabel: '🇨🇿 CZE',
+    },
+    sendCryptoSelect: SEND_CRYPTO_SELECT,
+    amountInCrypto: true,
     paymentMethod: undefined,
     provider: undefined,
-    amountInCrypto: false,
-    receiveAddress: 'bc1qreceive',
+    feePerUnit: '',
+    feeLimit: '',
+    options: ['broadcast'],
+    bitcoinLocktimeBlockHeight: '',
+    bitcoinLocktimeDatetime: '',
+    ethereumNonce: '',
+    transactionData: '',
+    destinationTag: '',
+    isCoinControlEnabled: false,
+    hasCoinControlBeenOpened: false,
+    utxoSorting: 'newestFirst',
+    selectedUtxos: [],
 };
 
 const NO_REFETCH_WAIT_MS = DEBOUNCE_DELAY_MS + 200;
@@ -78,45 +125,55 @@ const wait = (ms: number) =>
             }),
     );
 
-const renderBuyQuotes = (
-    defaultValues: TradingBuyFormProps,
-    options: { resolver?: Resolver<TradingBuyFormProps> } = {},
+const renderSellQuotes = (
+    defaultValues: TradingSellFormProps,
+    options: { resolver?: Resolver<TradingSellFormProps> } = {},
 ) => {
     const { resolver } = options;
+    const initialProps: { currentNetwork: Network | undefined } = {
+        currentNetwork: getNetwork('btc'),
+    };
+
     const store = configureMockStore({
         preloadedState: {
             wallet: {
                 trading: {
                     ...tradingInitialState,
-                    buy: { ...buyInitialState, quotes: QUOTES },
+                    sell: { ...sellInitialState, quotes: QUOTES },
                 },
             },
         },
     });
 
     return renderHookWithStoreProvider(
-        () => {
-            const methods = useForm<TradingBuyFormProps>({
+        ({ currentNetwork }) => {
+            const methods = useForm<TradingSellFormProps>({
                 mode: 'onChange',
                 defaultValues,
                 resolver,
             });
-            useBuyQuotes({ methods, network: getNetwork('btc'), shouldSendInSats: false });
+            useSellQuotes({
+                methods,
+                network: currentNetwork,
+                shouldSendInSats: false,
+                composeRequestCallback: jest.fn(),
+            });
 
             return methods;
         },
-        { store },
+        { store, initialProps },
     );
 };
 
-describe('useBuyQuotes', () => {
+describe('useSellQuotes', () => {
     beforeEach(() => {
         mockHandleRequest.mockClear();
         mockAbort.mockClear();
+        mockClearQuotes.mockClear();
     });
 
     it('dispatches a quotes request after the debounce when the form is valid', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -126,7 +183,6 @@ describe('useBuyQuotes', () => {
 
         expect(mockHandleRequest).toHaveBeenCalledWith(
             expect.objectContaining({
-                formValues: expect.objectContaining({ fiatInput: '100' }),
                 network: expect.objectContaining({ symbol: 'btc' }),
                 shouldSendInSats: false,
             }),
@@ -134,7 +190,7 @@ describe('useBuyQuotes', () => {
     });
 
     it('auto-selects the best quote payment method when none is selected', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -143,14 +199,14 @@ describe('useBuyQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
         await waitFor(() =>
             expect(result.current.getValues('paymentMethod')).toEqual({
-                value: 'creditCard',
-                label: 'Credit card',
+                value: 'bankTransfer',
+                label: 'Bank transfer',
             }),
         );
     });
 
     it('refetches immediately (without the debounce) when a select field changes', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -158,15 +214,15 @@ describe('useBuyQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
 
         await act(async () => {
-            result.current.setValue('currencySelect', { value: 'usd', label: 'USD' });
+            result.current.setValue('outputs.0.currency', { value: 'eur', label: 'EUR' });
             await result.current.trigger();
         });
 
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 200 });
     });
 
-    it('debounces the refetch when an amount field changes', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
+    it('does not refetch on an output-fiat edit but does on the synced output-amount edit', async () => {
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -174,18 +230,21 @@ describe('useBuyQuotes', () => {
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
 
         await act(async () => {
-            result.current.setValue('fiatInput', '200');
+            result.current.setValue('outputs.0.fiat', '99');
             await result.current.trigger();
         });
-
-        await wait(150);
+        await wait(NO_REFETCH_WAIT_MS);
         expect(mockHandleRequest).toHaveBeenCalledTimes(1);
 
+        await act(async () => {
+            result.current.setValue('outputs.0.amount', '0.003');
+            await result.current.trigger();
+        });
         await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(2), { timeout: 1500 });
     });
 
     it('does not refetch when only a non-key field (provider) changes', async () => {
-        const { result } = renderBuyQuotes(VALID_DEFAULTS);
+        const { result } = renderSellQuotes(VALID_DEFAULTS);
 
         await act(async () => {
             await result.current.trigger();
@@ -202,11 +261,11 @@ describe('useBuyQuotes', () => {
     });
 
     it('does not fetch while the form is invalid', async () => {
-        const invalidResolver: Resolver<TradingBuyFormProps> = () => ({
+        const invalidResolver: Resolver<TradingSellFormProps> = () => ({
             values: {},
-            errors: { fiatInput: { type: 'manual', message: 'invalid' } },
+            errors: { feePerUnit: { type: 'manual', message: 'invalid' } },
         });
-        const { result } = renderBuyQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
+        const { result } = renderSellQuotes(VALID_DEFAULTS, { resolver: invalidResolver });
 
         await act(async () => {
             await result.current.trigger();
@@ -214,5 +273,16 @@ describe('useBuyQuotes', () => {
         await wait(NO_REFETCH_WAIT_MS);
 
         expect(mockHandleRequest).not.toHaveBeenCalled();
+    });
+
+    it('clears quotes eagerly when the network becomes undefined', async () => {
+        const { rerender } = renderSellQuotes(VALID_DEFAULTS);
+
+        await waitFor(() => expect(mockHandleRequest).toHaveBeenCalledTimes(1), { timeout: 1500 });
+        expect(mockClearQuotes).not.toHaveBeenCalled();
+
+        rerender({ currentNetwork: undefined });
+
+        await waitFor(() => expect(mockClearQuotes).toHaveBeenCalled());
     });
 });


### PR DESCRIPTION
## Description

Moves the `useBuyQuotes` and `useSellQuotes` suites out of nested `__tests__` directories and directly beside their hook implementations. Local hook and shared quote-request imports are updated for the colocated paths without changing test behavior.

- Suite quote-hook violations: **2 -> 0**
- Hook suites: **2 passed**
- Hook tests: **13 passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/suite-quote-hook-tests/web/](https://dev.suite.sldev.cz/suite-web/test/suite-quote-hook-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/suite-quote-hook-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/suite-quote-hook-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:36:22.516Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T12:36:08.507Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->