### PR TITLE
fix(suite): do not report a device setup for an already set up device

### DIFF
--- a/packages/suite/src/actions/onboarding/goToSuite.test.ts
+++ b/packages/suite/src/actions/onboarding/goToSuite.test.ts
@@ -1,0 +1,48 @@
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
+import { type DeepPartial } from '@trezor/type-utils';
+
+import { goToSuite } from 'src/actions/onboarding/onboardingActions';
+import { type AppState } from 'src/types/suite';
+
+const device = mockSuiteDevice();
+
+const setup = () => {
+    const report = jest.fn();
+
+    const preloadedState: DeepPartial<AppState> = {
+        onboarding: {
+            path: ['create'],
+            onboardingAnalytics: { startTime: Date.now(), seed: 'create' },
+        },
+        device: { selectedDevice: device },
+        wallet: { settings: { enabledNetworks: ['btc'] } },
+    };
+
+    const store = configureMockStore({
+        extra: { services: { analytics: mockDesktopAnalytics(report) } },
+        preloadedState,
+    });
+
+    return { store, report };
+};
+
+describe('goToSuite', () => {
+    it('reports device-setup-completed by default', () => {
+        const { store, report } = setup();
+
+        store.dispatch(goToSuite());
+
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report.mock.calls[0][0].type).toBe('device-setup-completed');
+    });
+
+    it('does not report device-setup-completed when the event is skipped', () => {
+        const { store, report } = setup();
+
+        store.dispatch(goToSuite({ skipDeviceSetupCompletedEvent: true }));
+
+        expect(report).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -127,65 +127,76 @@ const resetOnboarding = (): OnboardingAction => ({
 
 type GoToSuiteDeps = { services: DesktopAnalyticsDep };
 
-const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: GoToSuiteDeps) => {
-    const device = selectSelectedDevice(getState());
-    const onboardingAnalytics = selectOnboardingAnalytics(getState());
-    // Clear modals that might block navigation. They aren't relevant anyway, as there is no <ModalSwitcher /> in onboarding.
-    // After device interaction, Connect sends UI_REQUEST.CLOSE_UI_WINDOW to close any open modal. On Web this is
-    // instant, so nothing blocks navigation, but on Desktop there is delay, so we must clear the modal manually to
-    // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
-    dispatch(closeModal());
+export type GoToSuiteOptions = {
+    skipDeviceSetupCompletedEvent?: boolean;
+};
 
-    // A non-empty onboarding path means the user went through a create or recovery flow, i.e. set up
-    // a device from scratch. Pairing an already set up device leaves the path empty.
-    const isFreshDeviceSetup = getState().onboarding.path.length > 0;
+const goToSuite =
+    ({ skipDeviceSetupCompletedEvent }: GoToSuiteOptions = {}) =>
+    (dispatch: Dispatch, getState: GetState, extra: GoToSuiteDeps) => {
+        const device = selectSelectedDevice(getState());
+        const onboardingAnalytics = selectOnboardingAnalytics(getState());
+        // Clear modals that might block navigation. They aren't relevant anyway, as there is no <ModalSwitcher /> in onboarding.
+        // After device interaction, Connect sends UI_REQUEST.CLOSE_UI_WINDOW to close any open modal. On Web this is
+        // instant, so nothing blocks navigation, but on Desktop there is delay, so we must clear the modal manually to
+        // ensure navigation to 'suite-index'. Particularly, setting PIN leaves ButtonRequest_Success hanging for a moment.
+        dispatch(closeModal());
 
-    dispatch(initialRunCompleted({ isFreshDeviceSetup }));
-    dispatch(resetOnboarding());
-    dispatch(closeModalApp(true));
+        // A non-empty onboarding path means the user went through a create or recovery flow, i.e. set up
+        // a device from scratch. Pairing an already set up device leaves the path empty.
+        const isFreshDeviceSetup = getState().onboarding.path.length > 0;
 
-    // For Bitcoin-only firmware, pre-activate BTC so the user lands on a populated dashboard
-    // instead of the empty "activate assets" state. Only do this on initial setup, when no
-    // networks have been explicitly enabled yet, to avoid overriding user's previous choices.
-    const isBitcoinOnlyFirmware = selectHasBitcoinOnlyFirmware(getState());
-    const enabledNetworks = selectEnabledNetworks(getState());
-    if (isBitcoinOnlyFirmware && enabledNetworks.length === 0) {
-        dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
-    }
+        dispatch(initialRunCompleted({ isFreshDeviceSetup }));
+        dispatch(resetOnboarding());
+        dispatch(closeModalApp(true));
 
-    // there must be a device to progress with onboarding
-    if (device?.features === undefined) return;
+        // For Bitcoin-only firmware, pre-activate BTC so the user lands on a populated dashboard
+        // instead of the empty "activate assets" state. Only do this on initial setup, when no
+        // networks have been explicitly enabled yet, to avoid overriding user's previous choices.
+        const isBitcoinOnlyFirmware = selectHasBitcoinOnlyFirmware(getState());
+        const enabledNetworks = selectEnabledNetworks(getState());
+        if (isBitcoinOnlyFirmware && enabledNetworks.length === 0) {
+            dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
+        }
 
-    dispatch(startDiscoveryThunk({ device }));
-    const reportAnalytics = () => {
-        const { analytics } = extra.services;
-        const { startTime, ...onboardingAttributes } = onboardingAnalytics;
-        const fullPayload = {
-            ...onboardingAttributes,
-            duration: Date.now() - startTime!,
-            device: device.features.internal_model,
-            unitPackaging: device.features.unit_packaging ?? 0,
+        // there must be a device to progress with onboarding
+        if (device?.features === undefined) return;
+
+        dispatch(startDiscoveryThunk({ device }));
+        const reportAnalytics = () => {
+            const { analytics } = extra.services;
+            const { startTime, ...onboardingAttributes } = onboardingAnalytics;
+            const fullPayload = {
+                ...onboardingAttributes,
+                duration: Date.now() - startTime!,
+                device: device.features.internal_model,
+                unitPackaging: device.features.unit_packaging ?? 0,
+            };
+
+            const hasConsent = analytics.isEnabled();
+            const payload = hasConsent
+                ? fullPayload
+                : {
+                      duration: fullPayload.duration,
+                      device: fullPayload.device,
+                      unitPackaging: fullPayload.unitPackaging,
+                  };
+
+            analytics.report(
+                {
+                    type: events.deviceSetupCompletedEvent.name,
+                    payload,
+                },
+                { force: true },
+            );
         };
 
-        const hasConsent = analytics.isEnabled();
-        const payload = hasConsent
-            ? fullPayload
-            : {
-                  duration: fullPayload.duration,
-                  device: fullPayload.device,
-                  unitPackaging: fullPayload.unitPackaging,
-              };
-
-        analytics.report(
-            {
-                type: events.deviceSetupCompletedEvent.name,
-                payload,
-            },
-            { force: true },
-        );
+        // Skipped when "Yes, I have used it before" is pressed on the security check page, as no
+        // setup happens on that flow.
+        if (!skipDeviceSetupCompletedEvent) {
+            reportAnalytics();
+        }
     };
-    reportAnalytics();
-};
 
 const goToNextStep = (nextStepId?: AnyStepId) => (dispatch: Dispatch, getState: GetState) => {
     if (nextStepId) {

--- a/packages/suite/src/hooks/suite/useOnboarding.ts
+++ b/packages/suite/src/hooks/suite/useOnboarding.ts
@@ -5,6 +5,7 @@ import { type BackupType } from '@suite-common/suite-types';
 import { UI_REQUEST } from '@trezor/connect';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
+import { type GoToSuiteOptions } from 'src/actions/onboarding/onboardingActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { type BackupMedium } from 'src/reducers/onboarding/onboardingReducer';
 import { type AnyPath, type AnyStepId } from 'src/types/onboarding';
@@ -36,7 +37,8 @@ export const useOnboarding = () => {
                 dispatch(onboardingActions.updateBackupType(payload)),
             updateBackupMedium: (payload: BackupMedium) =>
                 dispatch(onboardingActions.updateBackupMedium(payload)),
-            goToSuite: () => dispatch(onboardingActions.goToSuite()),
+            goToSuite: (options?: GoToSuiteOptions) =>
+                dispatch(onboardingActions.goToSuite(options)),
             resolveNextAfterSkipped: (requestedStepId: AnyStepId) =>
                 dispatch(onboardingActions.resolveNextAfterSkipped(requestedStepId)),
         }),

--- a/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
+++ b/packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx
@@ -319,7 +319,8 @@ export const SecurityCheck = () => {
             setCheckedDevices(prev => [...prev, selectedDevice?.id ?? '']); // Device ID must be available as firmware is already installed.
             dispatch(deviceActions.selectDevice(nextDeviceToCheck));
         } else {
-            goToSuite();
+            // "Yes, I have used it before" only enters Suite, nothing is set up here.
+            goToSuite({ skipDeviceSetupCompletedEvent: true });
         }
     };
 

--- a/packages/suite/src/views/onboarding/steps/FinalStep.tsx
+++ b/packages/suite/src/views/onboarding/steps/FinalStep.tsx
@@ -20,7 +20,10 @@ export const FinalStep = () => {
                 />
             }
             innerActions={
-                <OnboardingCard.Button data-testid="@onboarding/final-button" onClick={goToSuite}>
+                <OnboardingCard.Button
+                    data-testid="@onboarding/final-button"
+                    onClick={() => goToSuite()}
+                >
                     <Translation id="TR_ONBOARDING_FINAL_GO_TO_DASHBOARD" />
                 </OnboardingCard.Button>
             }


### PR DESCRIPTION
Answering "Yes, I have used it before" on the security check only passes through onboarding into Suite, with nothing being set up, yet it reached goToSuite and reported device-setup-completed. Add a disableAnalytics option to goToSuite and pass it from that flow.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

Device setup completled should not be send to analytics when just clicking at "Yes, I have" when connecting a device taht's already set-up.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/25921#issuecomment-5130634973

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the onboarding flow, touching device authenticity checks, the final onboarding step, and the underlying actions/hook that drive state transitions. The highest risk is user-visible breakage during device setup or the transition from onboarding to the dashboard. The recommended strategy is to run a compact set of onboarding-specific tests covering the authenticity check, full create-wallet flows on representative device models, and onboarding completion/persistence behavior, rather than the broad global set that transitively imports onboarding utilities.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/onboarding/goToSuite.test.ts`
- `packages/suite/src/actions/onboarding/onboardingActions.ts`
- `packages/suite/src/hooks/suite/useOnboarding.ts`
- `packages/suite/src/views/onboarding/steps/DeviceAuthenticityStep/SecurityCheck.tsx`
- `packages/suite/src/views/onboarding/steps/FinalStep.tsx`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Directly exercises the DeviceAuthenticityStep/SecurityCheck.tsx component and the surrounding onboarding flow where device authenticity checks are performed. A regression here would be immediately visible to users setting up new devices.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — Covers the complete onboarding flow on a modern touchscreen device, including the FinalStep.tsx where wallet creation concludes and the app transitions to the dashboard. This directly validates FinalStep behavior and onboarding action/hook state transitions.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Tests the initial onboarding entry flow and continuation, which relies on the onboarding actions and useOnboarding hook for state progression. Changes to onboarding state management could affect how users move past analytics consent.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Covers an adjacent onboarding security/firmware readiness step that shares infrastructure with the device authenticity check. Changes to onboarding action logic or security step orchestration could impact this path.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Validates the transition from completed onboarding into the main Suite dashboard, which is driven by the goToSuite/onboarding completion logic. Changes to FinalStep or onboarding actions could affect whether the dashboard loads correctly.
- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — Exercises the full onboarding flow through a legacy button-based device with a different backup/PIN path, still reaching the shared FinalStep. This catches device-specific state issues that could propagate to the final onboarding step.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests onboarding completion state persistence across page reloads, which depends heavily on onboardingActions and useOnboarding state management. A regression in onboarding state handling would be visible here.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/onboarding/goToSuite.test.ts`

_Updated: 2026-08-11T09:02:40.718Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=25921-fix-onbaoridng-complete-tracking&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=25921-fix-onbaoridng-complete-tracking&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T09:02:15.499Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T09:02:23.272Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/25921-fix-onbaoridng-complete-tracking/web/](https://dev.suite.sldev.cz/suite-web/25921-fix-onbaoridng-complete-tracking/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->