### PR TITLE
test(suite-native): use translations in trading queries

### DIFF
--- a/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListAddressItem.test.tsx
@@ -105,7 +105,9 @@ describe(AccountListAddressItem.name, () => {
             renderAccountListAddressItem(receiveAccount);
 
         expect(getByText('BTC_address')).toBeTruthy();
-        expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
+        expect(
+            queryByAccessibilityHint(getTranslation('moduleTrading.accountScreen.step2Hint')),
+        ).toBeNull();
     });
 
     it('should display address', () => {
@@ -130,7 +132,9 @@ describe(AccountListAddressItem.name, () => {
 
         expect(getByText('BTC_address')).toBeTruthy();
         expect(queryByText('My BTC account')).toBeNull();
-        expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
+        expect(
+            queryByAccessibilityHint(getTranslation('moduleTrading.accountScreen.step2Hint')),
+        ).toBeNull();
         expect(
             getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
         ).toHaveTextContent('$5,000,000.00');

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
@@ -94,7 +94,9 @@ describe('AccountListItem', () => {
             renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
-        expect(queryByAccessibilityHint('Select to display account addresses')).toBeNull();
+        expect(
+            queryByAccessibilityHint(getTranslation('moduleTrading.accountScreen.step2Hint')),
+        ).toBeNull();
         expect(
             getByLabelText(getTranslation('moduleTrading.accountScreen.balanceFiat')),
         ).toHaveTextContent('$10,000,000.00');
@@ -121,6 +123,8 @@ describe('AccountListItem', () => {
         const { getByText, getByAccessibilityHint } = renderAccountListItem(receiveAccount);
 
         expect(getByText('My BTC account')).toBeTruthy();
-        expect(getByAccessibilityHint('Select to display account addresses')).toBeTruthy();
+        expect(
+            getByAccessibilityHint(getTranslation('moduleTrading.accountScreen.step2Hint')),
+        ).toBeTruthy();
     });
 });

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.test.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetSheetHeader.test.tsx
@@ -35,7 +35,12 @@ describe('MyAssetSheetHeader', () => {
     it('should show filter tabs after focusing the search input', () => {
         const { getByPlaceholderText, getByText, queryByText } = renderComponent();
 
-        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent(
+            getByPlaceholderText(
+                getTranslation('moduleTrading.myAssetSheet.searchInputPlaceholder'),
+            ),
+            'focus',
+        );
 
         expect(getByText(getTranslation('moduleTrading.providerSheet.filters.all'))).toBeTruthy();
         expect(queryByText(getTranslation('moduleTrading.myAssetSheet.title'))).toBeNull();
@@ -44,7 +49,12 @@ describe('MyAssetSheetHeader', () => {
     it('should display cancel button after focusing the search input', () => {
         const { getByPlaceholderText, getByText } = renderComponent();
 
-        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent(
+            getByPlaceholderText(
+                getTranslation('moduleTrading.myAssetSheet.searchInputPlaceholder'),
+            ),
+            'focus',
+        );
 
         expect(getByText(getTranslation('generic.buttons.cancel'))).toBeTruthy();
     });
@@ -68,7 +78,12 @@ describe('MyAssetSheetHeader', () => {
         const onFilterChange = jest.fn();
         const { getByPlaceholderText } = renderComponent({ onFilterChange });
 
-        fireEvent.changeText(getByPlaceholderText(/Search/), 'Bitcoin');
+        fireEvent.changeText(
+            getByPlaceholderText(
+                getTranslation('moduleTrading.myAssetSheet.searchInputPlaceholder'),
+            ),
+            'Bitcoin',
+        );
 
         expect(onFilterChange).toHaveBeenCalledWith('Bitcoin');
     });
@@ -77,7 +92,12 @@ describe('MyAssetSheetHeader', () => {
         const onSelectedNetworkFilter = jest.fn();
         const { getByPlaceholderText, getByText } = renderComponent({ onSelectedNetworkFilter });
 
-        fireEvent(getByPlaceholderText(/Search/), 'focus');
+        fireEvent(
+            getByPlaceholderText(
+                getTranslation('moduleTrading.myAssetSheet.searchInputPlaceholder'),
+            ),
+            'focus',
+        );
         fireEvent.press(getByText('Bitcoin'));
 
         expect(onSelectedNetworkFilter).toHaveBeenCalledWith('btc');

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.test.tsx
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { getTranslation } from '@suite-native/intl';
 import {
     createLightStore,
     createStaticReducer,
@@ -62,17 +63,37 @@ describe('TradeableAssetListItem', () => {
     it('should add asset to favourites on star click', () => {
         const { getByAccessibilityHint } = renderComponent({ asset: btcAsset });
 
-        fireEvent.press(getByAccessibilityHint('Add to favourites'));
+        fireEvent.press(
+            getByAccessibilityHint(
+                getTranslation('moduleTrading.tradeableAssetsSheet.favouritesAdd'),
+            ),
+        );
 
-        expect(getByAccessibilityHint('Remove from favourites')).toBeTruthy();
+        expect(
+            getByAccessibilityHint(
+                getTranslation('moduleTrading.tradeableAssetsSheet.favouritesRemove'),
+            ),
+        ).toBeTruthy();
     });
 
     it('should remove asset from favourites on star click', () => {
         const { getByAccessibilityHint } = renderComponent({ asset: btcAsset });
 
-        fireEvent.press(getByAccessibilityHint('Add to favourites'));
-        fireEvent.press(getByAccessibilityHint('Remove from favourites'));
+        fireEvent.press(
+            getByAccessibilityHint(
+                getTranslation('moduleTrading.tradeableAssetsSheet.favouritesAdd'),
+            ),
+        );
+        fireEvent.press(
+            getByAccessibilityHint(
+                getTranslation('moduleTrading.tradeableAssetsSheet.favouritesRemove'),
+            ),
+        );
 
-        expect(getByAccessibilityHint('Add to favourites')).toBeTruthy();
+        expect(
+            getByAccessibilityHint(
+                getTranslation('moduleTrading.tradeableAssetsSheet.favouritesAdd'),
+            ),
+        ).toBeTruthy();
     });
 });


### PR DESCRIPTION
## Summary
- replace hardcoded translated accessibility hints in trading account and asset tests
- resolve the My Assets search placeholder through its translation ID
- keep tests stable across Crowdin copy updates

## Notes for QA
Do not test

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-trading-translation-queries&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->