### PR TITLE
fix(wallet-utils): use integer check instead of modulo 2 in dust check

### DIFF
--- a/suite-common/wallet-utils/src/balanceUtils.test.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.test.ts
@@ -16,6 +16,7 @@ test('formatBalanceUtils', () => {
     expect(formatCoinBalance('1000')).toEqual('1,000');
     expect(formatCoinBalance('1000.0001')).toEqual('1,000.0001');
     expect(formatCoinBalance('1000.000000001')).toEqual('1,000.00');
+    expect(formatCoinBalance('1001.000000001')).toEqual('1,001.00');
     expect(formatCoinBalance('2600.1')).toEqual('2,600.1');
     expect(formatCoinBalance('200000')).toEqual('200,000');
     expect(formatCoinBalance('2000000')).toEqual('2,000,000');

--- a/suite-common/wallet-utils/src/balanceUtils.ts
+++ b/suite-common/wallet-utils/src/balanceUtils.ts
@@ -35,7 +35,7 @@ export const formatCoinBalance = (value: string, locale: Locale = 'en-US') => {
         const fixedBalanceBig = new BigNumber(fixedBalance);
 
         // indicate the dust
-        const noDecimalsLeft = fixedBalanceBig.modulo(2).toFixed() === '0';
+        const noDecimalsLeft = fixedBalanceBig.isInteger();
         if (noDecimalsLeft) {
             return localizeNumber(fixedBalanceBig, locale, 2);
         }


### PR DESCRIPTION
### What

The dust-check in `formatCoinBalance` incorrectly used modulo(2) to detect when to apply dust formatting, which checks if a number is even rather than if it's an integer. This caused odd-valued balances (e.g., 1,001) rounded to whole numbers to be formatted inconsistently compared to even-valued balances (e.g., 1,000) when rendering in FormattedCryptoAmount.

### Root cause

At [line 38 in balanceUtils.ts on develop](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/wallet-utils/src/balanceUtils.ts#L38), the code tested `fixedBalanceBig.modulo(2).toFixed() === '0'` to determine if rounding left no decimals. This correctly returns true for even numbers like 1,000 but false for odd numbers like 1,001 (since 1,001 % 2 = 1). The intended logic was to check whether the rounded balance has any fractional part at all — both 1,000.5 (even) and 1,001.5 (odd) should trigger dust formatting, not just even numbers.

For example:
- Input: `'1000.000000001'` → rounds to 1,000 → `1,000 % 2 = 0` → formatted with 2 decimals → displays as `1,000.00` ✓
- Input: `'1001.000000001'` → rounds to 1,001 → `1,001 % 2 = 1` → skips dust formatting → displays as `1,001` ✗

### Fix

Changed [line 38 in balanceUtils.ts](https://github.com/trezor/trezor-suite/blob/495093470c46243d699df989a6b29b5badbccc62/suite-common/wallet-utils/src/balanceUtils.ts#L38) from `fixedBalanceBig.modulo(2).toFixed() === '0'` to `fixedBalanceBig.isInteger()`, which correctly detects whether the rounded balance has a fractional part, regardless of whether the integer part is odd or even.

### Impact

This is a reachable, user-visible bug affecting balance display consistency. Users viewing account balances across Suite (web, desktop, suite-native) that require rounding will see inconsistent `.00` formatting: even-valued balances will show `1,000.00` while odd-valued balances will show `1,001` (missing the dust decimals). The impact occurs in any area using `FormattedCryptoAmount` with `isBalance=true`, including account list views, staking dashboards, yield opportunities, and asset pickers. The bug does not affect calculation correctness, only UI presentation.

### Test

A regression test was added at [line 19 of balanceUtils.test.ts](https://github.com/trezor/trezor-suite/blob/495093470c46243d699df989a6b29b5badbccc62/suite-common/wallet-utils/src/balanceUtils.test.ts#L19) verifying that odd-valued amounts with dust decimals format consistently: `expect(formatCoinBalance('1001.000000001')).toEqual('1,001.00')`.

### Notes for QA

On develop (pre-fix), rendering a balance of `1001.000000001` via `FormattedCryptoAmount` with `isBalance=true` displays as `1,001` (no dust decimals). After this fix, it displays as `1,001.00`, matching the behavior of even-valued balances like `1000.000000001` → `1,000.00`.

To reproduce on develop:
1. Any account with a balance that, after rounding precision, produces an odd integer (e.g., 1,001, 3,005) with fractional parts that get rounded away
2. View the balance in an account list or staking dashboard
3. Observe the `.00` suffix missing compared to even-valued accounts

This cannot be easily triggered manually without crafting specific balance amounts, as the bug requires both an odd integer and rounding artifacts from precision truncation.

---

Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change to suite-common/wallet-utils/src/balanceUtils.ts touches a broad shared utility, but the highest regression risk is concentrated in tests that directly assert on balance display, balance truncation, and balance-dependent input calculations. The recommended set covers the core balance formatting path and representative balance-derived flows (sell, swap, staking inputs) without running the full 133 mapped tests. The companion balanceUtils.test.ts change is a unit test file with no E2E coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-utils/src/balanceUtils.test.ts`
- `suite-common/wallet-utils/src/balanceUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly asserts on account values, asset card fiat amounts, portfolio fiat amounts, and wallet fiat amounts being masked and revealed. A change to balanceUtils could alter how these balance values are formatted or resolved, breaking these assertions immediately.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — The core assertion is that the BTC balance of the first account is visible after wallet discovery. This directly depends on balanceUtils producing and formatting the account balance for display.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Explicitly validates account balance display, balance increases after transactions, and ellipsis truncation for long balance strings. These are direct consumers of balance formatting/calculation logic.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Verifies that activated coins show visible balances on the dashboard after discovery. A regression in balance aggregation or formatting would surface here across multiple networks.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests that percentage buttons calculate crypto amounts as fractions of the wallet balance and that the Max button subtracts fees from the balance. These calculations may rely on balanceUtils helpers.
- `suite/e2e/tests/trading/staking-form.test.ts` — Asserts on staking balance display, percentage-based staking amounts, and Max amount reserving a withdrawal buffer. Balance computation changes could affect these input calculations.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Validates fraction buttons compute correct portions of the sell token balance and that Max fills the full token balance. This is a concrete balance-dependent code path.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-utils/src/balanceUtils.test.ts`

_Updated: 2026-07-30T15:46:11.355Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/dust-check-integer-not-modulo2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/dust-check-integer-not-modulo2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/dust-check-integer-not-modulo2&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:48:34.865Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:47:32.811Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/dust-check-integer-not-modulo2/web/](https://dev.suite.sldev.cz/suite-web/mroz22/dust-check-integer-not-modulo2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->