### PR TITLE
test(suite): relocate initial app state mock

### DIFF
--- a/packages/suite/mocks/index.ts
+++ b/packages/suite/mocks/index.ts
@@ -1,1 +1,2 @@
 export { extraDependenciesDesktopMock } from '../src/support/tests/extraDependenciesDesktop.mock';
+export { mockInitialAppState } from './mockInitialAppState';

--- a/packages/suite/mocks/mockInitialAppState.ts
+++ b/packages/suite/mocks/mockInitialAppState.ts
@@ -13,7 +13,7 @@ import { type FirmwareUpdateState } from '@suite-common/firmware';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { type MetadataState } from '@suite-common/metadata-types';
 import { receiveInitialState } from '@suite-common/receive';
-import { quotaManagerInitialState } from '@suite-common/suite-sync-quota-manager/src/quotaManagerReducer';
+import { quotaManagerInitialState } from '@suite-common/suite-sync-quota-manager';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
 import { initialDesktopBluetoothState } from 'src/actions/bluetooth/desktopBluetoothReducer';
@@ -23,7 +23,7 @@ import { type ProtocolState } from 'src/reducers/suite/protocolReducer';
 import { suiteInitialState } from 'src/reducers/suite/suiteReducer';
 import { type WalletState } from 'src/reducers/wallet';
 
