### PR TITLE
feat(suite-desktop): display correct asset in the summary

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -30,6 +30,7 @@ export const YieldDepositForm = () => {
         apy,
         completedAmount,
         completedReceiptAmount,
+        wrappedAmount,
         maxAmount,
         liveAmount,
         errorMessage,
@@ -355,7 +356,17 @@ export const YieldDepositForm = () => {
                                         vault={vault}
                                         networkSymbol={account.symbol}
                                         input={{
-                                            token,
+                                            // When the deposit wrapped native → wrapped token, show
+                                            // the original native asset (ETH) the user started with;
+                                            // a deposit of already-held WETH keeps the token symbol.
+                                            token:
+                                                wrappedAmount !== null
+                                                    ? {
+                                                          networkSymbol: account.symbol,
+                                                          symbol: nativeSymbol,
+                                                          decimals: token.decimals,
+                                                      }
+                                                    : token,
                                             amount: completedAmount,
                                         }}
                                         output={{

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -81,6 +81,7 @@ export type UseYieldFlowResult = {
     completedAmount: string;
     completedReceiptAmount: string;
     unwrappedAmount: string | null;
+    wrappedAmount: string | null;
     errorMessage: TranslationKey | undefined;
     approveModalState: YieldApproveModalState | null;
     pendingTransaction: YieldPendingTransactionState | null;
@@ -795,6 +796,7 @@ export const useYieldFlow = ({
         completedAmount: session.result.completedAmount,
         completedReceiptAmount: session.result.completedReceiptAmount,
         unwrappedAmount: session.result.unwrappedAmount,
+        wrappedAmount: session.result.wrappedAmount,
         errorMessage: session.error ?? undefined,
         approveModalState: session.approval.modalState,
         pendingTransaction: session.action.pendingTransaction,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -102,6 +102,7 @@ export type StablecoinYieldSessionState = {
         completedReceiptAmount: string;
         completedRewards: YieldFlowCompleteRewardItem[];
         unwrappedAmount: string | null;
+        wrappedAmount: string | null;
     };
 };
 
@@ -144,6 +145,7 @@ export const initialStablecoinYieldSessionState: StablecoinYieldSessionState = {
         completedReceiptAmount: '0',
         completedRewards: [],
         unwrappedAmount: null,
+        wrappedAmount: null,
     },
 };
 
@@ -444,6 +446,9 @@ const stablecoinYieldSlice = createSlice({
 
                 if (action.payload.step === 'wrap' && action.payload.amount) {
                     session.action.amount = action.payload.amount;
+                    // Record that a wrap happened so the completed deposit can be shown in the
+                    // native asset (the user's original asset), mirroring `unwrappedAmount`.
+                    session.result.wrappedAmount = action.payload.amount;
                 }
                 session.step = getNextYieldFlowStep(
                     action.payload.flowType,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Simple change to see if asset was wrapped and then display the original asset of tx (ETH in this case)

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

It's easy to reproduce from the earn flow

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30544

## Screenshots:

| Wrap step | Wrap result | Weth result |
|--------|--------|--------|
| <img width="1074" height="795" alt="Screenshot 2026-07-30 at 16 09 07" src="https://github.com/user-attachments/assets/fd200321-61cb-499f-bd1c-138140cc8f21" /> | <img width="1278" height="557" alt="Screenshot 2026-07-30 at 16 10 52" src="https://github.com/user-attachments/assets/9ca40c18-bfef-4550-a456-5734e9603add" /> | <img width="1083" height="555" alt="Screenshot 2026-07-30 at 16 12 58" src="https://github.com/user-attachments/assets/a80979d2-90ac-4d39-8e9d-86561c393ec7" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to the stablecoin yield deposit UI and state. No E2E test functionally exercises the yield deposit flow; only the broad route health check touches /earn/yield/deposit. Run check-links to catch rendering or routing regressions on that page, and accept that deposit-specific logic has no E2E coverage in this set.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to /earn/yield/deposit as part of its route coverage and verifies the page content attaches and the bundle loader hides. A rendering crash or routing regression in YieldDepositForm would likely fail this smoke check, even though it does not exercise deposit business logic.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

_Updated: 2026-07-30T14:18:40.201Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/display-depositable-balance/web/](https://dev.suite.sldev.cz/suite-web/fix/display-depositable-balance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/display-depositable-balance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/display-depositable-balance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/display-depositable-balance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T14:21:19.008Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T14:20:27.029Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->