### PR TITLE
fix(trading): recompose DEX fees only on transaction shape change

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
@@ -11,6 +11,7 @@ import {
     type TradingExchangeFormProps,
 } from '@suite-common/trading';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
 
 import { useExchangeDexQuote } from './useExchangeDexQuote';
 
@@ -217,5 +218,41 @@ describe('useExchangeDexQuote', () => {
 
         expect(mockUpdateFeeInfo).toHaveBeenCalled();
         expect(mockComposeRequest).toHaveBeenCalled();
+    });
+
+    it('recomposes when an approval transaction changes to a revoke transaction', async () => {
+        const spender = '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae';
+        const approvalTransactionData = buildApprovalTransactionData({
+            spender,
+            amount: '9475047',
+        });
+        const revokeTransactionData = buildApprovalTransactionData({ spender, amount: '0' });
+        const { result } = renderExchangeDexQuote({
+            defaultValues: buildDefaults(),
+        });
+
+        await waitFor(() => {
+            expect(mockComposeRequest).toHaveBeenCalled();
+        });
+        mockUpdateFeeInfo.mockClear();
+        mockComposeRequest.mockClear();
+
+        act(() => {
+            result.current.methods.setValue('transactionData', approvalTransactionData);
+        });
+        await waitFor(() => {
+            expect(mockComposeRequest).toHaveBeenCalled();
+        });
+        mockUpdateFeeInfo.mockClear();
+        mockComposeRequest.mockClear();
+
+        act(() => {
+            result.current.methods.setValue('transactionData', revokeTransactionData);
+        });
+
+        await waitFor(() => {
+            expect(mockUpdateFeeInfo).toHaveBeenCalledTimes(1);
+            expect(mockComposeRequest).toHaveBeenCalledTimes(1);
+        });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
@@ -16,6 +16,7 @@ import {
 import { isAccountBasedNetwork } from '@suite-common/wallet-config';
 import { ETHEREUM_ADJUST_GAS_LIMIT, updateFeeInfoThunk } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
 
 import { useDispatch } from 'src/hooks/suite';
@@ -127,10 +128,11 @@ export const useExchangeDexQuote = ({
     ]);
 
     const fetchFeesAndComposeRef = useCurrentRef(fetchFeesAndCompose);
-    // fetch fees when transactionData changes
+    // Fetch fees when the transaction to estimate changes shape.
+    const transactionShape = getEvmTransactionTextSignature(transactionData);
     useEffect(() => {
         fetchFeesAndComposeRef.current();
-    }, [transactionData, outputAddress, ethereumAdjustGasLimit, fetchFeesAndComposeRef]);
+    }, [transactionShape, outputAddress, ethereumAdjustGasLimit, fetchFeesAndComposeRef]);
 
     return { fetchFeesAndCompose };
 };


### PR DESCRIPTION
## Description

Pressing Max with a DEX provider on EVM networks made the swap form reload forever.

- **Fix:** recompose only when the estimated transaction changes shape - different router, approval
  instead of swap, or no DEX transaction. Signing is unaffected, `recomposeAndSignTxThunk` recomposes
  from the selected quote.

## Notes for QA

- Max with a DEX provider on an EVM coin and on an ERC-20 - offer loads and stays loaded.
- DEX approval + revoke flow, CEX <-> DEX switch, provider switch - network fee still refreshes.

## Related Issue

Resolve #30643

## Screenshots:

_No UI changes._

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30643-dex-max-quote-loop/web/](https://dev.suite.sldev.cz/suite-web/fix/30643-dex-max-quote-loop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30643-dex-max-quote-loop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30643-dex-max-quote-loop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T22:59:17.876Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T22:59:47.000Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches a DEX-specific quote hook and its unit tests. Regression risk is concentrated in the DEX swap flow, while the many statically mapped CEX/live swap tests share little DEX-specific behavior. Running the targeted LI.FI DEX swap test provides the best signal with minimal runtime.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test directly exercises the DEX swap path via the LI.FI provider, including DEX-specific quote details (slippage, minimum received, 1.25 gas-limit buffer) and provider selection. Changes to useExchangeDexQuote.ts are likely to alter exactly these DEX quote calculations and UI flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx`

_Updated: 2026-07-31T22:57:19.846Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->