### PR TITLE
`TransactionComposer` refactor pt.2

### DIFF
--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -46,7 +46,6 @@ export const UI_REQUEST = {
     REQUEST_THP_PAIRING: 'ui-request_thp_pairing',
     SELECT_ACCOUNT: 'ui-select_account',
     SELECT_FEE: 'ui-select_fee',
-    UPDATE_CUSTOM_FEE: 'ui-update_custom_fee',
     INSUFFICIENT_FUNDS: 'ui-insufficient_funds',
     REQUEST_BUTTON: 'ui-button',
     REQUEST_WORD: 'ui-request_word',
@@ -227,14 +226,6 @@ export interface UiRequestSelectFee {
     };
 }
 
-export interface UpdateCustomFee {
-    type: typeof UI_REQUEST.UPDATE_CUSTOM_FEE;
-    payload: {
-        coinInfo: BitcoinNetworkInfo;
-        feeLevels: SelectFeeLevel[];
-    };
-}
-
 export interface BundleProgress<R> {
     type: typeof UI_REQUEST.BUNDLE_PROGRESS;
     payload: {
@@ -297,7 +288,6 @@ export type UiEvent =
     | UiRequestSelectAccount
     | UiRequestSelectFee
     | UiRequestThpPairing
-    | UpdateCustomFee
     | BundleProgress<any>
     | FirmwareProgress
     | FirmwareProgressUnexpectedDelay

--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -9,7 +9,7 @@ import type { DeviceButtonRequest, DeviceThpPairingPayload } from './device';
 import type { DiscoveryAccount, DiscoveryAccountType } from '../types/account';
 import type { BitcoinNetworkInfo, CoinInfo } from '../types/coinInfo';
 import type { Device } from '../types/device';
-import type { SelectFeeLevel } from '../types/fees';
+import type { FeeLevel } from '../types/fees';
 import { type MessageFactoryFn } from '../types/utils';
 
 export const UI_EVENT = 'UI_EVENT';
@@ -222,7 +222,7 @@ export interface UiRequestSelectFee {
     type: typeof UI_REQUEST.SELECT_FEE;
     payload: {
         coinInfo: BitcoinNetworkInfo;
-        feeLevels: SelectFeeLevel[];
+        feeLevels: FeeLevel[];
     };
 }
 

--- a/packages/connect-common/src/events/ui-response.ts
+++ b/packages/connect-common/src/events/ui-response.ts
@@ -2,6 +2,7 @@ import type { ThpPairingMethod } from '@trezor/protocol';
 
 import { type UI_EVENT } from './ui-request';
 import type { DiscoveryAccount } from '../types/account';
+import type { FeeLevel } from '../types/fees';
 import type { LocalFirmwares } from '../types/settings';
 
 /*
@@ -73,17 +74,9 @@ export interface UiResponseAccount {
 export interface UiResponseFee {
     type: typeof UI_RESPONSE.RECEIVE_FEE;
     payload:
-        | {
-              type: 'compose-custom';
-              value: string;
-          }
-        | {
-              type: 'change-account';
-          }
-        | {
-              type: 'send';
-              value: string;
-          };
+        | { type: 'change-account' }
+        | { type: 'select-fee'; value: Exclude<FeeLevel['label'], 'custom'> }
+        | { type: 'select-fee-custom'; value: string };
 }
 
 export interface UiResponseDiscoveryAccounts {

--- a/packages/connect-common/src/types/fees.ts
+++ b/packages/connect-common/src/types/fees.ts
@@ -29,22 +29,3 @@ export const FeeLevel = Type.Object({
     maxFeePerGas: Type.Optional(Type.String()),
     maxPriorityFeePerGas: Type.Optional(Type.String()),
 });
-
-export type SelectFeeLevel = Static<typeof SelectFeeLevel>;
-export const SelectFeeLevel = Type.Union([
-    Type.Object({
-        name: Type.String(),
-        fee: Type.Literal('0'),
-        feePerByte: Type.Optional(Type.Undefined()),
-        blocks: Type.Optional(Type.Undefined()),
-        disabled: Type.Literal(true),
-    }),
-    Type.Object({
-        name: Type.String(),
-        fee: Type.String(),
-        feePerByte: Type.String(),
-        blocks: Type.Number(),
-        minutes: Type.Number(),
-        total: Type.String(),
-    }),
-]);

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -4,6 +4,7 @@ import type { Address } from '@trezor/blockchain-link-types';
 import type {
     BitcoinNetworkInfo,
     ComposeResult,
+    ComposeResultFinal,
     ComposeUtxo,
     ComposedInputs,
     DiscoveryAccount,
@@ -25,7 +26,6 @@ type Options = {
     outputs: ComposeOutput[];
     coinInfo: BitcoinNetworkInfo;
     baseFee?: number;
-    feeLevels: FeeLevel[];
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };
 
@@ -36,11 +36,8 @@ export class TransactionComposer {
     private coinInfo: BitcoinNetworkInfo;
     private baseFee: number;
     private sortingStrategy: TransactionInputOutputSortingStrategy;
-    private feeLevels: FeeLevel[];
     private feePolicy: ComposeFeePolicy | undefined;
     private changeAddress: Address | undefined;
-
-    composed: { [key: string]: ComposeResult } = {};
 
     constructor(options: Options) {
         this.account = options.account;
@@ -48,7 +45,6 @@ export class TransactionComposer {
         this.coinInfo = options.coinInfo;
         this.baseFee = options.baseFee || 0;
         this.sortingStrategy = options.sortingStrategy;
-        this.feeLevels = options.feeLevels;
 
         const { addresses } = options.account;
         const allAddresses = new Set(
@@ -79,28 +75,24 @@ export class TransactionComposer {
     }
 
     // Composing fee levels for SelectFee view in popup
-    composeAllFeeLevels() {
-        if (!this.utxos.length) {
-            return false;
+    composeAllFeeLevels(feeLevels: FeeLevel[]) {
+        const requestedLevels = this.utxos.length ? feeLevels : [];
+        const levels = [];
+        const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
+
+        for (const level of requestedLevels) {
+            if (level.feePerUnit === '0') continue;
+            const tx = this.compose(level.feePerUnit);
+            if (tx.type !== 'final') continue;
+            levels.push(level);
+            transactions.set(level.label, tx);
         }
 
-        this.composed = Object.fromEntries(
-            this.feeLevels
-                .filter(({ feePerUnit }) => feePerUnit !== '0')
-                .map(({ label, feePerUnit }) => [label, this.compose(feePerUnit)]),
-        );
-
-        const atLeastOneValid = Object.values(this.composed).some(tx => tx.type === 'final');
-
-        return atLeastOneValid;
+        return { levels, transactions };
     }
 
     composeCustomFee(fee: string) {
         return this.compose(fee);
-    }
-
-    getFeeLevelList(): FeeLevel[] {
-        return this.feeLevels.filter(level => this.composed[level.label]?.type === 'final');
     }
 
     private compose(feeRate: string): ComposeResult {

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -76,11 +76,10 @@ export class TransactionComposer {
 
     // Composing fee levels for SelectFee view in popup
     composeAllFeeLevels(feeLevels: FeeLevel[]) {
-        const requestedLevels = this.utxos.length ? feeLevels : [];
         const levels = [];
         const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
 
-        for (const level of requestedLevels) {
+        for (const level of feeLevels) {
             if (level.feePerUnit === '0') continue;
             const tx = this.compose(level.feePerUnit);
             if (tx.type !== 'final') continue;
@@ -98,6 +97,7 @@ export class TransactionComposer {
     private compose(feeRate: string): ComposeResult {
         const { account, coinInfo, baseFee, changeAddress, feePolicy } = this;
 
+        if (!this.utxos.length) return { type: 'error', error: 'MISSING-UTXOS' };
         if (!changeAddress) return { type: 'error', error: 'ADDRESSES-NOT-SET' };
 
         return composeTx({

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -110,19 +110,13 @@ export class TransactionComposer {
             return false;
         }
 
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const lastLevel: (typeof levels)[number] = levels[levels.length - 1];
-        let lastFee = new BigNumber(lastLevel.feePerUnit);
-        while (lastFee.gt(this.coinInfo.minFee)) {
-            lastFee = lastFee.minus(1);
+        const minFee = String(this.coinInfo.minFee);
+        const minFeeTx = this.compose(minFee);
+        if (minFeeTx.type === 'final') {
+            this.customFee = minFee;
+            this.composed.custom = minFeeTx;
 
-            const tx = this.compose(lastFee.toString());
-            if (tx.type === 'final') {
-                this.customFee = lastFee.toString();
-                this.composed.custom = tx;
-
-                return true;
-            }
+            return true;
         }
 
         return false;

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -1,12 +1,11 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/core/methods/tx/TransactionComposer.js
 
-import type { Address } from '@trezor/blockchain-link-types';
 import type {
+    AccountAddresses,
     BitcoinNetworkInfo,
     ComposeResult,
     ComposeUtxo,
-    ComposedInputs,
-    DiscoveryAccount,
+    DiscoveryAccountType,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type {
@@ -19,7 +18,8 @@ import { composeTx, networks } from '@trezor/utxo-lib';
 import { DEFAULT_BITCOIN_LONGTERM_FEE_RATE } from '../../data/defaultFeeLevels';
 
 type Options = {
-    account: DiscoveryAccount;
+    txType: DiscoveryAccountType;
+    addresses?: AccountAddresses;
     utxos: ComposeUtxo[];
     outputs: ComposeOutput[];
     coinInfo: BitcoinNetworkInfo;
@@ -27,74 +27,53 @@ type Options = {
     sortingStrategy: TransactionInputOutputSortingStrategy;
 };
 
-export class TransactionComposer {
-    private account: DiscoveryAccount;
-    private utxos: ComposedInputs[];
-    private outputs: ComposeOutput[];
-    private coinInfo: BitcoinNetworkInfo;
-    private baseFee: number;
-    private sortingStrategy: TransactionInputOutputSortingStrategy;
-    private feePolicy: ComposeFeePolicy | undefined;
-    private changeAddress: Address | undefined;
+export const createComposer = (options: Options) => {
+    const { txType, addresses, outputs, coinInfo, baseFee = 0, sortingStrategy, utxos } = options;
 
-    constructor(options: Options) {
-        this.account = options.account;
-        this.outputs = options.outputs;
-        this.coinInfo = options.coinInfo;
-        this.baseFee = options.baseFee || 0;
-        this.sortingStrategy = options.sortingStrategy;
+    const allAddresses = new Set(
+        addresses?.used
+            .concat(addresses.unused)
+            .concat(addresses.change)
+            .map(a => a.address),
+    );
 
-        const { addresses } = options.account;
-        const allAddresses = new Set(
-            addresses?.used
-                .concat(addresses.unused)
-                .concat(addresses.change)
-                .map(a => a.address),
-        );
+    // find unused change address or fallback to the last in the list
+    const changeAddress = addresses?.change.find(a => !a.transfers) ?? addresses?.change.at(-1);
 
-        // find unused change address or fallback to the last in the list
-        this.changeAddress = addresses?.change.find(a => !a.transfers) ?? addresses?.change.at(-1);
+    // map to @trezor/utxo-lib/compose format
+    const utxosFiltered = utxos
+        // exclude amounts lower than dust limit if they are NOT required
+        .filter(u => u.required || new BigNumber(u.amount).gt(coinInfo.dustLimit))
+        .map(u => ({
+            ...u,
+            coinbase: typeof u.coinbase === 'boolean' ? u.coinbase : false, // decide it it can be spent immediately (false) or after 100 conf (true)
+            own: allAddresses.has(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
+        }));
 
-        // map to @trezor/utxo-lib/compose format
-        this.utxos = options.utxos
-            // exclude amounts lower than dust limit if they are NOT required
-            .filter(u => u.required || new BigNumber(u.amount).gt(this.coinInfo.dustLimit))
-            .map(u => ({
-                ...u,
-                coinbase: typeof u.coinbase === 'boolean' ? u.coinbase : false, // decide it it can be spent immediately (false) or after 100 conf (true)
-                own: allAddresses.has(u.address), // decide if it can be spent immediately (own) or after 6 conf (not own)
-            }));
-
-        if (networks.isNetworkType('doge', options.coinInfo.network)) {
-            this.feePolicy = 'doge';
-        } else if (networks.isNetworkType('zcash', options.coinInfo.network)) {
-            this.feePolicy = 'zcash';
-        }
+    let feePolicy: ComposeFeePolicy | undefined;
+    if (networks.isNetworkType('doge', coinInfo.network)) {
+        feePolicy = 'doge';
+    } else if (networks.isNetworkType('zcash', coinInfo.network)) {
+        feePolicy = 'zcash';
     }
 
-    composeCustomFee(fee: string) {
-        return this.compose(fee);
-    }
-
-    private compose(feeRate: string): ComposeResult {
-        const { account, coinInfo, baseFee, changeAddress, feePolicy } = this;
-
-        if (!this.utxos.length) return { type: 'error', error: 'MISSING-UTXOS' };
+    return (feeRate: string): ComposeResult => {
+        if (!utxosFiltered.length) return { type: 'error', error: 'MISSING-UTXOS' };
         if (!changeAddress) return { type: 'error', error: 'ADDRESSES-NOT-SET' };
 
         return composeTx({
-            txType: account.type,
-            utxos: this.utxos,
-            outputs: this.outputs,
+            txType,
+            utxos: utxosFiltered,
+            outputs,
             feeRate,
             // TODO https://github.com/trezor/trezor-suite/issues/18483 rewrite with response from a new planned blockbook API
             longTermFeeRate: DEFAULT_BITCOIN_LONGTERM_FEE_RATE,
-            sortingStrategy: this.sortingStrategy,
+            sortingStrategy,
             network: coinInfo.network,
             changeAddress,
             dustThreshold: coinInfo.dustLimit,
             baseFee,
             feePolicy,
         });
-    }
-}
+    };
+};

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -8,7 +8,6 @@ import type {
     ComposedInputs,
     DiscoveryAccount,
     FeeLevel,
-    SelectFeeLevel,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type {
@@ -135,26 +134,8 @@ export class TransactionComposer {
         this.customFee = tx.type === 'final' ? tx.feePerByte : fee;
     }
 
-    getFeeLevelList(): SelectFeeLevel[] {
-        return this.levels.map(level => {
-            const tx = this.composed[level.label];
-            if (tx?.type === 'final') {
-                return {
-                    name: level.label,
-                    fee: tx.fee,
-                    feePerByte: level.feePerUnit,
-                    blocks: level.blocks,
-                    minutes: level.blocks * this.coinInfo.blockTime,
-                    total: tx.totalSpent,
-                };
-            } else {
-                return {
-                    name: level.label,
-                    fee: '0',
-                    disabled: true,
-                };
-            }
-        });
+    getFeeLevelList(): FeeLevel[] {
+        return this.levels.filter(level => this.composed[level.label]?.type === 'final');
     }
 
     private compose(feeRate: string): ComposeResult {

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -4,11 +4,9 @@ import type { Address } from '@trezor/blockchain-link-types';
 import type {
     BitcoinNetworkInfo,
     ComposeResult,
-    ComposeResultFinal,
     ComposeUtxo,
     ComposedInputs,
     DiscoveryAccount,
-    FeeLevel,
 } from '@trezor/connect-common';
 import { BigNumber } from '@trezor/utils/src/bigNumber';
 import type {
@@ -72,22 +70,6 @@ export class TransactionComposer {
         } else if (networks.isNetworkType('zcash', options.coinInfo.network)) {
             this.feePolicy = 'zcash';
         }
-    }
-
-    // Composing fee levels for SelectFee view in popup
-    composeAllFeeLevels(feeLevels: FeeLevel[]) {
-        const levels = [];
-        const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
-
-        for (const level of feeLevels) {
-            if (level.feePerUnit === '0') continue;
-            const tx = this.compose(level.feePerUnit);
-            if (tx.type !== 'final') continue;
-            levels.push(level);
-            transactions.set(level.label, tx);
-        }
-
-        return { levels, transactions };
     }
 
     composeCustomFee(fee: string) {

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -126,6 +126,8 @@ export class TransactionComposer {
         const tx = this.compose(fee);
         this.composed.custom = tx;
         this.customFee = tx.type === 'final' ? tx.feePerByte : fee;
+
+        return tx;
     }
 
     getFeeLevelList(): FeeLevel[] {

--- a/packages/connect/src/api/bitcoin/TransactionComposer.ts
+++ b/packages/connect/src/api/bitcoin/TransactionComposer.ts
@@ -37,19 +37,10 @@ export class TransactionComposer {
     private baseFee: number;
     private sortingStrategy: TransactionInputOutputSortingStrategy;
     private feeLevels: FeeLevel[];
-    private customFee: string | undefined;
     private feePolicy: ComposeFeePolicy | undefined;
     private changeAddress: Address | undefined;
 
     composed: { [key: string]: ComposeResult } = {};
-
-    private get levels() {
-        return this.customFee
-            ? this.feeLevels.concat([
-                  { label: 'custom' as const, feePerUnit: this.customFee, blocks: -1 },
-              ])
-            : this.feeLevels;
-    }
 
     constructor(options: Options) {
         this.account = options.account;
@@ -89,49 +80,27 @@ export class TransactionComposer {
 
     // Composing fee levels for SelectFee view in popup
     composeAllFeeLevels() {
-        const { levels } = this;
-
         if (!this.utxos.length) {
             return false;
         }
 
         this.composed = Object.fromEntries(
-            levels
+            this.feeLevels
                 .filter(({ feePerUnit }) => feePerUnit !== '0')
                 .map(({ label, feePerUnit }) => [label, this.compose(feePerUnit)]),
         );
 
         const atLeastOneValid = Object.values(this.composed).some(tx => tx.type === 'final');
-        if (atLeastOneValid) {
-            return true;
-        }
 
-        if (this.composed.custom) {
-            return false;
-        }
-
-        const minFee = String(this.coinInfo.minFee);
-        const minFeeTx = this.compose(minFee);
-        if (minFeeTx.type === 'final') {
-            this.customFee = minFee;
-            this.composed.custom = minFeeTx;
-
-            return true;
-        }
-
-        return false;
+        return atLeastOneValid;
     }
 
     composeCustomFee(fee: string) {
-        const tx = this.compose(fee);
-        this.composed.custom = tx;
-        this.customFee = tx.type === 'final' ? tx.feePerByte : fee;
-
-        return tx;
+        return this.compose(fee);
     }
 
     getFeeLevelList(): FeeLevel[] {
-        return this.levels.filter(level => this.composed[level.label]?.type === 'final');
+        return this.feeLevels.filter(level => this.composed[level.label]?.type === 'final');
     }
 
     private compose(feeRate: string): ComposeResult {

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -251,15 +251,8 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         );
 
         // wait for fee selection
-        let resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice()).promise;
-
-        while (resp.payload.type === 'compose-custom') {
-            // recompose custom fee level with requested value
-            composer.composeCustomFee(resp.payload.value);
-
-            // wait for user action
-            resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice()).promise;
-        }
+        const resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice())
+            .promise;
 
         if (resp.payload.type === 'change-account') {
             // check for interruption
@@ -274,8 +267,16 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             return this.interactiveFlow(context);
         }
 
+        let composedKey;
+        if (resp.payload.type === 'select-fee-custom') {
+            // recompose custom fee level with requested value
+            composer.composeCustomFee(resp.payload.value);
+            composedKey = 'custom' as const;
+        } else {
+            composedKey = resp.payload.value;
+        }
+
         const { composed } = composer;
-        const composedKey = resp.payload.value;
         // @ts-expect-error: noUncheckedIndexedAccess
         const tx: ComposeResult = composed[composedKey];
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -30,7 +30,7 @@ import { requestExistingAccounts } from './common/requestExistingAccounts';
 import { fixCoinInfoNetwork, getBitcoinNetwork } from '../data/coinInfo';
 import { formatAmount } from '../utils/formatUtils';
 import * as pathUtils from '../utils/pathUtils';
-import { TransactionComposer } from './bitcoin/TransactionComposer';
+import { createComposer } from './bitcoin/TransactionComposer';
 import { enhanceSignTx } from './bitcoin/enhanceSignTx';
 import { inputToTrezor } from './bitcoin/inputs';
 import { outputToTrezor, validateHDOutput } from './bitcoin/outputs';
@@ -160,14 +160,9 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         const { coinInfo, outputs, baseFee, sortingStrategy } = this.params;
         const address_n = pathUtils.validatePath(account.path);
 
-        const composer = new TransactionComposer({
-            account: {
-                type: pathUtils.getAccountType(address_n),
-                label: 'Account',
-                descriptor: account.path,
-                address_n,
-                addresses: account.addresses,
-            },
+        const compose = createComposer({
+            txType: pathUtils.getAccountType(address_n),
+            addresses: account.addresses,
             utxos: account.utxo,
             coinInfo,
             outputs,
@@ -176,7 +171,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         });
 
         const levels = feeLevels.map(level => {
-            const tx = composer.composeCustomFee(level.feePerUnit);
+            const tx = compose(level.feePerUnit);
             if (tx.type === 'final') {
                 return {
                     ...tx,
@@ -216,8 +211,9 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         const feeLevels = getOrInitFeeLevels(coinInfo);
         await feeLevels.load(blockchain);
 
-        const composer = new TransactionComposer({
-            account,
+        const compose = createComposer({
+            txType: account.type,
+            addresses: account.addresses,
             utxos,
             coinInfo,
             outputs,
@@ -232,7 +228,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         // check if any of composed transactions is valid
         for (const level of feeLevels.levels) {
             if (level.feePerUnit === '0') continue;
-            const tx = composer.composeCustomFee(level.feePerUnit);
+            const tx = compose(level.feePerUnit);
             if (tx.type !== 'final') continue;
             composed.levels.push(level);
             composed.transactions.set(level.label, tx);
@@ -240,7 +236,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         if (!composed.levels.length) {
             const feePerUnit = String(coinInfo.minFee);
-            const minFeeTx = composer.composeCustomFee(feePerUnit);
+            const minFeeTx = compose(feePerUnit);
 
             if (minFeeTx.type === 'final') {
                 context.sendCoreMessage(
@@ -288,7 +284,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
 
         const tx =
             resp.payload.type === 'select-fee-custom'
-                ? composer.composeCustomFee(resp.payload.value) // recompose custom fee level with requested value
+                ? compose(resp.payload.value) // recompose custom fee level with requested value
                 : composed.transactions.get(resp.payload.value)!;
 
         const response = await this._sign(tx, context.sendCoreMessage);

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -170,7 +170,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             coinInfo,
             outputs,
             baseFee,
-            feeLevels: [], // Not needed for composeCustomFee
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 
@@ -220,15 +219,14 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             utxos,
             coinInfo,
             outputs,
-            feeLevels: feeLevels.levels,
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 
         // try to compose multiple transactions with different fee levels
         // check if any of composed transactions is valid
-        const hasFunds = composer.composeAllFeeLevels();
+        const composed = composer.composeAllFeeLevels(feeLevels.levels);
 
-        if (!hasFunds) {
+        if (!composed.levels.length) {
             const feePerUnit = String(coinInfo.minFee);
             const minFeeTx = composer.composeCustomFee(feePerUnit);
 
@@ -253,7 +251,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             // this view will be updated from discovery events
             context.sendCoreMessage(
                 createUiMessage(UI_REQUEST.SELECT_FEE, {
-                    feeLevels: composer.getFeeLevelList(),
+                    feeLevels: composed.levels,
                     coinInfo: this.params.coinInfo,
                 }),
             );
@@ -279,7 +277,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         const tx =
             resp.payload.type === 'select-fee-custom'
                 ? composer.composeCustomFee(resp.payload.value) // recompose custom fee level with requested value
-                : composer.composed[resp.payload.value]!;
+                : composed.transactions.get(resp.payload.value)!;
 
         const response = await this._sign(tx, context.sendCoreMessage);
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -2,7 +2,6 @@
 
 import {
     type BitcoinNetworkInfo,
-    type ComposeResult,
     type ComposeResultFinal,
     DEFAULT_SORTING_STRATEGY,
     type DiscoveryAccount,
@@ -285,7 +284,11 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         const tx =
             resp.payload.type === 'select-fee-custom'
                 ? compose(resp.payload.value) // recompose custom fee level with requested value
-                : composed.transactions.get(resp.payload.value)!;
+                : composed.transactions.get(resp.payload.value);
+
+        if (tx?.type !== 'final') {
+            throw ERRORS.TypedError('Runtime', 'ComposeTransaction: Trying to sign unfinished tx');
+        }
 
         const response = await this._sign(tx, context.sendCoreMessage);
 
@@ -455,12 +458,9 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         return { account, utxo };
     }
 
-    private async _sign(tx: ComposeResult, sendCoreMessage: MethodContext['sendCoreMessage']) {
+    private async _sign(tx: ComposeResultFinal, sendCoreMessage: MethodContext['sendCoreMessage']) {
         const device = this.getDevice();
         const { params } = this;
-
-        if (tx.type !== 'final')
-            throw ERRORS.TypedError('Runtime', 'ComposeTransaction: Trying to sign unfinished tx');
 
         const { coinInfo } = params;
 

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -227,24 +227,37 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         // try to compose multiple transactions with different fee levels
         // check if any of composed transactions is valid
         const hasFunds = composer.composeAllFeeLevels();
+
         if (!hasFunds) {
-            // show error view
-            context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
-            // wait few seconds...
-            await resolveAfter(2000);
+            const feePerUnit = String(coinInfo.minFee);
+            const minFeeTx = composer.composeCustomFee(feePerUnit);
 
-            // and go back to discovery
-            return this.interactiveFlow(context);
+            if (minFeeTx.type === 'final') {
+                context.sendCoreMessage(
+                    createUiMessage(UI_REQUEST.SELECT_FEE, {
+                        feeLevels: [{ label: 'custom', blocks: -1, feePerUnit }],
+                        coinInfo: this.params.coinInfo,
+                    }),
+                );
+            } else {
+                // show error view
+                context.sendCoreMessage(createUiMessage(UI_REQUEST.INSUFFICIENT_FUNDS));
+                // wait few seconds...
+                await resolveAfter(2000);
+
+                // and go back to discovery
+                return this.interactiveFlow(context);
+            }
+        } else {
+            // set select account view
+            // this view will be updated from discovery events
+            context.sendCoreMessage(
+                createUiMessage(UI_REQUEST.SELECT_FEE, {
+                    feeLevels: composer.getFeeLevelList(),
+                    coinInfo: this.params.coinInfo,
+                }),
+            );
         }
-
-        // set select account view
-        // this view will be updated from discovery events
-        context.sendCoreMessage(
-            createUiMessage(UI_REQUEST.SELECT_FEE, {
-                feeLevels: composer.getFeeLevelList(),
-                coinInfo: this.params.coinInfo,
-            }),
-        );
 
         // wait for fee selection
         const resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice())

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -256,16 +256,6 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         while (resp.payload.type === 'compose-custom') {
             // recompose custom fee level with requested value
             composer.composeCustomFee(resp.payload.value);
-            context.sendCoreMessage(
-                createUiMessage(
-                    UI_REQUEST.UPDATE_CUSTOM_FEE,
-                    {
-                        feeLevels: composer.getFeeLevelList(),
-                        coinInfo: this.params.coinInfo,
-                    },
-                    { requestId: resp.requestId },
-                ),
-            );
 
             // wait for user action
             resp = await context.createUiPromise(UI_RESPONSE.RECEIVE_FEE, this.getDevice()).promise;

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -3,9 +3,11 @@
 import {
     type BitcoinNetworkInfo,
     type ComposeResult,
+    type ComposeResultFinal,
     DEFAULT_SORTING_STRATEGY,
     type DiscoveryAccount,
     ERRORS,
+    type FeeLevel,
     type PermissionRequest,
     type PrecomposeParams,
     type PrecomposedResult,
@@ -222,9 +224,19 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             sortingStrategy: sortingStrategy ?? DEFAULT_SORTING_STRATEGY,
         });
 
+        const levels: FeeLevel[] = [];
+        const transactions = new Map<FeeLevel['label'], ComposeResultFinal>();
+        const composed = { levels, transactions };
+
         // try to compose multiple transactions with different fee levels
         // check if any of composed transactions is valid
-        const composed = composer.composeAllFeeLevels(feeLevels.levels);
+        for (const level of feeLevels.levels) {
+            if (level.feePerUnit === '0') continue;
+            const tx = composer.composeCustomFee(level.feePerUnit);
+            if (tx.type !== 'final') continue;
+            composed.levels.push(level);
+            composed.transactions.set(level.label, tx);
+        }
 
         if (!composed.levels.length) {
             const feePerUnit = String(coinInfo.minFee);

--- a/packages/connect/src/api/composeTransaction.ts
+++ b/packages/connect/src/api/composeTransaction.ts
@@ -175,11 +175,7 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
         });
 
         const levels = feeLevels.map(level => {
-            composer.composeCustomFee(level.feePerUnit);
-            const { composed } = composer;
-            // @ts-expect-error: noUncheckedIndexedAccess
-            const composedCustom: ComposeResult = composed['custom'];
-            const tx = { ...composedCustom }; // needs to spread otherwise flow has a problem with ComposeResult vs PrecomposedTransaction (max could be undefined)
+            const tx = composer.composeCustomFee(level.feePerUnit);
             if (tx.type === 'final') {
                 return {
                     ...tx,
@@ -267,18 +263,10 @@ export default class ComposeTransaction extends AbstractMethod<'composeTransacti
             return this.interactiveFlow(context);
         }
 
-        let composedKey;
-        if (resp.payload.type === 'select-fee-custom') {
-            // recompose custom fee level with requested value
-            composer.composeCustomFee(resp.payload.value);
-            composedKey = 'custom' as const;
-        } else {
-            composedKey = resp.payload.value;
-        }
-
-        const { composed } = composer;
-        // @ts-expect-error: noUncheckedIndexedAccess
-        const tx: ComposeResult = composed[composedKey];
+        const tx =
+            resp.payload.type === 'select-fee-custom'
+                ? composer.composeCustomFee(resp.payload.value) // recompose custom fee level with requested value
+                : composer.composed[resp.payload.value]!;
 
         const response = await this._sign(tx, context.sendCoreMessage);
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -130,9 +130,10 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
     const onSend = handleSubmit(data => {
         const { selectedFee, feePerUnit } = data;
         if (selectedFee === 'custom') {
-            dispatch(onReceiveFee({ type: 'compose-custom', value: feePerUnit }));
+            dispatch(onReceiveFee({ type: 'select-fee-custom', value: feePerUnit }));
+        } else {
+            dispatch(onReceiveFee({ type: 'select-fee', value: selectedFee ?? 'normal' }));
         }
-        dispatch(onReceiveFee({ type: 'send', value: selectedFee ?? 'normal' }));
     });
     const onChangeAccount = () => {
         dispatch(onReceiveFee({ type: 'change-account' }));

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -85,14 +85,7 @@ const getSelectFeeData = ({ coinInfo, feeLevels }: UiRequestSelectFee['payload']
     };
     const feeInfo = {
         levels: feeLevels
-            .filter(level => level.fee != '0')
-            .filter(level => level.name !== 'low') // this option is hidden in Suite
-            .map(level => ({
-                // level.name is just a string instead of enum
-                label: level.name as any,
-                feePerUnit: level.feePerByte!,
-                blocks: level.blocks!,
-            }))
+            .filter(({ label }) => label !== 'low') // this option is hidden in Suite
             .sort(sortLevels),
 
         minFee,

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -75,20 +75,16 @@ interface SelectAccountModalProps {
     data: UiRequestSelectFee['payload'];
 }
 
-export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
-    const dispatch = useDispatch();
-    const popupCall = useSelector(selectConnectPopupCall);
-
-    const fees = useMemo(() => data?.feeLevels ?? [], [data]);
-    const minFee = data.coinInfo.minFeeSatoshiKb / 1000;
-    const maxFee = data.coinInfo.maxFeeSatoshiKb / 1000;
+const getSelectFeeData = ({ coinInfo, feeLevels }: UiRequestSelectFee['payload']) => {
+    const minFee = coinInfo.minFeeSatoshiKb / 1000;
+    const maxFee = coinInfo.maxFeeSatoshiKb / 1000;
     const account = {
         networkType: 'bitcoin' as const,
-        symbol: data.coinInfo.shortcut.toLowerCase() as NetworkSymbol,
+        symbol: coinInfo.shortcut.toLowerCase() as NetworkSymbol,
         tokens: [],
     };
     const feeInfo = {
-        levels: fees
+        levels: feeLevels
             .filter(level => level.fee != '0')
             .filter(level => level.name !== 'low') // this option is hidden in Suite
             .map(level => ({
@@ -103,8 +99,17 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
         maxFee,
         minPriorityFee: -1,
         blockHeight: 0,
-        blockTime: data.coinInfo.blockTime,
+        blockTime: coinInfo.blockTime,
     };
+
+    return { account, feeInfo };
+};
+
+export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
+    const dispatch = useDispatch();
+    const popupCall = useSelector(selectConnectPopupCall);
+
+    const { account, feeInfo } = useMemo(() => getSelectFeeData(data), [data]);
 
     const methods = useForm<FormState>({
         defaultValues: {
@@ -125,26 +130,12 @@ export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
     const onSend = handleSubmit(data => {
         const { selectedFee, feePerUnit } = data;
         if (selectedFee === 'custom') {
-            dispatch(
-                onReceiveFee({
-                    type: 'compose-custom',
-                    value: feePerUnit,
-                }),
-            );
+            dispatch(onReceiveFee({ type: 'compose-custom', value: feePerUnit }));
         }
-        dispatch(
-            onReceiveFee({
-                type: 'send',
-                value: selectedFee || 'normal',
-            }),
-        );
+        dispatch(onReceiveFee({ type: 'send', value: selectedFee ?? 'normal' }));
     });
     const onChangeAccount = () => {
-        dispatch(
-            onReceiveFee({
-                type: 'change-account',
-            }),
-        );
+        dispatch(onReceiveFee({ type: 'change-account' }));
     };
     const onClose = () => {
         dispatch(onReceiveFee(null));


### PR DESCRIPTION
## Description

Continuation of #30453 and another prerequisite for #30253.

The main goal (apart from simplification) is to remove from `TransactionComposer` everything which will be needed only in future `sendTransaction` method and not in `composeTransaction`, therefore only pure composing will stay.

## Commits

- a bit improved memoization/code polishing in `SelectFeeModal`
- `UPDATE_CUSTOM_FEE` event removed as it was emitted but never listened to
- loop regarding custom fee tx composition removed from `composeTransaction` as it wasn't in fact loop
  - from `SelectFeeModal`, `send` was always responded right after `compose-custom`
  - refactored to two possible final outcomes `select-fee`/`select-fee-custom`
- remove `SelectFeeLevel` type in favor of existing `FeeLevel`
  - return only valid fee levels (tx type is final) from `TransactionComposer`
  - remove filtering and transformation from `SelectFeeModal`
- remove finding largest possible custom fee from `TransactionComposer`
  - directly try `minFee` instead, to find out whether composing is possible at all
- return composed tx from `composeCustomFee`
  - instead of having to get it from `composed` later
- extract custom fee logic from `TransactionComposer` to `composeTransaction` directly
- remove composed fee levels and txs from `TransactionComposer`
  - pass requested fee levels to `composeAllFeeLevels` call instead of constructor
  - return composed levels and txs from `composeAllFeeLevels` instead of accessing them on `TransactionComposer`
- check that at least one utxo is usable in `compose` call instead `of composeAllFeeLevels`
- extract fee level composition from `TransactionComposer` into `composeTransaction`
- make `TransactionComposer` higher-order fn instead of class
- move transaction finality check from `_sign` method in order to catch a bug when unknown/non-composed fee level is selected

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies Bitcoin transaction composition (TransactionComposer.ts, composeTransaction.ts), shared connect UI event types (ui-request.ts, ui-response.ts), fee types (fees.ts), and the Suite fee selection modal (SelectFeeModal.tsx). The highest-risk regressions are in UTXO-based send flows and fee display on device prompts. Run the six statically mapped Bitcoin-family send/trading tests as high priority, plus a small set of ETH fee UI and disconnected-device send tests as medium priority.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-common/src/events/ui-request.ts`
- `packages/connect-common/src/events/ui-response.ts`
- `packages/connect-common/src/types/fees.ts`
- `packages/connect/src/api/bitcoin/TransactionComposer.ts`
- `packages/connect/src/api/composeTransaction.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test confirms a BTC sell trade and initiates the send flow, requiring composeTransaction/TransactionComposer to build the Bitcoin transaction. It verifies device prompt amounts and fees, which would regress if fee or transaction composition logic changed.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Tests the BTC sell form with custom fee rates and percentage/Max buttons that depend on fee calculation and transaction composition. The custom fee path directly exercises TransactionComposer and composeTransaction.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Performs a BTC-to-ETH swap with custom transaction fees and verifies fee rate, total amount, and device display. This directly depends on Bitcoin transaction composition and the fee selection modal.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Sends Dogecoin and verifies device prompt amounts and fees. Dogecoin uses the Bitcoin transaction composition path, so changes to TransactionComposer/composeTransaction directly affect this test.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends Litecoin (a Bitcoin-like network) spending a MimbleWimble peg-out output. This directly exercises the Bitcoin-family transaction composition path end-to-end.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Sends Bitcoin regtest transactions with locktime, OP_RETURN, and satoshi unit switching. This is a direct end-to-end test of Bitcoin transaction composition and output handling.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum gas fee settings in the swap flow. While Ethereum uses different composition logic, the fee selection UI and shared fee types from connect-common are relevant infrastructure.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Tests custom Ethereum gas fees in the send flow. This exercises the fee selection modal and fee display components, which share the changed SelectFeeModal and fees.ts types.
- `suite/e2e/tests/wallet/without-device.test.ts` — Verifies the send form review behavior when the device is disconnected. The review path initiates transaction composition and connect UI request/response events, so changes to these layers could affect the connection modal timing.

</details>

_Updated: 2026-08-04T08:51:22.007Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/select-fee-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/select-fee-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-fee-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-fee-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/select-fee-modal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:50:16.194Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:50:20.624Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->