### PR TITLE
test(formatters): relocate mocked formatter provider

### DIFF
--- a/packages/suite/src/support/tests/hooksHelper.tsx
+++ b/packages/suite/src/support/tests/hooksHelper.tsx
@@ -13,7 +13,7 @@ import {
 import userEvent from '@testing-library/user-event';
 
 import { ServicesProvider } from '@suite-common/dependency-injection';
-import { MockedFormatterProvider } from '@suite-common/formatters';
+import { MockedFormatterProvider } from '@suite-common/formatters/mocks';
 
 import { ConnectedThemeProvider } from 'src/support/suite/ConnectedThemeProvider';
 

--- a/suite-common/formatters/mocks/MockedFormatterProvider.tsx
+++ b/suite-common/formatters/mocks/MockedFormatterProvider.tsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 
 import { PROTO } from '@trezor/connect';
 
-import { FormatterProviderContext, getFormatters } from '../FormatterProvider';
+import { FormatterProviderContext, getFormatters } from '../src/FormatterProvider';
 
 type MockedFormatterProviderProps = {
     children: ReactNode;

--- a/suite-common/formatters/mocks/index.ts
+++ b/suite-common/formatters/mocks/index.ts
@@ -1,0 +1,1 @@
+export { MockedFormatterProvider } from './MockedFormatterProvider';

--- a/suite-common/formatters/package.json
+++ b/suite-common/formatters/package.json
@@ -5,6 +5,16 @@
     "license": "See LICENSE.md in repo root",
     "sideEffects": false,
     "main": "src/index",
+    "exports": {
+        ".": {
+            "types": "./libDev/src/index.d.ts",
+            "default": "./src/index.ts"
+        },
+        "./mocks": {
+            "types": "./libDev/mocks/index.d.ts",
+            "default": "./mocks/index.ts"
+        }
+    },
     "scripts": {
         "test:unit": "yarn g:jest",
         "depcheck": "yarn g:depcheck",

--- a/suite-common/formatters/src/index.ts
+++ b/suite-common/formatters/src/index.ts
@@ -1,5 +1,4 @@
 export * from './FormatterProvider';
-export * from './tests/MockedFormatterProvider';
 export * from './useFormatters';
 export type * from './types';
 export * from './makeFormatter';

--- a/suite/test-utils/src/BasicProviderForTests.tsx
+++ b/suite/test-utils/src/BasicProviderForTests.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from 'react';
 
 import { IntlProviderForTests } from '@suite/intl';
 import { ServicesProvider } from '@suite-common/dependency-injection';
-import { MockedFormatterProvider } from '@suite-common/formatters';
+import { MockedFormatterProvider } from '@suite-common/formatters/mocks';
 import { ConnectedThemeProvider, ResponsiveContextProvider } from '@trezor/suite';
 import { extraDependenciesDesktopMock } from '@trezor/suite/mocks';
 


### PR DESCRIPTION
## Description

Relocates MockedFormatterProvider from the production source tree to the package-owned mocks directory and exposes it only through @suite-common/formatters/mocks. This keeps test infrastructure out of the production formatter entry point.

- Legacy non-E2E support files: **9 → 8**

## Notes for QA

No functional change; test infrastructure only.

## Related Issue

Part of #30302

## Screenshots

Not applicable.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/relocate-mocked-formatter-provider&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/relocate-mocked-formatter-provider&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/relocate-mocked-formatter-provider&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are almost entirely test infrastructure (mocks, test helpers, package config); only suite-common/formatters/src/index.ts is production code that could affect rendered values. Because there is no static coverage mapping, I inferred a minimal set of formatting-sensitive E2E tests focused on balance and currency display. These should quickly surface any formatter regression without running the full suite.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/support/tests/hooksHelper.tsx`
- `suite-common/formatters/mocks/MockedFormatterProvider.tsx`
- `suite-common/formatters/mocks/index.ts`
- `suite-common/formatters/package.json`
- `suite-common/formatters/src/index.ts`
- `suite/test-utils/src/BasicProviderForTests.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test directly asserts how fiat and crypto balances are rendered when discreet mode is toggled (e.g., '$###' vs '$0.00'). A change to the formatter provider or formatter exports could alter the formatting pipeline that produces these values, so it is the strongest regression signal.
- `suite/e2e/tests/settings/general.test.ts` — The test verifies currency symbol switching (USD '$0.00' to EUR '€0.00') and analytics around settings changes. These assertions depend on the formatter/currency plumbing, making this a direct check that formatter-related changes did not break currency rendering.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test checks balance display including ellipsis truncation for long balance strings. It shares the formatting layer with the changed files, so it can catch regressions in how large balances are rendered, though it is less directly tied to provider changes than the high-priority tests.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/support/tests/hooksHelper.tsx`
- `suite-common/formatters/mocks/index.ts`
- `suite-common/formatters/package.json`
- `suite/test-utils/src/BasicProviderForTests.tsx`

_Updated: 2026-07-31T09:57:57.130Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/relocate-mocked-formatter-provider/web/](https://dev.suite.sldev.cz/suite-web/test/relocate-mocked-formatter-provider/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:00:31.333Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T09:58:57.427Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->