### PR TITLE
Schedule mobile develop releases hourly

### DIFF
--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -1,13 +1,9 @@
 name: "[Release] suite-native develop"
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - "suite-native/**"
-      - "suite-common/**"
-      - "!**.md"
+  schedule:
+    # Run every hour at 21 minutes past the hour (UTC).
+    - cron: "21 * * * *"
   workflow_dispatch:
 
 concurrency:
@@ -41,7 +37,27 @@ jobs:
       - name: Install libs
         run: |
           yarn workspaces focus @suite-native/app
+      - name: Check existing EAS builds for commit
+        id: check-existing-builds
+        run: |
+          for PLATFORM in android ios; do
+            EXISTING_BUILD=$(eas build:list \
+              --platform "$PLATFORM" \
+              --build-profile develop \
+              --git-commit-hash "${{ github.sha }}" \
+              --limit 1 \
+              --non-interactive \
+              --json)
+
+            if [ "$EXISTING_BUILD" = "[]" ]; then
+              echo "$PLATFORM-build-exists=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "$PLATFORM-build-exists=true" >> "$GITHUB_OUTPUT"
+            fi
+          done
+        working-directory: suite-native/app
       - name: Build on EAS Android
+        if: steps.check-existing-builds.outputs.android-build-exists == 'false'
         run: eas build
           --platform android
           --profile develop
@@ -50,6 +66,7 @@ jobs:
           --message ${{ github.sha }}
         working-directory: suite-native/app
       - name: Build on EAS iOS
+        if: steps.check-existing-builds.outputs.ios-build-exists == 'false'
         run: eas build
           --platform ios
           --profile develop

--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -5,6 +5,11 @@ on:
     # Run every hour at 21 minutes past the hour (UTC).
     - cron: "21 * * * *"
   workflow_dispatch:
+    inputs:
+      commit:
+        description: "Full commit SHA from develop; leave empty for latest."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,6 +25,20 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          ref: ${{ inputs.commit || 'develop' }}
+          fetch-depth: 0
+      - name: Resolve selected commit
+        id: selected-commit
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+
+          if ! git merge-base --is-ancestor "$COMMIT_SHA" origin/develop; then
+            echo "Commit $COMMIT_SHA does not belong to develop." >&2
+            exit 1
+          fi
+
+          echo "sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: ".nvmrc"
@@ -44,7 +63,7 @@ jobs:
             EXISTING_BUILD=$(eas build:list \
               --platform "$PLATFORM" \
               --build-profile develop \
-              --git-commit-hash "${{ github.sha }}" \
+              --git-commit-hash "${{ steps.selected-commit.outputs.sha }}" \
               --limit 1 \
               --non-interactive \
               --json)
@@ -63,7 +82,7 @@ jobs:
           --profile develop
           --non-interactive
           --no-wait
-          --message ${{ github.sha }}
+          --message ${{ steps.selected-commit.outputs.sha }}
         working-directory: suite-native/app
       - name: Build on EAS iOS
         if: steps.check-existing-builds.outputs.ios-build-exists == 'false'
@@ -73,5 +92,5 @@ jobs:
           --non-interactive
           --auto-submit
           --no-wait
-          --message ${{ github.sha }}
+          --message ${{ steps.selected-commit.outputs.sha }}
         working-directory: suite-native/app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Submissions to TestFlight often fail for develop builds because we send too many of them. So, more and more often, we don't have a fresh iOS build for a couple of hours. This is because we do a new build on every push to develop where the suite-native/ or suite-common/ folder is touched and the limit is somewhere around 20 submissions per 24 hours.

Additionally, the option to select a specific commit when triggering a manual build is added, in case a specific build is needed.


## Notes for QA

Nothing to test, but keep in mind that from now on we don't do a build for each develop commit, but we batch the commits in hourly builds. If you need a specific commit, you can dispatch the workflow manually and select the exact commit as an input. But don't do that multiple time, otherwise you can again be rate-limited.



## Screenshots:
<img width="1446" height="1558" alt="image" src="https://github.com/user-attachments/assets/15072ee3-60a8-4b08-b5eb-7b190bd40908" />
