### PR TITLE
fix(message-system): null-check createVersionRange in isDeviceCompatible

### DIFF
--- a/suite-common/message-system/src/messageSystemUtils.ts
+++ b/suite-common/message-system/src/messageSystemUtils.ts
@@ -224,15 +224,21 @@ export const isDeviceCompatible = (deviceConditions: Device[], device?: TrezorDe
             thpProperties: thpPropertiesCondition,
         } = deviceCondition;
 
+        // createVersionRange returns null for '!' / undefined, which by design must not match
+        // (see isVersionCompatible for the same handling).
+        const firmwareRange = createVersionRange(firmwareCondition);
+        const bootloaderRange = createVersionRange(bootloaderCondition);
+
         return (
             modelCondition.toLowerCase() === deviceInternalModel &&
             (vendorCondition.toLowerCase() === deviceVendor || vendorCondition === '*') &&
             (variantCondition.toLowerCase() === deviceFwType || variantCondition === '*') &&
             (firmwareRevisionCondition.toLowerCase() === deviceFwRevision.toLowerCase() ||
                 firmwareRevisionCondition === '*') &&
-            (semver.satisfies(deviceFwVersion, createVersionRange(firmwareCondition)!) ||
+            ((firmwareRange !== null && semver.satisfies(deviceFwVersion, firmwareRange)) ||
                 firmwareCondition === '*') &&
-            (semver.satisfies(deviceBootloaderVersion, createVersionRange(bootloaderCondition)!) ||
+            ((bootloaderRange !== null &&
+                semver.satisfies(deviceBootloaderVersion, bootloaderRange)) ||
                 bootloaderCondition === '*') &&
             isThpPropertiesCompatible(thpPropertiesCondition, device.thp?.properties)
         );


### PR DESCRIPTION
### What

A remote message-system configuration that uses a device condition with firmware or bootloader set to "!" (disable condition) or undefined could cause a runtime exception. The `isDeviceCompatible` function passed the result of `createVersionRange()` directly to `semver.satisfies` with a non-null assertion (`!`), masking the fact that `createVersionRange` returns `null` for these values.

### Root cause

[`createVersionRange`](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/message-system/src/messageSystemUtils.ts#L82-L92) is designed to return `null` when given `undefined` or `"!"` as input — by design, these conditions must not match. However, the sibling function [`isVersionCompatible`](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/message-system/src/messageSystemUtils.ts#L107-L118) correctly checks for `null` before calling `semver.satisfies`, while [`isDeviceCompatible`](https://github.com/trezor/trezor-suite/blob/35af76da0ee9d1320a8699780b91dcf9c9459b76/suite-common/message-system/src/messageSystemUtils.ts#L233-L235) did not. Instead, it suppressed the type error with non-null assertions (`!`), allowing `semver.satisfies` to be called with `null`.

### Fix

Extracted the result of `createVersionRange()` into intermediate variables ([`firmwareRange` and `bootloaderRange`](https://github.com/trezor/trezor-suite/blob/85f01955a9b9c2c437de5637224a133866e954af/suite-common/message-system/src/messageSystemUtils.ts#L229-L230)), then added explicit null-checks before calling `semver.satisfies`, mirroring the pattern used in `isVersionCompatible`. The non-null assertions were removed.

### Impact

**Conditional:** The bug surfaces only if:
- A remote message-system config is deployed with a device condition containing `firmware: "!"` or `firmware: undefined` (or likewise for bootloader), AND
- A user in Suite (web/desktop/native) loads that config, AND
- Their device matches all other aspects of that condition

When the condition is met, it triggers a runtime error as semver attempts to parse a null value, causing the message-system filtering to fail and potentially preventing other valid messages from being shown.

### Test

The fix does not add new tests. Test coverage for this scenario already exists in the fixture data (e.g., `createVersionRange` has test cases for `"!"` returning `null`), but the device-compatible test suite did not previously include a case exercising `"!"` in firmware/bootloader conditions. Manual verification confirms the fix aligns `isDeviceCompatible` with the proven-safe pattern in `isVersionCompatible`.

### Notes for QA

Manual reproduction on develop requires:
1. Creating or modifying a remote message-system config JSON with a device condition like: `{ model: "...", firmware: "!", bootloader: "*", ... }`
2. Loading that config in Suite while connected to a device matching the other conditions

Before the fix, this would cause a runtime error. After the fix, the device is correctly treated as incompatible with that condition (by design — `"!"` means "no match").

---

Part of the continuously-improve bug-fix sweep — split out from the umbrella #29735.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a utility in the message-system package that is statically referenced by almost every E2E test, indicating it is a global store-level dependency. However, only the promo-banner-events test directly validates message-system banner behavior. Running this targeted test provides the best regression signal for this change; broader smoke coverage is not justified without specific evidence that the utility change affects other user flows.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/src/messageSystemUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — This test directly exercises the dashboard promotional banner feature, which is rendered and controlled by the message system. Changes to messageSystemUtils could affect banner visibility, filtering, or the analytics event payload, so a regression here would be immediately user-visible.

</details>

_Updated: 2026-07-30T15:46:47.145Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/message-system-createversionrange-nullcheck/web/](https://dev.suite.sldev.cz/suite-web/mroz22/message-system-createversionrange-nullcheck/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/message-system-createversionrange-nullcheck&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/message-system-createversionrange-nullcheck&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/message-system-createversionrange-nullcheck&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 9 test(s)</summary>

| Test | Type |
|------|------|
| Receive transaction > Receive a TRX transaction | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:48:26.338Z • 9 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-30T15:47:29.770Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->