### PR TITLE
feat(suite-desktop): restore warp/unwrap broadcast toast titles

### DIFF
--- a/packages/product-components/src/components/Notifications/TransactionIcon.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionIcon.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode } from 'react';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getWrappedNativeAddress,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 
 import {
     type TransactionNotificationToken,
@@ -40,6 +44,24 @@ export const TransactionIcon = ({
 }: TransactionIconProps) => {
     if (icon) {
         return icon;
+    }
+
+    // A wrap (ETH→WETH) is denominated in the wrapped-native token, so show its logo (e.g. WETH) to
+    // match the amount. An unwrap is denominated in the native coin and uses the native icon below.
+    if (notificationType === 'tx-wrap') {
+        const wrappedNativeAddress = getWrappedNativeAddress(symbol);
+
+        if (wrappedNativeAddress) {
+            return (
+                <TokenIcon
+                    symbol={symbol}
+                    contractAddress={wrappedNativeAddress}
+                    placeholder={getWrappedNativeSymbol(symbol) ?? symbol}
+                    size={20}
+                    shouldTryToFetch
+                />
+            );
+        }
     }
 
     if (shouldDisplayAssetLogo({ notificationType, token }) && token) {

--- a/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
+++ b/packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx
@@ -181,6 +181,26 @@ const transactionNotificationConfig: Record<
             },
         },
     },
