### PR TITLE
refactor(components): use ThemeProvider in Tooltip component for consistent theming

### DIFF
--- a/packages/components/src/components/Tooltip/TooltipBox.tsx
+++ b/packages/components/src/components/Tooltip/TooltipBox.tsx
@@ -1,5 +1,8 @@
 import { type ReactNode } from 'react';
 
+import { ThemeProvider } from 'styled-components';
+
+import { intermediaryTheme } from '../../config/colors';
 import { Box } from '../Box/Box';
 import { Column, Row } from '../Flex/Flex';
 import { Text } from '../typography/Text/Text';
@@ -12,6 +15,8 @@ export type TooltipBoxProps = {
 
 type TooltipBoxExtendedProps = TooltipBoxProps & Required<Pick<TooltipBoxProps, 'tooltipMaxWidth'>>;
 
+const tooltipContentTheme = { ...intermediaryTheme.dark, variant: 'dark' as const };
+
 export const TooltipBox = ({ addon, tooltipMaxWidth, content }: TooltipBoxExtendedProps) => (
     <Box
         maxWidth={tooltipMaxWidth}
@@ -23,17 +28,13 @@ export const TooltipBox = ({ addon, tooltipMaxWidth, content }: TooltipBoxExtend
         shadow="surfaceShadowModeless"
         padding={{ vertical: 6, horizontal: 8 }}
     >
-        <Column gap={6}>
-            <Text
-                typographyStyle="body-sm"
-                as="div"
-                isInverse
-                intent="neutral"
-                overflowWrap="anywhere"
-            >
-                {content}
-            </Text>
-            {addon && <Row>{addon}</Row>}
-        </Column>
+        <ThemeProvider theme={tooltipContentTheme}>
+            <Column gap={6}>
+                <Text typographyStyle="body-sm" as="div" intent="neutral" overflowWrap="anywhere">
+                    {content}
+                </Text>
+                {addon && <Row>{addon}</Row>}
+            </Column>
+        </ThemeProvider>
     </Box>
 );

--- a/packages/product-components/src/components/TooltipRow/TooltipRow.tsx
+++ b/packages/product-components/src/components/TooltipRow/TooltipRow.tsx
@@ -24,10 +24,8 @@ export const TooltipRow = ({
         <Column alignItems="start">
             <Text>{header}</Text>
             <Row gap={4}>
-                <Icon as={icon} intent={intent} size={12} isInverse />
-                <Text intent={intent} isInverse>
-                    {children}
-                </Text>
+                <Icon as={icon} intent={intent} size={12} />
+                <Text intent={intent}>{children}</Text>
             </Row>
         </Column>
     </Row>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -107,7 +107,6 @@ export const EarnYieldApyBreakdown = ({
                                     typographyStyle="body-sm"
                                     intent="neutral"
                                     priority="secondary"
-                                    isInverse
                                     data-testid="@earn/dashboard/apy-breakdown/description"
                                 >
                                     <Translation id={descriptionId} />
@@ -118,7 +117,6 @@ export const EarnYieldApyBreakdown = ({
                             typographyStyle="body-sm"
                             intent={hasRatePercent ? 'brand' : 'neutral'}
                             priority={hasRatePercent ? 'primary' : 'secondary'}
-                            isInverse
                             data-testid="@earn/dashboard/apy-breakdown/rate-percent"
                         >
                             {rateNode}
@@ -127,19 +125,12 @@ export const EarnYieldApyBreakdown = ({
                 );
             })}
             <Row gap={4} alignItems="center" margin={{ top: 4 }}>
-                <Icon
-                    as={ChartLineIcon}
-                    size={14}
-                    intent="neutral"
-                    priority="secondary"
-                    isInverse
-                />
+                <Icon as={ChartLineIcon} size={14} intent="neutral" priority="secondary" />
                 <Text
                     data-testid="@earn/dashboard/apy-breakdown/footer"
                     typographyStyle="body-sm"
                     intent="neutral"
                     priority="secondary"
-                    isInverse
                 >
                     <Translation id={footerId} />
                 </Text>

--- a/packages/suite/src/components/firmware/FirmwareOffer.tsx
+++ b/packages/suite/src/components/firmware/FirmwareOffer.tsx
@@ -88,11 +88,7 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                         <Column padding={4} gap={4}>
                             {parsedChangelog && (
                                 <Row justifyContent="space-between">
-                                    <Text
-                                        typographyStyle="body-sm-strong"
-                                        isInverse
-                                        intent="neutral"
-                                    >
+                                    <Text typographyStyle="body-sm-strong" intent="neutral">
                                         <Translation
                                             id="TR_VERSION"
                                             values={{ version: parsedChangelog.versionString }}
@@ -103,7 +99,6 @@ export const FirmwareOffer = ({ isCustomFirmware, targetFirmwareType }: Firmware
                                         intent="neutral"
                                         priority="secondary"
                                         href={changelogUrl}
-                                        isInverse
                                     >
                                         <Translation id="TR_VIEW_ALL" />
                                     </TextButton>

--- a/packages/suite/src/components/guide/GuideButton.tsx
+++ b/packages/suite/src/components/guide/GuideButton.tsx
@@ -92,7 +92,7 @@ export const GuideButton = memo(function GuideButton() {
                     content={
                         <Row gap={8}>
                             <Translation id="TR_GUIDE_SUPPORT_AND_FEEDBACK" />
-                            <ShortcutBadge shortcut={['F1']} isInverse />
+                            <ShortcutBadge shortcut={['F1']} />
                         </Row>
                     }
                     placement="top"

--- a/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
+++ b/packages/suite/src/components/guide/OpenGuideFromTooltip.tsx
@@ -22,7 +22,6 @@ export const OpenGuideFromTooltip = ({ id }: OpenGuideFromTooltipProps) => {
                 openNodeById(id);
             }}
             size="small"
-            isInverse
             iconLeft={LightbulbIcon}
         >
             <Translation id="TR_LEARN" />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx
@@ -114,7 +114,7 @@ export const DeviceSelector = () => {
                     content={
                         <Row gap={12} alignItems="center">
                             <Translation id="TR_GUIDE_KEYBOARD_SHORTCUTS_SWITCH_DEVICE" />
-                            <ShortcutBadge shortcut={['ALT', 'KEY_W']} isInverse />
+                            <ShortcutBadge shortcut={['ALT', 'KEY_W']} />
                         </Row>
                     }
                 >

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx
@@ -63,7 +63,7 @@ export const DeviceStatus = ({
                         content={
                             <Row gap={16} alignItems="center">
                                 {content}
-                                <ShortcutBadge shortcut={['ALT', 'KEY_W']} isInverse />
+                                <ShortcutBadge shortcut={['ALT', 'KEY_W']} />
                             </Row>
                         }
                     >

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -118,7 +118,7 @@ const NavItem = ({
                 shortcut ? (
                     <Row gap={12}>
                         <Title nameId={nameId} values={values} />
-                        <ShortcutBadge shortcut={shortcut} isInverse />
+                        <ShortcutBadge shortcut={shortcut} />
                     </Row>
                 ) : (
                     <Title nameId={nameId} values={values} />

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx
@@ -25,7 +25,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header={<Translation id="TR_EXPERIMENTAL_FEATURES_ALLOW" />}
-                leftItem={<Icon as={AtomIcon} intent="warning" isInverse size={16} />}
+                leftItem={<Icon as={AtomIcon} intent="warning" size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>
@@ -35,7 +35,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header={<Translation id="TR_EARLY_ACCESS" />}
-                leftItem={<Icon as={StarFourIcon} intent="info" isInverse size={16} />}
+                leftItem={<Icon as={StarFourIcon} intent="info" size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>
@@ -45,7 +45,7 @@ const DebugAndExperimentalTooltip = ({
                 icon={CheckIcon}
                 intent="brand"
                 header="Debug Mode"
-                leftItem={<Icon as={DotOutlineFilledIcon} intent="critical" isInverse size={16} />}
+                leftItem={<Icon as={DotOutlineFilledIcon} intent="critical" size={16} />}
             >
                 <Translation id="TR_QUICK_ACTION_DEBUG_EAP_EXPERIMENTAL_ENABLED" />
             </TooltipRow>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx
@@ -27,7 +27,7 @@ export const HideBalances = () => {
                 content: (
                     <Row gap={8}>
                         {translationString(translationLabel)}
-                        <ShortcutBadge shortcut={['ALT', 'KEY_H']} isInverse />
+                        <ShortcutBadge shortcut={['ALT', 'KEY_H']} />
                     </Row>
                 ),
             }}

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx
@@ -33,7 +33,6 @@ const BackendRow = ({
                         typographyStyle="body-xs"
                         intent="neutral"
                         priority="secondary"
-                        isInverse
                         case="capitalize"
                     >
                         {type}
@@ -59,7 +58,7 @@ export const NavBackends = ({ customBackends }: NavBackendsProps) => {
                     <BackendRow key={backend.symbol} backend={backend} blockchain={blockchain} />
                 ))}
             </Column>
-            <Note isInverse>
+            <Note>
                 <Translation id="TR_OTHER_COINS_USE_DEFAULT_BACKEND" />
             </Note>
         </Column>

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx
@@ -58,7 +58,6 @@ export function CollapsibleFeesHeader({
                             intent="neutral"
                             priority="secondary"
                             href={HELP_CENTER_TRANSACTION_FEES_URL}
-                            isInverse
                         >
                             <Translation id="TR_LEARN" />
                         </TextButton>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx
@@ -46,7 +46,7 @@ export const AddAccountButton = ({ device }: AddAccountButtonProps) => {
             content={
                 <Row gap={12}>
                     <Translation id="TR_ADD_ACCOUNT" />
-                    <ShortcutBadge shortcut={['ALT', 'KEY_A']} isInverse />
+                    <ShortcutBadge shortcut={['ALT', 'KEY_A']} />
                 </Row>
             }
         >

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx
@@ -37,17 +37,12 @@ type DeviceItemProps = {
 };
 
 const ListItem = ({ children, icon }: { children: ReactNode; icon: IconComponent }) => (
-    <List.Item
-        bulletComponent={
-            <Icon as={icon} intent="neutral" priority="secondary" isInverse size={20} />
-        }
-    >
+    <List.Item bulletComponent={<Icon as={icon} intent="neutral" priority="secondary" size={20} />}>
         <Paragraph
             typographyStyle="body-md"
             intent="neutral"
             priority="secondary"
             textWrap="pretty"
-            isInverse
         >
             {children}
         </Paragraph>
@@ -135,7 +130,6 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                     onTooltipClose();
                                                     onCancel?.();
                                                 }}
-                                                isInverse
                                             >
                                                 <Translation id="TR_DEVICE_DISCONNECTED_TOOLTIP_BUTTON_PRIMARY" />
                                             </Button>
@@ -143,7 +137,6 @@ export const DeviceItem = ({ device, instances, onCancel }: DeviceItemProps) => 
                                                 size="small"
                                                 intent="neutral"
                                                 priority="secondary"
-                                                isInverse
                                                 onClick={() => {
                                                     onTooltipClose();
                                                     dispatch(

--- a/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx
@@ -6,8 +6,17 @@ import { setConnectionModal, setConnectionMode, useDevice } from '@suite/device'
 import { Translation } from '@suite/intl';
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { isLowAnonymityWarning } from '@suite-common/wallet-utils';
-import { Banner, Button, Checkbox, Column, Paragraph, Tooltip } from '@trezor/components';
-import { paletteV2 } from '@trezor/theme';
+import {
+    Banner,
+    Button,
+    Checkbox,
+    Column,
+    H4,
+    Link,
+    List,
+    Paragraph,
+    Tooltip,
+} from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
@@ -17,23 +26,6 @@ const Container = styled.div`
     flex-direction: column;
     grid-column: 1 / 3;
     gap: 16px;
-`;
-const TooltipHeading = styled.p`
-    opacity: 0.6;
-`;
-
-const List = styled.ul`
-    list-style: disc;
-    margin-left: 16px;
-`;
-
-const TextButton = styled.button`
-    background: none;
-    border: none;
-    color: ${paletteV2.globalWhiteAlpha1000};
-    cursor: pointer;
-    padding: 0;
-    text-decoration: underline;
 `;
 
 export const ReviewButton = () => {
@@ -122,14 +114,14 @@ export const ReviewButton = () => {
     const tooltipContent =
         isLowAnonymity || confirmationRequired ? (
             <>
-                <TooltipHeading>
+                <H4>
                     <Translation id="TR_NOT_ENOUGH_ANONYMIZED_FUNDS_TOOLTIP" />
-                </TooltipHeading>
-                <List>
-                    <li>
+                </H4>
+                <List listStyleType="disc" gap={0}>
+                    <List.Item>
                         <Translation id="TR_ANONYMIZATION_OPTION_1" />
-                    </li>
-                    <li>
+                    </List.Item>
+                    <List.Item>
                         <Translation
                             id="TR_ANONYMIZATION_OPTION_2"
                             values={{
@@ -137,16 +129,14 @@ export const ReviewButton = () => {
                                     coinControlOpen ? (
                                         chunks
                                     ) : (
-                                        <TextButton onClick={toggleUtxoSelection}>
-                                            {chunks}
-                                        </TextButton>
+                                        <Link onClick={toggleUtxoSelection}>{chunks}</Link>
                                     ),
                             }}
                         />
-                    </li>
-                    <li>
+                    </List.Item>
+                    <List.Item>
                         <Translation id="TR_ANONYMIZATION_OPTION_3" />
-                    </li>
+                    </List.Item>
                 </List>
             </>
         ) : null;

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -118,7 +118,6 @@ export const FilterAction = () => {
                         priority="secondary"
                         size="small"
                         onClick={handleClose}
-                        isInverse
                         data-testid="@hideScamTransactionsTooltip/gotIt"
                     >
                         <Translation id="TR_GOT_IT_BUTTON" />


### PR DESCRIPTION
## Notes for QA
Updates Tooltip component to always use dark mode inside its content.


## Screenshots:
<img width="699" height="512" alt="image" src="https://github.com/user-attachments/assets/9e4dd8d3-0d2d-4880-ba5f-e2d6ee729ee4" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Most changed files are broad layout/UI components (tooltips, sidebar, device selector) with only indirect E2E coverage, so the highest-value tests are those that directly click or assert the changed components: discreet mode, guide, device status, account addition, send review, firmware install, and device switcher. A small set of medium-priority tests covers related navigation, backend, and fee infrastructure. Broad tooltip and presentational components lack direct E2E assertions, so they are not assigned dedicated tests.

<details><summary><b>Changed files (17)</b></summary>

- `packages/components/src/components/Tooltip/TooltipBox.tsx`
- `packages/product-components/src/components/TooltipRow/TooltipRow.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`
- `packages/suite/src/components/firmware/FirmwareOffer.tsx`
- `packages/suite/src/components/guide/GuideButton.tsx`
- `packages/suite/src/components/guide/OpenGuideFromTooltip.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceSelector.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/DeviceSelector/DeviceStatus.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/DebugAndExperimental.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/HideBalances.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/QuickActions/NavBackends.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFeesHeader.tsx`
- `packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AddAccountButton.tsx`
- `packages/suite/src/views/suite/SwitchDevice/DeviceItem/DeviceItem.tsx`
- `packages/suite/src/views/wallet/send/TotalSent/ReviewButton.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Directly toggles discreet mode and asserts balances are hidden/revealed across the dashboard, exercising the changed HideBalances quick-action component. A regression here would be immediately visible to users.
- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Installs custom firmware through the Settings > Device flow and verifies the firmware install UI, which includes the changed FirmwareOffer component.
- `suite/e2e/tests/general/suite-guide.test.ts` — Opens the Guide panel from the main UI, navigates articles, and submits feedback, directly clicking the changed GuideButton and using guide panel interactions.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Adds, ejects, and re-adds standard and hidden wallets through the device switcher, rendering DeviceItem rows and validating wallet labels and numbering.
- `suite/e2e/tests/suite/initial-run.test.ts` — Asserts the connected device status indicator after onboarding, exercising the changed DeviceStatus/DeviceSelector components in the main layout.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Clicks the Add Account button and creates accounts of different types, directly covering the changed AddAccountButton component.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Fills the Ethereum send form, sets custom gas fees in the fee section, clicks the review button, and verifies the device prompt, covering both CollapsibleFeesHeader and ReviewButton.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Builds and sends Bitcoin transactions with locktime and OP_RETURN outputs, clicking the review button and asserting post-send UI, which exercises the changed ReviewButton and send flow layout.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configures custom blockbook backends for BTC and ETH, touching the backend state that the changed NavBackends quick-action reflects.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Verifies device status and the device switcher panel when the Bridge session is stolen or reclaimed, exercising DeviceSelector, DeviceStatus, and DeviceItem rendering.
- `suite/e2e/tests/trading/navigation.test.ts` — Uses sidebar and global trading navigation entries to open buy/sell/swap forms, exercising the changed NavigationItem component.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Sets custom Ethereum swap fees and asserts their display on the device prompt, indirectly exercising the CollapsibleFeesHeader fee section in the swap form.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Configures custom Blockbook backends and completes discovery, sharing backend configuration infrastructure with the changed NavBackends quick-action.

</details>

_Updated: 2026-07-29T15:48:46.637Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tooltip-content/web/](https://dev.suite.sldev.cz/suite-web/fix/tooltip-content/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tooltip-content&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tooltip-content&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T15:51:19.729Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T15:50:08.260Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->