### PR TITLE
refactor(connect): add coin symbol cast helper

### DIFF
--- a/packages/connect-common/src/types/coinInfo.ts
+++ b/packages/connect-common/src/types/coinInfo.ts
@@ -179,6 +179,8 @@ export const coinSymbols = [
 // A supported coin symbol, e.g. `'btc'` / `'ada'`. See `coinSymbols`.
 export type CoinSymbol = (typeof coinSymbols)[number];
 
+export const asCoinSymbol = (value: string): CoinSymbol => value as CoinSymbol;
+
 const coinSymbolSet: ReadonlySet<string> = new Set(coinSymbols);
 
 // Runtime validation for `CoinSymbol`, derived from the same `coinSymbols` source as the type.

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -1,4 +1,4 @@
-import { ERRORS, UI_REQUEST } from '@trezor/connect-common';
+import { ERRORS, UI_REQUEST, asCoinSymbol } from '@trezor/connect-common';
 import type {
     CallMethodPayload,
     CallMethodResponse,
@@ -143,7 +143,7 @@ export abstract class AbstractMethod<Name extends CallMethodPayload['method'], P
     // to a known `CoinSymbol` (both derive from the same coin definitions), so
     // the cast is sound.
     private toCoinSymbol(shortcut: string): CoinSymbol {
-        return shortcut.toLowerCase() as CoinSymbol;
+        return asCoinSymbol(shortcut.toLowerCase());
     }
 
     // Build a `PermissionRequest` for a single coin (or coin-less when `coin` is

--- a/packages/connect/src/data/coinInfo.ts
+++ b/packages/connect/src/data/coinInfo.ts
@@ -1,11 +1,12 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/CoinInfo.js
 import { ERRORS } from '@trezor/connect-common/src/constants';
-import type {
-    BitcoinNetworkInfo,
-    CoinInfo,
-    CoinSymbol,
-    EthereumNetworkInfo,
-    MiscNetworkInfo,
+import {
+    type BitcoinNetworkInfo,
+    type CoinInfo,
+    type CoinSymbol,
+    type EthereumNetworkInfo,
+    type MiscNetworkInfo,
+    asCoinSymbol,
 } from '@trezor/connect-common/src/types/coinInfo';
 import coinsEth from '@trezor/connect-data/files/coins-eth.json';
 import coins from '@trezor/connect-data/files/coins.json';
@@ -121,7 +122,7 @@ const getCoinInfo = (coin: CoinSymbol) =>
 
 export const getCoinInfoOrThrow = (coin: string): Readonly<CoinInfo> => {
     // `coin` is unvalidated caller input; a non-shortcut resolves to undefined below
-    const coinInfo = getCoinInfo(coin as CoinSymbol);
+    const coinInfo = getCoinInfo(asCoinSymbol(coin));
     if (!coinInfo) {
         throw ERRORS.TypedError('Method_UnknownCoin');
     }

--- a/packages/connect/src/utils/addressUtils.test.ts
+++ b/packages/connect/src/utils/addressUtils.test.ts
@@ -1,4 +1,4 @@
-import type { CoinSymbol } from '@trezor/connect-common/src/types/coinInfo';
+import { asCoinSymbol } from '@trezor/connect-common';
 
 import * as fixtures from './__fixtures__/addressUtils';
 import * as utils from './addressUtils';
@@ -9,7 +9,7 @@ describe('utils/addressUtils', () => {
         fixtures.validAddresses.forEach(f => {
             it(`${f.description} ${f.address}`, () => {
                 expect(
-                    utils.isValidAddress(f.address, getBitcoinNetwork(f.coin as CoinSymbol)!),
+                    utils.isValidAddress(f.address, getBitcoinNetwork(asCoinSymbol(f.coin))!),
                 ).toEqual(true);
             });
         });
@@ -17,7 +17,7 @@ describe('utils/addressUtils', () => {
         fixtures.invalidAddresses.forEach(f => {
             it(`Invalid ${f.coin} ${f.address}`, () => {
                 expect(
-                    utils.isValidAddress(f.address, getBitcoinNetwork(f.coin as CoinSymbol)!),
+                    utils.isValidAddress(f.address, getBitcoinNetwork(asCoinSymbol(f.coin))!),
                 ).toEqual(false);
             });
         });

--- a/suite-common/connect-popup/src/permissions.ts
+++ b/suite-common/connect-popup/src/permissions.ts
@@ -4,6 +4,7 @@ import {
     type EnabledNetwork,
     GRANTABLE_PERMISSIONS,
     type PermissionRequest,
+    asCoinSymbol,
     isCoinSymbol,
 } from '@trezor/connect';
 import { unique } from '@trezor/utils/src/unique';
@@ -108,7 +109,7 @@ export const canonicalizePermissionCoins = (
     permissions.map(permission =>
         permission.coin === undefined
             ? permission
-            : { ...permission, coin: permission.coin.toLowerCase() as CoinSymbol },
+            : { ...permission, coin: asCoinSymbol(permission.coin.toLowerCase()) },
     );
 
 // Union two permission lists, de-duplicated by (permission, coin). `base` comes first, so on a


### PR DESCRIPTION
## Description

Coin symbol coercions are currently spread across Connect and connect-popup as direct casts, which makes boundary conversion inconsistent. This PR adds `asCoinSymbol` to `@trezor/connect-common` and uses it at every existing cast site, without changing runtime validation or behavior.\n\n- Direct call-site `as CoinSymbol` casts: **5 -> 0**\n- Cast implementation: **1 centralized helper**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files touch core TrezorConnect infrastructure (AbstractMethod, coinInfo types/data, popup permissions) and address utilities. Risk is concentrated in Connect API flows and address derivation/formatting. Run the full trezor-connect E2E suite as the highest priority, plus a targeted set of wallet tests covering address reveal and EVM/Cardano address handling. No broad suite-wide run is warranted because the static coverage mappings reflect global transitive imports rather than direct behavioral impact.

<details><summary><b>Changed files (5)</b></summary>

- `packages/connect-common/src/types/coinInfo.ts`
- `packages/connect/src/core/AbstractMethod.ts`
- `packages/connect/src/data/coinInfo.ts`
- `packages/connect/src/utils/addressUtils.test.ts`
- `suite-common/connect-popup/src/permissions.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises TrezorConnect.getAddress and cardanoGetAddress, permissions modal, popup lifecycle, and cancellation paths — all of which depend on AbstractMethod, permissions.ts, and coinInfo types.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Validates TrezorConnect.getAddress from a webextension context, covering permissions modal and address export paths that rely on AbstractMethod and permissions.ts.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests ethereumGetAddress with invalid derivation paths, directly exercising address/derivation validation and error handling in connect core.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Exercises TrezorConnect.ethereumSignMessage end-to-end, including permissions modal and sign-message flow that pass through AbstractMethod.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Validates TrezorConnect.ethereumSignTransaction permissions and on-device confirmation flow, dependent on AbstractMethod and coin info handling for Ethereum.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo with account type selection, directly depending on coin info and AbstractMethod for BTC account discovery.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Directly tests Bitcoin address export via TrezorConnect.getAddress, including bundle export, on-device verification, and permissions — all tightly coupled to AbstractMethod and address/coinInfo utilities.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Specifically validates the Connect permissions lifecycle (grant, remember, revoke, re-prompt), which is the primary consumer of suite-common/connect-popup/src/permissions.ts.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Tests TrezorConnect.selectAccount with permissions, account discovery, and address derivation for Ethereum — paths that depend on AbstractMethod, permissions, and coin info.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Exercises TrezorConnect.signTransaction through permissions and multi-step device prompts, relying on AbstractMethod and Bitcoin coin info handling.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Validates silent mode behavior in the permissions modal and connected apps settings, directly touching permissions.ts and AbstractMethod-driven signMessage flows.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — Covers Cardano address reveal, device confirmation, and address formatting; changes to coinInfo or address utilities could affect address display/validation for ADA.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests receive address reveal and clipboard copying for BTC, ETH, SOL, and TRX; coinInfo and address utility changes could alter address formats or derivation.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Verifies Cardano receive address derivation behind a passphrase-protected wallet, which depends on coin info and address formatting logic.
- `suite/e2e/tests/wallet/send-base.test.ts` — Tests Base network send flow with EVM address display and fee handling; changes to coinInfo or address utilities could impact EVM address formatting/derivation.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Covers Ethereum send flow with address verification on device; coinInfo and address utility changes could affect ETH address display and validation.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Exercises Bitcoin address selection and message signing/verification, which relies on address derivation and formatting that could be affected by addressUtils/coinInfo changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/connect/src/utils/addressUtils.test.ts`

_Updated: 2026-07-31T09:32:19.930Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/connect-as-coin-symbol/web/](https://dev.suite.sldev.cz/suite-web/refactor/connect-as-coin-symbol/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/connect-as-coin-symbol&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/connect-as-coin-symbol&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/connect-as-coin-symbol&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T09:33:19.500Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T09:34:27.279Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->