### PR TITLE
fix(connect-popup): treat an unreadable grant list as covering nothing

### DIFF
--- a/suite-common/connect-popup/src/permissions.test.ts
+++ b/suite-common/connect-popup/src/permissions.test.ts
@@ -123,6 +123,25 @@ describe('permissionsAreCovered', () => {
             false,
         );
     });
+
+    // A persisted record can reach this without `allowedPermissions` on native, where the
+    // reducer's storageLoad validation never runs (SUITE-NATIVE-4PR).
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['a non-array', 'read_address'],
+    ])('is not covered when the granted list is %s', (_name, badGranted) => {
+        expect(
+            permissionsAreCovered(
+                [{ permission: 'read_address', coin: 'btc' }],
+                badGranted as unknown as PermissionRequest[],
+            ),
+        ).toBe(false);
+    });
+
+    it('is not covered by an empty granted list, even for an empty request', () => {
+        expect(permissionsAreCovered([{ permission: 'read_features' }], [])).toBe(false);
+    });
 });
 
 describe('groupPermissionsByCoin', () => {

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -52,10 +52,16 @@ export const permissionIcons = {
     internal: 'cube',
 } as const satisfies Record<PermissionRequest['permission'], string>;
 
+// `granted` comes from a persisted remembered-app record. The reducer's storageLoad case drops
+// records whose `allowedPermissions` is not an array, but that case never runs on native
+// (redux-persist rehydrates instead), so a malformed record reaches this comparison — see
+// SUITE-NATIVE-4PR. Treat it as covering nothing: the user is prompted again rather than a call
+// being silently approved against a grant list we cannot read.
 export const permissionsAreCovered = (
     requested: PermissionRequest[],
     granted: PermissionRequest[],
 ): boolean =>
+    Array.isArray(granted) &&
     requested.every(req =>
         granted.some(g => g.permission === req.permission && g.coin === req.coin),
     );


### PR DESCRIPTION
## Description

Fixes [SUITE-NATIVE-4PR](https://satoshilabs.sentry.io/issues/7638169992/) — `TypeError: Cannot read property 'some' of undefined`, 5 events / 2 users, release `io.trezor.suite@26.7.1+159`, culprit `requested.every$argument_0 (suite-common/connect-popup/src/permissionsGrouping)`.

The crash is inside `permissionsAreCovered`:

```ts
requested.every(req => granted.some(g => ...))   // `granted` is undefined
```

`granted` is `app.allowedPermissions`, read from a persisted remembered-app record at the `isRemembered` lookup in `connectPopupCallThunkInner`.

### Why a persisted record can be malformed

The reducer already validates exactly this. Its `storageLoad` case drops any record whose `allowedPermissions` is not an array:

```ts
'allowedPermissions' in permission && Array.isArray(permission.allowedPermissions) && ...
```

That case never runs on native. `extra.actionTypes.storageLoad` is `notImplementedActionType('storageLoad')` there — a placeholder string that nothing ever dispatches — and native rehydrates through redux-persist, which writes the raw MMKV payload straight into state. So on mobile the validation is dead code and a malformed record reaches the comparison unchecked. That matches the Sentry data: the issue exists only in the `suite-native` project.

### The fix, and why it fails closed

```ts
Array.isArray(granted) && requested.every(...)
```

`permissionsAreCovered` decides whether consent can be skipped, so the failure direction matters:

- returning `true` would skip consent entirely,
- defaulting to `[]` would let an *empty* request pass vacuously (`[].every` is `true`),

so both would turn a crash into a silently approved call. An unreadable grant list therefore covers nothing, and the user is prompted again — the same outcome as never having remembered the app.

### Scope

This is containment, not a root-cause fix. The root cause is that native never applies the reducer's persisted-permission validation, which also means the coin canonicalization added alongside it is dead on mobile. That is tracked as item 8 of #30401 and wants a redux-persist migration.

Note the crash predates the upfront-permissions work. The Sentry culprit names `permissionsGrouping.ts`, the file name before #30261 renamed it to `permissions.ts`, and the release is 26.7.1 — `permissionsAreCovered` and its caller came from `4163843c48 feat(suite): granular permissions by coin`, which shipped in 26.7.1. #30261 is not in any release.

## Notes for QA

Hard to reproduce without a malformed record in storage, since nothing in the current code writes one. On mobile it can be forced by putting a `connectPopup` entry with `permissions: [{ origin: 'https://example.com' }]` (no `allowedPermissions`) into MMKV, then triggering a deeplink call from that origin:

- before: the call dies with the `TypeError` above,
- after: the consent screen is shown as if the app had never been remembered.

Regression check on the normal paths: remembering an app and re-calling it must still skip the prompt, and forgetting it must bring the prompt back — covered by `suite/e2e/tests/trezor-connect/permissions.test.ts`.

## Related Issue

Root cause tracked as item 8 of #30401. Sibling fixes from the same review: #30486, #30487, #30488, #30489.

## Testing

- `@suite-common/connect-popup` unit tests: 23 passed, up from 19. New cases cover an `undefined`, `null` and non-array grant list, plus a pin on the fail-closed direction (an empty grant list must not vacuously cover a request).
- `type-check`, `lint:js` and prettier green on `@suite-common/connect-popup`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are focused on connect-popup permission logic. Although permissions.ts statically maps to 133 tests, the vast majority are transitive importers; the real user-facing risk is concentrated in the TrezorConnect permission-grant flows. I recommend running the connect-popup-specific E2E tests that directly exercise granting, remembering, revoking, and canceling permissions, plus a few representative call types that must pass through the permissions modal.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/connect-popup/src/permissions.test.ts`
- `suite-common/connect-popup/src/permissions.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises the TrezorConnect web popup permissions modal, including granting permissions, address export, and cancellation flows that depend on the permissions logic in suite-common/connect-popup.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Explicitly tests permission grant/revoke lifecycle, the 'Remember' checkbox, connected apps list, and Connect settings tab — all directly backed by the changed permissions module.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests the silent-mode option inside the permissions modal and its interaction with the remember-permissions state, which is governed by the connect-popup permissions logic.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Covers the same permission-grant and cancellation paths as the web popup test, but in a webextension context where the permissions modal behavior may differ.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Triggers the Connect permissions modal before account selection, so a regression in permissions handling would block the account-info flow.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises permissions-granting followed by address confirmation; changes to permission state could break the transition from modal to address confirmation.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Requires granting permissions and then opening the account picker; permission logic changes could affect whether the picker is reached or how selected accounts are returned.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/permissions.test.ts`

_Updated: 2026-07-30T09:28:41.171Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-popup-covered-guard/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-popup-covered-guard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-popup-covered-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-popup-covered-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-popup-covered-guard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:31:03.019Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T09:30:23.413Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->