### PR TITLE
test(suite): relocate desktop dependencies mock

### DIFF
--- a/packages/suite/mocks/extraDependenciesDesktopMock.ts
+++ b/packages/suite/mocks/extraDependenciesDesktopMock.ts
@@ -8,7 +8,7 @@ import { type ExtraDependenciesStatic } from '@suite-common/redux-utils';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { ok } from '@trezor/type-utils';
 
-import { type SuiteServices } from '../extraDependencies';
+import { type SuiteServices } from '../src/support/extraDependencies';
 
 type ExtraDependenciesSuiteMock = ExtraDependenciesStatic & { services: SuiteServices };
 

--- a/packages/suite/mocks/index.ts
+++ b/packages/suite/mocks/index.ts
@@ -1,2 +1,2 @@
-export { extraDependenciesDesktopMock } from '../src/support/tests/extraDependenciesDesktop.mock';
+export { extraDependenciesDesktopMock } from './extraDependenciesDesktopMock';
 export { mockInitialAppState } from './mockInitialAppState';

--- a/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
@@ -13,11 +13,11 @@ import { type DeepPartial } from '@trezor/type-utils';
 import { type AppState } from 'src/reducers/store';
 import { type SuiteState } from 'src/reducers/suite/suiteReducer';
 import { configureStore } from 'src/support/tests/configureStore';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { Preloader } from './Preloader';
 import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
+import { extraDependenciesDesktopMock } from '../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../mocks/mockInitialAppState';
 
 jest.mock('@trezor/env-utils', () => ({

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
@@ -8,10 +8,10 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { type AppState } from 'src/reducers/store';
 import { configureStore } from 'src/support/tests/configureStore';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { DeviceCompromised } from './DeviceCompromised';
+import { extraDependenciesDesktopMock } from '../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
@@ -4,10 +4,10 @@ import { Translation } from '@suite/intl';
 import { configureMockStore, screen } from '@suite-common/test-utils';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
 
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { NotificationRenderer } from './NotificationRenderer';
+import { extraDependenciesDesktopMock } from '../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
 import { type NotificationViewProps } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
 

--- a/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useRbfForm.test.tsx
@@ -9,7 +9,6 @@ import TrezorConnect from '@trezor/connect';
 
 import { ChangeFee } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee';
 import { ReplaceTxButton } from 'src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ReplaceTxButton';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import {
     actionSequence,
     findByTestId,
@@ -19,6 +18,7 @@ import {
 
 import * as fixtures from './__fixtures__/useRbfForm';
 import { RbfContext, useRbf, useRbfContext } from './useRbfForm';
+import { extraDependenciesDesktopMock } from '../../../mocks/extraDependenciesDesktopMock';
 
 global.ResizeObserver = class MockedResizeObserver {
     observe = jest.fn();

--- a/packages/suite/src/hooks/wallet/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useSendForm.test.tsx
@@ -16,7 +16,6 @@ import {
 import { type FormState } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
 
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import {
     type UserAction,
     actionSequence,
@@ -29,6 +28,7 @@ import SendIndex from 'src/views/wallet/send';
 
 import * as fixtures from './__fixtures__/useSendForm';
 import { useSendFormContext } from './useSendForm';
+import { extraDependenciesDesktopMock } from '../../../mocks/extraDependenciesDesktopMock';
 
 const TEST_TIMEOUT = 35000;
 

--- a/packages/suite/src/support/tests/configureStore.tsx
+++ b/packages/suite/src/support/tests/configureStore.tsx
@@ -6,8 +6,8 @@ import { withExtraArgument } from 'redux-thunk';
 import type { ExtraDependencies } from '@suite-common/redux-utils';
 import { mergeDeepObject } from '@trezor/utils';
 
+import { extraDependenciesDesktopMock } from '../../../mocks/extraDependenciesDesktopMock';
 import { type SuiteServices, extraDependencies } from '../extraDependencies';
-import { extraDependenciesDesktopMock } from './extraDependenciesDesktop.mock';
 
 interface MiddlewareAPI<D extends Dispatch = Dispatch<AnyAction>, S = any> {
     dispatch: D;

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
@@ -9,10 +9,10 @@ import { configureMockStore } from '@suite-common/test-utils';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { SendContext } from 'src/hooks/wallet/useSendForm';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { EthereumNonce } from './EthereumNonce';
+import { extraDependenciesDesktopMock } from '../../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 const ethAccount = mockWalletAccount({ symbol: 'eth' }) as any;

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
@@ -4,10 +4,10 @@ import { screen } from '@testing-library/react';
 
 import { type AppState } from 'src/reducers/store';
 import { configureStore } from 'src/support/tests/configureStore';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingLayout } from './TradingLayout';
+import { extraDependenciesDesktopMock } from '../../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
@@ -12,10 +12,10 @@ import {
     createAccountKey,
 } from '@suite-common/wallet-types';
 
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingTransactionsList } from './TradingTransactionsList';
+import { extraDependenciesDesktopMock } from '../../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
@@ -8,10 +8,10 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
 import { type AppState } from 'src/reducers/store';
-import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingFormOfferSellActions } from './TradingFormOfferSellActions';
+import { extraDependenciesDesktopMock } from '../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
 
 const mockUseTradingFormContext = jest.fn();


### PR DESCRIPTION
## Description

Moves extraDependenciesDesktopMock into the Suite package mocks directory and updates Suite-internal consumers through relative imports. The package does not import itself, and no depcheck exception is added.

- Legacy non-E2E support files: **2 → 1**

## Notes for QA

No functional change; test infrastructure only.

## Related Issue

Part of #30302

## Screenshots

Not applicable.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/relocate-extra-dependencies-desktop-mock/web/](https://dev.suite.sldev.cz/suite-web/test/relocate-extra-dependencies-desktop-mock/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/relocate-extra-dependencies-desktop-mock&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/relocate-extra-dependencies-desktop-mock&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T11:35:19.791Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T11:35:12.403Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are exclusively unit test files (.test.tsx) and test infrastructure utilities (mocks under packages/suite/mocks/ and support/tests/configureStore.tsx). None of these are application source files that the E2E suite exercises, and there is no evidence from the test descriptions that E2E tests import or depend on these test-only artifacts. Therefore the risk to E2E behavior is negligible and no E2E tests need to run.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/mocks/extraDependenciesDesktopMock.ts`
- `packages/suite/mocks/index.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.test.tsx`
- `packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx`
- `packages/suite/src/hooks/wallet/useRbfForm.test.tsx`
- `packages/suite/src/hooks/wallet/useSendForm.test.tsx`
- `packages/suite/src/support/tests/configureStore.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (12)**
- `packages/suite/mocks/extraDependenciesDesktopMock.ts`
- `packages/suite/mocks/index.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.test.tsx`
- `packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx`
- `packages/suite/src/hooks/wallet/useRbfForm.test.tsx`
- `packages/suite/src/hooks/wallet/useSendForm.test.tsx`
- `packages/suite/src/support/tests/configureStore.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx`

_Updated: 2026-07-31T11:32:14.341Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->