### PR TITLE
fix(packages): add missing repository field to published packages (cherry pick)

### DIFF
--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-cardano",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/ripple/network-ripple/package.json
+++ b/networks/ripple/network-ripple/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-ripple",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/solana/network-solana/package.json
+++ b/networks/solana/network-solana/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-solana",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-stellar",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/networks/tron/network-tron/package.json
+++ b/networks/tron/network-tron/package.json
@@ -1,6 +1,10 @@
 {
     "name": "@trezor/network-tron",
     "version": "10.0.0-beta.1",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "./src/index.ts",

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/blockchain-link-types",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/blockchain-link-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/connect-mobile",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index.ts",

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/device-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index",

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -2,6 +2,10 @@
     "name": "@trezor/schema-utils",
     "version": "10.0.0-beta.1",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/trezor/trezor-suite.git"
+    },
     "license": "MIT",
     "sideEffects": false,
     "main": "src/index.ts",


### PR DESCRIPTION
## Description

Backport of #30591 (develop commit fa0cff0ddd) onto `release/connect/10.0.0-beta.1`.

Ten `publishConfig` packages had no `repository` field, so `repository.url` resolved to `""` at publish time and failed sigstore provenance validation. Adds the `repository` block using the existing `git://github.com/trezor/trezor-suite.git` convention.

## Notes for QA

Release-metadata-only change; no Suite runtime behaviour is affected. Verified via the connect NPM release run.
