### PR TITLE
feat(e2e): add USDC approval test

### DIFF
--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -39,6 +39,7 @@ export type PopoverProps = {
     onInteraction?: () => void;
     popoverOffset?: number;
     zIndex?: number;
+    'data-testid'?: string;
 };
 
 export function usePopover({
@@ -114,9 +115,10 @@ export const usePopoverContext = () =>
 
 type PopoverTriggerProps = {
     children: React.ReactNode;
+    'data-testid'?: string;
 };
 
-export const PopoverTrigger = ({ children }: PopoverTriggerProps) => {
+export const PopoverTrigger = ({ children, 'data-testid': dataTestId }: PopoverTriggerProps) => {
     const context = usePopoverContext();
     const ref = useMergeRefs([context.refs.setReference]);
 
@@ -124,6 +126,7 @@ export const PopoverTrigger = ({ children }: PopoverTriggerProps) => {
         <div
             ref={ref}
             data-state={context.open ? 'open' : 'closed'}
+            data-testid={dataTestId}
             {...context.getReferenceProps()}
             style={{
                 display: 'flex',
@@ -192,6 +195,7 @@ export const Popover = forwardRef(
             zIndex = zIndices.popover,
             children,
             onOpenChange,
+            'data-testid': dataTestId,
         }: PopoverProps & { children: React.ReactNode },
         ref,
     ) => {
@@ -210,7 +214,7 @@ export const Popover = forwardRef(
 
         return (
             <PopoverContext.Provider value={popover}>
-                <PopoverTrigger>{children}</PopoverTrigger>
+                <PopoverTrigger data-testid={dataTestId}>{children}</PopoverTrigger>
                 <PopoverContent style={{ zIndex }}>{content}</PopoverContent>
             </PopoverContext.Provider>
         );

--- a/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
+++ b/packages/product-components/src/components/PendingTransactionInfo/PendingTransactionInfo.tsx
@@ -42,6 +42,7 @@ export const PendingTransactionInfo = ({
 
                 <Row gap={4} flexWrap="wrap" alignItems="center">
                     <Paragraph
+                        data-testid="@pending-transaction/txid/label"
                         typographyStyle="body-md"
                         intent="neutral"
                         priority="secondary"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/AllowanceModalProviderInfo.tsx
@@ -37,7 +37,7 @@ export const AllowanceModalProviderInfo = ({
                 <Translation id={provider.label} />
             </Text>
             <Column alignItems="flex-end" gap={2}>
-                <Logo>
+                <Logo data-testid="@modal/approve/provider-value">
                     {provider.logo && (
                         <Row alignItems="center" justifyContent="center">
                             {typeof provider.logo === 'string' ? (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -121,7 +121,7 @@ export const ApproveModal = (props: ApproveModalProps) => {
                             <Text typographyStyle="body-sm">
                                 <Translation id="TR_ACCOUNT" />
                             </Text>
-                            <Row gap={8}>
+                            <Row gap={8} data-testid="@modal/approve/account-value">
                                 <NetworkIcon networkSymbol={account.symbol} size={20} />
                                 <AccountLabeling
                                     account={account}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
@@ -96,7 +96,12 @@ export const ApproveModalTypeSelector = ({
     );
 
     const renderOption = (type: SelectableType) => (
-        <CardList.Item key={type} onClick={() => handleSelect(type)} width="100%">
+        <CardList.Item
+            key={type}
+            onClick={() => handleSelect(type)}
+            width="100%"
+            data-testid={`@modal/approve/${type.toLowerCase()}-option`}
+        >
             <Column gap={4} flex="1" alignItems="flex-start">
                 <Row gap={8}>
                     <TokenIcon
@@ -133,7 +138,10 @@ export const ApproveModalTypeSelector = ({
                             size={20}
                             placeholder={displaySymbol}
                         />
-                        <Text typographyStyle="body-sm-strong">
+                        <Text
+                            typographyStyle="body-sm-strong"
+                            data-testid="@modal/approve/limit-value"
+                        >
                             <Translation
                                 id={TYPE_LABEL_ID[selectedType]}
                                 values={translationValues}
@@ -154,6 +162,7 @@ export const ApproveModalTypeSelector = ({
     return (
         <Popover
             ref={popoverRef}
+            data-testid="@modal/approve/limit-selector"
             placement={{ position: 'bottom', alignment: 'end' }}
             zIndex={zIndices.modal + 1}
             popoverOffset={-60}

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/MaximumFee.tsx
@@ -19,12 +19,7 @@ export function MaximumFee({ typographyStyle, txMaxFee }: MaximumFeeProps) {
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
 
     return (
-        <LoadingContent
-            size={20}
-            isLoading={areFeesLoading}
-            data-testid="@trading/quote/maximum-fee-amount-loading"
-            slideContent={false}
-        >
+        <LoadingContent size={20} isLoading={areFeesLoading} slideContent={false}>
             {txMaxFee ? (
                 <Column alignItems="flex-end">
                     <Text intent="neutral" typographyStyle={typographyStyle}>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -275,6 +275,7 @@ export const TradingFormApproval = () => {
                         </>
                     ) : (
                         <Button
+                            data-testid="@trading/form/approve-button"
                             onClick={() => handleApproveClick(onApproveTransactionClick)}
                             intent="brand"
                             size="large"
@@ -324,7 +325,13 @@ export const TradingFormApproval = () => {
             )}
 
             {approvalStep === 'LOADING' && (
-                <Button intent="brand" size="large" width="100%" isDisabled={true}>
+                <Button
+                    data-testid="@trading/form/swap-button"
+                    intent="brand"
+                    size="large"
+                    width="100%"
+                    isDisabled={true}
+                >
                     <Translation id="TR_TRADING_SWAP" />
                 </Button>
             )}
@@ -361,6 +368,7 @@ export const TradingFormApproval = () => {
                                 value={tx.approvalTxid}
                                 intent="brand"
                                 typographyStyle="body-md"
+                                data-testid="@pending-transaction/txid/value"
                             />
                         ) : (
                             <Translation id="TR_UNKNOWN" />

--- a/suite/e2e/support/fixtures.ts
+++ b/suite/e2e/support/fixtures.ts
@@ -23,6 +23,7 @@ import { PaginationControl } from './pageObjects/pagination';
 import { RecoveryModal } from './pageObjects/recoveryModal';
 import { SettingsPage } from './pageObjects/settings/settingsPage';
 import { StakingSection } from './pageObjects/staking/stakingSection';
+import { ToastSection } from './pageObjects/toastSection';
 import { FeeSection } from './pageObjects/trading/feeSection';
 import { TradingPage } from './pageObjects/trading/tradingPage';
 import { TrezorInput } from './pageObjects/trezorInput';
@@ -68,6 +69,7 @@ type Fixtures = {
     yieldMock: YieldMock;
     txSimulationModal: TxSimulationModal;
     paginationControl: PaginationControl;
+    toastSection: ToastSection;
     evoluClient: EvoluClient;
 };
 
@@ -178,6 +180,9 @@ const test = suiteBaseTest.extend<Fixtures>({
     },
     paginationControl: async ({ page }, use) => {
         await use(new PaginationControl(page));
+    },
+    toastSection: async ({ page }, use) => {
+        await use(new ToastSection(page));
     },
     evoluClient: async ({}, use) => {
         await checkEvoluRelayServerRunning();

--- a/suite/e2e/support/mocks/trading/tradingChainBackend.ts
+++ b/suite/e2e/support/mocks/trading/tradingChainBackend.ts
@@ -20,6 +20,8 @@ import {
 export interface TradingChainBackend {
     readonly backendType: BackendType;
     readonly url: string;
+    /** Txid of the broadcast answered locally by blockBroadcast(), once it has happened. */
+    lastBroadcastTxid: string | undefined;
     start(): Promise<void>;
     stop(): Promise<void>;
     blockBroadcast(): void;
@@ -46,7 +48,7 @@ const extractTxSignature = (base64Tx: string) =>
 class SolanaTradingBackend implements TradingChainBackend {
     readonly backendType: BackendType = 'solana';
     private readonly server = new SolanaRpcServerMock(SOL_UPSTREAM_URL);
-    private readonly blockedSignatures: string[] = [];
+    lastBroadcastTxid: string | undefined;
 
     get url() {
         return this.server.url;
@@ -54,14 +56,14 @@ class SolanaTradingBackend implements TradingChainBackend {
 
     blockBroadcast() {
         this.server.setHandler('sendTransaction', ([base64Tx]) => {
-            this.blockedSignatures.push(extractTxSignature(String(base64Tx ?? '')));
+            this.lastBroadcastTxid = extractTxSignature(String(base64Tx ?? ''));
 
             return sendTransactionResponse('0').result;
         });
 
         // Fake confirmation only for the blocked sends; other signature queries stay live.
         this.server.setHandler('getSignatureStatuses', ([signatures]) =>
-            (signatures as string[])?.some(signature => this.blockedSignatures.includes(signature))
+            (signatures as string[])?.some(signature => this.lastBroadcastTxid === signature)
                 ? getSignatureStatusesResponse('0').result
                 : PASSTHROUGH,
         );
@@ -81,6 +83,7 @@ class SolanaTradingBackend implements TradingChainBackend {
 class BlockbookTradingBackend implements TradingChainBackend {
     readonly backendType: BackendType = 'blockbook';
     private readonly proxy: BlockbookProxyMock;
+    lastBroadcastTxid: string | undefined;
 
     constructor(
         upstreamUrl: string,
@@ -96,8 +99,10 @@ class BlockbookTradingBackend implements TradingChainBackend {
     blockBroadcast() {
         this.proxy.setHandler('sendTransaction', params => {
             const { hex } = params as { hex: string };
+            const txid = this.deriveTxid(hex);
+            this.lastBroadcastTxid = txid;
 
-            return { result: this.deriveTxid(hex) };
+            return { result: txid };
         });
     }
 

--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -97,6 +97,16 @@ export class TradingMockNew {
         });
     }
 
+    // Txid of the broadcast blocked by the backend (source of truth for post-send assertions).
+    get lastBroadcastTxid(): string {
+        const txid = this.backend?.lastBroadcastTxid;
+        if (!txid) {
+            throw new Error('Backend has not recorded a broadcast yet (is startBackend set up?)');
+        }
+
+        return txid;
+    }
+
     @step()
     async mockProviderStatusPage() {
         if (this.tradeFlow !== 'swap') {

--- a/suite/e2e/support/pageObjects/toastSection.ts
+++ b/suite/e2e/support/pageObjects/toastSection.ts
@@ -1,0 +1,13 @@
+import { type Locator, type Page } from '@playwright/test';
+
+export class ToastSection {
+    readonly approved: Locator;
+    readonly approvedAmount: Locator;
+    readonly yieldDeposit: Locator;
+
+    constructor(private readonly page: Page) {
+        this.approved = this.page.getByTestId('@toast/tx-approved');
+        this.approvedAmount = this.page.getByTestId('@toast/tx-approved/amount');
+        this.yieldDeposit = this.page.getByTestId('@toast/tx-yield-deposit');
+    }
+}

--- a/suite/e2e/support/pageObjects/trading/approvalModal.ts
+++ b/suite/e2e/support/pageObjects/trading/approvalModal.ts
@@ -1,0 +1,42 @@
+import { Locator, Page } from '@playwright/test';
+
+import { step } from '../../common';
+import { expect } from '../../testExtends/customMatchers';
+
+export type ApprovalLimitType = 'minimal' | 'infinite';
+
+export class TradingApprovalModal {
+    readonly modal: Locator;
+    readonly heading: Locator;
+    readonly continueButton: Locator;
+    readonly accountValue: Locator;
+    readonly providerValue: Locator;
+    readonly limitSelector: Locator;
+    readonly limitValue: Locator;
+    // The limit dropdown renders in a portal outside the modal, so it is page-scoped.
+    readonly limitOption = (type: ApprovalLimitType) =>
+        this.page.getByTestId(`@modal/approve/${type}-option`);
+    readonly feeAmountWithSymbol: Locator;
+
+    constructor(private readonly page: Page) {
+        this.modal = this.page.getByTestId('@modal');
+        this.heading = this.modal.getByTestId('@modal/header');
+        this.continueButton = this.modal.getByTestId('@modal/approve/continue-button');
+        this.accountValue = this.modal.getByTestId('@modal/approve/account-value');
+        this.providerValue = this.modal.getByTestId('@modal/approve/provider-value');
+        this.limitSelector = this.modal.getByTestId('@modal/approve/limit-selector');
+        this.limitValue = this.modal.getByTestId('@modal/approve/limit-value');
+        this.feeAmountWithSymbol = this.modal.getByTestId(
+            '@trading/quote/maximum-fee-amount-with-symbol',
+        );
+    }
+
+    @step()
+    async selectLimit(type: ApprovalLimitType) {
+        await expect(this.feeAmountWithSymbol).toBeVisible();
+        await this.limitSelector.click();
+        await this.limitOption(type).click();
+        await expect(this.feeAmountWithSymbol).toBeHidden();
+        await expect(this.feeAmountWithSymbol).toBeVisible();
+    }
+}

--- a/suite/e2e/support/pageObjects/trading/feeSection.ts
+++ b/suite/e2e/support/pageObjects/trading/feeSection.ts
@@ -17,7 +17,6 @@ export class FeeSection {
     readonly rateOnCard = (feeType: FeeTypes) => this.page.getByTestId(`@fee-card/${feeType}-rate`);
     readonly collapsibleFeesToggle: Locator;
     readonly collapsibleFees: Locator;
-    readonly maxFeeLoading: Locator;
     readonly customInput: Locator;
     readonly maxFee: Locator;
     readonly maxFeeWithSymbol: Locator;
@@ -33,7 +32,6 @@ export class FeeSection {
     constructor(private readonly page: Page) {
         this.collapsibleFeesToggle = this.page.getByTestId('@wallet/fees/collapsible-fees-toggle');
         this.collapsibleFees = this.page.getByTestId('@wallet/fees/collapsible-fees');
-        this.maxFeeLoading = this.page.getByTestId('@trading/quote/maximum-fee-amount-loading');
         this.customInput = this.page.getByTestId('feePerUnit');
         this.maxFee = this.page.getByTestId('@trading/quote/maximum-fee-amount');
         this.maxFeeWithSymbol = this.page.getByTestId(
@@ -59,8 +57,7 @@ export class FeeSection {
             return;
         }
 
-        // Wait for maximum fee to be calculated
-        await this.maxFeeLoading.waitFor({ state: 'hidden', timeout: 5000 });
+        await expect(this.maximumFeeAmountToBeCalculated).toBeHidden();
 
         const isDisabled = await this.collapsibleFeesToggle.getAttribute('aria-disabled');
 

--- a/suite/e2e/support/pageObjects/trading/tradingPage.ts
+++ b/suite/e2e/support/pageObjects/trading/tradingPage.ts
@@ -4,6 +4,7 @@ import { messages } from '@suite/intl';
 import type { TradingCountryCode } from '@suite-common/trading';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
+import { TradingApprovalModal } from './approvalModal';
 import { TradingAssetPicker } from './assetsModal';
 import { TradingConfirmationModal } from './confirmationModal';
 import { TradingTransactionsSection } from './transactionsSection';
@@ -24,6 +25,7 @@ export class TradingPage {
     readonly receiveAccount: TradingReceiveAccount;
     readonly quotes: TradingQuotesSection;
     readonly confirmation: TradingConfirmationModal;
+    readonly approvalModal: TradingApprovalModal;
     readonly inputs: TradingFormInputs;
     readonly transactionDetailSidebar: TransactionDetailSidebar;
 
@@ -36,6 +38,11 @@ export class TradingPage {
     readonly swapBestOfferButton: Locator;
     readonly kycWarning: Locator;
     readonly proceedToPayButton: Locator;
+    readonly approveSpendingButton: Locator;
+    readonly pendingApprovalTransactionLabel: Locator;
+    readonly pendingApprovalTransactionIdLabel: Locator;
+    readonly pendingApprovalTransactionId: Locator;
+    readonly swapButton: Locator;
     readonly backToAccountButton = (type: 'Buy' | 'Sell' | 'Swap') =>
         this.page.getByRole('button', { name: `Make another ${type}` });
 
@@ -51,6 +58,7 @@ export class TradingPage {
     readonly transactionDetailStatus: Locator;
     readonly transactionDetailHeader: Locator;
     readonly transactionDetail: Locator;
+    readonly transactionDetailTxid: Locator;
     readonly transactions: TradingTransactionsSection;
 
     // Swap toast notifications
@@ -67,6 +75,7 @@ export class TradingPage {
         this.receiveAccount = new TradingReceiveAccount(page);
         this.quotes = new TradingQuotesSection(page);
         this.confirmation = new TradingConfirmationModal(page, devicePrompt);
+        this.approvalModal = new TradingApprovalModal(page);
         this.inputs = new TradingFormInputs(page);
         this.transactionDetailSidebar = new TransactionDetailSidebar(page);
 
@@ -78,6 +87,15 @@ export class TradingPage {
         this.swapBestOfferButton = this.page.getByTestId('@trading/form/exchange-button');
         this.kycWarning = this.page.getByTestId('@trading/form/kyc-warning');
         this.proceedToPayButton = this.page.getByRole('button', { name: 'Proceed to pay' });
+        this.approveSpendingButton = this.page.getByTestId('@trading/form/approve-button');
+        this.pendingApprovalTransactionLabel = this.page.getByTestId('@pending-transaction/title');
+        this.pendingApprovalTransactionIdLabel = this.page.getByTestId(
+            '@pending-transaction/txid/label',
+        );
+        this.pendingApprovalTransactionId = this.page.getByTestId(
+            '@pending-transaction/txid/value',
+        );
+        this.swapButton = this.page.getByTestId('@trading/form/swap-button');
 
         // Swap
         this.sendAddressInput = this.page.getByTestId('outputs.0.address');
@@ -90,6 +108,7 @@ export class TradingPage {
         this.transactionDetailStatus = this.page.getByTestId('@trading/transaction/detail/status');
         this.transactionDetailHeader = this.page.getByTestId('@trading/transaction/detail/header');
         this.transactionDetail = this.page.getByTestId('@trading/transaction/detail');
+        this.transactionDetailTxid = this.page.getByTestId('@tx-detail/txid-value');
         this.transactions = new TradingTransactionsSection(page);
 
         // Swap toast notifications

--- a/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
+++ b/suite/e2e/support/pageObjects/yield/yieldFlowSection.ts
@@ -8,11 +8,8 @@ export class YieldFlowSection {
     // Continue button of the shared allowance approve modal opened by the approve step
     readonly approveModalContinueButton: Locator;
     readonly pendingTransactionLabel: Locator;
-    readonly approvedToast: Locator;
-    readonly approvedToastAmount: Locator;
     // Deposit step
     readonly depositButton: Locator;
-    readonly depositedToast: Locator;
     // Flow-complete screen
     readonly flowCompleteHeading: Locator;
     readonly flowCompleteStatus: Locator;
@@ -26,10 +23,7 @@ export class YieldFlowSection {
         this.approveButton = this.page.getByTestId('@yield/form/approve-button');
         this.approveModalContinueButton = this.page.getByTestId('@modal/approve/continue-button');
         this.pendingTransactionLabel = this.page.getByTestId('@pending-transaction/title');
-        this.approvedToast = this.page.getByTestId('@toast/tx-approved');
-        this.approvedToastAmount = this.page.getByTestId('@toast/tx-approved/amount');
         this.depositButton = this.page.getByTestId('@yield/form/deposit-button');
-        this.depositedToast = this.page.getByTestId('@toast/tx-yield-deposit');
         this.flowCompleteHeading = this.page.getByTestId('@yield/flow-complete/heading');
         this.flowCompleteStatus = this.page.getByTestId('@yield/flow-complete/status');
         this.flowCompleteApy = this.page.getByTestId('@earn/dashboard/apy-percentage');

--- a/suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts
@@ -1,0 +1,200 @@
+import { getCompanyNameFromList } from '../../fixtures/trading';
+import { countDecimalPlaces } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+
+const approvalAmount = '10';
+const accountLabel = 'Ethereum #2';
+const dexProvider = getCompanyNameFromList('lifi', 'swapList');
+const providerName = 'LiFI Diamond';
+const positiveEthereumAmountPattern = /^(?!0+(?:\.0+)?\s*ETH$)\d+(?:\.\d+)?\s*ETH$/;
+
+test.describe('Trading - DEX swap approval (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
+    test.use({
+        deviceSetup: {
+            mnemonic: 'mnemonic_academic',
+            passphrase_protection: true,
+        },
+    });
+
+    test.beforeEach(
+        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            const ethBackend = await tradingMockNew.startBackend('eth');
+
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'eth', backend: ethBackend }],
+            });
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'eth', atIndex: 1 });
+        },
+    );
+
+    test('User can approve USDC spending for a LI.FI DEX swap', async ({
+        tradingPage,
+        devicePrompt,
+        device,
+        tradingMockNew,
+        toastSection,
+    }) => {
+        await test.step('Select USDC to ETH LI.FI DEX offer', async () => {
+            await tradingPage.fillSwapForm({
+                amount: approvalAmount,
+                sellAsset: {
+                    networkSymbol: 'eth',
+                    tokenSymbol: 'USDC',
+                    searchFilter: 'USDC',
+                    networkFilter: 'eth',
+                    accountIndex: 1,
+                },
+                buyAsset: {
+                    networkSymbol: 'eth',
+                },
+                selectReceiveAddress: async () => {
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(1, 'eth');
+                },
+            });
+            await tradingPage.quotes.chooseDifferentOfferIfAvailable(dexProvider);
+            await expect(tradingPage.approveSpendingButton).toHaveTranslation(
+                'TR_EXCHANGE_APPROVAL_FORM_APPROVE_BUTTON',
+            );
+            await tradingPage.quotes.waitForSync();
+        });
+
+        let approvalModalMaximumFee: string;
+
+        await test.step('Review the approval modal details', async () => {
+            await tradingPage.approveSpendingButton.click();
+            await expect(tradingPage.approvalModal.heading).toHaveTranslation(
+                'TR_APPROVAL_APPROVE_TOKEN_SPENDING',
+                { values: { displaySymbol: 'USDC' } },
+            );
+
+            await expect(tradingPage.approvalModal.accountValue).toHaveText(accountLabel);
+            await expect(tradingPage.approvalModal.providerValue).toHaveText(dexProvider);
+            await expect(tradingPage.approvalModal.limitValue).toHaveTranslation(
+                'TR_APPROVAL_VALUE_MINIMAL',
+                { values: { value: approvalAmount, send: 'USDC' } },
+            );
+        });
+
+        await test.step('Toggle approval limit between infinite and minimal', async () => {
+            await tradingPage.approvalModal.selectLimit('infinite');
+            await expect(tradingPage.approvalModal.limitValue).toHaveTranslation(
+                'TR_APPROVAL_VALUE_INFINITE',
+            );
+
+            await tradingPage.approvalModal.selectLimit('minimal');
+            await expect(tradingPage.approvalModal.limitValue).toHaveTranslation(
+                'TR_APPROVAL_VALUE_MINIMAL',
+                { values: { value: approvalAmount, send: 'USDC' } },
+            );
+        });
+
+        await test.step('Read the maximum fee and continue to the device', async () => {
+            await expect(tradingPage.approvalModal.feeAmountWithSymbol).toHaveText(
+                positiveEthereumAmountPattern,
+            );
+            approvalModalMaximumFee =
+                await tradingPage.approvalModal.feeAmountWithSymbol.innerText();
+
+            await tradingPage.approvalModal.continueButton.click();
+        });
+
+        await test.step('Review the token approval details on device', async () => {
+            await devicePrompt.confirmOnDevicePromptIsShown();
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [['Review details to', '\n', 'approve token', '\n', 'spending.']],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await devicePrompt.waitForPromptAndClick();
+
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [[providerName]],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Approve to' },
+                },
+            });
+            await device.pressYes();
+
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [
+                        ['Amount allowance'],
+                        [`${approvalAmount} USDC`],
+                        ['Chain'],
+                        ['Ethereum'],
+                    ],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Approve' },
+                },
+            });
+            await device.pressYes();
+        });
+
+        await test.step('Verify the device fee matches the modal and sign', async () => {
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(
+                positiveEthereumAmountPattern,
+            );
+            const dexMaximumFee = await devicePrompt.cryptoAmountWithSymbolOf('fee').innerText();
+
+            // Device prompt keeps full fee precision; the approval modal rounds to display.
+            expect(approvalModalMaximumFee).toMatch(/ ETH$/);
+            const approvalModalFeeAmount = approvalModalMaximumFee.replace(/ ETH$/, '');
+            const modalFeeDecimals = countDecimalPlaces(approvalModalFeeAmount);
+            const dexFeeRounded = Number.parseFloat(dexMaximumFee).toFixed(modalFeeDecimals);
+
+            expect(dexFeeRounded).toBe(approvalModalFeeAmount);
+
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Token approval' },
+                    body: [['Maximum fee'], device.wrapText(dexMaximumFee, { isAmount: true })],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+        });
+
+        await test.step('Submit the USDC approval with broadcast blocked by mock', async () => {
+            await devicePrompt.sendButton.click();
+            await expect(toastSection.approved).toBeVisible();
+            await expect(toastSection.approvedAmount).toHaveText(`${approvalAmount}USDC`);
+            await expect(tradingPage.pendingApprovalTransactionLabel).toHaveTranslation(
+                'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL',
+            );
+            await expect(tradingPage.pendingApprovalTransactionIdLabel).toHaveTranslation(
+                'TR_EXCHANGE_APPROVAL_FORM_TRANSACTION_ID',
+            );
+            // While the approval is confirming, the swap button replaces the approve button and is disabled.
+            await expect(tradingPage.swapButton).toBeDisabled();
+
+            // Pending TXID keeps the full value in its id attribute (text is truncated).
+            await expect(tradingPage.pendingApprovalTransactionId).toHaveAttribute(
+                'id',
+                tradingMockNew.lastBroadcastTxid,
+            );
+            await tradingPage.pendingApprovalTransactionId.click();
+            await expect(tradingPage.approvalModal.heading).toHaveTranslation(
+                'TR_TRANSACTION_DETAILS',
+            );
+            await expect(tradingPage.transactionDetailTxid).toHaveText(
+                tradingMockNew.lastBroadcastTxid,
+            );
+        });
+    });
+});

--- a/suite/e2e/tests/wallet/send-eth.test.ts
+++ b/suite/e2e/tests/wallet/send-eth.test.ts
@@ -40,7 +40,8 @@ test.describe('Send Eth', { tag: ['@T3W1', '@T3T1'] }, () => {
             await walletPage.openSendFormButton.click();
             // Race condition 1:5, if input is filled before form completely loads then
             // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
-            await tradingPage.fees.expectEthereumFeeCalculated();
+            // Seems to be resolved as fees do not load until form is filled
+            //await tradingPage.fees.expectEthereumFeeCalculated();
             await tradingPage.sendAddressInput.fill(sendAddress);
             await tradingPage.sendAmountInput.fill(sendAmount);
             await tradingPage.fees.setEthereumCustomFees({

--- a/suite/e2e/tests/yield/deposit.test.ts
+++ b/suite/e2e/tests/yield/deposit.test.ts
@@ -39,6 +39,7 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
         device,
         blockbookMock,
         yieldMock,
+        toastSection,
     }) => {
         await test.step('Check yield dashboard', async () => {
             await yieldSection.earnMenuButton.click();
@@ -161,8 +162,8 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
             });
             blockbookMock.updateAllowance('10000000'); // 10 USDC
             await devicePrompt.sendButton.click();
-            await expect(yieldFlowSection.approvedToast).toBeVisible();
-            await expect(yieldFlowSection.approvedToastAmount).toHaveText('10USDC');
+            await expect(toastSection.approved).toBeVisible();
+            await expect(toastSection.approvedAmount).toHaveText('10USDC');
             await expect(yieldFlowSection.pendingTransactionLabel).toHaveTranslation(
                 'TR_EXCHANGE_APPROVAL_FORM_CONFIRMING_APPROVAL',
             );
@@ -219,7 +220,7 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
             });
             await devicePrompt.waitForFinalPromptAndConfirm();
             await devicePrompt.sendButton.click();
-            await expect(yieldFlowSection.depositedToast).toBeVisible();
+            await expect(toastSection.yieldDeposit).toBeVisible();
             await expect(yieldFlowSection.flowCompleteHeading).toHaveTranslation(
                 'TR_EARN_YIELD_DEPOSIT_COMPLETE',
             );


### PR DESCRIPTION

## Description
Adds a new e2e test covering the full USDC approval flow for a LI.FI DEX swap (approve → sign on device → pending state → tx detail).
Toast locators were moved out of the yield flow section into a shared ToastSection page object, now used by both the trading and yield tests.

## Test coverage 
- **Offer selection**: USDC → ETH swap with the LI.FI offer; verifies the "Approve spending" CTA.
- **Approval modal**: asserts account, provider, and limit values; toggles infinite/minimal limit.
- **Fee consistency**: cross-checks the modal's max fee against the device prompt fee.
- **Device flow**: steps through token-approval screens (T3W1/T3T1) up to "Hold to sign".
- **Post-send state**: verifies approval toast, pending-tx info with txid, disabled swap button, and tx-detail modal.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/dex-approval-test/web/](https://dev.suite.sldev.cz/suite-web/dex-approval-test/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=dex-approval-test&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=dex-approval-test&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:29:15.009Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:28:47.085Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->