### PR TITLE
refactor(suite): discoveryMiddleware cleanup

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -100,6 +100,7 @@
         "@suite/debug": "workspace:*",
         "@suite/desktop-update": "workspace:*",
         "@suite/device": "workspace:*",
+        "@suite/discovery": "workspace:*",
         "@suite/discreet-mode": "workspace:*",
         "@suite/experimental": "workspace:*",
         "@suite/external-links": "workspace:*",

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -1,6 +1,7 @@
 import type { MiddlewareAPI } from 'redux';
 
 import { coinjoinMiddleware } from '@suite/coinjoin';
+import { prepareDiscoveryMiddleware } from '@suite/discovery';
 import { prepareConnectPopupMiddleware } from '@suite-common/connect-popup';
 import type { ExtraDependencies } from '@suite-common/redux-utils';
 import { prepareSuiteSyncMiddleware } from '@suite-common/suite-sync';
@@ -13,7 +14,6 @@ import {
 } from '@suite-common/wallet-core';
 import { prepareWalletConnectMiddleware } from '@suite-common/walletconnect';
 
-import { prepareDiscoveryMiddleware } from './discoveryMiddleware';
 import graphMiddleware from './graphMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
 import storageMiddleware from './storageMiddleware';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -172,6 +172,7 @@
         { "path": "../../suite/debug" },
         { "path": "../../suite/desktop-update" },
         { "path": "../../suite/device" },
+        { "path": "../../suite/discovery" },
         { "path": "../../suite/discreet-mode" },
         { "path": "../../suite/experimental" },
         { "path": "../../suite/external-links" },

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -175,6 +175,11 @@ export const selectShowRediscoverButton = (
     return symbols.some(symbol => !discoveredNetworks.has(symbol));
 };
 
+/**
+ * Whether re-discovery is needed (accounts missing or failed).
+ * Warning: this can be slightly expensive computation for large wallets. It isn't viable for memoization, because
+ * it depends on every account (with frequent account updates, it would fire too often to be practical).
+ */
 export const selectShouldRediscover = (
     state: WalletCoreCompoundRootState,
     device: TrezorDevice,

--- a/suite/discovery/jest.config.js
+++ b/suite/discovery/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest.config.base.swc');
+
+module.exports = {
+    ...baseConfig,
+    roots: ['<rootDir>/src'],
+};

--- a/suite/discovery/package.json
+++ b/suite/discovery/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "test:unit": "yarn g:jest",
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
@@ -21,5 +22,11 @@
         "@suite/locks": "workspace:*",
         "@suite/router": "workspace:*",
         "@suite/router-config": "workspace:*"
+    },
+    "devDependencies": {
+        "@suite-common/test-utils": "workspace:*",
+        "@suite-common/wallet-types": "workspace:*",
+        "@trezor/connect-common": "workspace:*",
+        "redux": "^5.0.1"
     }
 }

--- a/suite/discovery/package.json
+++ b/suite/discovery/package.json
@@ -14,10 +14,12 @@
         "@suite-common/connect-popup": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite/locks": "workspace:*",
-        "@suite/router": "workspace:*"
+        "@suite/router": "workspace:*",
+        "@suite/router-config": "workspace:*"
     }
 }

--- a/suite/discovery/package.json
+++ b/suite/discovery/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@suite/discovery",
+    "version": "1.0.0",
+    "private": true,
+    "license": "See LICENSE.md in repo root",
+    "sideEffects": false,
+    "main": "src/index",
+    "scripts": {
+        "depcheck": "yarn g:depcheck",
+        "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'",
+        "type-check": "yarn g:tsc --build"
+    },
+    "dependencies": {
+        "@suite-common/connect-popup": "workspace:*",
+        "@suite-common/device": "workspace:*",
+        "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/thp": "workspace:*",
+        "@suite-common/wallet-core": "workspace:*",
+        "@suite/locks": "workspace:*",
+        "@suite/router": "workspace:*"
+    }
+}

