### PR TITLE
chore(suite-desktop): add wrapping/unwrapping analytics for eth vaults

### DIFF
--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -1,8 +1,10 @@
+import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
 import { submitUnwrapNativeTokenThunk } from './unwrapNativeTokenThunks';
 
@@ -22,6 +24,7 @@ jest.mock('@suite/modal', () => ({
 
 jest.mock('./stablecoin-yield/signingHelpers', () => ({
     sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
+    getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
 const account = mockWalletAccount({ symbol: 'eth' }) as Account;
@@ -32,6 +35,17 @@ const token: YieldFlowDisplayToken & { contractAddress: string } = {
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 };
+
+const buildStore = (report: jest.Mock) =>
+    configureMockStore({
+        extra: { services: { analytics: mockAnalytics(report) } },
+        preloadedState: {},
+    });
+
+const dispatchUnwrap = (report: jest.Mock) =>
+    buildStore(report)
+        .dispatch(submitUnwrapNativeTokenThunk({ account, token, unwrapAmount: '1' }))
+        .unwrap();
 
 describe('submitUnwrapNativeTokenThunk', () => {
     beforeEach(() => {
@@ -44,20 +58,11 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
+        mockSendYieldTransaction.mockResolvedValue(undefined);
     });
 
     it('uses the shared unwrap composition from wallet-core', async () => {
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-        await store
-            .dispatch(
-                submitUnwrapNativeTokenThunk({
-                    account,
-                    token,
-                    unwrapAmount: '1',
-                }),
-            )
-            .unwrap();
+        await dispatchUnwrap(jest.fn());
 
         expect(mockComposeYieldUnwrapTransactionThunk).toHaveBeenCalledWith({
             account,
@@ -102,7 +107,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
     });
 
     it('shows an unwrap toast displaying both the wrapped and native assets', async () => {
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        const store = buildStore(jest.fn());
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
@@ -131,5 +136,113 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 },
             },
         });
+    });
+
+    it('does not report standalone unwrap analytics for the in-flow withdraw step', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+
+        await buildStore(report)
+            .dispatch(
+                submitUnwrapNativeTokenThunk({
+                    account,
+                    token,
+                    unwrapAmount: '1',
+                    yieldFlow: { flowKey: 'yield-flow', flowType: 'redeem' },
+                }),
+            )
+            .unwrap();
+
+        expect(report).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: events.yieldUnwrapEvent.name }),
+        );
+    });
+
+    it('reports the tx-simulation-modal cancel', async () => {
+        const report = jest.fn();
+
+        await dispatchUnwrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'tx-simulation-modal',
+                    action: 'cancel',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
+    });
+
+    it('reports an error carrying the compose reason when composition fails', async () => {
+        const report = jest.fn();
+        mockComposeYieldUnwrapTransactionThunk.mockImplementation(() => () => ({
+            unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
+        }));
+
+        await dispatchUnwrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'fee-estimation-failed',
+                }),
+            }),
+        );
+    });
+
+    it('reports tx-simulation-modal continue and submit-failed when the tx is not broadcast', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+
+        await dispatchUnwrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'tx-simulation-modal',
+                    action: 'continue',
+                }),
+            }),
+        );
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'submit-failed',
+                }),
+            }),
+        );
+    });
+
+    it('reports the sent event when the transaction is broadcast', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
+
+        await dispatchUnwrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'sent',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
     });
 });

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -127,6 +127,7 @@ export const submitUnwrapNativeTokenThunk = createThunk(
             dispatch(
                 notificationsActions.addToast({
                     type: 'tx-unwrap',
+                    isYieldFlowStep: !!yieldFlow,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -1,4 +1,5 @@
 import { openDeferredModal } from '@suite/modal';
+import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -10,7 +11,10 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
-import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
+import {
+    getYieldSubmitErrorAnalyticsMessage,
+    sendYieldTransaction,
+} from './stablecoin-yield/signingHelpers';
 
 const UNWRAP_NATIVE_TOKEN_PREFIX = '@wallet/unwrap-native-token';
 
@@ -28,14 +32,31 @@ export const submitUnwrapNativeTokenThunk = createThunk(
     `${UNWRAP_NATIVE_TOKEN_PREFIX}/submit`,
     async (
         { account, token, unwrapAmount, yieldFlow }: UnwrapNativeTokenPayload,
-        { dispatch, getState },
+        { dispatch, getState, extra },
     ) => {
+        // In-flow unwraps are already tracked as yield/withdraw type:'unwrap', so reporting here
+        // too would double-count them.
+        const reportError = (errorMessage: string) => {
+            if (yieldFlow) return;
+
+            extra.services.analytics.report({
+                type: events.yieldUnwrapEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: account.symbol,
+                    errorMessage,
+                },
+            });
+        };
+
         try {
             const result = await dispatch(
                 composeYieldUnwrapTransactionThunk({ account, token, unwrapAmount }),
             ).unwrap();
 
             if (result.type === 'error') {
+                reportError(result.reason);
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
@@ -57,6 +78,17 @@ export const submitUnwrapNativeTokenThunk = createThunk(
                 }),
             );
 
+            if (!yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldUnwrapEvent.name,
+                    payload: {
+                        type: 'tx-simulation-modal',
+                        action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                        networkSymbol: account.symbol,
+                    },
+                });
+            }
+
             if (userAcceptedTxSimulation?.value === false) {
                 return undefined;
             }
@@ -76,7 +108,20 @@ export const submitUnwrapNativeTokenThunk = createThunk(
             userAcceptedTxSimulation?.resolve();
 
             if (!sendResult) {
+                reportError('submit-failed');
+
                 return undefined;
+            }
+
+            if (!yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldUnwrapEvent.name,
+                    payload: {
+                        type: 'sent',
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                    },
+                });
             }
 
             dispatch(
@@ -106,6 +151,7 @@ export const submitUnwrapNativeTokenThunk = createThunk(
             return sendResult;
         } catch (error) {
             console.error(error);
+            reportError(getYieldSubmitErrorAnalyticsMessage(error));
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,3 +1,4 @@
+import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
@@ -7,6 +8,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
 import { PUSH_TRANSACTION_FAILED_CAUSE } from './stablecoin-yield/signingHelpers';
 import { submitWrapNativeTokenThunk } from './wrapNativeTokenThunks';
@@ -28,6 +30,7 @@ jest.mock('@suite/modal', () => ({
 jest.mock('./stablecoin-yield/signingHelpers', () => ({
     ...jest.requireActual('./stablecoin-yield/signingHelpers'),
     sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
+    getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
 const account = mockWalletAccount({ symbol: 'eth' }) as Account;
@@ -38,6 +41,17 @@ const token: YieldFlowDisplayToken & { contractAddress: string } = {
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 };
+
+const buildStore = (report: jest.Mock) =>
+    configureMockStore({
+        extra: { services: { analytics: mockAnalytics(report) } },
+        preloadedState: {},
+    });
+
+const dispatchWrap = (report: jest.Mock) =>
+    buildStore(report)
+        .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
+        .unwrap();
 
 describe('submitWrapNativeTokenThunk', () => {
     beforeAll(() => {
@@ -55,20 +69,11 @@ describe('submitWrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
+        mockSendYieldTransaction.mockResolvedValue(undefined);
     });
 
     it('uses the shared wrap composition from wallet-core', async () => {
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-        await store
-            .dispatch(
-                submitWrapNativeTokenThunk({
-                    account,
-                    token,
-                    wrapAmount: '1',
-                }),
-            )
-            .unwrap();
+        await dispatchWrap(jest.fn());
 
         expect(mockComposeYieldWrapTransactionThunk).toHaveBeenCalledWith({
             account,
@@ -132,7 +137,7 @@ describe('submitWrapNativeTokenThunk', () => {
 
     it('shows a wrap toast displaying both the native and wrapped assets', async () => {
         acceptModalAndSucceed();
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        const store = buildStore(jest.fn());
 
         await store
             .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1.5' }))
@@ -161,7 +166,7 @@ describe('submitWrapNativeTokenThunk', () => {
 
     it('starts tracking the wrapped native token after a successful wrap', async () => {
         acceptModalAndSucceed();
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        const store = buildStore(jest.fn());
 
         await store
             .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
@@ -185,7 +190,7 @@ describe('submitWrapNativeTokenThunk', () => {
                 },
             ],
         }) as Account;
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        const store = buildStore(jest.fn());
 
         await store
             .dispatch(
@@ -205,7 +210,7 @@ describe('submitWrapNativeTokenThunk', () => {
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
         mockSendYieldTransaction.mockResolvedValue(undefined);
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        const store = buildStore(jest.fn());
 
         await store
             .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
@@ -305,5 +310,110 @@ describe('submitWrapNativeTokenThunk', () => {
                 error: 'TR_EARN_YIELD_ERROR_GENERIC',
             });
         });
+    });
+
+    it('does not report standalone wrap analytics for the in-flow deposit step', async () => {
+        const report = jest.fn();
+        acceptModalAndSucceed();
+
+        await buildStore(report)
+            .dispatch(
+                submitWrapNativeTokenThunk({
+                    account,
+                    token,
+                    wrapAmount: '1',
+                    yieldFlow: { flowKey: 'yield-flow', flowType: 'deposit' },
+                }),
+            )
+            .unwrap();
+
+        expect(report).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: events.yieldWrapEvent.name }),
+        );
+    });
+
+    it('reports the tx-simulation-modal cancel', async () => {
+        const report = jest.fn();
+
+        await dispatchWrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'tx-simulation-modal',
+                    action: 'cancel',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
+    });
+
+    it('reports an error carrying the compose reason when composition fails', async () => {
+        const report = jest.fn();
+        mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
+            unwrap: () => Promise.resolve({ type: 'error', reason: 'unsupported-network' }),
+        }));
+
+        await dispatchWrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'unsupported-network',
+                }),
+            }),
+        );
+    });
+
+    it('reports tx-simulation-modal continue and submit-failed when the tx is not broadcast', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+
+        await dispatchWrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'tx-simulation-modal',
+                    action: 'continue',
+                }),
+            }),
+        );
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'submit-failed',
+                }),
+            }),
+        );
+    });
+
+    it('reports the sent event when the transaction is broadcast', async () => {
+        const report = jest.fn();
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
+
+        await dispatchWrap(report);
+
+        expect(report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'sent',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
     });
 });

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -164,6 +164,7 @@ export const submitWrapNativeTokenThunk = createThunk(
             dispatch(
                 notificationsActions.addToast({
                     type: 'tx-wrap',
+                    isYieldFlowStep: !!yieldFlow,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -1,4 +1,5 @@
 import { openDeferredModal } from '@suite/modal';
+import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
@@ -13,6 +14,7 @@ import { type TokenInfo } from '@trezor/connect';
 
 import {
     getYieldErrorTranslationKey,
+    getYieldSubmitErrorAnalyticsMessage,
     sendYieldTransaction,
 } from './stablecoin-yield/signingHelpers';
 import { addToken } from './tokenActions';
@@ -33,14 +35,31 @@ export const submitWrapNativeTokenThunk = createThunk(
     `${WRAP_NATIVE_TOKEN_PREFIX}/submit`,
     async (
         { account, token, wrapAmount, yieldFlow }: WrapNativeTokenPayload,
-        { dispatch, getState },
+        { dispatch, getState, extra },
     ) => {
+        // In-flow wraps are already tracked as yield/deposit type:'wrap', so reporting here too
+        // would double-count them.
+        const reportError = (errorMessage: string) => {
+            if (yieldFlow) return;
+
+            extra.services.analytics.report({
+                type: events.yieldWrapEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: account.symbol,
+                    errorMessage,
+                },
+            });
+        };
+
         try {
             const result = await dispatch(
                 composeYieldWrapTransactionThunk({ account, token, wrapAmount }),
             ).unwrap();
 
             if (result.type === 'error') {
+                reportError(result.reason);
                 dispatch(
                     notificationsActions.addToast({
                         type: 'sign-tx-error',
@@ -68,6 +87,17 @@ export const submitWrapNativeTokenThunk = createThunk(
                 }),
             );
 
+            if (!yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldWrapEvent.name,
+                    payload: {
+                        type: 'tx-simulation-modal',
+                        action: userAcceptedTxSimulation?.value === false ? 'cancel' : 'continue',
+                        networkSymbol: account.symbol,
+                    },
+                });
+            }
+
             if (userAcceptedTxSimulation?.value === false) {
                 return undefined;
             }
@@ -94,7 +124,20 @@ export const submitWrapNativeTokenThunk = createThunk(
             userAcceptedTxSimulation?.resolve();
 
             if (!sendResult) {
+                reportError('submit-failed');
+
                 return undefined;
+            }
+
+            if (!yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldWrapEvent.name,
+                    payload: {
+                        type: 'sent',
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                    },
+                });
             }
 
             // Make sure re-wrapping doesn't create a duplicate
@@ -145,13 +188,13 @@ export const submitWrapNativeTokenThunk = createThunk(
             return sendResult;
         } catch (error) {
             console.error(error);
+            reportError(getYieldSubmitErrorAnalyticsMessage(error));
             dispatch(
                 notificationsActions.addToast({
                     type: 'sign-tx-error',
                     error: error instanceof Error ? error.message : String(error),
                 }),
             );
-
             // Same reasoning as the compose failure above. A push failure in particular means the
             // transaction was already signed, which is worth saying rather than leaving the step
             // looking idle.

--- a/packages/suite/src/components/earn/yield/common/WrappedNativeFlowComplete.tsx
+++ b/packages/suite/src/components/earn/yield/common/WrappedNativeFlowComplete.tsx
@@ -1,6 +1,10 @@
 import { type ReactNode } from 'react';
 
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Button, Card, Column, Divider, Icon, IconCircle, Row, Text } from '@trezor/components';
 import { CheckCircleFilledIcon, CheckIcon } from '@trezor/icons';
@@ -11,6 +15,7 @@ import { useNavigateToAccountRoute } from './useNavigateToAccountRoute';
 
 type WrappedNativeFlowCompleteProps = {
     account: Account;
+    flow: WrappedNativeFlowType;
     heading: ReactNode;
     description: ReactNode;
     children?: ReactNode;
@@ -18,12 +23,27 @@ type WrappedNativeFlowCompleteProps = {
 
 export const WrappedNativeFlowComplete = ({
     account,
+    flow,
     heading,
     description,
     children,
 }: WrappedNativeFlowCompleteProps) => {
     const { isBelowMobile } = useLayoutSize();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const navigateToOverview = useNavigateToAccountRoute(account, 'wallet-tokens');
+
+    const handleBackToOverview = () => {
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: flow === 'wrap' ? 'wrap-form' : 'unwrap-form',
+                to: 'account-detail',
+                networkSymbol: account.symbol,
+            },
+        });
+        navigateToOverview();
+    };
 
     return (
         <Column gap={16}>
@@ -64,7 +84,7 @@ export const WrappedNativeFlowComplete = ({
                 </Column>
             </Card>
 
-            <Button intent="neutral" priority="secondary" onClick={navigateToOverview}>
+            <Button intent="neutral" priority="secondary" onClick={handleBackToOverview}>
                 <Translation id="TR_EARN_YIELD_BACK_TO_OVERVIEW" />
             </Button>
         </Column>

--- a/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
@@ -1,5 +1,9 @@
 import { AccountLabel } from '@suite/account';
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, type TranslationKey } from '@suite/intl';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon } from '@trezor/icons';
@@ -13,17 +17,33 @@ import { useNavigateToAccountRoute } from './useNavigateToAccountRoute';
 
 type WrappedNativePageHeaderProps = {
     titleId: TranslationKey;
+    flow: WrappedNativeFlowType;
     account?: Account;
     contractAddress?: string;
 };
 
 export const WrappedNativePageHeader = ({
     titleId,
+    flow,
     account,
     contractAddress,
 }: WrappedNativePageHeaderProps) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const navigateToTokenOverview = useNavigateToAccountRoute(account, 'wallet-tokens');
     const { isBelowMobile } = useLayoutSize();
+
+    const handleBack = () => {
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'cancel',
+                from: flow === 'wrap' ? 'wrap-form' : 'unwrap-form',
+                to: 'account-detail',
+                networkSymbol: account?.symbol,
+            },
+        });
+        navigateToTokenOverview();
+    };
 
     return (
         <PageHeader expandable>
@@ -33,7 +53,7 @@ export const WrappedNativePageHeader = ({
                     intent="neutral"
                     priority="secondary"
                     size="large"
-                    onClick={navigateToTokenOverview}
+                    onClick={handleBack}
                     isDisabled={!account}
                     data-testid="@account-subpage/back"
                     tooltip={{ content: <Translation id="TR_BACK" /> }}

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts
@@ -54,6 +54,25 @@ describe('useWrappedNativeFlowAnalytics', () => {
         );
     });
 
+    it.each([
+        ['wrap', 'wrap-max'],
+        ['unwrap', 'unwrap-max'],
+    ] as const)('reportMaxClick fires %s-max on the interaction event', (flowType, element) => {
+        const { result } = renderFlowAnalytics({
+            flowType,
+            status: null,
+            txid: null,
+            networkSymbol: 'eth',
+        });
+
+        act(() => result.current.reportMaxClick());
+
+        expect(mockReport).toHaveBeenCalledWith({
+            type: events.yieldInteractionEvent.name,
+            payload: { element, networkSymbol: 'eth' },
+        });
+    });
+
     it('reports success with a duration when the broadcast confirms', () => {
         const { rerender } = renderFlowAnalytics(pendingWrap);
 

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts
@@ -1,0 +1,134 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { events } from '@suite-common/analytics';
+
+import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
+
+const mockReport = jest.fn();
+
+// The reference must be stable across renders, or the resolution/leftPending effects re-bind.
+jest.mock('@suite-common/dependency-injection', () => {
+    const analytics = { report: (...args: unknown[]) => mockReport(...args) };
+
+    return { useServices: () => ({ analytics }) };
+});
+
+jest.mock('@suite/analytics', () => ({ selectDesktopAnalyticsDep: () => ({}) }));
+
+type Props = Parameters<typeof useWrappedNativeFlowAnalytics>[0];
+
+const pendingWrap: Props = {
+    flowType: 'wrap',
+    status: 'pending',
+    txid: '0xbroadcast',
+    networkSymbol: 'eth',
+};
+
+const renderFlowAnalytics = (initialProps: Props) =>
+    renderHook((props: Props) => useWrappedNativeFlowAnalytics(props), { initialProps });
+
+describe('useWrappedNativeFlowAnalytics', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('reportSubmit fires the submit event', () => {
+        const { result } = renderFlowAnalytics({
+            flowType: 'wrap',
+            status: null,
+            txid: null,
+            networkSymbol: 'eth',
+        });
+
+        act(() => result.current.reportSubmit());
+
+        expect(mockReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'submit',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
+    });
+
+    it('reports success with a duration when the broadcast confirms', () => {
+        const { rerender } = renderFlowAnalytics(pendingWrap);
+
+        expect(mockReport).not.toHaveBeenCalled();
+
+        rerender({ ...pendingWrap, status: 'confirmed' });
+
+        expect(mockReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'success',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                    durationMs: expect.any(Number),
+                }),
+            }),
+        );
+    });
+
+    it('reports an on-chain-failure error when the broadcast fails', () => {
+        const { rerender } = renderFlowAnalytics(pendingWrap);
+
+        rerender({ ...pendingWrap, status: 'failed' });
+
+        expect(mockReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldWrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    errorMessage: 'on-chain-failure',
+                    durationMs: expect.any(Number),
+                }),
+            }),
+        );
+    });
+
+    it('reports the resolution only once', () => {
+        const { rerender } = renderFlowAnalytics(pendingWrap);
+
+        rerender({ ...pendingWrap, status: 'confirmed' });
+        rerender({ ...pendingWrap, status: 'confirmed' });
+
+        const successReports = mockReport.mock.calls.filter(
+            ([event]) => event.payload.type === 'success',
+        );
+        expect(successReports).toHaveLength(1);
+    });
+
+    it('reports leftPending when unmounted while still pending', () => {
+        const { unmount } = renderFlowAnalytics({ ...pendingWrap, flowType: 'unwrap' });
+
+        unmount();
+
+        expect(mockReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.yieldUnwrapEvent.name,
+                payload: expect.objectContaining({
+                    type: 'leftPending',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                }),
+            }),
+        );
+    });
+
+    it('does not report leftPending when the flow already resolved', () => {
+        const { rerender, unmount } = renderFlowAnalytics(pendingWrap);
+
+        rerender({ ...pendingWrap, status: 'confirmed' });
+        unmount();
+
+        const leftPendingReports = mockReport.mock.calls.filter(
+            ([event]) => event.payload.type === 'leftPending',
+        );
+        expect(leftPendingReports).toHaveLength(0);
+    });
+});

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { type EventInstance, events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import { type WrappedNativePendingTxStatus } from './useWrappedNativePendingTx';
+
+// Wrap and unwrap share one attribute schema, so one payload type serves both events.
+type WrappedNativeFlowPayload = EventInstance<typeof events.yieldWrapEvent>['payload'];
+
+type UseWrappedNativeFlowAnalyticsParams = {
+    flowType: WrappedNativeFlowType;
+    status: WrappedNativePendingTxStatus | null;
+    txid: string | null;
+    networkSymbol: string;
+};
+
+/**
+ * Fires the `yield/wrap` / `yield/unwrap` events for the standalone wrap/unwrap flows: `submit` via
+ * the returned `reportSubmit`, `success` / `error` on-chain, `leftPending` if the user leaves first.
+ */
+export const useWrappedNativeFlowAnalytics = ({
+    flowType,
+    status,
+    txid,
+    networkSymbol,
+}: UseWrappedNativeFlowAnalyticsParams) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const hasReportedResolutionRef = useRef(false);
+    const startRef = useRef<{ txid: string; startedAt: number } | null>(null);
+
+    const report = useCallback(
+        (payload: WrappedNativeFlowPayload) => {
+            if (flowType === 'wrap') {
+                analytics.report({ type: events.yieldWrapEvent.name, payload });
+            } else {
+                analytics.report({ type: events.yieldUnwrapEvent.name, payload });
+            }
+        },
+        [analytics, flowType],
+    );
+
+    const reportSubmit = useCallback(() => {
+        report({ type: 'submit', action: 'continue', networkSymbol });
+    }, [report, networkSymbol]);
+
+    // Timed in an effect rather than during render so the hook stays pure.
+    useEffect(() => {
+        if (txid && startRef.current?.txid !== txid) {
+            startRef.current = { txid, startedAt: Date.now() };
+            hasReportedResolutionRef.current = false;
+        }
+    }, [txid]);
+
+    useEffect(() => {
+        if (hasReportedResolutionRef.current || (status !== 'confirmed' && status !== 'failed')) {
+            return;
+        }
+
+        hasReportedResolutionRef.current = true;
+        const durationMs = startRef.current ? Date.now() - startRef.current.startedAt : undefined;
+
+        report(
+            status === 'confirmed'
+                ? { type: 'success', action: 'continue', networkSymbol, durationMs }
+                : {
+                      type: 'error',
+                      action: 'continue',
+                      networkSymbol,
+                      errorMessage: 'on-chain-failure',
+                      durationMs,
+                  },
+        );
+    }, [status, networkSymbol, report]);
+
+    const latestRef = useCurrentRef({ status, networkSymbol });
+
+    useEffect(
+        () => () => {
+            const snapshot = latestRef.current;
+            if (hasReportedResolutionRef.current || snapshot.status !== 'pending') {
+                return;
+            }
+
+            report({
+                type: 'leftPending',
+                action: 'continue',
+                networkSymbol: snapshot.networkSymbol,
+                durationMs: startRef.current ? Date.now() - startRef.current.startedAt : undefined,
+            });
+        },
+        [report, latestRef],
+    );
+
+    return { reportSubmit };
+};

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts
@@ -21,6 +21,7 @@ type UseWrappedNativeFlowAnalyticsParams = {
 /**
  * Fires the `yield/wrap` / `yield/unwrap` events for the standalone wrap/unwrap flows: `submit` via
  * the returned `reportSubmit`, `success` / `error` on-chain, `leftPending` if the user leaves first.
+ * `reportMaxClick` fires the max-button `yield/interaction` event.
  */
 export const useWrappedNativeFlowAnalytics = ({
     flowType,
@@ -46,6 +47,17 @@ export const useWrappedNativeFlowAnalytics = ({
     const reportSubmit = useCallback(() => {
         report({ type: 'submit', action: 'continue', networkSymbol });
     }, [report, networkSymbol]);
+
+    // No `vaultId` — that is what separates these from the in-flow deposit-max / withdraw-max.
+    const reportMaxClick = useCallback(() => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: flowType === 'wrap' ? 'wrap-max' : 'unwrap-max',
+                networkSymbol,
+            },
+        });
+    }, [analytics, flowType, networkSymbol]);
 
     // Timed in an effect rather than during render so the hook stays pure.
     useEffect(() => {
@@ -95,5 +107,5 @@ export const useWrappedNativeFlowAnalytics = ({
         [report, latestRef],
     );
 
-    return { reportSubmit };
+    return { reportSubmit, reportMaxClick };
 };

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -186,6 +186,7 @@ export const YieldDepositForm = () => {
                 action: 'continue',
                 networkSymbol: token.networkSymbol,
                 vaultId: vault.id,
+                wrappedNative: flow.isWrappedNativeVault,
                 ...(apyBreakdown && { apyBreakdown }),
             },
         });

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 
 import { act, renderHook } from '@testing-library/react';
 
+import { events } from '@suite-common/analytics';
 import { type YieldFlowFormValues } from '@suite-common/wallet-core';
 
 import { useYieldFiatInput } from './useYieldFiatInput';
@@ -15,21 +16,38 @@ const mockState = {
     },
 };
 
