### PR TITLE
feat(suite-desktop): allow to skip approval if it already exists

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -5,7 +5,7 @@ import type {
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
 } from '@suite-common/wallet-core';
-import { Banner, Button, Column } from '@trezor/components';
+import { Banner, Button, Column, Row } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -44,6 +44,7 @@ export type YieldApproveStepProps = {
     pendingApproveTransaction?: YieldPendingTransactionState;
     onMaxClick?: () => void;
     onApprovalSubmit?: () => void;
+    onSkip?: () => void;
     onRevoke?: () => void;
     onPendingTxClick: (txid: string) => void;
 };
@@ -62,6 +63,7 @@ export const YieldApproveStep = ({
     pendingApproveTransaction,
     onMaxClick,
     onApprovalSubmit,
+    onSkip,
     onRevoke,
     onPendingTxClick,
 }: YieldApproveStepProps) => {
@@ -95,16 +97,30 @@ export const YieldApproveStep = ({
                 isDisabled={!!pendingApproveTransaction}
             />
 
-            <Button
-                size="large"
-                width="100%"
-                data-testid="@yield/form/approve-button"
-                onClick={onApprovalSubmit}
-                isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
-                isLoading={isLoading}
-            >
-                <Translation id={approveButtonId} values={{ tokenSymbol: token.symbol }} />
-            </Button>
+            <Row gap={8} width="100%">
+                <Button
+                    size="large"
+                    flex="1"
+                    data-testid="@yield/form/approve-button"
+                    onClick={onApprovalSubmit}
+                    isDisabled={isDisabled || !!pendingApproveTransaction || !onApprovalSubmit}
+                    isLoading={isLoading}
+                >
+                    <Translation id={approveButtonId} values={{ tokenSymbol: token.symbol }} />
+                </Button>
+                {onSkip && (
+                    <Button
+                        size="large"
+                        intent="neutral"
+                        priority="secondary"
+                        data-testid="@yield/form/approve-skip-button"
+                        onClick={onSkip}
+                        isDisabled={isLoading || !!pendingApproveTransaction}
+                    >
+                        <Translation id="TR_SKIP" />
+                    </Button>
+                )}
+            </Row>
 
             {approvalAction === 'revoke' && !isDisabled && (
                 <Banner

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -50,6 +50,7 @@ export const YieldDepositForm = () => {
         skipWrap,
         returnToWrapStep,
         submitApprovalAction,
+        skipApprove,
         submitAction,
         revokeAllowance,
         enterModifyApproval,
@@ -83,6 +84,20 @@ export const YieldDepositForm = () => {
         });
 
         submitApprovalAction();
+    };
+
+    const handleOnSkipApprove = () => {
+        analytics.report({
+            type: events.yieldDepositEvent.name,
+            payload: {
+                type: 'approve',
+                action: 'cancel',
+                networkSymbol: token.networkSymbol,
+                vaultId: vault.id,
+            },
+        });
+
+        skipApprove();
     };
 
     const handleOnRevoke = () => {
@@ -296,6 +311,9 @@ export const YieldDepositForm = () => {
                                         pendingApproveTransaction={approvalPendingTransaction}
                                         onMaxClick={handleMaxClick}
                                         onApprovalSubmit={handleOnApprovalSubmit}
+                                        onSkip={
+                                            canRevokeAllowance ? handleOnSkipApprove : undefined
+                                        }
                                         onRevoke={handleOnRevoke}
                                         onPendingTxClick={openPendingTransaction}
                                     />

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -101,6 +101,7 @@ export type UseYieldFlowResult = {
     submitUnwrap: () => void;
     skipUnwrap: () => void;
     submitApprovalAction: () => void;
+    skipApprove: () => void;
     submitAction: () => void;
     revokeAllowance: () => void;
     enterModifyApproval: () => void;
@@ -685,6 +686,16 @@ export const useYieldFlow = ({
         await submitApprove();
     }, [approvalAction, revokeAllowance, submitApprove]);
 
+    const skipApprove = useCallback(() => {
+        dispatch(
+            stablecoinYieldActions.skipApprovalStep({
+                flowType,
+                flowKey,
+                amount: methodsRef.current.getValues('amountInput'),
+            }),
+        );
+    }, [dispatch, flowKey, flowType, methodsRef]);
+
     const submitAction = useCallback(async () => {
         if (!isDeviceConnected) {
             openDeviceConnectionModal();
@@ -818,6 +829,7 @@ export const useYieldFlow = ({
         submitUnwrap,
         skipUnwrap,
         submitApprovalAction,
+        skipApprove,
         submitAction,
         revokeAllowance,
         enterModifyApproval,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -252,6 +252,26 @@ describe('stablecoinYieldReducer', () => {
             expect(getSession(state, 'deposit')?.action.amount).toBe('25');
         });
 
+        it('clears modify mode when the approval step is skipped so the action step re-guards allowance', () => {
+            const modifying = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.enterModifyMode({ flowType: 'deposit', flowKey: FLOW_KEY }),
+            );
+            expect(getSession(modifying, 'deposit')?.approval.isModifyMode).toBe(true);
+
+            const state = stablecoinYieldReducer(
+                modifying,
+                stablecoinYieldActions.skipApprovalStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '25',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.approval.isModifyMode).toBe(false);
+        });
+
         it('does not skip the wrap step when an allowance check resolves early', () => {
             const state = stablecoinYieldReducer(
                 initSession('deposit', true),

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -238,6 +238,20 @@ describe('stablecoinYieldReducer', () => {
             expect(getSession(state, 'deposit')?.step).toBe('action');
         });
 
+        it('carries the entered amount into the action step when the approval step is skipped', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.skipApprovalStep({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    amount: '25',
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.step).toBe('action');
+            expect(getSession(state, 'deposit')?.action.amount).toBe('25');
+        });
+
         it('does not skip the wrap step when an allowance check resolves early', () => {
             const state = stablecoinYieldReducer(
                 initSession('deposit', true),

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -409,13 +409,22 @@ const stablecoinYieldSlice = createSlice({
         },
         skipApprovalStep(
             state: StablecoinYieldState,
-            action: PayloadAction<StablecoinYieldSessionActionPayload>,
+            action: PayloadAction<
+                StablecoinYieldSessionActionPayload & {
+                    amount?: string;
+                }
+            >,
         ) {
             withSession(state, action.payload, session => {
                 if (session.step !== 'approve') {
                     return;
                 }
 
+                // A user-triggered skip carries the entered amount so the action step opens
+                // with it; the automatic allowance-check skip omits it and keeps the existing one.
+                if (action.payload.amount) {
+                    session.action.amount = action.payload.amount;
+                }
                 session.step = getNextYieldFlowStep(
                     action.payload.flowType,
                     'approve',

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -425,6 +425,11 @@ const stablecoinYieldSlice = createSlice({
                 if (action.payload.amount) {
                     session.action.amount = action.payload.amount;
                 }
+                // Leaving the approve step forward clears modify mode (mirrors `completeApproval`)
+                // so the action step's insufficient-allowance guard applies — otherwise a skip
+                // with an amount above the current allowance would slip past it.
+                session.approval.isModifyMode = false;
+                session.approval.isRevokeRequired = false;
                 session.step = getNextYieldFlowStep(
                     action.payload.flowType,
                     'approve',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If user already have allowance > 0 we're displaying button to allow skip and move to next step 

## Notes for QA

Navigating with changing the derivation index in URL could be useful:

https://dev.suite.sldev.cz/suite-web/develop/web/earn/yield/deposit#/eth/0/normal/ethereum-weth-steaketh-0x704cfb08969048a8dff298b214f959791d8da509-third-party-oav/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2

## Related Issue

Resolve #30562 

## Screenshots:

| Before | After |
|--------|--------|
| <img width="1065" height="722" alt="Screenshot 2026-07-30 at 14 10 21" src="https://github.com/user-attachments/assets/38200997-09bf-4ce8-96da-ce2bb2c9e68f" /> | <img width="1056" height="733" alt="Screenshot 2026-07-30 at 14 10 25" src="https://github.com/user-attachments/assets/cc17282b-7646-4457-8d3a-829d77952945" /> | 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are focused on the stablecoin yield UI and reducer, but none of the available E2E specs exercise the actual yield deposit/approve flow. The best existing E2E safeguard is the global route/link checker, which loads the earn/yield routes and can catch catastrophic render regressions. Confidence for the reducer logic should come from the updated unit test; consider adding a dedicated stablecoin-yield E2E spec if this area grows.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to every app route, including /earn/yield/deposit and related earn/yield routes, and verifies the page content attaches and the bundle loader hides. A crash in YieldDepositForm, YieldApproveStep, or useYieldFlow that prevents the yield deposit page from rendering would likely fail this smoke test.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`

_Updated: 2026-07-31T06:52:36.626Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/approve-skip/web/](https://dev.suite.sldev.cz/suite-web/feat/approve-skip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/approve-skip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/approve-skip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/approve-skip&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T06:53:12.523Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T06:53:59.162Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->