--- a/suite/discovery/src/conditions.ts
+++ b/suite/discovery/src/conditions.ts
@@ -1,0 +1,17 @@
+import { type RouterRootState, selectRouterApp } from '@suite/router';
+import type { TrezorDevice } from '@suite-common/suite-types';
+
+import { SHOULD_ROUTER_APP_START_DISCOVERY } from './config';
+
+type IsDeviceBecomingAcquiredParams = {
+    prevDevice: TrezorDevice;
+    device: TrezorDevice;
+};
+export const isDeviceBecomingAcquired = ({ prevDevice, device }: IsDeviceBecomingAcquiredParams) =>
+    prevDevice.features === undefined && device.features !== undefined;
+
+export const isDeviceBecomingConnected = ({ prevDevice, device }: IsDeviceBecomingAcquiredParams) =>
+    !prevDevice.connected && device.connected;
+
+export const selectShouldRouterAppStartDiscovery = (state: RouterRootState) =>
+    SHOULD_ROUTER_APP_START_DISCOVERY[selectRouterApp(state)];

--- a/suite/discovery/src/config.ts
+++ b/suite/discovery/src/config.ts
@@ -1,0 +1,35 @@
+import type { RouterApp } from '@suite/router-config';
+
+/**
+ * Only start account discovery on these router apps, i.e. apps that interact with accounts (view, receive, send, etc.).
+ * Discovery shall not be started at other pages, because it's not necessary, but in some cases, it might even be
+ * undesired (the user might wish to change settings BEFORE starting discovery).
+ */
+export const SHOULD_ROUTER_APP_START_DISCOVERY: Record<RouterApp, boolean> = {
+    dashboard: true,
+    wallet: true,
+    earn: true,
+    'earn-yield': true,
+    'earn-staking': true,
+
+    start: false,
+    version: false,
+    'bridge-requested': false,
+    bridge: false,
+    'bridge-deprecated': false,
+    'connect-popup': false,
+    udev: false,
+    'switch-device': false,
+    onboarding: false,
+    'password-manager': false,
+    settings: false,
+    recovery: false,
+    backup: false,
+    firmware: false,
+    'firmware-type': false,
+    'firmware-custom': false,
+    'create-multi-share-backup': false,
+    'create-wallet-backup': false,
+    notifications: false,
+    unknown: false,
+};

