### PR TITLE
fix(suite-desktop): force approval step if wrapping to ensure approved amount

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
@@ -1,0 +1,165 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore } from '@suite-common/test-utils';
+import { asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { BigNumber } from '@trezor/utils';
+
+import { initYieldAllowanceThunk } from './stablecoinYieldApprovalThunks';
+import {
+    type StablecoinYieldRootState,
+    stablecoinYieldActions,
+    stablecoinYieldReducer,
+} from './stablecoinYieldReducer';
+import { selectStablecoinYieldSession } from './stablecoinYieldSelectors';
+import { type YieldFlowResolvedData } from './stablecoinYieldTypes';
+import { fetchAllowance } from '../allowance/fetchAllowance';
+
+jest.mock('../allowance/fetchAllowance', () => ({
+    fetchAllowance: jest.fn(),
+}));
+
+const FLOW_KEY = 'account-key:yield-id:0xtoken';
+const OWNER_ADDRESS = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326';
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const VAULT_ADDRESS = '0xd63070114470f685b75B74D60EEc7c1113d33a3D';
+
+const account = mockWalletAccount({
+    symbol: 'eth',
+    descriptor: asAccountDescriptor(OWNER_ADDRESS),
+    deviceState: 'mock@device:0',
+});
+
+// Wrapped-native (WETH) deposit: 18 decimals, spender resolved from receiptToken.
+const flowData = {
+    account,
+    vault: { id: `eth-${VAULT_ADDRESS}`, chainId: 1 },
+    token: {
+        networkSymbol: 'eth',
+        symbol: 'weth',
+        decimals: 18,
+        contractAddress: WETH_ADDRESS,
+        balance: '100',
+    },
+    receiptToken: {
+        networkSymbol: 'eth',
+        symbol: 'wsteth',
+        decimals: 18,
+        contractAddress: VAULT_ADDRESS,
+    },
+} as unknown as YieldFlowResolvedData;
+
+// 0.2 WETH in subunits (18 decimals) — the amount the user just wrapped.
+const WRAPPED_AMOUNT = '0.2';
+const toSubunits = (weth: string) => new BigNumber(weth).shiftedBy(18);
+
+const initStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({ stablecoinYield: stablecoinYieldReducer }),
+        }),
+    });
+
+const getStep = (store: ReturnType<typeof initStore>) =>
+    selectStablecoinYieldSession(store.getState() as StablecoinYieldRootState, 'deposit', FLOW_KEY)
+        .step;
+
+// Seed a wrapped-native deposit session sitting on the `approve` step, with the
+// just-wrapped amount stored in `session.action.amount` (mirrors the wrap→approve
+// transition produced by resolveWrappedNativeStep after the wrap tx confirms).
+const seedWrappedDepositAtApprove = (store: ReturnType<typeof initStore>, amount: string) => {
+    store.dispatch(
+        stablecoinYieldActions.initSession({
+            flowType: 'deposit',
+            flowKey: FLOW_KEY,
+            isWrappedNativeVault: true,
+        }),
+    );
+    store.dispatch(
+        stablecoinYieldActions.resolveWrappedNativeStep({
+            flowType: 'deposit',
+            flowKey: FLOW_KEY,
+            step: 'wrap',
+            amount,
+        }),
+    );
+};
+
+describe('initYieldAllowanceThunk', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('keeps the approve step when a dust allowance is smaller than the wrapped amount (#30551)', async () => {
+        // Leftover dust allowance, far below the 0.2 WETH just wrapped.
+        (fetchAllowance as jest.Mock).mockResolvedValue(new BigNumber('1000'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+        expect(getStep(store)).toBe('approve');
+
+        await store
+            .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
+            .unwrap();
+
+        expect(getStep(store)).toBe('approve');
+    });
+
+    it('skips the approve step when the allowance already covers the wrapped amount', async () => {
+        // 0.3 WETH allowance ≥ 0.2 WETH wrapped.
+        (fetchAllowance as jest.Mock).mockResolvedValue(toSubunits('0.3'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+
+        await store
+            .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
+            .unwrap();
+
+        expect(getStep(store)).toBe('action');
+    });
+
+    it('skips the approve step when the allowance exactly equals the wrapped amount', async () => {
+        (fetchAllowance as jest.Mock).mockResolvedValue(toSubunits(WRAPPED_AMOUNT));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+
+        await store
+            .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
+            .unwrap();
+
+        expect(getStep(store)).toBe('action');
+    });
+
+    it('skips on any non-zero allowance when no amount is entered yet (non-wrapped deposit)', async () => {
+        // Non-wrapped deposit: the approve step precedes amount entry, so there is no
+        // request amount to compare against — legacy skip-on-nonzero behavior is preserved.
+        (fetchAllowance as jest.Mock).mockResolvedValue(new BigNumber('1000'));
+
+        const store = initStore();
+        store.dispatch(
+            stablecoinYieldActions.initSession({ flowType: 'deposit', flowKey: FLOW_KEY }),
+        );
+        expect(getStep(store)).toBe('approve');
+
+        await store
+            .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
+            .unwrap();
+
+        expect(getStep(store)).toBe('action');
+    });
+
+    it('keeps the approve step when there is no allowance at all', async () => {
+        (fetchAllowance as jest.Mock).mockResolvedValue(new BigNumber('0'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+
+        await store
+            .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
+            .unwrap();
+
+        expect(getStep(store)).toBe('approve');
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -231,7 +231,10 @@ export const handleYieldApproveCancelThunk = createThunk(
 
 export const initYieldAllowanceThunk = createThunk<void, InitYieldAllowancePayload, void>(
     `${YIELD_THUNK_PREFIX}/initAllowance`,
-    async ({ flowKey, flowType, flowData, shouldSkipApprovalStep = true }, { dispatch }) => {
+    async (
+        { flowKey, flowType, flowData, shouldSkipApprovalStep = true },
+        { dispatch, getState },
+    ) => {
         dispatch(stablecoinYieldActions.startInitializingAllowance({ flowType, flowKey }));
 
         try {
@@ -264,8 +267,29 @@ export const initYieldAllowanceThunk = createThunk<void, InitYieldAllowancePaylo
                 }),
             );
 
-            if (shouldSkipApprovalStep && amount !== '0') {
-                dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
+            if (shouldSkipApprovalStep) {
+                const { action } = selectStablecoinYieldSession(getState(), flowType, flowKey);
+                const requestAmount = action.amount;
+                const hasRequestAmount = !!requestAmount && new BigNumber(requestAmount).gt(0);
+
+                // Only skip the approve step when the existing allowance already covers the
+                // amount being deposited. For the wrapped-native flow `action.amount` holds
+                // the just-wrapped amount, so a leftover dust allowance must NOT skip approval
+                // (issue #30551). Without an entered amount (e.g. non-wrapped deposit, where the
+                // approve step precedes amount entry) fall back to skipping on any allowance —
+                // insufficiency is still caught later via the modify-approval path.
+                const allowanceCoversRequest = hasRequestAmount
+                    ? allowanceSubunits.gte(
+                          unitsToSubunits({
+                              value: asAmountUnit(new BigNumber(requestAmount)),
+                              decimals: flowData.token.decimals,
+                          }),
+                      )
+                    : amount !== '0';
+
+                if (allowanceCoversRequest) {
+                    dispatch(stablecoinYieldActions.skipApprovalStep({ flowType, flowKey }));
+                }
             }
         } catch (error) {
             dispatch(stablecoinYieldActions.setAllowanceError({ flowType, flowKey }));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables check to only skip approval step if existing one is enough 

## Notes for QA

Easy to reproduce on the eth vault deposit

## Related Issue

Resolve #30551

## Screenshots:

| Approved 0.00077777 | Wrapped 0.00088888 | Wrapped 0.0007 |
|--------|--------|--------|
| <img width="726" height="680" alt="Screenshot 2026-07-31 at 9 19 44" src="https://github.com/user-attachments/assets/8961f4d6-9e49-421f-b651-8da146edebd7" /> | <img width="1127" height="720" alt="Screenshot 2026-07-31 at 9 20 35" src="https://github.com/user-attachments/assets/5a3bf016-b8ef-4c62-acd2-904c26905fac" /> | <img width="694" height="699" alt="Screenshot 2026-07-31 at 9 21 35" src="https://github.com/user-attachments/assets/68529e3a-b303-4918-9b53-fbbf568cd0b0" /> | 


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrap-forces-approve&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->