### PR TITLE
Feat/download vault icons

### DIFF
--- a/suite-common/icons/jest.config.js
+++ b/suite-common/icons/jest.config.js
@@ -1,0 +1,5 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+};

--- a/suite-common/icons/package.json
+++ b/suite-common/icons/package.json
@@ -11,9 +11,11 @@
         "generate-icons": "yarn g:tsx generateIcons.mjs && yarn g:tsx generateIconFont.ts",
         "generate-icon-font": "yarn g:tsx generateIconFont.ts",
         "download-crypto-icons": "yarn g:tsx ./scripts/downloadCryptoIcons.ts",
-        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest"
     },
     "devDependencies": {
+        "@suite-common/wallet-config": "workspace:^",
         "chalk": "^5.6.2",
         "fantasticon": "4.1.0",
         "prettier": "^3.8.4",

--- a/suite-common/icons/scripts/constants/index.ts
+++ b/suite-common/icons/scripts/constants/index.ts
@@ -23,6 +23,11 @@ export const COINGECKO_API_KEY_VALUE = process.env.COINGECKO_API_KEY;
 export const RATE_LIMIT_PER_MINUTE = 240;
 export const RUN_LIMIT_SECONDS = 4 * 60 * 60; // 4 hour
 
+// The earn-yield worker is the source of truth for yield vaults; it serves all vault addresses
+// across environments. Kept in sync with suite-common/token-definitions, which consumes the same
+// endpoint to publish the vault addresses as known tokens.
+export const YIELD_VAULTS_URL = 'https://earn.trezor.io/yield/vaults/v1';
+
 // /coins/markets returns image URLs in bulk (max 250 per page), letting us avoid one
 // /coins/{id} call per coin (~72 pages cover the ~18k coins with market data).
 export const COIN_MARKETS_PER_PAGE = 250;

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -16,6 +16,7 @@ import {
     IMAGE_SIZE_SEPARATOR,
     createCoinImageName,
 } from '../src/coinImages';
+import { downloadVaultIcons } from './utils/downloadVaultIcons';
 import {
     fetchCoinList,
     fetchUpdatedIconsList,
@@ -208,6 +209,15 @@ async function ensureDirectoryExists(path: string) {
             // Only fingerprint on success so a failed coin is retried on the next run.
             ...(success ? { imageUrl } : {}),
         };
+    }
+
+    // Vault-position tokens are derived from other icons rather than fetched from CoinGecko —
+    // see downloadVaultIcons. A failure there must not discard the CoinGecko icons already
+    // produced by this run, so it only logs.
+    try {
+        await downloadVaultIcons();
+    } catch (error) {
+        console.error('Vault icons: 🔴 Error:', error);
     }
 
     console.log('All icons processed, writing updated icons list');

--- a/suite-common/icons/scripts/schemas/index.ts
+++ b/suite-common/icons/scripts/schemas/index.ts
@@ -50,3 +50,23 @@ export const coinMarketsSchema = z.array(
         image: z.string(),
     }),
 );
