### PR TITLE
feat(suite-desktop): use message system gating for wrap/unwrap

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
@@ -2,11 +2,11 @@ import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type Variant } from '@suite-common/suite-types';
-import type { YieldFlowType } from '@suite-common/wallet-core';
+import type { WrappedNativeFlowType, YieldFlowType } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 type YieldDisabledBannerProps = {
-    type: YieldFlowType;
+    type: YieldFlowType | WrappedNativeFlowType;
     content?: ReactNode;
     variant?: Variant;
 };
@@ -16,6 +16,8 @@ const yieldDisabledMessageMap = {
     withdraw: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     redeem: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     claim: 'TR_EARN_YIELD_CLAIM_DISABLED',
+    wrap: 'TR_EARN_YIELD_WRAP_DISABLED',
+    unwrap: 'TR_EARN_YIELD_UNWRAP_DISABLED',
 } as const;
 
 export const YieldDisabledBanner = ({ type, content, variant }: YieldDisabledBannerProps) => (

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -8,6 +8,7 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldDepositContext } from './useYieldDepositContext';
 import { YieldActionStep } from '../common/YieldActionStep';
@@ -15,6 +16,7 @@ import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldApproveModal } from '../common/YieldApproveModal';
 import { YieldApproveStep } from '../common/YieldApproveStep';
 import { YieldApprovedAmountCard } from '../common/YieldApprovedAmountCard';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteDeposit } from '../common/YieldFlowCompleteDeposit';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldWrapStep } from '../common/YieldWrapStep';
@@ -59,6 +61,8 @@ export const YieldDepositForm = () => {
         retryInitAllowance,
         flow,
     } = useYieldDepositContext();
+
+    const { isWrapDisabled, wrapMessageContent, wrapVariant } = useMessageSystemWrappedNative();
 
     const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
@@ -236,30 +240,37 @@ export const YieldDepositForm = () => {
                                     />
                                 ),
                                 onEdit: returnToWrapStep,
