### PR TITLE
test(analytics): document event instance type mapping

### DIFF
--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -22,16 +22,23 @@ export type AttributeDef<T> = AnalyticsBaseAttribute & {
 type Domain = string;
 type EventName = `${Domain}/${string}` | `${string}`;
 
-// Analytics definitions have two shapes. Attribute-based definitions describe every payload
-// property with AttributeDef, while payload-based definitions carry their payload type directly.
-// The empty attribute map is still an attribute-based definition, but HasKeys makes its event
-// instance a defined event without a payload.
+// An event can describe its data in two ways:
+// 1. List every field separately in `attributes`, for example `amount: AttributeDef<number>`.
+// 2. Describe the whole payload with one type in `payloadType`.
+// `HasKeys` checks whether the attributes list is empty. `IsAttributeMap` tells these two kinds of
+// event apart.
 type HasKeys<T> = keyof T extends never ? false : true;
 type IsAttributeMap<T> = T extends Record<string, AttributeDef<any>> ? true : false;
 
-// AttributeDef's optional value exists only as a type carrier in analytics metadata. Extract its
-// value type and map the metadata keys to the payload accepted by report(). Mapped types preserve
-// optional attributes, so an optional AttributeDef becomes an optional payload property.
+// `AttributeDef<string>` contains documentation plus `value?: string`. We never read `value`; it is
+// only a clue for TypeScript that this attribute will contain a string when the event is reported.
+// `AttributePayload` pulls out that string type. `NonNullable` first removes `undefined`, which may
+// be there when the attribute is optional.
+//
+// `AttributeEventInstance` then repeats this for every attribute:
+// `{ label: AttributeDef<string> }` becomes `payload: { label: string }`.
+// Optional attributes stay optional. If the attributes list is empty, the event has only `type`
+// and does not require a useless empty payload.
 type AttributePayload<T> = NonNullable<T> extends AttributeDef<infer V> ? V : never;
 
 type AttributeEventInstance<A, N> =
@@ -62,10 +69,13 @@ export type EventDef<A, N extends EventName = EventName> =
               payloadType?: A;
           };
 
-// Infer the payload and event name from each definition. Because E is the checked side of this
-// conditional type, TypeScript distributes the conversion over unions and produces a discriminated
-// union of event instances. Attribute maps are converted property by property; other payload types
-// are carried through unchanged.
+// `EventInstance` is the final translator from an event description to the object the app reports:
+// `EventDef<{ amount: AttributeDef<number> }, 'buy'>`
+// becomes `{ type: 'buy'; payload: { amount: number } }`.
+//
+// `infer` pulls the data type (`A`) and event name (`N`) out of `EventDef`. If `E` contains several
+// event definitions joined with `|`, TypeScript translates each one separately. This keeps every
+// event name paired with the correct payload.
 export type EventInstance<E extends EventDef<any, any>> =
     E extends EventDef<infer A, infer N>
         ? IsAttributeMap<A> extends true

--- a/suite-common/analytics/src/eventDefinition.ts
+++ b/suite-common/analytics/src/eventDefinition.ts
@@ -22,9 +22,16 @@ export type AttributeDef<T> = AnalyticsBaseAttribute & {
 type Domain = string;
 type EventName = `${Domain}/${string}` | `${string}`;
 
+// Analytics definitions have two shapes. Attribute-based definitions describe every payload
+// property with AttributeDef, while payload-based definitions carry their payload type directly.
+// The empty attribute map is still an attribute-based definition, but HasKeys makes its event
+// instance a defined event without a payload.
 type HasKeys<T> = keyof T extends never ? false : true;
 type IsAttributeMap<T> = T extends Record<string, AttributeDef<any>> ? true : false;
 
+// AttributeDef's optional value exists only as a type carrier in analytics metadata. Extract its
+// value type and map the metadata keys to the payload accepted by report(). Mapped types preserve
+// optional attributes, so an optional AttributeDef becomes an optional payload property.
 type AttributePayload<T> = NonNullable<T> extends AttributeDef<infer V> ? V : never;
 
 type AttributeEventInstance<A, N> =
@@ -55,6 +62,10 @@ export type EventDef<A, N extends EventName = EventName> =
               payloadType?: A;
           };
 
+// Infer the payload and event name from each definition. Because E is the checked side of this
+// conditional type, TypeScript distributes the conversion over unions and produces a discriminated
+// union of event instances. Attribute maps are converted property by property; other payload types
+// are carried through unchanged.
 export type EventInstance<E extends EventDef<any, any>> =
     E extends EventDef<infer A, infer N>
         ? IsAttributeMap<A> extends true

