### PR TITLE
refactor(requirements): enhance yield/generator usage

### DIFF
--- a/packages/requirements/src/fileSystem.test.ts
+++ b/packages/requirements/src/fileSystem.test.ts
@@ -7,6 +7,16 @@ import { normalizePath, walkDirectory } from './fileSystem';
 describe(walkDirectory.name, () => {
     let rootDirectory: string;
 
+    const generateMockFileSystem = () => {
+        const nestedDirectory = join(rootDirectory, 'nested');
+        const excludedDirectory = join(rootDirectory, 'excluded');
+        mkdirSync(nestedDirectory);
+        mkdirSync(excludedDirectory);
+        writeFileSync(join(rootDirectory, 'root.ts'), '');
+        writeFileSync(join(nestedDirectory, 'nested.ts'), '');
+        writeFileSync(join(excludedDirectory, 'excluded.ts'), '');
+    };
+
     beforeEach(() => {
         rootDirectory = mkdtempSync(join(tmpdir(), 'walk-directory-'));
     });
@@ -16,14 +26,7 @@ describe(walkDirectory.name, () => {
     });
 
     it('walks files recursively and skips excluded directories', () => {
-        const nestedDirectory = join(rootDirectory, 'nested');
-        const excludedDirectory = join(rootDirectory, 'excluded');
-        mkdirSync(nestedDirectory);
-        mkdirSync(excludedDirectory);
-        writeFileSync(join(rootDirectory, 'root.ts'), '');
-        writeFileSync(join(nestedDirectory, 'nested.ts'), '');
-        writeFileSync(join(excludedDirectory, 'excluded.ts'), '');
-
+        generateMockFileSystem();
         const files = [
             ...walkDirectory(rootDirectory, {
                 shouldEnterDirectory: ({ entry }) => entry.name !== 'excluded',
@@ -37,15 +40,23 @@ describe(walkDirectory.name, () => {
     });
 
     it('filters yielded files without affecting directory traversal', () => {
-        const nestedDirectory = join(rootDirectory, 'nested');
-        mkdirSync(nestedDirectory);
-        writeFileSync(join(rootDirectory, 'root.ts'), '');
-        writeFileSync(join(rootDirectory, 'root.md'), '');
-        writeFileSync(join(nestedDirectory, 'nested.ts'), '');
-        writeFileSync(join(nestedDirectory, 'nested.md'), '');
-
+        generateMockFileSystem();
         const files = [
             ...walkDirectory(rootDirectory, {
+                fileFilter: ({ entry }) => entry.name.endsWith('.ts'),
+            }),
+        ]
+            .map(({ path }) => normalizePath(relative(rootDirectory, path)))
+            .sort();
+
+        expect(files).toEqual(['excluded/excluded.ts', 'nested/nested.ts', 'root.ts']);
+    });
+
+    it('combines all options', () => {
+        generateMockFileSystem();
+        const files = [
+            ...walkDirectory(rootDirectory, {
+                shouldEnterDirectory: ({ entry }) => entry.name !== 'excluded',
                 fileFilter: ({ entry }) => entry.name.endsWith('.ts'),
             }),
         ]

--- a/packages/requirements/src/fileSystem.test.ts
+++ b/packages/requirements/src/fileSystem.test.ts
@@ -35,4 +35,23 @@ describe(walkDirectory.name, () => {
 
         expect(files).toEqual(['nested/nested.ts', 'root.ts']);
     });
+
+    it('filters yielded files without affecting directory traversal', () => {
+        const nestedDirectory = join(rootDirectory, 'nested');
+        mkdirSync(nestedDirectory);
+        writeFileSync(join(rootDirectory, 'root.ts'), '');
+        writeFileSync(join(rootDirectory, 'root.md'), '');
+        writeFileSync(join(nestedDirectory, 'nested.ts'), '');
+        writeFileSync(join(nestedDirectory, 'nested.md'), '');
+
+        const files = [
+            ...walkDirectory(rootDirectory, {
+                fileFilter: ({ entry }) => entry.name.endsWith('.ts'),
+            }),
+        ]
+            .map(({ path }) => normalizePath(relative(rootDirectory, path)))
+            .sort();
+
+        expect(files).toEqual(['nested/nested.ts', 'root.ts']);
+    });
 });

--- a/packages/requirements/src/fileSystem.ts
+++ b/packages/requirements/src/fileSystem.ts
@@ -7,7 +7,10 @@ export type WalkDirectoryEntry = {
 };
 
 export type WalkDirectoryOptions = {
+    /** Filter callback to crawl or exclude directories based on arbitrary condition. */
     readonly shouldEnterDirectory?: (entry: WalkDirectoryEntry) => boolean;
+    /** Filter callback to keep or exclude files based on arbitrary condition. */
+    readonly fileFilter?: (entry: WalkDirectoryEntry) => boolean;
 };
 
 export function* walkDirectory(
@@ -27,6 +30,11 @@ export function* walkDirectory(
 
             continue;
         }
+
+        // Technically, `shouldEnterDirectory` and `fileFilter` could be unified, as they both work over the Dirent abstraction,
+        // so one filter could do both. But in practice, different conditions are used to exclude directories vs. filter files.
+        // So it'd be impractical to use (would have to use isFile, isDirectory everywhere).
+        if (options.fileFilter?.(walkedEntry) === false) continue;
 
         yield walkedEntry;
     }

--- a/packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts
+++ b/packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts
@@ -9,20 +9,6 @@ const DOCS_DIR = 'docs';
 const SUMMARY_FILE = 'SUMMARY.md';
 const IGNORED_DOC_LINKS = new Set([SUMMARY_FILE, 'symlink/_README.md']);
 
-const collectMarkdownFiles = (directoryPath: string, docsPath: string): string[] => {
-    const markdownFiles: string[] = [];
-
-    for (const { entry, path } of walkDirectory(directoryPath)) {
-        if ((!entry.isFile() && !entry.isSymbolicLink()) || !entry.name.endsWith('.md')) {
-            continue;
-        }
-
-        markdownFiles.push(normalizePath(relative(docsPath, path)));
-    }
-
-    return markdownFiles;
-};
-
 /**
  * Verifies that docs/SUMMARY.md (the entrypoint for mdBook), is exhaustive = every markdown file in docs/ is linked
  */
@@ -34,12 +20,17 @@ export const requireDocsSummary: Requirement<'repo'> = {
         const docsPath = join(repoRoot, DOCS_DIR);
         const summaryPath = join(docsPath, SUMMARY_FILE);
         const summaryContent = stripComments(readFileSync(summaryPath, 'utf-8'));
-        const docFiles = collectMarkdownFiles(docsPath, docsPath);
 
-        for (const file of docFiles) {
-            if (IGNORED_DOC_LINKS.has(file)) continue;
+        const walkDirectoryGenerator = walkDirectory(docsPath, {
+            fileFilter: ({ entry }) =>
+                (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith('.md'),
+        });
+        for (const { path } of walkDirectoryGenerator) {
+            const normalizedPath = normalizePath(relative(docsPath, path));
 
-            const link = `./${file}`;
+            if (IGNORED_DOC_LINKS.has(normalizedPath)) continue;
+
+            const link = `./${normalizedPath}`;
 
             if (!summaryContent.includes(link)) {
                 errors.push(`${DOCS_DIR}/${SUMMARY_FILE} does not link to ${link}`);

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -23,16 +23,15 @@ const IGNORED_TEST_FILE_DIRECTORIES = new Set([
 ]);
 
 const hasUnitTestFile = (directoryPath: string): boolean => {
-    for (const { entry } of walkDirectory(directoryPath, {
+    const walkDirectoryGenerator = walkDirectory(directoryPath, {
         shouldEnterDirectory: ({ entry: directory }) =>
             !IGNORED_TEST_FILE_DIRECTORIES.has(directory.name),
-    })) {
-        if (entry.isFile() && entry.name.endsWith('.test.ts')) {
-            return true;
-        }
-    }
+        fileFilter: ({ entry }) => entry.isFile() && entry.name.endsWith('.test.ts'),
+    });
+    // generator yielded no items, equivalent to Array.length === 0
+    const isEmpty = walkDirectoryGenerator.next().done === true;
 
-    return false;
+    return !isEmpty;
 };
 
 const REQUIRED_SCRIPTS: Record<string, RequiredScriptConfig> = {

--- a/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
+++ b/packages/requirements/src/requirements/test-colocation/requireTestColocation.ts
@@ -53,14 +53,14 @@ export const verifyTestColocation = (filePaths: ReadonlyArray<string>): Readonly
 const listWorkspaceTestFiles = (repoRoot: string, workspaceDir: string): ReadonlyArray<string> => {
     const testFiles: string[] = [];
 
-    for (const { entry, path } of walkDirectory(workspaceDir, {
+    const walkDirectoryGenerator = walkDirectory(workspaceDir, {
         shouldEnterDirectory: ({ entry: directory }) =>
             !IGNORED_DIRECTORY_NAMES.has(directory.name),
-    })) {
-        if ((!entry.isFile() && !entry.isSymbolicLink()) || !isTestFile(entry.name)) {
-            continue;
-        }
+        fileFilter: ({ entry }) =>
+            (entry.isFile() || entry.isSymbolicLink()) && isTestFile(entry.name),
+    });
 
+    for (const { path } of walkDirectoryGenerator) {
         testFiles.push(normalizePath(relative(repoRoot, path)));
     }
 

--- a/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
+++ b/packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 
-import { normalizePath, walkDirectory } from '../../fileSystem';
+import { type WalkDirectoryOptions, normalizePath, walkDirectory } from '../../fileSystem';
 import { listAllWorkspaces } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
@@ -60,10 +60,10 @@ const KNOWN_DECLARATION_SIZE_VIOLATIONS = new Set<string>([
 
 const isDeclarationFile = (fileName: string) => /\.d\.[cm]?ts$/.test(fileName);
 
+const isDeclarationFileFilter: WalkDirectoryOptions['fileFilter'] = ({ entry }) =>
+    entry.isFile() && isDeclarationFile(entry.name);
 const listDeclarationFiles = (directory: string): ReadonlyArray<string> =>
-    [...walkDirectory(directory)]
-        .filter(({ entry }) => entry.isFile() && isDeclarationFile(entry.name))
-        .map(({ path }) => path);
+    [...walkDirectory(directory, { fileFilter: isDeclarationFileFilter })].map(({ path }) => path);
 
 const formatSize = (sizeBytes: number) => {
     if (sizeBytes < 1024) return `${sizeBytes} B`;


### PR DESCRIPTION
## Description

Followup to b205023a:
- Expand the `walkDirectory` with a new option `fileFilter` that's analogical to `shouldEnterDirectory`.
- Use it instead of filtering array of files ex-post
- Try to use generator idiomatically without serializing to array, where viable
- :nail_care: in tests

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are internal requirements tooling and unit tests under packages/requirements, not application code. They are not exercised by any Playwright E2E test in the provided candidate list, and there is no static coverage mapping. The risk to user-facing functionality is minimal, so no E2E tests are recommended.

<details><summary><b>Changed files (6)</b></summary>

- `packages/requirements/src/fileSystem.test.ts`
- `packages/requirements/src/fileSystem.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (6)**
- `packages/requirements/src/fileSystem.test.ts`
- `packages/requirements/src/fileSystem.ts`
- `packages/requirements/src/requirements/docs-summary/requireDocsSummary.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/test-colocation/requireTestColocation.ts`
- `packages/requirements/src/requirements/type-declarations/requireTypeDeclarationSize.ts`

_Updated: 2026-07-31T10:03:30.095Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/requirements-yield-hijinkery/web/](https://dev.suite.sldev.cz/suite-web/chore/requirements-yield-hijinkery/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/requirements-yield-hijinkery&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/requirements-yield-hijinkery&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:06:35.100Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:06:02.468Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->