### PR TITLE
ci(suite-native): configure EAS build lookup environment

### DIFF
--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -58,6 +58,8 @@ jobs:
           yarn workspaces focus @suite-native/app
       - name: Check existing EAS builds for commit
         id: check-existing-builds
+        env:
+          EXPO_PUBLIC_ENVIRONMENT: develop
         run: |
           for PLATFORM in android ios; do
             EXISTING_BUILD=$(eas build:list \


### PR DESCRIPTION
## Description

The scheduled Suite Native release fails while checking for existing EAS builds. `eas build:list --build-profile develop` uses the profile only as a query filter; it does not load the profile's environment variables. Consequently, `app.config.ts` falls back to the debug configuration, whose EAS project ID is empty, and the non-interactive lookup exits with `EAS project not configured`.

Set `EXPO_PUBLIC_ENVIRONMENT=develop` explicitly on the lookup step so both platform queries resolve the Suite Native develop project.

## Notes for QA

No application QA is required; this only changes the scheduled release workflow.

Validated with the same EAS CLI version used by the failing job (`21.4.0`):

- Reproduced the configuration error without `EXPO_PUBLIC_ENVIRONMENT`.
- Confirmed Android and iOS build lookups succeed with `EXPO_PUBLIC_ENVIRONMENT=develop`.

## Related Issue

Fixes the failure in https://github.com/trezor/trezor-suite/actions/runs/30549596148/job/90894489911

Resolves https://github.com/trezor/trezor-suite/pull/30531
