### PR TITLE
feat(connect-explorer): expose the Connect settings in the method testing tool

### DIFF
--- a/packages/connect-explorer/src/components/ApiPlayground.tsx
+++ b/packages/connect-explorer/src/components/ApiPlayground.tsx
@@ -1,15 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { Object, type TSchema } from '@sinclair/typebox';
-import styled from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
-import { CollapsibleBox, Select, Switch, variables } from '@trezor/components';
+import { CollapsibleBox, Icon, Select, Switch, variables } from '@trezor/components';
+import { GearIcon } from '@trezor/icons';
 
+import { ConnectSettingsPanel } from './ConnectSettingsPanel';
 import { Method, MethodContent } from './Method';
 import * as methodActions from '../actions/methodActions';
 import { useActions, useSelector } from '../hooks';
 import { type MethodState } from '../reducers/methodCommon';
 import { selectMethod } from '../reducers/methodReducer';
+import {
+    selectConnectInitError,
+    selectIsConnectInitSuccess,
+    selectIsConnectInitializing,
+} from '../reducers/trezorConnectReducer';
 
 const ApiPlaygroundWrapper = styled.div`
     display: block;
@@ -68,6 +75,81 @@ const SelectWrapper = styled.div`
     }
 `;
 
+const RightControls = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
+`;
+
+type ConnectStatus = 'ok' | 'pending' | 'error' | 'idle';
+
+const DOT_COLORS = {
+    ok: 'elementFillBrandBold',
+    pending: 'elementFillWarningBold',
+    error: 'elementFillCriticalBold',
+    idle: 'borderNeutral',
+} as const;
+
+const STATUS_LABELS: Record<ConnectStatus, string> = {
+    ok: 'initialized',
+    pending: 'initializing…',
+    error: 'initialization error',
+    idle: 'not initialized',
+};
+
+const pulse = keyframes`
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+`;
+
+const SettingsToggle = styled.button<{ $open: boolean }>`
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    transition:
+        background 0.15s,
+        border-color 0.15s,
+        color 0.15s;
+    border: 1px solid ${({ theme, $open }) => ($open ? theme.borderBrand : theme.borderNeutral)};
+    background: ${({ theme, $open }) => ($open ? theme.elementFillBrandSoft : 'transparent')};
+    color: ${({ theme, $open }) => ($open ? theme.contentBrand : theme.contentPrimary)};
+
+    &:hover {
+        border-color: ${({ theme }) => theme.borderBrand};
+    }
+`;
+
+const StatusDot = styled.span<{ $status: ConnectStatus }>`
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: ${({ theme, $status }) => theme[DOT_COLORS[$status]]};
+    ${({ $status }) =>
+        $status === 'pending' &&
+        css`
+            animation: ${pulse} 1s ease-in-out infinite;
+        `}
+`;
+
+const switchFade = keyframes`
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+`;
+
+// Keyed by mode so switching between the settings view and the method fades the incoming one in.
+const SwitchArea = styled.div`
+    animation: ${switchFade} 0.25s ease both;
+`;
+
 interface ApiPlaygroundProps {
     options: (
         | {
@@ -83,7 +165,11 @@ interface ApiPlaygroundProps {
 }
 export const ApiPlayground = ({ options }: ApiPlaygroundProps) => {
     const [selectedOption, setSelectedOption] = useState(0);
+    const [showSettings, setShowSettings] = useState(false);
     const method = useSelector(selectMethod);
+    const isInitSuccess = useSelector(selectIsConnectInitSuccess);
+    const isInitializing = useSelector(selectIsConnectInitializing);
+    const initError = useSelector(selectConnectInitError);
     const actions = useActions({
         onSetSchema: methodActions.onSetSchema,
         onSetMethod: methodActions.onSetMethod,
@@ -91,6 +177,19 @@ export const ApiPlayground = ({ options }: ApiPlaygroundProps) => {
     });
 
     const { manualMode } = method;
+
+    // Stable identity so the success screen's auto-switch timer isn't reset by re-renders (this
+    // component re-renders on isInitializing for the status dot).
+    const closeSettings = useCallback(() => setShowSettings(false), []);
+
+    const getConnectStatus = (): ConnectStatus => {
+        if (initError) return 'error';
+        if (isInitializing) return 'pending';
+        if (isInitSuccess) return 'ok';
+
+        return 'idle';
+    };
+    const connectStatus = getConnectStatus();
 
     useEffect(() => {
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
@@ -127,7 +226,7 @@ export const ApiPlayground = ({ options }: ApiPlaygroundProps) => {
                 <ContentWrapper>
                     <OptionsRow $manualMode={manualMode}>
                         <div>
-                            {options.length > 1 && (
+                            {!showSettings && options.length > 1 && (
                                 <SelectWrapper>
                                     <Select
                                         label="Select method"
@@ -145,14 +244,40 @@ export const ApiPlayground = ({ options }: ApiPlaygroundProps) => {
                             )}
                         </div>
                         <div>
-                            <Switch
-                                label="Manual mode"
-                                isChecked={!!manualMode}
-                                onChange={checked => actions.onSetManualMode(!!checked)}
-                            />
+                            <RightControls>
+                                <SettingsToggle
+                                    type="button"
+                                    $open={showSettings}
+                                    onClick={() => setShowSettings(open => !open)}
+                                    data-testid="@init/settings-toggle"
+                                    title={`Trezor Connect — ${STATUS_LABELS[connectStatus]}`}
+                                    aria-label={`Trezor Connect initialization — ${STATUS_LABELS[connectStatus]}`}
+                                >
+                                    <Icon
+                                        as={GearIcon}
+                                        size={16}
+                                        color={showSettings ? 'contentBrand' : 'contentSecondary'}
+                                    />
+                                    Connect
+                                    <StatusDot $status={connectStatus} />
+                                </SettingsToggle>
+                                {!showSettings && (
+                                    <Switch
+                                        label="Manual mode"
+                                        isChecked={!!manualMode}
+                                        onChange={checked => actions.onSetManualMode(!!checked)}
+                                    />
+                                )}
+                            </RightControls>
                         </div>
                     </OptionsRow>
-                    <Method />
+                    <SwitchArea key={showSettings ? 'settings' : 'method'}>
+                        {showSettings ? (
+                            <ConnectSettingsPanel onClose={closeSettings} />
+                        ) : (
+                            <Method />
+                        )}
+                    </SwitchArea>
                 </ContentWrapper>
             </CollapsibleBox>
         </ApiPlaygroundWrapper>

--- a/packages/connect-explorer/src/components/ConnectInitForm.tsx
+++ b/packages/connect-explorer/src/components/ConnectInitForm.tsx
@@ -168,7 +168,13 @@ const CopyWrapper = styled.div`
     }
 `;
 
-export const ConnectInitForm = () => {
+interface ConnectInitFormProps {
+    /** Called when a user-triggered (re-)init succeeds — the method tool uses it to switch to a
+     *  success screen; the standalone Settings page omits it and relies on the button confirmation. */
+    onInitialized?: () => void;
+}
+
+export const ConnectInitForm = ({ onInitialized }: ConnectInitFormProps = {}) => {
     const isInitializing = useSelector(selectIsConnectInitializing);
     const isInitSuccess = useSelector(selectIsConnectInitSuccess);
     const initError = useSelector(selectConnectInitError);
@@ -227,6 +233,14 @@ export const ConnectInitForm = () => {
         setJustInitialized(false);
         const initialized = await actions.initWithOptions(options);
         if (!initialized) return;
+
+        // In the method tool the panel shows a success overlay, so skip the button confirmation there;
+        // the standalone Settings page has no overlay and relies on it.
+        if (onInitialized) {
+            onInitialized();
+
+            return;
+        }
 
         setJustInitialized(true);
         clearTimeout(confirmationTimeout.current);

--- a/packages/connect-explorer/src/components/ConnectSettingsPanel.tsx
+++ b/packages/connect-explorer/src/components/ConnectSettingsPanel.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import styled, { keyframes } from 'styled-components';
+
+import { Icon, IconButton, Text } from '@trezor/components';
+import { CheckIcon, XIcon } from '@trezor/icons';
+
+import { ConnectInitForm } from './ConnectInitForm';
+
+// How long the success screen lingers before switching back to the method.
+const SUCCESS_HOLD_MS = 1400;
+
+const fadeIn = keyframes`
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+`;
+
+const overlayFade = keyframes`
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+`;
+
+const popIn = keyframes`
+    0% {
+        opacity: 0;
+        transform: scale(0.8);
+    }
+    60% {
+        transform: scale(1.04);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+`;
+
+const FadeIn = styled.div`
+    animation: ${fadeIn} 0.28s ease both;
+`;
+
+const FormWrapper = styled.div`
+    position: relative;
+`;
+
+const CloseButton = styled.div`
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 1;
+`;
+
+// The success screen covers the form in place (rather than swapping to a shorter view) so the tool
+// keeps the form's height during the celebration — only one height change happens, on the way back
+// to the method.
+const SuccessOverlay = styled.div`
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    text-align: center;
+    background: ${({ theme }) => theme.surfaceFillRaised};
+    animation: ${overlayFade} 0.2s ease both;
+`;
+
+const SuccessBadge = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.elementFillBrandBold};
+    animation: ${popIn} 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+`;
+
+interface ConnectSettingsPanelProps {
+    onClose: () => void;
+}
+
+export const ConnectSettingsPanel = ({ onClose }: ConnectSettingsPanelProps) => {
+    const [succeeded, setSucceeded] = useState(false);
+
+    // Stable identity so ConnectInitForm's success callback doesn't churn on parent re-renders.
+    const handleInitialized = useCallback(() => setSucceeded(true), []);
+
+    // Hold the success screen for a beat, then hand control back to the method (onClose).
+    useEffect(() => {
+        if (!succeeded) return;
+        const timeout = setTimeout(onClose, SUCCESS_HOLD_MS);
+
+        return () => clearTimeout(timeout);
+    }, [succeeded, onClose]);
+
+    return (
+        <FadeIn>
+            <FormWrapper data-testid="@init/settings-panel">
+                <CloseButton>
+                    <IconButton
+                        icon={XIcon}
+                        intent="neutral"
+                        priority="secondary"
+                        size="small"
+                        onClick={onClose}
+                        tooltip={{ isActive: false }}
+                        data-testid="@init/settings-close"
+                    />
+                </CloseButton>
+                <ConnectInitForm onInitialized={handleInitialized} />
+                {succeeded && (
+                    <SuccessOverlay data-testid="@init/success-screen">
+                        <SuccessBadge>
+                            <Icon as={CheckIcon} size={32} color="contentOnDarkBrand" />
+                        </SuccessBadge>
+                        <Text typographyStyle="body-md-strong">Success</Text>
+                    </SuccessOverlay>
+                )}
+            </FormWrapper>
+        </FadeIn>
+    );
+};

--- a/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
+++ b/packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts
@@ -10,8 +10,9 @@ export const trezorConnectMiddleware =
 
         next(action);
 
+        // Auto-init on the first method so the testing tool works out of the box (core mode is still
+        // read from ?core-mode=). Reconfiguring is optional via the Connect settings panel.
         if ([SET_SCHEMA, SET_METHOD].includes(action.type) && !prevConnectOptions) {
-            const options = {};
-            api.dispatch(init(options));
+            api.dispatch(init({}));
         }
     };


### PR DESCRIPTION
## Description

Second of two stacked PRs, on top of #30727. Surfaces the redesigned `TrezorConnect.init()` settings form inside every method testing tool via a gear **Connect** toggle, without making init a mandatory step.

The method tool keeps working out of the box (auto-init on the first method). A gear **Connect** toggle in the toolbar switches the tool between the method and the settings form (mutually exclusive — never stacked); a small status dot on the toggle reflects the connection state (initialized / initializing / error). On a (re-)init, a brief success screen is shown over the form and the tool switches back to the method automatically.

### What changed

- `ApiPlayground` — the content area switches between `<Method/>` and the settings view (keyed fade); the gear **Connect** toggle (with status dot) sits in the toolbar; the method-select and manual-mode controls hide while settings is open. `<Method/>` renders by default, so nothing gates it.
- `ConnectSettingsPanel` (new) — the settings view shown by the toggle, with a success overlay + auto-switch back on (re-)init.
- `ConnectInitForm` gains an `onInitialized` callback so the panel can drive the switch.
- Middleware auto-inits on the first method so the tool works out of the box.

## Preview

- A method page (the gear "Connect" toggle switches to the settings): https://dev.suite.sldev.cz/connect/mroz22/connect-explorer-init-form/methods/bitcoin/getAddress/

## Notes for QA

- Open any method page: the tool works immediately (auto-init) — run a method as usual, no extra step.
- Click the gear **Connect** toggle: the tool switches from the method to the settings form. Edit options and click **Re-initialize**: a brief success screen appears and the tool switches back to the method automatically. You can also close with the X or the gear.
- Status dot on the toggle: green = initialized, amber (pulsing) = initializing, red = error.
- Test IDs: `@init/settings-toggle`, `@init/settings-panel`, `@init/settings-close`, `@init/success-screen`. The method submit button keeps `@submit-button`.
- Stacked on #30727 (its base branch) — review/merge that first; GitHub will retarget this PR to `develop` once #30727 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the Connect Explorer package (ApiPlayground UI, init/settings panels, and TrezorConnect middleware). The highest regression risk is in the web-based Connect Explorer flows that directly render and interact with these components. The remaining TrezorConnect E2E tests run through Suite Desktop's own Connect UI and are unlikely to be affected by Connect Explorer changes. Run the two Connect Explorer popup tests; if resources permit, run the webextension variant as well.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect-explorer/src/components/ApiPlayground.tsx`
- `packages/connect-explorer/src/components/ConnectInitForm.tsx`
- `packages/connect-explorer/src/components/ConnectSettingsPanel.tsx`
- `packages/connect-explorer/src/middlewares/trezorConnectMiddleware.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test drives the Connect Explorer web UI end-to-end for getAddress/cardanoGetAddress and cancellation flows. It directly exercises the ApiPlayground submit/response/collapsible UI and relies on the trezorConnectMiddleware to initialize and route requests, so changes in these files would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — The webextension variant loads the Connect Explorer extension UI and exercises the same submit/response flow and permission modals. It shares the ApiPlayground and middleware code path, making it a strong secondary check for regressions in the explorer's Connect integration.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-explorer/src/components/ConnectInitForm.tsx`
- `packages/connect-explorer/src/components/ConnectSettingsPanel.tsx`

_Updated: 2026-09-04T06:59:21.396Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-init-form/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-init-form/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-init-form&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-init-form&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:02:09.329Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:02:16.350Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->