### PR TITLE
test(connect): make yarn install test model a real 3rd-party consumer

### DIFF
--- a/packages/connect/e2e/test-yarn-install.sh
+++ b/packages/connect/e2e/test-yarn-install.sh
@@ -20,9 +20,28 @@ echo "npmMinimalAgeGate: 0" > .yarnrc.yml
 
 # install connect package
 yarn add @trezor/connect@"$1"
-# prepare minimal typescript implementation
-echo import TrezorConnect from \"@trezor/connect\" >index.ts
 
-# compile with typescript — @trezor/connect is ESM-only since v10, so use NodeNext.
+# prepare a minimal consumer that actually exercises the public type surface,
+# not just module existence: it resolves the default export's type and a named
+# export, so it fails on a broken/empty .d.ts rather than only a missing module.
+# Kept version-agnostic on purpose — this same script runs against both the
+# ESM-only v10 (beta) and the older v9 (latest) default-export shapes.
+{
+    echo 'import TrezorConnect, { DEVICE } from "@trezor/connect";'
+    echo 'const _connect: typeof TrezorConnect = TrezorConnect;'
+    echo 'void _connect;'
+    echo 'void DEVICE;'
+} >index.ts
+
+# Compile the way a real 3rd party would:
+#   - no `--types` allowlist, so tsc auto-includes whatever @types are actually
+#     installed (@types/node here) instead of us hand-feeding connect the ambient
+#     types it needs — that masked whether the published package resolves on its own.
+#   - `--skipLibCheck`, which every mainstream consumer setup (Next.js, Vite, CRA,
+#     tsup, ...) turns on: we validate that a consumer can import AND use connect's
+#     public type surface, not that every transitive dependency's shipped .d.ts is
+#     internally pristine. (NodeNext .d.ts hygiene of deps belongs in a dedicated
+#     `attw`/publint check, not here.)
+# @trezor/connect is ESM-only since v10, so use NodeNext.
 yarn add typescript@5.8.3 @types/node@22.13.10
-yarn tsc ./index.ts --types node,w3c-web-usb --esModuleInterop --target ES2024 --module NodeNext --moduleResolution NodeNext
+yarn tsc ./index.ts --strict --skipLibCheck --esModuleInterop --target ES2024 --module NodeNext --moduleResolution NodeNext


### PR DESCRIPTION
## Problem

The scheduled **connect misc** job fails at step **Test yarn install (beta)** with `TS2688: Cannot find type definition file for 'w3c-web-usb'` ([failing run](https://github.com/trezor/trezor-suite/actions/runs/30594594791/job/91044098452#step:6:67)).

`packages/connect/e2e/test-yarn-install.sh` compiled the consumer smoke with `tsc … --types node,w3c-web-usb`, which forces those exact `@types` packages to be present. `@types/w3c-web-usb` is only a **devDependency** of connect/-web/-webext and is never shipped to consumers; v9 (`latest`) happened to hoist it transitively, v10 (`beta`) does not.

That allowlist was copied from connect's own **build** config (`tsconfig.lib.json` needs it to type-check `src/index.browser.ts`'s `window.navigator.usb`), not from any consumer need — the published Node `.d.ts` never references WebUSB globals (`transport-web` structurally casts `navigator.usb` precisely to avoid the dependency). So the flag was hand-feeding connect the ambient types it might need, masking whether the published package resolves its types on its own — the exact thing this test is supposed to guard.

## Fix

Make the smoke model a real 3rd-party consumer instead of connect's internal build:

- **Drop the `--types node,w3c-web-usb` allowlist** so `tsc` auto-includes whatever `@types` are actually installed (`@types/node`), forcing connect's shipped types to self-resolve.
- **Add `--skipLibCheck` (+ `--strict`)**, which every mainstream consumer setup turns on (Next.js, Vite, CRA, tsup). We validate that a consumer can import **and use** connect's public type surface, not that every transitive dependency's `.d.ts` is internally pristine.
- **Strengthen the smoke** from a bare default import (which would pass even against an `export default any` shim) to resolving the default export's type plus a named export (`DEVICE`). Kept version-agnostic on purpose — this script runs against both the ESM-only v10 (`beta`) and the older v9 (`latest`) default-export shapes.

Verified locally (corepack `yarn@4.14.1`, real npm install in a throwaway dir): the full script is green (`exit 0`, 0 tsc errors) against **both `beta` and `latest`**.

## Follow-ups (not in this PR)

Removing the allowlist surfaced pre-existing defects in the published v10 beta that the old `TS2688` abort was hiding. With `skipLibCheck` off, `@trezor/transport-common/lib/**/*.d.ts` use extensionless relative imports (invalid under NodeNext) and `@trezor/utils`'s `.d.ts` import an unresolvable `@trezor/type-utils`. These matter to stricter consumers (`skipLibCheck:false`, `tsc --build`); the right guard is a dedicated `attw`/publint check rather than `skipLibCheck:false` here. Separately, `test-npm-install.sh` checks no types at all (only `node index.js`) — type-resolution parity for the npm path is a further follow-up.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-07-31T08:23:08.194Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/ci-job-failure/web/](https://dev.suite.sldev.cz/suite-web/mroz22/ci-job-failure/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=mroz22/ci-job-failure&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:26:49.461Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:26:19.575Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->