### PR TITLE
fix(suite-native): use standard QR center icon background

### DIFF
--- a/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
@@ -69,7 +69,6 @@ export const ReceiveAddressDetails = ({
                         qrCodeSize={qrCodeSize}
                         paddingHorizontal="sp16"
                         paddingVertical="sp16"
-                        shouldUseStandardCenterIconBackground
                         centerIcon={
                             <TokenIcon
                                 symbol={networkSymbol}

--- a/suite-native/qr-code/src/components/QRCode.tsx
+++ b/suite-native/qr-code/src/components/QRCode.tsx
@@ -12,7 +12,6 @@ type QRCodeProps = {
     paddingHorizontal?: NativeSpacing;
     paddingVertical?: NativeSpacing;
     centerIcon?: ReactElement;
-    shouldUseStandardCenterIconBackground?: boolean;
 };
 
 const SCREEN_WIDTH = Dimensions.get('screen').width;
@@ -53,17 +52,13 @@ const qrCodeCenterIconWrapperStyle = prepareNativeStyle(() => ({
     justifyContent: 'center',
 }));
 
-const qrCodeCenterIconStyle = prepareNativeStyle<{
-    shouldUseStandardCenterIconBackground?: boolean;
-}>((utils, { shouldUseStandardCenterIconBackground }) => ({
+const qrCodeCenterIconStyle = prepareNativeStyle(utils => ({
     maxWidth: QR_CENTER_ICON_MAX_RATIO,
     maxHeight: QR_CENTER_ICON_MAX_RATIO,
     padding: QR_CENTER_ICON_PADDING,
     borderRadius: utils.borders.radii.round,
     overflow: 'hidden',
-    backgroundColor: shouldUseStandardCenterIconBackground
-        ? colorVariants.standard.surfaceFillRaised
-        : utils.colors.surfaceFillRaised,
+    backgroundColor: colorVariants.standard.surfaceFillRaised,
 }));
 
 export const QRCode = ({
@@ -72,7 +67,6 @@ export const QRCode = ({
     paddingHorizontal,
     paddingVertical,
     centerIcon,
-    shouldUseStandardCenterIconBackground,
 }: QRCodeProps) => {
     const { applyStyle } = useNativeStyles();
 
@@ -98,13 +92,7 @@ export const QRCode = ({
                 />
                 {hasCenterIcon && (
                     <View pointerEvents="none" style={applyStyle(qrCodeCenterIconWrapperStyle)}>
-                        <View
-                            style={applyStyle(qrCodeCenterIconStyle, {
-                                shouldUseStandardCenterIconBackground,
-                            })}
-                        >
-                            {centerIcon}
-                        </View>
+                        <View style={applyStyle(qrCodeCenterIconStyle)}>{centerIcon}</View>
                     </View>
                 )}
             </View>


### PR DESCRIPTION
## Description

Follow-up to #30625. Simplifies the QR center icon background handling based on review feedback:

https://github.com/trezor/trezor-suite/pull/30625#pullrequestreview-4827826917

`QRCode` already forces the QR surface to `colorVariants.standard.surfaceFillRaised`, so the center icon wrapper now always uses the same background instead of exposing an opt-in prop.

## Notes for QA

Check QR codes with center icons in light and dark mode. The icon padding/ring should match the white QR surface.

## Related Issue
No QA/project because the other PR is about to be tested. 

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/qr-center-icon-standard-background&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->