### PR TITLE
feat(suite-desktop): display dynamic outcome tokens based on the flow

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx
@@ -1,14 +1,12 @@
 import { Translation } from '@suite/intl';
 import { type YieldFlowCompleteValue } from '@suite-common/wallet-core';
-import { Column, Row, Text } from '@trezor/components';
 
 import { YieldFlowComplete } from './YieldFlowComplete';
 import { YieldFlowTransferRow } from './YieldFlowTransferRow';
-import { YieldTokenValue } from './YieldTokenValue';
 
 type YieldFlowCompleteWithdrawProps = {
     input: YieldFlowCompleteValue;
-    output?: YieldFlowCompleteValue;
+    output: YieldFlowCompleteValue;
     vaultId: string;
 };
 
@@ -16,49 +14,24 @@ export const YieldFlowCompleteWithdraw = ({
     input,
     output,
     vaultId,
-}: YieldFlowCompleteWithdrawProps) => {
-    const receivedValue = output ?? input;
-
-    return (
-        <YieldFlowComplete
-            type="withdraw"
-            heading={<Translation id="TR_EARN_YIELD_WITHDRAW_COMPLETE" />}
-            description={
-                <Translation
-                    id="TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION"
-                    values={{ displaySymbol: receivedValue.token.symbol }}
-                />
-            }
-            vaultId={vaultId}
-            showFeedback
-        >
-            {output ? (
-                <YieldFlowTransferRow
-                    inputLabelId="TR_EARN_YIELD_AMOUNT_TO_WITHDRAW"
-                    outputLabelId="TR_RECEIVED"
-                    input={input}
-                    output={output}
-                />
-            ) : (
-                <Row
-                    justifyContent="space-between"
-                    alignItems="center"
-                    padding={{ vertical: 16, horizontal: 20 }}
-                >
-                    <Column gap={8}>
-                        <Text typographyStyle="body-md">
-                            <Translation id="TR_RECEIVED" />
-                        </Text>
-                        <YieldTokenValue
-                            token={{
-                                ...receivedValue.token,
-                                contractAddress: receivedValue.token.contractAddress ?? null,
-                            }}
-                            amount={receivedValue.amount}
-                        />
-                    </Column>
-                </Row>
-            )}
-        </YieldFlowComplete>
-    );
-};
+}: YieldFlowCompleteWithdrawProps) => (
+    <YieldFlowComplete
+        type="withdraw"
+        heading={<Translation id="TR_EARN_YIELD_WITHDRAW_COMPLETE" />}
+        description={
+            <Translation
+                id="TR_EARN_YIELD_WITHDRAW_COMPLETE_DESCRIPTION"
+                values={{ displaySymbol: output.token.symbol }}
+            />
+        }
+        vaultId={vaultId}
+        showFeedback
+    >
+        <YieldFlowTransferRow
+            inputLabelId="TR_EARN_YIELD_WITHDRAWN"
+            outputLabelId="TR_RECEIVED"
+            input={input}
+            output={output}
+        />
+    </YieldFlowComplete>
+);

--- a/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
@@ -1,0 +1,87 @@
+import { type YieldFlowDisplayToken, type YieldFlowToken } from '@suite-common/wallet-core';
+
+import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
+
+type Params = Parameters<typeof getYieldWithdrawCompletedValues>[0];
+
+const token: YieldFlowToken = {
+    networkSymbol: 'eth',
+    symbol: 'WETH',
+    decimals: 18,
+    contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    balance: '5',
+};
+
+const receiptToken: YieldFlowDisplayToken = {
+    networkSymbol: 'eth',
+    symbol: 'trSHETHp',
+    decimals: 18,
+    contractAddress: '0x1111111111111111111111111111111111111111',
+};
+
+// 1 share (trSHETHp) is worth 1.05 WETH.
+const pricePerShareState: Params['pricePerShareState'] = {
+    price: '1.05',
+    shareToken: { symbol: 'trSHETHp', network: 'ethereum', name: 'trSHETHp', decimals: 18 },
+    quoteToken: { symbol: 'WETH', network: 'ethereum', name: 'Wrapped Ether', decimals: 18 },
+};
+
+const base = {
+    networkSymbol: 'eth',
+    token,
+    receiptToken,
+    pricePerShareState,
+} satisfies Omit<Params, 'flowType' | 'completedAmount' | 'unwrappedAmount'>;
+
+describe('getYieldWithdrawCompletedValues', () => {
+    it('redeem without unwrap: sends the trSHETHp shares entered, receives WETH', () => {
+        const { input, output } = getYieldWithdrawCompletedValues({
+            ...base,
+            flowType: 'redeem',
+            completedAmount: '2', // shares
+            unwrappedAmount: null,
+        });
+
+        expect(input).toEqual({ token: receiptToken, amount: '2' });
+        expect(output).toEqual({ token, amount: '2.1' }); // 2 shares * 1.05
+    });
+
+    it('redeem with unwrap: sends the trSHETHp shares, receives native ETH', () => {
+        const { input, output } = getYieldWithdrawCompletedValues({
+            ...base,
+            flowType: 'redeem',
+            completedAmount: '2', // shares
+            unwrappedAmount: '2.1', // ETH received after unwrap
+        });
+
+        expect(input).toEqual({ token: receiptToken, amount: '2' });
+        expect(output.token.symbol).toBe('ETH');
+        expect(output.amount).toBe('2.1');
+    });
+
+    it('withdraw (asset unit) without unwrap: derives the trSHETHp shares sent, receives WETH', () => {
+        const { input, output } = getYieldWithdrawCompletedValues({
+            ...base,
+            flowType: 'withdraw',
+            completedAmount: '2.1', // WETH
+            unwrappedAmount: null,
+        });
+
+        // 2.1 WETH / 1.05 = 2 trSHETHp shares burned.
+        expect(input).toEqual({ token: receiptToken, amount: '2' });
+        expect(output).toEqual({ token, amount: '2.1' });
+    });
+
+    it('withdraw (asset unit) with unwrap: derives the trSHETHp shares sent, receives native ETH', () => {
+        const { input, output } = getYieldWithdrawCompletedValues({
+            ...base,
+            flowType: 'withdraw',
+            completedAmount: '2.1', // WETH
+            unwrappedAmount: '2.1', // ETH received after unwrap
+        });
+
+        expect(input).toEqual({ token: receiptToken, amount: '2' });
+        expect(output.token.symbol).toBe('ETH');
+        expect(output.amount).toBe('2.1');
+    });
+});

