### PR TITLE
feat(suite-core): sending pending nonces and tx ids for blockbook

### DIFF
--- a/packages/blockchain-link-types/src/blockbook-api.ts
+++ b/packages/blockchain-link-types/src/blockbook-api.ts
@@ -764,6 +764,12 @@ export interface WsRes {
     /** Payload of the response, structure depends on the request. */
     data: any;
 }
+export interface WsPrivatePending {
+    /** Account nonces of the wallet's in-flight transactions for this address; 0 is valid (not a sentinel). Don't pad the array — each entry raises the reported pending nonce to at least value+1. */
+    nonces?: number[];
+    /** Tx hashes of those in-flight transactions; blockbook fetch-backs each (eth_getTransactionByHash) to cache the body and serve it in history, not just raise the nonce floor. */
+    txids?: string[];
+}
 export interface WsAccountInfoReq {
     /** Address or XPUB descriptor to query. */
     descriptor: string;
@@ -789,6 +795,8 @@ export interface WsAccountInfoReq {
     gap?: number;
     /** If true, additionally fetch and return the confirmed (mined-only) nonce for Ethereum-like addresses (extra backend call). */
     confirmedNonce?: boolean;
+    /** Ethereum-like only: the wallet's in-flight (locally pending) transactions for this address. */
+    privatePending?: WsPrivatePending;
 }
 export interface WsContractInfoReq {
     /** Contract address to query. */
@@ -901,6 +909,7 @@ export interface WsEstimateFeeReq {
         to?: string;
         data?: string;
         value?: string;
+        privatePending?: WsPrivatePending;
     };
 }
 export interface Eip1559Fee {

--- a/packages/blockchain-link-types/src/params.ts
+++ b/packages/blockchain-link-types/src/params.ts
@@ -22,6 +22,11 @@ export interface GetFiatRatesTickersListParams {
     token?: string;
 }
 
+export interface PrivatePendingParams {
+    nonces?: number[]; // EVM: nonces of the wallet's in-flight (locally pending) txs
+    txids?: string[]; // EVM: their tx hashes; blockbook fetch-backs each to cache+serve the body
+}
+
 export interface EstimateFeeParams {
     blocks?: number[];
     specific?: {
@@ -32,6 +37,7 @@ export interface EstimateFeeParams {
         data?: string; // eth tx data, sol tx message
         value?: string; // eth tx amount
         newAccountProgramName?: 'staking' | 'spl-token' | 'spl-token-2022'; // program name of the Solana account that is being created, default: 'spl-token'
+        privatePending?: PrivatePendingParams; // blockbook only (EVM), wallet's in-flight (locally pending) txs
     };
 }
 
@@ -60,4 +66,5 @@ export interface AccountInfoParams {
     tokenAccountsPubKeys?: string[]; // solana only, token accounts to fetch txids for
     protocols?: 'erc4626'[]; // protocols to include in the response (e.g. 'erc4626')
     confirmedNonce?: boolean; // blockbook only (EVM), additionally fetch the confirmed (mined-only) nonce
+    privatePending?: PrivatePendingParams; // blockbook only (EVM), wallet's in-flight (locally pending) txs
 }

--- a/packages/blockchain-link/src/estimateFee.test.ts
+++ b/packages/blockchain-link/src/estimateFee.test.ts
@@ -40,5 +40,31 @@ allTestWorkers.forEach(instance => {
                 }
             });
         });
+
+        // trezor/blockbook#1639: the privatePending hint must reach the WS request verbatim.
+        if (instance.name === 'blockbook') {
+            it('forwards the estimateFee privatePending hint verbatim to the backend', async () => {
+                server.setFixtures([
+                    { method: 'estimateFee', response: { data: [{ feePerUnit: '1000' }] } },
+                ]);
+                const received = new Promise<any>(resolve =>
+                    server.once('blockbook_estimateFee', resolve),
+                );
+
+                await blockchain.estimateFee({
+                    blocks: [1],
+                    specific: {
+                        from: '0xdead',
+                        privatePending: { nonces: [41, 42], txids: ['0xaa', '0xbb'] },
+                    },
+                });
+
+                const request = await received;
+                expect(request.params.specific.privatePending).toEqual({
+                    nonces: [41, 42],
+                    txids: ['0xaa', '0xbb'],
+                });
+            });
+        }
     });
 });