--- a/suite/discovery/src/discoveryMiddleware.test.ts
+++ b/suite/discovery/src/discoveryMiddleware.test.ts
@@ -1,0 +1,264 @@
+import { combineReducers } from 'redux';
+
+import { type LocksState, locksInitialState, locksReducer } from '@suite/locks';
+import {
+    type RouterState,
+    getRoute,
+    routerAppChanged,
+    routerLocationChange,
+    routerReducer,
+} from '@suite/router';
+import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
+import {
+    type DeviceReducerState,
+    deviceActions,
+    deviceReducerInitialState,
+    prepareDeviceReducer,
+} from '@suite-common/device';
+import { type AnyAction } from '@suite-common/redux-utils';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { type ThpState, initialThpState, prepareThpReducer, thpActions } from '@suite-common/thp';
+import * as walletCore from '@suite-common/wallet-core';
+import { discoveryInitialState, prepareDiscoveryReducer } from '@suite-common/wallet-core';
+import type { Discovery } from '@suite-common/wallet-types';
+import { asDeviceUniquePath } from '@trezor/connect-common';
+
+import { prepareDiscoveryMiddleware } from './discoveryMiddleware';
+
+jest.mock('@suite-common/wallet-core', () => {
+    const actual = jest.requireActual('@suite-common/wallet-core');
+
+    return {
+        ...actual,
+        startOrRestartDiscoveryThunk: jest.fn(() => ({ type: 'just-something-to-dispatch' })),
+    };
+});
+
+const mockedStartOrRestartDiscoveryThunk = jest.mocked(walletCore.startOrRestartDiscoveryThunk);
+
+const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
+const discoveryReducer = prepareDiscoveryReducer(extraDependenciesCommonMock);
+const thpReducer = prepareThpReducer(extraDependenciesCommonMock);
+
+type State = {
+    device: DeviceReducerState;
+    locks: LocksState;
+    router: RouterState;
+    thp: ThpState;
+    wallet: { discovery: Discovery };
+};
+
+type FixtureState = {
+    device?: Partial<DeviceReducerState>;
+    locks?: Partial<LocksState>;
+    router?: RouterStateOverrides;
+    thp?: Partial<ThpState>;
+    discovery?: Discovery;
+};
+
+type FixtureStep = {
+    action: AnyAction;
+    expectedCallCount: number;
+};
+
+type Fixture = {
+    description: string;
+    state?: FixtureState;
+    steps: FixtureStep[];
+};
+
+type LocationChangePayload = Parameters<typeof routerLocationChange>[0];
+const changeLocationToDashboard = {
+    pathname: '/',
+    app: 'dashboard' as const,
+    route: getRoute('suite-index'),
+    params: undefined,
+} as LocationChangePayload;
+
+const path = asDeviceUniquePath('device-path');
+
+const selectedDevice = mockSuiteDevice({
+    path,
+    connected: true,
+    available: true,
+    discovered: false, // selectShouldRediscover will return true
+    state: { staticSessionId: 'device@selected:1' },
+});
+
+const unacquiredDevice = mockSuiteDevice({
+    type: 'unacquired',
+    path,
+    connected: true,
+    available: false,
+    discovered: false, // selectShouldRediscover will return true
+});
+
+const disconnectedDevice = mockSuiteDevice({
+    path,
+    connected: false,
+    available: true,
+    discovered: false, // selectShouldRediscover will return true
+    state: { staticSessionId: 'device@selected:1' },
+});
+
+const fixtures: Fixture[] = [
+    {
+        description: 'starts discovery when device is selected',
+        state: {
+            router: { app: 'dashboard' },
+        },
+        steps: [
+            {
+                action: deviceActions.selectDevice(selectedDevice),
+                expectedCallCount: 1,
+            },
+        ],
+    },
+    {
+        description:
+            'does not start discovery in an excluded route, until an enabled route is visited',
+        state: {
+            router: { app: 'settings' },
+        },
+        steps: [
+            {
+                action: deviceActions.selectDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: routerLocationChange(changeLocationToDashboard),
+                expectedCallCount: 0,
+            },
+            {
+                action: routerAppChanged('dashboard'),
+                expectedCallCount: 1,
+            },
+        ],
+    },
+    {
+        description: 'starts discovery when device becomes acquired',
+        state: {
+            device: { selectedDevice: unacquiredDevice },
+            router: { app: 'dashboard' },
+        },
+        steps: [
+            {
+                action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 1,
+            },
+        ],
+    },
+    {
+        description: 'starts discovery when device becomes connected',
+        state: {
+            device: { selectedDevice: disconnectedDevice },
+            router: { app: 'dashboard' },
+        },
+        steps: [
+            {
+                action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 1,
+            },
+        ],
+    },
+    {
+        description:
+            'does nothing when device becomes connected and selectShouldRediscover returns false',
+        state: {
+            device: { selectedDevice: disconnectedDevice },
+            router: { app: 'dashboard' },
+            // selectShouldRediscover will return false
+            discovery: { [path]: { status: 'starting' } },
+        },
+        steps: [
+            {
+                action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+        ],
+    },
+    {
+        description: 'does nothing on unrelated action even when the other conditions are met',
+        state: {
+            device: { selectedDevice },
+            router: { app: 'dashboard' },
+        },
+        steps: [
+            {
+                action: { type: 'foo' },
+                expectedCallCount: 0,
+            },
+        ],
+    },
+    {
+        description:
+            'does not start discovery while THP autoconnect modal is open, until the flow is finished',
+        state: {
+            device: { selectedDevice: unacquiredDevice },
+            router: { app: 'dashboard' },
+            thp: { autoconnectStep: 'AutoconnectInfo' },
+        },
+        steps: [
+            {
+                action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: thpActions.finishAutoconnectFlow(),
+                expectedCallCount: 1,
+            },
+        ],
+    },
+];
+
+const getInitialState = (state: FixtureState = {}): State => ({
+    device: {
+        ...deviceReducerInitialState,
+        ...state.device,
+    },
+    locks: {
+        ...locksInitialState,
+        ...state.locks,
+    },
+    router: createRouterStateMock(state.router),
+    thp: {
+        ...initialThpState,
+        ...state.thp,
+    },
+    wallet: { discovery: { ...discoveryInitialState, ...state.discovery } },
+});
+
+const initStore = (state?: FixtureState) =>
+    configureMockStore({
+        middleware: [prepareDiscoveryMiddleware(() => extraDependenciesCommonMock)],
+        reducer: {
+            device: deviceReducer,
+            locks: locksReducer,
+            router: routerReducer,
+            thp: thpReducer,
+            wallet: combineReducers({ discovery: discoveryReducer }),
+        },
+        preloadedState: getInitialState(state),
+    });
+
+describe('discoveryMiddleware', () => {
+    beforeEach(() => {
+        mockedStartOrRestartDiscoveryThunk.mockClear();
+    });
+
+    fixtures.forEach(fixture => {
+        it(fixture.description, async () => {
+            const store = initStore(fixture.state);
+
+            for (const step of fixture.steps) {
+                // Must await the dispatch because this middleware is async.
+                // TS says it isn't async because a dispatch can return anything – but in this case that's a Promise.
+                await store.dispatch(step.action);
+                expect(mockedStartOrRestartDiscoveryThunk).toHaveBeenCalledTimes(
+                    step.expectedCallCount,
+                );
+            }
+        });
+    });
+});

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -2,7 +2,7 @@ import { selectIsDeviceLocked } from '@suite/locks';
 import { routerAppChanged } from '@suite/router';
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
-import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
+import { type AnyAction, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectThpAutoconnectStep, thpActions } from '@suite-common/thp';
 import {
@@ -12,9 +12,14 @@ import {
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
-// todo: this is crazy. needs some consideration
+import {
+    isDeviceBecomingAcquired,
+    isDeviceBecomingConnected,
+    selectShouldRouterAppStartDiscovery,
+} from './conditions';
+
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, getState }) => {
+    async (action, { dispatch, next, getState }): Promise<AnyAction> => {
         // We are only taking a snapshot, but yes, the same rules shall apply: prevState and nextState MUST NOT be used without a selector.
         // eslint-disable-next-line no-restricted-syntax
         const prevState: any = getState();
@@ -26,54 +31,55 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // eslint-disable-next-line no-restricted-syntax
         const nextState: any = getState();
 
-        if (
-            nextState.router.app !== 'wallet' &&
-            nextState.router.app !== 'dashboard' &&
-            nextState.router.app !== 'earn'
-        )
-            return action;
-
+        const prevDevice = selectSelectedDevice(prevState);
         const device = selectSelectedDevice(nextState);
         const isDeviceLocked = selectIsDeviceLocked(nextState);
-        // 1. selected device is acquired but doesn't have a state
 
-        // 2. selected device becomes acquired from unacquired or connected from disconnected
-        let becomesAcquired = false;
-        let becomesConnected = false;
-        if (deviceActions.updateSelectedDevice.match(action)) {
-            const prevDevice = prevState.device.selectedDevice;
-            becomesAcquired = !!(prevDevice && !prevDevice.features && device?.features);
-            becomesConnected = !!(prevDevice && !prevDevice.connected && device?.connected);
-        }
+        const wasDeviceUpdated =
+            !!prevDevice && !!device && deviceActions.updateSelectedDevice.match(action);
+        const becomesAcquired =
+            wasDeviceUpdated && isDeviceBecomingAcquired({ prevDevice, device });
+        const becomesConnected =
+            wasDeviceUpdated && isDeviceBecomingConnected({ prevDevice, device });
 
-        // device becomesAcquired (device-change event) and is locked at the same time.
-        // device-change is emitted right before acquireDevice ends (and unlocks)
+        /*
+         The following conditions always block discovery:
+        */
+
+        // 1. Discovery should only start on certain apps
+        if (!selectShouldRouterAppStartDiscovery(nextState)) return action;
+
+        // 2. Device must be unlocked. The only exception is, when it is locked and just has been acquired.
+        //    In that case, device-change is emitted right before acquireDevice ends (and unlocks the device).
         const isDeviceReady =
             device?.connected && isDeviceAcquired(device) && (!isDeviceLocked || becomesAcquired);
+        if (!isDeviceReady) return action;
 
-        // delay discovery if THP Autoconnect modal is open (discovery executed by the modal), as it is the only
-        // THP step that takes place *after* device acquisition, and also needs device interaction to complete.
+        // 3. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place
+        //    *after* device acquisition, and also needs device interaction to complete (would block discovery).
         const isTHPAutoconnectModal = selectThpAutoconnectStep(getState()) === 'AutoconnectInfo';
         const isTHPAutoconnectFinished = thpActions.finishAutoconnectFlow.match(action);
-        const isUIReady = !isTHPAutoconnectModal;
+        if (isTHPAutoconnectModal) return action;
 
+        /*
+         Start discovery only on the following actions:
+        */
         if (
             becomesAcquired ||
             becomesConnected ||
-            isTHPAutoconnectFinished ||
-            action.type === routerAppChanged.type ||
+            isTHPAutoconnectFinished || // now that the THP Autoconnect was finished, resume the delayed discovery
+            routerAppChanged.match(action) || // may no longer be one of the apps where discovery is disabled
             connectPopupCallThunkInner.fulfilled.match(action) ||
             deviceActions.selectDevice.match(action) ||
             changeNetworks.match(action) ||
             accountsActions.updateAccount.match(action) || // empty account can become nonempty
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            if (isDeviceReady && isUIReady) {
-                const shouldRediscover = selectShouldRediscover(getState(), device);
-                if (shouldRediscover) {
-                    dispatch(startOrRestartDiscoveryThunk());
-                }
-            }
+            // 4. Nothing to discover (discovery would be no-op). It's intentionally inside the action matcher condition
+            // so it won't be called on every action, because the selector is expensive and not viable for memoization.
+            const shouldRediscover = selectShouldRediscover(getState(), device);
+            if (!shouldRediscover) return action;
+            dispatch(startOrRestartDiscoveryThunk());
         }
 
         return action;

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -15,13 +15,17 @@ import {
 // todo: this is crazy. needs some consideration
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, getState }) => {
-        const prevState = getState();
+        // We are only taking a snapshot, but yes, the same rules shall apply: prevState and nextState MUST NOT be used without a selector.
+        // eslint-disable-next-line no-restricted-syntax
+        const prevState: any = getState();
 
         // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
         // Note: TS says next(action) generally isn't async, but the action may return anything; sometimes it's a Promise → needs to be awaited
         await next(action);
 
-        const nextState = getState();
+        // eslint-disable-next-line no-restricted-syntax
+        const nextState: any = getState();
+
         if (
             nextState.router.app !== 'wallet' &&
             nextState.router.app !== 'dashboard' &&

--- a/suite/discovery/src/index.ts
+++ b/suite/discovery/src/index.ts
@@ -1,0 +1,1 @@
+export { prepareDiscoveryMiddleware } from './discoveryMiddleware';

--- a/suite/discovery/tsconfig.json
+++ b/suite/discovery/tsconfig.json
@@ -21,6 +21,15 @@
         },
         { "path": "../locks" },
         { "path": "../router" },
-        { "path": "../router-config" }
+        { "path": "../router-config" },
+        {
+            "path": "../../suite-common/test-utils"
+        },
+        {
+            "path": "../../suite-common/wallet-types"
+        },
+        {
+            "path": "../../packages/connect-common"
+        }
     ]
 }

--- a/suite/discovery/tsconfig.json
+++ b/suite/discovery/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/connect-popup"
+        },
+        { "path": "../../suite-common/device" },
+        {
+            "path": "../../suite-common/redux-utils"
+        },
+        {
+            "path": "../../suite-common/suite-utils"
+        },
+        { "path": "../../suite-common/thp" },
+        {
+            "path": "../../suite-common/wallet-core"
+        },
+        { "path": "../locks" },
+        { "path": "../router" }
+    ]
+}

