### PR TITLE
fix(ci): handle empty npm dist-tags in connect release scripts

### DIFF
--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -241,6 +241,9 @@ const bumpConnect = async () => {
             await updateConnectChangelog(CONNECT_CHANGELOG_PATH, version, '-');
         } else {
             const distributionTags = await gettingNpmDistributionTags('@trezor/connect');
+            if (!distributionTags?.latest) {
+                throw new Error('Could not resolve the latest @trezor/connect version from NPM');
+            }
             await updateConnectChangelog(CONNECT_CHANGELOG_PATH, distributionTags.latest, version);
         }
 

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -12,31 +12,31 @@ const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const updateNeeded: string[] = [];
 
-export const gettingNpmDistributionTags = async (packageName: string) => {
+export const gettingNpmDistributionTags = async (
+    packageName: string,
+): Promise<Record<string, string> | undefined> => {
     const npmRegistryUrl = `https://registry.npmjs.org/${packageName}`;
     const response = await fetch(npmRegistryUrl);
     const data = await response.json();
+    // Package does not exist on NPM yet (e.g. a newly added or renamed package).
     if (data.error) {
-        return { success: false };
+        return undefined;
     }
 
     return data['dist-tags'];
 };
 
 export const getNpmRemoteGreatestVersion = async (moduleName: string) => {
-    try {
-        const distributionTags = await gettingNpmDistributionTags(moduleName);
+    const distributionTags = await gettingNpmDistributionTags(moduleName);
 
-        const versionArray: string[] = Object.values(distributionTags);
-        const greatestVersion = versionArray.reduce((max, current) =>
-            semver.gt(current, max) ? current : max,
-        );
-
-        return greatestVersion;
-    } catch (error) {
-        console.error('error:', error);
-        throw new Error('Not possible to get remote greatest version');
+    const versionArray = distributionTags ? Object.values(distributionTags) : [];
+    // No published versions/dist-tags (new, renamed or unpublished package) means there is
+    // nothing to compare against, so there is no remote greatest version.
+    if (versionArray.length === 0) {
+        return undefined;
     }
+
+    return versionArray.reduce((max, current) => (semver.gt(current, max) ? current : max));
 };
 
 export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {


### PR DESCRIPTION
## Description

The `get-connect-dependencies-to-release` CI step crashed with `TypeError: Reduce of empty array with no initial value` whenever a dependency in connect's recursive `@trezor/*` tree returned empty/absent npm `dist-tags` — which now happens because the newly added/renamed `@trezor/network-*` packages are not yet published (or only reserved) on npm. 

Failed run here: https://github.com/trezor/trezor-suite/actions/runs/30456113851/job/90590374239

`getNpmRemoteGreatestVersion` now returns `undefined` for that case instead of throwing, so the caller treats the package as needing release, matching the intent of the earlier missing-remote-version fix. `gettingNpmDistributionTags` now returns `undefined` (rather than a bogus `{ success: false }`) when a package is absent from npm, and `connect-bump-versions` guards the `@trezor/connect` lookup accordingly.

## Notes for QA

CI-only change to the connect npm release scripts; no product/runtime code is affected. Best validated by running the connect npm release workflow — the "Get packages that need release" step should complete successfully even when a connect dependency (e.g. a `@trezor/network-*` package) is not yet published on npm.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files (`scripts/ci/connect-bump-versions.ts` and `scripts/ci/helpers.ts`) are CI/build automation scripts for bumping `@trezor/connect` package versions. They are not application source code and are not exercised by any Playwright E2E test. None of the 42 candidate tests reference these scripts, and there is no concrete evidence that version-bumping logic would alter the runtime behavior tested by any specific user-facing flow. Therefore, no E2E tests are recommended for this changeset; validation should occur at the CI script/unit level instead.

<details><summary><b>Changed files (2)</b></summary>

- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/helpers.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `scripts/ci/connect-bump-versions.ts`
- `scripts/ci/helpers.ts`

_Updated: 2026-07-29T14:08:41.025Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-empty-npm-version-reduce&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-empty-npm-version-reduce&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T14:11:48.187Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T14:10:51.004Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->