### PR TITLE
fix(suite-native-30570): fix trading e2e asset selection

### DIFF
--- a/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
+++ b/suite-native/app/e2e/pageObjects/trading/TradingFormActions.ts
@@ -200,8 +200,9 @@ export abstract class TradingFormActions extends TradingActions {
             await networkFilterTab.tap();
         }
 
-        await waitForVisible(by.text(asset));
-        await element(by.text(asset)).tap();
+        const firstMatchingAsset = element(by.text(asset)).atIndex(0);
+        await waitForVisible(firstMatchingAsset);
+        await firstMatchingAsset.tap();
 
         await waitFor(this.getElementById('asset-send-button/symbol'))
             .toHaveText(asset)


### PR DESCRIPTION
## Description

- Select the first matching asset when picking an asset in trading E2E tests.
- Prevent ambiguous duplicate asset labels from blocking asset selection.

## Notes for QA
<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30570

## Screenshots:
<!--- Keep just title, empty for later add -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30570-fix-trading-e2e-tests-unable-to-pick-the-asset&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->