### PR TITLE
fix(graph): guard empty balance movements in show-all-data path

### DIFF
--- a/suite-common/graph/src/graphDataFetching.ts
+++ b/suite-common/graph/src/graphDataFetching.ts
@@ -417,11 +417,16 @@ export const getMultipleAccountBalanceHistoryWithFiat = async ({
     if (!startOfTimeFrameDate) {
         // if startOfTimeFrameDate is not provided, it means we want to show all available data
         // so we need to find the oldest date balance movement in all accounts
-        startOfTimeFrameDate = pipe(
+        const oldestBalanceMovementTimestamp = findOldestBalanceMovementTimestamp(
             accountsWithBalanceHistoryFlattened,
-            findOldestBalanceMovementTimestamp,
-            fromUnixTime,
         );
+
+        // findOldestBalanceMovementTimestamp returns Infinity when there are no balance movements
+        // at all (Math.min of an empty list). Anchor the range to the end of the time frame so the
+        // no-movements branch below fires with a valid start date instead of an Invalid Date.
+        startOfTimeFrameDate = Number.isFinite(oldestBalanceMovementTimestamp)
+            ? fromUnixTime(oldestBalanceMovementTimestamp)
+            : new Date(endOfTimeFrameDate);
 
         // if there were no balance movements at all,
         // findOldestBalanceMovementTimestamp resulted with start date being the same as end date

--- a/suite-common/graph/src/graphUtils.test.ts
+++ b/suite-common/graph/src/graphUtils.test.ts
@@ -382,4 +382,16 @@ describe(findOldestBalanceMovementTimestamp.name, () => {
 
         expect(findOldestBalanceMovementTimestamp(balanceHistory)).toBe(2);
     });
+
+    it('returns a non-finite value when there are no balance movements at all', () => {
+        // Math.min of an empty list is Infinity; callers must guard for it (fromUnixTime(Infinity)
+        // is an Invalid Date) rather than assume a real timestamp is returned.
+        const noMovements: AccountWithBalanceHistory[] = [
+            { symbol: 'btc', descriptor: 'awdawd', balanceHistory: [] },
+            { symbol: 'eth', descriptor: 'awdawd', balanceHistory: [] },
+        ];
+
+        expect(Number.isFinite(findOldestBalanceMovementTimestamp(noMovements))).toBe(false);
+        expect(Number.isFinite(findOldestBalanceMovementTimestamp([]))).toBe(false);
+    });
 });


### PR DESCRIPTION
### What

Accounts with no balance movements in show-all-data mode produced `Math.min(...[]) === Infinity` from `findOldestBalanceMovementTimestamp`, which `fromUnixTime` turned into an Invalid Date. That `NaN` timestamp bypassed the no-movements guard, so the graph never fell back to the "1 year of zeroes" range and graph data fetching broke for those accounts.

### Relationship to #30603 (this is a two-part fix)

Both parts are needed for the empty-account graph to render correctly; neither fixes the user-visible bug on its own:

- **#30603 (merged)** corrected the fallback branch itself — `setDate(getHours() - 8760)` jumped ~24 years back instead of 1 year (`setDate` → `setHours`). On its own that branch was unreachable, so #30603 was effectively a no-op on develop until this PR lands.
- **This PR** makes the fallback branch actually reachable. Without the guard, the branch never fired: the Invalid Date made the `start === end` check evaluate `NaN === …`, which is always false. With this PR the guard fires, and because #30603 is now on develop the range is a correct 1-year window of zeroes.

### Root cause

`findOldestBalanceMovementTimestamp` returns `Math.min(...[])` = `Infinity` when every account has an empty balance history. The caller piped that straight into `fromUnixTime`, producing an Invalid Date whose `getTime()` is `NaN`, so the `startOfTimeFrameDate.getTime() === endOfTimeFrameDate.getTime()` guard never matched and the synthetic zero-balance fallback never returned.

### Fix

Extract the timestamp before converting to a Date. When `findOldestBalanceMovementTimestamp` returns a non-finite value, anchor `startOfTimeFrameDate` to a clone of `endOfTimeFrameDate` (`new Date(endOfTimeFrameDate)`) so the no-movements guard detects equality and returns a year of zeroes. The clone is load-bearing: the guard branch mutates `startDate` via `setHours`, and cloning keeps `endOfTimeFrameDate` (read later at `getUnixTime`) intact.

### Impact

Reachable in suite-native only — `graphDataFetching.ts` is consumed exclusively by `suite-native/graph/src/graphThunks.ts`; `packages/suite` (web/desktop) does not use this path. Affects users viewing an account with no balance movements in show-all-data mode (triggered when `timeframeHours` is `null`). Before: the guard never fired and downstream code received an Invalid Date, breaking the graph. After (together with #30603): the account shows a 1-year window of zero-balance data points.

### Test

Added a unit test asserting `findOldestBalanceMovementTimestamp` returns a non-finite value for empty balance history, documenting the invariant callers must guard against before calling `fromUnixTime`. The end-to-end fallback rendering is verified manually in suite-native (see the QA hand-off in the comments).

### Notes for QA

**Before fix:** Select show-all-data on a suite-native account with no balance movements; the graph fails to render or shows an error state.

**After fix:** The same scenario shows a 1-year window of zero-balance data points, matching the documented behavior for accounts with no movements.

---

Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735. Sibling: #30603 (merged).

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to the suite-common/graph module (graph data fetching logic and its unit tests). The primary E2E risk is that portfolio or account graph data no longer loads correctly after discovery. The minimal high-confidence test is blockbook-discovery, which explicitly asserts the portfolio graph renders after backend discovery. transactions.test.ts provides secondary coverage for account graph interactions. No other tests in the candidate set specifically exercise graph fetching behavior.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/graph/src/graphDataFetching.ts`
- `suite-common/graph/src/graphUtils.test.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test explicitly verifies that the portfolio graph is visible after discovery completes with custom Blockbook backends for BTC and LTC. Since graphDataFetching.ts is responsible for fetching graph data, this test directly exercises the changed production code path end-to-end.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test interacts with the account transaction overview graph and its time range filters. While it primarily validates UI filtering, changing graph range selections can trigger graph data fetching/refetching, so it shares infrastructure with the modified graph module.

</details>

_Updated: 2026-07-31T14:24:04.850Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/graph-empty-balance-movements-guard/web/](https://dev.suite.sldev.cz/suite-web/mroz22/graph-empty-balance-movements-guard/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/graph-empty-balance-movements-guard&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/graph-empty-balance-movements-guard&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/graph-empty-balance-movements-guard&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T14:26:39.726Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T14:26:29.425Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
