### PR TITLE
feat(suite-native): internationalize Portfolio Tracker header

### DIFF
--- a/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
+++ b/suite-native/device-manager/src/components/DeviceItem/DeviceItemContent.tsx
@@ -82,8 +82,9 @@ export const DeviceItemContent = React.memo(
         const isPortfolioTrackerDevice = deviceItem?.id === PORTFOLIO_TRACKER_DEVICE_ID;
 
         const deviceHeader =
-            (isPortfolioTrackerDevice ? deviceItem?.name : deviceItem?.label) ??
-            translate('deviceManager.defaultHeader');
+            (isPortfolioTrackerDevice
+                ? translate('deviceManager.portfolioTrackerHeader')
+                : deviceItem?.label) ?? translate('deviceManager.defaultHeader');
 
         // todo: only makes sense device is already authorized (has state)
         const fallbackLabel = deviceItem?.useEmptyPassphrase ? (

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2160,6 +2160,7 @@ export const messages = {
             bootloader: 'Bootloader mode',
         },
         defaultHeader: 'Hi there!',
+        portfolioTrackerHeader: 'Portfolio Tracker',
         wallet: {
             standard: 'Standard wallet',
             defaultPassphrase: 'Passphrase wallet #{index}',


### PR DESCRIPTION
## Description

_Portfolio Tracker_ header may now be localized.

## Related Issue

Resolve #30246


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/portfolio-tracker-i18n&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->