### PR TITLE
fix(ci): disable PMG dependency cooldown in connect release job

### DIFF
--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -61,6 +61,8 @@ jobs:
         continue-on-error: true
         with:
           version: v0.19.1
+          # Our just-published @trezor packages trip the cooldown. Malware scanning still runs.
+          cooldown-enabled: "false"
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
## Description

The `[Release] Connect NPM` workflow was failing because SafeDep PMG's dependency-cooldown blocked our own just-published `@trezor` packages - see [here](https://github.com/trezor/trezor-suite/actions/runs/30465721095/job/90816642697)

Unfortunately it's not possible to allowlist by wildcard, so we'd have to list out all the individual packages. I went with the approach of just disabling PMG's dependency cooldown for this particular job.

## Notes for QA

CI-only change