### PR TITLE
Mobile Trade: Display amount instead of rate in buy and sell pickers

### DIFF
--- a/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.test.ts
+++ b/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.test.ts
@@ -1,0 +1,221 @@
+import { renderHook } from '@testing-library/react';
+import { type BuyTrade, type CryptoId, type ExchangeTrade, type SellFiatTrade } from 'invity-api';
+
+import { useSelector } from './useSelector';
+import { useTradingRequestedAmountShortfall } from './useTradingRequestedAmountShortfall';
+
+jest.mock('./useSelector', () => ({
+    useSelector: jest.fn(),
+}));
+
+const mockedUseSelector = jest.mocked(useSelector);
+
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+
+const buyQuote = {
+    exchange: 'test-buy',
+    fiatCurrency: 'USD',
+    fiatStringAmount: '10',
+    receiveCurrency: BITCOIN_CRYPTO_ID,
+    receiveStringAmount: '0.002',
+    paymentMethod: 'creditCard',
+    paymentMethodName: 'Credit Card',
+    orderId: 'order-id-buy',
+} satisfies BuyTrade;
+
+const sellQuote = {
+    exchange: 'test-sell',
+    fiatCurrency: 'USD',
+    fiatStringAmount: '80',
+    cryptoCurrency: ETHEREUM_CRYPTO_ID,
+    cryptoStringAmount: '2',
+    amountInCrypto: true,
+    country: 'CZ',
+    paymentMethod: 'bankTransfer',
+    paymentMethodName: 'Bank Transfer',
+    orderId: 'order-id-sell',
+} satisfies SellFiatTrade;
+
+const exchangeQuote = {
+    exchange: 'test-exchange',
+    send: BITCOIN_CRYPTO_ID,
+    sendStringAmount: '1.5',
+    receive: ETHEREUM_CRYPTO_ID,
+    receiveStringAmount: '10',
+    orderId: 'order-id-exchange',
+    rate: 100,
+    min: 0,
+    max: 100,
+} satisfies ExchangeTrade;
+
+const mockQuotesRequests = ({
+    buyQuotesRequest,
+    sellQuotesRequest,
+    exchangeQuotesRequest,
+}: {
+    buyQuotesRequest?: unknown;
+    sellQuotesRequest?: unknown;
+    exchangeQuotesRequest?: unknown;
+}) => {
+    mockedUseSelector
+        .mockReturnValueOnce(buyQuotesRequest)
+        .mockReturnValueOnce(sellQuotesRequest)
+        .mockReturnValueOnce(exchangeQuotesRequest);
+};
+
+const renderUseTradingRequestedAmountShortfall = (
+    quote: BuyTrade | SellFiatTrade | ExchangeTrade,
+) => renderHook(() => useTradingRequestedAmountShortfall({ quote }));
+
+describe('useTradingRequestedAmountShortfall', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('returns crypto shortfall for buy when wantCrypto is true', () => {
+        mockQuotesRequests({
+            buyQuotesRequest: {
+                wantCrypto: true,
+                fiatCurrency: 'USD',
+                receiveCurrency: BITCOIN_CRYPTO_ID,
+                cryptoStringAmount: '1',
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall({
+            ...buyQuote,
+            receiveStringAmount: '0.8',
+        });
+
+        expect(result.current?.shortfallRatio).toBeCloseTo(0.2);
+        expect(result.current?.cryptoShortfall).toEqual({
+            amount: '0.2',
+            cryptoId: BITCOIN_CRYPTO_ID,
+        });
+        expect(result.current?.fiatShortfall).toBeUndefined();
+    });
+
+    it('returns shortfall for buy when wantCrypto is false', () => {
+        mockQuotesRequests({
+            buyQuotesRequest: {
+                wantCrypto: false,
+                fiatCurrency: 'USD',
+                receiveCurrency: BITCOIN_CRYPTO_ID,
+                fiatStringAmount: '100',
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall({
+            ...buyQuote,
+            fiatStringAmount: '90',
+        });
+
+        expect(result.current).toEqual({
+            shortfallRatio: 0.1,
+            fiatShortfall: 10,
+        });
+    });
+
+    it('returns crypto shortfall for sell when amountInCrypto is true', () => {
+        mockQuotesRequests({
+            sellQuotesRequest: {
+                amountInCrypto: true,
+                cryptoCurrency: ETHEREUM_CRYPTO_ID,
+                fiatCurrency: 'USD',
+                country: 'CZ',
+                fiatStringAmount: '80',
+                cryptoStringAmount: '2.5',
+                flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall(sellQuote);
+
+        expect(result.current).toEqual({
+            shortfallRatio: 0.2,
+            cryptoShortfall: {
+                amount: '0.5',
+                cryptoId: ETHEREUM_CRYPTO_ID,
+            },
+        });
+    });
+
+    it('returns shortfall for sell when amountInCrypto is false', () => {
+        mockQuotesRequests({
+            sellQuotesRequest: {
+                amountInCrypto: false,
+                cryptoCurrency: ETHEREUM_CRYPTO_ID,
+                fiatCurrency: 'USD',
+                country: 'CZ',
+                fiatStringAmount: '100',
+                flows: ['BANK_ACCOUNT', 'PAYMENT_GATE'],
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall({
+            ...sellQuote,
+            fiatStringAmount: '70',
+        });
+
+        expect(result.current).toEqual({
+            shortfallRatio: 0.3,
+            fiatShortfall: 30,
+        });
+    });
+
+    it('does not return shortfall for exchange', () => {
+        mockQuotesRequests({
+            exchangeQuotesRequest: {
+                send: BITCOIN_CRYPTO_ID,
+                receive: ETHEREUM_CRYPTO_ID,
+                sendStringAmount: '2',
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall(exchangeQuote);
+
+        expect(result.current).toEqual(null);
+    });
+
+    it('returns null on exact match', () => {
+        mockQuotesRequests({
+            buyQuotesRequest: {
+                wantCrypto: true,
+                fiatCurrency: 'USD',
+                receiveCurrency: BITCOIN_CRYPTO_ID,
+                cryptoStringAmount: buyQuote.receiveStringAmount,
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall(buyQuote);
+
+        expect(result.current).toBeNull();
+    });
+
+    it('returns null when request is missing', () => {
+        mockQuotesRequests({});
+
+        const { result } = renderUseTradingRequestedAmountShortfall(buyQuote);
+
+        expect(result.current).toBeNull();
+    });
+
+    it('returns null when request amount or quote amount is missing', () => {
+        mockQuotesRequests({
+            buyQuotesRequest: {
+                wantCrypto: true,
+                fiatCurrency: 'USD',
+                receiveCurrency: BITCOIN_CRYPTO_ID,
+                cryptoStringAmount: '1',
+            },
+        });
+
+        const { result } = renderUseTradingRequestedAmountShortfall({
+            ...buyQuote,
+            receiveStringAmount: undefined,
+        });
+
+        expect(result.current).toBeNull();
+    });
+});

--- a/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.ts
+++ b/suite-common/trading/src/hooks/useTradingRequestedAmountShortfall.ts
@@ -1,0 +1,173 @@
+import { type BuyTrade, type CryptoId, type SellFiatTrade } from 'invity-api';
+
+import { BigNumber } from '@trezor/utils';
+
+import {
+    selectTradingBuyQuotesRequest,
+    selectTradingSellQuotesRequest,
+} from '../selectors/tradingSelectors';
+import type { TradingTradeType } from '../types';
+import { isBuyTrade, isSellFiatTrade } from '../utils';
+import { useSelector } from './useSelector';
+
+type UseTradingRequestedAmountShortfallProps = {
+    quote: TradingTradeType | undefined;
+};
+
+export type TradingRequestedAmountShortfallResult = {
+    shortfallRatio: number;
+    fiatShortfall?: number;
+    cryptoShortfall?: {
+        amount: string;
+        cryptoId: CryptoId;
+    };
+};
+
+type RequestedAndQuoteAmounts = {
+    requestedAmount: string;
+    quoteAmount: string;
+    cryptoId?: CryptoId;
+};
+
+const parsePositiveNumber = (value: string | undefined): number | null => {
+    if (!value) {
+        return null;
+    }
+
+    const parsedValue = Number(value);
+
+    return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : null;
+};
+
+const getBuyRequestedAndQuoteAmounts = (
+    quote: BuyTrade,
+    quotesRequest: ReturnType<typeof selectTradingBuyQuotesRequest>,
+): RequestedAndQuoteAmounts | null => {
+    if (!quotesRequest) {
+        return null;
+    }
+
+    if (quotesRequest.wantCrypto) {
+        if (
+            !quotesRequest.cryptoStringAmount ||
+            !quote.receiveStringAmount ||
+            !quote.receiveCurrency
+        ) {
+            return null;
+        }
+
+        return {
+            requestedAmount: quotesRequest.cryptoStringAmount,
+            quoteAmount: quote.receiveStringAmount,
+            cryptoId: quote.receiveCurrency,
+        };
+    }
+
+    if (!quotesRequest.fiatStringAmount || !quote.fiatStringAmount) {
+        return null;
+    }
+
+    return {
+        requestedAmount: quotesRequest.fiatStringAmount,
+        quoteAmount: quote.fiatStringAmount,
+    };
+};
+
+const getSellRequestedAndQuoteAmounts = (
+    quote: SellFiatTrade,
+    quotesRequest: ReturnType<typeof selectTradingSellQuotesRequest>,
+): RequestedAndQuoteAmounts | null => {
+    if (!quotesRequest) {
+        return null;
+    }
+
+    if (quotesRequest.amountInCrypto) {
+        if (
+            !quotesRequest.cryptoStringAmount ||
+            !quote.cryptoStringAmount ||
+            !quote.cryptoCurrency
+        ) {
+            return null;
+        }
+
+        return {
+            requestedAmount: quotesRequest.cryptoStringAmount,
+            quoteAmount: quote.cryptoStringAmount,
+            cryptoId: quote.cryptoCurrency,
+        };
+    }
+
+    if (!quotesRequest.fiatStringAmount || !quote.fiatStringAmount) {
+        return null;
+    }
+
+    return {
+        requestedAmount: quotesRequest.fiatStringAmount,
+        quoteAmount: quote.fiatStringAmount,
+    };
+};
+
+const getRequestedAndQuoteAmounts = ({
+    quote,
+    buyQuotesRequest,
+    sellQuotesRequest,
+}: {
+    quote: TradingTradeType;
+    buyQuotesRequest: ReturnType<typeof selectTradingBuyQuotesRequest>;
+    sellQuotesRequest: ReturnType<typeof selectTradingSellQuotesRequest>;
+}) => {
+    if (isBuyTrade(quote)) {
+        return getBuyRequestedAndQuoteAmounts(quote, buyQuotesRequest);
+    }
+
+    if (isSellFiatTrade(quote)) {
+        return getSellRequestedAndQuoteAmounts(quote, sellQuotesRequest);
+    }
+
+    return null;
+};
+
+export const useTradingRequestedAmountShortfall = ({
+    quote,
+}: UseTradingRequestedAmountShortfallProps): TradingRequestedAmountShortfallResult | null => {
+    const buyQuotesRequest = useSelector(selectTradingBuyQuotesRequest);
+    const sellQuotesRequest = useSelector(selectTradingSellQuotesRequest);
+
+    const requestedAndQuoteAmounts = quote
+        ? getRequestedAndQuoteAmounts({
+              quote,
+              buyQuotesRequest,
+              sellQuotesRequest,
+          })
+        : null;
+
+    const requestedAmountNumber = parsePositiveNumber(requestedAndQuoteAmounts?.requestedAmount);
+    const quoteAmountNumber = parsePositiveNumber(requestedAndQuoteAmounts?.quoteAmount);
+
+    if (
+        requestedAmountNumber === null ||
+        quoteAmountNumber === null ||
+        quoteAmountNumber >= requestedAmountNumber
+    ) {
+        return null;
+    }
+
+    const shortfallRatio = (requestedAmountNumber - quoteAmountNumber) / requestedAmountNumber;
+
+    if (requestedAndQuoteAmounts?.cryptoId) {
+        return {
+            shortfallRatio,
+            cryptoShortfall: {
+                amount: new BigNumber(requestedAndQuoteAmounts.requestedAmount)
+                    .minus(requestedAndQuoteAmounts.quoteAmount)
+                    .toString(),
+                cryptoId: requestedAndQuoteAmounts.cryptoId,
+            },
+        };
+    }
+
+    return {
+        shortfallRatio,
+        fiatShortfall: requestedAmountNumber - quoteAmountNumber,
+    };
+};

--- a/suite-common/trading/src/hooks/useTradingRequestedSide.test.ts
+++ b/suite-common/trading/src/hooks/useTradingRequestedSide.test.ts
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react';
+import { type BuyTrade, type CryptoId, type ExchangeTrade, type SellFiatTrade } from 'invity-api';
+
+import { useSelector } from './useSelector';
+import { useTradingRequestedSide } from './useTradingRequestedSide';
+
+jest.mock('./useSelector', () => ({
+    useSelector: jest.fn(),
+}));
+
+const mockedUseSelector = jest.mocked(useSelector);
+
+const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
+const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+
+const buyQuote = {
+    exchange: 'test-buy',
+    fiatCurrency: 'USD',
+    fiatStringAmount: '10',
+    receiveCurrency: BITCOIN_CRYPTO_ID,
+    receiveStringAmount: '0.002',
+    orderId: 'order-id-buy',
+} satisfies BuyTrade;
+
+const sellQuote = {
+    exchange: 'test-sell',
+    fiatCurrency: 'USD',
+    fiatStringAmount: '80',
+    cryptoCurrency: ETHEREUM_CRYPTO_ID,
+    cryptoStringAmount: '2',
+    orderId: 'order-id-sell',
+} satisfies SellFiatTrade;
+
+const exchangeQuote = {
+    exchange: 'test-exchange',
+    send: BITCOIN_CRYPTO_ID,
+    sendStringAmount: '1.5',
+    receive: ETHEREUM_CRYPTO_ID,
+    receiveStringAmount: '10',
+    orderId: 'order-id-exchange',
+    rate: 100,
+    min: 0,
+    max: 100,
+} satisfies ExchangeTrade;
+
+const mockQuotesRequests = (buyQuotesRequest?: unknown, sellQuotesRequest?: unknown) => {
+    mockedUseSelector.mockReturnValueOnce(buyQuotesRequest).mockReturnValueOnce(sellQuotesRequest);
+};
+
+describe('useTradingRequestedSide', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns 'to' for buy when wantCrypto is true", () => {
+        mockQuotesRequests({ wantCrypto: true });
+
+        const { result } = renderHook(() => useTradingRequestedSide(buyQuote));
+
+        expect(result.current).toBe('to');
+    });
+
+    it("returns 'from' for buy when wantCrypto is false", () => {
+        mockQuotesRequests({ wantCrypto: false });
+
+        const { result } = renderHook(() => useTradingRequestedSide(buyQuote));
+
+        expect(result.current).toBe('from');
+    });
+
+    it("returns 'from' for buy when there is no request", () => {
+        mockQuotesRequests();
+
+        const { result } = renderHook(() => useTradingRequestedSide(buyQuote));
+
+        expect(result.current).toBe('from');
+    });
+
+    it("returns 'from' for sell when amountInCrypto is true", () => {
+        mockQuotesRequests(undefined, { amountInCrypto: true });
+
+        const { result } = renderHook(() => useTradingRequestedSide(sellQuote));
+
+        expect(result.current).toBe('from');
+    });
+
+    it("returns 'to' for sell when amountInCrypto is false", () => {
+        mockQuotesRequests(undefined, { amountInCrypto: false });
+
+        const { result } = renderHook(() => useTradingRequestedSide(sellQuote));
+
+        expect(result.current).toBe('to');
+    });
+
+    it('returns undefined for exchange', () => {
+        mockQuotesRequests();
+
+        const { result } = renderHook(() => useTradingRequestedSide(exchangeQuote));
+
+        expect(result.current).toBeUndefined();
+    });
+
+    it('returns undefined when there is no quote', () => {
+        mockQuotesRequests();
+
+        const { result } = renderHook(() => useTradingRequestedSide(undefined));
+
+        expect(result.current).toBeUndefined();
+    });
+});

--- a/suite-common/trading/src/hooks/useTradingRequestedSide.ts
+++ b/suite-common/trading/src/hooks/useTradingRequestedSide.ts
@@ -1,0 +1,30 @@
+import {
+    selectTradingBuyQuotesRequest,
+    selectTradingSellQuotesRequest,
+} from '../selectors/tradingSelectors';
+import type { TradingTradeType } from '../types';
+import { isBuyTrade, isSellFiatTrade } from '../utils';
+import { useSelector } from './useSelector';
+
+export type TradingRequestedSide = 'from' | 'to';
+
+export const useTradingRequestedSide = (
+    quote: TradingTradeType | undefined,
+): TradingRequestedSide | undefined => {
+    const buyQuotesRequest = useSelector(selectTradingBuyQuotesRequest);
+    const sellQuotesRequest = useSelector(selectTradingSellQuotesRequest);
+
+    if (!quote) {
+        return undefined;
+    }
+
+    if (isBuyTrade(quote)) {
+        return buyQuotesRequest?.wantCrypto ? 'to' : 'from';
+    }
+
+    if (isSellFiatTrade(quote)) {
+        return sellQuotesRequest?.amountInCrypto ? 'from' : 'to';
+    }
+
+    return undefined;
+};

--- a/suite-common/trading/src/index.ts
+++ b/suite-common/trading/src/index.ts
@@ -12,6 +12,8 @@ export * from './hooks/useExchangeIssue';
 export * from './hooks/useProviderMetadataChangeEffect';
 export * from './hooks/useTradingFiatValues';
 export * from './hooks/useExchangeFiatDeviation';
+export * from './hooks/useTradingRequestedAmountShortfall';
+export * from './hooks/useTradingRequestedSide';
 export * from './hooks/useApprovalStep';
 export * from './hooks/useTradingExchangeWatchApproval';
 export * from './hooks/useTradingRefetchScheduler';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3957,6 +3957,7 @@ export const messages = {
             centralizedExchange: 'Centralized exchange',
             anonymous: 'Anonymous',
             kycRequired: 'KYC is required',
+            lessToReceiveThanRequested: '{percent} less to receive than requested ({amount})',
         },
         myAssetSheet: {
             title: 'Your assets',

--- a/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.test.tsx
@@ -1,11 +1,15 @@
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
-import { getInitializedTradingState } from '@suite-native/trading-fixtures';
+import { act } from '@suite-native/test-utils-store';
+import { btcAsset, getInitializedTradingState } from '@suite-native/trading-fixtures';
 import { type BuyFormType } from '@suite-native/trading-types';
+import { PROTO } from '@trezor/connect';
 
 import { BuyCard } from './BuyCard';
 import { useBuyForm } from '../../hooks/buy/useBuyForm';
 import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
     createTradingFeatureFlags,
     renderHookWithTradingProvider,
     renderWithTradingProvider,
@@ -21,9 +25,9 @@ describe('BuyCard', () => {
 
     const renderForm = () => renderHookWithTradingProvider(() => useBuyForm(), { overrides });
 
-    const renderBuyCard = () =>
+    const renderBuyCard = (extraOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {}) =>
         renderWithTradingProvider(<BuyCard isAmountInputActive={false} />, {
-            overrides,
+            overrides: { ...overrides, ...extraOverrides },
             wrapper: ({ children }) => <Form form={form}>{children}</Form>,
         });
 
@@ -46,5 +50,24 @@ describe('BuyCard', () => {
         expect(getByTestId('@trading/buyCard/cryptoSection')).toHaveStyle({
             borderBottomWidth: 0,
         });
+    });
+
+    it('should convert cryptoValue to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', () => {
+        act(() => {
+            form.setValue('asset', btcAsset);
+        });
+        act(() => {
+            form.setValue('amountInCrypto', true);
+        });
+        act(() => {
+            form.setValue('cryptoValue', '1234567123456');
+        });
+
+        const { getByText, queryByText } = renderBuyCard({
+            wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
+        });
+
+        expect(getByText('12345.67123456-bitcoin')).toBeOnTheScreen();
+        expect(queryByText('1234567123456-bitcoin')).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/buy/BuyCard.tsx
+++ b/suite-native/module-trading/src/components/buy/BuyCard.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack } from '@suite-native/atoms';
 import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { CryptoToFiatValueBadge } from '@suite-native/trading-quote-utils';
 
 import { BuyFiatCurrencyPicker } from './BuyFiatCurrencyPicker';
@@ -8,6 +9,7 @@ import { BuyFormFieldErrorBadge } from './BuyFormFieldErrorBadge';
 import { BuyReceiveAccountCryptoBalance } from './BuyReceiveAccountCryptoBalance';
 import { BuyTradeableAssetPicker } from './BuyTradeableAssetPicker';
 import { useBuyFormContext } from '../../hooks/buy/useBuyFormContext';
+import { useConvertFormValueToBaseUnit } from '../../hooks/general/useConvertFormValueToBaseUnit';
 import { TradeableAssetNetworkInfo } from '../general/TradeableAssetNetworkInfo';
 import { TradingCard } from '../general/TradingCard';
 import { TradingCardSection } from '../general/TradingCardSection';
@@ -22,6 +24,9 @@ const BUY_CARD_TEST_ID = '@trading/buyCard';
 export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardProps) => {
     const { control } = useBuyFormContext();
     const [cryptoValue, asset] = useWatch({ control, name: ['cryptoValue', 'asset'] });
+    const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
+    const symbol = getSymbolFromTradeableAsset(asset);
+    const cryptoValueInBaseUnit = symbol ? convertStrToBaseUnit(cryptoValue, symbol) : cryptoValue;
 
     return (
         <TradingCard
@@ -45,7 +50,10 @@ export const BuyCard = ({ isAmountInputActive, shouldAnimateEntering }: BuyCardP
                 title={<Translation id="moduleTrading.selectCoin.title" />}
                 titleAction={
                     <BuyFormFieldErrorBadge fieldName="cryptoValue">
-                        <CryptoToFiatValueBadge amount={cryptoValue} cryptoId={asset?.cryptoId} />
+                        <CryptoToFiatValueBadge
+                            amount={cryptoValueInBaseUnit}
+                            cryptoId={asset?.cryptoId}
+                        />
                     </BuyFormFieldErrorBadge>
                 }
             >

--- a/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeCard.test.tsx
@@ -6,8 +6,9 @@ import {
     renderWithStoreProvider,
     within,
 } from '@suite-native/test-utils-store';
-import { ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
+import { btcAsset, ethOnBaseAsset, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
+import { PROTO } from '@trezor/connect';
 
 import { ExchangeCard } from './ExchangeCard';
 import { useExchangeForm } from '../../hooks/exchange/useExchangeForm';
@@ -94,5 +95,41 @@ describe('ExchangeCard', () => {
         expect(
             within(receiveSection).getByText(getTranslation('moduleTrading.tradingScreen.balance')),
         ).toBeOnTheScreen();
+    });
+
+    it('should convert receiveCryptoAmount to the base unit before passing it to CryptoToFiatValueBadge when bitcoin amount unit is sats', () => {
+        const satsPreloadedState = createTradingPreloadedState({
+            tradeType: 'exchange',
+            overrides: {
+                wallet: {
+                    settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI },
+                    trading: {
+                        exchange: {
+                            exchangeInfo: {
+                                buyCryptoIds: [],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        act(() => {
+            form.setValue('receiveAsset', btcAsset);
+        });
+        act(() => {
+            form.setValue('receiveCryptoAmount', '1234567123456');
+        });
+
+        const { getByText, queryByText } = renderWithStoreProvider(
+            <ExchangeCard isAmountInputActive={false} />,
+            {
+                preloadedState: satsPreloadedState,
+                wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+            },
+        );
+
+        expect(getByText('12345.67123456-bitcoin')).toBeOnTheScreen();
+        expect(queryByText('1234567123456-bitcoin')).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangeCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeCard.tsx
@@ -1,11 +1,13 @@
 import { useWatch } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
+import { getSymbolFromTradeableAsset } from '@suite-native/trading-atoms';
 import { CryptoToFiatValueBadge } from '@suite-native/trading-quote-utils';
 
 import { ExchangeReceiveContent } from './receive/ExchangeReceiveContent';
 import { ExchangeSendAmountBadge } from './send/ExchangeSendAmountBadge';
 import { ExchangeSendContent } from './send/ExchangeSendContent';
 import { useExchangeFormContext } from '../../hooks/exchange/useExchangeFormContext';
+import { useConvertFormValueToBaseUnit } from '../../hooks/general/useConvertFormValueToBaseUnit';
 import { TradingCard } from '../general/TradingCard';
 import { TradingCardSection } from '../general/TradingCardSection';
 
@@ -21,6 +23,11 @@ export const ExchangeCard = ({ isAmountInputActive }: ExchangeCardProps) => {
         name: ['receiveAsset', 'receiveCryptoAmount'],
         control,
     });
+    const { convertStrToBaseUnit } = useConvertFormValueToBaseUnit();
+    const receiveSymbol = getSymbolFromTradeableAsset(receiveAsset);
+    const receiveCryptoAmountInBaseUnit = receiveSymbol
+        ? convertStrToBaseUnit(receiveCryptoAmount, receiveSymbol)
+        : receiveCryptoAmount;
 
     return (
         <TradingCard isAmountInputActive={isAmountInputActive}>
@@ -39,7 +46,7 @@ export const ExchangeCard = ({ isAmountInputActive }: ExchangeCardProps) => {
                 titleAction={
                     <CryptoToFiatValueBadge
                         cryptoId={receiveAsset?.cryptoId}
-                        amount={receiveCryptoAmount}
+                        amount={receiveCryptoAmountInBaseUnit}
                     />
                 }
             >

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.test.tsx
@@ -1,32 +1,139 @@
 import { getTranslation } from '@suite-native/intl';
-import { act, renderWithStoreProvider, userEvent } from '@suite-native/test-utils-store';
+import { act, userEvent } from '@suite-native/test-utils-store';
 import {
+    banxaBankTransferSellQuote,
     cexdirectCreditCardBuyQuote,
-    getInitializedTradingState,
+    getInitializedTradingStateWithQuotes,
     mercuryoApplePayBuyQuote,
 } from '@suite-native/trading-fixtures';
 
 import { PaymentMethodListItem, type PaymentMethodListItemProps } from './PaymentMethodListItem';
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    renderWithTradingProvider,
+} from '../../../test-utils/tradingTestUtils';
 
 describe('PaymentMethodListItem', () => {
-    const getPreloadedState = () => ({ wallet: { trading: getInitializedTradingState() } });
+    const defaultOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        wallet: {
+            trading: getInitializedTradingStateWithQuotes(),
+        },
+    };
 
-    const renderPaymentMethodListItem = (props: Partial<PaymentMethodListItemProps<any>>) =>
-        renderWithStoreProvider(
+    const shortfallQuote = {
+        ...mercuryoApplePayBuyQuote,
+        fiatStringAmount: '8',
+        orderId: 'order-id-payment-method-shortfall',
+    };
+
+    const shortfallOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        wallet: {
+            trading: {
+                ...getInitializedTradingStateWithQuotes(),
+                buy: {
+                    ...getInitializedTradingStateWithQuotes().buy,
+                    quotesRequest: {
+                        wantCrypto: false,
+                        receiveCurrency: shortfallQuote.receiveCurrency,
+                        fiatCurrency: 'USD',
+                        fiatStringAmount: '10',
+                    },
+                },
+            },
+        },
+    };
+
+    const wantCryptoOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        wallet: {
+            trading: {
+                ...getInitializedTradingStateWithQuotes(),
+                buy: {
+                    ...getInitializedTradingStateWithQuotes().buy,
+                    quotesRequest: {
+                        wantCrypto: true,
+                        receiveCurrency: mercuryoApplePayBuyQuote.receiveCurrency,
+                        fiatCurrency: 'EUR',
+                        cryptoStringAmount: mercuryoApplePayBuyQuote.receiveStringAmount,
+                    },
+                },
+            },
+        },
+    };
+
+    const cryptoShortfallOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+        wallet: {
+            trading: {
+                ...getInitializedTradingStateWithQuotes(),
+                buy: {
+                    ...getInitializedTradingStateWithQuotes().buy,
+                    quotesRequest: {
+                        wantCrypto: true,
+                        receiveCurrency: mercuryoApplePayBuyQuote.receiveCurrency,
+                        fiatCurrency: 'EUR',
+                        cryptoStringAmount: '0.002',
+                    },
+                },
+            },
+        },
+    };
+
+    const renderPaymentMethodListItem = (
+        props: Partial<PaymentMethodListItemProps<any>>,
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = defaultOverrides,
+    ) =>
+        renderWithTradingProvider(
             <PaymentMethodListItem
                 quote={mercuryoApplePayBuyQuote}
                 onPress={jest.fn()}
                 {...props}
             />,
-            { preloadedState: getPreloadedState() },
+            { overrides },
         );
 
-    it('should render given name and rate', () => {
-        const { getByText } = renderPaymentMethodListItem({});
+    it('should render given name and receive amount', () => {
+        const { getByText, queryByText } = renderPaymentMethodListItem({});
 
         expect(getByText('Apple Pay')).toBeOnTheScreen();
-        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
-        expect(getByText(getTranslation('moduleTrading.providerListItem.rate'))).toBeOnTheScreen();
+        expect(getByText('0.00100017 BTC')).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.providerListItem.rate'))).toBeNull();
+    });
+
+    it('should display fiat amount instead of receive amount when user requested a crypto amount', () => {
+        const { getByText, queryByText } = renderPaymentMethodListItem({}, wantCryptoOverrides);
+
+        expect(getByText('€10.00')).toBeOnTheScreen();
+        expect(queryByText('0.00100017 BTC')).toBeNull();
+    });
+
+    it('should display crypto amount difference in shortfall note when user requested a crypto amount', () => {
+        const cryptoShortfallQuote = {
+            ...mercuryoApplePayBuyQuote,
+            receiveStringAmount: '0.001',
+            orderId: 'order-id-crypto-shortfall',
+        };
+
+        const { getByText } = renderPaymentMethodListItem(
+            { quote: cryptoShortfallQuote },
+            cryptoShortfallOverrides,
+        );
+
+        expect(getByText('50% less to receive than requested (0.001 BTC)')).toBeOnTheScreen();
+    });
+
+    it('should render shortfall note for a shortfall quote', () => {
+        const { getByText } = renderPaymentMethodListItem(
+            { quote: shortfallQuote },
+            shortfallOverrides,
+        );
+
+        expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
+    });
+
+    it('should not render shortfall note when shortfall is not present', () => {
+        const { queryByText } = renderPaymentMethodListItem({});
+
+        expect(queryByText(/less to receive/)).toBeNull();
     });
 
     it('should render payment method logo for branded payment methods', () => {
@@ -54,12 +161,99 @@ describe('PaymentMethodListItem', () => {
         expect(onPress).toHaveBeenCalledTimes(1);
     });
 
-    it('should not render rate row when rate is unknown', () => {
+    it('should not render receive amount row when receive amount is unknown', () => {
         const { getByText, queryByText } = renderPaymentMethodListItem({
-            quote: { ...mercuryoApplePayBuyQuote, rate: undefined, receiveStringAmount: undefined },
+            quote: { ...mercuryoApplePayBuyQuote, receiveStringAmount: undefined },
         });
 
         expect(getByText('Apple Pay')).toBeOnTheScreen();
-        expect(queryByText('€9,998.32 / 1 BTC')).toBeNull();
+        expect(queryByText('0.00100017 BTC')).toBeNull();
+    });
+
+    describe('sell trade', () => {
+        const sellQuote = {
+            ...banxaBankTransferSellQuote,
+            cryptoStringAmount: '1',
+            fiatStringAmount: '100.00',
+        };
+
+        const sellFiatRequestOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+            wallet: {
+                trading: {
+                    ...getInitializedTradingStateWithQuotes(),
+                    sell: {
+                        ...getInitializedTradingStateWithQuotes().sell,
+                        quotesRequest: {
+                            amountInCrypto: false,
+                            country: 'CZ',
+                            cryptoCurrency: sellQuote.cryptoCurrency,
+                            fiatCurrency: 'USD',
+                            fiatStringAmount: '100',
+                            paymentMethod: 'bankTransfer',
+                        },
+                    },
+                },
+            },
+        };
+
+        const sellCryptoRequestOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+            wallet: {
+                trading: {
+                    ...getInitializedTradingStateWithQuotes(),
+                    sell: {
+                        ...getInitializedTradingStateWithQuotes().sell,
+                        quotesRequest: {
+                            amountInCrypto: true,
+                            country: 'CZ',
+                            cryptoCurrency: sellQuote.cryptoCurrency,
+                            fiatCurrency: 'USD',
+                            cryptoStringAmount: '1',
+                            paymentMethod: 'bankTransfer',
+                        },
+                    },
+                },
+            },
+        };
+
+        it('should display crypto amount to sell when user requested a fixed fiat amount', () => {
+            const { getByText, queryByText } = renderPaymentMethodListItem(
+                { quote: sellQuote },
+                sellFiatRequestOverrides,
+            );
+
+            expect(getByText('1 ETH')).toBeOnTheScreen();
+            expect(queryByText('$100.00')).toBeNull();
+        });
+
+        it('should display fiat amount to receive when user requested a fixed crypto amount', () => {
+            const { getByText, queryByText } = renderPaymentMethodListItem(
+                { quote: sellQuote },
+                sellCryptoRequestOverrides,
+            );
+
+            expect(getByText('$100.00')).toBeOnTheScreen();
+            expect(queryByText('1 ETH')).toBeNull();
+        });
+
+        it('should render shortfall note when sell quote receives less fiat than requested', () => {
+            const shortfallSellQuote = {
+                ...sellQuote,
+                fiatStringAmount: '70',
+                orderId: 'order-id-sell-shortfall',
+            };
+
+            const { getByText } = renderPaymentMethodListItem(
+                { quote: shortfallSellQuote },
+                sellFiatRequestOverrides,
+            );
+
+            expect(getByText('30% less to receive than requested ($30.00)')).toBeOnTheScreen();
+        });
+
+        it('should not render shortfall note for a sell quote when there is no shortfall', () => {
+            const { queryByText } = renderPaymentMethodListItem({ quote: sellQuote });
+
+            expect(queryByText(/less to receive/)).toBeNull();
+        });
     });
 });

--- a/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
+++ b/suite-native/module-trading/src/components/general/PaymentMethodSheet/PaymentMethodListItem.tsx
@@ -2,12 +2,14 @@ import { Pressable } from 'react-native';
 
 import type { BuyTrade, SellFiatTrade } from 'invity-api';
 
+import { useTradingRequestedSide } from '@suite-common/trading';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { PaymentMethodIcon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
 import { PaymentMethodTranslation } from '@suite-native/trading-atoms';
 import { useChangeStringsExtractor } from '@suite-native/trading-quote-utils';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { RequestedAmountShortfallNote } from '../RequestedAmountShortfallNote';
 
 export type PaymentMethodListItemProps<T extends BuyTrade | SellFiatTrade> = {
     quote: T;
@@ -16,12 +18,12 @@ export type PaymentMethodListItemProps<T extends BuyTrade | SellFiatTrade> = {
     isLast?: boolean;
 };
 
-export const PAYMENT_METHOD_LIST_ITEM_HEIGHT = 72 as const;
+export const PAYMENT_METHOD_LIST_ITEM_HEIGHT = 80 as const;
 
 const itemStyle = prepareNativeStyle<{ isFirst: boolean; isLast: boolean }>(
     (
         {
-            spacings: { sp1, sp12, sp20 },
+            spacings: { sp1, sp12, sp20, sp64 },
             colors: { surfaceFillRaised },
             borders: {
                 radii: { r20 },
@@ -33,6 +35,8 @@ const itemStyle = prepareNativeStyle<{ isFirst: boolean; isLast: boolean }>(
         paddingVertical: sp12,
         backgroundColor: surfaceFillRaised,
         marginBottom: sp1,
+        minHeight: sp64,
+        justifyContent: 'center',
         extend: [
             {
                 condition: isFirst,
@@ -59,45 +63,32 @@ export const PaymentMethodListItem = <T extends BuyTrade | SellFiatTrade>({
     isLast = false,
 }: PaymentMethodListItemProps<T>) => {
     const { applyStyle } = useNativeStyles();
-    const { formattedRate } = useChangeStringsExtractor(quote);
+    const requestedSide = useTradingRequestedSide(quote);
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+
+    const displayValue = requestedSide === 'to' ? fromStringValue : toStringValue;
 
     return (
         <Pressable onPress={onPress} style={applyStyle(itemStyle, { isFirst, isLast })}>
-            <VStack spacing="sp4">
-                <HStack alignItems="center" spacing="sp12" flex={1} flexShrink={1}>
-                    <PaymentMethodIcon paymentMethod={quote.paymentMethod} />
-                    <Text
-                        variant="body-md"
-                        color="contentPrimary"
-                        numberOfLines={1}
-                        ellipsizeMode="tail"
-                    >
-                        <PaymentMethodTranslation
-                            paymentMethod={quote.paymentMethod}
-                            paymentMethodName={quote.paymentMethodName}
-                        />
-                    </Text>
-                </HStack>
-                {!!formattedRate && (
-                    <HStack alignItems="center" justifyContent="space-between" paddingLeft="sp32">
-                        <Text
-                            variant="body-sm"
-                            color="contentSecondary"
-                            numberOfLines={1}
-                            ellipsizeMode="tail"
-                        >
-                            <Translation id="moduleTrading.providerListItem.rate" />
-                        </Text>
-                        <Text
-                            variant="body-sm"
-                            color="contentSecondary"
-                            numberOfLines={1}
-                            ellipsizeMode="tail"
-                        >
-                            {formattedRate}
+            <VStack spacing="sp8">
+                <HStack alignItems="center" justifyContent="space-between">
+                    <HStack alignItems="center" spacing="sp12" flex={1} flexShrink={1}>
+                        <PaymentMethodIcon paymentMethod={quote.paymentMethod} />
+                        <Text variant="body-sm" numberOfLines={1} ellipsizeMode="tail">
+                            <PaymentMethodTranslation
+                                paymentMethod={quote.paymentMethod}
+                                paymentMethodName={quote.paymentMethodName}
+                            />
                         </Text>
                     </HStack>
-                )}
+                    {!!displayValue && (
+                        <Text variant="body-sm-strong" numberOfLines={1} ellipsizeMode="tail">
+                            {displayValue}
+                        </Text>
+                    )}
+                </HStack>
+
+                <RequestedAmountShortfallNote quote={quote} />
             </VStack>
         </Pressable>
     );

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.test.tsx
@@ -27,6 +27,7 @@ describe('ProviderListItem', () => {
     const renderProviderListItem = (
         quote: TradingTradeType,
         props?: Partial<ProviderListItemProps<TradingTradeType>>,
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = baseOverrides,
     ) =>
         renderWithTradingProvider(
             <ProviderListItem
@@ -37,7 +38,7 @@ describe('ProviderListItem', () => {
                 tradingType="buy"
                 {...props}
             />,
-            { overrides: baseOverrides },
+            { overrides },
         );
 
     it('should render provider information correctly', () => {
@@ -46,13 +47,22 @@ describe('ProviderListItem', () => {
         expect(getByText('Mercuryo')).toBeOnTheScreen();
     });
 
-    it('should render trading information with formatted strings', () => {
+    it('should render the amount in the header and not the rate row for a buy quote', () => {
         const { getByText, queryByText } = renderProviderListItem(mercuryoApplePayBuyQuote);
 
         expect(
             queryByText(getTranslation('moduleTrading.providerListItem.centralizedExchange')),
         ).toBeNull();
-        expect(getByText('€9,998.32 / 1 BTC')).toBeOnTheScreen();
+        expect(getByText('0.00100017 BTC')).toBeOnTheScreen();
+        expect(queryByText('€9,998.32 / 1 BTC')).toBeNull();
+    });
+
+    it('should render the rate row for an exchange quote', () => {
+        const { getByText } = renderProviderListItem(cexdirectFloatingQuote, {
+            tradingType: 'exchange',
+        });
+
+        expect(getByText('112,210.7767229964765816 USDC / 1 BTC')).toBeOnTheScreen();
     });
 
     it('should render centralized exchange information for CEX providers when enabled', () => {

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItem.tsx
@@ -12,6 +12,7 @@ import { Card, CardDivider, HStack, Text, VStack } from '@suite-native/atoms';
 import { ProviderLogo } from '@suite-native/trading-atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { ProviderListItemAmount } from './ProviderListItemAmount';
 import { ProviderListItemInfo } from './ProviderListItemInfo';
 import { ProviderListItemValueRow } from './ProviderListItemValueRow';
 
@@ -25,6 +26,10 @@ export type ProviderListItemProps<T extends TradingTradeType> = {
 
 const wrapperStyle = prepareNativeStyle(({ spacings }) => ({
     marginVertical: spacings.sp4,
+}));
+
+const companyNameStyle = prepareNativeStyle(() => ({
+    flexShrink: 1,
 }));
 
 export const ProviderListItem = <T extends TradingTradeType>({
@@ -47,23 +52,43 @@ export const ProviderListItem = <T extends TradingTradeType>({
         return null;
     }
 
+    const isExchange = tradingType === 'exchange';
+
     return (
         <Pressable onPress={() => onPress(quote)} style={applyStyle(wrapperStyle)}>
             <Card>
                 <VStack>
-                    <HStack alignItems="center" paddingBottom="sp2">
-                        <ProviderLogo logo={logo} />
-                        <Text variant="body-md" color="contentPrimary">
-                            {companyName}
-                        </Text>
+                    <HStack
+                        justifyContent="space-between"
+                        alignItems="center"
+                        paddingBottom="sp2"
+                        spacing="sp4"
+                    >
+                        <HStack alignItems="center" flex={1} flexShrink={1} spacing="sp4">
+                            <ProviderLogo logo={logo} />
+                            <Text
+                                variant="body-md"
+                                color="contentPrimary"
+                                numberOfLines={1}
+                                ellipsizeMode="tail"
+                                style={applyStyle(companyNameStyle)}
+                            >
+                                {companyName}
+                            </Text>
+                        </HStack>
+                        {!isExchange && <ProviderListItemAmount quote={quote} />}
                     </HStack>
                     <ProviderListItemInfo
                         provider={provider}
                         quote={quote}
                         shouldShowExchangeType={shouldShowExchangeType}
                     />
-                    <CardDivider />
-                    <ProviderListItemValueRow quote={quote} />
+                    {isExchange && (
+                        <>
+                            <CardDivider />
+                            <ProviderListItemValueRow quote={quote} />
+                        </>
+                    )}
                 </VStack>
             </Card>
         </Pressable>

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.test.tsx
@@ -1,0 +1,94 @@
+import type { TradingTradeType } from '@suite-common/trading';
+import {
+    banxaCreditCardSellQuote,
+    getInitializedTradingStateWithQuotes,
+    mercuryoApplePayBuyQuote,
+} from '@suite-native/trading-fixtures';
+
+import { ProviderListItemAmount } from './ProviderListItemAmount';
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    renderWithTradingProvider,
+} from '../../../test-utils/tradingTestUtils';
+
+const overridesWithQuotes: PreloadedStatePartial<TradingTestPreloadedState> = {
+    wallet: { trading: getInitializedTradingStateWithQuotes() },
+};
+
+// The user requested a crypto amount to receive ("to" side), so the fiat amount they pay is shown.
+const buyWantCryptoOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+    wallet: {
+        trading: {
+            ...getInitializedTradingStateWithQuotes(),
+            buy: {
+                ...getInitializedTradingStateWithQuotes().buy,
+                quotesRequest: {
+                    wantCrypto: true,
+                    receiveCurrency: mercuryoApplePayBuyQuote.receiveCurrency,
+                    fiatCurrency: 'EUR',
+                    cryptoStringAmount: mercuryoApplePayBuyQuote.receiveStringAmount,
+                },
+            },
+        },
+    },
+};
+
+// The user entered a crypto amount to sell ("from" side), so the fiat amount they receive is shown.
+const sellAmountInCryptoOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+    wallet: {
+        trading: {
+            ...getInitializedTradingStateWithQuotes(),
+            sell: {
+                ...getInitializedTradingStateWithQuotes().sell,
+                quotesRequest: {
+                    amountInCrypto: true,
+                    cryptoCurrency: banxaCreditCardSellQuote.cryptoCurrency,
+                    fiatCurrency: 'USD',
+                },
+            },
+        },
+    },
+};
+
+describe('ProviderListItemAmount', () => {
+    const renderProviderListItemAmount = (
+        quote: TradingTradeType,
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = overridesWithQuotes,
+    ) => renderWithTradingProvider(<ProviderListItemAmount quote={quote} />, { overrides });
+
+    it('should render the received amount when the user entered the "from" amount', () => {
+        const { getByText } = renderProviderListItemAmount(mercuryoApplePayBuyQuote);
+
+        expect(getByText('0.00100017 BTC')).toBeOnTheScreen();
+    });
+
+    it('should render the fiat amount when the user requested a crypto ("to") amount for buy', () => {
+        const { getByText } = renderProviderListItemAmount(
+            mercuryoApplePayBuyQuote,
+            buyWantCryptoOverrides,
+        );
+
+        expect(getByText('€10.00')).toBeOnTheScreen();
+    });
+
+    it('should render the received fiat amount when the user entered a crypto amount for sell', () => {
+        const { getByText } = renderProviderListItemAmount(
+            banxaCreditCardSellQuote,
+            sellAmountInCryptoOverrides,
+        );
+
+        expect(getByText('$90.17')).toBeOnTheScreen();
+    });
+
+    it('should render nothing when the amount is missing', () => {
+        const quoteWithoutReceiveAmount = {
+            ...mercuryoApplePayBuyQuote,
+            receiveStringAmount: undefined,
+        } as TradingTradeType;
+
+        const { toJSON } = renderProviderListItemAmount(quoteWithoutReceiveAmount);
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemAmount.tsx
@@ -1,0 +1,25 @@
+import { type TradingTradeType, useTradingRequestedSide } from '@suite-common/trading';
+import { Text } from '@suite-native/atoms';
+import { useChangeStringsExtractor } from '@suite-native/trading-quote-utils';
+
+export type ProviderListItemAmountProps<T extends TradingTradeType> = {
+    quote: T;
+};
+
+export const ProviderListItemAmount = <T extends TradingTradeType>({
+    quote,
+}: ProviderListItemAmountProps<T>) => {
+    const { fromStringValue, toStringValue } = useChangeStringsExtractor(quote);
+    const requestedSide = useTradingRequestedSide(quote);
+    const displayValue = requestedSide === 'to' ? fromStringValue : toStringValue;
+
+    if (!displayValue) {
+        return null;
+    }
+
+    return (
+        <Text variant="body-md-strong" color="contentPrimary">
+            {displayValue}
+        </Text>
+    );
+};

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.test.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.test.tsx
@@ -1,0 +1,69 @@
+import { type TradingProviderInfo, type TradingTradeType } from '@suite-common/trading';
+import {
+    getInitializedTradingStateWithQuotes,
+    mercuryoApplePayBuyQuote,
+} from '@suite-native/trading-fixtures';
+
+import { ProviderListItemInfo } from './ProviderListItemInfo';
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    renderWithTradingProvider,
+} from '../../../test-utils/tradingTestUtils';
+
+const provider = { companyName: 'Mercuryo', logo: '' } as TradingProviderInfo;
+
+const overridesWithQuotes: PreloadedStatePartial<TradingTestPreloadedState> = {
+    wallet: { trading: getInitializedTradingStateWithQuotes() },
+};
+
+describe('ProviderListItemInfo', () => {
+    const renderProviderListItemInfo = (
+        quote: TradingTradeType,
+        overrides: PreloadedStatePartial<TradingTestPreloadedState> = overridesWithQuotes,
+    ) =>
+        renderWithTradingProvider(
+            <ProviderListItemInfo
+                quote={quote}
+                provider={provider}
+                shouldShowExchangeType={false}
+            />,
+            { overrides },
+        );
+
+    it('should render shortfall note for a shortfall quote', () => {
+        const shortfallQuote = {
+            ...mercuryoApplePayBuyQuote,
+            fiatStringAmount: '8',
+            orderId: 'order-id-shortfall-note',
+        };
+
+        const shortfallOverrides: PreloadedStatePartial<TradingTestPreloadedState> = {
+            wallet: {
+                trading: {
+                    ...getInitializedTradingStateWithQuotes(),
+                    buy: {
+                        ...getInitializedTradingStateWithQuotes().buy,
+                        quotesRequest: {
+                            wantCrypto: false,
+                            receiveCurrency: shortfallQuote.receiveCurrency,
+                            fiatCurrency: 'EUR',
+                            fiatStringAmount: '10',
+                        },
+                    },
+                },
+            },
+        };
+
+        const { getByText } = renderProviderListItemInfo(shortfallQuote, shortfallOverrides);
+
+        // The note is shown in the fiat currency the user is trading in (EUR from the quote).
+        expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
+    });
+
+    it('should not render shortfall note when quote does not have shortfall', () => {
+        const { queryByText } = renderProviderListItemInfo(mercuryoApplePayBuyQuote);
+
+        expect(queryByText(/less to receive/)).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
+++ b/suite-native/module-trading/src/components/general/ProviderSheet/ProviderListItemInfo.tsx
@@ -9,6 +9,7 @@ import {
 import { Translation } from '@suite-native/intl';
 import { KycPolicyWarning, hasKycPolicyWarning } from '@suite-native/trading-provider-utils';
 
+import { RequestedAmountShortfallNote } from '../RequestedAmountShortfallNote';
 import { InfoLineItem } from './InfoLineItem';
 
 export type ProviderListItemInfoProps<T extends TradingTradeType> = {
@@ -41,6 +42,7 @@ export const ProviderListItemInfo = <T extends TradingTradeType>({
 
     return (
         <>
+            <RequestedAmountShortfallNote quote={quote} />
             {shouldShowExchangeType && (
                 <InfoLineItem
                     iconName="info"

--- a/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.test.tsx
+++ b/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.test.tsx
@@ -1,0 +1,88 @@
+import { mercuryoApplePayBuyQuote } from '@suite-native/trading-fixtures';
+
+import { RequestedAmountShortfallNote } from './RequestedAmountShortfallNote';
+import {
+    type PreloadedStatePartial,
+    type TradingTestPreloadedState,
+    renderWithTradingProvider,
+} from '../../test-utils/tradingTestUtils';
+
+describe('RequestedAmountShortfallNote', () => {
+    const renderNote = (
+        quote: typeof mercuryoApplePayBuyQuote,
+        overrides: PreloadedStatePartial<TradingTestPreloadedState>,
+    ) => renderWithTradingProvider(<RequestedAmountShortfallNote quote={quote} />, { overrides });
+
+    it('renders a fiat shortfall formatted in the quote fiat currency', () => {
+        const quote = { ...mercuryoApplePayBuyQuote, fiatStringAmount: '8' };
+
+        const { getByText } = renderNote(quote, {
+            wallet: {
+                trading: {
+                    buy: {
+                        quotesRequest: {
+                            wantCrypto: false,
+                            receiveCurrency: quote.receiveCurrency,
+                            fiatCurrency: 'USD',
+                            fiatStringAmount: '10',
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(getByText('20% less to receive than requested (€2.00)')).toBeOnTheScreen();
+    });
+
+    it('renders nothing when there is a fiat shortfall but the quote has no fiat currency', () => {
+        const quote = {
+            ...mercuryoApplePayBuyQuote,
+            fiatCurrency: undefined,
+            fiatStringAmount: '8',
+        };
+
+        const { toJSON } = renderNote(quote, {
+            wallet: {
+                trading: {
+                    buy: {
+                        quotesRequest: {
+                            wantCrypto: false,
+                            receiveCurrency: quote.receiveCurrency,
+                            fiatCurrency: 'USD',
+                            fiatStringAmount: '10',
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('renders a crypto shortfall amount when the user requested a fixed crypto amount', () => {
+        const quote = { ...mercuryoApplePayBuyQuote, receiveStringAmount: '0.001' };
+
+        const { getByText } = renderNote(quote, {
+            wallet: {
+                trading: {
+                    buy: {
+                        quotesRequest: {
+                            wantCrypto: true,
+                            receiveCurrency: quote.receiveCurrency,
+                            fiatCurrency: 'EUR',
+                            cryptoStringAmount: '0.002',
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(getByText('50% less to receive than requested (0.001 BTC)')).toBeOnTheScreen();
+    });
+
+    it('renders nothing when there is no requested amount shortfall', () => {
+        const { toJSON } = renderNote(mercuryoApplePayBuyQuote, {});
+
+        expect(toJSON()).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.tsx
+++ b/suite-native/module-trading/src/components/general/RequestedAmountShortfallNote.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useFormatters } from '@suite-common/formatters';
+import {
+    type TradingTradeType,
+    isBuyTrade,
+    isSellFiatTrade,
+    useTradingRequestedAmountShortfall,
+} from '@suite-common/trading';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { Text } from '@suite-native/atoms';
+import { Translation, selectLocale } from '@suite-native/intl';
+import { useFormatCryptoValue } from '@suite-native/trading-atoms';
+import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { BigNumber } from '@trezor/utils';
+
+export type RequestedAmountShortfallNoteProps = {
+    quote: TradingTradeType;
+};
+
+export const RequestedAmountShortfallNote = ({ quote }: RequestedAmountShortfallNoteProps) => {
+    const locale = useSelector(selectLocale);
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+    const formatCryptoValue = useFormatCryptoValue();
+    const shortfall = useTradingRequestedAmountShortfall({ quote });
+
+    const percentFormatter = useMemo(
+        () =>
+            new Intl.NumberFormat(locale, {
+                style: 'percent',
+                maximumFractionDigits: 1,
+            }),
+        [locale],
+    );
+
+    if (!shortfall) {
+        return null;
+    }
+
+    const fiatCurrency =
+        isBuyTrade(quote) || isSellFiatTrade(quote)
+            ? (quote.fiatCurrency?.toLowerCase() as BaseCurrencyCode | undefined)
+            : undefined;
+
+    const getFormattedShortfall = () => {
+        if (shortfall.cryptoShortfall) {
+            return formatCryptoValue(
+                shortfall.cryptoShortfall.amount,
+                shortfall.cryptoShortfall.cryptoId,
+            );
+        }
+
+        if (shortfall.fiatShortfall !== undefined && fiatCurrency) {
+            return BaseCurrencyAmountFormatter.format(
+                asBaseCurrencyAmount(new BigNumber(shortfall.fiatShortfall)),
+                { currency: fiatCurrency },
+            );
+        }
+
+        return undefined;
+    };
+
+    const formattedShortfall = getFormattedShortfall();
+
+    if (!formattedShortfall) {
+        return null;
+    }
+
+    const formattedShortfallRatio = percentFormatter.format(shortfall.shortfallRatio);
+
+    return (
+        <Text variant="body-sm" color="contentSecondary">
+            <Translation
+                id="moduleTrading.providerListItem.lessToReceiveThanRequested"
+                values={{ percent: formattedShortfallRatio, amount: formattedShortfall }}
+            />
+        </Text>
+    );
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Keep rates only for exchange
- Display amount in pickers
- When quote is for different amount than specified by user, display warning.

<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30504

## Screenshots:
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-07-30 at 17 38 03" src="https://github.com/user-attachments/assets/06ebf372-549b-42ba-ab09-d0a511b9e3e1" />
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-07-30 at 17 38 12" src="https://github.com/user-attachments/assets/dcc20108-33e1-4c90-ad59-1a3f78e7335e" />
<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-07-30 at 17 41 00" src="https://github.com/user-attachments/assets/5951ea3e-e981-4ef3-830f-9ec8e661d3c4" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/30504-replace-rates-in-pickers/web/](https://dev.suite.sldev.cz/suite-web/30504-replace-rates-in-pickers/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=30504-replace-rates-in-pickers&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=30504-replace-rates-in-pickers&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=30504-replace-rates-in-pickers&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-09T22:37:47.416Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-09T22:38:55.334Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->