### PR TITLE
fix(trading): keep native coin in FROM picker with hidden tokens

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
@@ -105,17 +105,17 @@ export function useAccountWithTokensOptions({
                 return false;
             }
 
-            if (account.tokens?.length === 0) {
-                return new BigNumber(account.balance).gt(0);
+            if (new BigNumber(account.balance).gt(0)) {
+                return true;
             }
 
-            const tokens = getTokens({
+            const { shownWithBalance, hiddenWithBalance } = getTokens({
                 tokens: account.tokens ?? [],
                 symbol: account.symbol,
                 tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
             });
 
-            return tokens.shownWithBalance.length > 0;
+            return shownWithBalance.length > 0 || hiddenWithBalance.length > 0;
         });
 
         const networks = new Set(validAccounts.map(account => account.symbol));
@@ -182,7 +182,10 @@ export function useAccountWithTokensOptions({
         const accountsWithTokensOptions: AccountWithTokensOption[] = [];
 
         for (const { account, tokens, nonTradableTokens } of accountsWithTokens) {
-            if (supportedCryptoIds.has(getCryptoId(account.symbol))) {
+            if (
+                supportedCryptoIds.has(getCryptoId(account.symbol)) &&
+                new BigNumber(account.balance).gt(0)
+            ) {
                 accountsWithTokensOptions.push(createAccountOption(account));
             }
 


### PR DESCRIPTION
## Description

- Keep accounts eligible in the FROM picker when they have a positive native balance, even if hidden tokens are present.
- Treat hidden tokens with balance the same as visible tokens when deciding whether an account should appear.
- Show the native account option only when the native balance is positive, while still listing token options for zero-balance accounts.

## Notes for QA

- In Trade -> Swap or Sell on an EVM account with native balance and only hidden tokens, open the FROM asset picker and verify the native coin is listed.
- In the same picker on an account with zero native balance but token balance, verify token options are listed but the native coin row is not shown.

## Related Issue

Resolve #30185

## Screenshots:
<img width="609" height="635" alt="image" src="https://github.com/user-attachments/assets/9b8982cb-7431-4cb8-bb52-2d0e98d383b1" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is localized to a hook that builds options for the sell-side asset picker modal. Most mapped tests launch the swap flow with a preselected coin and are unlikely to exercise this hook. The recommended set focuses on tests that explicitly interact with the sell asset picker or select tokens as sell assets, giving targeted confidence with minimal runtime cost.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test explicitly opens the sell-side swap asset picker and selects a token (USDC on ETH), directly exercising the account-with-tokens option logic in the changed hook. It also validates balance-driven behavior tied to the selected sell asset, so a regression here would be immediately visible.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — The test fills the swap form by selecting the sell asset (SOL) and a cross-network buy token, using the sell/buy asset selectors that depend on the changed hook. This confirms the hook still produces usable options when swapping a native coin to a token.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — It selects an SPL token (USDT on Solana) as the sell asset and Bitcoin as the buy asset, so it exercises the token-bearing-account option path of the changed hook on Solana.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps one SPL token for another (USDT to USDC) on Solana and uses the sell/buy asset selectors, relying on the hook to list token accounts correctly for the sell side.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — The live test selects an SPL token (USDT on Solana) as the sell asset, so it exercises the same account-with-tokens option path against real backend data, complementing the mocked coverage.

</details>

_Updated: 2026-07-29T13:38:28.215Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30185-trading-from-picker-hidden-tokens/web/](https://dev.suite.sldev.cz/suite-web/fix/30185-trading-from-picker-hidden-tokens/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30185-trading-from-picker-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30185-trading-from-picker-hidden-tokens&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:41:05.723Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T13:40:48.508Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->