### PR TITLE
feat(connect-explorer): add requestedPermissions to settings page

### DIFF
--- a/packages/connect-explorer/src/components/RequestedPermissions.tsx
+++ b/packages/connect-explorer/src/components/RequestedPermissions.tsx
@@ -1,0 +1,150 @@
+import styled from 'styled-components';
+
+import { Button, IconButton, Select, Text } from '@trezor/components';
+import {
+    type CoinSymbol,
+    type MethodPermission,
+    type PermissionRequest,
+    coinSymbols,
+} from '@trezor/connect-common';
+import { PlusIcon, XIcon } from '@trezor/icons';
+
+import * as trezorConnectActions from '../actions/trezorConnectActions';
+import { useActions, useSelector } from '../hooks';
+import type { Field } from '../types';
+
+// Permissions a dapp may declare up front. Mirrors GRANTABLE_PERMISSIONS in
+// suite-common/connect-popup — `management`/`internal` are never grantable, so they are
+// intentionally omitted here.
+const GRANTABLE_PERMISSIONS: MethodPermission[] = [
+    'read_address',
+    'read_xpub',
+    'read_account_info',
+    'read_features',
+    'sign',
+    'sign_message',
+    'verify_message',
+    'push_tx',
+];
+
+type CoinOption = CoinSymbol | '';
+
+const permissionOptions = GRANTABLE_PERMISSIONS.map(permission => ({
+    value: permission,
+    label: permission,
+}));
+
+const NO_COIN: CoinOption = '';
+const coinOptions: { value: CoinOption; label: string }[] = [
+    { value: NO_COIN, label: '— coin-less —' },
+    ...coinSymbols.map(coin => ({ value: coin, label: coin })),
+];
+
+// The reducer keys the change by `field.name` only; `value` carries the whole updated array.
+const asField = (value: PermissionRequest[]): Field<PermissionRequest[]> => ({
+    name: 'requestedPermissions',
+    type: 'json',
+    value,
+});
+
+const Wrapper = styled.div`
+    margin: 16px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+`;
+
+const PermissionRow = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+`;
+
+const SelectWrapper = styled.div`
+    flex: 1;
+    min-width: 0;
+`;
+
+export const RequestedPermissions = () => {
+    const permissions = useSelector(state => state.connect?.options?.requestedPermissions) ?? [];
+    const coreMode = useSelector(state => state.connect?.options?.coreMode) ?? 'auto';
+    const isDeeplink = coreMode === 'deeplink';
+    const actions = useActions({
+        onFieldChange: trezorConnectActions.onConnectOptionChange,
+    });
+
+    const update = (next: PermissionRequest[]) => actions.onFieldChange(asField(next), next);
+
+    const updateAt = (index: number, patch: (p: PermissionRequest) => PermissionRequest) =>
+        update(permissions.map((p, i) => (i === index ? patch(p) : p)));
+
+    const addPermission = () => update([...permissions, { permission: 'read_address' }]);
+
+    const removePermission = (index: number) => update(permissions.filter((_, i) => i !== index));
+
+    const setPermission = (index: number, permission: MethodPermission) =>
+        updateAt(index, p => ({ ...p, permission }));
+
+    const setCoin = (index: number, coin: CoinOption) =>
+        updateAt(index, p => ({ permission: p.permission, ...(coin ? { coin } : {}) }));
+
+    return (
+        <Wrapper>
+            <Text typographyStyle="body-md-strong">Requested permissions (upfront)</Text>
+            <Text typographyStyle="body-sm" priority="secondary">
+                Permissions the dapp declares up front. They are sanitized by the popup and merged
+                with the call-specific permissions into a single consent screen.
+            </Text>
+            {isDeeplink && (
+                <Text typographyStyle="body-sm" intent="warning">
+                    Not forwarded in deeplink (mobile) mode — the mobile transport does not carry
+                    upfront permissions. Use the Suite web core mode to test the consent flow.
+                </Text>
+            )}
+
+            {permissions.map((permission, index) => (
+                <PermissionRow key={index} data-testid={`@requested-permissions/row/${index}`}>
+                    <SelectWrapper>
+                        <Select
+                            data-testid={`@requested-permissions/permission/${index}`}
+                            label="Permission"
+                            value={permissionOptions.find(o => o.value === permission.permission)}
+                            options={permissionOptions}
+                            onChange={({ value }) => setPermission(index, value)}
+                            isSearchable
+                        />
+                    </SelectWrapper>
+                    <SelectWrapper>
+                        <Select
+                            data-testid={`@requested-permissions/coin/${index}`}
+                            label="Coin (optional)"
+                            value={coinOptions.find(o => o.value === (permission.coin ?? NO_COIN))}
+                            options={coinOptions}
+                            onChange={({ value }) => setCoin(index, value)}
+                            isSearchable
+                        />
+                    </SelectWrapper>
+                    <IconButton
+                        icon={XIcon}
+                        intent="neutral"
+                        priority="secondary"
+                        onClick={() => removePermission(index)}
+                        tooltip={{ isActive: false }}
+                        data-testid={`@requested-permissions/remove/${index}`}
+                    />
+                </PermissionRow>
+            ))}
+
+            <Button
+                priority="secondary"
+                size="small"
+                iconLeft={PlusIcon}
+                onClick={addPermission}
+                data-testid="@requested-permissions/add"
+                margin={{ top: 4 }}
+            >
+                Add permission
+            </Button>
+        </Wrapper>
+    );
+};

--- a/packages/connect-explorer/src/components/Settings.tsx
+++ b/packages/connect-explorer/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import { Button } from '@trezor/components';
 
 import * as trezorConnectActions from '../actions/trezorConnectActions';
 import { getField } from '../components/Method';
+import { RequestedPermissions } from '../components/RequestedPermissions';
 import { useActions, useSelector } from '../hooks';
 
 export const SettingsContent = styled.section`