--- a/suite/discovery/tsconfig.json
+++ b/suite/discovery/tsconfig.json
@@ -10,6 +10,9 @@
             "path": "../../suite-common/redux-utils"
         },
         {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/suite-utils"
         },
         { "path": "../../suite-common/thp" },
@@ -17,6 +20,7 @@
             "path": "../../suite-common/wallet-core"
         },
         { "path": "../locks" },
-        { "path": "../router" }
+        { "path": "../router" },
+        { "path": "../router-config" }
     ]
 }

--- a/suite/router-config/src/routerApps.ts
+++ b/suite/router-config/src/routerApps.ts
@@ -22,4 +22,6 @@ export type RouterApp =
     | 'create-multi-share-backup'
     | 'create-wallet-backup'
     | 'wallet'
-    | 'notifications';
+    | 'notifications'
+    // A meta route name as a fallback when no route matches the URL path pattern. Not declared in `routes`, but in RouterAppWithParams
+    | 'unknown';

--- a/yarn.lock
+++ b/yarn.lock
@@ -14753,6 +14753,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@suite/discovery@workspace:*, @suite/discovery@workspace:suite/discovery":
+  version: 0.0.0-use.local
+  resolution: "@suite/discovery@workspace:suite/discovery"
+  dependencies:
+    "@suite-common/connect-popup": "workspace:*"
+    "@suite-common/device": "workspace:*"
+    "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/thp": "workspace:*"
+    "@suite-common/wallet-core": "workspace:*"
+    "@suite/locks": "workspace:*"
+    "@suite/router": "workspace:*"
+  languageName: unknown
+  linkType: soft
+
 "@suite/discreet-mode@workspace:*, @suite/discreet-mode@workspace:suite/discreet-mode":
   version: 0.0.0-use.local
   resolution: "@suite/discreet-mode@workspace:suite/discreet-mode"
