### PR TITLE
Feat/add new feature badge

### DIFF
--- a/packages/components/src/components/Badge/types.ts
+++ b/packages/components/src/components/Badge/types.ts
@@ -1,6 +1,13 @@
 import { type UIIntent, type UISize } from '../../config/types';
 
-export const badgeIntents = ['brand', 'neutral', 'info', 'warning', 'critical'] as const;
+export const badgeIntents = [
+    'brand',
+    'neutral',
+    'info',
+    'warning',
+    'critical',
+    'accentViolet',
+] as const satisfies UIIntent[];
 export type BadgeIntent = Extract<UIIntent, (typeof badgeIntents)[number]>;
 
 export const badgeSizes = ['medium', 'small'] as const;

--- a/packages/components/src/components/Badge/utils.ts
+++ b/packages/components/src/components/Badge/utils.ts
@@ -10,6 +10,7 @@ export const mapIntentToBackgroundColor = (intent: BadgeIntent): Color => {
         info: 'elementFillInfoSoft',
         warning: 'elementFillWarningSoft',
         critical: 'elementFillCriticalSoft',
+        accentViolet: 'elementFillAccentVioletSoft',
     };
 
     return colorMap[intent];
@@ -22,6 +23,7 @@ export const mapIntentToIconColor = (intent: BadgeIntent): Color => {
         info: 'contentInfo',
         warning: 'contentWarning',
         critical: 'contentCritical',
+        accentViolet: 'contentAccentViolet',
     };
 
     return colorMap[intent];

--- a/packages/components/src/components/Dot/Dot.stories.tsx
+++ b/packages/components/src/components/Dot/Dot.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { Dot as DotComponent, dotIntents } from './Dot';
+import { Dot as DotComponent } from './Dot';
+import { dotIntents } from './types';
 
 const meta: Meta<typeof DotComponent> = {
     title: 'Dot',
@@ -19,7 +20,7 @@ export const Dot: StoryObj<typeof meta> = {
         },
         intent: {
             options: dotIntents,
-            control: 'radio',
+            control: 'select',
         },
     },
 };

--- a/packages/components/src/components/Dot/Dot.tsx
+++ b/packages/components/src/components/Dot/Dot.tsx
@@ -1,11 +1,9 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import styled, { css, keyframes } from 'styled-components';
 
+import { type DotIntent } from './types';
+import { mapIntentToBackgroundColor } from './utils';
 import { motionEasing } from '../../config/motion';
-import { type UIIntent } from '../../config/types';
-
-export const dotIntents = ['neutral', 'critical'] as const;
-export type DotIntent = Extract<UIIntent, (typeof dotIntents)[number]>;
 
 const DEFAULT_SIZE = 4;
 
