### PR TITLE
fix(suite-desktop): fix long tx wrap/unwrap labels

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -130,15 +130,17 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
         return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
     }
 
-    // WETH wrap/unwrap are shown as their own labels (with the amount) instead of the generic
-    // contract-call name ("deposit"/"withdraw") that the indexer parses.
+    // WETH wrap/unwrap are shown as their own labels instead of the generic contract-call name
+    // ("deposit"/"withdraw") that the indexer parses. The wrapped-token amount isn't obvious from
+    // the transaction row, so it's spelled out while the native side stays a bare symbol
+    // ("Wrap ETH into 0.1 WETH" / "Unwrap 0.1 WETH to ETH", see trezor/trezor-suite#30552).
     const wrapKind = getNativeWrapTxKind(transaction);
     if (wrapKind) {
         return (
             <Translation
                 id={wrapKind === 'wrap' ? 'TR_TX_WRAP' : 'TR_TX_UNWRAP'}
                 values={{
-                    nativeAmount: <WrapTxAmount transaction={transaction} />,
+                    nativeSymbol: getNetworkDisplaySymbol(transaction.symbol),
                     wrappedAmount: <WrapTxAmount transaction={transaction} wrapped />,
                 }}
             />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -11377,11 +11377,11 @@ export const messages = defineMessages({
     },
     TR_TX_WRAP: {
         id: 'TR_TX_WRAP',
-        defaultMessage: 'Wrap {nativeAmount} into {wrappedAmount}',
+        defaultMessage: 'Wrap {nativeSymbol} into {wrappedAmount}',
     },
     TR_TX_UNWRAP: {
         id: 'TR_TX_UNWRAP',
-        defaultMessage: 'Unwrap {wrappedAmount} into {nativeAmount}',
+        defaultMessage: 'Unwrap {wrappedAmount} to {nativeSymbol}',
     },
     TR_WRAP_NATIVE_TOKEN: {
         id: 'TR_WRAP_NATIVE_TOKEN',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

By mistake was changed in some other branch to display full amounts

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Open account with existing transactions or create new ones

Resolve #30552 

## Screenshots:

| Before | After |
|--------|--------|
| <img width="1230" height="591" alt="Screenshot 2026-07-30 at 14 29 21" src="https://github.com/user-attachments/assets/c06260b6-3921-4494-a1c7-971cac0c2603" /> | <img width="1216" height="578" alt="Screenshot 2026-07-30 at 14 29 10" src="https://github.com/user-attachments/assets/3ad7635b-4d7f-42c2-a8b1-32b749e6d4c4" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** TransactionHeader.tsx is a widely imported component (133 static matches), so the broad-utility heuristic is applied. The most targeted coverage comes from tests that actually render wallet transaction lists and assert on transaction item content. The messages.ts change is treated as related to TransactionHeader's labels; if the message edits are unrelated, broader translation-key tests would be needed. The recommended tests provide focused, high-confidence coverage with minimal runtime.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — This test navigates paginated transaction lists and asserts that specific transaction items render the expected address text on each page. TransactionHeader is part of the transaction item rendered in these lists, so a change there would be exercised directly.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test loads the account transaction overview, cycles graph filters, and searches transactions by address. It renders the wallet transaction list where TransactionHeader is used, making it a direct smoke test for TransactionHeader and its translated labels.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test sends a transaction and then asserts that the pending transaction list shows the expected target address label ('OP_RETURN (meow)'). It exercises the transaction list rendering path that includes TransactionHeader, though it does not focus on header content specifically.

</details>

_Updated: 2026-07-30T12:35:52.697Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/long-tx-label/web/](https://dev.suite.sldev.cz/suite-web/feat/long-tx-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/long-tx-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/long-tx-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T12:38:10.152Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->