### PR TITLE
chore: unify transport-web and transport-common version to 10.0.0-beta.1 (cherry pick)

### DIFF
--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport-common",
-    "version": "1.0.0-alpha.1",
+    "version": "10.0.0-beta.1",
     "description": "Environment-agnostic transport abstractions: types, errors, abstract base classes, structural USB interface, sessions backend, THP, utils.",
     "license": "MIT",
     "repository": {

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/transport-web",
-    "version": "1.0.0-alpha.1",
+    "version": "10.0.0-beta.1",
     "description": "Browser-only transports for @trezor/connect: WebUSB and SharedWorker-backed sessions backend.",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION
## Description

Backport of #30575 (develop commit 4fb77b067c) onto `release/connect/10.0.0-beta.1`. Bumps `@trezor/transport-web` and `@trezor/transport-common` from `1.0.0-alpha.1` to `10.0.0-beta.1` to match the other transport packages.

## Notes for QA

Version-only change to two package manifests; no runtime behavior affected.