### PR TITLE
chore: unify transport-web and transport-common version to 10.0.0-beta.1

### DIFF
--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport-common",
-    "version": "1.0.0-alpha.1",
+    "version": "10.0.0-beta.1",
     "description": "Environment-agnostic transport abstractions: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils.",
     "license": "MIT",
     "repository": {

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport-web",
-    "version": "1.0.0-alpha.1",
+    "version": "10.0.0-beta.1",
     "description": "Browser-only transports for @trezor/connect: WebUSB and SharedWorker-backed sessions backend.",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
## Description

The newly added `@trezor/transport-web` and `@trezor/transport-common` packages were left at `1.0.0-alpha.1`. This bumps both to `10.0.0-beta.1` to match the other transport packages (e.g. `@trezor/transport`). All dependents reference them via `workspace:*`, so no version pins needed updating.

## Notes for QA

Version-only change to two package manifests; no runtime behavior affected.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to package manifests in transport-common and transport-web, so the primary risk is to transport initialization, Bridge session management, and WebUSB fallback behavior. The minimal high-value suite is the two tests that directly cover those exact behaviors. No broader device/integration coverage is needed unless these targeted tests reveal regressions.

<details><summary><b>Changed files (2)</b></summary>

- `packages/transport-common/package.json`
- `packages/transport-web/package.json`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/bridge.test.ts` — This test directly exercises the WebUSB transport fallback path from the Bridge page, including choosing WebUSB and displaying the connect-device prompt. Because the change is in transport-web's package manifest, the transport-web behavior validated here is the most likely to regress.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test directly exercises BridgeTransport session enumerate/acquire logic from transport-common, including session stealing, reclaiming, and multi-tab takeover. Changes to transport-common dependencies or configuration are most likely to surface in this session-management behavior.

</details>

_Updated: 2026-07-30T09:09:34.569Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/florence/web/](https://dev.suite.sldev.cz/suite-web/florence/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=florence&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=florence&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:12:27.031Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:12:15.373Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->