### PR TITLE
fix(ci): handle empty npm dist-tags in connect release scripts (cherry pick)

### DIFF
--- a/scripts/ci/connect-bump-versions.ts
+++ b/scripts/ci/connect-bump-versions.ts
@@ -241,6 +241,9 @@ const bumpConnect = async () => {
             await updateConnectChangelog(CONNECT_CHANGELOG_PATH, version, '-');
         } else {
             const distributionTags = await gettingNpmDistributionTags('@trezor/connect');
+            if (!distributionTags?.latest) {
+                throw new Error('Could not resolve the latest @trezor/connect version from NPM');
+            }
             await updateConnectChangelog(CONNECT_CHANGELOG_PATH, distributionTags.latest, version);
         }
 

--- a/scripts/ci/helpers.ts
+++ b/scripts/ci/helpers.ts
@@ -12,31 +12,31 @@ const ROOT = path.join(import.meta.dirname, '..', '..');
 
 const updateNeeded: string[] = [];
 
-export const gettingNpmDistributionTags = async (packageName: string) => {
+export const gettingNpmDistributionTags = async (
+    packageName: string,
+): Promise<Record<string, string> | undefined> => {
     const npmRegistryUrl = `https://registry.npmjs.org/${packageName}`;
     const response = await fetch(npmRegistryUrl);
     const data = await response.json();
+    // Package does not exist on NPM yet (e.g. a newly added or renamed package).
     if (data.error) {
-        return { success: false };
+        return undefined;
     }
 
     return data['dist-tags'];
 };
 
 export const getNpmRemoteGreatestVersion = async (moduleName: string) => {
-    try {
-        const distributionTags = await gettingNpmDistributionTags(moduleName);
+    const distributionTags = await gettingNpmDistributionTags(moduleName);
 
-        const versionArray: string[] = Object.values(distributionTags);
-        const greatestVersion = versionArray.reduce((max, current) =>
-            semver.gt(current, max) ? current : max,
-        );
-
-        return greatestVersion;
-    } catch (error) {
-        console.error('error:', error);
-        throw new Error('Not possible to get remote greatest version');
+    const versionArray = distributionTags ? Object.values(distributionTags) : [];
+    // No published versions/dist-tags (new, renamed or unpublished package) means there is
+    // nothing to compare against, so there is no remote greatest version.
+    if (versionArray.length === 0) {
+        return undefined;
     }
+
+    return versionArray.reduce((max, current) => (semver.gt(current, max) ? current : max));
 };
 
 export const getTrezorDependencies = async (packageNameWithoutTrezorPrefix: string) => {


### PR DESCRIPTION
## Description

Backport of #30528 (develop commit f0d2bea655) onto `release/connect/10.0.0-beta.1`

## Notes for QA

CI-only change