+const mockReport = jest.fn();
+
 jest.mock('src/hooks/suite', () => ({
     useSelector: (selector: (state: unknown) => unknown) => selector(mockState),
 }));
 
-const renderYieldFiatInput = () =>
+jest.mock('@suite-common/dependency-injection', () => {
+    const analytics = { report: (...args: unknown[]) => mockReport(...args) };
+
+    return { useServices: () => ({ analytics }) };
+});
+
+jest.mock('@suite/analytics', () => ({ selectDesktopAnalyticsDep: () => ({}) }));
+
+const renderYieldFiatInput = (vaultId?: string) =>
     renderHook(() => {
         const methods = useForm<YieldFlowFormValues>({
             mode: 'onChange',
             defaultValues: { amountInput: '', fiatInput: '' },
         });
 
-        return { methods, fiat: useYieldFiatInput({ methods, symbol: 'eth', decimals: 18 }) };
+        return {
+            methods,
+            fiat: useYieldFiatInput({ methods, symbol: 'eth', decimals: 18, vaultId }),
+        };
     });
 
 describe('useYieldFiatInput', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('offers the fiat switch when a rate is available', () => {
         const { result } = renderYieldFiatInput();
 
@@ -68,5 +86,38 @@ describe('useYieldFiatInput', () => {
         act(() => result.current.fiat.fiatToggle?.onFiatAmountChange('333.33'));
 
         expect(result.current.methods.getValues('amountInput')).toBe('0.099998500007499963');
+    });
+
+    it('reports the unit switched to, in both directions', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+
+        expect(mockReport.mock.calls.map(([event]) => event.payload.value)).toEqual([
+            'fiat',
+            'crypto',
+        ]);
+        expect(mockReport).toHaveBeenCalledWith({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'amount-currency-toggle',
+                value: 'fiat',
+                networkSymbol: 'eth',
+                vaultId: undefined,
+            },
+        });
+    });
+
+    it('carries the vault id when the amount belongs to a vault flow', () => {
+        const { result } = renderYieldFiatInput('morpho-weth');
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+
+        expect(mockReport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                payload: expect.objectContaining({ vaultId: 'morpho-weth' }),
+            }),
+        );
     });
 });

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowFormValues,
@@ -28,6 +31,7 @@ type UseYieldFiatInputParams = {
     symbol: NetworkSymbol | undefined;
     tokenAddress?: TokenAddress;
     decimals: number;
+    vaultId?: string;
 };
 
 export type UseYieldFiatInputResult = {
@@ -46,7 +50,9 @@ export const useYieldFiatInput = ({
     symbol,
     tokenAddress,
     decimals,
+    vaultId,
 }: UseYieldFiatInputParams): UseYieldFiatInputResult => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const currentFiatRates = useSelector(selectCurrentFiatRates);
     const [currency, setCurrency] = useState<YieldCurrency>('crypto');
@@ -96,11 +102,28 @@ export const useYieldFiatInput = ({
         [currentRate, decimals, methods],
     );
 
+    // Derived from `currency` rather than the `setCurrency` updater, which React may invoke twice.
+    const onToggle = useCallback(() => {
+        const nextCurrency: YieldCurrency = currency === 'crypto' ? 'fiat' : 'crypto';
+
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'amount-currency-toggle',
+                value: nextCurrency,
+                networkSymbol: symbol,
+                vaultId,
+            },
+        });
+
+        setCurrency(nextCurrency);
+    }, [analytics, currency, symbol, vaultId]);
+
     const fiatToggle: YieldAmountCardFiatToggleProps | undefined = hasFiatRate
         ? {
               currency,
               fiatSymbol,
-              onToggle: () => setCurrency(prev => (prev === 'crypto' ? 'fiat' : 'crypto')),
+              onToggle,
               onFiatAmountChange,
           }
         : undefined;

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -189,6 +189,7 @@ export const useYieldFlow = ({
         symbol: rateToken?.symbol,
         tokenAddress: rateToken?.tokenAddress,
         decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
+        vaultId: vault.id,
     });
 
     const getMaxAmount = () => {

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -21,6 +21,7 @@ import {
     getNativeWrapTxKind,
     getWrappedNativeTxTarget,
     isPending,
+    isWrappedNativeToken,
 } from '@suite-common/wallet-utils';
 import { type Analytics } from '@trezor/analytics-uploader';
 import { useCurrentRef } from '@trezor/react-utils';
@@ -84,6 +85,7 @@ type ReportContext = {
     networkSymbol: string;
     vault?: YieldDtoV2 | null;
     durationMs?: number;
+    wrappedNative?: boolean;
 };
 
 const resolveReportedType = <T extends string>(
@@ -119,6 +121,7 @@ const reportResolution = (
                 networkSymbol: context.networkSymbol,
                 vaultId: context.vault?.id,
                 durationMs: context.durationMs,
+                ...(isDepositSuccess ? { wrappedNative: context.wrappedNative } : {}),
                 ...(apyBreakdown && { apyBreakdown }),
                 ...errorMessage,
             },
@@ -142,6 +145,7 @@ const reportResolution = (
                 networkSymbol: context.networkSymbol,
                 vaultId: context.vault?.id,
                 durationMs: context.durationMs,
+                ...(outcome === 'success' ? { wrappedNative: context.wrappedNative } : {}),
                 ...(apyBreakdown && { apyBreakdown }),
                 ...errorMessage,
             },
@@ -244,6 +248,7 @@ export const useYieldPendingTransactionTracking = ({
             networkSymbol: account.symbol,
             vault,
             durationMs,
+            wrappedNative: isWrappedNativeToken(account.symbol, vault?.token.address),
         };
 
         const wrappedNativeFlowType =

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -27,6 +27,7 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
+import { useWrappedNativeFlowAnalytics } from '../common/useWrappedNativeFlowAnalytics';
 import { useWrappedNativePendingTx } from '../common/useWrappedNativePendingTx';
 import { useYieldFiatInput } from '../hooks/useYieldFiatInput';
 
@@ -73,6 +74,13 @@ export const UnwrapNativeToken = ({
     });
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'unwrap');
+
+    const { reportSubmit } = useWrappedNativeFlowAnalytics({
+        flowType: 'unwrap',
+        status: pendingTxStatus,
+        txid: broadcast?.txid ?? null,
+        networkSymbol: account.symbol,
+    });
 
     const amountInput = useWatch({ control: methods.control, name: 'amountInput' });
     const amount = new BigNumber(amountInput || '');
@@ -130,6 +138,8 @@ export const UnwrapNativeToken = ({
     });
 
     const handleSubmit = methods.handleSubmit(async ({ amountInput: unwrapAmount }) => {
+        reportSubmit();
+
         if (!(await ensureDeviceReady())) {
             return;
         }
@@ -155,6 +165,7 @@ export const UnwrapNativeToken = ({
             return (
                 <WrappedNativeFlowComplete
                     account={account}
+                    flow="unwrap"
                     heading={<Translation id="TR_UNWRAP_COMPLETE_HEADING" />}
                     description={
                         <Translation

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -75,7 +75,7 @@ export const UnwrapNativeToken = ({
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'unwrap');
 
-    const { reportSubmit } = useWrappedNativeFlowAnalytics({
+    const { reportSubmit, reportMaxClick } = useWrappedNativeFlowAnalytics({
         flowType: 'unwrap',
         status: pendingTxStatus,
         txid: broadcast?.txid ?? null,
@@ -146,6 +146,12 @@ export const UnwrapNativeToken = ({
 
         unwrapMutation.mutate(unwrapAmount);
     });
+
+    const handleMaxClick = () => {
+        reportMaxClick();
+
+        setMaxAmount(tokenBalance);
+    };
 
     const openTxDetail = (txid: string) => {
         dispatch(
@@ -223,7 +229,7 @@ export const UnwrapNativeToken = ({
                                 : undefined
                         }
                         fiatToggle={fiatToggle}
-                        onMaxClick={() => setMaxAmount(tokenBalance)}
+                        onMaxClick={handleMaxClick}
                         onSubmit={handleSubmit}
                         onPendingTxClick={openTxDetail}
                     />

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -93,6 +93,7 @@ export const YieldWithdrawForm = () => {
                 action: 'continue',
                 networkSymbol: token.networkSymbol,
                 vaultId: vault.id,
+                wrappedNative: flow.isWrappedNativeVault,
                 ...(apyBreakdown && { apyBreakdown }),
             },
         });

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -28,6 +28,7 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldWrapStep } from '../common/YieldWrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
+import { useWrappedNativeFlowAnalytics } from '../common/useWrappedNativeFlowAnalytics';
 import { useWrappedNativePendingTx } from '../common/useWrappedNativePendingTx';
 import { useYieldFiatInput } from '../hooks/useYieldFiatInput';
 
@@ -59,6 +60,13 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     });
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'wrap');
+
+    const { reportSubmit } = useWrappedNativeFlowAnalytics({
+        flowType: 'wrap',
+        status: pendingTxStatus,
+        txid: broadcast?.txid ?? null,
+        networkSymbol: account.symbol,
+    });
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
     const nativeToken: YieldFlowDisplayToken = {
@@ -110,6 +118,8 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     });
 
     const handleSubmit = methods.handleSubmit(async ({ amountInput: wrapAmount }) => {
+        reportSubmit();
+
         if (!(await ensureDeviceReady())) {
             return;
         }
@@ -154,6 +164,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
             return (
                 <WrappedNativeFlowComplete
                     account={account}
+                    flow="wrap"
                     heading={<Translation id="TR_WRAP_COMPLETE_HEADING" />}
                     description={
                         <Translation

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -61,7 +61,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'wrap');
 
-    const { reportSubmit } = useWrappedNativeFlowAnalytics({
+    const { reportSubmit, reportMaxClick } = useWrappedNativeFlowAnalytics({
         flowType: 'wrap',
         status: pendingTxStatus,
         txid: broadcast?.txid ?? null,
@@ -126,6 +126,12 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
 
         wrapMutation.mutate(wrapAmount);
     });
+
+    const handleMaxClick = () => {
+        reportMaxClick();
+
+        setMaxAmount(maxWrapAmount);
+    };
 
     const openTxDetail = (txid: string) => {
         dispatch(
@@ -218,7 +224,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                                 : undefined
                         }
                         fiatToggle={fiatToggle}
-                        onMaxClick={() => setMaxAmount(maxWrapAmount)}
+                        onMaxClick={handleMaxClick}
                         onSubmit={handleSubmit}
                         onPendingTxClick={openTxDetail}
                     />

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
@@ -1,7 +1,8 @@
 import '@suite-common/test-utils/globalOverrides';
 
 import { Translation } from '@suite/intl';
-import { configureMockStore, screen } from '@suite-common/test-utils';
+import { events } from '@suite-common/analytics';
+import { configureMockStore, fireEvent, screen } from '@suite-common/test-utils';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
 
 import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
@@ -12,9 +13,19 @@ import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
 import { type NotificationViewProps } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
 
 type TradingErrorNotification = Extract<NotificationEntry, { type: 'trading-error' }>;
+type WrapNotification = Extract<NotificationEntry, { type: 'tx-wrap' | 'tx-unwrap' }>;
+
+const mockReport = jest.fn();
 
 const MessageView = ({ message, messageValues }: NotificationViewProps) => (
     <Translation id={message} values={messageValues} />
+);
+
+// Stands in for ToastNotificationView, the only view that wires `onCancel`.
+const DismissableView = ({ onCancel }: NotificationViewProps & { onCancel?: () => void }) => (
+    <button type="button" onClick={onCancel}>
+        dismiss
+    </button>
 );
 
 const renderTradingError = (payload: Omit<TradingErrorNotification, 'context' | 'id'>) => {
@@ -30,6 +41,64 @@ const renderTradingError = (payload: Omit<TradingErrorNotification, 'context' | 
         <NotificationRenderer render={MessageView} notification={notification} />,
     );
 };
+
+const renderWrapToast = (payload: Omit<WrapNotification, 'context' | 'id'>) => {
+    const notification = { context: 'toast', id: 0, ...payload } as WrapNotification;
+    const store = configureMockStore({
+        preloadedState: mockInitialAppState,
+        serializableCheck: { ignoredActions: [] },
+    });
+    const services = {
+        ...extraDependenciesDesktopMock.services,
+        analytics: { ...extraDependenciesDesktopMock.services.analytics, report: mockReport },
+    };
+
+    renderWithProviders(
+        store,
+        services,
+        <NotificationRenderer render={DismissableView} notification={notification} />,
+    );
+
+    fireEvent.click(screen.getByText('dismiss'));
+};
+
+const wrapMetadata = {
+    send: { symbol: 'eth', displaySymbol: 'ETH', amount: '1' },
+    receive: { symbol: 'eth', displaySymbol: 'WETH', amount: '1' },
+} as const;
+
+const wrapToastPayload = {
+    type: 'tx-wrap',
+    metadata: wrapMetadata,
+    descriptor: '0xdescriptor',
+    symbol: 'eth',
+    txid: '0xwrap',
+    formattedAmount: '1',
+} as const;
+
+describe('NotificationRenderer wrap toast dismissal', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it.each([
+        ['tx-wrap', 'yieldWrapEvent'],
+        ['tx-unwrap', 'yieldUnwrapEvent'],
+    ] as const)('reports %s dismissal as sent/close', (type, eventKey) => {
+        renderWrapToast({ ...wrapToastPayload, type });
+
+        expect(mockReport).toHaveBeenCalledWith({
+            type: events[eventKey].name,
+            payload: { type: 'sent', action: 'close', networkSymbol: 'eth' },
+        });
+    });
+
+    it('stays silent for an in-flow yield step', () => {
+        renderWrapToast({ ...wrapToastPayload, isYieldFlowStep: true });
+
+        expect(mockReport).not.toHaveBeenCalled();
+    });
+});
 
 describe('NotificationRenderer trading-error', () => {
     it('step 1: renders the structured message when data is present, ignoring the partner message', () => {

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx
@@ -1,5 +1,8 @@
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { type WrapTransactionAsset } from '@suite-common/toast-notifications';
 import { ExchangeInfoNotification } from '@trezor/product-components';
 
@@ -16,11 +19,34 @@ const withFormattedAmount = (asset: WrapTransactionAsset) => ({
 });
 
 export const WrapInfoRenderer = ({ render: View, ...props }: WrapInfoRendererProps) => {
-    const { send, receive } = props.notification.metadata;
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const { notification } = props;
+    const { send, receive } = notification.metadata;
+
+    // Pairs with the `sent` report the thunk fires when this toast is dispatched. In-flow steps
+    // report on yield/deposit instead, so counting them here would skew the dismissal rate.
+    const handleDismiss = () => {
+        if (notification.isYieldFlowStep) {
+            return;
+        }
+
+        analytics.report({
+            type:
+                notification.type === 'tx-wrap'
+                    ? events.yieldWrapEvent.name
+                    : events.yieldUnwrapEvent.name,
+            payload: {
+                type: 'sent',
+                action: 'close',
+                networkSymbol: notification.symbol,
+            },
+        });
+    };
 
     return (
         <View
             {...props}
+            onCancel={handleDismiss}
             message="TOAST_TX_COMPOSED"
             messageValues={{
                 content: (

--- a/packages/suite/src/views/earn/yield/unwrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/unwrap/index.tsx
@@ -26,6 +26,7 @@ export const EarnUnwrap = () => {
         'Earn',
         <WrappedNativePageHeader
             titleId="TR_UNWRAP_NATIVE_TOKEN"
+            flow="unwrap"
             account={account}
             contractAddress={wrappedNative?.address}
         />,

--- a/packages/suite/src/views/earn/yield/wrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/wrap/index.tsx
@@ -25,6 +25,7 @@ export const EarnWrap = () => {
         'Earn',
         <WrappedNativePageHeader
             titleId="TR_WRAP_NATIVE_TOKEN"
+            flow="wrap"
             account={account}
             contractAddress={wrappedNative?.address}
         />,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -321,6 +321,16 @@ const TokenRowBasicActions = ({
             return;
         }
 
+        analytics.report({
+            type: sharedEvents.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: 'account-defi-tokens',
+                to: 'unwrap-form',
+                networkSymbol: account.symbol,
+            },
+        });
+
         dispatch(
             goto({
                 routeName: 'earn-yield-unwrap',

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -68,7 +68,7 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
             type: events.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'account-defi-tokens',
+                from: 'account-tradebox',
                 to: 'wrap-form',
                 networkSymbol: account.symbol,
             },

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -1,9 +1,12 @@
 import { type MouseEvent } from 'react';
 
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { selectIsDebugModeActive } from '@suite/debug';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import {
     getNetworkType,
@@ -30,6 +33,7 @@ type WrapNativeTokenButtonProps = {
 export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const device = useSelector(selectSelectedDevice);
     const isFirmwareOutdated = !isWrappedNativeFlowSupported(device);
@@ -59,6 +63,16 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
 
             return;
         }
+
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: 'account-defi-tokens',
+                to: 'wrap-form',
+                networkSymbol: account.symbol,
+            },
+        });
 
         dispatch(
             goto({

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -41,4 +41,6 @@ export enum EventType {
     YieldDeposit = 'yield/deposit',
     YieldWithdraw = 'yield/withdraw',
     YieldClaim = 'yield/claim',
+    YieldWrap = 'yield/wrap',
+    YieldUnwrap = 'yield/unwrap',
 }

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -41,3 +41,5 @@ export { yieldNavigateEvent } from './yieldNavigateEvent';
 export { yieldDepositEvent } from './yieldDepositEvent';
 export { yieldWithdrawEvent } from './yieldWithdrawEvent';
 export { yieldClaimEvent } from './yieldClaimEvent';
+export { yieldWrapEvent } from './yieldWrapEvent';
+export { yieldUnwrapEvent } from './yieldUnwrapEvent';

--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -28,6 +28,7 @@ type Attributes = {
     durationMs?: AttributeDef<number>;
     errorMessage?: AttributeDef<string>;
     apyBreakdown?: AttributeDef<string>;
+    wrappedNative?: AttributeDef<boolean>;
 };
 
 export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
@@ -78,6 +79,11 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
             description:
                 'Per-component breakdown of the displayed APY as a single comma-separated string in `SYMBOL,APY,SYMBOL,APY,…` order, sorted alphabetically by symbol. APYs are decimal percentages (e.g. `USDT,3.45,MORPHO,0.5` means 3.45% paid in USDT plus 0.5% paid in MORPHO). Each reward component is emitted independently; if two components share a token symbol they appear twice in the string. Reported on `type=deposit` (click/tap to submit) and `type=success` (deposit confirmed).',
             changelog: [{ version: '26.5.2', notes: 'added' }],
+        },
+        wrappedNative: {
+            description:
+                'Whether the deposited vault token is the wrapped-native token of the network (e.g. WETH on Ethereum), meaning the deposit involves a native wrap step. Reported on `type=deposit` (submit) and `type=success` (confirmed). Desktop only for now.',
+            changelog: [{ version: '26.8.0', notes: 'added' }],
         },
     },
 };

--- a/suite-common/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite-common/analytics/src/events/yieldInteractionEvent.ts
@@ -8,8 +8,11 @@ type Attributes = {
         | 'earn-dashboard-claim-rewards'
         | 'in-a-nutshell-process-tab'
         | 'withdraw-unit-toggle'
+        | 'amount-currency-toggle'
         | 'deposit-max'
         | 'withdraw-max'
+        | 'wrap-max'
+        | 'unwrap-max'
         | 'pending-tx-open'
         | 'show-more-accounts'
         | 'feedback-submit'
@@ -34,19 +37,29 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
     attributes: {
         element: {
             description:
-                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `insufficient-funds-banner` = get-token button',
+                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `amount-currency-toggle` = crypto/fiat amount input switch (any yield amount form), `insufficient-funds-banner` = get-token button. The max-button values name the form the button belongs to: `deposit-max` / `withdraw-max` cover the deposit and withdraw forms including their in-flow wrap/unwrap steps, while `wrap-max` / `unwrap-max` are the standalone wrap/unwrap pages (desktop only, no `vaultId`).',
             changelog: [
                 { version: '26.5.2', notes: 'added' },
                 {
                     version: '26.7.1',
                     notes: 'added `earn-dashboard-claim-rewards` value (mobile)',
                 },
+                {
+                    version: '26.8.0',
+                    notes: 'added `amount-currency-toggle`, `wrap-max`, `unwrap-max` values (desktop)',
+                },
             ],
         },
         value: {
             description:
-                'Optional sub-identifier — for `in-a-nutshell-process-tab`: `deposit` | `withdraw` | `claim`; for `withdraw-unit-toggle`: the unit being switched to (`asset` = underlying deposit token, `shares` = vault receipt token); for `withdraw-max`: the current unit (`asset` | `shares`); for `pending-tx-open`: the pending tx type (`approve` | `revoke` | `deposit` | `withdraw` | `claim`); omitted for `deposit-max`',
-            changelog: [{ version: '26.5.2', notes: 'added' }],
+                'Optional sub-identifier — for `in-a-nutshell-process-tab`: `deposit` | `withdraw` | `claim`; for `withdraw-unit-toggle`: the unit being switched to (`asset` = underlying deposit token, `shares` = vault receipt token); for `amount-currency-toggle`: the input unit being switched to (`crypto` | `fiat`); for `withdraw-max`: the current unit (`asset` | `shares`); for `pending-tx-open`: the pending tx type (`approve` | `revoke` | `deposit` | `withdraw` | `claim`); omitted for `deposit-max`, `wrap-max` and `unwrap-max`',
+            changelog: [
+                { version: '26.5.2', notes: 'added' },
+                {
+                    version: '26.8.0',
+                    notes: 'added `amount-currency-toggle` values (`crypto` | `fiat`)',
+                },
+            ],
         },
         networkSymbol: {
             changelog: [{ version: '26.5.2', notes: 'added' }],

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -17,6 +17,8 @@ type Attributes = {
         | 'deposit-form'
         | 'withdraw-form'
         | 'claim-form'
+        | 'wrap-form'
+        | 'unwrap-form'
         | 'choose-account-sheet'
         | 'account-detail'
         | 'insufficient-balance-screen'
@@ -26,6 +28,8 @@ type Attributes = {
         | 'deposit-form'
         | 'withdraw-form'
         | 'claim-form'
+        | 'wrap-form'
+        | 'unwrap-form'
         | 'deposit-in-a-nutshell-modal'
         | 'deposit-legal-modal'
         | 'claim-select-account-modal'
@@ -53,7 +57,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         from: {
             description:
-                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens` and `claim-select-account-modal` are desktop-only; `account-tokens` = yield badge on the account Tokens tab, `account-defi-tokens` also covers the yield badge on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
+                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens`, `claim-select-account-modal`, `wrap-form` and `unwrap-form` are desktop-only; `account-tokens` = yield badge on the account Tokens tab, `account-defi-tokens` also covers the yield badge on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -62,7 +66,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
                 },
                 {
                     version: '26.8.0',
-                    notes: 'added `account-tokens`, `account-tradebox` values',
+                    notes: 'added `account-tokens`, `account-tradebox` values, and `wrap-form`, `unwrap-form` values (desktop)',
                 },
             ],
         },
@@ -73,6 +77,10 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
                 {
                     version: '26.7.1',
                     notes: 'added `choose-account-sheet`, `account-detail`, `insufficient-balance-screen` values (mobile)',
+                },
+                {
+                    version: '26.8.0',
+                    notes: 'added `wrap-form` and `unwrap-form` values (desktop)',
                 },
             ],
         },

--- a/suite-common/analytics/src/events/yieldUnwrapEvent.ts
+++ b/suite-common/analytics/src/events/yieldUnwrapEvent.ts
@@ -1,0 +1,14 @@
+import { EventType } from '../constants';
+import type { EventDef } from '../eventDefinition';
+import {
+    type WrappedNativeFlowAttributes,
+    wrappedNativeFlowAttributes,
+} from './yieldWrappedNativeAttributes';
+
+export const yieldUnwrapEvent: EventDef<WrappedNativeFlowAttributes, EventType.YieldUnwrap> = {
+    name: EventType.YieldUnwrap,
+    descriptionTrigger: 'fired on native-token unwrap actions (e.g. WETH → ETH)',
+    changelog: [{ version: '26.8.0', notes: 'added' }],
+
+    attributes: wrappedNativeFlowAttributes,
+};

--- a/suite-common/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite-common/analytics/src/events/yieldWithdrawEvent.ts
@@ -21,6 +21,7 @@ type Attributes = {
     durationMs?: AttributeDef<number>;
     errorMessage?: AttributeDef<string>;
     apyBreakdown?: AttributeDef<string>;
+    wrappedNative?: AttributeDef<boolean>;
 };
 
 export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> = {
@@ -72,6 +73,11 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
             description:
                 'Per-component breakdown of the displayed APY as a single comma-separated string in `SYMBOL,APY,SYMBOL,APY,…` order, sorted alphabetically by symbol. APYs are decimal percentages (e.g. `USDT,3.45,MORPHO,0.5` means 3.45% paid in USDT plus 0.5% paid in MORPHO). Each reward component is emitted independently; if two components share a token symbol they appear twice in the string. Reported on `type=withdraw` (click/tap to submit) and `type=success` (withdraw confirmed).',
             changelog: [{ version: '26.5.2', notes: 'added' }],
+        },
+        wrappedNative: {
+            description:
+                'Whether the withdrawn vault token is the wrapped-native token of the network (e.g. WETH on Ethereum), meaning the withdraw involves a native unwrap step. Reported on `type=withdraw` (submit) and `type=success` (confirmed). Desktop only for now.',
+            changelog: [{ version: '26.8.0', notes: 'added' }],
         },
     },
 };

--- a/suite-common/analytics/src/events/yieldWrapEvent.ts
+++ b/suite-common/analytics/src/events/yieldWrapEvent.ts
@@ -1,0 +1,14 @@
+import { EventType } from '../constants';
+import type { EventDef } from '../eventDefinition';
+import {
+    type WrappedNativeFlowAttributes,
+    wrappedNativeFlowAttributes,
+} from './yieldWrappedNativeAttributes';
+
+export const yieldWrapEvent: EventDef<WrappedNativeFlowAttributes, EventType.YieldWrap> = {
+    name: EventType.YieldWrap,
+    descriptionTrigger: 'fired on native-token wrap actions (e.g. ETH → WETH)',
+    changelog: [{ version: '26.8.0', notes: 'added' }],
+
+    attributes: wrappedNativeFlowAttributes,
+};

--- a/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
+++ b/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
@@ -1,0 +1,55 @@
+import type { EarnModalAction } from '@suite-common/suite-types';
+
+import type { AttributeDef } from '../eventDefinition';
+
+/**
+ * Shared attribute schema for the native-token wrap (ETH → WETH) and unwrap (WETH → ETH) flows.
+ * Both `yieldWrapEvent` and `yieldUnwrapEvent` are structurally identical, so they reuse this
+ * single type + metadata object.
+ *
+ * Fired from the standalone Wrap/Unwrap pages (no `vaultId`) and, as an in-flow step, from the
+ * yield deposit/withdraw flows for wrapped-native vaults (`vaultId` set to the vault being
+ * deposited into / withdrawn from).
+ *
+ * Deliberately carries NO amount/balance/txid/descriptor — those are device-confidential and must
+ * never leave the device (see CLAUDE.md), mirroring `yieldDepositEvent` / `yieldWithdrawEvent`.
+ */
+export type WrappedNativeFlowAttributes = {
+    action: AttributeDef<EarnModalAction>;
+    type: AttributeDef<
+        'submit' | 'tx-simulation-modal' | 'sent' | 'success' | 'error' | 'leftPending'
+    >;
+    networkSymbol?: AttributeDef<string>;
+    vaultId?: AttributeDef<string>;
+    durationMs?: AttributeDef<number>;
+    errorMessage?: AttributeDef<string>;
+};
+
+export const wrappedNativeFlowAttributes = {
+    action: {
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+    type: {
+        description:
+            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted (the "transaction sent" toast is shown), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction',
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+    networkSymbol: {
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+    vaultId: {
+        description:
+            'Internal vault identifier (vault.id) when the wrap/unwrap runs as an in-flow step of a yield deposit/withdraw; absent for the standalone wrap/unwrap pages.',
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+    durationMs: {
+        description:
+            'Milliseconds between broadcast (tx appearing in state) and resolution (success / error / leftPending)',
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+    errorMessage: {
+        description:
+            'Classified failure reason. On compose failure, the specific compose reason (e.g. `unsupported-network`, `not-wrapped-native`, `missing-chain-id`, `missing-fee-level`, `fee-estimation-failed`). On submit failure, `submit-failed` (signing/review cancelled or failed) or `push-failed` (broadcast rejected by backend). On on-chain revert, `on-chain-failure`.',
+        changelog: [{ version: '26.8.0', notes: 'added' }],
+    },
+} satisfies WrappedNativeFlowAttributes;

--- a/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
+++ b/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
@@ -3,16 +3,10 @@ import type { EarnModalAction } from '@suite-common/suite-types';
 import type { AttributeDef } from '../eventDefinition';
 
 /**
- * Shared attribute schema for the native-token wrap (ETH → WETH) and unwrap (WETH → ETH) flows.
- * Both `yieldWrapEvent` and `yieldUnwrapEvent` are structurally identical, so they reuse this
- * single type + metadata object.
+ * Shared by `yieldWrapEvent` and `yieldUnwrapEvent`, which are structurally identical.
  *
- * Fired from the standalone Wrap/Unwrap pages (no `vaultId`) and, as an in-flow step, from the
- * yield deposit/withdraw flows for wrapped-native vaults (`vaultId` set to the vault being
- * deposited into / withdrawn from).
- *
- * Deliberately carries NO amount/balance/txid/descriptor — those are device-confidential and must
- * never leave the device (see CLAUDE.md), mirroring `yieldDepositEvent` / `yieldWithdrawEvent`.
+ * Carries no amount/balance/txid/descriptor — those are device-confidential and must never leave
+ * the device (see CLAUDE.md).
  */
 export type WrappedNativeFlowAttributes = {
     action: AttributeDef<EarnModalAction>;
@@ -27,11 +21,13 @@ export type WrappedNativeFlowAttributes = {
 
 export const wrappedNativeFlowAttributes = {
     action: {
+        description:
+            'What the user did with the surface the `type` names. `continue` on every lifecycle report; `cancel` when the tx-simulation modal was declined; `close` when the "transaction sent" toast was dismissed with its dismiss button.',
         changelog: [{ version: '26.8.0', notes: 'added' }],
     },
     type: {
         description:
-            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted (the "transaction sent" toast is shown), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction',
+            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted — emitted with `action=continue` when the "transaction sent" toast is shown and again with `action=close` if the user dismisses that toast (letting it auto-close is not reported), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction',
         changelog: [{ version: '26.8.0', notes: 'added' }],
     },
     networkSymbol: {

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -65,15 +65,23 @@ type WrapTransactionMetadata = {
     receive: WrapTransactionAsset;
 };
 
+// Set when the wrap/unwrap is a step of a yield deposit/withdraw rather than the standalone page,
+// which report their analytics on `yield/deposit` / `yield/withdraw` instead.
+type YieldFlowStepFlag = {
+    isYieldFlowStep?: boolean;
+};
+
 type WrapTransactionNotification = {
     type: 'tx-wrap';
     metadata: WrapTransactionMetadata;
-} & TransactionNotificationPayload;
+} & YieldFlowStepFlag &
+    TransactionNotificationPayload;
 
 type UnwrapTransactionNotification = {
     type: 'tx-unwrap';
     metadata: WrapTransactionMetadata;
-} & TransactionNotificationPayload;
+} & YieldFlowStepFlag &
+    TransactionNotificationPayload;
 
 type ReceivedTransactionNotification = {
     type: 'tx-received' | 'tx-confirmed';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds definitions and firing of events related to wrapping and unwrapping process. Adds events for:

## New events

| Event | Trigger |
| --- | --- |
| `yield/wrap` | native-token wrap actions (ETH → WETH) |
| `yield/unwrap` | native-token unwrap actions (WETH → ETH) |

| Attribute | Values |
| --- | --- |
| `type` | `submit` · `tx-simulation-modal` · `sent` · `success` · `error` · `leftPending` |
| `action` | `continue` · `cancel` · `close` |
| `networkSymbol` | e.g. `eth` |
| `vaultId` | set when running as an in-flow deposit/withdraw step; absent on the standalone pages |
| `durationMs` | broadcast → on-chain resolution |
| `errorMessage` | classified reason (`unsupported-network`, `submit-failed`, `push-failed`, `on-chain-failure`, …) |

## Extended existing events

| Event | Added |
| --- | --- |
| `yield/deposit` | `wrappedNative: boolean` — whether the vault token is the network's wrapped native, i.e. the deposit involves a wrap step |
| `yield/withdraw` | `wrappedNative: boolean` — same, for the unwrap step |
| `yield/navigate` | `wrap-form` / `unwrap-form` in both `from` and `to` |
| `yield/interaction` | `wrap-max`, `unwrap-max` (max button on the standalone pages), `amount-currency-toggle` with `value: crypto \| fiat` |

## Where it fires

- **Lifecycle** — `wrapNativeTokenThunks.ts` / `unwrapNativeTokenThunks.ts` emit `submit` →
  `tx-simulation-modal` → `sent` → `error`; `useWrappedNativeFlowAnalytics.ts` resolves
  `success` / `error` / `leftPending` on-chain and times `durationMs`.
- **Toast** — `sent` is emitted with `action: 'continue'` when the "transaction sent" toast appears,
  and again with `action: 'close'` if the user dismisses it. In-flow steps report their broadcast on
  `yield/deposit` / `yield/withdraw` instead, so the toast carries `isYieldFlowStep` and stays silent
  — keeping shown/dismissed counts paired. Letting the toast auto-close is not reported (it isn't a
  user action, and react-toastify's timeout isn't observable from redux).
- **Max button** — `wrap-max` / `unwrap-max` from the standalone pages. The deposit/withdraw forms
  already reported `deposit-max` / `withdraw-max`, including for their in-flow wrap/unwrap steps;
  that is unchanged.
- **Currency toggle** — reported from the shared `useYieldFiatInput`, so deposit, withdraw, wrap and
  unwrap are all covered by one call site. Reports the unit switched *to*, in both directions.
- **Navigation** — also fixes `WrapNativeTokenButton` to report `from: 'account-tradebox'` (it sent
  `account-defi-tokens` while rendering in the trade box).

## Notes for QA

I tested events sendings on the flows below. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29861

## Screenshots:

| Screenshot1 | Screenshot2 | Screenshot3 |
|--------|--------|--------|
| <img width="1281" height="1054" alt="Screenshot 2026-08-05 at 10 07 12" src="https://github.com/user-attachments/assets/99346c3e-e288-437b-8114-60e7512a91e5" /> | <img width="1282" height="1050" alt="Screenshot 2026-08-05 at 10 06 25" src="https://github.com/user-attachments/assets/9f523e3f-8013-4436-9bf8-e907d4487a22" /> | <img width="1277" height="1049" alt="Screenshot 2026-08-05 at 10 04 34" src="https://github.com/user-attachments/assets/49c2469a-2147-48dd-b757-2dcbe517b998" /> | 



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is mainly about yield deposit/withdraw flows and a new wrapped-native-token wrap/unwrap feature. Existing staking E2E tests already exercise the changed YieldDepositForm, YieldWithdrawForm, pending-transaction tracking, and yield analytics, so a focused staking subset gives strong confidence. The new wrap/unwrap views and their dedicated components have no direct E2E coverage; check-links only verifies they load, so wrap/unwrap functionality should be covered by manual QA or new tests before release.

<details><summary><b>Changed files (26)</b></summary>

- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/common/WrappedNativeFlowComplete.tsx`
- `packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx`
- `packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts`
- `packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/views/earn/yield/unwrap/index.tsx`
- `packages/suite/src/views/earn/yield/wrap/index.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx`
- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/yieldDepositEvent.ts`
- `suite-common/analytics/src/events/yieldNavigateEvent.ts`
- `suite-common/analytics/src/events/yieldUnwrapEvent.ts`
- `suite-common/analytics/src/events/yieldWithdrawEvent.ts`
- `suite-common/analytics/src/events/yieldWrapEvent.ts`
- `suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Initiates Cardano staking through the yield deposit form and fires yield deposit/navigate analytics, so changes to YieldDepositForm, pending-transaction tracking, or yield analytics events directly affect this flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Opens the unstake/claim flow that uses YieldWithdrawForm and yield withdraw analytics, making it a direct regression target for withdraw-form and pending-transaction changes.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — First-time Ethereum staking exercises YieldDepositForm, amount/fee validation, pending-transaction tracking, and yield deposit analytics — the core deposit path touched by this change set.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim flows rely on YieldWithdrawForm and yield withdraw/pending-transaction logic; a regression here would be immediately visible in the staking UI.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana first-time staking uses YieldDepositForm with Solana-specific rent/fee handling and pending-transaction tracking, covering another coin implementation of the changed deposit code.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstake/claim uses YieldWithdrawForm and pending-transaction tracking, providing a direct test of the changed withdraw path for Solana.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly exercises the ETH staking form inputs, validation errors, percentage buttons, Max handling, and fiat/crypto switching that live in YieldDepositForm.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — Enumerates app routes including the new /earn/yield/wrap and /earn/yield/unwrap views and token account pages, so it catches broken links or route-load regressions introduced by the new views and TokenRowActions changes.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Reward claiming is part of the yield withdraw lifecycle and shares unstake/claim infrastructure and pending-transaction tracking; it is a sensible follow-up to the withdraw-form changes.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Re-staking into an already-staked account reuses YieldDepositForm via the Stake More button with a different initial state, providing extra deposit-form coverage.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Same re-staking scenario for Solana, covering the deposit form with existing stake accounts and epoch-based pending tracking.

</details>

⚠️ **Changes with no test coverage (18)**
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/common/WrappedNativeFlowComplete.tsx`
- `packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx`
- `packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.test.ts`
- `packages/suite/src/components/earn/yield/common/useWrappedNativeFlowAnalytics.ts`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/views/earn/yield/unwrap/index.tsx`
- `packages/suite/src/views/earn/yield/wrap/index.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/yieldUnwrapEvent.ts`
- `suite-common/analytics/src/events/yieldWrapEvent.ts`
- `suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts`

_Updated: 2026-07-30T07:54:49.951Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/wrapped-native-analytics/web/](https://dev.suite.sldev.cz/suite-web/chore/wrapped-native-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/wrapped-native-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/wrapped-native-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/wrapped-native-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T10:42:47.652Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T10:42:41.316Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->