### PR TITLE
fix(walletconnect): return empty namespace when there are no matching bitcoin accounts

### DIFF
--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -220,7 +220,7 @@ export const getChainId = (network: Network) => {
     return [];
 };
 
-export const getNamespace = (accounts: Account[]) => {
+export const getNamespace = (accounts: Account[]): Record<string, WalletConnectNamespace> => {
     const bip122 = {
         chains: [],
         accounts: [],
@@ -244,6 +244,10 @@ export const getNamespace = (accounts: Account[]) => {
             bip122.accounts.push(`${network.caipId}:${firstAddress}`);
         }
     });
+
+    if (bip122.chains.length === 0) {
+        return {};
+    }
 
     return { bip122 };
 };


### PR DESCRIPTION
### What
The WalletConnect bitcoin adapter's `getNamespace` returned `{ bip122: { chains: [], accounts: [], ... } }` when the user had no visible bitcoin accounts with supported chains, instead of returning an empty `{}` like its four sibling adapters do. This PR adds the missing empty-namespace guard so the bitcoin adapter behaves identically to the rest.

### Root cause
The team established a "don't send empty namespace" convention in [`fix(walletconnect): don't send empty namespace`](https://github.com/trezor/trezor-suite/commit/913b4b466737e683e0c49cefea3fc328cbec8c5a), which added the `chains.length === 0` guard to the ethereum and solana adapters. The bitcoin adapter did not exist yet at that commit and was introduced later without the guard, so it was the only one of the five adapters still returning a non-empty object for the empty case.

### Fix
Added the same guard the four other adapters already have — return `{}` once the namespace still has no chains after processing all accounts — and aligned the return type annotation with the siblings (`Record<string, WalletConnectNamespace>`).

All five adapters now share the identical guard (each link points at its `chains.length === 0` check):

- [ethereum.ts](https://github.com/trezor/trezor-suite/blob/c0b87b5e892e4924ed05f3c9029c34420d5a6402/suite-common/walletconnect/src/adapters/ethereum.ts#L261-L263)
- [solana.ts](https://github.com/trezor/trezor-suite/blob/c0b87b5e892e4924ed05f3c9029c34420d5a6402/suite-common/walletconnect/src/adapters/solana.ts#L203-L205)
- [stellar.ts](https://github.com/trezor/trezor-suite/blob/c0b87b5e892e4924ed05f3c9029c34420d5a6402/suite-common/walletconnect/src/adapters/stellar.ts#L199-L201)
- [tron.ts](https://github.com/trezor/trezor-suite/blob/c0b87b5e892e4924ed05f3c9029c34420d5a6402/suite-common/walletconnect/src/adapters/tron.ts#L63-L65)
- [bitcoin.ts (this PR)](https://github.com/trezor/trezor-suite/blob/c0b87b5e892e4924ed05f3c9029c34420d5a6402/suite-common/walletconnect/src/adapters/bitcoin.ts#L248-L250)

### Impact
Low — this is a consistency/correctness cleanup, not a user-facing bug fix.

The empty `{ bip122 }` is merged into `supportedNamespaces` and passed to WalletConnect's `buildApprovedNamespaces` (`@walletconnect/utils`). That function builds the approved namespaces only from the keys the dApp actually requests in its proposal and prunes any namespace with empty `chains`/`accounts` before returning. In normal session flows the empty bitcoin namespace is therefore filtered out before anything reaches the peer — it does not produce malformed data on the wire, contrary to what an earlier version of this description claimed.

The guard still matters for:
- Consistency: all five adapters behave identically and follow the team's established convention.
- The degenerate case where a proposal carries neither required nor optional namespaces, in which `buildApprovedNamespaces` echoes `supportedNamespaces` back unpruned.
- Any code that reads `getNamespaces()` output directly rather than through `buildApprovedNamespaces` (e.g. the `supportedNamespaces.eip155` read in `sessionAuthenticateThunk`).

### Test
No automated test added — the `suite-common/walletconnect` package currently has no unit tests, and `getNamespace` is exercised indirectly by the WalletConnect e2e suite. Since `getNamespace` is a pure function, a small unit test (empty input → `{}`) would be a cheap follow-up that would lock the convention for all five adapters.

### Notes for QA
Low-risk internal consistency change with no expected externally observable behavior difference in normal WalletConnect flows.

To confirm the fix at the source level:
1. Open a profile with no visible bitcoin accounts (or no bitcoin accounts with supported chains).
2. Trigger a WalletConnect session approval (`sessionProposalApproveThunk` / `switchSelectedAccountThunk`).
3. Inspect the `getNamespaces()` result / the `supportedNamespaces` passed to `buildApprovedNamespaces`: it now omits the `bip122` key entirely instead of including `bip122: { chains: [], accounts: [] }`, matching the ethereum/solana/stellar/tron adapters.

---
Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the WalletConnect Bitcoin adapter inside a broad shared module, so the main risk is a break in WalletConnect initialization or proposal handling. The targeted WalletConnect events test provides sufficient coverage; other tests that merely transitively import the shared WalletConnect module are not meaningfully affected.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/walletconnect/src/adapters/bitcoin.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test exercises the WalletConnect integration end-to-end (initialization, pairing, approving/rejecting proposals) and emits the associated analytics events. The changed file is the WalletConnect Bitcoin adapter, which is part of the WalletConnect integration module this test covers, so a regression here would be directly observable.

</details>

_Updated: 2026-07-30T15:45:35.905Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/walletconnect-bitcoin-empty-namespace/web/](https://dev.suite.sldev.cz/suite-web/mroz22/walletconnect-bitcoin-empty-namespace/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/walletconnect-bitcoin-empty-namespace&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/walletconnect-bitcoin-empty-namespace&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/walletconnect-bitcoin-empty-namespace&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:48:30.874Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:48:00.445Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
