### PR TITLE
chore(connect): update trezor-common, drop EIP-7702 fixture

### DIFF
--- a/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignTransaction.ts
@@ -10,13 +10,6 @@ const legacyResults: Record<string, LegacyResult[]> = {
             success: false,
         },
     ],
-    'EIP-7702 - Uniswap': [
-        {
-            // EIP-7702 (tx_type 4) added in firmware 2.10.0
-            rules: ['<2.10.0'],
-            success: false,
-        },
-    ],
     'Hoodi Testnet, testnet path': [
         {
             // Hoodi testnet (chain_id 560048) definitions sent from host since 2.6.0
@@ -32,19 +25,9 @@ const ethereumSignTransaction: TestCase = {
     },
     tests: commonFixtures.tests
         .flatMap(({ name, parameters, result, skip_models }: any) => {
-            const isEIP7702 = parameters.tx_type === 4;
             const fixture: Fixture = {
                 description: `${name} ${parameters.comment ?? ''}`,
                 skip: skip_models?.includes('t1') ? ['1'] : undefined,
-                // EIP-7702 requires safety_checks disabled on the device
-                ...(isEIP7702 && {
-                    setup: {
-                        mnemonic: commonFixtures.setup.mnemonic,
-                        settings: {
-                            safety_checks: 2,
-                        },
-                    },
-                }),
                 params: {
                     path: parameters.path,
                     transaction: {

--- a/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
+++ b/packages/connect/e2e/__fixtures__/stellarSignTransaction.ts
@@ -190,7 +190,8 @@ const stellarSignTransaction: TestCase = {
     },
     tests: [
         ...commonFixtures.tests
-            .filter((test: any) => !test.experimental)
+            // payment request tests need PaymentRequest data that can't be expressed in this fixture format
+            .filter((test: any) => !test.experimental && !test.parameters.payment_request)
             .flatMap(({ name, result, parameters, skip_models }: any) => [
                 {
                     name,


### PR DESCRIPTION
## Description

Bumps the `trezor-common` submodule `abbd66f` → `b2e5283`, which drops EIP-7702 delegation support ([trezor-firmware#7275](https://github.com/trezor/trezor-firmware/pull/7275)) and removes the `EIP-7702 - Uniswap` `sign_tx` fixture.

The device now rejects `tx_type: 4` with `Failure_DataError: tx_type out of bounds`, so the fixture's expected `success` result no longer holds and the e2e test was failing:

```
TrezorConnect.ethereumSignTransaction > EIP-7702 - Uniswap
  expected { error: { code: "Failure_DataError", message: "tx_type out of bounds" } }
  to match object { success: true, ... }
```

## Changes

- **Submodule bump** `trezor-common` `abbd66f` → `b2e5283`.
- **`ethereumSignTransaction.ts`** — removed the obsolete EIP-7702 handling (dead `legacyResults` entry + `safety_checks` special-casing). Generic `skip_models`/`tx_type` handling retained.
- **`stellarSignTransaction.ts`** — extended the fixture filter to also skip `payment_request` tests. The bump adds a new `Payment request with invalid op` test that (unlike the pre-existing ones) wasn't marked `experimental`; payment requests can't be expressed in this fixture format.

## Blast radius

The bump touches 38 files, but only two fixtures are consumed by e2e wrappers:
- `ethereum/sign_tx.json` — adds 17 ERC-4626 vault / merkl clear-signing tests. These are standard `data` signing with deterministic signatures (clear-signing affects device *display*, not signed bytes), and `skip_models: ["t1"]` is already handled — so no version gating needed.
- `stellar/sign_tx.json` — the +1 payment-request test, now filtered.

Not consumed: the protobuf files (`@trezor/protobuf` regenerates from a separate `trezor-firmware` clone), `defs/`/`releases.json`/`tools/` changes (`models.json` unchanged), and the changed solana/tron/`sign_tx_error`/`sign_tx_clear_signing`/`sign_tx_erc20` fixtures (no wrapper imports them).

## Testing

ESLint passes on both wrappers. The 17 new vault tests couldn't be run locally (no emulator) — **relying on CI e2e to confirm** the new fixtures sign as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)