### PR TITLE
Track Cardano staking completions, failures, and vote-change modal steps

### DIFF
--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,6 +1,8 @@
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { closeModal, openDeferredModal, openModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -87,7 +89,8 @@ export const cancelSignTx =
 
 // private, called from signTransaction only
 const pushTransaction =
-    (stakeType: StakeType) => async (dispatch: Dispatch, getState: GetState) => {
+    (stakeType: StakeType) =>
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { serializedTx, precomposedTx } = getState().wallet.stake;
         const { account } = getState().wallet.selectedAccount;
         const device = selectSelectedDevice(getState());
@@ -192,6 +195,11 @@ const pushTransaction =
                         cardanoSpecific,
                     }),
                 );
+
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.stakingConfirmEvent.name,
+                    payload: { action: stakeType, networkSymbol: account.symbol },
+                });
             }
 
             // notification from the backend may be delayed.
@@ -208,6 +216,11 @@ const pushTransaction =
                     error: sentTx.error.message,
                 }),
             );
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.stakingConfirmEvent.name,
+                payload: { action: stakeType, networkSymbol: account.symbol, success: false },
+            });
         }
 
         dispatch(cancelSignTx(sentTx.success, account));

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { FormProvider } from 'react-hook-form';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import {
     DEFAULT_VOTING_OPTION,
@@ -34,6 +36,7 @@ export const StakeChangeDelegateModalLoaded = ({
     selectedAccount,
 }: StakeChangeDelegateModalProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const { account } = selectedAccount;
@@ -63,6 +66,30 @@ export const StakeChangeDelegateModalLoaded = ({
         dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
 
         onCancel?.();
+
+        analytics.report({
+            type: events.stakingChangeDelegateEvent.name,
+            payload: {
+                action: 'cancel',
+                step: 'change-delegate-form-modal',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
+    const handleContinue = () => {
+        handleSubmit(() => {
+            analytics.report({
+                type: events.stakingChangeDelegateEvent.name,
+                payload: {
+                    action: 'continue',
+                    step: 'change-delegate-form-modal',
+                    networkSymbol: account.symbol,
+                },
+            });
+
+            signTx();
+        })();
     };
 
     const { isDisabled: isSelectionInvalid, errorType } = useMemo(() => {
@@ -114,10 +141,7 @@ export const StakeChangeDelegateModalLoaded = ({
                     onCancel={handleCancel}
                     bottomContent={
                         <Tooltip content={tooltipContent}>
-                            <Modal.Button
-                                isDisabled={isDisabled}
-                                onClick={() => handleSubmit(signTx)()}
-                            >
+                            <Modal.Button isDisabled={isDisabled} onClick={handleContinue}>
                                 <Translation id="TR_CONTINUE" />
                             </Modal.Button>
                         </Tooltip>

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -19,6 +19,7 @@ export type EarnYieldContext = {
 export type EarnModalAction = 'continue' | 'cancel' | 'close';
 
 export type EarnAnalyticsStep =
+    | 'change-delegate-form-modal'
     | 'claim-form-modal'
     | 'earn-dashboard'
     | 'entry-period-stake-modal'

--- a/suite/analytics/src/events/stakingChangeDelegateEvent.ts
+++ b/suite/analytics/src/events/stakingChangeDelegateEvent.ts
@@ -5,7 +5,9 @@ import { EventType } from '../constants';
 
 type Attributes = {
     action: AttributeDef<EarnModalAction>;
-    step: AttributeDef<Extract<EarnAnalyticsStep, 'staking-dashboard'>>;
+    step: AttributeDef<
+        Extract<EarnAnalyticsStep, 'staking-dashboard' | 'change-delegate-form-modal'>
+    >;
     networkSymbol?: AttributeDef<string>;
     currency?: AttributeDef<'crypto' | 'fiat'>;
 };
@@ -29,9 +31,15 @@ export const stakingChangeDelegateEvent: EventDef<Attributes, EventType.StakingC
                 'The action taken by the user: `continue` to proceed with changing delegate, `cancel` to abort the process, `close` to dismiss the modal',
         },
         step: {
-            changelog: [{ version: '25.4.0', notes: 'added' }],
+            changelog: [
+                { version: '25.4.0', notes: 'added' },
+                {
+                    version: '26.8.0',
+                    notes: 'added `change-delegate-form-modal` value for the change delegate/vote form modal',
+                },
+            ],
             description:
-                'The current step in the change delegate flow: `staking-dashboard` when initiated from the staking dashboard',
+                'The current step in the change delegate flow: `staking-dashboard` when initiated from the staking dashboard, `change-delegate-form-modal` when in the change delegate form',
         },
         networkSymbol: {
             changelog: [{ version: '25.4.0', notes: 'added' }],

--- a/suite/analytics/src/events/stakingConfirmEvent.ts
+++ b/suite/analytics/src/events/stakingConfirmEvent.ts
@@ -5,6 +5,7 @@ import { EventType } from '../constants';
 type Attributes = {
     action: AttributeDef<'stake' | 'unstake' | 'claim' | 'change-delegate' | 'withdraw'>;
     networkSymbol?: AttributeDef<string>;
+    success?: AttributeDef<boolean>;
 };
 
 export const stakingConfirmEvent: EventDef<Attributes, EventType.StakingConfirm> = {
@@ -24,6 +25,11 @@ export const stakingConfirmEvent: EventDef<Attributes, EventType.StakingConfirm>
         },
         networkSymbol: {
             changelog: [{ version: '25.12.0', notes: 'added' }],
+        },
+        success: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Set to `false` when the signed staking transaction fails to broadcast to the blockchain; absent otherwise',
         },
     },
 };


### PR DESCRIPTION
## Description

Adds missing completion and broadcast-failure analytics for Cardano unstake, claim, and change-delegate, plus continue/cancel step events in `StakeChangeDelegateModal`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30044