-                                content: () => (
-                                    <YieldWrapStep
-                                        token={token}
-                                        nativeSymbol={nativeSymbol}
-                                        availableAmount={maxAmount}
-                                        receivingAmount={liveAmount || '0'}
-                                        isSubmitting={isSubmittingAction}
-                                        isSubmitDisabled={
-                                            isAmountEmpty ||
-                                            isAmountTooHigh ||
-                                            isAmountInvalidDecimals
-                                        }
-                                        warning={
-                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                                <YieldActionStepWarning isInsufficientFunds />
-                                            ) : undefined
-                                        }
-                                        pendingTransaction={wrapPendingTransaction}
-                                        onMaxClick={handleMaxClick}
-                                        onSubmit={handleOnWrap}
-                                        onSkip={handleOnSkipWrap}
-                                        onPendingTxClick={openPendingTransaction}
-                                    />
-                                ),
+                                content: () =>
+                                    isWrapDisabled ? (
+                                        <YieldDisabledBanner
+                                            type="wrap"
+                                            content={wrapMessageContent}
+                                            variant={wrapVariant}
+                                        />
+                                    ) : (
+                                        <YieldWrapStep
+                                            token={token}
+                                            nativeSymbol={nativeSymbol}
+                                            availableAmount={maxAmount}
+                                            receivingAmount={liveAmount || '0'}
+                                            isSubmitting={isSubmittingAction}
+                                            isSubmitDisabled={
+                                                isAmountEmpty ||
+                                                isAmountTooHigh ||
+                                                isAmountInvalidDecimals
+                                            }
+                                            warning={
+                                                !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                                    <YieldActionStepWarning isInsufficientFunds />
+                                                ) : undefined
+                                            }
+                                            pendingTransaction={wrapPendingTransaction}
+                                            onMaxClick={handleMaxClick}
+                                            onSubmit={handleOnWrap}
+                                            onSkip={handleOnSkipWrap}
+                                            onPendingTxClick={openPendingTransaction}
+                                        />
+                                    ),
                             },
                             approve: {
                                 title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -14,9 +14,11 @@ import { BigNumber } from '@trezor/utils';
 
 import { submitUnwrapNativeTokenThunk } from 'src/actions/wallet/unwrapNativeTokenThunks';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { WrappedNativeFlowComplete } from '../common/WrappedNativeFlowComplete';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
@@ -44,6 +46,8 @@ export const UnwrapNativeToken = ({
 }: UnwrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
+    const { isUnwrapDisabled, unwrapMessageContent, unwrapVariant } =
+        useMessageSystemWrappedNative();
     const [broadcast, setBroadcast] = useState<BroadcastUnwrap | null>(null);
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',
@@ -121,6 +125,16 @@ export const UnwrapNativeToken = ({
     };
 
     const renderContent = () => {
+        if (isUnwrapDisabled) {
+            return (
+                <YieldDisabledBanner
+                    type="unwrap"
+                    content={unwrapMessageContent}
+                    variant={unwrapVariant}
+                />
+            );
+        }
+
         if (broadcast && pendingTxStatus === 'confirmed') {
             return (
                 <WrappedNativeFlowComplete

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -10,10 +10,12 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldWithdrawContext } from './useYieldWithdrawContext';
 import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
@@ -49,6 +51,9 @@ export const YieldWithdrawForm = () => {
         openPendingTransaction,
         flow,
     } = useYieldWithdrawContext();
+
+    const { isUnwrapDisabled, unwrapMessageContent, unwrapVariant } =
+        useMessageSystemWrappedNative();
 
     const { actionPendingTransaction: withdrawPendingTransaction } = splitYieldPendingTransaction(
         pendingTransaction,
@@ -259,27 +264,36 @@ export const YieldWithdrawForm = () => {
                                     }}
                                 />
                             ),
-                            content: () => (
-                                <YieldUnwrapStep
-                                    tokenSymbol={token.symbol}
-                                    tokenDecimals={token.decimals}
-                                    tokenBalance={token.balance}
-                                    onMaxClick={() => setAmountInput(token.balance)}
-                                    isSubmitting={isSubmittingAction}
-                                    isSubmitDisabled={
-                                        isAmountEmpty || isAmountTooHigh || isAmountInvalidDecimals
-                                    }
-                                    warning={
-                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                            <YieldActionStepWarning isInsufficientFunds />
-                                        ) : undefined
-                                    }
-                                    pendingTransaction={unwrapPendingTransaction}
-                                    onSubmit={handleOnUnwrap}
-                                    onSkip={handleOnSkipUnwrap}
-                                    onPendingTxClick={openPendingTransaction}
-                                />
-                            ),
+                            content: () =>
+                                isUnwrapDisabled ? (
+                                    <YieldDisabledBanner
+                                        type="unwrap"
+                                        content={unwrapMessageContent}
+                                        variant={unwrapVariant}
+                                    />
+                                ) : (
+                                    <YieldUnwrapStep
+                                        tokenSymbol={token.symbol}
+                                        tokenDecimals={token.decimals}
+                                        tokenBalance={token.balance}
+                                        onMaxClick={() => setAmountInput(token.balance)}
+                                        isSubmitting={isSubmittingAction}
+                                        isSubmitDisabled={
+                                            isAmountEmpty ||
+                                            isAmountTooHigh ||
+                                            isAmountInvalidDecimals
+                                        }
+                                        warning={
+                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                                <YieldActionStepWarning isInsufficientFunds />
+                                            ) : undefined
+                                        }
+                                        pendingTransaction={unwrapPendingTransaction}
+                                        onSubmit={handleOnUnwrap}
+                                        onSkip={handleOnSkipUnwrap}
+                                        onPendingTxClick={openPendingTransaction}
+                                    />
+                                ),
                         },
                         complete: {
                             isListItem: false,

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -18,9 +18,11 @@ import { BigNumber } from '@trezor/utils';
 
 import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenThunks';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { WrappedNativeFlowComplete } from '../common/WrappedNativeFlowComplete';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldWrapStep } from '../common/YieldWrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
@@ -39,6 +41,7 @@ type BroadcastWrap = {
 export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
+    const { isWrapDisabled, wrapMessageContent, wrapVariant } = useMessageSystemWrappedNative();
     const [broadcast, setBroadcast] = useState<BroadcastWrap | null>(null);
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',
@@ -110,6 +113,16 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     };
 
     const renderContent = () => {
+        if (isWrapDisabled) {
+            return (
+                <YieldDisabledBanner
+                    type="wrap"
+                    content={wrapMessageContent}
+                    variant={wrapVariant}
+                />
+            );
+        }
+
         if (broadcast && pendingTxStatus === 'confirmed') {
             return (
                 <WrappedNativeFlowComplete

--- a/packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts
@@ -1,0 +1,10 @@
+import { selectLanguage } from '@suite/settings';
+import { useMessageSystemWrappedNative as useMessageSystemWrappedNativeCore } from '@suite-common/message-system';
+
+import { useSelector } from './useSelector';
+
+export const useMessageSystemWrappedNative = () => {
+    const locale = useSelector(selectLanguage);
+
+    return useMessageSystemWrappedNativeCore({ locale });
+};

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -67,6 +67,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { setSendFormPrefill } from 'src/actions/suite/suiteActions';
 import { getEarnRouteParams } from 'src/components/earn/utils/getEarnRouteParams';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import type { TokensTableType } from './types';
@@ -131,6 +132,8 @@ const TokenRowBasicActions = ({
 
     const isDepositButtonDisabled = !availableVault?.status.enter;
     const isWithdrawButtonDisabled = !availableVault?.status.exit;
+
+    const { isUnwrapDisabled } = useMessageSystemWrappedNative();
 
     if (!unusedAddress || !device) return null;
 
@@ -431,7 +434,7 @@ const TokenRowBasicActions = ({
                                     },
                                 }),
                             ),
-                        isDisabled: token.balance === '0',
+                        isDisabled: token.balance === '0' || isUnwrapDisabled,
                         isHidden: !isWrappedNativeToken(account.symbol, token.contract),
                     },
                     {

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
@@ -25,6 +25,11 @@ jest.mock('@suite/debug', () => ({
     selectIsDebugModeActive: () => mockSelectIsDebugModeActive(),
 }));
 
+const mockUseMessageSystemWrappedNative = jest.fn();
+jest.mock('src/hooks/suite/useMessageSystemWrappedNative', () => ({
+    useMessageSystemWrappedNative: () => mockUseMessageSystemWrappedNative(),
+}));
+
 const mockGetNetworkType = jest.fn();
 const mockGetWrappedNativeAddress = jest.fn();
 const mockGetWrappedNativeSymbol = jest.fn();
@@ -59,6 +64,10 @@ describe('WrapNativeTokenButton', () => {
         mockGetNetworkType.mockReturnValue('ethereum');
         mockGetWrappedNativeAddress.mockReturnValue('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
         mockGetWrappedNativeSymbol.mockReturnValue('WETH');
+        mockUseMessageSystemWrappedNative.mockReturnValue({
+            isWrapDisabled: false,
+            wrapMessageContent: undefined,
+        });
     });
 
     it('renders nothing when debug mode is off', () => {
@@ -93,5 +102,22 @@ describe('WrapNativeTokenButton', () => {
             params: { symbol: 'eth', accountIndex: 0, accountType: 'normal' },
         });
         expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the button and does not navigate when wrap is gated off by the message system', () => {
+        mockUseMessageSystemWrappedNative.mockReturnValue({
+            isWrapDisabled: true,
+            wrapMessageContent: 'Wrapping is currently disabled.',
+        });
+        renderButton();
+
+        const button = screen.getByTestId(WRAP_BUTTON_TESTID);
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
+
+        fireEvent.click(button);
+
+        expect(mockGoto).not.toHaveBeenCalled();
+        expect(mockDispatch).not.toHaveBeenCalled();
     });
 });

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -8,9 +8,11 @@ import {
     getWrappedNativeAddress,
     getWrappedNativeSymbol,
 } from '@suite-common/wallet-config';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
+import { InfoIcon } from '@trezor/icons';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 import { type Account } from 'src/types/wallet';
 
 type WrapNativeTokenButtonProps = {
@@ -25,6 +27,7 @@ type WrapNativeTokenButtonProps = {
 export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
     const dispatch = useDispatch();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const { isWrapDisabled, wrapMessageContent } = useMessageSystemWrappedNative();
 
     const { symbol } = account;
     const wrappedAddress = getWrappedNativeAddress(symbol);
@@ -55,13 +58,17 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
     };
 
     return (
-        <Button
-            intent="accentViolet"
-            size="small"
-            onClick={onClick}
-            data-testid="@trading/menu/wrap-native-token"
-        >
-            <Translation id="TR_WRAP_NATIVE_TOKEN" />
-        </Button>
+        <Tooltip content={wrapMessageContent}>
+            <Button
+                intent="accentViolet"
+                size="small"
+                onClick={onClick}
+                isDisabled={isWrapDisabled}
+                iconLeft={isWrapDisabled ? InfoIcon : undefined}
+                data-testid="@trading/menu/wrap-native-token"
+            >
+                <Translation id="TR_WRAP_NATIVE_TOKEN" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -16,4 +16,5 @@ export * from './useExperiment';
 export * from './useMessageSystemEarnDashboard';
 export * from './useMessageSystemMessageForm';
 export * from './useMessageSystemStaking';
+export * from './useMessageSystemWrappedNative';
 export * from './useMessageSystemYield';

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -112,6 +112,9 @@ export const Feature = {
             redeem: 'earn.yield.redeem',
             claim: 'earn.yield.claim',
         } as const satisfies Record<YieldFlowType, string>,
+        // Global (non-vault-scoped) flags for the native-token wrap/unwrap feature (e.g. ETH ↔ WETH)
+        wrap: 'earn.wrap',
+        unwrap: 'earn.unwrap',
     },
     mevProtection: 'settings.mevProtection',
     suiteSync: 'settings.suiteSync',

--- a/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
+++ b/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
@@ -1,0 +1,103 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { useMessageSystemWrappedNative } from './useMessageSystemWrappedNative';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const stateWithDisabledFeatures = {
+    ...messageSystemInitialState,
+    config: {
+        version: 1,
+        timestamp: '2023-01-01',
+        sequence: 1,
+        actions: [
+            {
+                message: {
+                    id: 'wrapDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    variant: 'warning',
+                    category: ['feature'],
+                    content: { en: 'Wrapping disabled', cs: 'Wrapování vypnuté' },
+                    feature: [{ domain: 'earn.wrap', flag: false }],
+                },
+            },
+            {
+                message: {
+                    id: 'unwrapDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    variant: 'critical',
+                    category: ['feature'],
+                    content: { en: 'Unwrapping disabled' },
+                    feature: [{ domain: 'earn.unwrap', flag: false }],
+                },
+            },
+        ],
+        experiments: [],
+    },
+    validMessages: {
+        banner: [],
+        context: [],
+        modal: [],
+        feature: ['wrapDisabledMsg', 'unwrapDisabledMsg'],
+    },
+} as unknown as MessageSystemState;
+
+const createStore = (state: MessageSystemState = stateWithDisabledFeatures) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
+    });
+
+const renderHook = (locale = 'en') =>
+    renderHookWithStoreProvider(() => useMessageSystemWrappedNative({ locale }), {
+        store: createStore(),
+    });
+
+describe('useMessageSystemWrappedNative', () => {
+    it('returns disabled states, messages and variants when features are disabled', () => {
+        const { result } = renderHook();
+
+        expect(result.current).toMatchObject({
+            isWrapDisabled: true,
+            isUnwrapDisabled: true,
+            wrapMessageContent: 'Wrapping disabled',
+            unwrapMessageContent: 'Unwrapping disabled',
+            wrapVariant: 'warning',
+            unwrapVariant: 'critical',
+        });
+    });
+
+    it('returns localized message content', () => {
+        const { result } = renderHook('cs');
+
+        expect(result.current.wrapMessageContent).toBe('Wrapování vypnuté');
+    });
+
+    it('returns not disabled when no feature messages configured', () => {
+        const store = createStore(messageSystemInitialState);
+        const { result } = renderHookWithStoreProvider(
+            () => useMessageSystemWrappedNative({ locale: 'en' }),
+            { store },
+        );
+
+        expect(result.current).toMatchObject({
+            isWrapDisabled: false,
+            isUnwrapDisabled: false,
+            wrapMessageContent: undefined,
+            unwrapMessageContent: undefined,
+            wrapVariant: undefined,
+            unwrapVariant: undefined,
+        });
+    });
+});

--- a/suite-common/message-system/src/useMessageSystemWrappedNative.ts
+++ b/suite-common/message-system/src/useMessageSystemWrappedNative.ts
@@ -1,0 +1,51 @@
+import { useSelector } from 'react-redux';
+
+import {
+    selectFeatureMessage,
+    selectFeatureMessageContent,
+    selectIsFeatureDisabled,
+} from './messageSystemSelectors';
+import { Feature, type MessageSystemRootState } from './messageSystemTypes';
+
+interface UseMessageSystemWrappedNativeProps {
+    locale: string;
+}
+
+/**
+ * Reads the remote message-system gate for the native-token wrap/unwrap feature (e.g. ETH ↔ WETH).
+ *
+ * These are global flags evaluated with the plain (non-vault-scoped) selectors, so wrap/unwrap
+ * gating stays independent of the `earn.yield.*` vault flags.
+ */
+export const useMessageSystemWrappedNative = ({ locale }: UseMessageSystemWrappedNativeProps) => {
+    const isWrapDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, Feature.earn.wrap),
+    );
+    const isUnwrapDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, Feature.earn.unwrap),
+    );
+
+    const wrapMessageContent = useSelector((state: MessageSystemRootState) =>
+        selectFeatureMessageContent(state, Feature.earn.wrap, locale),
+    );
+    const unwrapMessageContent = useSelector((state: MessageSystemRootState) =>
+        selectFeatureMessageContent(state, Feature.earn.unwrap, locale),
+    );
+
+    const wrapVariant = useSelector(
+        (state: MessageSystemRootState) => selectFeatureMessage(state, Feature.earn.wrap)?.variant,
+    );
+    const unwrapVariant = useSelector(
+        (state: MessageSystemRootState) =>
+            selectFeatureMessage(state, Feature.earn.unwrap)?.variant,
+    );
+
+    return {
+        isWrapDisabled,
+        isUnwrapDisabled,
+        wrapMessageContent,
+        unwrapMessageContent,
+        wrapVariant,
+        unwrapVariant,
+    };
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10249,6 +10249,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
         defaultMessage: 'Withdrawal is currently disabled.',
     },
