### PR TITLE
feat(suite-desktop): introduce fiat input toggle

### DIFF
--- a/packages/suite/src/components/earn/yield/common/TruncatedAmount.tsx
+++ b/packages/suite/src/components/earn/yield/common/TruncatedAmount.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode } from 'react';
+
+import { selectIsDiscreteModeActive } from '@suite-common/discreet-mode';
+import { TOOLTIP_DELAY_LONG, TruncateWithTooltip } from '@trezor/components';
+
+import { useSelector } from 'src/hooks/suite';
+
+type TruncatedAmountProps = {
+    children: ReactNode;
+};
+
+// Ellipsis + hover tooltip for read-only amounts so a long value can't stretch the layout.
+// Skips the tooltip in discreet mode so a hidden amount can't be revealed on hover (matches BaseCurrency).
+export const TruncatedAmount = ({ children }: TruncatedAmountProps) => {
+    const isDiscreetMode = useSelector(selectIsDiscreteModeActive);
+
+    if (isDiscreetMode) {
+        return <>{children}</>;
+    }
+
+    return <TruncateWithTooltip delayShow={TOOLTIP_DELAY_LONG}>{children}</TruncateWithTooltip>;
+};

--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -10,6 +10,7 @@ import { Button, Column } from '@trezor/components';
 
 import {
     YieldAmountCard,
+    type YieldAmountCardFiatToggleProps,
     type YieldAmountCardUnitToggleProps,
     type YieldApproxFiat,
 } from './YieldAmountCard';