--- a/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.ts
@@ -1,0 +1,101 @@
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
+import {
+    type YieldFlowCompleteValue,
+    type YieldFlowDisplayToken,
+    type YieldFlowToken,
+    type YieldWithdrawFlowType,
+    getConvertedOutputTokenBalanceToInputTokenAmount,
+    getWithdrawRequestAmount,
+} from '@suite-common/wallet-core';
+
+type PricePerShareState = NonNullable<YieldDtoV2['state']>['pricePerShareState'];
+
+type GetYieldWithdrawCompletedValuesParams = {
+    networkSymbol: NetworkSymbol;
+    flowType: YieldWithdrawFlowType;
+    completedAmount: string;
+    unwrappedAmount: string | null;
+    token: YieldFlowToken;
+    receiptToken: YieldFlowDisplayToken;
+    pricePerShareState: PricePerShareState;
+};
+
+type YieldWithdrawCompletedValues = {
+    input: YieldFlowCompleteValue;
+    output: YieldFlowCompleteValue;
+};
+
+/**
+ * Build the "sent → received" pair shown on the withdrawal-complete screen.
+ *
+ * A vault withdrawal always spends the vault receipt token (e.g. trSHETHp) and returns the
+ * underlying token (WETH) — or the native token (ETH) when the user unwraps. The completion screen
+ * must communicate that outgoing receipt token in every case (issue #30548), not only for the
+ * `redeem` unit.
+ *
+ * `completedAmount` is expressed in the input unit: shares for `redeem`, the underlying asset for
+ * `withdraw`. The receipt (shares) amount for the `withdraw` unit is therefore derived from the
+ * vault price-per-share, mirroring how the deposit flow derives its received receipt amount.
+ */
+export const getYieldWithdrawCompletedValues = ({
+    networkSymbol,
+    flowType,
+    completedAmount,
+    unwrappedAmount,
+    token,
+    receiptToken,
+    pricePerShareState,
+}: GetYieldWithdrawCompletedValuesParams): YieldWithdrawCompletedValues => {
+    const isSharesInput = flowType === 'redeem';
+
+    const sentReceiptAmount = isSharesInput
+        ? completedAmount
+        : (getWithdrawRequestAmount({
+              networkSymbol,
+              amount: completedAmount,
+              token,
+              receiptToken,
+              pricePerShare: pricePerShareState?.price,
+          }) ?? completedAmount);
+
+    const input: YieldFlowCompleteValue = {
+        token: receiptToken,
+        amount: sentReceiptAmount,
+    };
+
+    if (unwrappedAmount !== null) {
+        return {
+            input,
+            output: {
+                token: {
+                    networkSymbol,
+                    symbol: getNetworkDisplaySymbol(networkSymbol),
+                    decimals: getNetwork(networkSymbol).decimals,
+                },
+                amount: unwrappedAmount,
+            },
+        };
+    }
+
+    return {
+        input,
+        output: {
+            token,
+            amount:
+                isSharesInput && pricePerShareState
+                    ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                          networkSymbol,
+                          token,
+                          outputToken: receiptToken,
+                          outputTokenBalance: completedAmount,
+                          pricePerShareState,
+                      })
+                    : completedAmount,
+        },
+    };
+};

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -2,14 +2,10 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import {
-    type YieldFlowCompleteValue,
-    type YieldWithdrawFlowType,
-    getConvertedOutputTokenBalanceToInputTokenAmount,
-} from '@suite-common/wallet-core';
+import { type YieldFlowCompleteValue, type YieldWithdrawFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
+import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
 import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow';
 
 type UseYieldWithdrawProps = {
@@ -21,7 +17,7 @@ type UseYieldWithdrawProps = {
 export type YieldWithdrawContextValues = Omit<YieldFlowContextValues, 'flowType'> & {
     flowType: YieldWithdrawFlowType;
     completedInput: YieldFlowCompleteValue;
-    completedOutput?: YieldFlowCompleteValue;
+    completedOutput: YieldFlowCompleteValue;
     toggleWithdrawFlowType: () => void;
     selectMaxWithdraw: () => void;
     isMaxWithdrawInfoVisible: boolean;
@@ -94,37 +90,15 @@ export const useYieldWithdraw = ({
     }
 
     const { completedAmount, unwrappedAmount } = flowResult;
-    const isSharesInput = flowType === 'redeem';
-    const pricePerShareState = vault.state?.pricePerShareState;
-    const completedInput = {
-        token: isSharesInput ? receiptToken : token,
-        amount: completedAmount,
-    };
-    let completedOutput: YieldFlowCompleteValue | undefined;
-
-    if (unwrappedAmount !== null) {
-        completedOutput = {
-            token: {
-                networkSymbol: account.symbol,
-                symbol: getNetworkDisplaySymbol(account.symbol),
-                decimals: getNetwork(account.symbol).decimals,
-            },
-            amount: unwrappedAmount,
-        };
-    } else if (isSharesInput) {
-        completedOutput = {
-            token,
-            amount: pricePerShareState
-                ? getConvertedOutputTokenBalanceToInputTokenAmount({
-                      networkSymbol: token.networkSymbol,
-                      token,
-                      outputToken: receiptToken,
-                      outputTokenBalance: completedAmount,
-                      pricePerShareState,
-                  })
-                : completedAmount,
-        };
-    }
+    const { input: completedInput, output: completedOutput } = getYieldWithdrawCompletedValues({
+        networkSymbol: account.symbol,
+        flowType,
+        completedAmount,
+        unwrappedAmount,
+        token,
+        receiptToken,
+        pricePerShareState: vault.state?.pricePerShareState,
+    });
 
     return {
         ...flowResult,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10189,6 +10189,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_AMOUNT_TO_WITHDRAW',
         defaultMessage: 'Withdrawal amount',
     },
+    TR_EARN_YIELD_WITHDRAWN: {
+        id: 'TR_EARN_YIELD_WITHDRAWN',
+        defaultMessage: 'Withdrawn',
+    },
     TR_EARN_YIELD_ENTER_AMOUNT_IN_TOKEN: {
         id: 'TR_EARN_YIELD_ENTER_AMOUNT_IN_TOKEN',
         defaultMessage: 'Enter amount in {tokenSymbol}',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Displays transapent summary of changes depending on user actions

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Make sure to test all the permutations:

- from: weth, trSHETHp, eth
- to: eth/weth
- wrap/unwrap standalone

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30548

## Screenshots:

| Withdraw WETH | Cancel unwrap |
|--------|--------|
| <img width="619" height="827" alt="Screenshot 2026-07-31 at 14 15 01" src="https://github.com/user-attachments/assets/671b4f72-f632-4cb5-baba-8f718dfb057f" /> | <img width="639" height="498" alt="Screenshot 2026-07-31 at 15 00 32" src="https://github.com/user-attachments/assets/69a7ae23-c901-4800-a3d7-9df633ffd779" /> | 


| Wrap | Unwrap |
|--------|--------|
| <img width="581" height="495" alt="Screenshot 2026-07-31 at 14 52 46" src="https://github.com/user-attachments/assets/8374767a-7c1a-40a4-9d4a-3d332439e2b7" /> | <img width="565" height="466" alt="Screenshot 2026-07-31 at 14 53 37" src="https://github.com/user-attachments/assets/8634bfdf-ce53-4684-bedb-f10d3518b224" /> | 



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the earn/yield withdrawal completion flow. The highest-risk regressions would appear in the unstake-to-claim flows for ETH and SOL, where the changed completion values and hook directly determine what the user sees and signs. ADA reward claiming shares related infrastructure and should be run at medium priority. Other staking tests (initial stake, stake-more, rewards display) do not touch the withdrawal completion path and are omitted.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldFlowCompleteWithdraw.tsx`
- `packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts`
- `packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.ts`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test directly exercises the post-unstake claim flow for Ethereum, including the claim modal, claim transaction, and updated balances. The changed `YieldFlowCompleteWithdraw`, `useYieldWithdraw`, and `getYieldWithdrawCompletedValues` files are all part of the yield withdrawal completion logic that this flow depends on.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers the full Solana unstake-and-claim flow, including the claim card, claim modal, device confirmation, and post-claim UI state. It directly uses the yield withdrawal completion path affected by the changed files.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test covers claiming Cardano staking rewards, which is a yield withdrawal action and shares the earn/withdraw infrastructure. While less directly tied to the 'complete withdraw' component than ETH/SOL unstake-to-claim, it is the most relevant ADA test for verifying withdrawal completion behavior.

</details>

_Updated: 2026-07-31T13:12:45.479Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/withdraw-complete-assets-outcomes/web/](https://dev.suite.sldev.cz/suite-web/feat/withdraw-complete-assets-outcomes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:14:37.270Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:13:46.234Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/withdraw-complete-assets-outcomes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->