### PR TITLE
fix(ci): disable PMG dependency cooldown in connect release job (cherry pick)

### DIFF
--- a/.github/workflows/release-connect-npm.yml
+++ b/.github/workflows/release-connect-npm.yml
@@ -61,6 +61,8 @@ jobs:
         continue-on-error: true
         with:
           version: v0.19.1
+          # Our just-published @trezor packages trip the cooldown. Malware scanning still runs.
+          cooldown-enabled: "false"
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
## Description

Backport of #30568 (develop commit 73be0654) onto `release/connect/10.0.0-beta.1`.

## Notes for QA

CI-only change.