### PR TITLE
fix(wallet-config): Hyperliquid token name

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -303,6 +303,7 @@ export const networks = {
         symbol: 'hype',
         displaySymbol: 'HYPE',
         name: 'HyperEVM',
+        displaySymbolName: 'Hyperliquid',
         networkType: 'ethereum',
         chainId: 999,
         bip43Path: "m/44'/60'/0'/0/i",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- @MiroslavProchazka's bot skipped `displaySymbolName`
Coingecko
<img width="523" height="181" alt="Screenshot 2026-07-31 at 14 58 38" src="https://github.com/user-attachments/assets/dd734a70-4b29-493c-b1b6-ff83c9a6e12c" />


## Screenshots:

<img width="852" height="338" alt="Screenshot 2026-07-31 at 14 56 01" src="https://github.com/user-attachments/assets/552ac077-b650-45c6-a771-a3a4b9bf7c6e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** networksConfig.ts is a global dependency referenced by 133 tests, so the risk is broad but diffuse. The highest-value tests are those that directly verify network enablement, custom backend configuration, and the network-related analytics payload. A small set of focused settings and analytics tests will catch the most likely regressions, supplemented by broader discovery/asset tests as sanity checks.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly asserts the SuiteReady analytics payload contains enabledNetworks and customBackends values, so a change to network definitions or backend config in networksConfig.ts would be caught immediately.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Exercises configuring custom Blockbook backend URLs per coin and verifying discovery succeeds or fails based on backend config, which is tightly coupled to networksConfig.ts.
- `suite/e2e/tests/settings/coins.test.ts` — Covers enabling/disabling networks, testnet visibility, and setting a custom Blockbook backend for ETH with the custom-backend indicator, directly validating network configuration UI/state.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Validates discovery completes when using custom Blockbook backends for BTC and LTC, making it a direct regression test for backend/network configuration changes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Enables a new asset (ETH) via the Activate Assets modal and verifies it appears in dashboard views, serving as a regression guard for network enablement flows.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates eight different coins and verifies discovery completes and balances appear, providing broad coverage of network definitions without testing configuration UI directly.

</details>

_Updated: 2026-07-31T13:02:56.656Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/hype/web/](https://dev.suite.sldev.cz/suite-web/fix/hype/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hype&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hype&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/hype&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:05:35.626Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:05:09.225Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->