### PR TITLE
fix(suite-desktop): sync header re-used amount component

### DIFF
--- a/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
@@ -1,10 +1,13 @@
+import { AccountLabel } from '@suite/account';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { type Account } from '@suite-common/wallet-types';
-import { IconButton, Row, Text } from '@trezor/components';
+import { Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
 
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { PageHeader } from 'src/components/suite/layouts/SuiteLayout';
+import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 
 import { useNavigateToAccountRoute } from './useNavigateToAccountRoute';
 
@@ -20,6 +23,7 @@ export const WrappedNativePageHeader = ({
     contractAddress,
 }: WrappedNativePageHeaderProps) => {
     const navigateToTokenOverview = useNavigateToAccountRoute(account, 'wallet-tokens');
+    const { isBelowMobile } = useLayoutSize();
 
     return (
         <PageHeader expandable>
@@ -35,7 +39,7 @@ export const WrappedNativePageHeader = ({
                     tooltip={{ content: <Translation id="TR_BACK" /> }}
                 />
 
-                <Row alignItems="center" gap={12}>
+                <Row alignItems="center" gap={12} overflow="hidden">
                     {account && (
                         <TokenIcon
                             symbol={account.symbol}
@@ -43,11 +47,45 @@ export const WrappedNativePageHeader = ({
                             showNetworkIcon
                             size={32}
                             isBordered={false}
+                            wrappedTokenIcon="network"
                         />
                     )}
-                    <Text typographyStyle="body-md-strong">
-                        <Translation id={titleId} />
-                    </Text>
+                    {account ? (
+                        <Column gap={2} overflow="hidden">
+                            <Text
+                                typographyStyle="body-md-strong"
+                                ellipsisLineCount={isBelowMobile ? 0 : 1}
+                            >
+                                <Translation id={titleId} />
+                            </Text>
+                            <Row justifyContent="space-between" alignItems="center" gap={24}>
+                                <AccountLabel
+                                    account={account}
+                                    showAccountTypeBadge
+                                    accountTypeBadgeSize="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    typographyStyle="body-sm"
+                                />
+                                <Text
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    <FormattedCryptoAmount
+                                        value={account.formattedBalance}
+                                        symbol={account.symbol}
+                                        isBalance
+                                        data-testid="@yield/page-header/balance"
+                                    />
+                                </Text>
+                            </Row>
+                        </Column>
+                    ) : (
+                        <Text typographyStyle="body-md-strong">
+                            <Translation id={titleId} />
+                        </Text>
+                    )}
                 </Row>
             </Row>
         </PageHeader>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Re-uses existing amount component display on wrap/unwrap page 

## Notes for QA

Quite-straight forward. 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30507
Resolve https://github.com/trezor/trezor-suite/issues/30547

## Screenshots:

<img width="1029" height="437" alt="Screenshot 2026-07-30 at 12 34 44" src="https://github.com/user-attachments/assets/87266450-3ba7-410a-80ff-02f98ade74df" />
<img width="490" height="100" alt="Screenshot 2026-07-30 at 12 34 37" src="https://github.com/user-attachments/assets/d94b6637-71ab-441f-bfc1-36242cd3e46a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to a single earn/yield common header component. No E2E tests statically reference it, but the all-routes link check loads every /earn/yield/* page and would catch a render-time failure. Running that one smoke test is the minimal way to gain confidence; targeted header-specific assertions should be added if this component grows business logic.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to every /earn/yield/* route (deposit, withdraw, claim, wrap, unwrap, etc.) and asserts that each page's layout content attaches and the bundle loader hides. Since WrappedNativePageHeader is a common header in the earn/yield UI, a rendering crash or layout regression there would likely cause those pages to fail the content-attached check, making this the best available smoke test for the changed component. This coverage is inferred from the route list, not a static mapping.

</details>

_Updated: 2026-07-30T10:39:49.387Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/unwrap-header/web/](https://dev.suite.sldev.cz/suite-web/fix/unwrap-header/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/unwrap-header&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/unwrap-header&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:42:24.294Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:42:14.621Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->