@@ -37,8 +35,7 @@ const ringExpand = keyframes`
 `;
 
 const intentBackground = css<{ $intent: DotIntent }>`
-    background: ${({ theme, $intent }) =>
-        $intent === 'critical' ? theme.elementFillCriticalBold : theme.elementFillNeutralBold};
+    background: ${({ theme, $intent }) => theme[mapIntentToBackgroundColor($intent)]};
 `;
 
 const Circle = styled.div<{ $size: number; $intent: DotIntent }>`

--- a/packages/components/src/components/Dot/types.ts
+++ b/packages/components/src/components/Dot/types.ts
@@ -1,0 +1,12 @@
+import { type UIIntent } from '../../config/types';
+
+export const dotIntents = [
+    'brand',
+    'neutral',
+    'info',
+    'warning',
+    'critical',
+    'accentViolet',
+] as const satisfies UIIntent[];
+
+export type DotIntent = Extract<UIIntent, (typeof dotIntents)[number]>;

--- a/packages/components/src/components/Dot/utils.ts
+++ b/packages/components/src/components/Dot/utils.ts
@@ -1,0 +1,15 @@
+import { type Color } from '@trezor/theme';
+
+import { type DotIntent } from './types';
+
+const intentToBackgroundColorMap: Record<DotIntent, Color> = {
+    brand: 'elementFillBrandBold',
+    neutral: 'elementFillNeutralBold',
+    info: 'elementFillInfoBold',
+    warning: 'elementFillWarningBold',
+    critical: 'elementFillCriticalBold',
+    accentViolet: 'elementFillAccentVioletBold',
+};
+
+export const mapIntentToBackgroundColor = (intent: DotIntent): Color =>
+    intentToBackgroundColorMap[intent];

--- a/packages/components/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/packages/components/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { StatusBadge as StatusBadgeComponent } from './StatusBadge';
-import { dotIntents } from '../Dot/Dot';
+import { dotIntents } from '../Dot/types';
 
 const meta: Meta<typeof StatusBadgeComponent> = {
     title: 'StatusBadge',

--- a/packages/components/src/components/StatusBadge/StatusBadge.tsx
+++ b/packages/components/src/components/StatusBadge/StatusBadge.tsx
@@ -3,7 +3,8 @@ import { type ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { Box } from '../Box/Box';
-import { Dot, type DotIntent } from '../Dot/Dot';
+import { Dot } from '../Dot/Dot';
+import { type DotIntent } from '../Dot/types';
 
 const DOT_SIZE = 8;
 const OUTLINE_WIDTH = 2;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -90,13 +90,8 @@ export * from './components/Image/Image';
 export * from './components/Image/SvgImage';
 export * from './components/Image/images';
 export { DotIndicator, type DotIndicatorProps } from './components/DotIndicator/DotIndicator';
-export {
-    Dot,
-    dotIntents,
-    type DotProps,
-    type DotIntent,
-    DOT_RINGING_DURATION,
-} from './components/Dot/Dot';
+export { Dot, type DotProps, DOT_RINGING_DURATION } from './components/Dot/Dot';
+export { dotIntents, type DotIntent } from './components/Dot/types';
 export {
     StatusBadge,
     type StatusBadgeProps,

--- a/packages/suite/src/actions/suite/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/storageActions.test.ts
@@ -2,7 +2,13 @@ import '@suite-common/test-utils/globalOverrides';
 
 import { coinjoinReducer } from '@suite/coinjoin';
 import { prepareDesktopDeviceReducer } from '@suite/device';
-import { initialRunCompleted, prepareFlagsReducer } from '@suite/flags';
+import {
+    NewContentIndicatorId,
+    initialRunCompleted,
+    markNewContentIndicatorAsSeen,
+    prepareFlagsReducer,
+    setNewContentIndicatorSeen,
+} from '@suite/flags';
 import { initialMetadataState, metadataReducer } from '@suite/metadata';
 import { suiteSettingsInitialState } from '@suite/settings';
 import { prepareSuiteSyncReducer } from '@suite/suite-sync';
@@ -27,7 +33,7 @@ import { type StaticSessionId, asWalletDescriptor } from '@trezor/device-utils';
 
 import { suiteSyncQuotaManagerSlice } from 'src/actions/suiteSyncQuotaManager/suiteSyncQuotaManagerSlice';
 import { SETTINGS } from 'src/config/suite';
-import storageMiddleware from 'src/middlewares/wallet/storageMiddleware';
+import { storageMiddleware } from 'src/middlewares/wallet/storageMiddleware';
 import suiteReducer from 'src/reducers/suite/suiteReducer';
 import { accountsReducer, fiatRatesReducer, transactionsReducer } from 'src/reducers/wallet';
 import graphReducer from 'src/reducers/wallet/graphReducer';
@@ -230,9 +236,20 @@ describe('Storage actions', () => {
         global.fetch = mockFetch({ TR_ID: 'Message' });
         await store.dispatch(storageActions.saveSuiteSettings());
         await store.dispatch(initialRunCompleted({ isFreshDeviceSetup: true }));
+        await store.dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Activity26_8));
+        await store.dispatch(
+            setNewContentIndicatorSeen({
+                indicatorId: NewContentIndicatorId.Earn26_8,
+                isSeen: true,
+            }),
+        );
         store.dispatch(await preloadStore());
 
         expect(store.getState().flags.initialRun).toEqual(false);
+        expect(store.getState().flags.seenNewContentIndicators).toEqual({
+            [NewContentIndicatorId.Activity26_8]: true,
+            [NewContentIndicatorId.Earn26_8]: true,
+        });
         global.fetch = f;
     });
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -1,14 +1,20 @@
 import { type FC, useCallback, useMemo } from 'react';
 
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
-import { selectIsInitialRun } from '@suite/flags';
+import {
+    NewContentIndicatorId,
+    markNewContentIndicatorAsSeen,
+    selectIsInitialRun,
+    selectIsNewContentIndicatorVisible,
+} from '@suite/flags';
 import { type Route, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import { Column } from '@trezor/components';
 import { BellIcon, GearSixIcon, HouseIcon, PiggyBankIcon, RepeatIcon } from '@trezor/icons';
 
-import { useActivityNotificationPhase, useSelector } from 'src/hooks/suite';
+import { useActivityNotificationPhase, useDispatch, useSelector } from 'src/hooks/suite';
+import { type AppState } from 'src/reducers/store';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 import { isTransactionNotification } from 'src/utils/suite/notification';
 
@@ -26,19 +32,27 @@ type NavigationProps = {
     children?: React.ReactNode;
 };
 
+const selectHasUnseenNotifications = (state: AppState) =>
+    state.notifications.some(
+        notification => !notification.seen && isTransactionNotification(notification),
+    );
+
 export const Navigation = ({ children }: NavigationProps) => {
     const { isSidebarCollapsed } = useResponsiveContext();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const dispatch = useDispatch();
 
     const isInitialRun = useSelector(selectIsInitialRun);
     const startRoute: Route['name'] = isInitialRun ? 'suite-start' : 'suite-index';
 
     const isBtcOnly = useSelector(selectHasBitcoinOnlyFirmware);
 
-    const hasUnseenNotifications = useSelector(state =>
-        state.notifications.some(
-            notification => !notification.seen && isTransactionNotification(notification),
-        ),
+    const hasUnseenNotifications = useSelector(selectHasUnseenNotifications);
+    const isActivityNewContentIndicatorVisible = useSelector(
+        selectIsNewContentIndicatorVisible(NewContentIndicatorId.Activity26_8),
+    );
+    const isEarnNewContentIndicatorVisible = useSelector(
+        selectIsNewContentIndicatorVisible(NewContentIndicatorId.Earn26_8),
     );
 
     const isActivityOpen = useSelector(selectRouteName) === 'notifications-index';
@@ -46,6 +60,7 @@ export const Navigation = ({ children }: NavigationProps) => {
         hasUnseenNotifications,
         isActivityOpen,
     );
+    const hasActivityIndicator = activityNotificationPhase !== 'off';
 
     const reportSwapNavigation = useCallback(() => {
         analytics.report({
@@ -57,6 +72,42 @@ export const Navigation = ({ children }: NavigationProps) => {
             },
         });
     }, [analytics]);
+
+    const handleActivityNavigation = useCallback(() => {
+        if (isActivityNewContentIndicatorVisible) {
+            if (!isSidebarCollapsed || !hasActivityIndicator) {
+                analytics.report({
+                    type: events.appNewContentBadgeEvent.name,
+                    payload: {
+                        badgeId: NewContentIndicatorId.Activity26_8,
+                        origin: 'nav',
+                    },
+                });
+            }
+
+            dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Activity26_8));
+        }
+    }, [
+        analytics,
+        dispatch,
+        hasActivityIndicator,
+        isActivityNewContentIndicatorVisible,
+        isSidebarCollapsed,
+    ]);
+
+    const handleEarnNavigation = useCallback(() => {
+        if (isEarnNewContentIndicatorVisible) {
+            analytics.report({
+                type: events.appNewContentBadgeEvent.name,
+                payload: {
+                    badgeId: NewContentIndicatorId.Earn26_8,
+                    origin: 'nav',
+                },
+            });
+
+            dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Earn26_8));
+        }
+    }, [analytics, dispatch, isEarnNewContentIndicatorVisible]);
 
     const navItems: Array<NavigationItemProps & { CustomComponent?: FC<NavigationItemProps> }> =
         useMemo(
@@ -82,6 +133,8 @@ export const Navigation = ({ children }: NavigationProps) => {
                               nameId: 'TR_EARN',
                               icon: PiggyBankIcon,
                               goToRoute: 'suite-earn',
+                              hasNewContentIndicator: isEarnNewContentIndicatorVisible,
+                              onClick: handleEarnNavigation,
                               shortcut: ['ALT', 'KEY_E'],
                               routes: [
                                   'suite-earn',
@@ -105,8 +158,10 @@ export const Navigation = ({ children }: NavigationProps) => {
                     icon: BellIcon,
                     goToRoute: 'notifications-index',
                     routes: ['notifications-index'],
-                    hasIndicator: activityNotificationPhase !== 'off',
+                    hasIndicator: hasActivityIndicator,
                     isIndicatorAnimated: activityNotificationPhase === 'ringing',
+                    hasNewContentIndicator: isActivityNewContentIndicatorVisible,
+                    onClick: handleActivityNavigation,
                     'data-testid': '@suite/menu/notifications',
                     shortcut: ['ALT', 'KEY_I'],
                 },
@@ -119,7 +174,17 @@ export const Navigation = ({ children }: NavigationProps) => {
                     shortcut: ['MOD', 'COMMA'],
                 },
             ],
-            [startRoute, isBtcOnly, reportSwapNavigation, activityNotificationPhase],
+            [
+                startRoute,
+                isBtcOnly,
+                reportSwapNavigation,
+                isEarnNewContentIndicatorVisible,
+                handleEarnNavigation,
+                hasActivityIndicator,
+                activityNotificationPhase,
+                isActivityNewContentIndicatorVisible,
+                handleActivityNavigation,
+            ],
         );
 
     return (

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx
@@ -5,6 +5,7 @@ import styled, { css } from 'styled-components';
 import { type ExtendedMessageDescriptor, Translation, type TranslationKey } from '@suite/intl';
 import { type Route, goto, selectRouteName } from '@suite/router';
 import {
+    Badge,
     Icon,
     type IconComponent,
     Paragraph,
@@ -60,6 +61,7 @@ export type NavigationItemProps = {
     isActive?: boolean;
     hasIndicator?: boolean;
     isIndicatorAnimated?: boolean;
+    hasNewContentIndicator?: boolean;
     'data-testid'?: string;
     className?: string;
     values?: ExtendedMessageDescriptor['values'];
@@ -83,6 +85,7 @@ const NavItem = ({
     isActive,
     hasIndicator,
     isIndicatorAnimated,
+    hasNewContentIndicator,
     'data-testid': dataTest,
     values,
     preserveParams,
@@ -111,6 +114,12 @@ const NavItem = ({
     const isItemActive = isActive || isActiveRoute;
 
     const isTooltipActive = expanded ? shortcut !== undefined : true;
+    const isNewContentBadgeShown = expanded === true && hasNewContentIndicator === true;
+    const isNewContentDotShown =
+        expanded !== true && hasNewContentIndicator === true && hasIndicator !== true;
+    const isIconIndicatorShown = hasIndicator === true || isNewContentDotShown;
+    const iconIndicatorIntent = hasIndicator === true ? 'critical' : 'accentViolet';
+    const navigationItemTestId = dataTest || `@suite/menu/${goToRoute}`;
 
     return (
         <Tooltip
@@ -133,13 +142,13 @@ const NavItem = ({
             <Container
                 $isActive={isItemActive}
                 onClick={handleClick}
-                data-testid={dataTest || `@suite/menu/${goToRoute}`}
+                data-testid={navigationItemTestId}
                 type="button"
             >
                 <StatusBadge
-                    isShown={hasIndicator}
-                    isAnimated={isIndicatorAnimated}
-                    intent="critical"
+                    isShown={isIconIndicatorShown}
+                    isAnimated={hasIndicator === true && isIndicatorAnimated}
+                    intent={iconIndicatorIntent}
                     offset={{ x: -6, y: 5 }}
                 >
                     <Icon
@@ -151,13 +160,32 @@ const NavItem = ({
                     />
                 </StatusBadge>
                 {expanded && (
-                    <Paragraph
-                        typographyStyle="body-md"
-                        intent="neutral"
-                        priority={isItemActive ? 'primary' : 'secondary'}
+                    <Row
+                        flex="1"
+                        minWidth={0}
+                        gap={8}
+                        justifyContent="space-between"
+                        alignItems="center"
                     >
-                        <Translation id={nameId} values={values} />
-                    </Paragraph>
+                        <Paragraph
+                            typographyStyle="body-md"
+                            intent="neutral"
+                            priority={isItemActive ? 'primary' : 'secondary'}
+                            minWidth={0}
+                            overflowWrap="anywhere"
+                        >
+                            <Translation id={nameId} values={values} />
+                        </Paragraph>
+                        {isNewContentBadgeShown && (
+                            <Badge
+                                size="small"
+                                intent="accentViolet"
+                                data-testid={`${navigationItemTestId}/new-content-indicator`}
+                            >
+                                <Translation id="TR_NEW" />
+                            </Badge>
+                        )}
+                    </Row>
                 )}
             </Container>
         </Tooltip>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/consts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/consts.ts
@@ -1,6 +1,6 @@
 import { isDesktop } from '@trezor/env-utils';
 
-export const SIDEBAR_COLLAPSED_WIDTH = 200;
+export const SIDEBAR_COLLAPSED_WIDTH = 280;
 export const SIDEBAR_MIN_WIDTH = isDesktop() ? 80 : 58;
 export const SIDEBAR_MAX_WIDTH = 400;
 export const SIDEBAR_AUTO_COLLAPSE_BREAKPOINT = 400;

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -16,7 +16,7 @@ import { prepareWalletConnectMiddleware } from '@suite-common/walletconnect';
 
 import graphMiddleware from './graphMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
-import storageMiddleware from './storageMiddleware';
+import { storageMiddleware } from './storageMiddleware';
 import { tradingMiddleware } from './tradingMiddleware';
 import walletMiddleware from './walletMiddleware';
 

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -4,7 +4,7 @@ import { type MiddlewareAPI } from 'redux';
 import { COINJOIN } from '@suite/coinjoin';
 import { debugActions } from '@suite/debug';
 import { featureUsed, feedbackDismissed, feedbackRequested } from '@suite/feature-feedback';
-import { setFlag } from '@suite/flags';
+import { markNewContentIndicatorAsSeen, setFlag, setNewContentIndicatorSeen } from '@suite/flags';
 import { METADATA, metadataActions } from '@suite/metadata';
 import { suiteSettingsActions } from '@suite/settings';
 import { dismissUnsupportedDeviceBanner } from '@suite/suite-sync';
@@ -286,7 +286,7 @@ const rememberedDeviceHandlers: RememberedDeviceHandler[] = [
     }),
 ];
 
-const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
+export const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
     db.onBlocking = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocking' });
     db.onBlocked = () => api.dispatch({ type: STORAGE.ERROR, payload: 'blocked' });
 
@@ -496,6 +496,8 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                     break;
                 case suiteSettingsActions.setLanguage.type:
                 case setFlag.type:
+                case markNewContentIndicatorAsSeen.type:
+                case setNewContentIndicatorSeen.type:
                 case suiteSettingsActions.setDebugMode.type:
                 case suiteSettingsActions.setExperimentalFeatures.type:
                 case suiteSettingsActions.setOnionLinks.type:
@@ -551,5 +553,3 @@ const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
             return action;
         };
 };
-
-export default storageMiddleware;

--- a/packages/suite/src/support/suite/ResponsiveContext.tsx
+++ b/packages/suite/src/support/suite/ResponsiveContext.tsx
@@ -1,13 +1,13 @@
-import React, { createContext, useContext, useMemo, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
-import { selectSidebarWidth } from '@suite/settings';
+import { selectSidebarWidth, suiteSettingsActions } from '@suite/settings';
 import { throwError } from '@trezor/utils';
 
 import {
     SIDEBAR_COLLAPSED_WIDTH,
     SIDEBAR_MIN_WIDTH,
 } from '../../components/suite/layouts/SuiteLayout/Sidebar/consts';
-import { useSelector } from '../../hooks/suite';
+import { useDispatch, useSelector } from '../../hooks/suite';
 
 type ResponsiveContextType = {
     sidebarWidth: number;
@@ -26,13 +26,23 @@ type ResponsiveContextType = {
     setAutoCollapseSuppressed: (v: boolean) => void;
 };
 
+export const normalizePersistedSidebarWidth = (width: number) => {
+    if (width <= SIDEBAR_MIN_WIDTH) {
+        return SIDEBAR_MIN_WIDTH;
+    }
+
+    return Math.max(width, SIDEBAR_COLLAPSED_WIDTH);
+};
+
 export const ResponsiveContext = createContext<ResponsiveContextType | undefined>(undefined);
 
 export const ResponsiveContextProvider = ({ children }: { children: React.ReactNode }) => {
     const sidebarWidthFromRedux = useSelector(selectSidebarWidth);
+    const dispatch = useDispatch();
+    const initialSidebarWidth = normalizePersistedSidebarWidth(sidebarWidthFromRedux);
 
-    const [sidebarWidthManual, setSidebarWidthManual] = useState<number>(sidebarWidthFromRedux);
-    const [sidebarWidthRaw, setSidebarWidthRaw] = useState<number>(sidebarWidthFromRedux);
+    const [sidebarWidthManual, setSidebarWidthManual] = useState<number>(initialSidebarWidth);
+    const [sidebarWidthRaw, setSidebarWidthRaw] = useState<number>(initialSidebarWidth);
     const [forcedSidebarWidth, setForcedSidebarWidth] = useState<number | undefined>(undefined);
     const [contentWidth, setContentWidth] = useState<number | undefined>(undefined);
     const [autoCollapsed, setAutoCollapsed] = useState<boolean>(false);
@@ -48,6 +58,12 @@ export const ResponsiveContextProvider = ({ children }: { children: React.ReactN
         () => effectiveWidth < SIDEBAR_COLLAPSED_WIDTH,
         [effectiveWidth],
     );
+
+    useEffect(() => {
+        if (sidebarWidthFromRedux !== initialSidebarWidth) {
+            dispatch(suiteSettingsActions.setSidebarWidth(initialSidebarWidth));
+        }
+    }, [dispatch, initialSidebarWidth, sidebarWidthFromRedux]);
 
     const setSidebarWidth = (width: number) => {
         if (typeof forcedSidebarWidth === 'number' && !userResizingSidebar) return;

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/dashboardBanners.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/dashboardBanners.tsx
@@ -1,4 +1,4 @@
-import { type FlagsState } from '@suite/flags';
+import { type BooleanFlagKey } from '@suite/flags';
 import { type selectSelectedDevice } from '@suite-common/device';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
@@ -18,7 +18,7 @@ type BannerEligibilityContext = {
 };
 
 type DashboardBannerDefinition = {
-    flag: keyof FlagsState;
+    flag: BooleanFlagKey;
     isEligible?: (context: BannerEligibilityContext) => boolean;
     render: (handlers: BannerHandlers) => React.ReactNode;
 };

--- a/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Flags.tsx
@@ -1,23 +1,32 @@
-import { selectFlags, setFlag } from '@suite/flags';
+import {
+    type BooleanFlagKey,
+    type FlagsState,
+    NewContentIndicatorId,
+    selectFlags,
+    setFlag,
+    setNewContentIndicatorSeen,
+} from '@suite/flags';
 import { Switch } from '@trezor/components';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
-import { typedObjectEntries } from '@trezor/utils';
+import { typedObjectEntries, typedObjectValues } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
+type FlagEntry = [keyof FlagsState, FlagsState[keyof FlagsState]];
+type BooleanFlagEntry = [BooleanFlagKey, boolean];
+
+const isBooleanFlagEntry = (entry: FlagEntry): entry is BooleanFlagEntry =>
+    typeof entry[1] === 'boolean';
 
 export const Flags = () => {
     const dispatch = useDispatch();
     const flags = useSelector(selectFlags);
 
-    const entries = typedObjectEntries(flags);
+    const entries = typedObjectEntries(flags).filter(isBooleanFlagEntry);
 
     return (
         <>
             {entries.map(([key, value]) => {
-                if (typeof value !== 'boolean') {
-                    return null;
-                }
-
                 const handleChange = () => {
                     dispatch(setFlag({ key, value: !value }));
                 };
@@ -27,6 +36,21 @@ export const Flags = () => {
                         <TextColumn title={key} />
                         <ActionColumn>
                             <Switch isChecked={value} onChange={handleChange} />
+                        </ActionColumn>
+                    </SectionItem>
+                );
+            })}
+            {typedObjectValues(NewContentIndicatorId).map(indicatorId => {
+                const isSeen = flags.seenNewContentIndicators[indicatorId] === true;
+                const handleChange = () => {
+                    dispatch(setNewContentIndicatorSeen({ indicatorId, isSeen: !isSeen }));
+                };
+
+                return (
+                    <SectionItem key={indicatorId}>
+                        <TextColumn title={`seenNewContentIndicators.${indicatorId}`} />
+                        <ActionColumn>
+                            <Switch isChecked={isSeen} onChange={handleChange} />
                         </ActionColumn>
                     </SectionItem>
                 );

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -51,6 +51,7 @@ export enum EventType {
     GuideNodeNavigation = 'guide/node/navigation',
     GuideTooltipLinkNavigation = 'guide/tooltip-link/navigation',
     MenuGuide = 'menu/guide',
+    AppNewContentBadge = 'app/new-content-badge',
     MenuNotificationsToggle = 'menu/notifications/toggle',
     MenuToggleDiscreet = 'menu/toggle-discreet',
     PromoDashboardBanner = 'promo/dashboard-banner',

--- a/suite/analytics/src/events/appNewContentBadgeEvent.ts
+++ b/suite/analytics/src/events/appNewContentBadgeEvent.ts
@@ -1,0 +1,26 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type Attributes = {
+    badgeId: AttributeDef<string>;
+    origin: AttributeDef<'nav'>;
+};
+
+export const appNewContentBadgeEvent: EventDef<Attributes, EventType.AppNewContentBadge> = {
+    name: EventType.AppNewContentBadge,
+    descriptionTrigger:
+        'User clicks an element while its new-content badge or dot is visible, clearing that badge',
+    changelog: [{ version: '26.8.0', notes: 'added' }],
+
+    attributes: {
+        badgeId: {
+            description: 'The release-specific identifier of the new-content badge',
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+        },
+        origin: {
+            description: 'The kind of element on which the badge was displayed',
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+        },
+    },
+};

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -8,6 +8,7 @@ export { accountsTokensStatusEvent } from './accountsTokensStatusEvent';
 export { accountsTransactionsExportEvent } from './accountsTransactionsExportEvent';
 export { addTokenEvent } from './addTokenEvent';
 export { appFormPercentButtonsEvent } from './appFormPercentButtonsEvent';
+export { appNewContentBadgeEvent } from './appNewContentBadgeEvent';
 export { appUpdateEvent } from './appUpdateEvent';
 export { appUriHandlerEvent } from './appUriHandlerEvent';
 export { autostartModalEvent } from './autostartModalEvent';

--- a/suite/desktop-update/src/quickActions/updateQuickActionTypes.ts
+++ b/suite/desktop-update/src/quickActions/updateQuickActionTypes.ts
@@ -32,7 +32,7 @@ export const mapUpdateStatusToIntent: Record<UpdateStatus, UIIntent> = {
     'update-downloaded-manual': 'info',
     'update-downloaded-auto-restart-to-update': 'info',
     'up-to-date': 'brand',
-    'update-available': 'info',
+    'update-available': 'accentViolet',
     'just-updated': 'accentViolet',
 };
 

--- a/suite/flags/src/flagsConstants.ts
+++ b/suite/flags/src/flagsConstants.ts
@@ -1,1 +1,9 @@
 export const FLAGS_MODULE_PREFIX = '@suite/flags';
+
+export const NewContentIndicatorId = {
+    Activity26_8: 'activity-26.8',
+    Earn26_8: 'earn-26.8',
+} as const;
+
+export type NewContentIndicatorId =
+    (typeof NewContentIndicatorId)[keyof typeof NewContentIndicatorId];

--- a/suite/flags/src/flagsSlice.test.ts
+++ b/suite/flags/src/flagsSlice.test.ts
@@ -3,7 +3,16 @@ import { configureStore } from '@reduxjs/toolkit';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { DEVICE } from '@trezor/connect';
 
-import { flagsInitialState, prepareFlagsReducer, selectFlags, setFlag } from './flagsSlice';
+import { NewContentIndicatorId } from './flagsConstants';
+import {
+    flagsInitialState,
+    markNewContentIndicatorAsSeen,
+    prepareFlagsReducer,
+    selectFlags,
+    selectIsNewContentIndicatorVisible,
+    setFlag,
+    setNewContentIndicatorSeen,
+} from './flagsSlice';
 
 const flagsReducer = prepareFlagsReducer(extraDependenciesCommonMock);
 
@@ -39,6 +48,57 @@ describe('flagsSlice', () => {
         expect(state.taprootBannerClosed).toBe(true);
         expect(state.initialRun).toBe(flagsInitialState.initialRun);
         expect(state.dashboardAssetsGridMode).toBe(flagsInitialState.dashboardAssetsGridMode);
+    });
+
+    it('shows unseen new-content indicators by default', () => {
+        const store = initStore();
+
+        expect(
+            selectIsNewContentIndicatorVisible(NewContentIndicatorId.Activity26_8)(
+                store.getState(),
+            ),
+        ).toBe(true);
+        expect(
+            selectIsNewContentIndicatorVisible(NewContentIndicatorId.Earn26_8)(store.getState()),
+        ).toBe(true);
+    });
+
+    it('marks only the selected new-content indicator as seen', () => {
+        const store = initStore();
+
+        store.dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Activity26_8));
+
+        expect(
+            selectIsNewContentIndicatorVisible(NewContentIndicatorId.Activity26_8)(
+                store.getState(),
+            ),
+        ).toBe(false);
+        expect(
+            selectIsNewContentIndicatorVisible(NewContentIndicatorId.Earn26_8)(store.getState()),
+        ).toBe(true);
+    });
+
+    it('marks a new-content indicator as seen idempotently', () => {
+        const store = initStore();
+
+        store.dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Earn26_8));
+        store.dispatch(markNewContentIndicatorAsSeen(NewContentIndicatorId.Earn26_8));
+
+        expect(store.getState().flags.seenNewContentIndicators).toEqual({
+            [NewContentIndicatorId.Earn26_8]: true,
+        });
+    });
+
+    it('allows a new-content indicator to be toggled for debugging', () => {
+        const store = initStore();
+        const indicatorId = NewContentIndicatorId.Activity26_8;
+
+        store.dispatch(setNewContentIndicatorSeen({ indicatorId, isSeen: true }));
+        expect(selectIsNewContentIndicatorVisible(indicatorId)(store.getState())).toBe(false);
+
+        store.dispatch(setNewContentIndicatorSeen({ indicatorId, isSeen: false }));
+        expect(selectIsNewContentIndicatorVisible(indicatorId)(store.getState())).toBe(true);
+        expect(store.getState().flags.seenNewContentIndicators).toEqual({});
     });
 
     it('should disable no-device eShop banners once a device connects', () => {

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -3,6 +3,8 @@ import { type PayloadAction } from '@reduxjs/toolkit';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import { DEVICE } from '@trezor/connect';
 
+import { type NewContentIndicatorId } from './flagsConstants';
+
 export type FlagsState = {
     initialRun: boolean;
     taprootBannerClosed: boolean;
@@ -33,9 +35,14 @@ export type FlagsState = {
     hasSeenDisconnectTooltip: boolean;
     showNoDeviceEshopSidebarBanner: boolean;
     areNoDeviceEshopBannersDisabled: boolean;
+    seenNewContentIndicators: Partial<Record<NewContentIndicatorId, true>>;
 };
 
 export type FlagsRootState = { flags: FlagsState };
+
+export type BooleanFlagKey = {
+    [Key in keyof FlagsState]: FlagsState[Key] extends boolean ? Key : never;
+}[keyof FlagsState];
 
 export const flagsInitialState: FlagsState = {
     initialRun: true,
@@ -67,6 +74,7 @@ export const flagsInitialState: FlagsState = {
     hasSeenDisconnectTooltip: false,
     showNoDeviceEshopSidebarBanner: true,
     areNoDeviceEshopBannersDisabled: false,
+    seenNewContentIndicators: {},
 };
 
 const flagsSlice = createSliceWithExtraDeps({
@@ -75,9 +83,25 @@ const flagsSlice = createSliceWithExtraDeps({
     reducers: {
         setFlag: (
             state: FlagsState,
-            { payload }: PayloadAction<{ key: keyof FlagsState; value: boolean }>,
+            { payload }: PayloadAction<{ key: BooleanFlagKey; value: boolean }>,
         ) => {
             state[payload.key] = payload.value;
+        },
+        markNewContentIndicatorAsSeen: (
+            state: FlagsState,
+            { payload }: PayloadAction<NewContentIndicatorId>,
+        ) => {
+            state.seenNewContentIndicators[payload] = true;
+        },
+        setNewContentIndicatorSeen: (
+            state: FlagsState,
+            { payload }: PayloadAction<{ indicatorId: NewContentIndicatorId; isSeen: boolean }>,
+        ) => {
+            if (payload.isSeen) {
+                state.seenNewContentIndicators[payload.indicatorId] = true;
+            } else {
+                delete state.seenNewContentIndicators[payload.indicatorId];
+            }
         },
     },
     extraReducers: (builder, extra) => {
@@ -92,7 +116,8 @@ const flagsSlice = createSliceWithExtraDeps({
     },
 });
 
-export const { setFlag } = flagsSlice.actions;
+export const { markNewContentIndicatorAsSeen, setFlag, setNewContentIndicatorSeen } =
+    flagsSlice.actions;
 export const flagsActions = flagsSlice.actions;
 export const prepareFlagsReducer = flagsSlice.prepareReducer;
 
@@ -118,3 +143,6 @@ export const selectIsNoDeviceEshopSidebarBannerShown = (state: FlagsRootState) =
     state.flags.showNoDeviceEshopSidebarBanner;
 export const selectAreNoDeviceEshopBannersDisabled = (state: FlagsRootState) =>
     state.flags.areNoDeviceEshopBannersDisabled;
+export const selectIsNewContentIndicatorVisible =
+    (indicatorId: NewContentIndicatorId) => (state: FlagsRootState) =>
+        state.flags.seenNewContentIndicators[indicatorId] !== true;

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -5073,6 +5073,10 @@ export const messages = defineMessages({
         id: 'TR_NOTIFICATIONS',
         defaultMessage: 'Activity',
     },
+    TR_NEW: {
+        id: 'TR_NEW',
+        defaultMessage: 'New',
+    },
     TR_PERSONALIZATION: {
         id: 'TR_PERSONALIZATION',
         defaultMessage: 'Customization',


### PR DESCRIPTION
## Notes for QA
Added new feature badge to sidebar.

## Screenshots:
<img width="594" height="680" alt="image" src="https://github.com/user-attachments/assets/5a7356ca-d23c-4b52-946c-cd76d2f8b90e" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/add-new-feature-badge/web/](https://dev.suite.sldev.cz/suite-web/feat/add-new-feature-badge/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/add-new-feature-badge&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/add-new-feature-badge&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T21:23:53.827Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T21:24:05.379Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set spans UI badge/dot components, sidebar navigation, dashboard promo banners, feature flags, analytics plumbing, and wallet storage middleware. The most user-visible risks are promo banner rendering/flag toggling and sidebar navigation entry points, so the highest priority test is promo-banner-events. Medium-priority tests cover the feature-flagged Suite Sync flow, sidebar trading navigation, and persistence smoke tests for the changed storage middleware. Several low-level/type/story files and new analytics event code have no direct E2E coverage.

<details><summary><b>Changed files (26)</b></summary>

- `packages/components/src/components/Badge/types.ts`
- `packages/components/src/components/Badge/utils.ts`
- `packages/components/src/components/Dot/Dot.stories.tsx`
- `packages/components/src/components/Dot/Dot.tsx`
- `packages/components/src/components/Dot/types.ts`
- `packages/components/src/components/Dot/utils.ts`
- `packages/components/src/components/StatusBadge/StatusBadge.stories.tsx`
- `packages/components/src/components/StatusBadge/StatusBadge.tsx`
- `packages/components/src/index.ts`
- `packages/suite/src/actions/suite/storageActions.test.ts`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/NavigationItem.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/consts.ts`
- `packages/suite/src/middlewares/wallet/index.ts`
- `packages/suite/src/middlewares/wallet/storageMiddleware.ts`
- `packages/suite/src/support/suite/ResponsiveContext.tsx`
- `packages/suite/src/views/dashboard/DashboardPromoBanner/dashboardBanners.tsx`
- `packages/suite/src/views/settings/SettingsDebug/Flags.tsx`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/appNewContentBadgeEvent.ts`
- `suite/analytics/src/events/index.ts`
- `suite/desktop-update/src/quickActions/updateQuickActionTypes.ts`
- `suite/flags/src/flagsConstants.ts`
- `suite/flags/src/flagsSlice.test.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly exercises the dashboard promo banner component (dashboardBanners.tsx) and toggles debug/feature flags via SettingsDebug/Flags to add banners, then verifies banner clicks fire the correct analytics event. A regression in banner rendering or debug-flag plumbing would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — Validates that wallet/settings state persists across Suite versions via IndexedDB and the wallet storage middleware. Changes to storageMiddleware.ts or wallet middleware index.ts could corrupt persisted settings or break migration logic.
- `suite/e2e/tests/suite/initial-run.test.ts` — Relies on persisted onboarding/initial-run state and navigation through the onboarding flow. Storage middleware changes could break persistence of the initialRun flag, causing onboarding to reappear or skip incorrectly after reload.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Enables debug mode and the Suite Sync feature flag through SettingsDebug/Flags, then verifies labels sync from the relay. This exercises the changed flag plumbing for a feature-gated capability.
- `suite/e2e/tests/trading/navigation.test.ts` — Exercises sidebar navigation items (Navigation.tsx, NavigationItem.tsx, consts.ts) to open Buy/Sell/Swap flows. Changes to sidebar item rendering or constants could break these primary entry points, and this test covers navigation from the sidebar directly.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/components/src/components/Badge/types.ts`
- `packages/components/src/components/Dot/Dot.stories.tsx`
- `packages/components/src/components/Dot/types.ts`
- `packages/components/src/components/Dot/utils.ts`
- `packages/components/src/components/StatusBadge/StatusBadge.stories.tsx`
- `packages/suite/src/actions/suite/storageActions.test.ts`
- `suite/analytics/src/events/appNewContentBadgeEvent.ts`
- `suite/desktop-update/src/quickActions/updateQuickActionTypes.ts`
- `suite/flags/src/flagsSlice.test.ts`

_Updated: 2026-07-30T21:22:43.406Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->