@@ -43,6 +44,7 @@ export type YieldActionStepProps = {
     warning?: ReactNode;
     pendingTransaction?: YieldPendingTransactionState;
     unitToggle?: YieldAmountCardUnitToggleProps;
+    fiatToggle?: YieldAmountCardFiatToggleProps;
     onMaxClick?: () => void;
     onSubmit: () => void;
     onPendingTxClick: (txid: string) => void;
@@ -58,6 +60,7 @@ export const YieldActionStep = ({
     warning,
     pendingTransaction,
     unitToggle,
+    fiatToggle,
     onMaxClick,
     onSubmit,
     onPendingTxClick,
@@ -80,6 +83,7 @@ export const YieldActionStep = ({
                     amountLabelTranslationId,
                 }}
                 unitToggle={pendingTransaction ? undefined : unitToggle}
+                fiatToggle={pendingTransaction ? undefined : fiatToggle}
                 warning={warning}
                 isDisabled={!!pendingTransaction}
             />

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -4,7 +4,6 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { Translation, useTranslation } from '@suite/intl';
 import type { TranslationKey } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
-import { formInputsMaxLength } from '@suite-common/validators';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { YieldFlowFormValues } from '@suite-common/wallet-core';
 import { toTokenAddress } from '@suite-common/wallet-types';
@@ -14,6 +13,14 @@ import { NumberInput } from '@trezor/product-components';
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useSelector } from 'src/hooks/suite';
 import { validateDecimals } from 'src/utils/suite/validation';
+
+import { TruncatedAmount } from './TruncatedAmount';
+
+const FIAT_DECIMALS = 2;
+// Amount inputs never need the 255-char default; cap them so a long value can't stretch the field
+// (an over-long value also breaks the card's max-width and lets sibling amounts grow with it).
+const FIAT_INPUT_MAX_LENGTH = 18;
+const AMOUNT_INPUT_MAX_LENGTH = 30;
 
 type YieldAmountCardSummaryProps = {
     value: ReactNode;
@@ -35,12 +42,20 @@ export type YieldApproxFiat = {
     tokenContractAddress?: string | null;
 };
 
+export type YieldAmountCardFiatToggleProps = {
+    currency: 'crypto' | 'fiat';
+    fiatSymbol: string;
+    onToggle: () => void;
+    onFiatAmountChange: (value: string) => void;
+};
+
 type YieldAmountCardProps = {
     tokenSymbol: string;
     decimals?: number;
     summary?: YieldAmountCardSummaryProps;
     heading?: YieldAmountCardHeadingProps;
     unitToggle?: YieldAmountCardUnitToggleProps;
+    fiatToggle?: YieldAmountCardFiatToggleProps;
     warning?: ReactNode;
     isDisabled?: boolean;
     approxFiat?: YieldApproxFiat;
@@ -52,6 +67,7 @@ export const YieldAmountCard = ({
     summary,
     heading,
     unitToggle,
+    fiatToggle,
     warning,
     isDisabled = false,
     approxFiat,
@@ -64,6 +80,8 @@ export const YieldAmountCard = ({
         trigger,
     } = useFormContext<YieldFlowFormValues>();
 
+    const isFiatMode = fiatToggle?.currency === 'fiat';
+
     const rules = useMemo(
         () =>
             decimals !== undefined
@@ -72,13 +90,47 @@ export const YieldAmountCard = ({
         [translationString, decimals],
     );
 
+    const fiatRules = useMemo(
+        () => ({
+            validate: {
+                decimals: validateDecimals(translationString, { decimals: FIAT_DECIMALS }),
+            },
+        }),
+        [translationString],
+    );
+
     const amountInput = useWatch({ control, name: 'amountInput' });
+    const fiatInput = useWatch({ control, name: 'fiatInput' });
 
     useEffect(() => {
         if (amountInput) {
             trigger('amountInput');
         }
     }, [amountInput, trigger]);
+
+    useEffect(() => {
+        if (fiatInput && isFiatMode) {
+            trigger('fiatInput');
+        }
+    }, [fiatInput, isFiatMode, trigger]);
+
+    // The switch offers the opposite unit to the one currently active.
+    const fiatSwitch = fiatToggle ? (
+        <TextButton
+            type="button"
+            size="small"
+            onClick={fiatToggle.onToggle}
+            isUnderlined
+            data-testid="@yield/form/fiat-switch"
+        >
+            <Translation
+                id="TR_EARN_ENTER_AMOUNT_IN"
+                values={{ currency: isFiatMode ? tokenSymbol : fiatToggle.fiatSymbol }}
+            />
+        </TextButton>
+    ) : undefined;
+
+    const activeError = isFiatMode ? errors.fiatInput : errors.amountInput;
 
     return (
         <Card paddingType="none">
@@ -87,7 +139,11 @@ export const YieldAmountCard = ({
                     <Text typographyStyle="body-md">
                         <Translation id={heading?.amountLabelTranslationId ?? 'AMOUNT'} />
                     </Text>
-                    {unitToggle && (
+                    {fiatSwitch}
+                </Row>
+                {/* Only the withdraw flow passes a unit toggle; it gets its own row below the label. */}
+                {unitToggle && (
+                    <Row justifyContent="flex-end" width="100%">
                         <TextButton
                             type="button"
                             size="small"
@@ -99,31 +155,56 @@ export const YieldAmountCard = ({
                                 values={{ tokenSymbol: unitToggle.otherTokenSymbol }}
                             />
                         </TextButton>
-                    )}
-                </Row>
-                <NumberInput
-                    name="amountInput"
-                    data-testid="@yield/form/amount-input"
-                    locale={locale}
-                    control={control}
-                    rules={rules}
-                    maxLength={formInputsMaxLength.amount}
-                    isDisabled={isDisabled}
-                    rightContent={
-                        <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                            {tokenSymbol}
-                        </Text>
-                    }
-                />
+                    </Row>
+                )}
+                {isFiatMode ? (
+                    <NumberInput
+                        name="fiatInput"
+                        data-testid="@yield/form/fiat-input"
+                        locale={locale}
+                        control={control}
+                        rules={fiatRules}
+                        onChange={fiatToggle?.onFiatAmountChange}
+                        maxLength={FIAT_INPUT_MAX_LENGTH}
+                        isDisabled={isDisabled}
+                        rightContent={
+                            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                                {fiatToggle?.fiatSymbol}
+                            </Text>
+                        }
+                    />
+                ) : (
+                    <NumberInput
+                        name="amountInput"
+                        data-testid="@yield/form/amount-input"
+                        locale={locale}
+                        control={control}
+                        rules={rules}
+                        maxLength={AMOUNT_INPUT_MAX_LENGTH}
+                        isDisabled={isDisabled}
+                        rightContent={
+                            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                                {tokenSymbol}
+                            </Text>
+                        }
+                    />
+                )}
 
                 {summary && (
                     <Row justifyContent="space-between" alignItems="center" gap={8} width="100%">
-                        <Row alignItems="center" gap={8}>
+                        <Row alignItems="center" gap={8} minWidth={0}>
                             <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                                <Translation id={summary.labelTranslationId} />
-                                {': '}
-                                {summary.value}
+                                <Translation id={summary.labelTranslationId} />:
                             </Text>
+                            <TruncatedAmount>
+                                <Text
+                                    typographyStyle="body-md"
+                                    intent="neutral"
+                                    priority="secondary"
+                                >
+                                    {summary.value}
+                                </Text>
+                            </TruncatedAmount>
                             {summary.onMaxClick && (
                                 <Button
                                     type="button"
@@ -163,11 +244,8 @@ export const YieldAmountCard = ({
                     </Row>
                 )}
 
-                {errors.amountInput?.message && (
-                    <Banner
-                        intent="warning"
-                        description={<Text>{errors.amountInput.message}</Text>}
-                    />
+                {activeError?.message && (
+                    <Banner intent="warning" description={<Text>{activeError.message}</Text>} />
                 )}
 
                 {warning}

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -9,7 +9,11 @@ import { Banner, Button, Column, Row } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
-import { YieldAmountCard, type YieldApproxFiat } from './YieldAmountCard';
+import {
+    YieldAmountCard,
+    type YieldAmountCardFiatToggleProps,
+    type YieldApproxFiat,
+} from './YieldAmountCard';
 import { YieldApprovedAmountCard } from './YieldApprovedAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 import type { YieldApprovalAction } from '../yieldFlowUtils';
@@ -43,6 +47,7 @@ export type YieldApproveStepProps = {
     canRevokeAllowance: boolean;
     warning?: ReactNode;
     pendingApproveTransaction?: YieldPendingTransactionState;
+    fiatToggle?: YieldAmountCardFiatToggleProps;
     onMaxClick?: () => void;
     onApprovalSubmit?: () => void;
     onSkip?: () => void;
@@ -63,6 +68,7 @@ export const YieldApproveStep = ({
     canRevokeAllowance,
     warning,
     pendingApproveTransaction,
+    fiatToggle,
     onMaxClick,
     onApprovalSubmit,
     onSkip,
@@ -96,6 +102,7 @@ export const YieldApproveStep = ({
                 heading={{
                     amountLabelTranslationId: 'AMOUNT',
                 }}
+                fiatToggle={pendingApproveTransaction ? undefined : fiatToggle}
                 warning={warning}
                 isDisabled={!!pendingApproveTransaction}
             />

--- a/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
@@ -6,7 +6,11 @@ import { Button, Column, Row } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
-import { YieldAmountCard, type YieldApproxFiat } from './YieldAmountCard';
+import {
+    YieldAmountCard,
+    type YieldAmountCardFiatToggleProps,
+    type YieldApproxFiat,
+} from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 type YieldUnwrapStepProps = {
@@ -21,6 +25,7 @@ type YieldUnwrapStepProps = {
     isSubmitDisabled?: boolean;
     warning?: ReactNode;
     pendingTransaction?: YieldPendingTransactionState;
+    fiatToggle?: YieldAmountCardFiatToggleProps;
     onPendingTxClick?: (txid: string) => void;
 };
 
@@ -36,6 +41,7 @@ export const YieldUnwrapStep = ({
     isSubmitDisabled = false,
     warning,
     pendingTransaction,
+    fiatToggle,
     onPendingTxClick,
 }: YieldUnwrapStepProps) => (
     <Column gap={16}>
@@ -54,6 +60,7 @@ export const YieldUnwrapStep = ({
                 ),
                 onMaxClick: pendingTransaction ? undefined : onMaxClick,
             }}
+            fiatToggle={pendingTransaction ? undefined : fiatToggle}
             warning={warning}
         />
 

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -5,12 +5,13 @@ import type {
     YieldFlowDisplayToken,
     YieldPendingTransactionState,
 } from '@suite-common/wallet-core';
-import { Button, Card, Column, Row, Text } from '@trezor/components';
+import { Box, Button, Card, Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
-import { YieldAmountCard } from './YieldAmountCard';
+import { TruncatedAmount } from './TruncatedAmount';
+import { YieldAmountCard, type YieldAmountCardFiatToggleProps } from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 type YieldWrapStepProps = {
@@ -26,6 +27,7 @@ type YieldWrapStepProps = {
     isSubmitDisabled?: boolean;
     warning?: ReactNode;
     pendingTransaction?: YieldPendingTransactionState;
+    fiatToggle?: YieldAmountCardFiatToggleProps;
     onPendingTxClick?: (txid: string) => void;
 };
 
@@ -42,6 +44,7 @@ export const YieldWrapStep = ({
     isSubmitDisabled = false,
     warning,
     pendingTransaction,
+    fiatToggle,
     onPendingTxClick,
 }: YieldWrapStepProps) => (
     <Column gap={16}>
@@ -65,16 +68,17 @@ export const YieldWrapStep = ({
                 ),
                 onMaxClick: pendingTransaction ? undefined : onMaxClick,
             }}
+            fiatToggle={pendingTransaction ? undefined : fiatToggle}
             warning={warning}
         />
 
         {shouldShowReceivingRow && (
             <Card type="contrast" paddingType="small">
-                <Row justifyContent="space-between" alignItems="center" width="100%">
+                <Row justifyContent="space-between" alignItems="center" width="100%" gap={8}>
                     <Text typographyStyle="body-md">
                         <Translation id="TR_EARN_YIELD_WRAP_RECEIVING" />
                     </Text>
-                    <Row alignItems="center" gap={8}>
+                    <Row alignItems="center" gap={8} minWidth={0}>
                         <TokenIcon
                             size={20}
                             symbol={token.networkSymbol}
@@ -83,9 +87,16 @@ export const YieldWrapStep = ({
                             showNetworkIcon
                             isBordered={false}
                         />
-                        <Text typographyStyle="body-md">
-                            <FormattedCryptoAmount value={receivingAmount} symbol={token.symbol} />
-                        </Text>
+                        <Box minWidth={0}>
+                            <TruncatedAmount>
+                                <Text typographyStyle="body-md" ellipsisLineCount={1}>
+                                    <FormattedCryptoAmount
+                                        value={receivingAmount}
+                                        symbol={token.symbol}
+                                    />
+                                </Text>
+                            </TruncatedAmount>
+                        </Box>
                     </Row>
                 </Row>
             </Card>

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -52,7 +52,6 @@ export const YieldDepositForm = () => {
         isApprovalInsufficient,
         isSubmittingApprove,
         isSubmittingAction,
-        setAmountInput,
         submitWrap,
         skipWrap,
         returnToWrapStep,
@@ -65,6 +64,8 @@ export const YieldDepositForm = () => {
         handleApproveSuccessTxid,
         openPendingTransaction,
         retryInitAllowance,
+        fiatToggle,
+        setMaxAmount,
         flow,
     } = useYieldDepositContext();
 
@@ -224,7 +225,8 @@ export const YieldDepositForm = () => {
             },
         });
 
-        setAmountInput(maxAmount);
+        // Fill the exact crypto max (and the rounded-down fiat display in fiat mode) without switching.
+        setMaxAmount(maxAmount);
     };
 
     const handleRetryAllowance = () => {
@@ -307,6 +309,7 @@ export const YieldDepositForm = () => {
                                         }
                                         warning={renderWrapWarning()}
                                         pendingTransaction={wrapPendingTransaction}
+                                        fiatToggle={fiatToggle}
                                         onMaxClick={handleMaxClick}
                                         onSubmit={handleOnWrap}
                                         onSkip={
@@ -362,6 +365,7 @@ export const YieldDepositForm = () => {
                                         }
                                         isLoading={isSubmittingApprove}
                                         pendingApproveTransaction={approvalPendingTransaction}
+                                        fiatToggle={fiatToggle}
                                         onMaxClick={handleMaxClick}
                                         onApprovalSubmit={handleOnApprovalSubmit}
                                         onSkip={
@@ -414,6 +418,7 @@ export const YieldDepositForm = () => {
                                         }
                                         isPending={isSubmittingAction}
                                         pendingTransaction={depositPendingTransaction}
+                                        fiatToggle={fiatToggle}
                                         onMaxClick={handleMaxClick}
                                         onSubmit={handleOnDeposit}
                                         onPendingTxClick={openPendingTransaction}

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
@@ -1,0 +1,72 @@
+import { useForm } from 'react-hook-form';
+
+import { act, renderHook } from '@testing-library/react';
+
+import { type YieldFlowFormValues } from '@suite-common/wallet-core';
+
+import { useYieldFiatInput } from './useYieldFiatInput';
+
+const ETH_RATE = 3333.35;
+
+const mockState = {
+    wallet: {
+        settings: { localCurrency: 'usd' },
+        fiat: { current: { 'eth-usd': { rate: ETH_RATE } } },
+    },
+};
+
+jest.mock('src/hooks/suite', () => ({
+    useSelector: (selector: (state: unknown) => unknown) => selector(mockState),
+}));
+
+const renderYieldFiatInput = () =>
+    renderHook(() => {
+        const methods = useForm<YieldFlowFormValues>({
+            mode: 'onChange',
+            defaultValues: { amountInput: '', fiatInput: '' },
+        });
+
+        return { methods, fiat: useYieldFiatInput({ methods, symbol: 'eth', decimals: 18 }) };
+    });
+
+describe('useYieldFiatInput', () => {
+    it('offers the fiat switch when a rate is available', () => {
+        const { result } = renderYieldFiatInput();
+
+        expect(result.current.fiat.fiatToggle).toBeDefined();
+        expect(result.current.fiat.fiatToggle?.currency).toBe('crypto');
+        expect(result.current.fiat.fiatToggle?.fiatSymbol).toBe('USD');
+    });
+
+    it('keeps Max in crypto units when crypto is the active input', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.setMaxAmount('0.1'));
+
+        expect(result.current.methods.getValues('amountInput')).toBe('0.1');
+    });
+
+    // The Max button must fill the active unit rather than switching back to crypto.
+    it('fills the rounded-down fiat max when fiat is the active input, without switching', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+        expect(result.current.fiat.fiatToggle?.currency).toBe('fiat');
+
+        act(() => result.current.fiat.setMaxAmount('0.1'));
+
+        // Stays in fiat, shows the floored fiat max, and keeps the exact crypto max underneath.
+        expect(result.current.fiat.fiatToggle?.currency).toBe('fiat');
+        expect(result.current.methods.getValues('fiatInput')).toBe('333.33');
+        expect(result.current.methods.getValues('amountInput')).toBe('0.1');
+    });
+
+    it('converts a typed fiat amount into the crypto source of truth', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+        act(() => result.current.fiat.fiatToggle?.onFiatAmountChange('333.33'));
+
+        expect(result.current.methods.getValues('amountInput')).toBe('0.099998500007499963');
+    });
+});

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type UseFormReturn, useWatch } from 'react-hook-form';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type YieldFlowFormValues,
+    getTokenFiatRate,
+    selectBaseCurrency,
+    selectCurrentFiatRates,
+} from '@suite-common/wallet-core';
+import { type TokenAddress } from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
+import {
+    getYieldCryptoInputValue,
+    getYieldFiatInputValue,
+    getYieldMaxFiatInputValue,
+} from '../yieldFlowUtils';
+
+export type YieldCurrency = 'crypto' | 'fiat';
+
+type UseYieldFiatInputParams = {
+    methods: UseFormReturn<YieldFlowFormValues>;
+    // Symbol/token that prices the amount. `symbol` undefined (e.g. redeeming shares) disables fiat entry.
+    symbol: NetworkSymbol | undefined;
+    tokenAddress?: TokenAddress;
+    decimals: number;
+};
+
+export type UseYieldFiatInputResult = {
+    fiatToggle: YieldAmountCardFiatToggleProps | undefined;
+    // Fills the exact crypto max and, in fiat mode, the rounded-down max fiat display, without
+    // switching the active unit.
+    setMaxAmount: (cryptoMax: string) => void;
+};
+
+/**
+ * Fiat/crypto entry for a yield amount form. `amountInput` stays the crypto source of truth; the
+ * display-only `fiatInput` is kept in sync (crypto mode) and drives `amountInput` back (fiat mode).
+ */
+export const useYieldFiatInput = ({
+    methods,
+    symbol,
+    tokenAddress,
+    decimals,
+}: UseYieldFiatInputParams): UseYieldFiatInputResult => {
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const currentFiatRates = useSelector(selectCurrentFiatRates);
+    const [currency, setCurrency] = useState<YieldCurrency>('crypto');
+
+    const fiatSymbol = baseCurrencyCode.toUpperCase();
+
+    const currentRate = useMemo(() => {
+        if (!symbol) {
+            return undefined;
+        }
+
+        return getTokenFiatRate(
+            currentFiatRates,
+            getFiatRateKey(symbol, baseCurrencyCode, tokenAddress),
+        );
+    }, [currentFiatRates, baseCurrencyCode, symbol, tokenAddress]);
+
+    const hasFiatRate = currentRate !== undefined;
+
+    const liveAmount = useWatch({ control: methods.control, name: 'amountInput' });
+
+    // Keep the display-only fiat field in sync with the crypto source of truth. Runs only in crypto
+    // mode so it never fights the user's fiat typing (onFiatAmountChange drives the reverse direction).
+    useEffect(() => {
+        if (currency !== 'crypto') {
+            return;
+        }
+
+        const nextFiat = getYieldFiatInputValue({ amount: liveAmount, rate: currentRate });
+        if (methods.getValues('fiatInput') !== nextFiat) {
+            methods.setValue('fiatInput', nextFiat);
+        }
+    }, [currency, currentRate, liveAmount, methods]);
+
+    // Fiat entry is impossible without a rate (e.g. redeeming shares); fall back to crypto.
+    useEffect(() => {
+        if (!hasFiatRate && currency === 'fiat') {
+            setCurrency('crypto');
+        }
+    }, [currency, hasFiatRate]);
+
+    const onFiatAmountChange = useCallback(
+        (fiat: string) => {
+            const crypto = getYieldCryptoInputValue({ fiat, rate: currentRate, decimals });
+            methods.setValue('amountInput', crypto, { shouldValidate: true, shouldDirty: true });
+        },
+        [currentRate, decimals, methods],
+    );
+
+    const fiatToggle: YieldAmountCardFiatToggleProps | undefined = hasFiatRate
+        ? {
+              currency,
+              fiatSymbol,
+              onToggle: () => setCurrency(prev => (prev === 'crypto' ? 'fiat' : 'crypto')),
+              onFiatAmountChange,
+          }
+        : undefined;
+
+    const setMaxAmount = useCallback(
+        (cryptoMax: string) => {
+            methods.setValue('amountInput', cryptoMax, { shouldValidate: true, shouldDirty: true });
+
+            // In fiat mode the crypto→fiat sync effect is disabled, so fill the fiat display here.
+            if (currency === 'fiat') {
+                methods.setValue(
+                    'fiatInput',
+                    getYieldMaxFiatInputValue({ amount: cryptoMax, rate: currentRate }),
+                );
+            }
+        },
+        [currency, currentRate, methods],
+    );
+
+    return { fiatToggle, setMaxAmount };
+};

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -9,6 +9,7 @@ import { type EarnParams } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { getNetwork } from '@suite-common/wallet-config';
 import {
     type YieldAllowanceStatus,
     type YieldApproveModalState,
@@ -42,10 +43,13 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { useEnsureYieldDeviceSession } from './useEnsureYieldDeviceSession';
 import { useResolvedYieldFlowData } from './useResolvedYieldFlowData';
+import { useYieldFiatInput } from './useYieldFiatInput';
 import { useYieldPendingTransactionTracking } from './useYieldPendingTransactionTracking';
+import { type YieldAmountCardFiatToggleProps } from '../common/YieldAmountCard';
 import {
     type YieldApprovalAction,
     getYieldApprovalAction,
+    getYieldFiatRateToken,
     getYieldModifyAmountInput,
     getYieldUnwrapDefaultAmount,
     isAmountGreaterThan,
@@ -112,6 +116,8 @@ export type UseYieldFlowResult = {
     handleApproveSuccessTxid: (txid: string) => void;
     openPendingTransaction: (txid: string) => void;
     retryInitAllowance: () => void;
+    fiatToggle: YieldAmountCardFiatToggleProps | undefined;
+    setMaxAmount: (cryptoMax: string) => void;
     methods: UseFormReturn<YieldFlowFormValues>;
     flow: UseYieldFlowStepsResult;
 };
@@ -139,6 +145,7 @@ export const useYieldFlow = ({
         mode: 'onChange',
         defaultValues: {
             amountInput: '',
+            fiatInput: '',
         },
     });
     const methodsRef = useCurrentRef(methods);
@@ -171,6 +178,21 @@ export const useYieldFlow = ({
 
     const isSharesInput = flowType === 'redeem';
     const canToggleWithdrawUnit = isYieldWithdrawFlow(flowType) && !!token && !!receiptToken;
+
+    // Fiat entry prices the amount by the token currently shown (native for wrap/unwrap, the vault
+    // asset for deposit/withdraw, none while redeeming shares).
+    const rateToken = getYieldFiatRateToken({
+        step: session.step,
+        flowType,
+        accountSymbol: account.symbol,
+        token,
+    });
+    const { fiatToggle, setMaxAmount } = useYieldFiatInput({
+        methods,
+        symbol: rateToken?.symbol,
+        tokenAddress: rateToken?.tokenAddress,
+        decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
+    });
 
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
@@ -216,7 +238,7 @@ export const useYieldFlow = ({
             );
         }
 
-        methodsRef.current.reset({ amountInput: '' });
+        methodsRef.current.reset({ amountInput: '', fiatInput: '' });
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
@@ -314,11 +336,14 @@ export const useYieldFlow = ({
 
         if (prevStep !== null && prevStep !== nextStep) {
             if (prevStep === 'wrap' && nextStep === 'approve') {
-                methodsRef.current.reset({ amountInput: session.action.amount ?? '' });
+                methodsRef.current.reset({
+                    amountInput: session.action.amount ?? '',
+                    fiatInput: '',
+                });
             }
 
             if (nextStep === 'wrap') {
-                methodsRef.current.reset({ amountInput: '' });
+                methodsRef.current.reset({ amountInput: '', fiatInput: '' });
             }
 
             if (prevStep === 'approve' && nextStep === 'action') {
@@ -331,6 +356,7 @@ export const useYieldFlow = ({
                     : actionAmount;
                 methodsRef.current.reset({
                     amountInput: cappedAmount,
+                    fiatInput: '',
                 });
             }
 
@@ -341,6 +367,7 @@ export const useYieldFlow = ({
                         actionAmount: session.action.amount,
                         maxAmount,
                     }),
+                    fiatInput: '',
                 });
             }
         }
@@ -380,7 +407,7 @@ export const useYieldFlow = ({
             unwrapDefaultAmountRef.current === null ||
             currentAmount === unwrapDefaultAmountRef.current
         ) {
-            methodsRef.current.reset({ amountInput: unwrapDefaultAmount });
+            methodsRef.current.reset({ amountInput: unwrapDefaultAmount, fiatInput: '' });
         }
 
         unwrapDefaultAmountRef.current = unwrapDefaultAmount;
@@ -675,7 +702,7 @@ export const useYieldFlow = ({
                 amount,
             }),
         );
-        methodsRef.current.reset({ amountInput: '' });
+        methodsRef.current.reset({ amountInput: '', fiatInput: '' });
     }, [
         account,
         flowKey,
@@ -872,6 +899,8 @@ export const useYieldFlow = ({
         handleApproveSuccessTxid,
         openPendingTransaction,
         retryInitAllowance: runInitAllowance,
+        fiatToggle,
+        setMaxAmount,
         methods,
         flow,
     };

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -26,6 +26,7 @@ import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
 import { useWrappedNativePendingTx } from '../common/useWrappedNativePendingTx';
+import { useYieldFiatInput } from '../hooks/useYieldFiatInput';
 
 type UnwrapNativeTokenProps = {
     account: Account;
@@ -54,7 +55,14 @@ export const UnwrapNativeToken = ({
         mode: 'onChange',
         defaultValues: {
             amountInput: tokenBalance,
+            fiatInput: '',
         },
+    });
+
+    const { fiatToggle, setMaxAmount } = useYieldFiatInput({
+        methods,
+        symbol: account.symbol,
+        decimals: tokenDecimals,
     });
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'unwrap');
@@ -99,7 +107,7 @@ export const UnwrapNativeToken = ({
             }),
         );
         setBroadcast(null);
-        methods.reset({ amountInput: tokenBalance });
+        methods.reset({ amountInput: tokenBalance, fiatInput: '' });
     }, [pendingTxStatus, dispatch, methods, tokenBalance]);
 
     const unwrapMutation = useMutation({
@@ -185,11 +193,8 @@ export const UnwrapNativeToken = ({
                                 ? { type: 'unwrap', txid: broadcast.txid, amount: broadcast.amount }
                                 : undefined
                         }
-                        onMaxClick={() =>
-                            methods.setValue('amountInput', tokenBalance, {
-                                shouldValidate: true,
-                            })
-                        }
+                        fiatToggle={fiatToggle}
+                        onMaxClick={() => setMaxAmount(tokenBalance)}
                         onSubmit={handleSubmit}
                         onPendingTxClick={openTxDetail}
                     />

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -43,10 +43,11 @@ export const YieldWithdrawForm = () => {
         isMaxWithdrawInfoVisible,
         toggleWithdrawFlowType,
         submitAction,
-        setAmountInput,
         submitUnwrap,
         skipUnwrap,
         openPendingTransaction,
+        fiatToggle,
+        setMaxAmount,
         flow,
     } = useYieldWithdrawContext();
 
@@ -249,6 +250,7 @@ export const YieldWithdrawForm = () => {
                                               }
                                             : undefined
                                     }
+                                    fiatToggle={fiatToggle}
                                     onMaxClick={handleMaxClick}
                                     onSubmit={handleOnWithdraw}
                                     onPendingTxClick={openPendingTransaction}
@@ -277,7 +279,8 @@ export const YieldWithdrawForm = () => {
                                     tokenDecimals={token.decimals}
                                     tokenBalance={token.balance}
                                     approxFiat={unwrapApproxFiat}
-                                    onMaxClick={() => setAmountInput(token.balance)}
+                                    fiatToggle={fiatToggle}
+                                    onMaxClick={() => setMaxAmount(token.balance)}
                                     isSubmitting={isSubmittingAction}
                                     isSubmitDisabled={
                                         isAmountEmpty || isAmountTooHigh || isAmountInvalidDecimals

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -48,6 +48,7 @@ export const useYieldWithdraw = ({
     }, []);
 
     const selectMaxWithdraw = useCallback(() => {
+        // Max redeems the whole share balance; shares have no fiat rate, so the input stays in crypto.
         if (flowType === 'redeem') {
             setAmountInput(depositedSharesAmount);
 

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -27,6 +27,7 @@ import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldWrapStep } from '../common/YieldWrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
 import { useWrappedNativePendingTx } from '../common/useWrappedNativePendingTx';
+import { useYieldFiatInput } from '../hooks/useYieldFiatInput';
 
 type WrapNativeTokenProps = {
     account: Account;
@@ -46,6 +47,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
         mode: 'onChange',
         defaultValues: {
             amountInput: '',
+            fiatInput: '',
         },
     });
 
@@ -61,6 +63,12 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     // Max leaves the gas reserve aside, but the field shows the full balance and the user may wrap
     // up to it; eating into the reserve only triggers a non-blocking recommendation.
     const maxWrapAmount = getWrappableNativeBalance(account.formattedBalance);
+
+    const { fiatToggle, setMaxAmount } = useYieldFiatInput({
+        methods,
+        symbol: account.symbol,
+        decimals: token.decimals,
+    });
 
     const amountInput = useWatch({ control: methods.control, name: 'amountInput' });
     const amount = new BigNumber(amountInput || '');
@@ -80,7 +88,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
             }),
         );
         setBroadcast(null);
-        methods.reset({ amountInput: '' });
+        methods.reset({ amountInput: '', fiatInput: '' });
     }, [pendingTxStatus, dispatch, methods]);
 
     const wrapMutation = useMutation({
@@ -179,11 +187,8 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                                 ? { type: 'wrap', txid: broadcast.txid, amount: broadcast.amount }
                                 : undefined
                         }
-                        onMaxClick={() =>
-                            methods.setValue('amountInput', maxWrapAmount, {
-                                shouldValidate: true,
-                            })
-                        }
+                        fiatToggle={fiatToggle}
+                        onMaxClick={() => setMaxAmount(maxWrapAmount)}
                         onSubmit={handleSubmit}
                         onPendingTxClick={openTxDetail}
                     />

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -1,6 +1,18 @@
 import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
 
-import { getYieldFlowSteps, getYieldUnwrapDefaultAmount } from './yieldFlowUtils';
+import {
+    getYieldCryptoInputValue,
+    getYieldFiatInputValue,
+    getYieldFiatRateToken,
+    getYieldFlowSteps,
+    getYieldMaxFiatInputValue,
+    getYieldUnwrapDefaultAmount,
+} from './yieldFlowUtils';
+
+// Checksummed WETH address; the helper lower-cases it for the (evm) rate key.
+const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const WETH_LOWER = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const ethToken = { networkSymbol: 'eth', contractAddress: WETH } as const;
 
 const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
 const depositWithWrapSequence = getYieldFlowStepSequence({
@@ -185,6 +197,116 @@ describe('yieldFlowUtils', () => {
                     fallbackAmount: '5',
                 }),
             ).toBe('5');
+        });
+    });
+
+    describe('getYieldFiatRateToken', () => {
+        it('prices wrap/unwrap by the account native symbol (no token address)', () => {
+            expect(
+                getYieldFiatRateToken({
+                    step: 'wrap',
+                    flowType: 'deposit',
+                    accountSymbol: 'eth',
+                    token: ethToken,
+                }),
+            ).toEqual({ symbol: 'eth' });
+
+            expect(
+                getYieldFiatRateToken({
+                    step: 'unwrap',
+                    flowType: 'withdraw',
+                    accountSymbol: 'eth',
+                    token: ethToken,
+                }),
+            ).toEqual({ symbol: 'eth' });
+        });
+
+        it('prices deposit/withdraw by the asset token contract address (lower-cased)', () => {
+            expect(
+                getYieldFiatRateToken({
+                    step: 'action',
+                    flowType: 'deposit',
+                    accountSymbol: 'eth',
+                    token: ethToken,
+                }),
+            ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
+
+            expect(
+                getYieldFiatRateToken({
+                    step: 'action',
+                    flowType: 'withdraw',
+                    accountSymbol: 'eth',
+                    token: ethToken,
+                }),
+            ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
+        });
+
+        it('returns null when fiat entry is impossible (redeeming shares or no token address)', () => {
+            expect(
+                getYieldFiatRateToken({
+                    step: 'action',
+                    flowType: 'redeem',
+                    accountSymbol: 'eth',
+                    token: ethToken,
+                }),
+            ).toBeNull();
+
+            expect(
+                getYieldFiatRateToken({
+                    step: 'action',
+                    flowType: 'deposit',
+                    accountSymbol: 'eth',
+                    token: null,
+                }),
+            ).toBeNull();
+
+            expect(
+                getYieldFiatRateToken({
+                    step: 'action',
+                    flowType: 'deposit',
+                    accountSymbol: 'eth',
+                    token: { networkSymbol: 'eth', contractAddress: null },
+                }),
+            ).toBeNull();
+        });
+    });
+
+    describe('getYieldFiatInputValue', () => {
+        it('converts crypto to fiat with two decimals', () => {
+            expect(getYieldFiatInputValue({ amount: '2', rate: 1500 })).toBe('3000.00');
+            expect(getYieldFiatInputValue({ amount: '0.001', rate: 1234.5 })).toBe('1.23');
+        });
+
+        it('returns an empty string for an empty amount or missing rate', () => {
+            expect(getYieldFiatInputValue({ amount: '', rate: 1500 })).toBe('');
+            expect(getYieldFiatInputValue({ amount: '2', rate: undefined })).toBe('');
+        });
+    });
+
+    describe('getYieldMaxFiatInputValue', () => {
+        it('rounds the max fiat down so it never converts back above the balance', () => {
+            // 0.1 * 3333.35 = 333.335 → down = 333.33 (half-up would overstate it as 333.34).
+            expect(getYieldMaxFiatInputValue({ amount: '0.1', rate: 3333.35 })).toBe('333.33');
+            expect(getYieldFiatInputValue({ amount: '0.1', rate: 3333.35 })).toBe('333.34');
+        });
+
+        it('returns an empty string for an empty amount or missing rate', () => {
+            expect(getYieldMaxFiatInputValue({ amount: '', rate: 1500 })).toBe('');
+            expect(getYieldMaxFiatInputValue({ amount: '1', rate: undefined })).toBe('');
+        });
+    });
+
+    describe('getYieldCryptoInputValue', () => {
+        it('converts fiat to crypto, trimming trailing zeros and capping at the token decimals', () => {
+            expect(getYieldCryptoInputValue({ fiat: '3000', rate: 1500, decimals: 18 })).toBe('2');
+            expect(getYieldCryptoInputValue({ fiat: '10', rate: 3, decimals: 6 })).toBe('3.333333');
+        });
+
+        it('returns an empty string for an empty fiat or missing rate', () => {
+            expect(getYieldCryptoInputValue({ fiat: '', rate: 1500, decimals: 18 })).toBe('');
+            expect(getYieldCryptoInputValue({ fiat: '100', rate: undefined, decimals: 6 })).toBe(
+                '',
+            );
         });
     });
 });

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,14 +1,24 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowStepId,
     type YieldFlowToken,
+    type YieldPositionFlowType,
     type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
 } from '@suite-common/wallet-core';
+import { type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
+import {
+    fromBaseCurrencyToCryptoUnit,
+    getContractAddressForNetworkSymbol,
+    toFiatCurrency,
+} from '@suite-common/wallet-utils';
 import type { StepListItemState } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 export { getYieldApprovalAction, type YieldApprovalAction } from '@suite-common/wallet-core';
+
+const FIAT_DISPLAY_DECIMALS = 2;
 
 type AmountComparisonParams = {
     amount?: string;
@@ -84,6 +94,112 @@ export const getYieldUnwrapDefaultAmount = ({
     }
 
     return withdrawnAssetAmount;
+};
+
+export type YieldFiatRateToken = {
+    symbol: NetworkSymbol;
+    tokenAddress?: TokenAddress;
+};
+
+type YieldFiatRateTokenParams = {
+    step: YieldFlowStepId;
+    flowType: YieldPositionFlowType;
+    accountSymbol: NetworkSymbol;
+    token: Pick<YieldFlowDisplayToken, 'networkSymbol' | 'contractAddress'> | null;
+};
+
+/**
+ * The token whose fiat rate prices the amount currently being entered:
+ * - wrap/unwrap operate on the native coin (priced by the account's native symbol),
+ * - redeem enters share units, which have no direct fiat price → no fiat entry,
+ * - deposit/withdraw/approve enter the vault asset token (priced by its contract address).
+ *
+ * Returns `null` when fiat entry is not possible for the current step.
+ */
+export const getYieldFiatRateToken = ({
+    step,
+    flowType,
+    accountSymbol,
+    token,
+}: YieldFiatRateTokenParams): YieldFiatRateToken | null => {
+    if (step === 'wrap' || step === 'unwrap') {
+        return { symbol: accountSymbol };
+    }
+
+    if (flowType === 'redeem') {
+        return null;
+    }
+
+    if (!token?.contractAddress) {
+        return null;
+    }
+
+    return {
+        symbol: token.networkSymbol,
+        tokenAddress: toTokenAddress(
+            getContractAddressForNetworkSymbol(token.networkSymbol, token.contractAddress),
+        ),
+    };
+};
+
+/** Crypto → fiat for display. Empty string when the amount is empty or no rate is available. */
+export const getYieldFiatInputValue = ({
+    amount,
+    rate,
+}: {
+    amount: string;
+    rate: number | undefined;
+}): string => {
+    if (!amount || rate === undefined) {
+        return '';
+    }
+
+    return toFiatCurrency({ amount, rate })?.toFixed(FIAT_DISPLAY_DECIMALS) ?? '';
+};
+
+/**
+ * Crypto → fiat for a Max amount. Rounds **down** (unlike the half-up `getYieldFiatInputValue`) so
+ * the shown value, if re-entered in fiat mode, never converts back above the balance — which would
+ * otherwise trip a false "insufficient funds" on the exact max.
+ */
+export const getYieldMaxFiatInputValue = ({
+    amount,
+    rate,
+}: {
+    amount: string;
+    rate: number | undefined;
+}): string => {
+    if (!amount || rate === undefined) {
+        return '';
+    }
+
+    return (
+        toFiatCurrency({ amount, rate })?.toFixed(FIAT_DISPLAY_DECIMALS, BigNumber.ROUND_DOWN) ?? ''
+    );
+};
+
+/** Fiat → crypto (the source of truth). Empty string when the fiat is empty or no rate is available. */
+export const getYieldCryptoInputValue = ({
+    fiat,
+    rate,
+    decimals,
+}: {
+    fiat: string;
+    rate: number | undefined;
+    decimals: number;
+}): string => {
+    if (!fiat || rate === undefined) {
+        return '';
+    }
+
+    // Trim trailing zeros so a round conversion shows "2" instead of "2.000000000000000000"
+    // (which visually blows out the input). `decimalPlaces` keeps full token precision and
+    // `toFixed()` (no arg) avoids the exponential notation the number input can't parse.
+    return (
+        fromBaseCurrencyToCryptoUnit({ fiatAmount: fiat, rate })
+            ?.decimalPlaces(decimals)
+            .toFixed() ?? ''
+    );
 };
 
 export type YieldFlowStepView = {

--- a/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts
+++ b/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts
@@ -75,7 +75,7 @@ const getUniqueTickers = (tickers: TickerId[]): TickerId[] =>
         ),
     );
 
-const getTokenFiatRate = (
+export const getTokenFiatRate = (
     currentFiatRates: RatesByKey | undefined,
     fiatRateKey: CryptoBaseCurrencyPair,
 ): number | undefined => {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts
@@ -14,7 +14,10 @@ export type YieldFlowStepId = (typeof YIELD_FLOW_STEPS)[number];
 export type WrappedNativeStepId = Extract<YieldFlowStepId, 'wrap' | 'unwrap'>;
 
 export type YieldFlowFormValues = {
+    // Crypto/token amount — the single source of truth submitted to every yield thunk.
     amountInput: string;
+    // Display-only fiat amount, kept in sync with amountInput; never submitted.
+    fiatInput: string;
 };
 
 export type YieldFlowDisplayToken = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds option to enter fiat amount to be deposited/unwrapped

## Notes for QA

Don't forget to check the separate wrap/unwrap flows together with deposit/withdraw

## Related Issue

Resolve #30539 

## Screenshots:

| Wrap page | Unwrap page | Withdraw USD |
|--------|--------|--------|
| <img width="592" height="415" alt="Screenshot 2026-08-04 at 13 24 54" src="https://github.com/user-attachments/assets/f342dc0f-995f-4b72-a1ec-a31434881619" /> | <img width="600" height="355" alt="Screenshot 2026-08-04 at 13 25 00" src="https://github.com/user-attachments/assets/9047e865-fb39-42bb-bfaa-1f070695ee53" /> | <img width="615" height="541" alt="Screenshot 2026-08-04 at 13 25 53" src="https://github.com/user-attachments/assets/8c28a679-bbab-48a8-b0b1-794578275df5" /> |



| Input size | Input size 2 |
|--------|--------|
| <img width="646" height="696" alt="Screenshot 2026-08-04 at 13 26 48" src="https://github.com/user-attachments/assets/00e2d349-a752-4fb9-85a2-f9e52888b1a9" /> | <img width="630" height="742" alt="Screenshot 2026-08-04 at 13 26 43" src="https://github.com/user-attachments/assets/b9deba7d-83ed-4982-b3cf-402bb9a9e8c8" /> |

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/fiat-input-wrap/web/](https://dev.suite.sldev.cz/suite-web/feat/fiat-input-wrap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fiat-input-wrap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fiat-input-wrap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fiat-input-wrap&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:48:25.785Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:47:37.670Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files live in the earn/yield feature (deposit, withdraw, wrap, unwrap, fiat input, and flow utilities). No candidate E2E test directly exercises these yield flows; the broad static mapping to 133 tests is best treated as a transitive/global import artifact. The only relevant E2E coverage is the general route/link check, which at least ensures the /earn/yield pages still load. Consider adding dedicated yield E2E tests if this feature is critical, since the current suite provides little regression protection for these changes.

<details><summary><b>Changed files (18)</b></summary>

- `packages/suite/src/components/earn/yield/common/TruncatedAmount.tsx`
- `packages/suite/src/components/earn/yield/common/YieldActionStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`
- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldTypes.ts`

</details>

**Recommended tests (1)**

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test explicitly loads the /earn/yield/* routes (deposit, withdraw, wrap, unwrap, claim) and verifies each page renders and its links are valid. Changes to the yield components could introduce runtime errors that prevent these routes from loading, which check-links would surface, though it does not exercise the actual deposit/withdraw/wrap/unwrap user flows.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/components/earn/yield/common/TruncatedAmount.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `suite-common/wallet-core/src/earn/earnDepositsFiatUtils.ts`

_Updated: 2026-08-04T11:46:10.251Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->