--- a/packages/blockchain-link/src/getAccountInfo.test.ts
+++ b/packages/blockchain-link/src/getAccountInfo.test.ts
@@ -49,5 +49,46 @@ allTestWorkers.forEach(instance => {
                 }
             });
         });
+
+        // trezor/blockbook#1639: the privatePending hint must reach the WS request verbatim.
+        if (instance.name === 'blockbook') {
+            it('forwards the getAccountInfo privatePending hint verbatim to the backend', async () => {
+                server.setFixtures([
+                    {
+                        method: 'getAccountInfo',
+                        response: {
+                            data: {
+                                address: '0xdead',
+                                balance: '0',
+                                totalSent: '0',
+                                totalReceived: '0',
+                                txs: 0,
+                                unconfirmedBalance: '0',
+                                unconfirmedTxs: 0,
+                            },
+                        },
+                    },
+                ]);
+                const received = new Promise<any>(resolve =>
+                    server.once('blockbook_getAccountInfo', resolve),
+                );
+
+                // The response transform is irrelevant here — swallow it and assert the request only.
+                const promise = blockchain
+                    .getAccountInfo({
+                        descriptor: '0xdead',
+                        details: 'basic',
+                        privatePending: { nonces: [41, 42], txids: ['0xaa', '0xbb'] },
+                    })
+                    .catch(() => undefined);
+
+                const request = await received;
+                expect(request.params.privatePending).toEqual({
+                    nonces: [41, 42],
+                    txids: ['0xaa', '0xbb'],
+                });
+                await promise;
+            });
+        }
     });
 });

--- a/packages/connect/src/api/blockchainEstimateFee.ts
+++ b/packages/connect/src/api/blockchainEstimateFee.ts
@@ -47,6 +47,7 @@ export default class BlockchainEstimateFee extends AbstractMethod<'blockchainEst
                     { name: 'to', type: 'string' },
                     { name: 'txsize', type: 'number' },
                     { name: 'newAccountProgramName', type: 'string' },
+                    { name: 'privatePending', type: 'object' },
                 ]);
             }
         }

--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -55,6 +55,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                 { name: 'marker', type: 'object' },
                 { name: 'protocols', type: 'array' },
                 { name: 'confirmedNonce', type: 'boolean' },
+                { name: 'privatePending', type: 'object' },
                 { name: 'defaultAccountType', type: 'string' },
                 { name: 'derivationType', type: 'number' },
                 { name: 'suppressBackupWarning', type: 'boolean' },
@@ -245,6 +246,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     tokenAccountsPubKeys: request.tokenAccountsPubKeys,
                     protocols: request.protocols,
                     confirmedNonce: request.confirmedNonce,
+                    privatePending: request.privatePending,
                 });
 
                 if (this.disposed) break;

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -32,7 +32,10 @@ import { selectAccountByKey } from './accountsSelectors';
 import { selectBlockchainHeightBySymbol, selectGapLimit } from '../blockchain/blockchainReducer';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 import { transactionsActions } from '../transactions/transactionsActions';
