### PR TITLE
fix(graph): jump exactly one year back in balance-history fallback

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -428,7 +428,7 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
         // use 1 year into past and return zeroes for the range
         if (startOfTimeFrameDate.getTime() === endOfTimeFrameDate.getTime()) {
             const startDate = startOfTimeFrameDate;
-            startDate.setDate(startDate.getHours() - 8760);
+            startDate.setHours(startDate.getHours() - 8760);
 
             return [
                 ...getTimestampsInTimeFrame(startDate, endOfTimeFrameDate, numberOfPoints - 1),


### PR DESCRIPTION
## Description

The balance-history fallback graph (used when an account has no transactions) was jumping approximately 24 years into the past instead of 1 year, resulting in incorrect or empty balance graph data for new/inactive accounts in suite-native.

### Root cause

The "no transactions" fallback in [`getMultipleAccountBalanceHistoryWithFiat`](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/graph/src/graphDataFetching.ts#L345) uses `setDate()` to jump back in time. However, [line 431 on develop](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/graph/src/graphDataFetching.ts#L431) mistakenly calls `setDate(startDate.getHours() - 8760)`, which sets the day-of-month to a value between 0–23 (the current hour), not subtracting 8760 hours. This jumps the date back approximately 24 years instead of the intended 1 year (8760 hours).

The fallback triggers [at line 434](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/graph/src/graphDataFetching.ts#L434) when `startOfTimeFrameDate.getTime() === endOfTimeFrameDate.getTime()`, indicating no balance movements were found for any account.

### Fix

Changed [line 431](https://github.com/trezor/trezor-suite/blob/f8c911cc2b052236ce3a60feb5783506b418f6f6/suite-common/graph/src/graphDataFetching.ts#L431) from `setDate()` to [`setHours()`](https://github.com/trezor/trezor-suite/blob/f8c911cc2b052236ce3a60feb5783506b418f6f6/suite-common/graph/src/graphDataFetching.ts#L431), correctly subtracting 8760 hours from the current time to achieve a 1-year lookback.

### Impact

**Reachable in suite-native only** — the graph module is used exclusively in the suite-native (mobile) codebase. The bug affects any user viewing the balance history graph for an account with zero transactions (typically new or never-used accounts). The graph would display incorrect timestamps or become empty. After the fix, affected accounts correctly display a 1-year balance history populated with zero values.

### Test

No test changes in this commit. Manual verification: create or recover an account with no transaction history, then view the balance-history graph and confirm it displays a 1-year timeframe with zero balances (before the fix, the graph would be empty or malformed due to the date jumping ~24 years into the past).

## Notes for QA

**Manual reproduction (develop branch, pre-fix):**
1. In suite-native, create a new account or recover an account known to have no transactions.
2. Navigate to the account's balance-history graph (typically the "Charts" or "Portfolio" view).
3. Observe: the graph is empty, missing data, or displays an unexpected time range (dating to ~2002–2003 instead of 1 year ago).

**After fix:**
- The same account displays a 1-year balance history with zero-value points at regular intervals.

**Note:** This bug cannot be reproduced on live testnet/mainnet if the account receives its first transaction during testing. The condition only triggers when `startOfTimeFrameDate === endOfTimeFrameDate`, which happens before any balance movements are recorded.

---

Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735. Sibling: #30604 (makes this fallback branch actually reachable; the two together fix the empty-account graph).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite-common/graph/src/graphDataFetching.ts affects how portfolio and account graph data is fetched. Because no static coverage mapping exists, I inferred coverage from the LLM test descriptions. The highest-confidence tests are wallet/transactions.test.ts (time-range graph filters) and wallet/blockbook-discovery.test.ts (portfolio graph with custom backends). dashboard/discreet-mode.test.ts provides medium-confidence coverage of the dashboard graph value pipeline. No changed files are completely uncovered once inferred tests are considered.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/graph/src/graphDataFetching.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test asserts that the portfolio graph becomes visible after discovery completes with custom Blockbook backends for BTC and LTC. Custom backend configuration changes the data source and fetching path for graph data, so a regression in graphDataFetching.ts would be directly observable here. (Inferred from LLM analysis; no static mapping was available.)
- `suite/e2e/tests/wallet/transactions.test.ts` — This test exercises the account transaction overview graph's time range filters (day/week/month/year/all). Those filters control the parameters passed to the graph data fetching logic, making this the most likely E2E test to catch a regression in graphDataFetching.ts. (Inferred from LLM analysis; no static mapping was available.)

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test verifies portfolio and wallet fiat values on the dashboard are hidden/revealed in discreet mode. While its primary focus is UI masking, the values are rendered from the same dashboard portfolio/graph data pipeline and would fail to display correctly if graph fetching broke. (Inferred from LLM analysis; no static mapping was available.)

</details>

_Updated: 2026-07-30T15:45:46.259Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/graph-balance-history-one-year-fallback/web/](https://dev.suite.sldev.cz/suite-web/mroz22/graph-balance-history-one-year-fallback/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/graph-balance-history-one-year-fallback&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/graph-balance-history-one-year-fallback&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/graph-balance-history-one-year-fallback&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:48:19.967Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:47:57.388Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
