### PR TITLE
feat(suite-native): report settings/networks/explorer analytics event

### DIFF
--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -18,6 +18,7 @@ export enum EventType {
     SettingsDeviceWipe = 'settings/device/wipe',
     SettingsGeneralLabeling = 'settings/general/labeling',
     SettingsNetworkSearchUsed = 'settings/network-search-used',
+    SettingsNetworksExplorer = 'settings/network-explorer',
     SettingsTestnetNetworksToggle = 'settings/testnet-networks-toggle',
     // eslint-disable-next-line local-rules/analytics-event-name
     SuiteSyncLabelCreated = 'suite-sync/label',

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -10,6 +10,7 @@ export { settingsDeviceChangeLabelEvent } from './settingsDeviceChangeLabelEvent
 export { settingsDeviceWipeEvent } from './settingsDeviceWipeEvent';
 export { settingsGeneralLabelingEvent } from './settingsGeneralLabelingEvent';
 export { settingsNetworkSearchUsedEvent } from './settingsNetworkSearchUsedEvent';
+export { settingsNetworksExplorerEvent } from './settingsNetworksExplorerEvent';
 export { settingsTestnetNetworksToggleEvent } from './settingsTestnetNetworksToggleEvent';
 export { walletConnectInitEvent } from './walletConnectInitEvent';
 export { walletConnectPairedEvent } from './walletConnectPairedEvent';

--- a/suite-common/analytics/src/events/settingsNetworksExplorerEvent.ts
+++ b/suite-common/analytics/src/events/settingsNetworksExplorerEvent.ts
@@ -1,0 +1,29 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+
+import { EventType } from '../constants';
+import type { AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    networkSymbol: AttributeDef<NetworkSymbol>;
+    type: AttributeDef<'custom' | 'default'>;
+};
+
+export const settingsNetworksExplorerEvent: EventDef<
+    Attributes,
+    EventType.SettingsNetworksExplorer
+> = {
+    name: EventType.SettingsNetworksExplorer,
+    descriptionTrigger: 'User configures a custom network explorer or sets the default one',
+    changelog: [{ version: '26.8.1', notes: 'added' }],
+
+    attributes: {
+        networkSymbol: {
+            description: 'The symbol of the configured network (e.g. `btc`)',
+            changelog: [{ version: '26.8.1', notes: 'added' }],
+        },
+        type: {
+            description: 'The network explorer configured (`custom` or `default`)',
+            changelog: [{ version: '26.8.1', notes: 'added' }],
+        },
+    },
+};

--- a/suite-common/wallet-core/src/explorer/explorerSelectors.ts
+++ b/suite-common/wallet-core/src/explorer/explorerSelectors.ts
@@ -5,6 +5,9 @@ import { type ExplorerItem, type ExplorerState } from './explorerReducer';
 export const selectNetworkExplorers = (state: ExplorerState, symbol: NetworkSymbol): ExplorerItem =>
     state.wallet.explorer[symbol];
 
+export const selectNetworkExplorerType = (state: ExplorerState, symbol: NetworkSymbol) =>
+    state.wallet.explorer[symbol].custom ? 'custom' : 'default';
+
 export const selectExplorer = (
     state: ExplorerState,
     symbol?: NetworkSymbol,

--- a/suite-common/wallet-core/src/explorer/explorerThunks.ts
+++ b/suite-common/wallet-core/src/explorer/explorerThunks.ts
@@ -1,0 +1,20 @@
+import { events } from '@suite-common/analytics';
+import { createThunk } from '@suite-common/redux-utils';
+import type { Explorer, NetworkSymbol } from '@suite-common/wallet-config';
+
+import { EXPLORER_MODULE_PREFIX, explorerActions } from './explorerActions';
+import { selectNetworkExplorerType } from './explorerSelectors';
+
+export const setNetworkExplorerThunk = createThunk(
+    `${EXPLORER_MODULE_PREFIX}/setExplorerThunk`,
+    (payload: { symbol: NetworkSymbol; explorer?: Explorer }, { dispatch, getState, extra }) => {
+        dispatch(explorerActions.setExplorer(payload));
+        extra.services.analytics.report({
+            type: events.settingsNetworksExplorerEvent.name,
+            payload: {
+                networkSymbol: payload.symbol,
+                type: selectNetworkExplorerType(getState(), payload.symbol),
+            },
+        });
+    },
+);

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -31,6 +31,7 @@ export * from './earn/earnDepositsFiatUtils';
 export * from './explorer/explorerActions';
 export * from './explorer/explorerReducer';
 export * from './explorer/explorerSelectors';
+export * from './explorer/explorerThunks';
 export * from './fees/feesActions';
 export * from './fees/feesConstants';
 export * from './fees/feesReducer';

--- a/suite-native/module-settings/src/hooks/useNetworkExplorerForm.ts
+++ b/suite-native/module-settings/src/hooks/useNetworkExplorerForm.ts
@@ -6,8 +6,8 @@ import { yup } from '@suite-common/validators';
 import { type Explorer, type Network } from '@suite-common/wallet-config';
 import {
     type ExplorerState,
-    explorerActions,
     selectNetworkExplorers,
+    setNetworkExplorerThunk,
 } from '@suite-common/wallet-core';
 import { useForm } from '@suite-native/forms';
 import { type TxKeyPath, useTranslate } from '@suite-native/intl';
@@ -61,13 +61,13 @@ export const useNetworkExplorerForm = ({ symbol }: Network) => {
     const { isDirty } = form.formState;
 
     const submit = form.handleSubmit(values => {
-        dispatch(explorerActions.setExplorer({ symbol, explorer: values }));
+        dispatch(setNetworkExplorerThunk({ symbol, explorer: values }));
         form.reset(values);
         Keyboard.dismiss();
     });
 
     const setToDefault = () => {
-        dispatch(explorerActions.setExplorer({ symbol }));
+        dispatch(setNetworkExplorerThunk({ symbol }));
         form.reset(networkExplorers.default);
         Keyboard.dismiss();
     };


### PR DESCRIPTION
## Description

- `settings/networks/explorer` analytics event introduced.
- `setNetworkExplorerThunk` with analytics reporting introduced.
-  `setNetworkExplorerThunk` used in the mobile app.

## Related Issue

Resolve #30590

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/network-explorer-analytics/web/](https://dev.suite.sldev.cz/suite-web/feat/native/network-explorer-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set introduces a new analytics event for network explorer settings and modifies wallet-core explorer state management, plus a native mobile hook. The web/desktop E2E risk is concentrated in analytics event emission and network/backend settings flows. Run the core analytics events test and the custom backend settings test unconditionally, and add the analytics toggle and coins settings tests as medium-confidence coverage for shared infrastructure.

<details><summary><b>Changed files (7)</b></summary>

- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/settingsNetworksExplorerEvent.ts`
- `suite-common/wallet-core/src/explorer/explorerSelectors.ts`
- `suite-common/wallet-core/src/explorer/explorerThunks.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-native/module-settings/src/hooks/useNetworkExplorerForm.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly exercises analytics event emission after changing application settings including enabled networks and custom backends; the new settingsNetworksExplorerEvent and changes to analytics events/constants are most likely to affect this test's assertions or require it to validate the new event.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly configures custom blockbook backends for BTC and ETH networks and verifies discovery/account loading; changes to explorer selectors/thunks that manage network backend/explorer configuration are directly exercised here.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/toggle.test.ts` — Validates analytics event emission for settings toggles and consent state; while it does not change explorer settings, it shares the analytics event infrastructure being modified and could catch regressions in event payload or session handling.
- `suite/e2e/tests/settings/coins.test.ts` — Covers enabling/disabling coin networks and configuring a custom ETH backend, which shares the network settings state and UI flow with explorer configuration changes in wallet-core.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/index.ts`
- `suite-native/module-settings/src/hooks/useNetworkExplorerForm.ts`

_Updated: 2026-07-31T14:29:07.940Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/network-explorer-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/network-explorer-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/network-explorer-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T14:31:53.026Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T14:31:39.194Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->