### PR TITLE
fix(connect): repair NPM release (provenance repository field + PMG cooldown)

### DIFF
--- a/.github/actions/release-connect-npm/action.yml
+++ b/.github/actions/release-connect-npm/action.yml
@@ -31,6 +31,8 @@ runs:
       continue-on-error: true
       with:
         version: v0.19.1
+        # Our just-published @trezor packages trip the cooldown. Malware scanning still runs.
+        cooldown-enabled: "false"
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/release-connect/action.yml
+++ b/.github/actions/release-connect/action.yml
@@ -68,6 +68,8 @@ runs:
       continue-on-error: true
       with:
         version: v0.19.1
+        # Our just-published @trezor packages trip the cooldown. Malware scanning still runs.
+        cooldown-enabled: "false"
 
     - name: Install dependencies
       shell: bash

--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-cardano",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/ripple/network-ripple/package.json
+++ b/networks/ripple/network-ripple/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-ripple",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/solana/network-solana/package.json
+++ b/networks/solana/network-solana/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-solana",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-stellar",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/tron/network-tron/package.json
+++ b/networks/tron/network-tron/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-tron",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/blockchain-link-types",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/blockchain-link-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/connect-mobile",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/device-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index",

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/schema-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index.ts",


### PR DESCRIPTION
## Description

Fixes the `@trezor` NPM release pipeline for connect packages.

- **Provenance:** Ten `publishConfig` packages (five `packages/*`, all five `networks/*`) had no `repository` field, so `repository.url` resolved to `""` at publish time and failed sigstore provenance validation. Added the `repository` block using the existing `git://github.com/trezor/trezor-suite.git` convention.
- **CI:** The connect release composite actions set up SafeDep PMG independently from the release workflow, so an earlier cooldown fix did not reach them; PMG's block banner leaked into the `npm view --json` stdout parsed by `check-version.js` and broke the release with `SyntaxError: Unexpected token '⊘'`. Disabled the PMG dependency cooldown in both actions — malware scanning stays on.

## Notes for QA

CI/release-only change. No Suite runtime behaviour is affected; verification happens through a connect NPM release run.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-package-json-repo-urls/web/](https://dev.suite.sldev.cz/suite-web/fix-package-json-repo-urls/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-package-json-repo-urls&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-package-json-repo-urls&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T11:48:34.007Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->