+    TR_EARN_YIELD_WRAP_DISABLED: {
+        id: 'TR_EARN_YIELD_WRAP_DISABLED',
+        defaultMessage: 'Wrapping is currently disabled.',
+    },
+    TR_EARN_YIELD_UNWRAP_DISABLED: {
+        id: 'TR_EARN_YIELD_UNWRAP_DISABLED',
+        defaultMessage: 'Unwrapping is currently disabled.',
+    },
     TR_EARN_YIELD_MAX_WITHDRAW_INFO: {
         id: 'TR_EARN_YIELD_MAX_WITHDRAW_INFO',
         defaultMessage:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in shared Earn/Yield UI (deposit, withdraw, wrap/unwrap, disabled banner) and token-row/tradebox actions for wrapped-native tokens. The highest regression risk is in staking deposit/withdraw flows and token-level swap navigation, so run the representative ADA/ETH/SOL staking tests plus the live token swap tests. No e2e tests directly exercise the message-system wrapped-native hook or the Wrap/unwrap native components themselves, so those areas rely on the unit tests already included in the PR.

<details><summary><b>Changed files (14)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.test.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — The change modifies YieldDepositForm and YieldDisabledBanner, which are the core UI components used when initiating ADA staking deposits. This test directly walks through the ADA staking deposit flow and will fail if the deposit form or its disabled state regress.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — The change modifies YieldWithdrawForm, which is used for ADA unstaking/claim flows. This test exercises the unstake-to-claim modal and device confirmation path, making it the most direct regression guard for the changed withdraw component.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH initial stake opens the earn/yield staking form and submits a deposit transaction. Since YieldDepositForm is part of the shared earn/yield deposit UI, this test is a direct end-to-end check that the changed deposit form still renders, validates amounts, and submits.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking uses the shared yield withdraw flow. This test verifies the unstake form, claim modal, and device prompts, so it directly covers the YieldWithdrawForm changes and any banner state shown when the action is unavailable.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL first-time staking uses the earn/yield deposit form to enter an amount and confirm. It is the best Solana regression guard for the changed YieldDepositForm and YieldDisabledBanner components in the staking context.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstaking/claiming exercises the YieldWithdrawForm path for Solana. It verifies the unstake form, claim card, claim modal, and device prompts, directly validating the changed withdraw UI.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — TokenRowActions was changed and this test initiates a swap directly from a Solana account's token actions. If the token row action menu or its swap entry point regressed, this live swap test would fail.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This test opens the swap flow from an SPL token (USDT) row action. Because TokenRowActions is modified, it is a direct end-to-end check that token-level swap navigation still works for Solana SPL tokens.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test navigates to buy/sell/swap forms from token-level pages, which rely on TokenRowActions and TradeBox entry points. It is a lighter coverage than the live swap tests but useful for catching broken navigation from token rows.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test focuses on the ETH staking form's input validation, percentage buttons, and fiat/crypto switching. It shares the earn/yield form infrastructure with the changed deposit/withdraw components and can catch generic form regressions.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.test.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-07-30T11:00:12.739Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/message-system-wrap-unwrap/web/](https://dev.suite.sldev.cz/suite-web/feat/message-system-wrap-unwrap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/message-system-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/message-system-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/message-system-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T11:02:18.021Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T11:02:12.926Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->