### PR TITLE
test(suite-native): co-locate transaction management tests

### DIFF
--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputHexData.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputHexData.test.tsx
@@ -1,7 +1,7 @@
 import { getTranslation } from '@suite-native/intl';
 import { renderWithBasicProvider, userEvent } from '@suite-native/test-utils';
 
-import { ReviewOutputHexData } from '../ReviewOutputHexData';
+import { ReviewOutputHexData } from './ReviewOutputHexData';
 
 const mockCopyToClipboard = jest.fn();
 

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
@@ -6,8 +6,8 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { getWalletState } from '../../../__fixtures__/walletState';
-import { useFeesFetching } from '../useFeesFetching';
+import { useFeesFetching } from './useFeesFetching';
+import { getWalletState } from '../../__fixtures__/walletState';
 
 // Mock the fee hooks since they have side effects and we want to test the hook's logic
 jest.mock('@suite-common/wallet-core', () => ({

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
@@ -1,7 +1,7 @@
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { type UseFeesFormProps, useFeesForm } from '../useFeesForm';
+import { type UseFeesFormProps, useFeesForm } from './useFeesForm';
 
 const ETH_ACCOUNT_KEY = mockAccountKey({ symbol: 'eth', descriptor: 'eth1' });
 

--- a/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
@@ -2,8 +2,8 @@ import { type Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { ETH_ACCOUNT_KEY, getWalletState } from '../../../__fixtures__/walletState';
-import { useTronFeeBreakdown } from '../useTronFeeBreakdown';
+import { useTronFeeBreakdown } from './useTronFeeBreakdown';
+import { ETH_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 
 const TRON_ACCOUNT_DESCRIPTOR = 'TRX1234567890abcdefghijklmnopqrstuvwxyz';
 const TRON_ACCOUNT_KEY = mockAccountKey({

--- a/suite-native/transaction-management/src/hooks/useActiveStepOffset.test.ts
+++ b/suite-native/transaction-management/src/hooks/useActiveStepOffset.test.ts
@@ -2,7 +2,7 @@ import { type LayoutChangeEvent } from 'react-native';
 
 import { act, renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { useActiveStepOffset } from '../useActiveStepOffset';
+import { useActiveStepOffset } from './useActiveStepOffset';
 
 describe('useActiveStepOffset', () => {
     const getLayoutEvent = (height: number) =>

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
@@ -9,7 +9,7 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { useIsNetworkReserveBannerVisible } from '../useIsNetworkReserveBannerVisible';
+import { useIsNetworkReserveBannerVisible } from './useIsNetworkReserveBannerVisible';
 
 // SOL nativeTokenReserve: "0.003"; base: "0.0002"
 describe('useIsNetworkReserveBannerVisible', () => {

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
@@ -1,13 +1,13 @@
 import { type FormState, type TokenAddress } from '@suite-common/wallet-types';
 import { renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 
-import { BTC_ACCOUNT_KEY, ETH_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
-import { useMaxSpendableAmount } from '../useMaxSpendableAmount';
+import { useMaxSpendableAmount } from './useMaxSpendableAmount';
+import { BTC_ACCOUNT_KEY, ETH_ACCOUNT_KEY, getWalletState } from '../__fixtures__/walletState';
 
 const mockCalculateFeeLevelsMaxAmountThunk = jest.fn();
 
-jest.mock('../../thunks', () => ({
-    ...jest.requireActual('../../thunks'),
+jest.mock('../thunks', () => ({
+    ...jest.requireActual('../thunks'),
     calculateFeeLevelsMaxAmountThunk: (...args: unknown[]) =>
         mockCalculateFeeLevelsMaxAmountThunk(...args),
 }));

--- a/suite-native/transaction-management/src/hooks/useNavigationRemoveInterceptorAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/useNavigationRemoveInterceptorAlert.test.ts
@@ -1,7 +1,7 @@
 import { useNavigationRemoveActionInterceptor } from '@suite-native/navigation';
 import { renderHookWithBasicProvider } from '@suite-native/test-utils';
 
-import { useNavigationRemoveInterceptorAlert } from '../useNavigationRemoveInterceptorAlert';
+import { useNavigationRemoveInterceptorAlert } from './useNavigationRemoveInterceptorAlert';
 
 const mockShowStayOnScreenAlert = jest.fn();
 const mockHideStayOnScreenAlert = jest.fn();
@@ -11,7 +11,7 @@ jest.mock('@suite-native/navigation', () => ({
     useNavigationRemoveActionInterceptor: jest.fn(),
 }));
 
-jest.mock('../useShowStayOnScreenAlert', () => ({
+jest.mock('./useShowStayOnScreenAlert', () => ({
     useShowStayOnScreenAlert: () => ({
         showStayOnScreenAlert: mockShowStayOnScreenAlert,
         hideStayOnScreenAlert: mockHideStayOnScreenAlert,

--- a/suite-native/transaction-management/src/hooks/useOutputsReviewBackInterceptor.test.ts
+++ b/suite-native/transaction-management/src/hooks/useOutputsReviewBackInterceptor.test.ts
@@ -1,6 +1,6 @@
 import { renderHookWithBasicProvider, waitFor } from '@suite-native/test-utils';
 
-import { useOutputsReviewBackInterceptor } from '../useOutputsReviewBackInterceptor';
+import { useOutputsReviewBackInterceptor } from './useOutputsReviewBackInterceptor';
 
 const mockShowReviewCancellationAlert = jest.fn();
 
@@ -13,7 +13,7 @@ jest.mock('@suite-native/navigation', () => ({
     }) => onInterceptedAction(),
 }));
 
-jest.mock('../useShowReviewCancellationAlert', () => ({
+jest.mock('./useShowReviewCancellationAlert', () => ({
     useShowReviewCancellationAlert: () => mockShowReviewCancellationAlert,
 }));
 

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
@@ -7,7 +7,7 @@ import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-nat
 import {
     type UsePrecomposedTransactionErrorProps,
     usePrecomposedTransactionError,
-} from '../usePrecomposedTransactionError';
+} from './usePrecomposedTransactionError';
 
 const ErrorText = (props: UsePrecomposedTransactionErrorProps) => {
     const msg = usePrecomposedTransactionError(props);

--- a/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
+++ b/suite-native/transaction-management/src/hooks/useShowReviewCancellationAlert.test.ts
@@ -4,7 +4,7 @@ import {
     renderHookWithStoreProvider,
 } from '@suite-native/test-utils-store';
 
-import { useShowReviewCancellationAlert } from '../useShowReviewCancellationAlert';
+import { useShowReviewCancellationAlert } from './useShowReviewCancellationAlert';
 
 const mockShowAlert = jest.fn();
 

--- a/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts
+++ b/suite-native/transaction-management/src/hooks/useSubscribeForSolanaBlockUpdates.test.ts
@@ -2,7 +2,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { renderHook } from '@suite-native/test-utils';
 import TrezorConnect from '@trezor/connect';
 
-import { useSubscribeForSolanaBlockUpdates } from '../useSubscribeForSolanaBlockUpdates';
+import { useSubscribeForSolanaBlockUpdates } from './useSubscribeForSolanaBlockUpdates';
 
 // Mock TrezorConnect
 jest.mock('@trezor/connect', () => ({

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
@@ -4,7 +4,7 @@ import { act } from '@suite-native/test-utils';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 import { type WalletAccountTransaction, mockTransaction } from '@suite-native/tokens';
 
-import { useTransactionDetails } from '../useTransactionDetails';
+import { useTransactionDetails } from './useTransactionDetails';
 
 const mockOpenLink = jest.fn();
 

--- a/suite-native/transaction-management/src/hooks/useTxValidityTimer.test.tsx
+++ b/suite-native/transaction-management/src/hooks/useTxValidityTimer.test.tsx
@@ -3,7 +3,7 @@ import { getTxValidityTimeoutInMs } from '@suite-common/wallet-utils';
 import { act, renderHook } from '@suite-native/test-utils';
 import TrezorConnect from '@trezor/connect';
 
-import { useTxValidityTimer } from '../useTxValidityTimer';
+import { useTxValidityTimer } from './useTxValidityTimer';
 
 type Params = Parameters<typeof useTxValidityTimer>[0];
 

--- a/suite-native/transaction-management/src/hooks/useWaitForButtonRequest.test.ts
+++ b/suite-native/transaction-management/src/hooks/useWaitForButtonRequest.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import { useWaitForButtonRequest } from '../useWaitForButtonRequest';
+import { useWaitForButtonRequest } from './useWaitForButtonRequest';
 
 const mockSelectDeviceButtonRequestsCodes = jest.fn().mockReturnValue([]);
 


### PR DESCRIPTION
## Description

Moves the remaining 15 transaction-management tests beside their implementations and updates relative imports without changing test behavior.

Validation:
- 39 test suites, 370 tests passed
- package lint passed
- package type-check passed

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-transaction-management-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->