### PR TITLE
fix(suite-desktop): respect --log-level CLI switch

### DIFF
--- a/packages/suite-desktop-core/src/app.ts
+++ b/packages/suite-desktop-core/src/app.ts
@@ -126,7 +126,6 @@ const init = async () => {
     const logger = new Logger();
 
     global.logger = logger;
-    logger.level = isDevEnv ? 'debug' : 'info';
 
     logger.info('main', `Application starting`);
 

--- a/packages/suite-desktop-core/src/libs/logger.ts
+++ b/packages/suite-desktop-core/src/libs/logger.ts
@@ -30,7 +30,7 @@ export type Options = {
 };
 
 const logLevelSwitchValue = getSwitchValue('log-level');
-const logLevelByEnv = isDevEnv ? 'debug' : 'error';
+const logLevelByEnv = isDevEnv ? 'debug' : 'info';
 const logLevelDefault = isLogLevel(logLevelSwitchValue) ? logLevelSwitchValue : logLevelByEnv;
 
 type RepeatedLogMessage = LogMessage & {


### PR DESCRIPTION
## Description

The Desktop app ignored the `--log-level` CLI switch and always logged at INFO. The `Logger` constructor already reads the switch (via `logLevelDefault`), but `app.ts` overwrote the level with a hardcoded value immediately after construction, discarding it. 

This removes the override so the switch is honored, and changes the production env default from `error` to `info` so we keep the current behavior that was perhaps now expected.

## Notes for QA

Build/run the desktop app with `--log-level=error` (or `warn`/`debug`) and confirm the terminal only shows entries at or below that level. With no flag, production defaults to INFO and dev builds default to DEBUG, as before.

## Related Issue

Resolve #15670

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in suite-desktop-core's main entry point and logger. The highest risk is to the Electron main process lifecycle (bridge spawning, daemon mode, offline handling), so the bridge tests should be run unconditionally. The offline onboarding test provides additional coverage for app-level offline bootstrap. No E2E test explicitly validates logging behavior, so logger.ts is effectively uncovered.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/app.ts`
- `packages/suite-desktop-core/src/libs/logger.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — This test launches the Electron app in bridge daemon mode and verifies the node-bridge lifecycle across app start/quit. This directly exercises the main Electron process entry point in app.ts, including daemon argument handling and bridge process orchestration.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This test verifies that the desktop app spawns and stops the bundled bridge on startup/shutdown and reconnects after external bridge restarts. These behaviors are core responsibilities of the Electron main process defined in app.ts.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — This test runs the desktop onboarding flow in offline mode and asserts the disconnection banner persists through onboarding. Offline mode configuration and the network-aware app bootstrap are handled in app.ts, making this a plausible regression target.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite-desktop-core/src/libs/logger.ts`

_Updated: 2026-07-31T13:56:36.767Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/issue-15670/web/](https://dev.suite.sldev.cz/suite-web/issue-15670/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=issue-15670&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=issue-15670&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Trading - Swap,Swap SOL to BTC" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap,Swap SOL to BTC with live quotes and blocked send" | 🙋 manual |
| Quarantine test: "Trading POC - passthru swap ETH,Swap ETH to BTC with live quotes and blocked send" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:58:31.759Z • 8 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |
| Firmware not ready | 🙋 manual |

</details>

_Updated: 2026-07-31T13:58:15.728Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->