### PR TITLE
Fix download crypto icons script

### DIFF
--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { createHash } from 'crypto';
 import fs from 'fs/promises';
 import { join } from 'path';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -52,8 +53,24 @@ function isValidUrl(url: string): boolean {
     }
 }
 
+// Fingerprint of the files updateIcon derives from a single coin: one icon per platform contract,
+// in every image size. Changing either input means new file names, so the coin has to be
+// reprocessed even when its source image stayed the same.
+function getOutputsHash(platforms: Record<string, string>) {
+    const sortedPlatforms = Object.entries(platforms).sort(([a], [b]) => (a < b ? -1 : 1));
+
+    // We don't need a cryptographically secure hash here, just a unique fingerprint of the output file set.
+    return (
+        createHash('sha1')
+            .update(JSON.stringify([sortedPlatforms, COIN_IMAGE_SIZES]))
+            .digest('hex')
+            // Keep the size of icons.json small. It's better to miss sometime (but extremely rarely) than to serve a large file to every client.
+            .slice(0, 16)
+    );
+}
+
 // Returns true only if the icon was written successfully, so the caller can persist the
-// image-url fingerprint (and thereby skip this coin next run) exclusively on success.
+// fingerprints (and thereby skip this coin next run) exclusively on success.
 const updateIcon = async (
     logPrefix: string,
     coinId: string,
@@ -128,7 +145,7 @@ async function ensureDirectoryExists(path: string) {
 }
 
 (async () => {
-    const updatedIcons = await fetchUpdatedIconsList();
+    const previousIcons = await fetchUpdatedIconsList();
 
     const startedAt = Date.now();
     const coins = await fetchCoinList();
@@ -143,15 +160,23 @@ async function ensureDirectoryExists(path: string) {
     const marketImageUrls = await getCoinMarketImageUrls();
     console.log(new Date().toISOString(), 'Total market image urls fetched:', marketImageUrls.size);
 
+    // Drop the entries of coins that are no longer listed. Without pruning, the checkpoint keeps
+    // every coin CoinGecko has ever listed, which inflates the file and skews the counts below.
+    const listedCoinIds = new Set(coins.map(coin => coin.id));
+    const updatedIcons = Object.fromEntries(
+        Object.entries(previousIcons).filter(([coinId]) => listedCoinIds.has(coinId)),
+    );
+    const prunedIconsCount = Object.keys(previousIcons).length - Object.keys(updatedIcons).length;
+
     // process missing icons and icons updated the longest time ago first
     coins.sort(
         (a, b) => (updatedIcons[a.id]?.updatedAt ?? 0) - (updatedIcons[b.id]?.updatedAt ?? 0),
     );
 
-    const newIconsCount = coins.length - Object.keys(updatedIcons).length;
+    const newIconsCount = coins.filter(coin => !updatedIcons[coin.id]).length;
 
     console.log(
-        `Total coins: ${coins.length}, new icons: ${newIconsCount}, market image urls: ${marketImageUrls.size}`,
+        `Total coins: ${coins.length}, new icons: ${newIconsCount}, delisted icons pruned: ${prunedIconsCount}, market image urls: ${marketImageUrls.size}`,
     );
 
     await ensureDirectoryExists(FILES_CRYPTOICONS_PATH);
@@ -195,8 +220,12 @@ async function ensureDirectoryExists(path: string) {
             continue;
         }
 
-        // Skip coins whose source image is unchanged since the last successful run.
-        if (updatedIcons[coin.id]?.imageUrl === imageUrl) {
+        // Skip coins whose source image and derived file set are both unchanged since the last
+        // successful run.
+        const outputsHash = getOutputsHash(platforms);
+        const previousIcon = updatedIcons[coin.id];
+
+        if (previousIcon?.imageUrl === imageUrl && previousIcon?.outputsHash === outputsHash) {
             console.log(logPrefix, `Skipping unchanged icon.`);
             continue;
         }
@@ -206,7 +235,7 @@ async function ensureDirectoryExists(path: string) {
         updatedIcons[coin.id] = {
             updatedAt: Math.floor(Date.now() / 1000),
             // Only fingerprint on success so a failed coin is retried on the next run.
-            ...(success ? { imageUrl } : {}),
+            ...(success ? { imageUrl, outputsHash } : {}),
         };
     }
 

--- a/suite-common/icons/scripts/schemas/index.ts
+++ b/suite-common/icons/scripts/schemas/index.ts
@@ -10,6 +10,12 @@ export const updatedIconsListSchema = z.record(
             // Source image URL (incl. CoinGecko's version query param) of the last successfully
             // written icon. Used to skip coins whose logo has not changed since the previous run.
             imageUrl: z.string().optional(),
+            // Fingerprint of the file set the last successful run wrote for this coin (its platform
+            // contracts and the image sizes). Needed alongside imageUrl because CoinGecko keeps
+            // listing existing coins on new platforms without touching their logo — matching on the
+            // source image alone would skip such a coin forever and its new contract would never
+            // get an icon.
+            outputsHash: z.string().optional(),
         })
         .catch({ updatedAt: 0 }),
 );


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fingerprint of the file set the last successful run wrote for this coin (its platform contracts and the image sizes). Needed alongside imageUrl because CoinGecko keeps listing existing coins on new platforms without touching their logo – matching on the source image alone would skip such a coin forever and its new contract would never get an icon.

## Related Issue

Resolve #30115

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are build-time scripts for downloading and validating cryptocurrency icon assets (`suite-common/icons/scripts/downloadCryptoIcons.ts` and `suite-common/icons/scripts/schemas/index.ts`). They are not runtime application code and no E2E test in the suite exercises icon-download scripts or their schemas. Any impact would manifest at build time or as missing/fallback icons in the UI, but none of the analyzed tests assert on icon rendering or the download pipeline. Therefore, no E2E tests are recommended for this change set.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/schemas/index.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/schemas/index.ts`

_Updated: 2026-07-29T16:19:52.538Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/coin-icons-outputs-fingerprint/web/](https://dev.suite.sldev.cz/suite-web/fix/coin-icons-outputs-fingerprint/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/coin-icons-outputs-fingerprint&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/coin-icons-outputs-fingerprint&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/coin-icons-outputs-fingerprint&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T16:22:47.163Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T16:22:21.080Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->