### PR TITLE
feat(requirements): unify release fields across the connect closure

### DIFF
--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -51,5 +51,9 @@
     "dependencies": {
         "@fivebinaries/coin-selection": "3.0.0",
         "cbor": "^10.0.12"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/ripple/network-ripple/package.json
+++ b/networks/ripple/network-ripple/package.json
@@ -50,5 +50,9 @@
     },
     "dependencies": {
         "xrpl": "4.6.0"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/solana/network-solana/package.json
+++ b/networks/solana/network-solana/package.json
@@ -60,5 +60,9 @@
         "@solana/rpc-types": "^6.9.0",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -51,5 +51,9 @@
     "dependencies": {
         "@stellar/stellar-sdk": "14.5.0",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/tron/network-tron/package.json
+++ b/networks/tron/network-tron/package.json
@@ -45,5 +45,9 @@
     },
     "dependencies": {
         "@noble/hashes": "^2.0.1"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -45,5 +45,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -45,5 +45,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -35,5 +35,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -34,5 +34,9 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -51,5 +51,6 @@
         "react-native": {
             "optional": true
         }
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -53,5 +53,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -23,6 +23,10 @@ Optional flags:
 # Run only one requirement by name
 yarn workspace @trezor/requirements requirements:verify --only=package-json
 
+# Align release-critical package.json fields (version, repository, bugs, author) across
+# every published package in the @trezor/connect release closure
+yarn workspace @trezor/requirements requirements:fix --only=connect-closure-fields
+
 # Limit to affected workspaces containing the given text
 yarn workspace @trezor/requirements requirements:verify --filter=@trezor/connect
 

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -1,5 +1,6 @@
 import type { Requirement, RequirementScope } from './Requirement';
 import { requireAgentsSkills } from './agents-skills/requireAgentsSkills';
+import { requireConnectClosureUnifiedFields } from './connect-closure-fields/requireConnectClosureUnifiedFields';
 import { requireUnifiedDependencyVersions } from './dependency-versions/requireUnifiedDependencyVersions';
 import { requireDocsSummary } from './docs-summary/requireDocsSummary';
 import { requireFirmwareReleaseVersionMonotonicity } from './firmware-releases/requireFirmwareReleaseVersionMonotonicity';
@@ -13,6 +14,7 @@ import { requireTypeDeclarationSize } from './type-declarations/requireTypeDecla
 export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireAgentsSkills,
     requireUnifiedDependencyVersions,
+    requireConnectClosureUnifiedFields,
     requireConnectPublicDependencies,
     requireDocsSummary,
     requireFirmwareReleaseVersionMonotonicity,

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
@@ -1,0 +1,213 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+jest.mock('node:child_process');
+
+import type { RepoContext } from '../Requirement';
+import { requireConnectClosureUnifiedFields } from './requireConnectClosureUnifiedFields';
+
+type Workspace = {
+    readonly location: string;
+    readonly json: Record<string, unknown>;
+};
+
+const REPO = { type: 'git', url: 'git://github.com/trezor/trezor-suite.git' };
+const BUGS = { url: 'https://github.com/trezor/trezor-suite/issues' };
+const AUTHOR = 'Trezor <info@trezor.io>';
+const CANONICAL = '10.0.0-beta.1';
+
+const setupRepo = (workspaces: ReadonlyArray<Workspace>): RepoContext => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'connect-closure-fields-'));
+
+    const write = (location: string, json: Record<string, unknown>) => {
+        const dir = join(repoRoot, location);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, 'package.json'), `${JSON.stringify(json, null, 4)}\n`);
+    };
+
+    write('.', { name: 'trezor-suite', private: true });
+    for (const ws of workspaces) write(ws.location, ws.json);
+
+    const list = [
+        { location: '.', name: 'trezor-suite' },
+        ...workspaces.map(w => ({ location: w.location, name: w.json.name })),
+    ]
+        .map(w => JSON.stringify(w))
+        .join('\n');
+
+    jest.mocked(execFileSync).mockReturnValue(list);
+
+    return { repoRoot };
+};
+
+// connect -> {connect-common -> utils} (canonical) + {transport-web -> transport-common} (lagging).
+const closure = (transportJson: Record<string, unknown>): ReadonlyArray<Workspace> => [
+    {
+        location: 'packages/connect',
+        json: {
+            name: '@trezor/connect',
+            version: CANONICAL,
+            repository: REPO,
+            bugs: BUGS,
+            author: AUTHOR,
+            license: 'SEE LICENSE IN LICENSE.md',
+            dependencies: {
+                '@trezor/connect-common': 'workspace:*',
+                '@trezor/transport-web': 'workspace:*',
+            },
+            devDependencies: { '@trezor/unrelated': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/connect-common',
+        json: {
+            name: '@trezor/connect-common',
+            version: CANONICAL,
+            repository: REPO,
+            bugs: BUGS,
+            author: AUTHOR,
+            license: 'MIT', // license legitimately differs across the family — must be ignored
+            dependencies: { '@trezor/utils': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/utils',
+        json: {
+            name: '@trezor/utils',
+            version: CANONICAL,
+            repository: REPO,
+            bugs: BUGS,
+            author: AUTHOR,
+        },
+    },
+    {
+        location: 'packages/transport-web',
+        json: {
+            name: '@trezor/transport-web',
+            ...transportJson,
+            dependencies: { '@trezor/transport-common': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/transport-common',
+        json: { name: '@trezor/transport-common', ...transportJson },
+    },
+    // Only a devDependency of connect — outside the prod closure, ignored.
+    {
+        location: 'packages/unrelated',
+        json: { name: '@trezor/unrelated', version: '1.2.3' },
+    },
+];
+
+const readJson = (context: RepoContext, location: string) =>
+    JSON.parse(readFileSync(join(context.repoRoot, location, 'package.json'), 'utf-8'));
+
+const tempRoots: string[] = [];
+const remember = (context: RepoContext): RepoContext => {
+    tempRoots.push(context.repoRoot);
+
+    return context;
+};
+
+afterEach(() => {
+    for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+    tempRoots.length = 0;
+    jest.clearAllMocks();
+});
+
+describe(requireConnectClosureUnifiedFields.name, () => {
+    it('has repo scope', () => {
+        expect(requireConnectClosureUnifiedFields.scope).toBe('repo');
+    });
+
+    const UNIFIED = { version: CANONICAL, repository: REPO, bugs: BUGS, author: AUTHOR };
+
+    it('passes when every field is unified across the closure', async () => {
+        const context = remember(setupRepo(closure(UNIFIED)));
+
+        expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+    });
+
+    it('flags a version left behind (the #30575 scenario)', async () => {
+        const context = remember(setupRepo(closure({ ...UNIFIED, version: '1.0.0-alpha.1' })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+        const versionErrors = errors.filter(e => e.includes('"version"'));
+
+        expect(versionErrors).toHaveLength(2);
+        expect(versionErrors.join('\n')).toContain('@trezor/transport-web');
+        expect(versionErrors.join('\n')).toContain(CANONICAL);
+    });
+
+    it('flags missing repository / bugs / author fields (the #30591 scenario)', async () => {
+        const context = remember(setupRepo(closure({ version: CANONICAL })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        for (const field of ['repository', 'bugs', 'author']) {
+            const missing = errors.filter(e => e.includes(`no "${field}" field`));
+            expect(missing).toHaveLength(2);
+            expect(missing.join('\n')).toContain('@trezor/transport-web');
+            expect(missing.join('\n')).toContain('@trezor/transport-common');
+        }
+    });
+
+    it('ignores fields that legitimately vary (license)', async () => {
+        const context = remember(setupRepo(closure(UNIFIED)));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        // connect is "SEE LICENSE IN LICENSE.md", connect-common is "MIT" — not flagged.
+        expect(errors).toEqual([]);
+    });
+
+    it('ignores packages outside the production closure', async () => {
+        const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        expect(errors.join('\n')).not.toContain('@trezor/unrelated');
+    });
+
+    it('errors when no Connect closure root is present', async () => {
+        const context = remember(
+            setupRepo([
+                { location: 'packages/utils', json: { name: '@trezor/utils', version: CANONICAL } },
+            ]),
+        );
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('No Connect closure packages found');
+    });
+
+    describe('fix mode', () => {
+        it('aligns version and fills missing repository / bugs / author per package', async () => {
+            const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+            const errors = await requireConnectClosureUnifiedFields.fix!(context);
+            expect(errors).toEqual([]);
+
+            for (const location of ['packages/transport-web', 'packages/transport-common']) {
+                const pkg = readJson(context, location);
+                expect(pkg.version).toBe(CANONICAL);
+                expect(pkg.repository).toEqual(REPO);
+                expect(pkg.bugs).toEqual(BUGS);
+                expect(pkg.author).toBe(AUTHOR);
+            }
+
+            expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+        });
+
+        it('does not touch packages outside the closure', async () => {
+            const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+            await requireConnectClosureUnifiedFields.fix!(context);
+
+            expect(readJson(context, 'packages/unrelated').version).toBe('1.2.3');
+        });
+    });
+});

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
@@ -1,0 +1,175 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { arrayToDictionary, deepEqual, typedObjectEntries } from '@trezor/utils';
+
+import { mostCommon, pickCanonicalVersion } from '../../versions';
+import type { Requirement } from '../Requirement';
+import {
+    type WorkspacePackage,
+    collectProdWorkspaceClosure,
+    collectWorkspacePackages,
+} from '../connectClosure';
+
+/**
+ * Entry packages of the Trezor Connect family. Every internal workspace package
+ * reachable from these through production dependencies (`dependencies` and
+ * `optionalDependencies`) is published together as part of a Connect release.
+ *
+ * `@trezor/connect` (the core) is included on purpose: the public entry points
+ * (`connect-web`/`connect-mobile`/`connect-webextension`) are thin and do not
+ * reach deeper packages such as `@trezor/transport-*`, which nevertheless ship
+ * with every Connect release.
+ */
+const CONNECT_CLOSURE_ROOTS = [
+    '@trezor/connect',
+    '@trezor/connect-web',
+    '@trezor/connect-mobile',
+    '@trezor/connect-webextension',
+] as const;
+
+type UnifiedField = {
+    readonly name: string;
+    /** Chooses the value the whole closure should agree on. */
+    readonly pickCanonical: (values: ReadonlyArray<unknown>) => unknown;
+};
+
+/**
+ * package.json fields that every published package in the Connect closure must
+ * share. Each field either shares one value across the closure or is missing on
+ * the packages that lag behind; both are treated as drift and aligned on fix.
+ *
+ * A field only belongs here if it (1) is release/publish metadata, (2) has a
+ * single canonical value the whole family should share, and (3) is safe to
+ * rewrite. Deliberately excluded:
+ * - `license` — NOT uniform for a real reason: `@trezor/connect` and several
+ *   others are under the repository's TREZOR REFERENCE SOURCE LICENSE (via
+ *   "SEE LICENSE IN LICENSE.md"), while the utility packages are "MIT". These are
+ *   two different licenses, so unifying to the most common value (MIT) would
+ *   mis-license the restricted packages. License changes need human review.
+ * - `type`, `sideEffects` — build/bundler semantics, not release metadata.
+ * - `homepage`, `main`, `exports`, `publishConfig`, `browser`, `keywords`, … —
+ *   inherently per-package.
+ * - `dependencies` / `devDependencies` versions are covered by
+ *   requireUnifiedDependencyVersions.
+ */
+const UNIFIED_FIELDS: ReadonlyArray<UnifiedField> = [
+    // Release lockstep — see #30575.
+    { name: 'version', pickCanonical: values => pickCanonicalVersion(values.map(String)) },
+    // NPM provenance requires a repository field on every published package — see #30591.
+    { name: 'repository', pickCanonical: mostCommon },
+    // Issue tracker; every published package should point at the same tracker.
+    { name: 'bugs', pickCanonical: mostCommon },
+    // Package author; uniform across the Trezor-published family.
+    { name: 'author', pickCanonical: mostCommon },
+];
+
+type FieldDrift = {
+    readonly field: string;
+    readonly packageName: string;
+    readonly dir: string;
+    readonly actual: unknown;
+    readonly canonical: unknown;
+};
+
+const analyzeClosure = (
+    repoRoot: string,
+): { readonly drifts: ReadonlyArray<FieldDrift> } | { readonly error: string } => {
+    const packages = collectWorkspacePackages(repoRoot);
+    const closureNames = [...collectProdWorkspaceClosure(CONNECT_CLOSURE_ROOTS, packages)].sort();
+
+    if (closureNames.length === 0) {
+        return {
+            error: `No Connect closure packages found. Expected at least one of: ${CONNECT_CLOSURE_ROOTS.join(', ')}.`,
+        };
+    }
+
+    const publicPackages = closureNames
+        .map(name => packages.get(name))
+        .filter(
+            (pkg): pkg is WorkspacePackage => pkg !== undefined && pkg.packageJson.private !== true,
+        );
+
+    if (publicPackages.length === 0) {
+        return { error: 'No published Connect closure packages found.' };
+    }
+
+    const drifts: FieldDrift[] = [];
+
+    for (const field of UNIFIED_FIELDS) {
+        const presentValues = publicPackages
+            .map(pkg => pkg.packageJson[field.name])
+            .filter(value => value !== undefined);
+
+        if (presentValues.length === 0) continue;
+
+        const canonical = field.pickCanonical(presentValues);
+
+        for (const pkg of publicPackages) {
+            const actual = pkg.packageJson[field.name];
+
+            if (deepEqual(actual, canonical)) continue;
+
+            drifts.push({
+                field: field.name,
+                packageName: pkg.name,
+                dir: pkg.dir,
+                actual,
+                canonical,
+            });
+        }
+    }
+
+    return { drifts };
+};
+
+const formatDriftError = ({ field, packageName, actual, canonical }: FieldDrift): string => {
+    const current =
+        actual === undefined
+            ? `has no "${field}" field`
+            : `has "${field}" = ${JSON.stringify(actual)}`;
+
+    return `"${packageName}" ${current} but the Connect closure uses ${JSON.stringify(canonical)}. Run requirements:fix --only=connect-closure-fields.`;
+};
+
+/**
+ * Verifies that every published package in the `@trezor/connect` production
+ * closure shares the same value for a set of release-critical package.json fields
+ * (see UNIFIED_FIELDS), so the whole family is published in lockstep and no
+ * package is released with stale or missing metadata.
+ */
+export const requireConnectClosureUnifiedFields: Requirement<'repo'> = {
+    name: 'connect-closure-fields',
+    scope: 'repo',
+    verify: ({ repoRoot }) => {
+        const analysis = analyzeClosure(repoRoot);
+
+        if ('error' in analysis) {
+            return Promise.resolve([analysis.error]);
+        }
+
+        return Promise.resolve(analysis.drifts.map(formatDriftError));
+    },
+    fix: ({ repoRoot }) => {
+        const analysis = analyzeClosure(repoRoot);
+
+        if ('error' in analysis) {
+            return Promise.resolve([analysis.error]);
+        }
+
+        const driftsByDir = arrayToDictionary([...analysis.drifts], drift => drift.dir, true);
+
+        for (const [dir, drifts] of typedObjectEntries(driftsByDir)) {
+            const pkgPath = join(dir, 'package.json');
+            const parsed = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+
+            for (const drift of drifts) {
+                parsed[drift.field] = drift.canonical;
+            }
+
+            writeFileSync(pkgPath, JSON.stringify(parsed, null, 4) + '\n', 'utf-8');
+        }
+
+        return Promise.resolve([]);
+    },
+};

--- a/packages/requirements/src/requirements/connectClosure.test.ts
+++ b/packages/requirements/src/requirements/connectClosure.test.ts
@@ -1,0 +1,80 @@
+import { type WorkspacePackage, collectProdWorkspaceClosure } from './connectClosure';
+
+const pkg = (
+    name: string,
+    packageJson: WorkspacePackage['packageJson'] = {},
+): [string, WorkspacePackage] => [name, { name, dir: `/repo/${name}`, packageJson }];
+
+describe('collectProdWorkspaceClosure', () => {
+    it('follows dependencies and optionalDependencies transitively', () => {
+        const packages = new Map<string, WorkspacePackage>([
+            pkg('@trezor/connect', {
+                dependencies: { '@trezor/transport-web': 'workspace:*' },
+                optionalDependencies: { '@trezor/optional': 'workspace:*' },
+            }),
+            pkg('@trezor/transport-web', {
+                dependencies: { '@trezor/transport-common': 'workspace:*' },
+            }),
+            pkg('@trezor/transport-common', {}),
+            pkg('@trezor/optional', {}),
+        ]);
+
+        const closure = collectProdWorkspaceClosure(['@trezor/connect'], packages);
+
+        expect([...closure].sort()).toEqual([
+            '@trezor/connect',
+            '@trezor/optional',
+            '@trezor/transport-common',
+            '@trezor/transport-web',
+        ]);
+    });
+
+    it('ignores devDependencies and non-workspace specifiers', () => {
+        const packages = new Map<string, WorkspacePackage>([
+            pkg('@trezor/connect', {
+                dependencies: { 'external-lib': '^1.0.0' },
+                devDependencies: { '@trezor/dev-only': 'workspace:*' },
+            }),
+            pkg('@trezor/dev-only', {}),
+        ]);
+
+        const closure = collectProdWorkspaceClosure(['@trezor/connect'], packages);
+
+        expect([...closure]).toEqual(['@trezor/connect']);
+    });
+
+    it('unions the closures of multiple roots and traverses through version-less packages', () => {
+        const packages = new Map<string, WorkspacePackage>([
+            pkg('@trezor/connect', { dependencies: { '@trezor/utils': 'workspace:*' } }),
+            pkg('@trezor/connect-web', {
+                dependencies: { '@trezor/connect-common': 'workspace:*' },
+            }),
+            // No version field — must still be traversed so its dependency is reached.
+            pkg('@trezor/connect-common', { dependencies: { '@trezor/utils': 'workspace:*' } }),
+            pkg('@trezor/utils', { version: '10.0.0-beta.1' }),
+        ]);
+
+        const closure = collectProdWorkspaceClosure(
+            ['@trezor/connect', '@trezor/connect-web'],
+            packages,
+        );
+
+        expect([...closure].sort()).toEqual([
+            '@trezor/connect',
+            '@trezor/connect-common',
+            '@trezor/connect-web',
+            '@trezor/utils',
+        ]);
+    });
+
+    it('skips roots that are not workspace packages', () => {
+        const packages = new Map<string, WorkspacePackage>([pkg('@trezor/connect', {})]);
+
+        const closure = collectProdWorkspaceClosure(
+            ['@trezor/connect', '@trezor/does-not-exist'],
+            packages,
+        );
+
+        expect([...closure]).toEqual(['@trezor/connect']);
+    });
+});

--- a/packages/requirements/src/requirements/connectClosure.ts
+++ b/packages/requirements/src/requirements/connectClosure.ts
@@ -1,0 +1,89 @@
+import { listAllWorkspaces, readPackageJson } from '../workspaces';
+
+export type PackageJson = {
+    readonly name?: string;
+    readonly version?: string;
+    readonly private?: boolean;
+    readonly dependencies?: Record<string, string>;
+    readonly optionalDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
+    readonly devDependencies?: Record<string, string>;
+    // package.json carries arbitrary metadata fields (repository, bugs, author, …).
+    readonly [field: string]: unknown;
+};
+
+export type WorkspacePackage = {
+    readonly name: string;
+    readonly dir: string;
+    readonly packageJson: PackageJson;
+};
+
+/**
+ * Read every workspace's package.json into a name-keyed map. Packages without a
+ * `name` are skipped; version-less packages are kept so a closure traversal can
+ * still walk through them.
+ */
+export const collectWorkspacePackages = (repoRoot: string): Map<string, WorkspacePackage> => {
+    const packages = new Map<string, WorkspacePackage>();
+
+    for (const workspace of listAllWorkspaces(repoRoot)) {
+        const packageJson = readPackageJson<PackageJson>(workspace.dir);
+        if (!packageJson.name) continue;
+
+        packages.set(packageJson.name, {
+            name: packageJson.name,
+            dir: workspace.dir,
+            packageJson,
+        });
+    }
+
+    return packages;
+};
+
+/**
+ * Compute the production closure of the given root packages: every internal
+ * workspace package reachable through `dependencies` and `optionalDependencies`
+ * (i.e. what actually ships when the roots are published). `devDependencies` and
+ * `peerDependencies` are intentionally not traversed.
+ */
+export const collectProdWorkspaceClosure = (
+    roots: ReadonlyArray<string>,
+    packages: ReadonlyMap<string, WorkspacePackage>,
+): ReadonlySet<string> => {
+    const getProdWorkspaceDeps = (
+        deps: Record<string, string> | undefined,
+    ): ReadonlyArray<string> =>
+        Object.entries(deps ?? {})
+            .filter(([name, version]) => version.startsWith('workspace:') && packages.has(name))
+            .map(([name]) => name);
+
+    const closure = new Set<string>();
+    const queue: string[] = roots.filter(root => packages.has(root));
+
+    for (const root of queue) {
+        closure.add(root);
+    }
+
+    while (queue.length > 0) {
+        const name = queue.shift();
+        if (name === undefined) continue;
+
+        const pkg = packages.get(name);
+        if (pkg === undefined) continue;
+
+        const nextDeps = [
+            ...getProdWorkspaceDeps(pkg.packageJson.dependencies),
+            ...getProdWorkspaceDeps(pkg.packageJson.optionalDependencies),
+        ];
+
+        for (const dep of nextDeps) {
+            if (closure.has(dep)) continue;
+
+            closure.add(dep);
+            queue.push(dep);
+        }
+    }
+
+    return closure;
+};

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import * as semver from 'semver';
 
+import { pickCanonicalVersion } from '../../versions';
 import { listAllWorkspaces, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
@@ -123,34 +123,6 @@ const formatDriftError = (depName: string, occurrences: VersionOccurrence[]): st
 };
 
 /**
- * Strip common version range prefixes (^, ~, >=, <=, >, <, =) so that the
- * bare version string can be compared numerically.
- */
-const stripRangePrefix = (specifier: string): string => specifier.replace(/^[~^]|^[><=]+\s*/g, '');
-
-/**
- * Pick the canonical version for a drifted dependency.
- * Strategy: most frequent version wins; ties broken by the numerically higher
- * version specifier (e.g. "^10.2.0" wins over "^9.5.0").
- */
-const pickCanonicalVersion = (occurrences: VersionOccurrence[]): string => {
-    const frequencyMap = new Map<string, number>();
-
-    for (const o of occurrences) {
-        frequencyMap.set(o.version, (frequencyMap.get(o.version) ?? 0) + 1);
-    }
-
-    const sorted = [...frequencyMap.entries()].sort((a, b) => {
-        if (b[1] !== a[1]) return b[1] - a[1]; // higher frequency first
-
-        // later versions first
-        return semver.rcompare(stripRangePrefix(a[0]), stripRangePrefix(b[0]), { loose: true });
-    });
-
-    return sorted[0]?.[0] ?? '';
-};
-
-/**
  * Verifies that every external (non-workspace) dependency uses the same version specifier
  * across all workspaces in the monorepo.
  */
@@ -189,7 +161,10 @@ export const requireUnifiedDependencyVersions: Requirement<'repo'> = {
         const canonicalVersions = new Map<string, string>();
 
         for (const [depName, occurrences] of drifts) {
-            canonicalVersions.set(depName, pickCanonicalVersion(occurrences));
+            canonicalVersions.set(
+                depName,
+                pickCanonicalVersion(occurrences.map(occurrence => occurrence.version)),
+            );
         }
 
         // Apply fixes to workspace package.json files

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -1,22 +1,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { listAllWorkspaces, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
-
-type PackageJson = {
-    readonly name?: string;
-    readonly dependencies?: Record<string, string>;
-    readonly optionalDependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-    readonly peerDependencies?: Record<string, string>;
-    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
-};
-
-type WorkspacePackage = {
-    readonly name: string;
-    readonly packageJson: PackageJson;
-};
+import {
+    type PackageJson,
+    type WorkspacePackage,
+    collectProdWorkspaceClosure,
+    collectWorkspacePackages,
+} from '../connectClosure';
 
 type Snapshot = {
     readonly prod: ReadonlyArray<string>;
@@ -40,32 +31,6 @@ const SNAPSHOT_DIR = join(
 
 const readJson = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, 'utf8')) as T;
 
-const collectWorkspacePackages = (repoRoot: string) => {
-    const pkgMap = new Map<string, WorkspacePackage>();
-
-    for (const workspace of listAllWorkspaces(repoRoot)) {
-        const packageJson = readPackageJson<PackageJson>(workspace.dir);
-        if (!packageJson.name) continue;
-
-        pkgMap.set(packageJson.name, {
-            name: packageJson.name,
-            packageJson,
-        });
-    }
-
-    return pkgMap;
-};
-
-const getWorkspaceDeps = (
-    deps: Record<string, string> | undefined,
-    workspacePackages: Map<string, WorkspacePackage>,
-) =>
-    Object.entries(deps ?? {})
-        .filter(
-            ([name, version]) => version.startsWith('workspace:') && workspacePackages.has(name),
-        )
-        .map(([name]) => name);
-
 const collectDependencyNames = (
     collector: Set<string>,
     deps: Record<string, string> | undefined,
@@ -88,38 +53,18 @@ const createSnapshot = (
     target: string,
     workspacePackages: Map<string, WorkspacePackage>,
 ): Snapshot => {
-    const prodClosure = new Set<string>([target]);
-    const prodQueue = [target];
-
-    while (prodQueue.length > 0) {
-        const packageName = prodQueue.shift();
-        if (!packageName) continue;
-
-        const pkg = workspacePackages.get(packageName);
-        if (!pkg) continue;
-
-        const nextWorkspaceDeps = [
-            ...getWorkspaceDeps(pkg.packageJson.dependencies, workspacePackages),
-            ...getWorkspaceDeps(pkg.packageJson.optionalDependencies, workspacePackages),
-        ];
-
-        for (const depName of nextWorkspaceDeps) {
-            if (prodClosure.has(depName)) continue;
-
-            prodClosure.add(depName);
-            prodQueue.push(depName);
-        }
-    }
-
+    const prodClosure = collectProdWorkspaceClosure([target], workspacePackages);
     const prodDependencies = new Set<string>(prodClosure);
 
     for (const packageName of prodClosure) {
         const pkg = workspacePackages.get(packageName);
         if (!pkg) continue;
 
-        collectDependencyNames(prodDependencies, pkg.packageJson.dependencies);
-        collectDependencyNames(prodDependencies, pkg.packageJson.optionalDependencies);
-        collectDependencyNames(prodDependencies, getRequiredPeerDependencies(pkg.packageJson));
+        const { packageJson } = pkg;
+
+        collectDependencyNames(prodDependencies, packageJson.dependencies);
+        collectDependencyNames(prodDependencies, packageJson.optionalDependencies);
+        collectDependencyNames(prodDependencies, getRequiredPeerDependencies(packageJson));
     }
 
     return {

--- a/packages/requirements/src/versions.test.ts
+++ b/packages/requirements/src/versions.test.ts
@@ -1,0 +1,53 @@
+import { mostCommon, pickCanonicalVersion, stripRangePrefix } from './versions';
+
+describe('stripRangePrefix', () => {
+    it.each([
+        ['^4.17.21', '4.17.21'],
+        ['~1.2.3', '1.2.3'],
+        ['>=2.0.0', '2.0.0'],
+        ['10.0.0-beta.1', '10.0.0-beta.1'],
+        ['1.0.0', '1.0.0'],
+    ])('strips %s -> %s', (input, expected) => {
+        expect(stripRangePrefix(input)).toBe(expected);
+    });
+});
+
+describe('pickCanonicalVersion', () => {
+    it('returns the most frequent version', () => {
+        expect(pickCanonicalVersion(['^4.17.21', '^4.17.21', '^4.17.15'])).toBe('^4.17.21');
+    });
+
+    it('breaks frequency ties by the numerically higher version', () => {
+        expect(pickCanonicalVersion(['^9.5.0', '^10.2.0'])).toBe('^10.2.0');
+    });
+
+    it('compares bare and prefixed specifiers consistently', () => {
+        expect(pickCanonicalVersion(['1.0.0-alpha.1', '10.0.0-beta.1'])).toBe('10.0.0-beta.1');
+    });
+
+    it('returns an empty string for empty input', () => {
+        expect(pickCanonicalVersion([])).toBe('');
+    });
+});
+
+describe('mostCommon', () => {
+    it('returns the most frequent value', () => {
+        expect(mostCommon(['a', 'a', 'b'])).toBe('a');
+    });
+
+    it('deep-compares object values', () => {
+        const repo = { type: 'git', url: 'git://example' };
+        expect(mostCommon([repo, { type: 'git', url: 'git://example' }, { url: 'other' }])).toEqual(
+            repo,
+        );
+    });
+
+    it('breaks ties deterministically regardless of input order', () => {
+        expect(mostCommon(['b', 'a'])).toBe('a');
+        expect(mostCommon(['a', 'b'])).toBe('a');
+    });
+
+    it('returns undefined for empty input', () => {
+        expect(mostCommon([])).toBeUndefined();
+    });
+});

--- a/packages/requirements/src/versions.ts
+++ b/packages/requirements/src/versions.ts
@@ -1,0 +1,60 @@
+import * as semver from 'semver';
+
+/**
+ * Strip common version range prefixes (^, ~, >=, <=, >, <, =) so that the bare
+ * version string can be compared numerically. Exact versions pass through
+ * unchanged.
+ */
+export const stripRangePrefix = (specifier: string): string =>
+    specifier.replace(/^[~^]|^[><=]+\s*/g, '');
+
+/**
+ * Pick the canonical version among the given version specifiers.
+ * Strategy: the most frequent version wins; ties are broken by the numerically
+ * higher (later) version (e.g. "^10.2.0" wins over "^9.5.0").
+ */
+export const pickCanonicalVersion = (versions: ReadonlyArray<string>): string => {
+    const frequency = new Map<string, number>();
+
+    for (const version of versions) {
+        frequency.set(version, (frequency.get(version) ?? 0) + 1);
+    }
+
+    const sorted = [...frequency.entries()].sort((a, b) => {
+        if (b[1] !== a[1]) return b[1] - a[1]; // higher frequency first
+
+        // later version first
+        return semver.rcompare(stripRangePrefix(a[0]), stripRangePrefix(b[0]), { loose: true });
+    });
+
+    return sorted[0]?.[0] ?? '';
+};
+
+/**
+ * Pick the most common value among the given values (deep-compared via their JSON
+ * representation). Ties are broken deterministically by that representation, so
+ * the result is stable regardless of input order. Returns `undefined` for empty
+ * input.
+ */
+export const mostCommon = (values: ReadonlyArray<unknown>): unknown => {
+    const counts = new Map<string, { readonly value: unknown; count: number }>();
+
+    for (const value of values) {
+        const key = JSON.stringify(value) ?? 'undefined';
+        const entry = counts.get(key);
+
+        if (entry) {
+            entry.count += 1;
+        } else {
+            counts.set(key, { value, count: 1 });
+        }
+    }
+
+    const sorted = [...counts.entries()].sort((a, b) => {
+        if (b[1].count !== a[1].count) return b[1].count - a[1].count; // higher frequency first
+
+        return a[0].localeCompare(b[0]); // deterministic tie-break
+    });
+
+    return sorted[0]?.[1].value;
+};

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -43,5 +43,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -69,5 +69,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -32,5 +32,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }


### PR DESCRIPTION
## Description

Adds a repo-scoped requirement `connect-closure-fields` to `@trezor/requirements` that verifies every **published package in the production closure of the Trezor Connect family** shares the same value for a set of release-critical `package.json` fields — so the whole family is published in lockstep with no stale or missing metadata.

The closure roots are `@trezor/connect`, `@trezor/connect-web`, `@trezor/connect-mobile` and `@trezor/connect-webextension`, traversed through `dependencies` + `optionalDependencies`. `@trezor/connect` (core) is included on purpose — the public entry points are thin shims and do not reach deeper packages such as `@trezor/transport-*`, which nevertheless ship with every Connect release. Only public (non-`private`) packages are checked.

For each configured field the closure's canonical value is derived from the packages themselves (most common; `version` breaks ties by higher semver). A package that diverges from — or is missing — the field is drift; `verify()` reports it and `fix()` writes the canonical value.

### Checked fields

`UNIFIED_FIELDS` is a single, easily extended list. A field belongs there only if it (1) is release/publish metadata, (2) has a single canonical value the whole family should share, and (3) is safe to rewrite:

| field | why | incident / notes |
|---|---|---|
| `version` | release lockstep | #30575 |
| `repository` | required for NPM provenance on every published package | #30591 |
| `bugs` | every published package should point at the same issue tracker | filled on 10 packages that lacked it |
| `author` | uniform across the Trezor-published family | filled on 16 packages that lacked it |

### Deliberately excluded

- **`license`** — not uniform for a real reason: `@trezor/connect` and several others are under the repository's **TREZOR REFERENCE SOURCE LICENSE** (via `"SEE LICENSE IN LICENSE.md"`), while the utility packages are `"MIT"`. These are two different licenses, so unifying to the most common value (MIT) would **mis-license** the restricted packages — that needs human review, not an auto-fixer.
- **`type`, `sideEffects`** — build/bundler semantics, not release metadata.
- **`homepage`, `main`, `exports`, `publishConfig`, `browser`, `keywords`, …** — inherently per-package.
- **`dependencies` / `devDependencies`** versions are already covered by `requireUnifiedDependencyVersions`.

### Also: `@trezor/connect` in the public-dependency snapshot

The pre-existing `connect-public-dependencies` requirement snapshotted only the three public entry points. For the Connect release, `@trezor/connect` (the core, also published) is now counted as a root too, so its public dependency surface is snapshotted (`connect.json`) and reviewed on change like the others.

### DRY

The new requirement reuses the shared `connectClosure` (closure traversal) and `versions` (canonical-value pickers) helpers extracted from the existing requirements in the first commit — no closure/version tooling is duplicated, and `pickCanonicalVersion` is the very one already used by `requireUnifiedDependencyVersions`. Value comparison and grouping reuse `deepEqual` / `arrayToDictionary` from `@trezor/utils`. Everything runs by default in `yarn requirements:verify`, so this class of drift is caught in CI instead of by ad-hoc follow-up fixes.

## Notes for QA

Dev-tooling plus package.json metadata. The only non-manifest change is the requirement code; the 16 touched `package.json` files just gain the canonical `bugs` / `author` values (no version/dependency changes). Validated locally: `type-check`, `lint:js`, and the full `@trezor/requirements` suite (160 tests) are green; the requirement reports no drift against the repo.

## Related Issues

Generalises the follow-up hardening for #30575 and #30591.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is almost entirely package.json dependency/version bumps across network and core packages, plus internal requirements tooling. The highest runtime risk is concentrated in network-specific flows (Cardano, Solana), transport/bridge lifecycle, blockchain-link discovery/backends, and TrezorConnect message handling. I recommend running the targeted high-priority tests above; they exercise each changed runtime package directly while avoiding broad, low-yield coverage. The requirements files and several utility/network package.json files have no meaningful E2E coverage and should be validated by their own unit/dependency checks instead.

<details><summary><b>Changed files (27)</b></summary>

- `networks/cardano/network-cardano/package.json`
- `networks/ripple/network-ripple/package.json`
- `networks/solana/network-solana/package.json`
- `networks/stellar/network-stellar/package.json`
- `networks/tron/network-tron/package.json`
- `packages/blockchain-link-types/package.json`
- `packages/blockchain-link-utils/package.json`
- `packages/connect-mobile/package.json`
- `packages/device-utils/package.json`
- `packages/env-utils/package.json`
- `packages/protobuf/package.json`
- `packages/protocol/package.json`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts`
- `packages/requirements/src/requirements/connectClosure.test.ts`
- `packages/requirements/src/requirements/connectClosure.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect.json`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`
- `packages/requirements/src/versions.test.ts`
- `packages/requirements/src/versions.ts`
- `packages/schema-utils/package.json`
- `packages/transport-common/package.json`
- `packages/transport-web/package.json`
- `packages/type-utils/package.json`

</details>

**Recommended tests (16)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test validates the desktop app's bridge lifecycle (spawn, keep-alive after UI close, stop on daemon exit). Changes to transport-common and transport-web packages directly affect the bridge transport layer that the app uses to spawn and manage the node-bridge process.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test covers bridge spawning on app startup, bridge version reporting, and device reconnection after external bridge restart. Transport package dependency changes could break bridge discovery, version negotiation, or session acquisition.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test exercises Bridge session stealing, reclaiming, and session state across tabs. Transport-common/web changes affect how Bridge sessions are enumerated, acquired, and released, which is the core behavior under test.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. Changes to blockchain-link-types or blockchain-link-utils can alter backend configuration parsing, account discovery, or blockbook response handling.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates eight coin networks and verifies multi-coin discovery completes, including recovery after page reload. Blockchain-link types/utils are foundational to the discovery logic that fetches accounts and balances across networks.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test enables ETH/BTC with custom blockbook backends and asserts correct vs. wrong backend behavior. It directly exercises the blockchain-link backend selection and connection path affected by blockchain-link package changes.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This test performs a full Cardano staking transaction including custom Blockfrost backend, reward/deposit amounts, and device signing. Changes to the network-cardano package dependency could break Cardano backend communication or transaction serialization.
- `suite/e2e/tests/wallet/cardano.test.ts` — This test covers core Cardano wallet flows: account details, public key reveal, send form, and receive address confirmation. It directly depends on the Cardano network package for address derivation, xpub handling, and device messages.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises first-time Solana staking including epoch advancement, stake account creation, and device signing. Changes to network-solana package dependencies could affect Solana RPC interactions, stake account logic, or transaction formatting.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test covers the full Solana send flow with max amount calculation, network reserve handling, and device confirmation. It is a direct regression target for changes in the Solana network package that could impact balance fetching or transaction construction.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises TrezorConnect getAddress and cardanoGetAddress via the suite-web popup, including permissions, device confirmation, and popup lifecycle. Changes to device-utils, protobuf, or protocol packages can affect message serialization, device prompts, or address derivation in Connect.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test builds on Cardano staking by claiming rewards and verifying balance updates. A regression in the Cardano network package would likely also surface here after the stake test, providing additional coverage of reward/withdrawal transactions.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test covers Cardano unstaking and deposit return. It shares the same Cardano network and staking infrastructure as the stake test, so it helps confirm the dependency change does not break deregistration transactions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test exercises Solana unstaking and claiming through epoch advancement. It uses the same Solana network stack as the initial-stake and send tests, offering a broader check of transaction state transitions.
- `suite/e2e/tests/trading/sell-solana.test.ts` — This test performs a Solana sell trade including balance display, form validation, and transaction broadcast. Trading flows rely on the Solana network package for balance/account state and would regress if the dependency change affects token handling.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — This test exercises single and bundle Bitcoin address exports through TrezorConnect, including device verification. It relies on protobuf/protocol/device-utils for message encoding and address derivation, providing focused Connect coverage alongside connectPopupWeb.

</details>

⚠️ **Changes with no test coverage (18)**
- `networks/ripple/network-ripple/package.json`
- `networks/stellar/network-stellar/package.json`
- `networks/tron/network-tron/package.json`
- `packages/connect-mobile/package.json`
- `packages/env-utils/package.json`
- `packages/schema-utils/package.json`
- `packages/type-utils/package.json`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts`
- `packages/requirements/src/requirements/connectClosure.test.ts`
- `packages/requirements/src/requirements/connectClosure.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `packages/requirements/src/requirements/public-package-dependencies/__snapshots__/connect.json`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.test.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`
- `packages/requirements/src/versions.test.ts`
- `packages/requirements/src/versions.ts`

_Updated: 2026-07-31T07:29:08.713Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-version-check/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-version-check/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-closure-version-check&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-closure-version-check&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T12:35:17.921Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T12:35:30.191Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->