### PR TITLE
feat(suite-desktop): don't allow to skip wrapping step if user has no WETH

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -39,6 +39,7 @@ export const YieldDepositForm = () => {
         allowanceStatus,
         approvalAction,
         canRevokeAllowance,
+        hasWrappedTokenBalance,
         isAmountEmpty,
         isAmountTooHigh,
         isAmountInvalidDecimals,
@@ -256,7 +257,9 @@ export const YieldDepositForm = () => {
                                         pendingTransaction={wrapPendingTransaction}
                                         onMaxClick={handleMaxClick}
                                         onSubmit={handleOnWrap}
-                                        onSkip={handleOnSkipWrap}
+                                        onSkip={
+                                            hasWrappedTokenBalance ? handleOnSkipWrap : undefined
+                                        }
                                         onPendingTxClick={openPendingTransaction}
                                     />
                                 ),

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -88,6 +88,7 @@ export type UseYieldFlowResult = {
     allowanceStatus: YieldAllowanceStatus;
     approvalAction: YieldApprovalAction;
     canRevokeAllowance: boolean;
+    hasWrappedTokenBalance: boolean;
     isAmountEmpty: boolean;
     isAmountTooHigh: boolean;
     isAmountInvalidDecimals: boolean;
@@ -159,9 +160,11 @@ export const useYieldFlow = ({
     const sessionRef = useCurrentRef(session);
 
     const isWrappedNativeVault = isWrappedNativeToken(account.symbol, vault.token.address);
-    const hasWrappedTokenBalanceRef = useCurrentRef(
-        isAmountGreaterThan({ amount: token?.balance ?? '0', threshold: '0' }),
-    );
+    const hasWrappedTokenBalance = isAmountGreaterThan({
+        amount: token?.balance ?? '0',
+        threshold: '0',
+    });
+    const hasWrappedTokenBalanceRef = useCurrentRef(hasWrappedTokenBalance);
 
     const isSharesInput = flowType === 'redeem';
     const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
@@ -802,6 +805,7 @@ export const useYieldFlow = ({
         allowanceStatus: session.approval.allowanceStatus,
         approvalAction,
         canRevokeAllowance,
+        hasWrappedTokenBalance,
         isAmountEmpty,
         isAmountTooHigh,
         isAmountInvalidDecimals,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If user has weth balance then he may skip the wrapping step. However because of the minimum ETH to remain (0.005) it might be tricky in some of the cases

## Notes for QA

It's not possible to navigate to the weth flow when user has no asset except of manualy changing deviation path in the URL to open different accounts

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30542

## Screenshots:

| Has WETH | Has WETH + ETH below (0.005) | Has no WETH/ETH |
|--------|--------|--------|
| <img width="1062" height="732" alt="Screenshot 2026-07-30 at 12 45 20" src="https://github.com/user-attachments/assets/3b86b629-357f-4e58-8cb3-eedd9dfed046" /> | <img width="1061" height="731" alt="Screenshot 2026-07-30 at 12 45 49" src="https://github.com/user-attachments/assets/905d6801-9c67-485a-b159-3fdc10aace67" /> | <img width="1029" height="716" alt="Screenshot 2026-07-30 at 12 45 56" src="https://github.com/user-attachments/assets/bcdb23c5-0270-4bb9-9222-02a19120ec25" /> | 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the earn/yield deposit form and its yield-flow hook, so the main risk lies in staking deposit flows across ETH, SOL, and ADA. Six high-priority tests directly exercise deposit form submission and validation. Four medium-priority tests cover related unstake/claim flows that share the same hook lifecycle. The static coverage maps to 133 tests per file, but those are broad global imports; most should be omitted to keep the run targeted and fast.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test initiates the Cardano staking flow through the staking nutshell modal, reviews deposit/fee amounts, and confirms on the device. It directly exercises the yield deposit form and the underlying yield flow hook on the ADA network.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The test opens the ETH staking form, enters a staking amount, reviews fees, and confirms the stake on the device. The changed deposit form and yield flow hook are central to this code path.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test re-enters the ETH staking form from an already-staked account and submits another stake. It relies on the same deposit form and yield flow logic as an additional deposit.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — The test opens the SOL staking form, fills in a stake amount, reviews fees, and confirms on the device. SOL staking uses the same yield deposit form and flow hook infrastructure.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test stakes additional SOL from an existing staked account, which reuses the yield deposit form and the yield flow hook for submitting another deposit.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly validates the staking form inputs, percentage buttons, max amount handling, and fiat/crypto switching for ETH. It is the most focused test for the YieldDepositForm component behavior.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Claiming rewards is part of the same yield flow lifecycle managed by useYieldFlow. A regression in the hook could affect the claim modal transition or reward handling after staking.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — The unstake flow follows the deposit flow in the yield lifecycle and is likely orchestrated by the same useYieldFlow hook, so changes could affect the unstake modal or state transitions.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test exercises the ETH unstake and claim flow, which reuses the yield flow hook for state management after staking. It is a good cross-network check for hook regressions.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers the SOL unstake and claim flow. It shares the yield flow hook with the deposit path and can surface hook-related regressions on Solana.

</details>

_Updated: 2026-07-30T10:53:57.677Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/skip-weth-nonzero/web/](https://dev.suite.sldev.cz/suite-web/feat/skip-weth-nonzero/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/skip-weth-nonzero&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/skip-weth-nonzero&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:56:56.710Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T10:56:16.420Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->