-import { selectTransactions } from '../transactions/transactionsSelectors';
+import {
+    selectEvmPrivatePendingHint,
+    selectTransactions,
+} from '../transactions/transactionsSelectors';
 
 const fetchAccountTokens = async (account: Account, payloadTokens: AccountInfo['tokens']) => {
     const tokens: TokenInfo[] = [];
@@ -121,6 +124,12 @@ export const fetchAndUpdateAccountThunk = createThunk(
         if (!account || account.failed || account.accountType === 'placeholder') return;
 
         if (!isTrezorConnectBackendType(account.backendType)) return; // skip unsupported backend type
+
+        // trezor/blockbook#1639: declare our local pending txs so blockbook reports the right
+        // pending nonce and serves them in history. undefined for non-EVM / nothing pending — the
+        // field is then omitted.
+        const privatePending = selectEvmPrivatePendingHint(getState(), account.key);
+
         // first basic check, traffic optimization
         // basic check returns only small amount of data without full transaction history
         const tokenAccountsPubKeys =
@@ -140,6 +149,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             suppressBackupWarning: true,
             tokenAccountsPubKeys,
             protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
+            privatePending,
             gap,
         });
 
@@ -173,6 +183,7 @@ export const fetchAndUpdateAccountThunk = createThunk(
             pageSize,
             suppressBackupWarning: true,
             protocols: account.networkType === 'ethereum' ? ['erc4626'] : undefined,
+            privatePending,
             gap:
                 account.networkType === 'bitcoin'
                     ? selectGapLimit(getState(), account.symbol)

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -58,7 +58,10 @@ import {
     type SignTransactionThunkArguments,
 } from './sendFormTypes';
 import { selectAddressDisplayType } from '../settings/walletSettingsReducer';
-import { selectAccountTransactions } from '../transactions/transactionsSelectors';
+import {
+    selectAccountTransactions,
+    selectEvmPrivatePendingHint,
+} from '../transactions/transactionsSelectors';
 
 /**
  * Returns fee info with levels bumped above the original transaction's gas price,
@@ -312,6 +315,10 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
                       formState.transactionData,
                   );
 
+        // trezor/blockbook#1639: declare our local pending txs so blockbook estimates gas against
+        // the correct pending state. undefined for non-EVM / nothing pending — the field is omitted.
+        const privatePending = selectEvmPrivatePendingHint(getState(), account.key);
+
         // gasLimit calculation based on address, amount and data size
         // amount in essential for a proper calculation of gasLimit (via blockbook/geth)
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({
@@ -322,6 +329,7 @@ export const composeEthereumTransactionFeeLevelsThunk = createThunk<
                 specific: {
                     from: account.descriptor,
                     ...ethereumEstimateFeeParams,
+                    privatePending,
                 },
             },
         });

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
@@ -7,7 +7,10 @@ import {
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { type TransactionsRootState } from './transactionsReducerTypes';
-import { selectTransactionsWithMissingRates } from './transactionsSelectors';
+import {
+    selectEvmPrivatePendingHint,
+    selectTransactionsWithMissingRates,
+} from './transactionsSelectors';
 import { type AccountsRootState } from '../accounts/accountsReducer';
 import { type FiatRatesRootState } from '../fiat-rates/fiatRatesTypes';
 
@@ -70,5 +73,39 @@ describe('selectTransactionsWithMissingRates', () => {
         );
 
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('selectEvmPrivatePendingHint', () => {
+    const HINT_ACCOUNT_KEY = 'account-hint' as AccountKey;
+
+    const pendingSentTx = (nonce: number): WalletAccountTransaction =>
+        ({
+            txid: `pending-${nonce}`,
+            type: 'sent',
+            blockHeight: -1,
+            ethereumSpecific: { nonce },
+        }) as unknown as WalletAccountTransaction;
+
+    const getHintState = (
+        transactions: WalletAccountTransaction[],
+    ): TransactionsRootState & AccountsRootState =>
+        ({
+            wallet: {
+                transactions: { transactions: { [HINT_ACCOUNT_KEY]: transactions } },
+            },
+        }) as unknown as TransactionsRootState & AccountsRootState;
+
+    it('returns the sorted nonces and txids of all local pending sent txs', () => {
+        const state = getHintState([pendingSentTx(7), pendingSentTx(6)]);
+        expect(selectEvmPrivatePendingHint(state, HINT_ACCOUNT_KEY)).toEqual({
+            nonces: [6, 7],
+            txids: ['pending-6', 'pending-7'],
+        });
+    });
+
+    it('returns undefined when the account has no transactions', () => {
+        const state = getHintState([pendingSentTx(7)]);
+        expect(selectEvmPrivatePendingHint(state, 'missing-account' as AccountKey)).toBeUndefined();
     });
 });

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -18,6 +18,7 @@ import type {
 import {
     getConfirmations,
     getErc4626Contracts,
+    getEvmPrivatePendingHint,
     getFiatRateKey,
     isCardanoStakingTx,
     isClaimTx,
@@ -116,6 +117,15 @@ export const selectAllPendingTransactions = createMemoizedSelector(
             {} as typeof transactions,
         ),
 );
+
+/**
+ * Account-scoped `privatePending` hint (trezor/blockbook#1639) — see `getEvmPrivatePendingHint`.
+ * Non-EVM accounts yield `undefined`; callers spread the result so the field is omitted when absent.
+ */
+export const selectEvmPrivatePendingHint = (
+    state: TransactionsRootState & AccountsRootState,
+    accountKey: AccountKey,
+) => getEvmPrivatePendingHint(selectAccountTransactions(state, accountKey));
 
 export const selectTransactionByAccountKeyAndTxid = createMemoizedSelector(
     [selectAccountTransactions, (_state, _accountKey: AccountKey | null, txid: string) => txid],

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -12,6 +12,7 @@ import {
     getEvmNonceInfo,
     getEvmNonceInfoFromConfirmedNonce,
     getEvmNonceStatus,
+    getEvmPrivatePendingHint,
     getPendingEvmNonceStatus,
     getRbfParams,
     getTargetAmount,
@@ -533,6 +534,75 @@ describe('transaction utils', () => {
                 nextNonce: 43,
                 pendingNonces: [42],
                 confirmedNonces: [41],
+            });
+        });
+    });
+
+    describe('getEvmPrivatePendingHint', () => {
+        const pendingTx = (
+            nonce: number,
+            {
+                type = 'sent',
+                txid = `0x${nonce}`,
+            }: { type?: WalletAccountTransaction['type']; txid?: string } = {},
+        ) =>
+            getWalletTransaction({
+                txid,
+                blockHeight: -1,
+                type,
+                ethereumSpecific: { nonce } as any,
+            });
+
+        it('returns undefined when there is no pending own-nonce tx', () => {
+            expect(getEvmPrivatePendingHint([])).toBeUndefined();
+            // an incoming pending tx does not consume our nonce and must not be declared
+            expect(getEvmPrivatePendingHint([pendingTx(41, { type: 'recv' })])).toBeUndefined();
+        });
+
+        it('declares a local pending nonce and its txid', () => {
+            expect(getEvmPrivatePendingHint([pendingTx(41)])).toEqual({
+                nonces: [41],
+                txids: ['0x41'],
+            });
+        });
+
+        it('declares all pending sent/self/contract nonces and their txids', () => {
+            const transactions = [
+                pendingTx(43, { type: 'contract' }),
+                pendingTx(41, { type: 'sent' }),
+                pendingTx(42, { type: 'self' }),
+                pendingTx(40, { type: 'recv' }), // ignored — not an own-nonce-consuming tx
+                pendingTx(44, { type: 'sent' }),
+            ];
+            expect(getEvmPrivatePendingHint(transactions)).toEqual({
+                nonces: [41, 42, 43, 44],
+                txids: ['0x41', '0x42', '0x43', '0x44'],
+            });
+        });
+
+        it('excludes the nonce and txid of a tx that is already locally confirmed', () => {
+            const confirmedTx41 = getWalletTransaction({
+                txid: '0x41-confirmed',
+                blockHeight: 100,
+                type: 'sent',
+                ethereumSpecific: { nonce: 41 } as any,
+            });
+            const transactions = [confirmedTx41, pendingTx(41), pendingTx(42)];
+            expect(getEvmPrivatePendingHint(transactions)).toEqual({
+                nonces: [42],
+                txids: ['0x42'],
+            });
+        });
+
+        it('dedupes the shared nonce of an RBF replacement but declares both txids', () => {
+            // speed-up/cancel keeps the same nonce, only the txid changes — one nonce, both hashes
+            const transactions = [
+                pendingTx(41, { txid: '0xnew' }),
+                pendingTx(41, { txid: '0xold' }),
+            ];
+            expect(getEvmPrivatePendingHint(transactions)).toEqual({
+                nonces: [41],
+                txids: ['0xnew', '0xold'],
             });
         });
     });

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -110,7 +110,7 @@ export type EvmNonceInfo = {
     confirmedNonces: number[];
 };
 