@@ -52,6 +53,7 @@ export const Settings = () => {
         <SettingsContent>
             {/* @ts-expect-error: actions is simplified for this case */}
             {fields.map(field => getField(field, { actions }))}
+            <RequestedPermissions />
             <Button onClick={actions.onSubmitInit} data-testid="@submit-button">
                 {submitButton}
             </Button>

--- a/packages/connect-explorer/src/types/actions.ts
+++ b/packages/connect-explorer/src/types/actions.ts
@@ -1,6 +1,10 @@
 import type { TSchema } from '@sinclair/typebox';
 
-import type { ConnectDynamicSettings, ConnectMobileSettings } from '@trezor/connect-common';
+import type {
+    ConnectDynamicSettings,
+    ConnectMobileSettings,
+    PermissionRequest,
+} from '@trezor/connect-common';
 import type { TrezorConnectPublicAPI } from '@trezor/connect-web';
 
 import type { Field } from './common';
@@ -34,9 +38,14 @@ export type MethodAction =
     | { type: typeof SET_METHOD_PROCESSING; payload: boolean };
 
 // TrezorConnect action types
+// `requestedPermissions` is spelled out here as well: `Partial<A | B>` only exposes the keys
+// A and B share (`manifest`, `coreMode`), while `requestedPermissions` lives solely on the
+// `ConnectDynamicSettings` branch — the intersection makes it readable/writable on both.
 export type ConnectOptions = Partial<
     (ConnectMobileSettings & { coreMode: 'deeplink' }) | ConnectDynamicSettings
->;
+> & {
+    requestedPermissions?: PermissionRequest[];
+};
 
 export type TrezorConnectAction =
     | { type: typeof ON_CHANGE_CONNECT_OPTIONS; payload: ConnectOptions }


### PR DESCRIPTION
## Description

Adds a UI to the connect-explorer settings page (`/connect/develop/settings/`) for configuring the upfront `requestedPermissions` init option introduced in #30261.

The new section renders a small builder: each row is a permission dropdown (the grantable set — `read_address`, `read_xpub`, `read_account_info`, `read_features`, `sign`, `sign_message`, `verify_message`, `push_tx`; `management`/`internal` are intentionally excluded) plus an optional coin selector (any `CoinSymbol`, or coin-less). Rows can be added and removed. The resulting `PermissionRequest[]` is stored in the connect options and forwarded to `TrezorConnect.init` alongside the other settings, so the upfront-permissions consent flow can be exercised straight from the explorer.

The local `ConnectOptions` type is widened so `requestedPermissions` — declared only on the `ConnectDynamicSettings` branch of the union, which `Partial<A | B>` hides behind the shared keys — is readable and writable on the settings state.

## Preview

https://dev.suite.sldev.cz/connect/mroz22/connect-explorer-upfront-permissions/settings/

<img width="896" height="707" alt="image" src="https://github.com/user-attachments/assets/65ab2c52-7420-4197-af72-5af3c1f2f81c" />


## Notes for QA

- Open the connect-explorer settings page, add one or more requested permissions (with and without a coin), then click **Init Connect**.
- To see the declared permissions reach the consent screen, use core mode **Suite web** — that host path forwards `requestedPermissions` to the popup (desktop/webextension forwarding is tracked separately).
- Adding a permission defaults to `read_address` with no coin; the coin dropdown is searchable and offers every `CoinSymbol` plus a coin-less option.
- Test IDs `@requested-permissions/{add,remove,permission,coin,row}/…` are available for future e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the connect-explorer package, which is rendered as the TrezorConnect popup in suite-web and webextension modes. The highest-value tests are the two popup tests that directly load connect-explorer. Suite-desktop connect tests use Suite's own permissions UI and are not directly affected, so they are omitted to keep the run minimal. The Settings component and action types have no inferred E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect-explorer/src/components/RequestedPermissions.tsx`
- `packages/connect-explorer/src/components/Settings.tsx`
- `packages/connect-explorer/src/types/actions.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test directly loads the Connect Explorer app (packages/connect-explorer) in suite-web popup mode and exercises the permissions modal, address confirmation, and cancellation flows. Changes to RequestedPermissions.tsx and connect-explorer actions/types are likely to manifest here.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test runs the Connect Explorer webextension build and validates the full getAddress permissions and address confirmation flow. Since it renders the connect-explorer UI in a webextension context, it directly covers the changed components.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-explorer/src/components/Settings.tsx`
- `packages/connect-explorer/src/types/actions.ts`

_Updated: 2026-07-30T09:23:18.138Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-upfront-permissions/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-upfront-permissions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-upfront-permissions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-upfront-permissions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:25:29.025Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:25:04.478Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->