@@ -17254,6 +17269,7 @@ __metadata:
     "@suite/debug": "workspace:*"
     "@suite/desktop-update": "workspace:*"
     "@suite/device": "workspace:*"
+    "@suite/discovery": "workspace:*"
     "@suite/discreet-mode": "workspace:*"
     "@suite/experimental": "workspace:*"
     "@suite/external-links": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14762,11 +14762,15 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/test-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
+    "@suite-common/wallet-types": "workspace:*"
     "@suite/locks": "workspace:*"
     "@suite/router": "workspace:*"
     "@suite/router-config": "workspace:*"
+    "@trezor/connect-common": "workspace:*"
+    redux: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14760,11 +14760,13 @@ __metadata:
     "@suite-common/connect-popup": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite/locks": "workspace:*"
     "@suite/router": "workspace:*"
+    "@suite/router-config": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Cleanup in Suite discoveryMiddleware: :eyes: CR commit-by-commit is recommended, because file was moved.

- move to a new `@suite` package
- cleanup the logic, so it is easier to read and understand, extract some small utils
- add test, because this is very important

### Notes

I wanted to do a larger refactoring, dismantle the logic, but I came to conclusion that `deviceMiddleware` is not wrong, just extremely confusing due to its history.

Essentially, the problem is:
- There are conditions to always block discovery, and conditions to start it (blocking takes precedence)
- They are from many domains, crossing each other
- If only that was the general problem, that might be solved with DI – compose blocking conditions in composition root, then imperatively run discovery from thunks/onClick/whatever instead of the starting conditions.
- But not if you take a close look at the conditions – they actually do need to match actions with state snapshot before/after
→ Middleware is the right choice. Might be possible to dismantle it, but it is not reasonable. With commentary and tests, I hope it's now clearer :slightly_smiling_face: 

