### PR TITLE
fix(suite-desktop): display weth on APY tooltip

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -4,8 +4,8 @@ import {
     type TokenDtoV2,
     sortRewardsByUnderlyingToken,
 } from '@suite-common/earn-stablecoin-api';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { getApyPercent } from '@suite-common/wallet-utils';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getApyPercent, isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { Column, Icon, Row, Text } from '@trezor/components';
 import { ChartLineIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
@@ -73,6 +73,11 @@ export const EarnYieldApyBreakdown = ({
                 const hasRatePercent = ratePercent !== null && ratePercent > 0;
                 const descriptionId = getYieldSourceDescriptionId(reward.yieldSource);
                 const rateTranslationId = getRateTranslationId(reward.yieldSource);
+                // A wrapped-native reward (e.g. WETH in an ETH vault) is presented as its native
+                // asset (#29881), matching how the vault itself is labelled across the earn UI.
+                const displaySymbol = isWrappedNativeToken(networkSymbol, reward.token.address)
+                    ? getNetworkDisplaySymbol(networkSymbol)
+                    : reward.token.symbol;
 
                 let rateNode;
                 if (!hasRatePercent) {
@@ -88,10 +93,11 @@ export const EarnYieldApyBreakdown = ({
                 return (
                     <Row key={index} gap={8} alignItems="center">
                         <TokenIcon
-                            placeholder={reward.token.symbol || reward.token.name || 'token'}
+                            placeholder={displaySymbol || reward.token.name || 'token'}
                             symbol={networkSymbol}
                             contractAddress={reward.token.address}
                             showNetworkIcon
+                            wrappedTokenIcon="network"
                             size={20}
                             isBordered={false}
                         />
@@ -100,7 +106,7 @@ export const EarnYieldApyBreakdown = ({
                                 data-testid="@earn/dashboard/apy-breakdown/symbol"
                                 typographyStyle="body-sm"
                             >
-                                {reward.token.symbol}
+                                {displaySymbol}
                             </Text>
                             {descriptionId && (
                                 <Text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Displays the original asset on a tooltip for weth

## Notes for QA

You should see a weth on a tooltip

## Related Issue

Resolve #30549 

## Screenshots:

<img width="1211" height="428" alt="Screenshot 2026-07-30 at 13 16 21" src="https://github.com/user-attachments/assets/b7db96d3-335b-4c08-b52a-1fbd419a7813" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** EarnYieldApyBreakdown.tsx is a UI component in the Earn/Staking dashboard. Its static mapping to most of the suite suggests it is treated as a broad dependency, so I recommend only a targeted cross-chain sample of staking dashboard tests (ETH, SOL, ADA). None of the candidate tests explicitly assert the APY breakdown, but these exercises load the relevant dashboard and verify card/amount/progress rendering where the component appears. No changed files are completely uncovered.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test navigates to the Cardano Staking/Earn dashboard, checks staking card states, reward amounts, and post-stake UI. EarnYieldApyBreakdown.tsx is part of the Earn dashboard yield UI, so a regression in its rendering or layout would likely surface here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The test opens the Ethereum staking/earn dashboard, verifies empty and staked dashboard cards, progress indicators, and reward amounts. The changed component sits in the same Earn dashboard yield surface, making this a good representative check.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test exercises the Solana staking/earn dashboard, including empty card visibility, staking amounts, and progress indicators. It provides cross-chain coverage of the dashboard area that consumes the changed APY breakdown component.

</details>

_Updated: 2026-07-30T11:23:27.818Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/weth-replacements/web/](https://dev.suite.sldev.cz/suite-web/feat/weth-replacements/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/weth-replacements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/weth-replacements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T11:27:13.143Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T11:27:01.122Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->