### PR TITLE
feat(suite-desktop): min-amount improvements deposit weth page

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx
@@ -5,6 +5,8 @@ type YieldActionStepWarningProps = {
     isInsufficientFunds?: boolean;
     isApprovalInsufficient?: boolean;
     isApproveOverBalance?: boolean;
+    /** Non-blocking recommendation to keep a native-coin reserve aside for the follow-up fees. */
+    reserveRecommendation?: { amount: string; nativeSymbol: string };
     onModifyApproval?: () => void;
 };
 
@@ -12,8 +14,28 @@ export const YieldActionStepWarning = ({
     isInsufficientFunds = false,
     isApprovalInsufficient = false,
     isApproveOverBalance = false,
+    reserveRecommendation,
     onModifyApproval,
 }: YieldActionStepWarningProps) => {
+    if (reserveRecommendation) {
+        return (
+            <Banner
+                intent="info"
+                description={
+                    <Text>
+                        <Translation
+                            id="TR_EARN_YIELD_WRAP_RESERVE_RECOMMENDED"
+                            values={{
+                                amount: reserveRecommendation.amount,
+                                nativeSymbol: reserveRecommendation.nativeSymbol,
+                            }}
+                        />
+                    </Text>
+                }
+            />
+        );
+    }
+
     if (isApproveOverBalance) {
         return (
             <Banner

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -50,7 +50,7 @@ export const YieldWrapStep = ({
             decimals={token.decimals}
             isDisabled={!!pendingTransaction}
             heading={{
-                amountLabelTranslationId: 'TR_EARN_YIELD_WRAP_AMOUNT',
+                amountLabelTranslationId: 'TR_BALANCE',
             }}
             summary={{
                 labelTranslationId: 'TR_EARN_YIELD_AVAILABLE_TO_WRAP',

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -3,7 +3,12 @@ import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
+import {
+    getYieldFlowStepSequence,
+    shouldRecommendWrapReserve,
+    splitYieldPendingTransaction,
+} from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
@@ -71,6 +76,36 @@ export const YieldDepositForm = () => {
         flowType: 'deposit',
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
+
+    // Wrapping into the gas reserve is allowed (Max keeps it aside, but a manual entry may not),
+    // so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the full
+    // balance now, and `shouldRecommendWrapReserve` already excludes that over-balance case.
+    // Wrapping into the gas reserve is allowed (Max fills the full balance), so recommend keeping
+    // it rather than blocking. `isAmountTooHigh` only fires above the full balance, and
+    // `shouldRecommendWrapReserve` already excludes that over-balance case.
+    const showWrapReserveRecommendation =
+        flow.currentStep === 'wrap' &&
+        !isAmountInvalidDecimals &&
+        shouldRecommendWrapReserve(liveAmount, account.formattedBalance);
+
+    const renderWrapWarning = () => {
+        if (!isAmountInvalidDecimals && isAmountTooHigh) {
+            return <YieldActionStepWarning isInsufficientFunds />;
+        }
+
+        if (showWrapReserveRecommendation) {
+            return (
+                <YieldActionStepWarning
+                    reserveRecommendation={{
+                        amount: WETH_WRAP_GAS_RESERVE.toString(),
+                        nativeSymbol,
+                    }}
+                />
+            );
+        }
+
+        return null;
+    };
 
     const handleOnApprovalSubmit = () => {
         analytics.report({
@@ -241,7 +276,7 @@ export const YieldDepositForm = () => {
                                     <YieldWrapStep
                                         token={token}
                                         nativeSymbol={nativeSymbol}
-                                        availableAmount={maxAmount}
+                                        availableAmount={account.formattedBalance}
                                         receivingAmount={liveAmount || '0'}
                                         isSubmitting={isSubmittingAction}
                                         isSubmitDisabled={
@@ -249,11 +284,7 @@ export const YieldDepositForm = () => {
                                             isAmountTooHigh ||
                                             isAmountInvalidDecimals
                                         }
-                                        warning={
-                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                                <YieldActionStepWarning isInsufficientFunds />
-                                            ) : undefined
-                                        }
+                                        warning={renderWrapWarning()}
                                         pendingTransaction={wrapPendingTransaction}
                                         onMaxClick={handleMaxClick}
                                         onSubmit={handleOnWrap}

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -172,6 +172,8 @@ export const useYieldFlow = ({
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
             if (session.step === 'wrap') {
+                // Max leaves the gas reserve aside; the field still shows the full balance and the
+                // user may wrap up to it (see `amountTooHighThreshold`), with a recommendation.
                 return getWrappableNativeBalance(account.formattedBalance);
             }
 
@@ -769,7 +771,15 @@ export const useYieldFlow = ({
         !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
-    const isAmountTooHigh = isAmountGreaterThan({ amount: liveAmount, threshold: maxAmount });
+    // On the wrap step the hard cap is the full native balance: `maxAmount` only holds the gas
+    // reserve aside for the Max button, and manually eating into it is a non-blocking
+    // recommendation rather than an "insufficient funds" error.
+    const amountTooHighThreshold =
+        flowType === 'deposit' && session.step === 'wrap' ? account.formattedBalance : maxAmount;
+    const isAmountTooHigh = isAmountGreaterThan({
+        amount: liveAmount,
+        threshold: amountTooHighThreshold,
+    });
     const isAmountInvalidDecimals = !!methods.formState.errors.amountInput;
     const isApprovalInsufficient =
         !session.approval.isModifyMode &&

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -7,10 +7,12 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowFormValues,
     getWrappableNativeBalance,
+    shouldRecommendWrapReserve,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
@@ -56,11 +58,14 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
         decimals: token.decimals,
     };
 
+    // Max leaves the gas reserve aside, but the field shows the full balance and the user may wrap
+    // up to it; eating into the reserve only triggers a non-blocking recommendation.
     const maxWrapAmount = getWrappableNativeBalance(account.formattedBalance);
 
     const amountInput = useWatch({ control: methods.control, name: 'amountInput' });
     const amount = new BigNumber(amountInput || '');
-    const isAmountTooHigh = amount.gt(maxWrapAmount);
+    const isAmountTooHigh = amount.gt(account.formattedBalance);
+    const isReserveRecommended = shouldRecommendWrapReserve(amountInput, account.formattedBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
     useEffect(() => {
@@ -109,6 +114,25 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
         );
     };
 
+    const renderWrapWarning = () => {
+        if (isAmountTooHigh) {
+            return <YieldActionStepWarning isInsufficientFunds />;
+        }
+
+        if (isReserveRecommended) {
+            return (
+                <YieldActionStepWarning
+                    reserveRecommendation={{
+                        amount: WETH_WRAP_GAS_RESERVE.toString(),
+                        nativeSymbol,
+                    }}
+                />
+            );
+        }
+
+        return null;
+    };
+
     const renderContent = () => {
         if (broadcast && pendingTxStatus === 'confirmed') {
             return (
@@ -145,15 +169,11 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                     <YieldWrapStep
                         token={token}
                         nativeSymbol={nativeSymbol}
-                        availableAmount={maxWrapAmount}
+                        availableAmount={account.formattedBalance}
                         shouldShowReceivingRow={false}
                         isSubmitting={wrapMutation.isPending}
                         isSubmitDisabled={!isAmountValid}
-                        warning={
-                            isAmountTooHigh ? (
-                                <YieldActionStepWarning isInsufficientFunds />
-                            ) : undefined
-                        }
+                        warning={renderWrapWarning()}
                         pendingTransaction={
                             broadcast
                                 ? { type: 'wrap', txid: broadcast.txid, amount: broadcast.amount }

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -18,6 +18,7 @@ import {
     getYieldWrapAmount,
     hasYieldVaultPosition,
     isYieldVaultOperational,
+    shouldRecommendWrapReserve,
     splitYieldPendingTransaction,
 } from './stablecoinYieldUtils';
 
@@ -408,6 +409,37 @@ describe('stablecoinYieldUtils', () => {
 
         it('treats an empty balance as zero', () => {
             expect(getWrappableNativeBalance('')).toBe('0');
+        });
+    });
+
+    describe('shouldRecommendWrapReserve', () => {
+        it('does not recommend when enough native coin is left for the reserve', () => {
+            expect(shouldRecommendWrapReserve('0.9', '1')).toBe(false);
+        });
+
+        it('recommends at exactly balance minus the reserve (the Max amount)', () => {
+            expect(shouldRecommendWrapReserve('0.995', '1')).toBe(true);
+        });
+
+        it('recommends when the amount eats into the reserve', () => {
+            expect(shouldRecommendWrapReserve('0.996', '1')).toBe(true);
+        });
+
+        it('recommends when wrapping the whole balance', () => {
+            expect(shouldRecommendWrapReserve('1', '1')).toBe(true);
+        });
+
+        it('does not recommend when the amount exceeds the balance (hard error case)', () => {
+            expect(shouldRecommendWrapReserve('1.5', '1')).toBe(false);
+        });
+
+        it('does not recommend for an empty or zero amount', () => {
+            expect(shouldRecommendWrapReserve('', '1')).toBe(false);
+            expect(shouldRecommendWrapReserve('0', '1')).toBe(false);
+        });
+
+        it('does not recommend for non-numeric input', () => {
+            expect(shouldRecommendWrapReserve('abc', '1')).toBe(false);
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -384,6 +384,29 @@ export const getWrappableNativeBalance = (nativeFormattedBalance: string): strin
     ).toString();
 
 /**
+ * Whether wrapping `amountInput` out of `nativeFormattedBalance` would leave at most
+ * `WETH_WRAP_GAS_RESERVE` behind — i.e. no safety margin above the reserve needed for the
+ * follow-up approve + deposit fees. Used to surface a non-blocking recommendation to keep a
+ * reserve; this also covers the "Max" amount, which leaves exactly the reserve.
+ *
+ * The amount is assumed to be within the balance; wrapping more than the whole balance is a
+ * hard "insufficient funds" error handled separately, so it does not count as a recommendation.
+ */
+export const shouldRecommendWrapReserve = (
+    amountInput: string,
+    nativeFormattedBalance: string,
+): boolean => {
+    const amount = new BigNumber(amountInput || '0');
+    const balance = new BigNumber(nativeFormattedBalance || '0');
+
+    if (!amount.isFinite() || !balance.isFinite()) {
+        return false;
+    }
+
+    return amount.gt(0) && amount.lte(balance) && balance.minus(amount).lte(WETH_WRAP_GAS_RESERVE);
+};
+
+/**
  * Balance available for a yield deposit. For a wrapped-native (WETH) vault the native balance can
  * be wrapped, so it counts in after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the follow-up
  * wrap + approve + deposit (+ exit) fees.

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10100,6 +10100,11 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_AVAILABLE_TO_WRAP',
         defaultMessage: 'Available to wrap',
     },
+    TR_EARN_YIELD_WRAP_RESERVE_RECOMMENDED: {
+        id: 'TR_EARN_YIELD_WRAP_RESERVE_RECOMMENDED',
+        defaultMessage:
+            "It's recommended to leave {amount} {nativeSymbol} so you can pay for withdrawal fees.",
+    },
     TR_EARN_YIELD_WRAP_RECEIVING: {
         id: 'TR_EARN_YIELD_WRAP_RECEIVING',
         defaultMessage: 'Receiving',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Displays full amount for deposit and shows alert about dust funds to pay for gas 

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30540

## Screenshots:



https://github.com/user-attachments/assets/3139fb4e-c12e-4845-8459-4e390e6d879b



<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/wrap-min-amount&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/wrap-min-amount&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wrap-min-amount&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T08:19:35.521Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T08:10:44.888Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/wrap-min-amount/web/](https://dev.suite.sldev.cz/suite-web/fix/wrap-min-amount/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly focused on the new stablecoin-yield UI and utility code, and there are no dedicated E2E tests for that flow in the candidate set. The most relevant E2E coverage is the general check-links smoke test, which loads the affected /earn/yield routes. Deeper functional validation should come from the included unit tests; the broad lists of staking, onboarding, and metadata tests should not be run unless there is concrete evidence they exercise these yield-specific components.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldActionStepWarning.tsx`
- `packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to the affected /earn/yield/* routes (/earn/yield/deposit, /earn/yield/wrap, etc.) and verifies that each page loads and its content is attached. Because the PR changes the earn/yield UI components and stablecoin-yield utilities rendered on those routes, this is the only E2E candidate likely to catch gross rendering or routing regressions in the changed area.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`

_Updated: 2026-08-03T08:24:10.553Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->