:arrow_right: next step is to add new conditions for security checks, to fix [bugs](https://github.com/trezor/trezor-suite/issues/26830). This PR serves as a preparation to do it cleanly. 

## Notes for QA

Test that discovery starts when it should (or at least, as before this PR).
There mustn't be a flow when you enter your wallet but the app "forgot" to perform the discovery.
On the other hand, there mustn't be a flow where discovery starts but device is not ready and it fails.

In Screenshots there are just a few cases I tested manually, probably a lot more to try.
The refactoring should be no-op, so not thorough catch-all testing is needed.
Just some tricky flows that come to your mind, and vigilance for bugs..

## Screenshots

Just a few cases I tested manually. There are a lot more to try.

- [restart when going to dashboard from settings](https://github.com/user-attachments/assets/b23262d2-09a9-4db4-bbb3-0ba64a7a1cbf)
- [start when acquiring](https://github.com/user-attachments/assets/7456b3c3-e1f7-4358-90cd-4e9d34810899)
- [restart when becoming connected](https://github.com/user-attachments/assets/d5e9ab5d-30b7-421f-a90e-39f9dba26fe0)
- [start only after THP autoconnection modal](https://github.com/user-attachments/assets/6138db19-d0a7-4929-bf2f-f57b6aefe9ab)



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set moves/refactors the wallet discovery middleware and related selectors into a new suite/discovery package, and also tweaks router app definitions. The highest risk is discovery failing to start, complete, or recover across network/backend changes. Run the dedicated discovery lifecycle tests plus the custom-backend and wallet-discovery tests for direct coverage, and check-links for route regressions. A small set of dashboard/onboarding asset activation tests provides broader confidence without bloating the run.

<details><summary><b>Changed files (13)</b></summary>

- `packages/suite/package.json`
- `packages/suite/src/middlewares/wallet/discoveryMiddleware.ts`
- `packages/suite/src/middlewares/wallet/index.ts`
- `packages/suite/tsconfig.json`
- `suite-common/wallet-core/src/selectors.ts`
- `suite/discovery/package.json`
- `suite/discovery/src/conditions.ts`
- `suite/discovery/src/config.ts`
- `suite/discovery/src/discoveryMiddleware.test.ts`
- `suite/discovery/src/discoveryMiddleware.ts`
- `suite/discovery/src/index.ts`
- `suite/discovery/tsconfig.json`
- `suite/router-config/src/routerApps.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test enumerates every route defined in router-config and verifies that the SECTIONS mapping covers them all. Because suite/router-config/src/routerApps.ts was changed, route groupings or app route definitions may have shifted, making this the most direct regression guard for broken/missing routes.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — The test's entire purpose is to add/eject wallets and verify that account discovery finishes and balances load. It directly exercises the discovery middleware flow and wallet selectors that were moved/updated.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Enables coins and configures custom blockbook backends, then asserts discovery completes, accounts load, or discovery errors surface. This directly stresses discovery conditions/config and the middleware's backend-aware discovery path.
- `suite/e2e/tests/wallet/discovery.test.ts` — Explicitly validates the discovery lifecycle: it starts when networks are activated, reaches completion, and recovers correctly after a page reload mid-discovery. This is the most direct end-to-end coverage of the discovery middleware changes.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Activates a new asset via the dashboard 'Activate Assets' modal and asserts it appears after discovery finishes. This covers the discovery trigger path from network activation in a different UI entry point than settings.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Enables multiple coins through the post-onboarding 'get started' modal and relies on discovery completing before assets appear on the dashboard. A regression in discovery start/completion would break the empty-header and asset assertions.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Configures custom Blockbook backends for BTC and LTC and verifies discovery completes and the portfolio graph renders. It complements the settings custom-backend test by covering backend-specific discovery from the wallet/dashboard perspective.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/package.json`
- `packages/suite/tsconfig.json`
- `suite/discovery/package.json`
- `suite/discovery/tsconfig.json`
- `suite/discovery/src/conditions.ts`
- `suite/discovery/src/config.ts`
- `suite/discovery/src/discoveryMiddleware.test.ts`

_Updated: 2026-07-30T17:00:39.852Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/discovery-middleware-cleanup/web/](https://dev.suite.sldev.cz/suite-web/refactor/discovery-middleware-cleanup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/discovery-middleware-cleanup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/discovery-middleware-cleanup&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/discovery-middleware-cleanup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T17:02:16.130Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T17:02:55.506Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->