### PR TITLE
fix(suite-native): keep receive network icon border white

### DIFF
--- a/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
@@ -69,6 +69,7 @@ export const ReceiveAddressDetails = ({
                         qrCodeSize={qrCodeSize}
                         paddingHorizontal="sp16"
                         paddingVertical="sp16"
+                        shouldUseStandardCenterIconBackground
                         centerIcon={
                             <TokenIcon
                                 symbol={networkSymbol}

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -12,6 +12,7 @@ type QRCodeProps = {
     paddingHorizontal?: NativeSpacing;
     paddingVertical?: NativeSpacing;
     centerIcon?: ReactElement;
+    shouldUseStandardCenterIconBackground?: boolean;
 };
 
 const SCREEN_WIDTH = Dimensions.get('screen').width;
@@ -52,13 +53,17 @@ const qrCodeCenterIconWrapperStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
 }));
 
-const qrCodeCenterIconStyle = prepareNativeStyle(utils => ({
+const qrCodeCenterIconStyle = prepareNativeStyle<{
+    shouldUseStandardCenterIconBackground?: boolean;
+}>((utils, { shouldUseStandardCenterIconBackground }) => ({
     maxWidth: QR_CENTER_ICON_MAX_RATIO,
     maxHeight: QR_CENTER_ICON_MAX_RATIO,
     padding: QR_CENTER_ICON_PADDING,
     borderRadius: utils.borders.radii.round,
     overflow: 'hidden',
-    backgroundColor: utils.colors.surfaceFillRaised,
+    backgroundColor: shouldUseStandardCenterIconBackground
+        ? colorVariants.standard.surfaceFillRaised
+        : utils.colors.surfaceFillRaised,
 }));
 
 export const QRCode = ({
@@ -67,6 +72,7 @@ export const QRCode = ({
     paddingHorizontal,
     paddingVertical,
     centerIcon,
+    shouldUseStandardCenterIconBackground,
 }: QRCodeProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -92,7 +98,13 @@ export const QRCode = ({
                 />
                 {hasCenterIcon && (
                     <View pointerEvents="none" style={applyStyle(qrCodeCenterIconWrapperStyle)}>
-                        <View style={applyStyle(qrCodeCenterIconStyle)}>{centerIcon}</View>
+                        <View
+                            style={applyStyle(qrCodeCenterIconStyle, {
+                                shouldUseStandardCenterIconBackground,
+                            })}
+                        >
+                            {centerIcon}
+                        </View>
                     </View>
                 )}
             </View>


### PR DESCRIPTION
## Description

Keeps the small border around the overlaid network icon white for the mobile receive QR code in all color modes.

## Notes for QA

Check the mobile receive flow in dark mode. The small line around the network icon inside the QR code should stay white.

Also verify other places that render token icons with network badges still use their default border styling.


## Screenshots:
Before
<img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/5b4f111a-6c61-424c-b9b8-0ae4cf42c4dc" />
After
<img width="376" height="841" alt="image" src="https://github.com/user-attachments/assets/4cfb5b40-2039-440f-a48b-82aa289ec53f" />
<img width="373" height="588" alt="image" src="https://github.com/user-attachments/assets/cc9426e4-588a-4f21-8d0e-e557a2349f0c" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/receive-icon-border&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->