-export const initialAppState: AppState = {
+export const mockInitialAppState: AppState = {
     suite: suiteInitialState,
     discreetMode: {
         isActive: false,

--- a/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.test.tsx
@@ -12,13 +12,13 @@ import { type DeepPartial } from '@trezor/type-utils';
 
 import { type AppState } from 'src/reducers/store';
 import { type SuiteState } from 'src/reducers/suite/suiteReducer';
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { findByTestId, renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { Preloader } from './Preloader';
 import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
+import { mockInitialAppState } from '../../../../mocks/mockInitialAppState';
 
 jest.mock('@trezor/env-utils', () => ({
     ...jest.requireActual('@trezor/env-utils'),
@@ -93,12 +93,12 @@ const getInitialState = ({
     device,
     analytics,
 }: GetInitialStateProps = {}): AppState => ({
-    ...initialAppState,
-    router: { ...initialAppState.router, ...router } as unknown as RouterState,
-    device: { ...initialAppState.device, ...device } as DesktopDeviceState,
-    analytics: { ...initialAppState.analytics, ...analytics },
+    ...mockInitialAppState,
+    router: { ...mockInitialAppState.router, ...router } as unknown as RouterState,
+    device: { ...mockInitialAppState.device, ...device } as DesktopDeviceState,
+    analytics: { ...mockInitialAppState.analytics, ...analytics },
     suite: {
-        ...initialAppState.suite,
+        ...mockInitialAppState.suite,
         lifecycle: {
             status: 'ready',
         },
@@ -106,9 +106,9 @@ const getInitialState = ({
         ...suite,
     },
     wallet: {
-        ...initialAppState.wallet,
-        selectedAccount: initialAppState.wallet?.selectedAccount ?? { account: null },
-        accounts: initialAppState.wallet?.accounts ?? [],
+        ...mockInitialAppState.wallet,
+        selectedAccount: mockInitialAppState.wallet?.selectedAccount ?? { account: null },
+        accounts: mockInitialAppState.wallet?.accounts ?? [],
     },
 });
 

--- a/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
+++ b/packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts
@@ -2,10 +2,10 @@ import { defaultDevicePersistentData, mockSuiteDevice } from '@suite-common/suit
 import * as deviceUtils from '@suite-common/suite-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { type AcquiredDevice, type AppState } from 'src/types/suite';
 
 import { selectShouldDisplayDeviceCompromisedOnRoute } from './selectShouldDisplayDeviceCompromisedOnRoute';
+import { mockInitialAppState } from '../../../../mocks/mockInitialAppState';
 
 type Fixture = {
     description: string;
@@ -39,9 +39,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns false if all checks pass',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 selectedDevice: {
                     ...defaultDevice,
                     authenticityChecks: authenticityChecksSuccess,
@@ -53,10 +53,10 @@ const fixtures: Fixture[] = [
     {
         description: 'returns false if check errors, but on a skipped route',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             router: {
-                ...initialAppState.router,
-                // @ts-expect-error see defaultAppState comment about routerReducer typing
+                ...mockInitialAppState.router,
+                // @ts-expect-error see mockInitialAppState comment about routerReducer typing
                 route: {
                     name: 'settings-index',
                     pattern: '/settings',
@@ -64,7 +64,7 @@ const fixtures: Fixture[] = [
                 },
             },
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 selectedDevice: {
                     ...defaultDevice,
                     authenticityChecks: authenticityChecksFail,
@@ -76,9 +76,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns true if firmware check errored and not dismissed',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 selectedDevice: {
                     ...defaultDevice,
                     authenticityChecks: authenticityChecksFail,
@@ -90,9 +90,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns false if firmware check errored and dismissed',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 dismissedSecurityChecks: { firmwareAuthenticity: ['device-id'] },
                 selectedDevice: {
                     ...defaultDevice,
@@ -105,9 +105,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns false if a firmware check errored but is disabled',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 selectedDevice: {
                     ...defaultDevice,
                     authenticityChecks: {
@@ -117,9 +117,9 @@ const fixtures: Fixture[] = [
                 },
             },
             suiteSettings: {
-                ...initialAppState.suiteSettings,
+                ...mockInitialAppState.suiteSettings,
                 enabledSecurityChecks: {
-                    ...initialAppState.suiteSettings.enabledSecurityChecks,
+                    ...mockInitialAppState.suiteSettings.enabledSecurityChecks,
                     firmwareRevision: false,
                 },
             },
@@ -129,9 +129,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns true if entropy check errored',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 persistentDeviceData: [
                     {
                         ...matchingDevicePersistentData,
@@ -149,9 +149,9 @@ const fixtures: Fixture[] = [
     {
         description: 'returns false if entropy check errored but is disabled',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 persistentDeviceData: [
                     {
                         ...matchingDevicePersistentData,
@@ -164,9 +164,9 @@ const fixtures: Fixture[] = [
                 },
             },
             suiteSettings: {
-                ...initialAppState.suiteSettings,
+                ...mockInitialAppState.suiteSettings,
                 enabledSecurityChecks: {
-                    ...initialAppState.suiteSettings.enabledSecurityChecks,
+                    ...mockInitialAppState.suiteSettings.enabledSecurityChecks,
                     entropy: false,
                 },
             },
@@ -176,17 +176,20 @@ const fixtures: Fixture[] = [
     {
         description: 'returns true for a device with an invalid id',
         state: {
-            ...initialAppState,
-            device: { ...initialAppState.device, selectedDevice: { ...defaultDevice, id: null } },
+            ...mockInitialAppState,
+            device: {
+                ...mockInitialAppState.device,
+                selectedDevice: { ...defaultDevice, id: null },
+            },
         },
         result: true,
     },
     {
         description: 'returns true for a device with mismatch against its persistent data',
         state: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: {
-                ...initialAppState.device,
+                ...mockInitialAppState.device,
                 persistentDeviceData: [matchingDevicePersistentData],
                 selectedDevice: {
                     ...defaultDevice,

--- a/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
+++ b/packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx
@@ -7,12 +7,12 @@ import * as deviceUtils from '@suite-common/suite-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { type AppState } from 'src/reducers/store';
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { DeviceCompromised } from './DeviceCompromised';
+import { mockInitialAppState } from '../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 
@@ -37,12 +37,12 @@ const initStore = (state: AppState) => mockStore(state);
 
 const getInitialState = (device: DeviceReducerState): AppState =>
     ({
-        ...initialAppState,
+        ...mockInitialAppState,
         device,
         wallet: {
-            ...initialAppState.wallet,
-            selectedAccount: initialAppState.wallet?.selectedAccount ?? { account: null },
-            accounts: initialAppState.wallet?.accounts ?? [],
+            ...mockInitialAppState.wallet,
+            selectedAccount: mockInitialAppState.wallet?.selectedAccount ?? { account: null },
+            accounts: mockInitialAppState.wallet?.accounts ?? [],
         },
     }) as AppState;
 
@@ -156,13 +156,13 @@ const deviceCompromisedFixtures: Array<{
     },
     {
         description: 'Device Id check error',
-        device: { ...initialAppState.device, selectedDevice: { ...defaultDevice, id: null } },
+        device: { ...mockInitialAppState.device, selectedDevice: { ...defaultDevice, id: null } },
         result: 'TR_DEVICE_COMPROMISED_INVALID_ID_TEXT',
     },
     {
         description: 'Device invariability check error',
         device: {
-            ...initialAppState.device,
+            ...mockInitialAppState.device,
             persistentDeviceData: [matchingDevicePersistentData],
             selectedDevice: {
                 ...defaultDevice,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
@@ -4,11 +4,11 @@ import { Translation } from '@suite/intl';
 import { configureMockStore, screen } from '@suite-common/test-utils';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
 
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { NotificationRenderer } from './NotificationRenderer';
+import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
 import { type NotificationViewProps } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
 
 type TradingErrorNotification = Extract<NotificationEntry, { type: 'trading-error' }>;
@@ -20,7 +20,7 @@ const MessageView = ({ message, messageValues }: NotificationViewProps) => (
 const renderTradingError = (payload: Omit<TradingErrorNotification, 'context' | 'id'>) => {
     const notification: TradingErrorNotification = { context: 'toast', id: 0, ...payload };
     const store = configureMockStore({
-        preloadedState: initialAppState,
+        preloadedState: mockInitialAppState,
         serializableCheck: { ignoredActions: [] },
     });
 

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
@@ -9,11 +9,11 @@ import { configureMockStore } from '@suite-common/test-utils';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { SendContext } from 'src/hooks/wallet/useSendForm';
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { EthereumNonce } from './EthereumNonce';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 const ethAccount = mockWalletAccount({ symbol: 'eth' }) as any;
 
@@ -72,11 +72,11 @@ const pendingAtNonce6 = {
 const render = (props: Props) => {
     const store = configureMockStore({
         preloadedState: {
-            ...initialAppState,
+            ...mockInitialAppState,
             wallet: {
-                ...initialAppState.wallet,
+                ...mockInitialAppState.wallet,
                 transactions: {
-                    ...initialAppState.wallet.transactions,
+                    ...mockInitialAppState.wallet.transactions,
                     transactions: { [ethAccount.key]: [pendingAtNonce6] },
                 },
             },

--- a/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx
@@ -3,12 +3,12 @@ import '@suite-common/test-utils/globalOverrides';
 import { screen } from '@testing-library/react';
 
 import { type AppState } from 'src/reducers/store';
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { configureStore } from 'src/support/tests/configureStore';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingLayout } from './TradingLayout';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 
@@ -24,9 +24,9 @@ jest.mock('./TradingLayoutNavigation', () => ({
 }));
 
 const buildState = (): AppState => ({
-    ...initialAppState,
+    ...mockInitialAppState,
     router: {
-        ...initialAppState.router,
+        ...mockInitialAppState.router,
         app: 'wallet',
         route: {
             name: 'wallet-trading-buy',

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
@@ -12,11 +12,11 @@ import {
     createAccountKey,
 } from '@suite-common/wallet-types';
 
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingTransactionsList } from './TradingTransactionsList';
+import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
 jest.mock('@suite-common/tx-simulation', () => ({}));
 
@@ -108,13 +108,13 @@ const buildState = ({
     },
     trades = [],
 }: BuildStateParams = {}) => ({
-    ...initialAppState,
+    ...mockInitialAppState,
     device: {
-        ...initialAppState.device,
+        ...mockInitialAppState.device,
         selectedDevice: SELECTED_DEVICE,
     },
     wallet: {
-        ...initialAppState.wallet,
+        ...mockInitialAppState.wallet,
         accounts: [btcAccount],
         selectedAccount: selectedAccountStatus,
         trading: {

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
@@ -8,11 +8,11 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
 import { type AppState } from 'src/reducers/store';
-import { initialAppState } from 'src/support/tests/__fixtures__/defaultAppState';
 import { extraDependenciesDesktopMock } from 'src/support/tests/extraDependenciesDesktop.mock';
 import { renderWithProviders } from 'src/support/tests/hooksHelper';
 
 import { TradingFormOfferSellActions } from './TradingFormOfferSellActions';
+import { mockInitialAppState } from '../../../../../mocks/mockInitialAppState';
 
 const mockUseTradingFormContext = jest.fn();
 const mockUseTradingFormOfferCommon = jest.fn();
@@ -55,10 +55,10 @@ const account = mockWalletAccount({ symbol: 'eth', balance: '1000000000000000000
 const renderWithNetworkFee = (composed: { fee: string } | undefined) => {
     const store = configureMockStore({
         preloadedState: {
-            ...initialAppState,
+            ...mockInitialAppState,
             device: { selectedDevice: { state: { staticSessionId: DEVICE_STATE } } },
             wallet: {
-                ...initialAppState.wallet,
+                ...mockInitialAppState.wallet,
                 accounts: [account],
                 trading: {
                     ...tradingInitialState,


### PR DESCRIPTION
## Description

Moves the Suite initial-state fixture into the package mocks directory, renames it to mockInitialAppState so the filename and export match, and updates Suite-internal consumers through relative imports. It also replaces the fixture deep import with the public suite-sync quota-manager entry point.

- Legacy non-E2E support files: **1 → 0**

## Notes for QA

No functional change; test infrastructure only.

## Related Issue

Part of #30302

## Screenshots

Not applicable.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit-test files (.test.tsx/.test.ts) and internal suite mocks. They do not modify production source code, so no Playwright E2E tests are needed to validate them. The recommended strategy is to rely on the existing unit-test execution and skip the E2E suite for this change set.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/mocks/index.ts`
- `packages/suite/mocks/mockInitialAppState.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.test.tsx`
- `packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts`
- `packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (10)**
- `packages/suite/mocks/index.ts`
- `packages/suite/mocks/mockInitialAppState.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.test.tsx`
- `packages/suite/src/components/suite/Preloader/selectShouldDisplayDeviceCompromisedOnRoute.test.ts`
- `packages/suite/src/components/suite/SecurityCheck/DeviceCompromised.test.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingLayout/TradingLayout.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx`
- `packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx`

_Updated: 2026-07-31T09:59:12.257Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/relocate-mock-initial-app-state/web/](https://dev.suite.sldev.cz/suite-web/test/relocate-mock-initial-app-state/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/relocate-mock-initial-app-state&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/relocate-mock-initial-app-state&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:01:44.981Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:01:22.218Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->