### PR TITLE
fix(ci): skip hooks for crowdin sync commit

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -114,7 +114,8 @@ jobs:
           COMMIT_MSG="chore(${COMMIT_SCOPE}): crowdin translation update${SUFFIX}"
 
           git add .
-          git commit -m "${COMMIT_MSG}"
+          # The focused install intentionally does not include all dependencies required by Husky Git hooks (pre-commit/commit-msg), so skip hook verification.
+          git commit -m "${COMMIT_MSG}" --no-verify
           git push origin ${{ env.BRANCH_NAME }} -f
 
           gh config set prompt disabled


### PR DESCRIPTION
## Description

Skip Husky hooks for the generated Crowdin sync commit because the workflow uses a focused install that does not include every pre-commit dependency. 

- `f36c057a1c` changed the Crowdin workflow install to yarn workspaces focus trezor-suite @suite/intl @suite-native/intl, leaving some hook dependencies out of node_modules.
- `59e219b63c` added the Stylelint Husky hook to pre-commit, making the bot commit run Stylelint when staged .ts files appear.
- `0d06e7f45d` (This PR) fixes the CI failure by adding --no-verify to the generated Crowdin commit and a short comment explaining that focused installs do not include all developer hook dependencies.

## Notes for QA

No manual QA needed; this only changes the Crowdin sync workflow commit step.

## Related Issue

N/A

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-crowdin-sync-hooks/web/](https://dev.suite.sldev.cz/suite-web/fix-crowdin-sync-hooks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-crowdin-sync-hooks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-crowdin-sync-hooks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T07:48:49.212Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T07:48:23.009Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->