### PR TITLE
feat(suite-desktop): on unwrapping use previous step weth result

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -47,6 +47,7 @@ import {
     type YieldApprovalAction,
     getYieldApprovalAction,
     getYieldModifyAmountInput,
+    getYieldUnwrapDefaultAmount,
     isAmountGreaterThan,
 } from '../yieldFlowUtils';
 
@@ -340,6 +341,25 @@ export const useYieldFlow = ({
         prevStepRef.current = nextStep;
     }, [session.step, session.action.amount, methodsRef, maxAmount]);
 
+    // The withdraw flow's unwrap step must default to the amount just withdrawn (in asset units),
+    // not the account's whole wrapped-native balance — otherwise it would sweep in unrelated WETH
+    // the user never meant to unwrap (trezor/trezor-suite#30559).
+    const pricePerShareState = vault.state?.pricePerShareState;
+    const unwrapDefaultAmount = useMemo(() => {
+        if (!token || !receiptToken || !isYieldWithdrawFlow(flowType)) {
+            return token?.balance ?? '';
+        }
+
+        return getYieldUnwrapDefaultAmount({
+            flowType,
+            withdrawnAmount: session.result.completedAmount,
+            token,
+            receiptToken,
+            pricePerShareState,
+            fallbackAmount: token.balance,
+        });
+    }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
+
     useEffect(() => {
         if (session.step !== 'unwrap') {
             unwrapDefaultAmountRef.current = null;
@@ -347,18 +367,17 @@ export const useYieldFlow = ({
             return;
         }
 
-        const nextDefaultAmount = token?.balance ?? '';
         const currentAmount = methodsRef.current.getValues('amountInput');
 
         if (
             unwrapDefaultAmountRef.current === null ||
             currentAmount === unwrapDefaultAmountRef.current
         ) {
-            methodsRef.current.reset({ amountInput: nextDefaultAmount });
+            methodsRef.current.reset({ amountInput: unwrapDefaultAmount });
         }
 
-        unwrapDefaultAmountRef.current = nextDefaultAmount;
-    }, [methodsRef, session.step, token?.balance]);
+        unwrapDefaultAmountRef.current = unwrapDefaultAmount;
+    }, [methodsRef, session.step, unwrapDefaultAmount]);
 
     const flow = useMemo(
         () => ({ currentStep: session.step, isWrappedNativeVault }),

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -1,6 +1,6 @@
 import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
 
-import { getYieldFlowSteps } from './yieldFlowUtils';
+import { getYieldFlowSteps, getYieldUnwrapDefaultAmount } from './yieldFlowUtils';
 
 const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
 const depositWithWrapSequence = getYieldFlowStepSequence({
@@ -12,6 +12,48 @@ const withdrawWithUnwrapSequence = getYieldFlowStepSequence({
     flowType: 'withdraw',
     isWrappedNativeVault: true,
 });
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const VAULT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+
+// Vault price-per-share: 1 share (trSHETHp) is worth 0.02 WETH.
+const pricePerShareState = {
+    price: '0.02',
+    shareToken: {
+        symbol: 'trSHETHp',
+        network: 'ethereum',
+        name: 'Trezor Staked Holesky ETH',
+        decimals: 18,
+        address: VAULT_ADDRESS,
+    },
+    quoteToken: {
+        symbol: 'WETH',
+        network: 'ethereum',
+        name: 'Wrapped Ether',
+        decimals: 18,
+        address: WETH_ADDRESS,
+    },
+};
+
+const baseUnwrapParams: Parameters<typeof getYieldUnwrapDefaultAmount>[0] = {
+    flowType: 'withdraw',
+    withdrawnAmount: '0.5',
+    token: {
+        networkSymbol: 'eth',
+        symbol: 'WETH',
+        decimals: 18,
+        contractAddress: WETH_ADDRESS,
+        balance: '5',
+    },
+    receiptToken: {
+        networkSymbol: 'eth',
+        symbol: 'trSHETHp',
+        decimals: 18,
+        contractAddress: VAULT_ADDRESS,
+    },
+    pricePerShareState,
+    fallbackAmount: '5',
+};
 
 describe('yieldFlowUtils', () => {
     describe('getYieldFlowSteps', () => {
@@ -97,6 +139,52 @@ describe('yieldFlowUtils', () => {
                 unwrap: { state: 'done', indicator: { index: 0, total: 1 } },
                 complete: { state: 'pending', indicator: { index: 0, total: 1 } },
             });
+        });
+    });
+
+    describe('getYieldUnwrapDefaultAmount', () => {
+        // The regression from #30559: the unwrap step must not default to the full WETH balance.
+        it('defaults to the withdrawn asset amount for an asset (withdraw) input', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'withdraw',
+                    withdrawnAmount: '0.5',
+                }),
+            ).toBe('0.5');
+        });
+
+        it('converts the withdrawn shares to their asset equivalent for a redeem input', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'redeem',
+                    withdrawnAmount: '1',
+                }),
+            ).toBe('0.02');
+        });
+
+        it('falls back to the balance when the withdrawn amount is zero', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'withdraw',
+                    withdrawnAmount: '0',
+                    fallbackAmount: '5',
+                }),
+            ).toBe('5');
+        });
+
+        it('falls back to the balance when shares cannot be converted without a price', () => {
+            expect(
+                getYieldUnwrapDefaultAmount({
+                    ...baseUnwrapParams,
+                    flowType: 'redeem',
+                    withdrawnAmount: '1',
+                    pricePerShareState: undefined,
+                    fallbackAmount: '5',
+                }),
+            ).toBe('5');
         });
     });
 });

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,4 +1,10 @@
-import { type YieldFlowStepId } from '@suite-common/wallet-core';
+import {
+    type YieldFlowDisplayToken,
+    type YieldFlowStepId,
+    type YieldFlowToken,
+    type YieldWithdrawFlowType,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+} from '@suite-common/wallet-core';
 import type { StepListItemState } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -28,6 +34,56 @@ export const getYieldModifyAmountInput = ({
     return isAmountGreaterThan({ amount: nextAmount, threshold: maxAmount })
         ? maxAmount
         : nextAmount;
+};
+
+type YieldUnwrapDefaultAmountParams = {
+    flowType: YieldWithdrawFlowType;
+    /** Amount just withdrawn, in the flow's input unit — assets for `withdraw`, shares for `redeem`. */
+    withdrawnAmount: string;
+    /** Vault asset token being unwrapped (the wrapped-native token, e.g. WETH). */
+    token: YieldFlowToken;
+    /** Vault receipt/share token (e.g. trSHETHp). */
+    receiptToken: YieldFlowDisplayToken;
+    pricePerShareState?: Parameters<
+        typeof getConvertedOutputTokenBalanceToInputTokenAmount
+    >[0]['pricePerShareState'];
+    /** Fallback used when the withdrawn asset amount can't be resolved (e.g. missing price). */
+    fallbackAmount: string;
+};
+
+/**
+ * Amount to pre-fill in the withdraw flow's unwrap (wrapped-native → native) step.
+ *
+ * It must default to the asset amount that was just withdrawn — NOT the account's full
+ * wrapped-native balance, which would sweep in unrelated WETH the user never meant to unwrap
+ * (see trezor/trezor-suite#30559). A `withdraw` yields the asset amount directly; a `redeem`
+ * yields shares, so those are converted to their asset (WETH) equivalent via the vault
+ * price-per-share. Falls back to the full balance only when the asset amount can't be resolved.
+ */
+export const getYieldUnwrapDefaultAmount = ({
+    flowType,
+    withdrawnAmount,
+    token,
+    receiptToken,
+    pricePerShareState,
+    fallbackAmount,
+}: YieldUnwrapDefaultAmountParams): string => {
+    const withdrawnAssetAmount =
+        flowType === 'redeem'
+            ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                  networkSymbol: token.networkSymbol,
+                  token,
+                  outputToken: receiptToken,
+                  outputTokenBalance: withdrawnAmount,
+                  pricePerShareState,
+              })
+            : withdrawnAmount;
+
+    if (!withdrawnAssetAmount || new BigNumber(withdrawnAssetAmount).lte(0)) {
+        return fallbackAmount;
+    }
+
+    return withdrawnAssetAmount;
 };
 
 export type YieldFlowStepView = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On withdrawing from Eth Vault we pre-fill the amount of weth that was withdrawn.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Test with underlying asset as well as weth

## Related Issue

Resolve #30559 

## Screenshots:

| Withdraw amount | Matched unwrap | Underlying asset | Header |
|--------|--------|--------|--------|
| <img width="1063" height="562" alt="Screenshot 2026-07-31 at 9 09 07" src="https://github.com/user-attachments/assets/8932f7df-d913-42d9-867a-07a8b46fe2dc" /> | <img width="1070" height="573" alt="Screenshot 2026-07-31 at 9 10 02" src="https://github.com/user-attachments/assets/dc88c9bb-8909-4921-8296-311d815431dd" /> | <img width="649" height="519" alt="Screenshot 2026-07-31 at 10 32 37" src="https://github.com/user-attachments/assets/8fbfe971-2846-47c8-ba7b-b435022423f1" /> | <img width="628" height="538" alt="Screenshot 2026-07-31 at 10 33 09" src="https://github.com/user-attachments/assets/03c8b51b-1ebd-4e6c-98c7-955639f17921" /> | 




<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/full-withdraw-amount/web/](https://dev.suite.sldev.cz/suite-web/fix/full-withdraw-amount/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/full-withdraw-amount&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/full-withdraw-amount&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:43:05.002Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T08:42:39.079Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->