--- a/suite-common/analytics/src/eventDefinition.type-test.ts
+++ b/suite-common/analytics/src/eventDefinition.type-test.ts
@@ -1,0 +1,79 @@
+import type { AttributeDef, EventDef, EventInstance } from './eventDefinition';
+
+type AttributeEventDefinition = EventDef<
+    {
+        requiredAttribute: AttributeDef<string>;
+        optionalAttribute?: AttributeDef<number>;
+    },
+    'test/attribute-event'
+>;
+
+type EmptyAttributeEventDefinition = EventDef<Record<never, never>, 'test/empty-attribute-event'>;
+
+type PayloadEventDefinition = EventDef<boolean, 'test/payload-event'>;
+
+const attributeEvent: EventInstance<AttributeEventDefinition> = {
+    type: 'test/attribute-event',
+    payload: { requiredAttribute: 'value' },
+};
+
+const attributeEventWithOptionalAttribute: EventInstance<AttributeEventDefinition> = {
+    type: 'test/attribute-event',
+    payload: { requiredAttribute: 'value', optionalAttribute: 42 },
+};
+
+// @ts-expect-error Attribute events with defined keys require a payload.
+const attributeEventWithoutPayload: EventInstance<AttributeEventDefinition> = {
+    type: 'test/attribute-event',
+};
+
+const attributeEventWithoutRequiredAttribute: EventInstance<AttributeEventDefinition> = {
+    type: 'test/attribute-event',
+    // @ts-expect-error Required attributes remain required in the event payload.
+    payload: {},
+};
+
+const emptyAttributeEvent: EventInstance<EmptyAttributeEventDefinition> = {
+    type: 'test/empty-attribute-event',
+};
+
+const emptyAttributeEventWithPayload: EventInstance<EmptyAttributeEventDefinition> = {
+    type: 'test/empty-attribute-event',
+    // @ts-expect-error Empty attribute maps produce events without a payload.
+    payload: {},
+};
+
+const payloadEvent: EventInstance<PayloadEventDefinition> = {
+    type: 'test/payload-event',
+    payload: true,
+};
+
+// @ts-expect-error Payload-based events require their direct payload type.
+const payloadEventWithoutPayload: EventInstance<PayloadEventDefinition> = {
+    type: 'test/payload-event',
+};
+
+type EventDefinitionUnion =
+    AttributeEventDefinition | EmptyAttributeEventDefinition | PayloadEventDefinition;
+
+const eventFromDefinitionUnion: EventInstance<EventDefinitionUnion> = {
+    type: 'test/payload-event',
+    payload: false,
+};
+
+const mismatchedEventFromDefinitionUnion: EventInstance<EventDefinitionUnion> = {
+    type: 'test/empty-attribute-event',
+    // @ts-expect-error Union conversion keeps the payload paired with its event name.
+    payload: false,
+};
+
+void attributeEvent;
+void attributeEventWithOptionalAttribute;
+void attributeEventWithoutPayload;
+void attributeEventWithoutRequiredAttribute;
+void emptyAttributeEvent;
+void emptyAttributeEventWithPayload;
+void payloadEvent;
+void payloadEventWithoutPayload;
+void eventFromDefinitionUnion;
+void mismatchedEventFromDefinitionUnion;


### PR DESCRIPTION
## Description

Explains the type conversion in `eventDefinition.ts` using concrete input/output examples: how `AttributeDef<number>` becomes a numeric payload field, why an empty attributes object needs no payload, and how each event name stays paired with the correct payload. Adds compile-time tests for required and optional attributes, empty events, direct payload events, and union handling.

Type-test coverage: **5 accepted shapes + 5 expected type errors**. Focused analytics type-check and lint pass; all **545** applicable repository requirements passed for the behavior-changing commit. Runtime impact: **none**.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/analytics-event-definition-types/web/](https://dev.suite.sldev.cz/suite-web/test/analytics-event-definition-types/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/analytics-event-definition-types&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/analytics-event-definition-types&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/analytics-event-definition-types&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T15:39:03.032Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap SPL token to coin via CEX > Swap USDT to SOL via CEX | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-09T15:39:23.701Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files define analytics event types and runtime payloads, so the primary risk is incorrect event structure, missing fields, or broken event constants. The analytics suite tests provide direct coverage; running the two broad analytics tests plus the three focused event-family tests gives high confidence while keeping the list small. No other E2E tests are likely to catch event-definition regressions.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/analytics/src/eventDefinition.ts`
- `suite-common/analytics/src/eventDefinition.type-test.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly validates the payload structure and firing of core analytics events (SuiteReady, DeviceConnect, TransportType, DeviceDisconnect, SettingsAnalytics) that are defined in eventDefinition.ts. A regression in event definitions would be caught here.
- `suite/e2e/tests/analytics/toggle.test.ts` — Exercises the analytics enable/disable lifecycle and asserts on events such as settingsAnalyticsEvent, settingsGeneralChangeFiatEvent, suiteReadyEvent and routerLocationChangeEvent, all of which depend on eventDefinition.ts.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/promo-banner-events.test.ts` — Verifies the PromoDashboardBanner event payload and bannerType, a specific analytics event defined in eventDefinition.ts not covered by the broader analytics tests.
- `suite/e2e/tests/analytics/staking-events.test.ts` — Validates StakingNavigate analytics events for ETH and ADA, which are defined in eventDefinition.ts and not exercised in the general analytics event tests.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Tests WalletConnect analytics events (WalletConnectInit, WalletConnectPaired, WalletConnectProposal, etc.) defined in eventDefinition.ts, providing coverage for this specific event family.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/analytics/src/eventDefinition.type-test.ts`

_Updated: 2026-09-09T15:37:20.637Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->