+
+// Yield vaults as served by the earn-yield worker, grouped by CoinGecko asset platform id. Keys are
+// kept open so a newly supported platform cannot fail the whole response — a platform this repo does
+// not know is reported and skipped by the consumer instead.
+export const yieldVaultsSchema = z.record(
+    z.string(),
+    z.array(
+        z.object({
+            yieldId: z.string(),
+            // Address of the vault-position token, i.e. the icon file name to write.
+            address: z.string(),
+            // Address and CoinGecko coin id of the token the vault is denominated in, i.e. the icon
+            // to copy. The id is chain-specific (`l2-standard-bridged-weth-base`, not `weth`).
+            underlyingToken: z.string(),
+            coingeckoId: z.string(),
+        }),
+    ),
+);
+export type YieldVaults = z.infer<typeof yieldVaultsSchema>;
+export type YieldVault = YieldVaults[string][number];

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
@@ -1,0 +1,319 @@
+import fs from 'fs/promises';
+import { join } from 'path';
+
+import { COIN_IMAGE_SIZES, ICONS_URL_BASE, createCoinImageName } from '../../src/coinImages';
+import { FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
+
+jest.mock('fs/promises', () => ({
+    writeFile: jest.fn(),
+}));
+
+const fetchMock = jest.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+// `createHttpClient` captures `globalThis.fetch` when the module under test is first evaluated, so
+// the mock above has to be installed before that happens — hence the require instead of a top-level
+// import, which would be hoisted above the assignment.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { downloadVaultIcons } = require('./downloadVaultIcons') as {
+    downloadVaultIcons: () => Promise<void>;
+};
+
+const ETH_WETH_VAULT = '0x704cfb08969048a8dff298b214f959791d8da509';
+const ETH_USDT_VAULT = '0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829';
+const BASE_WETH_VAULT = '0x4edc6ab1964e25eb2c202ab9f201e9548baa53df';
+const BASE_USDC_VAULT = '0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e';
+
+// Underlying tokens; the WETH ones are the wrapped-native contracts from @suite-common/wallet-config.
+const ETH_WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const BASE_WETH = '0x4200000000000000000000000000000000000006';
+const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const ETH_USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
+
+type FakeResponseInit = { status?: number; json?: unknown; buffer?: ArrayBuffer };
+
+const fakeResponse = ({ status = 200, json, buffer }: FakeResponseInit): Response => {
+    const response = {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'Not Found',
+        headers: new Headers({ 'content-type': json ? 'application/json' : 'image/webp' }),
+        json: () => Promise.resolve(json),
+        text: () => Promise.resolve(json ? JSON.stringify(json) : ''),
+        arrayBuffer: () => Promise.resolve(buffer ?? new ArrayBuffer(0)),
+        clone: () => fakeResponse({ status, json, buffer }),
+    };
+
+    return response as unknown as Response;
+};
+
+const vault = ({
+    address,
+    underlyingAddress,
+    coingeckoId,
+}: {
+    address: string;
+    underlyingAddress: string;
+    coingeckoId: string;
+}) => ({ yieldId: `vault-${address}`, address, underlyingAddress, coingeckoId });
+
+const iconUrl = (coingeckoId: string, size: (typeof COIN_IMAGE_SIZES)[number]) =>
+    `${ICONS_URL_BASE}/${createCoinImageName({ coingeckoId, size })}`;
+
+const sourceIconRoutes = (coingeckoId: string) =>
+    Object.fromEntries(
+        COIN_IMAGE_SIZES.map(size => [
+            iconUrl(coingeckoId, size),
+            fakeResponse({ buffer: new Uint8Array([size]).buffer }),
+        ]),
+    );
+
+const vaultListRoute = (vaults: Record<string, unknown[]>) => ({
+    [YIELD_VAULTS_URL]: fakeResponse({ json: vaults }),
+});
+
+// up-fetch hands `fetch` a Request instance rather than a URL string.
+const urlOf = (input: unknown) =>
+    typeof input === 'object' && input !== null && 'url' in input
+        ? String((input as Request).url)
+        : String(input);
+
+const mockFetchRoutes = (routes: Record<string, Response>) => {
+    fetchMock.mockImplementation((input: unknown) =>
+        Promise.resolve(routes[urlOf(input)] ?? fakeResponse({ status: 404 })),
+    );
+};
+
+const writtenFiles = () => (fs.writeFile as jest.Mock).mock.calls.map(([path]) => String(path));
+
+const requestedUrls = () => fetchMock.mock.calls.map(([input]) => urlOf(input));
+
+describe('downloadVaultIcons', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+    let consoleLogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+        consoleLogSpy.mockRestore();
+    });
+
+    it('writes the underlying icon under the vault address file name in every size', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                ethereum: [
+                    vault({
+                        address: ETH_USDT_VAULT,
+                        underlyingAddress: ETH_USDT,
+                        coingeckoId: 'tether',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('tether'),
+        });
+
+        await downloadVaultIcons();
+
+        for (const size of COIN_IMAGE_SIZES) {
+            expect(fs.writeFile).toHaveBeenCalledWith(
+                join(FILES_CRYPTOICONS_PATH, `ethereum--${ETH_USDT_VAULT}@${size}.webp`),
+                Buffer.from([size]),
+            );
+        }
+        expect(fs.writeFile).toHaveBeenCalledTimes(COIN_IMAGE_SIZES.length);
+    });
+
+    it('substitutes the native coin icon when the underlying is the wrapped native token', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                ethereum: [
+                    vault({
+                        address: ETH_WETH_VAULT,
+                        underlyingAddress: ETH_WETH,
+                        coingeckoId: 'weth',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('ethereum'),
+        });
+
+        await downloadVaultIcons();
+
+        // The WETH icon must never be requested — the vault reads as ETH.
+        expect(requestedUrls()).toContain(iconUrl('ethereum', 24));
+        expect(requestedUrls()).not.toContain(iconUrl('weth', 24));
+        expect(writtenFiles()).toContain(
+            join(FILES_CRYPTOICONS_PATH, `ethereum--${ETH_WETH_VAULT}@24.webp`),
+        );
+    });
+
+    it('resolves an L2 wrapped-native underlying to the settlement layer native coin', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                base: [
+                    vault({
+                        address: BASE_WETH_VAULT,
+                        underlyingAddress: BASE_WETH,
+                        coingeckoId: 'l2-standard-bridged-weth-base',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('ethereum'),
+        });
+
+        await downloadVaultIcons();
+
+        expect(requestedUrls()).toContain(iconUrl('ethereum', 24));
+        expect(requestedUrls()).not.toContain(iconUrl('l2-standard-bridged-weth-base', 24));
+        expect(writtenFiles()).toContain(
+            join(FILES_CRYPTOICONS_PATH, `base--${BASE_WETH_VAULT}@24.webp`),
+        );
+    });
+
+    it('keeps the underlying coin id for a non-wrapped underlying on the same platform', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                base: [
+                    vault({
+                        address: BASE_USDC_VAULT,
+                        underlyingAddress: BASE_USDC,
+                        coingeckoId: 'usd-coin',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('usd-coin'),
+        });
+
+        await downloadVaultIcons();
+
+        expect(requestedUrls()).toContain(iconUrl('usd-coin', 24));
+        expect(writtenFiles()).toContain(
+            join(FILES_CRYPTOICONS_PATH, `base--${BASE_USDC_VAULT}@24.webp`),
+        );
+    });
+
+    it('lowercases the vault address in the written file name', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                base: [
+                    vault({
+                        address: BASE_USDC_VAULT.toUpperCase().replace('0X', '0x'),
+                        underlyingAddress: BASE_USDC,
+                        coingeckoId: 'usd-coin',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('usd-coin'),
+        });
+
+        await downloadVaultIcons();
+
+        expect(writtenFiles()).toContain(
+            join(FILES_CRYPTOICONS_PATH, `base--${BASE_USDC_VAULT}@24.webp`),
+        );
+    });
+
+    it('skips and reports a platform with no known network, still processing the rest', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                'brand-new-chain': [
+                    vault({
+                        address: '0xabc',
+                        underlyingAddress: '0xdef',
+                        coingeckoId: 'usd-coin',
+                    }),
+                ],
+                ethereum: [
+                    vault({
+                        address: ETH_USDT_VAULT,
+                        underlyingAddress: ETH_USDT,
+                        coingeckoId: 'tether',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('tether'),
+        });
+
+        await downloadVaultIcons();
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('brand-new-chain'),
+            expect.anything(),
+        );
+        expect(fs.writeFile).toHaveBeenCalledTimes(COIN_IMAGE_SIZES.length);
+        expect(writtenFiles().every(path => path.includes('ethereum--'))).toBe(true);
+    });
+
+    it('skips sizes whose source icon is not published and writes the remaining ones', async () => {
+        const routes: Record<string, Response> = {
+            ...vaultListRoute({
+                ethereum: [
+                    vault({
+                        address: ETH_USDT_VAULT,
+                        underlyingAddress: ETH_USDT,
+                        coingeckoId: 'tether',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('tether'),
+        };
+        delete routes[iconUrl('tether', 80)];
+
+        mockFetchRoutes(routes);
+
+        await downloadVaultIcons();
+
+        expect(fs.writeFile).toHaveBeenCalledTimes(COIN_IMAGE_SIZES.length - 1);
+        expect(writtenFiles()).not.toContain(
+            join(FILES_CRYPTOICONS_PATH, `ethereum--${ETH_USDT_VAULT}@80.webp`),
+        );
+        expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('downloads each source rendition once when several vaults share an underlying', async () => {
+        mockFetchRoutes({
+            ...vaultListRoute({
+                ethereum: [
+                    vault({
+                        address: ETH_WETH_VAULT,
+                        underlyingAddress: ETH_WETH,
+                        coingeckoId: 'weth',
+                    }),
+                ],
+                base: [
+                    vault({
+                        address: BASE_WETH_VAULT,
+                        underlyingAddress: BASE_WETH,
+                        coingeckoId: 'l2-standard-bridged-weth-base',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('ethereum'),
+        });
+
+        await downloadVaultIcons();
+
+        // Both vaults resolve to native ETH: one vault-list request plus one per source size.
+        expect(fetchMock).toHaveBeenCalledTimes(1 + COIN_IMAGE_SIZES.length);
+        expect(fs.writeFile).toHaveBeenCalledTimes(2 * COIN_IMAGE_SIZES.length);
+    });
+
+    it('throws when the vault list cannot be fetched', async () => {
+        mockFetchRoutes({});
+
+        await expect(downloadVaultIcons()).rejects.toThrow();
+        expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('throws when the vault list does not match the expected schema', async () => {
+        mockFetchRoutes(vaultListRoute({ ethereum: [{ yieldId: 'missing-fields' }] }));
+
+        await expect(downloadVaultIcons()).rejects.toThrow();
+        expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+});

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
@@ -14,7 +14,6 @@ global.fetch = fetchMock as unknown as typeof fetch;
 // `createHttpClient` captures `globalThis.fetch` when the module under test is first evaluated, so
 // the mock above has to be installed before that happens — hence the require instead of a top-level
 // import, which would be hoisted above the assignment.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { downloadVaultIcons } = require('./downloadVaultIcons') as {
     downloadVaultIcons: () => Promise<void>;
 };
@@ -49,13 +48,13 @@ const fakeResponse = ({ status = 200, json, buffer }: FakeResponseInit): Respons
 
 const vault = ({
     address,
-    underlyingAddress,
+    underlyingToken,
     coingeckoId,
 }: {
     address: string;
-    underlyingAddress: string;
+    underlyingToken: string;
     coingeckoId: string;
-}) => ({ yieldId: `vault-${address}`, address, underlyingAddress, coingeckoId });
+}) => ({ yieldId: `vault-${address}`, address, underlyingToken, coingeckoId });
 
 const iconUrl = (coingeckoId: string, size: (typeof COIN_IMAGE_SIZES)[number]) =>
     `${ICONS_URL_BASE}/${createCoinImageName({ coingeckoId, size })}`;
@@ -109,7 +108,7 @@ describe('downloadVaultIcons', () => {
                 ethereum: [
                     vault({
                         address: ETH_USDT_VAULT,
-                        underlyingAddress: ETH_USDT,
+                        underlyingToken: ETH_USDT,
                         coingeckoId: 'tether',
                     }),
                 ],
@@ -134,7 +133,7 @@ describe('downloadVaultIcons', () => {
                 ethereum: [
                     vault({
                         address: ETH_WETH_VAULT,
-                        underlyingAddress: ETH_WETH,
+                        underlyingToken: ETH_WETH,
                         coingeckoId: 'weth',
                     }),
                 ],
@@ -158,7 +157,7 @@ describe('downloadVaultIcons', () => {
                 base: [
                     vault({
                         address: BASE_WETH_VAULT,
-                        underlyingAddress: BASE_WETH,
+                        underlyingToken: BASE_WETH,
                         coingeckoId: 'l2-standard-bridged-weth-base',
                     }),
                 ],
@@ -181,7 +180,7 @@ describe('downloadVaultIcons', () => {
                 base: [
                     vault({
                         address: BASE_USDC_VAULT,
-                        underlyingAddress: BASE_USDC,
+                        underlyingToken: BASE_USDC,
                         coingeckoId: 'usd-coin',
                     }),
                 ],
@@ -203,7 +202,7 @@ describe('downloadVaultIcons', () => {
                 base: [
                     vault({
                         address: BASE_USDC_VAULT.toUpperCase().replace('0X', '0x'),
-                        underlyingAddress: BASE_USDC,
+                        underlyingToken: BASE_USDC,
                         coingeckoId: 'usd-coin',
                     }),
                 ],
@@ -224,14 +223,14 @@ describe('downloadVaultIcons', () => {
                 'brand-new-chain': [
                     vault({
                         address: '0xabc',
-                        underlyingAddress: '0xdef',
+                        underlyingToken: '0xdef',
                         coingeckoId: 'usd-coin',
                     }),
                 ],
                 ethereum: [
                     vault({
                         address: ETH_USDT_VAULT,
-                        underlyingAddress: ETH_USDT,
+                        underlyingToken: ETH_USDT,
                         coingeckoId: 'tether',
                     }),
                 ],
@@ -255,7 +254,7 @@ describe('downloadVaultIcons', () => {
                 ethereum: [
                     vault({
                         address: ETH_USDT_VAULT,
-                        underlyingAddress: ETH_USDT,
+                        underlyingToken: ETH_USDT,
                         coingeckoId: 'tether',
                     }),
                 ],
@@ -281,14 +280,14 @@ describe('downloadVaultIcons', () => {
                 ethereum: [
                     vault({
                         address: ETH_WETH_VAULT,
-                        underlyingAddress: ETH_WETH,
+                        underlyingToken: ETH_WETH,
                         coingeckoId: 'weth',
                     }),
                 ],
                 base: [
                     vault({
                         address: BASE_WETH_VAULT,
-                        underlyingAddress: BASE_WETH,
+                        underlyingToken: BASE_WETH,
                         coingeckoId: 'l2-standard-bridged-weth-base',
                     }),
                 ],

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.ts
@@ -1,0 +1,148 @@
+/* eslint-disable no-console */
+import fs from 'fs/promises';
+import { join } from 'path';
+import { z } from 'zod';
+
+import { createHttpClient, isResponseError } from '@suite-common/http-client';
+import {
+    type Network,
+    getNetwork,
+    getNetworkByCoingeckoId,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+
+import {
+    COIN_IMAGE_SIZES,
+    type CoinImageSize,
+    ICONS_URL_BASE,
+    createCoinImageName,
+} from '../../src/coinImages';
+import { FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
+import { type YieldVault, yieldVaultsSchema } from '../schemas';
+
+const earnYieldApi = createHttpClient({
+    onError: error => {
+        console.error('Vault icons: error fetching yield vaults:', error);
+    },
+});
+
+const fetchYieldVaults = earnYieldApi(YIELD_VAULTS_URL, {
+    method: 'GET',
+    schema: yieldVaultsSchema,
+});
+
+// Errors are handled per icon by the caller (a missing rendition only skips that one file), so this
+// client stays silent instead of logging every expected 404 twice.
+const iconsCdnApi = createHttpClient({});
+
+const fetchPublishedIcon = (fileName: string) =>
+    iconsCdnApi(`${ICONS_URL_BASE}/${fileName}`, {
+        method: 'GET',
+        parseResponse: response => response.arrayBuffer(),
+        schema: z.instanceof(ArrayBuffer),
+        // The CDN is the source of every vault icon, so ride out a transient 5xx rather than
+        // silently leaving the icon unpublished until the next nightly run.
+        retry: {
+            attempts: 2,
+            delay: 1000,
+            when: ({ response }) => (response?.status ?? 0) >= 500,
+        },
+    })();
+
+/**
+ * A vault-position token renders as the asset the vault is denominated in — except that a
+ * wrapped-native underlying reads as the native coin: a WETH vault is an ETH vault.
+ * On an L2 the native coin is the settlement layer's, so ETH is
+ * resolved through `settlementLayer` rather than from the L2 itself.
+ */
+const resolveSourceCoingeckoId = (network: Network, vault: YieldVault) => {
+    if (!isWrappedNativeToken(network.symbol, vault.underlyingToken)) {
+        return vault.coingeckoId;
+    }
+
+    return getNetwork(network.settlementLayer ?? network.symbol).tradeCryptoId;
+};
+
+const fetchSourceIcon = async (
+    coingeckoId: string,
+    size: CoinImageSize,
+): Promise<Buffer | undefined> => {
+    const fileName = createCoinImageName({ coingeckoId, size });
+
+    try {
+        return Buffer.from(await fetchPublishedIcon(fileName));
+    } catch (error) {
+        if (isResponseError(error)) {
+            console.error('Vault icons: source icon is not published:', fileName, error.status);
+        } else {
+            console.error('Vault icons: failed to fetch source icon:', fileName, error);
+        }
+
+        return undefined;
+    }
+};
+
+/**
+ * Derives icons for yield-vault position tokens. The vault contracts are not listed on CoinGecko
+ * (and even if they were, they would carry the vault operator's branding), so the main
+ * CoinGecko-driven pipeline never produces them — instead, copy the underlying asset's already
+ * published renditions under each vault-address file name.
+ */
+export const downloadVaultIcons = async (): Promise<void> => {
+    const vaults = await fetchYieldVaults();
+
+    // The same underlying backs vaults on several platforms, so fetch each source rendition once.
+    const sourceIconCache = new Map<string, Buffer | undefined>();
+    const savedIcons: string[] = [];
+
+    for (const [assetPlatformId, platformVaults] of Object.entries(vaults)) {
+        if (platformVaults.length === 0) {
+            continue;
+        }
+
+        const network = getNetworkByCoingeckoId(assetPlatformId);
+        if (!network) {
+            console.error(
+                `Vault icons: no network known for CoinGecko asset platform "${assetPlatformId}", skipping its vaults:`,
+                platformVaults.map(vault => vault.yieldId),
+            );
+            continue;
+        }
+
+        for (const vault of platformVaults) {
+            const sourceCoingeckoId = resolveSourceCoingeckoId(network, vault);
+            if (!sourceCoingeckoId) {
+                console.error(
+                    `Vault icons: no source coin resolved for "${vault.yieldId}", skipping it:`,
+                    vault.address,
+                );
+                continue;
+            }
+
+            for (const size of COIN_IMAGE_SIZES) {
+                const cacheKey = createCoinImageName({ coingeckoId: sourceCoingeckoId, size });
+                if (!sourceIconCache.has(cacheKey)) {
+                    sourceIconCache.set(cacheKey, await fetchSourceIcon(sourceCoingeckoId, size));
+                }
+
+                const imageBuffer = sourceIconCache.get(cacheKey);
+                if (!imageBuffer) {
+                    continue;
+                }
+
+                // All vault platforms are EVM chains, where Suite requests icons by the lowercased
+                // contract address.
+                const fileName = createCoinImageName({
+                    coingeckoId: assetPlatformId,
+                    contractAddress: vault.address.toLowerCase(),
+                    size,
+                });
+
+                await fs.writeFile(join(FILES_CRYPTOICONS_PATH, fileName), imageBuffer);
+                savedIcons.push(fileName);
+            }
+        }
+    }
+
+    console.log(`Vault icons: 🟢 Saved ${savedIcons.length} files:\n`, savedIcons);
+};

--- a/suite-common/icons/tsconfig.json
+++ b/suite-common/icons/tsconfig.json
@@ -2,5 +2,8 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "include": [".", "**/*.json"],
-    "references": [{ "path": "../http-client" }]
+    "references": [
+        { "path": "../http-client" },
+        { "path": "../wallet-config" }
+    ]
 }

--- a/suite-common/token-definitions/scripts/index.ts
+++ b/suite-common/token-definitions/scripts/index.ts
@@ -5,10 +5,7 @@ import { join } from 'path';
 import { DEFINITIONS_FILENAME_SUFFIX, FILES_PATH } from './constants';
 import { buildCoinDataForPlatform, fetchAllCoins } from './utils/fetchCoins';
 import { fetchNftData } from './utils/fetchNft';
-import {
-    VAULT_NETWORK_BY_ASSET_PLATFORM,
-    fetchVaultDefinitions,
-} from './utils/fetchVaultDefinitions';
+import { fetchVaultDefinitions } from './utils/fetchVaultDefinitions';
 import { signData } from './utils/sign';
 import { validateStructure } from './utils/validate';
 import { DefinitionType, TokenStructure, TokenStructureType } from '../src/tokenDefinitionsTypes';
@@ -86,28 +83,22 @@ const main = async () => {
         const allCoins = await fetchAllCoins();
 
         const vaultDefinitions =
-            structure === TokenStructureType.SIMPLE &&
-            assetPlatformIds.some(id => id in VAULT_NETWORK_BY_ASSET_PLATFORM)
-                ? await fetchVaultDefinitions()
-                : null;
+            structure === TokenStructureType.SIMPLE ? await fetchVaultDefinitions() : null;
 
         for (const assetPlatformId of assetPlatformIds) {
             console.log('Building coin data for:', assetPlatformId);
-            const data = await buildCoinDataForPlatform(allCoins, assetPlatformId, structure);
+            const coinData = await buildCoinDataForPlatform(allCoins, assetPlatformId, structure);
 
-            const vaultNetwork = VAULT_NETWORK_BY_ASSET_PLATFORM[assetPlatformId];
-            if (vaultNetwork && vaultDefinitions?.[vaultNetwork]?.length && Array.isArray(data)) {
-                const vaultAddresses = vaultDefinitions[vaultNetwork];
-                const newVaultAddresses = vaultAddresses
-                    .filter(vault => !data.includes(vault.address))
-                    .map(vault => vault.address);
-
-                data.push(...newVaultAddresses);
+            const vaults = vaultDefinitions?.[assetPlatformId];
+            if (Array.isArray(vaults) && coinData instanceof Set) {
+                vaults.forEach(vault => coinData.add(vault.address));
 
                 console.log(
-                    `Merged ${newVaultAddresses.length} vault address(es) from the earn-yield worker for ${assetPlatformId}`,
+                    `Merged vault address(es) from the earn-yield worker for ${assetPlatformId}`,
                 );
             }
+
+            const data: TokenStructure = coinData instanceof Set ? Array.from(coinData) : coinData;
 
             const length = countRecords(data, structure);
             console.log('Records for specific platform:', length);

--- a/suite-common/token-definitions/scripts/utils/fetchCoins.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchCoins.ts
@@ -3,11 +3,7 @@ import * as toml from 'toml';
 
 import { blockfrostUtils } from '@trezor/blockchain-link-utils';
 
-import {
-    AdvancedTokenStructure,
-    SimpleTokenStructure,
-    TokenStructureType,
-} from '../../src/tokenDefinitionsTypes';
+import { AdvancedTokenStructure, TokenStructureType } from '../../src/tokenDefinitionsTypes';
 import { COIN_LIST_URL, STELLAR_EXPERT_URL, STELLAR_HORIZON_URL } from '../constants';
 import { CoinData } from '../types';
 
@@ -255,11 +251,16 @@ export const fetchAllCoins = async (): Promise<CoinData[]> => {
     }
 };
 
+/**
+ * Returns a Set for the simple structure rather than SimpleTokenStructure (string[]), so the caller
+ * can merge extra addresses with `has`/`add` instead of a linear scan over tens of thousands of
+ * contracts. Convert with `Array.from` before writing the definition files.
+ */
 export const buildCoinDataForPlatform = async (
     allCoins: CoinData[],
     assetPlatformId: string,
     structure: TokenStructureType,
-): Promise<AdvancedTokenStructure | SimpleTokenStructure> => {
+): Promise<AdvancedTokenStructure | Set<string>> => {
     if (structure === TokenStructureType.ADVANCED) {
         const result: AdvancedTokenStructure = {};
 
@@ -292,5 +293,5 @@ export const buildCoinDataForPlatform = async (
         contractAddresses.add(contractAddress);
     }
 
-    return [...contractAddresses];
+    return contractAddresses;
 };

--- a/suite-common/token-definitions/scripts/utils/fetchVaultDefinitions.ts
+++ b/suite-common/token-definitions/scripts/utils/fetchVaultDefinitions.ts
@@ -1,37 +1,26 @@
-import { NetworkSymbol } from '@suite-common/wallet-config';
-
+/* eslint-disable no-console */
 import { YIELD_VAULTS_URL } from '../constants';
 
 /**
- * Mirror of the worker's `YieldDefinitions` schema, narrowed to the keys this
- * script needs. Inlined to keep the script free of a runtime dep on
+ * Mirror of the worker's `YieldVaults` schema, narrowed to the keys this script
+ * needs. Inlined to keep the script free of a runtime dep on
  * `@suite-common/earn-stablecoin-api`.
+ *
+ * Keyed by CoinGecko asset platform id — the same ids this script takes as CLI
+ * args — so no network-symbol mapping is needed. A platform the worker does not
+ * support for vaults is simply absent.
  */
 type YieldDefinitions = Record<
-    Extract<NetworkSymbol, 'eth' | 'op' | 'arb' | 'base'>,
-    {
-        yieldId: string;
-        address: string;
-    }[]
+    string,
+    | {
+          yieldId: string;
+          address: string;
+      }[]
+    | undefined
 >;
 
-/**
- * Maps a CoinGecko asset platform id (as used by this script's CLI args) to
- * the worker's vault network key. Networks not present here have no vaults.
- */
-export const VAULT_NETWORK_BY_ASSET_PLATFORM: Partial<Record<string, keyof YieldDefinitions>> = {
-    ethereum: 'eth',
-    'arbitrum-one': 'arb',
-    base: 'base',
-    'optimistic-ethereum': 'op',
-};
-
 export const fetchVaultDefinitions = async (): Promise<YieldDefinitions> => {
-    const response = await fetch(YIELD_VAULTS_URL, {
-        headers: {
-            'X-Suite-Version': 'latest',
-        },
-    });
+    const response = await fetch(YIELD_VAULTS_URL);
 
     if (!response.ok) {
         throw new Error(
@@ -39,5 +28,10 @@ export const fetchVaultDefinitions = async (): Promise<YieldDefinitions> => {
         );
     }
 
-    return response.json();
+    const vaultDefinitions: YieldDefinitions = await response.json();
+    const platformIds = Object.keys(vaultDefinitions);
+
+    console.log('Vault definitions fetched for platforms:', platformIds.join(', '));
+
+    return vaultDefinitions;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10593,6 +10593,7 @@ __metadata:
   resolution: "@suite-common/icons@workspace:suite-common/icons"
   dependencies:
     "@suite-common/http-client": "workspace:^"
+    "@suite-common/wallet-config": "workspace:^"
     chalk: "npm:^5.6.2"
     fantasticon: "npm:4.1.0"
     prettier: "npm:^3.8.4"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Extended worker in https://github.com/trezor/cloudflare-workers/pull/99 so it returns via `/yield/vaults/v1` `Map<CoingeckoId, Vaults[]>` (instead of `Map<NetworkSymbol, Vaults>`) and each vault contains now an address of underlying token. 
- So it's now possible to simplify the tokens defs script (no need for the mapping) and the download crypto icons script can now download icons for vaults (i.e. download icon of underlying token and uploads it under vault address). 
   
Output example:
```
Vault icons: 🟢 Saved 20 files:
 [
  'ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@24.webp',
  'ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@40.webp',
  'ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@48.webp',
  'ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@80.webp',

  'ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@24.webp',
  'ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@40.webp',
  'ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@48.webp',
  'ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@80.webp',

  'ethereum--0x704cfb08969048a8dff298b214f959791d8da509@24.webp',
  'ethereum--0x704cfb08969048a8dff298b214f959791d8da509@40.webp',
  'ethereum--0x704cfb08969048a8dff298b214f959791d8da509@48.webp',
  'ethereum--0x704cfb08969048a8dff298b214f959791d8da509@80.webp',

  'base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@24.webp',
  'base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@40.webp',
  'base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@48.webp',
  'base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@80.webp',
  
  'base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@24.webp',
  'base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@40.webp',
  'base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@48.webp',
  'base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@80.webp'
]
```

Fixes the current state:

Vault | Icon asset | Status
-- | -- | --
eth steakUSDT 0xe4db…3829 | ethereum--0xe4db…@*.webp | ✅ 200
eth steakUSDC 0xde6c…c889 | ethereum--0xde6c…@*.webp | ✅ 200
eth steakETH (trSHETHp) 0x704c…a509 | ethereum--0x704c…@*.webp | ❌ 404
base steakETH 0x4edc…53df | base--0x4edc…@*.webp | ❌ 404
base steakUSDC 0x5e6f…c53e | base--0x5e6f…@*.webp | ❌ 404

## Related Issue

Resolve #29862

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all build/CI scripts and configuration under suite-common/icons and suite-common/token-definitions (icon download/fetch and token definition fetch utilities). They are not runtime application code, so no Playwright E2E test directly exercises them. The best place to gain confidence in these changes is the existing unit tests for the scripts themselves (e.g., downloadVaultIcons.test.ts). Running user-facing E2E suites would not materially increase confidence and would be inefficient.

<details><summary><b>Changed files (10)</b></summary>

- `suite-common/icons/package.json`
- `suite-common/icons/scripts/constants/index.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/schemas/index.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.test.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.ts`
- `suite-common/icons/tsconfig.json`
- `suite-common/token-definitions/scripts/index.ts`
- `suite-common/token-definitions/scripts/utils/fetchCoins.ts`
- `suite-common/token-definitions/scripts/utils/fetchVaultDefinitions.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `suite-common/icons/package.json`
- `suite-common/icons/scripts/constants/index.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/schemas/index.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.test.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.ts`
- `suite-common/icons/tsconfig.json`
- `suite-common/token-definitions/scripts/index.ts`
- `suite-common/token-definitions/scripts/utils/fetchCoins.ts`
- `suite-common/token-definitions/scripts/utils/fetchVaultDefinitions.ts`

_Updated: 2026-07-30T06:53:13.538Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/download-vault-icons/web/](https://dev.suite.sldev.cz/suite-web/feat/download-vault-icons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/download-vault-icons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/download-vault-icons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/download-vault-icons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T06:55:30.959Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T06:54:33.890Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->