### PR TITLE
feat(connect-common): export GRANTABLE_PERMISSIONS as single source

### DIFF
--- a/packages/connect-common/src/types/index.ts
+++ b/packages/connect-common/src/types/index.ts
@@ -5,7 +5,7 @@ export * from './definitions';
 export * from './device';
 export * from './fees';
 export type * from './firmware';
-export type * from './method';
+export * from './method';
 export * from './params';
 export * from './settings';
 

--- a/packages/connect-common/src/types/method.ts
+++ b/packages/connect-common/src/types/method.ts
@@ -37,6 +37,25 @@ export type PermissionRequest = {
 };
 
 /**
+ * Permission categories a host/dapp may be granted up front.
+ *
+ * `management` and `internal` are device/host-internal scopes that are never
+ * grantable to a 3rd-party app and are therefore excluded. Ordered for display.
+ * This is the base allowlist; the connect popup additionally drops `push_tx` on
+ * deeplink sources at sanitize time (a contextual restriction, not part of this set).
+ */
+export const GRANTABLE_PERMISSIONS: readonly MethodPermission[] = [
+    'read_address',
+    'read_xpub',
+    'read_account_info',
+    'read_features',
+    'sign',
+    'sign_message',
+    'verify_message',
+    'push_tx',
+];
+
+/**
  * Static and runtime metadata describing a `@trezor/connect` method call.
  *
  * Returned by `AbstractMethod.getMethodInfo()` and consumed by the connect

--- a/packages/connect-explorer/src/components/RequestedPermissions.tsx
+++ b/packages/connect-explorer/src/components/RequestedPermissions.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Button, IconButton, Select, Text } from '@trezor/components';
 import {
     type CoinSymbol,
+    GRANTABLE_PERMISSIONS,
     type MethodPermission,
     type PermissionRequest,
     coinSymbols,
@@ -12,20 +13,6 @@ import { PlusIcon, XIcon } from '@trezor/icons';
 import * as trezorConnectActions from '../actions/trezorConnectActions';
 import { useActions, useSelector } from '../hooks';
 import type { Field } from '../types';
-
-// Permissions a dapp may declare up front. Mirrors GRANTABLE_PERMISSIONS in
-// suite-common/connect-popup — `management`/`internal` are never grantable, so they are
-// intentionally omitted here.
-const GRANTABLE_PERMISSIONS: MethodPermission[] = [
-    'read_address',
-    'read_xpub',
-    'read_account_info',
-    'read_features',
-    'sign',
-    'sign_message',
-    'verify_message',
-    'push_tx',
-];
 
 type CoinOption = CoinSymbol | '';
 

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -2,6 +2,7 @@ import { networks } from '@suite-common/wallet-config';
 import {
     type CoinSymbol,
     type EnabledNetwork,
+    GRANTABLE_PERMISSIONS,
     type PermissionRequest,
     isCoinSymbol,
 } from '@trezor/connect';
@@ -84,21 +85,6 @@ export const groupPermissionsByCoin = (permissions: PermissionRequest[]): Groupe
     return groups;
 };
 
-// Permissions a 3rd-party app may be granted up front. `management` and `internal` are never
-// grantable to a dapp, and `push_tx` is additionally excluded on deeplink sources — mirrors the
-// hard block in connectPopupCallThunkInner. Everything else (including unknown/garbage values from
-// untrusted host input, and coins that are not a known `CoinSymbol`) is dropped.
-const GRANTABLE_PERMISSIONS: ReadonlySet<PermissionRequest['permission']> = new Set([
-    'read_address',
-    'read_xpub',
-    'read_account_info',
-    'read_features',
-    'sign',
-    'sign_message',
-    'verify_message',
-    'push_tx',
-]);
-
 // Sanitize the host-declared `requestedPermissions`: drop entries whose permission is not
 // grantable, `push_tx` on deeplinks, and unknown coins; lowercase each `coin` to its `CoinSymbol`.
 export const sanitizeRequestedPermissions = (
@@ -106,7 +92,7 @@ export const sanitizeRequestedPermissions = (
     isDeeplink: boolean,
 ): PermissionRequest[] =>
     (requested ?? []).flatMap(({ permission, coin }) => {
-        if (!GRANTABLE_PERMISSIONS.has(permission)) return [];
+        if (!GRANTABLE_PERMISSIONS.includes(permission)) return [];
         if (permission === 'push_tx' && isDeeplink) return [];
         if (coin === undefined) return [{ permission }];
         const symbol = coin.toLowerCase();


### PR DESCRIPTION
## Description

Follow-up to #30567. Moves the base allowlist of upfront-grantable permissions into `@trezor/connect-common` (next to `MethodPermission`/`PermissionRequest`) so there is a single source of truth instead of two hand-maintained copies.

Both consumers now derive from it: the connect-popup sanitizer (`sanitizeRequestedPermissions`) builds its membership `Set` from the exported array, and the connect-explorer permission builder imports it for its dropdown instead of hardcoding a mirror. The contextual `push_tx`-on-deeplink drop stays in the sanitizer (it is not part of the base set).

`packages/connect-common/src/types/index.ts` switches the `./method` re-export from `export type *` to `export *` so the new runtime value is exported alongside the types.

## Stacked on

Base branch is `mroz22/connect-explorer-upfront-permissions` (#30567), which introduced the now-removed hardcoded copy — review/merge that first. GitHub will retarget this PR to `develop` automatically once #30567 lands.

## Notes for QA

No behavior change: the grantable set is byte-identical to the two previous copies, so the popup sanitizes host-declared permissions exactly as before. Preview (settings page): https://dev.suite.sldev.cz/connect/mroz22/connect-common-grantable-permissions/settings/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/connect-common-grantable-permissions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-common-grantable-permissions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-common-grantable-permissions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-grantable-permissions/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-common-grantable-permissions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect TrezorConnect permissions logic and UI, plus connect method type definitions. The highest regression risk lies in the Connect permissions modal flow. Run the focused connect permissions/popup tests first; other connect tests that pass through the permissions modal provide medium-confidence coverage. The type files have no E2E coverage.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-common/src/types/index.ts`
- `packages/connect-common/src/types/method.ts`
- `packages/connect-explorer/src/components/RequestedPermissions.tsx`
- `suite-common/connect-popup/src/permissions.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the Connect popup permissions modal and address confirmation flow in a web context, directly covering changes to suite-common/connect-popup/src/permissions.ts and the connect-explorer RequestedPermissions component.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test exercises the Connect popup permissions flow from a webextension context, directly covering permissions.ts and the RequestedPermissions component rendered by connect-explorer.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test specifically validates granting, remembering, forgetting, and reconnecting app permissions, which is the core behavior of suite-common/connect-popup/src/permissions.ts.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test validates the silent mode checkbox and remembered permissions state in the Connect permissions modal, directly tied to permissions.ts logic.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — This test passes through the Connect permissions modal before signing, so changes to permissions.ts could affect the initial grant step.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — This test passes through the Connect permissions modal before transaction signing, sharing the permissions infrastructure.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — This test requires confirming permissions and selecting an account, so permissions modal changes could impact the flow.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises getAddress through the Connect permissions modal and address confirmation, sharing permissions infrastructure.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test requires permissions modal confirmation before account selection, making it sensitive to permissions.ts changes.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — This test passes through the Connect permissions modal before Bitcoin transaction signing, sharing permissions infrastructure.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-common/src/types/index.ts`
- `packages/connect-common/src/types/method.ts`

_Updated: 2026-07-30T10:16:11.602Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:18:50.307Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:17:58.580Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->