+    'tx-wrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Wrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 WETH',
+        transaction: {
+            notificationType: 'tx-wrap',
+            symbol: 'eth',
+        },
+    },
+    'tx-unwrap': {
+        toastIcon: ArrowUpIcon,
+        intent: 'brand',
+        message: 'Unwrap transaction from Ethereum #1 has been broadcast',
+        amount: '1.495 ETH',
+        transaction: {
+            notificationType: 'tx-unwrap',
+            symbol: 'eth',
+        },
+    },
 };
 
 export const Default: Story = {

--- a/packages/product-components/src/components/Notifications/notificationsTypes.ts
+++ b/packages/product-components/src/components/Notifications/notificationsTypes.ts
@@ -28,7 +28,9 @@ export type TransactionNotificationType =
     | 'tx-revoked'
     | 'tx-yield-deposit'
     | 'tx-yield-withdraw'
-    | 'tx-yield-claim';
+    | 'tx-yield-claim'
+    | 'tx-wrap'
+    | 'tx-unwrap';
 
 type TransactionNotificationWithToken = Extract<
     NotificationEntry,

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -2,6 +2,7 @@ import { openDeferredModal } from '@suite/modal';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     type YieldWithdrawFlowType,
@@ -80,7 +81,9 @@ export const submitUnwrapNativeTokenThunk = createThunk(
 
             dispatch(
                 notificationsActions.addToast({
-                    type: 'raw-tx-sent',
+                    type: 'tx-unwrap',
+                    // Amount shown in the destination unit — the native coin (e.g. ETH).
+                    formattedAmount: `${unwrapAmount} ${getNetworkDisplaySymbol(account.symbol)}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -2,7 +2,11 @@ import { openDeferredModal } from '@suite/modal';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    getNetwork,
+    getNetworkDisplaySymbol,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     composeYieldWrapTransactionThunk,
@@ -85,9 +89,14 @@ export const submitWrapNativeTokenThunk = createThunk(
                 return undefined;
             }
 
+            const wrappedSymbol =
+                getWrappedNativeSymbol(account.symbol) ?? getNetworkDisplaySymbol(account.symbol);
+
             dispatch(
                 notificationsActions.addToast({
-                    type: 'raw-tx-sent',
+                    type: 'tx-wrap',
+                    // Amount shown in the destination unit — the wrapped-native token (e.g. WETH).
+                    formattedAmount: `${wrapAmount} ${wrappedSymbol}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -652,6 +652,34 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-wrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_WRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
+        case 'tx-unwrap':
+            return (
+                <TransactionRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_UNWRAP"
+                    messageValues={{
+                        account: notification.descriptor,
+                    }}
+                />
+            );
+
         case 'successful-claim':
             return renderNotificationView(render, notification, {
                 variant: 'success',

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -81,6 +81,17 @@ type YieldClaimTransactionNotification = {
     type: 'tx-yield-claim';
 } & BaseTransactionNotificationPayload;
 
+// Wrap/unwrap toasts show the amount in the destination unit: the wrapped-native token (WETH) for
+// a wrap, the native coin (ETH) for an unwrap. That destination unit is baked into `formattedAmount`
+// by the dispatcher.
+type WrapNativeTokenTransactionNotification = {
+    type: 'tx-wrap';
+} & TransactionNotificationPayload;
+
+type UnwrapNativeTokenTransactionNotification = {
+    type: 'tx-unwrap';
+} & TransactionNotificationPayload;
+
 export type ErrorToastPayload = {
     type:
         | 'error'
@@ -207,6 +218,8 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | YieldDepositTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
+    | WrapNativeTokenTransactionNotification
+    | UnwrapNativeTokenTransactionNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11608,6 +11608,14 @@ export const messages = defineMessages({
         id: 'TOAST_TX_YIELD_CLAIM',
         defaultMessage: 'Claim transaction from {account} has been broadcast',
     },
+    TOAST_TX_WRAP: {
+        id: 'TOAST_TX_WRAP',
+        defaultMessage: 'Wrap transaction from {account} has been broadcast',
+    },
+    TOAST_TX_UNWRAP: {
+        id: 'TOAST_TX_UNWRAP',
+        defaultMessage: 'Unwrap transaction from {account} has been broadcast',
+    },
     TOAST_SUCCESSFUL_CLAIM: {
         id: 'TOAST_SUCCESSFUL_CLAIM',
         defaultMessage: '{networkDisplaySymbol} claimed successfully',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes from https://github.com/trezor/trezor-suite/pull/30167 were somehow removed and this PR adds it back

## Notes for QA

Trigger wrap/unwrap transaction from the dedicated page and deposit flow

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29877

## Screenshots:

<img width="461" height="128" alt="Screenshot 2026-07-30 at 9 23 11" src="https://github.com/user-attachments/assets/7be13b2e-b465-4acb-b3f6-7d5a3f10a1bd" />
<img width="491" height="153" alt="Screenshot 2026-07-30 at 9 22 22" src="https://github.com/user-attachments/assets/7b64df5c-d2c5-4ab0-bc01-a5e540f7e46e" />
<img width="1232" height="776" alt="Screenshot 2026-07-30 at 9 25 08" src="https://github.com/user-attachments/assets/1d461407-77a0-4dbf-96c3-061b36d29383" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches notification rendering (TransactionIcon, NotificationRenderer, toast types) and native-token wrap/unwrap thunks. Notification changes are global but most observable on transaction toasts, while the thunk changes are concentrated in staking/earn flows. Running a small set of ETH and SOL staking tests plus representative send/pending-transaction tests provides focused coverage of both the wrap/unwrap logic and notification rendering without invoking the full suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/product-components/src/components/Notifications/TransactionIcon.tsx`
- `packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx`
- `packages/product-components/src/components/Notifications/notificationsTypes.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH first-time staking is the most likely user flow to exercise the wrapNativeTokenThunks (wrapping ETH for staking/earn operations) and the test explicitly verifies staking success toast notifications, which are rendered via NotificationRenderer and TransactionIcon.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test completes an Ethereum send transaction end-to-end and verifies the tx-sent toast notification, directly exercising the transaction notification rendering path (TransactionIcon, NotificationRenderer) and notification types.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking/claim flows are plausible callers of unwrapNativeTokenThunks when converting wrapped/staked ETH back, and the test verifies unstake/claim toasts that depend on the notification components.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking may wrap native SOL (e.g., into wSOL/SPL form) via wrapNativeTokenThunks during the stake flow, and the test verifies the staking success toast notification.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions and asserts pending/confirmed transaction state and labels; it is a representative transaction flow that will trigger transaction notifications rendered by the changed notification components.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/product-components/src/components/Notifications/TransactionNotification.stories.tsx`
- `packages/product-components/src/components/Notifications/notificationsTypes.ts`

_Updated: 2026-07-29T16:32:48.766Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/wrap-unwrap-toast/web/](https://dev.suite.sldev.cz/suite-web/fix/wrap-unwrap-toast/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wrap-unwrap-toast&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wrap-unwrap-toast&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wrap-unwrap-toast&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T16:34:55.204Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-29T16:34:31.614Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->