### PR TITLE
fix(eslint): enforce layering rules in networks packages

### DIFF
--- a/eslint-local-rules/rules.test.ts
+++ b/eslint-local-rules/rules.test.ts
@@ -204,6 +204,136 @@ ruleTester.run('no-suite-imports-in-suite-common', rules['no-suite-imports-in-su
     ],
 });
 
+ruleTester.run('no-cross-network-imports', rules['no-cross-network-imports'], {
+    valid: [
+        // Importing the shared network module is always allowed
+        {
+            code: "import { foo } from '@trezor/network-module-suite-common-types';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+        },
+        // Importing from the package's own network is allowed
+        {
+            code: "import { foo } from '@trezor/network-cardano-suite-common';",
+            filename: '/repo/networks/cardano/network-cardano/src/file.ts',
+        },
+        // Generic (non-network) @trezor packages are allowed
+        {
+            code: "import { foo } from '@trezor/utils';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+        },
+        // Third-party imports are allowed
+        {
+            code: "import { foo } from '@solana/kit';",
+            filename: '/repo/networks/solana/network-solana/src/file.ts',
+        },
+        // Files outside the networks tree are not restricted
+        {
+            code: "import { foo } from '@trezor/network-cardano-suite-common';",
+            filename: '/repo/suite-common/wallet-core/src/file.ts',
+        },
+        // The shared module importing generic packages is allowed
+        {
+            code: "import { foo } from '@trezor/utils';",
+            filename: '/repo/networks/network-module/network-module-suite-common-types/src/file.ts',
+        },
+        // Relative imports that stay inside the package are allowed
+        {
+            code: "import { foo } from './helper';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+        },
+        {
+            code: "import { foo } from '../constants';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/sub/file.ts',
+        },
+    ],
+    invalid: [
+        // A network importing another network is forbidden
+        {
+            code: "import { foo } from '@trezor/network-cardano-suite-common';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath: '@trezor/network-cardano-suite-common',
+                        ownNetwork: 'bitcoin',
+                    },
+                },
+            ],
+        },
+        // Dynamic import() of another network is forbidden
+        {
+            code: "const load = () => import('@trezor/network-cardano-suite-common');",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+            languageOptions: { ecmaVersion: 2020, sourceType: 'module' },
+            errors: [
+                {
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath: '@trezor/network-cardano-suite-common',
+                        ownNetwork: 'bitcoin',
+                    },
+                },
+            ],
+        },
+        // require() of another network is forbidden
+        {
+            code: "const solana = require('@trezor/network-solana');",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath: '@trezor/network-solana',
+                        ownNetwork: 'bitcoin',
+                    },
+                },
+            ],
+        },
+        // A relative import escaping the package is forbidden (a disguised cross-package/network path)
+        {
+            code: "import { foo } from '../../cardano/network-cardano-suite-common/src/foo';",
+            filename: '/repo/networks/bitcoin/network-bitcoin-suite-common/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotEscapePackage',
+                    data: {
+                        sourcePath: '../../cardano/network-cardano-suite-common/src/foo',
+                    },
+                },
+            ],
+        },
+        // Re-exports across networks are forbidden too
+        {
+            code: "export * from '@trezor/network-solana';",
+            filename: '/repo/networks/ethereum/network-ethereum-suite-common/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath: '@trezor/network-solana',
+                        ownNetwork: 'ethereum',
+                    },
+                },
+            ],
+        },
+        // The shared network module must not import a specific network
+        {
+            code: "import { foo } from '@trezor/network-tron-suite-common';",
+            filename: '/repo/networks/network-module/network-module-suite-common-types/src/file.ts',
+            errors: [
+                {
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath: '@trezor/network-tron-suite-common',
+                        ownNetwork: 'module',
+                    },
+                },
+            ],
+        },
+    ],
+});
+
 const typescriptRuleTester = new RuleTester({
     languageOptions: {
         parser,

--- a/eslint-local-rules/rules.ts
+++ b/eslint-local-rules/rules.ts
@@ -119,6 +119,72 @@ const isSuiteCommonFile = (filename: string) => filename.includes('/suite-common
 const isSuiteOrSuiteNativeImport = (sourcePath: string) =>
     sourcePath.startsWith('@suite/') || sourcePath.startsWith('@suite-native/');
 
+// The shared network module is importable from every network (`networks/network-module/*`).
+const SHARED_NETWORK_KEY = 'module';
+
+// Extracts the network key of a file living under networks/<category>/network-<key>-*.
+// e.g. networks/bitcoin/network-bitcoin-suite-common/src/x.ts -> "bitcoin"
+//      networks/network-module/network-module-suite-common-types/src/x.ts -> "module"
+const getFileNetworkKey = (filename: string): string | null => {
+    const match = filename.match(/(?:^|\/)networks\/[^/]+\/network-([a-z0-9]+)/);
+
+    return match?.[1] ?? null;
+};
+
+// Extracts the network key of an imported @trezor/network-<key>* package, or null when the
+// import does not target a network package. e.g. @trezor/network-cardano-suite-common -> "cardano".
+const getImportNetworkKey = (sourcePath: string): string | null => {
+    const match = sourcePath.match(/^@trezor\/network-([a-z0-9]+)/);
+
+    return match?.[1] ?? null;
+};
+
+// Package root of a networks file: .../networks/<category>/<package>
+const getNetworkPackageRoot = (filename: string): string | null => {
+    const match = filename.match(/^(.*\/networks\/[^/]+\/[^/]+)(?:\/|$)/);
+
+    return match?.[1] ?? null;
+};
+
+const getDirName = (filename: string): string => filename.slice(0, filename.lastIndexOf('/'));
+
+// Resolves a POSIX-style relative import against the importing file's directory, collapsing
+// "." and ".." segments. Path separators are expected to be normalized to "/" beforehand.
+const resolveRelativeImport = (fromDir: string, relativePath: string): string => {
+    const isAbsolute = fromDir.startsWith('/');
+    const resolvedSegments: string[] = [];
+
+    for (const segment of `${fromDir}/${relativePath}`.split('/')) {
+        if (segment === '' || segment === '.') {
+            continue;
+        }
+
+        if (segment === '..') {
+            resolvedSegments.pop();
+        } else {
+            resolvedSegments.push(segment);
+        }
+    }
+
+    return `${isAbsolute ? '/' : ''}${resolvedSegments.join('/')}`;
+};
+
+// Extracts a static string source from a require('...') call expression, or null otherwise.
+const getRequireSourcePath = (node: Rule.Node): string | null => {
+    if (
+        'callee' in node &&
+        node.callee.type === 'Identifier' &&
+        node.callee.name === 'require' &&
+        'arguments' in node &&
+        node.arguments[0]?.type === 'Literal' &&
+        typeof node.arguments[0].value === 'string'
+    ) {
+        return node.arguments[0].value;
+    }
+
+    return null;
+};
+
 export const rules = {
     'no-override-ds-component': {
         meta: {
@@ -316,6 +382,115 @@ export const rules = {
                 ImportDeclaration: checkNode,
                 ExportAllDeclaration: checkNode,
                 ExportNamedDeclaration: checkNode,
+            };
+        },
+    },
+    'no-cross-network-imports': {
+        meta: {
+            type: 'problem',
+            docs: {
+                description:
+                    'Disallows importing one network package from another. A network package may only import the shared network module and packages from its own network.',
+                category: 'Best Practices',
+                recommended: false,
+            },
+            messages: {
+                doNotImportOtherNetwork:
+                    "Importing '{{sourcePath}}' from the '{{ownNetwork}}' network is not allowed. A network package may only import the shared network module (@trezor/network-module-*) and packages from its own network.",
+                doNotEscapePackage:
+                    "Relative import '{{sourcePath}}' escapes the package. Import other packages through their public @trezor/... entry point so cross-package and cross-network boundaries stay enforced.",
+            },
+            schema: [],
+        },
+        create(context) {
+            const filename =
+                'filename' in context && typeof context.filename === 'string'
+                    ? normalizePathSeparators(context.filename)
+                    : null;
+
+            if (filename === null) {
+                return {};
+            }
+
+            const fileNetwork = getFileNetworkKey(filename);
+
+            if (fileNetwork === null) {
+                return {};
+            }
+
+            const packageRoot = getNetworkPackageRoot(filename);
+
+            const checkSource = (node: Rule.Node, sourcePath: string) => {
+                // A relative import that resolves into a *different* network package is a
+                // disguised cross-package/cross-network reference that bypasses the
+                // @trezor/network-* checks below. Escapes into non-network locations (e.g. the
+                // repo-root jest.config.base) are left to other rules.
+                if (sourcePath.startsWith('.')) {
+                    if (packageRoot === null) {
+                        return;
+                    }
+
+                    const resolved = resolveRelativeImport(getDirName(filename), sourcePath);
+
+                    if (resolved === packageRoot || resolved.startsWith(`${packageRoot}/`)) {
+                        return;
+                    }
+
+                    if (getNetworkPackageRoot(resolved) === null) {
+                        return;
+                    }
+
+                    context.report({
+                        node,
+                        messageId: 'doNotEscapePackage',
+                        data: { sourcePath },
+                    });
+
+                    return;
+                }
+
+                const importNetwork = getImportNetworkKey(sourcePath);
+
+                if (
+                    importNetwork === null ||
+                    importNetwork === fileNetwork ||
+                    importNetwork === SHARED_NETWORK_KEY
+                ) {
+                    return;
+                }
+
+                context.report({
+                    node,
+                    messageId: 'doNotImportOtherNetwork',
+                    data: {
+                        sourcePath,
+                        ownNetwork: fileNetwork,
+                    },
+                });
+            };
+
+            // Static import/export declarations and dynamic import() all expose the specifier
+            // through `node.source`; require('...') exposes it through the first argument.
+            const checkDeclaration = (node: Rule.Node) => {
+                const sourcePath = getNodeSourcePath(node);
+
+                if (sourcePath !== null) {
+                    checkSource(node, sourcePath);
+                }
+            };
+
+            return {
+                ImportDeclaration: checkDeclaration,
+                ExportAllDeclaration: checkDeclaration,
+                ExportNamedDeclaration: checkDeclaration,
+                ImportExpression: checkDeclaration,
+                CallExpression: (node: Rule.Node) => {
+                    const sourcePath = getRequireSourcePath(node);
+
+                    if (sourcePath !== null) {
+                        checkSource(node, sourcePath);
+                    }
+                },
             };
         },
     },

--- a/packages/eslint/src/localRulesConfig.mjs
+++ b/packages/eslint/src/localRulesConfig.mjs
@@ -60,6 +60,7 @@ export const localRulesConfig = [
             'suite/**/*.{js,mjs,cjs,ts,jsx,tsx}',
             'suite-native/**/*.{js,mjs,cjs,ts,jsx,tsx}',
             'suite-common/**/*.{js,mjs,cjs,ts,jsx,tsx}',
+            'networks/**/*.{js,mjs,cjs,ts,jsx,tsx}',
         ],
         rules: {
             'local-rules/no-package-deep-imports': [
@@ -85,6 +86,15 @@ export const localRulesConfig = [
         files: ['suite-common/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
         rules: {
             'local-rules/no-suite-imports-in-suite-common': 'error',
+        },
+    },
+    {
+        // A network package may only import the shared network module and its own network's
+        // packages — never another network. (@suite*/@suite-common imports are blocked separately
+        // by the packages-layer no-restricted-imports guard in typescriptConfig.mjs.)
+        files: ['networks/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+        rules: {
+            'local-rules/no-cross-network-imports': 'error',
         },
     },
 ];

--- a/packages/eslint/src/typescriptConfig.mjs
+++ b/packages/eslint/src/typescriptConfig.mjs
@@ -42,9 +42,9 @@ const connectDeepImportPatterns = [
 
 // Deny importing internal suite packages from outside the suite app itself.
 const suiteInternalPatterns = {
-    group: ['@suite-common/**', '@suite-native/**'],
+    group: ['@suite/**', '@suite-common/**', '@suite-native/**'],
     message:
-        '@suite-common/* and @suite-native/* packages are private to the suite apps and must not be imported by other workspace packages.',
+        '@suite/*, @suite-common/* and @suite-native/* packages are private to the suite apps and must not be imported by other workspace packages.',
 };
 
 export const restrictedImportsPatterns = [
@@ -104,8 +104,10 @@ export const typescriptConfig = [
         },
     },
     {
-        // restrict import of suite-common and suite-native packages outside of suite
-        files: ['packages/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+        // restrict import of suite, suite-common and suite-native packages outside of suite.
+        // networks/* packages are @trezor/* (packages layer) and sit below suite-common,
+        // so they are subject to the same restriction.
+        files: ['packages/**/*.{js,mjs,cjs,ts,jsx,tsx}', 'networks/**/*.{js,mjs,cjs,ts,jsx,tsx}'],
         ignores: ['packages/suite*/**/*'],
         rules: {
             '@typescript-eslint/no-restricted-imports': [


### PR DESCRIPTION
## Description

The `networks/*` packages are `@trezor/*` packages (the packages layer): they sit **below** `@suite-common` and are **isolated per network**. None of that layering was enforced — the `networks/` tree was simply missing from the relevant ESLint globs, so several guards silently skipped it. Surfaced by review feedback on the first version of this PR.

### What's enforced now

1. **No deep imports** — `no-package-deep-imports` now lints `networks/**`, so networks source must import package entry points, not deep `src/...` paths.
2. **No imports of the private suite packages** — the existing packages-layer `@typescript-eslint/no-restricted-imports` guard (which already forbade `@suite-common/**` and `@suite-native/**` for `packages/**`) now also covers `networks/**`, and is extended to forbid `@suite/**` too. No non-app workspace package should reach into the suite apps.
3. **No cross-network imports** — a new `no-cross-network-imports` local rule: a `networks/<net>` package may only import the shared network module (`@trezor/network-module-*`) and packages from its own network. The rule covers **static `import`/`export`, dynamic `import()` and `require()`**, and also forbids **relative paths that resolve into a different network package** (so the boundary can't be bypassed with `../`). Generic `@trezor/*` utilities (e.g. `@trezor/utils`) and third-party packages remain importable; relative escapes to non-network locations (e.g. the repo-root `jest.config.base`) are intentionally left to other rules.

### Notes / follow-up

- Verified there are **no current violations** — this only closes the gap for future changes; CI stays green on these rules.
- A stricter "networks may only import a curated allow-list of utility packages" policy would require splitting `packages/` into networks-consumable utils vs. the rest. That is deferred as a separate change.

## Notes for QA

Tooling-only change (ESLint config + one new local rule). No runtime/product impact. Verified locally: 52/52 local-rule unit tests pass; end-to-end lint probes confirm each rule fires (including `import()`, `require()` and relative cross-network paths) while `@trezor/utils`, the shared network module, own-network, third-party and repo-root config imports pass; `tsc` and Prettier are clean.

## Related Issue

N/A — follow-up hardening after the `networks/*` layer was introduced.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/moroni/web/](https://dev.suite.sldev.cz/suite-web/mroz22/moroni/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/moroni&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/moroni&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:52:44.853Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:47:01.972Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are an ESLint local rule and its unit test, which affect static linting rather than runtime application behavior. None of the E2E tests exercise linting rules, and there is no indication these changes impact any user-facing flows or components covered by the suite. Therefore no E2E tests need to run for this change set; rely on the existing unit test in eslint-local-rules/rules.test.ts and any lint job in CI.

<details><summary><b>Changed files (2)</b></summary>

- `eslint-local-rules/rules.test.ts`
- `eslint-local-rules/rules.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `eslint-local-rules/rules.test.ts`
- `eslint-local-rules/rules.ts`

_Updated: 2026-08-03T15:06:44.693Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->