-const getOwnEvmNonceSets = (transactions: WalletAccountTransaction[]) => {
+export const getOwnEvmNonceSets = (transactions: WalletAccountTransaction[]) => {
     const ownNonceTxs = transactions.filter(isSentTransaction);
 
     // A nonce that's confirmed locally is ground truth. If a stale "pending" record for the same
@@ -214,6 +214,45 @@ export const getEvmNonceInfoFromConfirmedNonce = (
         nextNonce,
         pendingNonces: [...pendingNonceSet],
         confirmedNonces: [...confirmedNonces],
+    };
+};
+
+/**
+ * Builds the blockbook `privatePending` hint (trezor/blockbook#1639) for an EVM account from the
+ * wallet's own pending sends, which blockbook's public provider may not see (private-relay
+ * broadcast, or lag — trezor/blockbook#1562). The nonces raise its reported pending nonce to max+1;
+ * the txids let it fetch-back each body (eth_getTransactionByHash) so the tx shows up in history.
+ *
+ * Nonces come from `getOwnEvmNonceSets`' `pendingNonceSet` — Suite's own local pending-nonce view,
+ * already excluding locally-confirmed nonces. Returns `undefined` when nothing is pending, so
+ * callers omit the field (blockbook must not receive an empty array).
+ */
+export const getEvmPrivatePendingHint = (
+    transactions: WalletAccountTransaction[],
+): { nonces: number[]; txids?: string[] } | undefined => {
+    const { pendingNonceSet } = getOwnEvmNonceSets(transactions);
+
+    if (pendingNonceSet.size === 0) return undefined;
+
+    // hashes of those same pending sends (confirmed nonces are already out of pendingNonceSet)
+    const txids = [
+        ...new Set(
+            transactions
+                .filter(isPending)
+                .filter(isSentTransaction)
+                .filter(tx => {
+                    const nonce = tx.ethereumSpecific?.nonce;
+
+                    return typeof nonce === 'number' && pendingNonceSet.has(nonce);
+                })
+                .map(tx => tx.txid)
+                .filter(Boolean),
+        ),
+    ].sort();
+
+    return {
+        nonces: [...pendingNonceSet].sort((a, b) => a - b),
+        ...(txids.length > 0 ? { txids } : {}),
     };
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR would add pending transactions and their hashes 

> [!CAUTION]
> Adds `tx_ids` to the network request for account data to instance of blockbook from settings

## Notes for QA

No client-side changes


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches fee estimation, account discovery/info, Ethereum send composition, and transaction list selection/formatting. High-risk user-visible regressions are most likely in EVM sends/swaps with custom fees, multi-coin discovery, custom backends, and pending/confirmed transaction grouping. Run the targeted high tests unconditionally, then use the medium set as a regression sweep across staking, sell, exports, and account-list flows. Broad-utility files like accountsThunks and transactionUtils are covered only where the test's own assertions directly depend on them.

<details><summary><b>Changed files (12)</b></summary>

- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/params.ts`
- `packages/blockchain-link/src/estimateFee.test.ts`
- `packages/blockchain-link/src/getAccountInfo.test.ts`
- `packages/connect/src/api/blockchainEstimateFee.ts`
- `packages/connect/src/api/getAccountInfo.ts`
- `suite-common/wallet-core/src/accounts/accountsThunks.ts`
- `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (21)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises coin activation, custom backend configuration, and discovery success/error states. The changed blockchain-link types, getAccountInfo, accountsThunks, and fee-estimation code are all on the critical path for this flow.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Covers adding accounts of various types and asserts the resulting account metadata/analytics. This directly invokes the changed accountsThunks and getAccountInfo logic.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Validates discovery against a custom Blockbook backend. Changes to blockbook-api/params types, getAccountInfo, and accountsThunks directly affect whether discovery completes and graph data appears.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery and post-reload recovery are central to getAccountInfo and accountsThunks; a regression here would be immediately visible across all coins.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Groups transactions into pending/confirmed sets and asserts labels/counts. This is a direct user-facing use of transactionsSelectors and transactionUtils, which were modified.
- `suite/e2e/tests/wallet/send-base.test.ts` — Sends on Base with custom EVM fees and asserts device prompts for gas limit, max fee, and priority fee. The changed Ethereum send thunks and fee-estimation code are exercised end-to-end.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly tests the Ethereum send form with custom gas parameters and device fee display. sendFormEthereumThunks and blockchainEstimateFee are core to this flow.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — ETH-to-USDC DEX swap asserts slippage, minimum received, gas limit, and max fee. The fee-estimation and Ethereum transaction composition changes directly impact these assertions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Custom Ethereum fee settings (gas limit, max fee, priority fee) are verified on both the modal and the device. This directly targets the changed sendFormEthereumThunks and fee-estimation logic.

</details>

<details><summary>🟡 <b>Medium priority (12)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejects a wallet and rediscovers a standard wallet. This shares the discovery/account thunk path and is a good regression check, though less broad than the dedicated discovery test.
- `suite/e2e/tests/settings/coins.test.ts` — Activating mainnet/testnet coins and verifying discovery completion. Changes to account info and account thunks could alter which coins appear or whether discovery finishes.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking asserts deposit and fee values on the device. Changes to fee estimation or transaction utility formatting could affect these displayed amounts.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking submits a contract transaction and checks amounts, fees, and progress states. The Ethereum send thunks and transaction utilities are involved in composing this transaction.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Additional ETH staking from an existing staked account reuses the same transaction composition and fee-estimation stack as initial-stake.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — ETH sell flow fills the form, sets custom fees, and confirms the send. It shares Ethereum send-form/fee infrastructure with the changed files.
- `suite/e2e/tests/wallet/account-search.test.ts` — Filters the account list by query. Account state shape and selector behavior depend on accountsThunks and related transaction/account selectors.
- `suite/e2e/tests/wallet/cardano.test.ts` — Displays Cardano account details, derivation path, and public key. getAccountInfo and account thunks provide the underlying account data.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports transaction lists in multiple formats. Transaction formatting and selection logic from transactionUtils/transactionsSelectors are used to generate the export payload.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Shows and verifies xpub/public-key values for BTC/LTC/ADA accounts. These values come from getAccountInfo results and the account state produced by accountsThunks.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Solana send-max calculation uses fee estimation and account balance/reserve data. Changes to blockchainEstimateFee and account info could affect the computed max amount.
- `suite/e2e/tests/wallet/transactions.test.ts` — Transaction list time-range filtering and address search rely on transaction selectors and utility formatting from the changed files.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/blockchain-link-types/src/blockbook-api.ts`
- `packages/blockchain-link-types/src/params.ts`
- `packages/blockchain-link/src/estimateFee.test.ts`
- `packages/blockchain-link/src/getAccountInfo.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`

_Updated: 2026-07-30T08:24:28.587Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/pending-bb-hint/web/](https://dev.suite.sldev.cz/suite-web/chore/pending-bb-hint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/pending-bb-hint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/pending-bb-hint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/pending-bb-hint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T08:25:19.150Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T08:24:37.513Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->