### PR TITLE
fix(suite-desktop): display pointer cursor

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx
@@ -25,6 +25,13 @@ const EditIndicator = styled.div`
     }
 `;
 
+// Let the Card inherit the pointer so the whole clickable area reads as one.
+const ClickableStepContent = styled.div`
+    section {
+        cursor: inherit;
+    }
+`;
+
 export type YieldFlowStepDefinition = {
     /** Label on the title row next to the step number. */
     title?: ReactNode;
@@ -144,7 +151,11 @@ export const YieldFlowStepList = <TSequence extends readonly YieldFlowStepId[]>(
                             </Column>
                         }
                     >
-                        {renderStepContent(stepId)}
+                        {onEdit ? (
+                            <ClickableStepContent>{renderStepContent(stepId)}</ClickableStepContent>
+                        ) : (
+                            renderStepContent(stepId)
+                        )}
                     </StepList.Item>
                 );
             })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add cursor pointer to the whole card-clickable area

## Notes for QA

You need to start with deposit flow, continue after approval and return back to previous step by clicking on the approved amount block

## Related Issue

Resolve #30554 

## Screenshots:

https://github.com/user-attachments/assets/7c1973ac-39f3-446f-834b-251b4f7efd59




<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a common component in the earn/yield step list UI, which is rendered during staking modals across networks. Because the static mapping covers 133 tests, the broad-utility heuristic was applied: only staking-specific tests that actually traverse the yield flow are recommended. The minimal set focuses on representative stake flows (ETH, ADA, SOL) plus the staking-form validation test, with one unstake/claim and one navigation test for additional coverage of alternate step states.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldFlowStepList.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test walks through the full Cardano staking modal flow, including the staking nutshell modal, stake token modal, and device confirmation steps. YieldFlowStepList renders the step indicator for these yield modals, so a regression here would be directly user-visible.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers the first-time Ethereum staking flow from an empty state through the staking form, confirmation, and progress indicators. The step list UI guides the user across these phases, making this a direct exercise of the changed component.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Exercises the Solana initial staking flow including the staking nutshell modal, stake form, and post-stake progress indicators. This flow renders the yield step list and would catch layout or navigation regressions in the component.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly interacts with the staking form UI (input validation, fraction buttons, fiat/crypto switching, max amount). YieldFlowStepList is part of the staking form presentation, so this test validates the component in its primary context.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — Covers the Ethereum unstake and claim flow, which uses a different set of yield steps (unstake modal, claim modal, transaction status). This verifies the step list behaves correctly in non-stake yield actions.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Navigates to staking entry points from both the account menu and dashboard assets. While it primarily asserts analytics events, it confirms the staking navigation surfaces render and that users can reach the yield flows affected by the component.

</details>

_Updated: 2026-07-31T10:49:33.269Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/deposit-cursor-approve/web/](https://dev.suite.sldev.cz/suite-web/feat/deposit-cursor-approve/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/deposit-cursor-approve&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/deposit-cursor-approve&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:52:11.015Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T10:51:53.365Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->