### PR TITLE
test(wallet-core): cover selectShouldRediscover

### DIFF
--- a/suite-common/wallet-core/src/selectors.test.ts
+++ b/suite-common/wallet-core/src/selectors.test.ts
@@ -1,50 +1,90 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type Account } from '@suite-common/wallet-types';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type Account,
+    type AccountFailureSpecific,
+    type DiscoveryStatus,
+} from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import { selectDiscoveryAccountsParam } from './selectors';
+import { blockchainInitialState } from './blockchain/blockchainReducer';
+import {
+    type WalletCoreCompoundRootState,
+    selectDiscoveryAccountsParam,
+    selectShouldRediscover,
+} from './selectors';
+import { initialWalletSettingsState } from './settings/walletSettingsReducer';
 
 const STATIC_SESSION_ID: `${string}@${string}:${number}` =
     'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1';
-const DEVICE = mockSuiteDevice({ state: { staticSessionId: STATIC_SESSION_ID } });
+const DEVICE_PATH = 'device-path';
 
-const mockSolAccount = (override: Partial<Account>): Account =>
-    ({
-        symbol: 'sol',
-        accountType: 'normal',
-        index: 0,
-        deviceState: STATIC_SESSION_ID,
-        empty: false,
-        visible: true,
-        ...override,
-    }) as unknown as Account;
-
-const getState = (accounts: Account[]) =>
-    ({
-        wallet: {
-            accounts,
-            settings: { enabledNetworks: ['sol'] },
-            blockchain: {},
+const mockSolAccount = (
+    account: Omit<Partial<Account>, 'failed' | 'error'>,
+    accountFailure: AccountFailureSpecific = { failed: false },
+) =>
+    mockWalletAccount(
+        {
+            symbol: 'sol',
+            deviceState: STATIC_SESSION_ID,
+            ...account,
         },
-        device: { devices: [DEVICE], selectedDevice: DEVICE, persistentDeviceData: [] },
-    }) as any;
+        undefined,
+        accountFailure,
+    );
+
+const mockDeviceWithPathAndState = (device?: Partial<TrezorDevice>) =>
+    mockSuiteDevice({
+        path: DEVICE_PATH,
+        discovered: true,
+        state: { staticSessionId: STATIC_SESSION_ID },
+        ...device,
+    });
+
+type GetStateOptions = {
+    accounts?: Account[];
+    device?: TrezorDevice;
+    discovery?: DiscoveryStatus;
+    enabledNetworks?: NetworkSymbol[];
+};
+
+const getState = ({
+    accounts = [],
+    device = mockDeviceWithPathAndState(),
+    discovery,
+    enabledNetworks = ['sol'],
+}: GetStateOptions = {}): WalletCoreCompoundRootState => ({
+    wallet: {
+        accounts,
+        settings: { ...initialWalletSettingsState, enabledNetworks },
+        blockchain: blockchainInitialState,
+        discovery: discovery ? { [device.path]: discovery } : {},
+    },
+    device: {
+        devices: [device],
+        selectedDevice: device,
+        persistentDeviceData: [],
+    },
+});
 
 const getSolKnown = (accounts: Account[]) =>
-    selectDiscoveryAccountsParam(getState(accounts), STATIC_SESSION_ID).find(
+    selectDiscoveryAccountsParam(getState({ accounts }), STATIC_SESSION_ID).find(
         coin => coin.symbol === 'sol',
     )?.known;
 
-describe('selectDiscoveryAccountsParam', () => {
+describe(selectDiscoveryAccountsParam.name, () => {
     it('rediscovers from a failed account at the end of the chain', () => {
-        expect(getSolKnown([mockSolAccount({ failed: true, empty: true })])).toEqual([
-            { type: 'normal', skip: 0 },
-        ]);
+        expect(
+            getSolKnown([mockSolAccount({ empty: true }, { failed: true, error: 'Failed.' })]),
+        ).toEqual([{ type: 'normal', skip: 0 }]);
     });
 
     it('rediscovers from the first failed account even when it sits below other accounts', () => {
         expect(
             getSolKnown([
                 mockSolAccount({ index: 0 }),
-                mockSolAccount({ index: 1, failed: true, empty: true }),
+                mockSolAccount({ index: 1, empty: true }, { failed: true, error: 'Failed.' }),
                 mockSolAccount({ index: 2 }),
                 mockSolAccount({ index: 3, empty: true, visible: false }),
             ]),
@@ -68,8 +108,71 @@ describe('selectDiscoveryAccountsParam', () => {
         expect(
             getSolKnown([
                 mockSolAccount({ index: 0, empty: true }),
-                mockSolAccount({ accountType: 'ledger', index: 0, failed: true, empty: true }),
+                mockSolAccount(
+                    { accountType: 'ledger', index: 0, empty: true },
+                    { failed: true, error: 'Failed.' },
+                ),
             ]),
         ).toEqual([{ type: 'normal' }, { type: 'ledger', skip: 0 }]);
+    });
+});
+
+describe(selectShouldRediscover.name, () => {
+    it('returns false while discovery is in progress', () => {
+        const device = mockDeviceWithPathAndState();
+
+        expect(
+            selectShouldRediscover(
+                getState({
+                    device,
+                    discovery: { status: 'progress', total: 1, progress: 0 },
+                }),
+                device,
+            ),
+        ).toBe(false);
+    });
+
+    it('returns true when the device has no static session id', () => {
+        const device = mockDeviceWithPathAndState({ state: undefined });
+        expect(selectShouldRediscover(getState({ device }), device)).toBe(true);
+    });
+
+    it('returns true when the device is not discovered yet', () => {
+        const device = mockDeviceWithPathAndState({ discovered: false });
+        expect(selectShouldRediscover(getState({ device }), device)).toBe(true);
+    });
+
+    it('returns true when an enabled network has no known accounts yet', () => {
+        const device = mockDeviceWithPathAndState();
+        expect(selectShouldRediscover(getState({ device }), device)).toBe(true);
+    });
+
+    it('returns true when the last known account is used', () => {
+        const device = mockDeviceWithPathAndState();
+        expect(
+            selectShouldRediscover(
+                getState({
+                    device,
+                    accounts: [mockSolAccount({ index: 0, empty: false })],
+                }),
+                device,
+            ),
+        ).toBe(true);
+    });
+
+    it('returns false when the account chain is already fully discovered', () => {
+        const device = mockDeviceWithPathAndState();
+        expect(
+            selectShouldRediscover(
+                getState({
+                    device,
+                    accounts: [
+                        mockSolAccount({ index: 0, empty: false }),
+                        mockSolAccount({ index: 1, empty: true, visible: false }),
+                    ],
+                }),
+                device,
+            ),
+        ).toBe(false);
     });
 });

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -176,7 +176,7 @@ export const selectShowRediscoverButton = (
 };
 
 /**
- * Whether re-discovery is needed (accounts missing or failed).
+ * Whether re-discovery is needed (accounts missing).
  * Warning: this can be slightly expensive computation for large wallets. It isn't viable for memoization, because
  * it depends on every account (with frequent account updates, it would fire too often to be practical).
  */

--- a/suite-common/wallet-types/mocks/mockWalletAccount.ts
+++ b/suite-common/wallet-types/mocks/mockWalletAccount.ts
@@ -137,6 +137,7 @@ export const mockWalletAccount = (
     > &
         MandatoryAccountData,
     networkSpecific?: NetworkSpecificDefault,
+    accountFailure: AccountFailureSpecific = { failed: false },
 ): Account => {
     const descriptor = account.descriptor ?? asAccountDescriptor(account.symbol);
 
@@ -168,14 +169,9 @@ export const mockWalletAccount = (
         symbol: account.symbol,
     };
 
-    // This is needed as typing the `Account` type with the union-type of
+    // This is needed to be separated, as typing the `Account` type with the union-type of
     // the Networks and Backends seems impossible.
-    // This way, we at least get type-safe for AccountBase data.
-
-    const accountFailure: AccountFailureSpecific = {
-        failed: false,
-    };
-
+    // This way, we at least get type-safety for AccountBase and AccountFailureSpecific data.
     return {
         ...accountBase,
         ...accountFailure,


### PR DESCRIPTION
## Description

- Cover `selectShouldRediscover` with a unit test, because it is a very important selector (drives discovery).
- Modify fixtures and helpers for existing `selectDiscoveryAccountsParam` for completeness & type-safety 
- Enrich the `mockWalletAccount` so that it supports failed accounts

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Changes to wallet-core selectors and the wallet account mock could broadly affect account, balance, and discovery state derivation. Since selectors.ts is a global dependency referenced by 133 tests, this recommendation limits coverage to wallet tests that directly exercise selector-dependent behavior. The high-priority tests target account search, account creation, balance display, and discovery status. Medium-priority tests extend coverage to custom-backend discovery and transaction grouping/filtering. The changed unit test file and mock utility have no direct E2E coverage.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/selectors.test.ts`
- `suite-common/wallet-core/src/selectors.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — This test directly exercises account search and filtering behavior, which is a primary consumer of wallet account selectors. A regression in selectors.ts would likely manifest as accounts not appearing or filtering incorrectly.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test validates adding accounts of different types and checks account state (counts, paths, symbols). Changes to account selectors could break how newly added accounts are reflected in the UI or analytics.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test verifies that account balances are correctly displayed after receiving funds. Balance display is a core selector responsibility, so selector changes could directly affect this behavior.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test checks the wallet discovery state machine (starting, complete) and that discovered coin balances appear on the dashboard. Discovery status and account visibility are heavily selector-dependent.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test covers account discovery with a custom Blockbook backend. It shares discovery/selector infrastructure with the high-priority wallet tests and could catch backend-specific selector regressions.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test validates pending vs confirmed transaction grouping and labels, which depends on wallet transaction selectors and account state. Selector changes could affect how transactions are categorized.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test exercises transaction search and time-range filtering on an account, which relies on selectors that derive transaction subsets and account details.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/selectors.test.ts`
- `suite-common/wallet-types/mocks/mockWalletAccount.ts`

_Updated: 2026-07-31T08:16:07.187Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/selectShouldRediscover/web/](https://dev.suite.sldev.cz/suite-web/test/selectShouldRediscover/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/selectShouldRediscover&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/selectShouldRediscover&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/selectShouldRediscover&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:17:54.515Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:17:41.138Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->