### PR TITLE
test(suite): fix thp pairing in test setups

### DIFF
--- a/suite/e2e/support/device.ts
+++ b/suite/e2e/support/device.ts
@@ -15,6 +15,9 @@ import {
     parseDisplayContent,
 } from './helpers/displayContentNormalizedParser';
 
+const THP_PAIRING_CODE_LENGTH = 6;
+const THP_PAIRING_CODE_REGEX = new RegExp(`(\\d\\s*){${THP_PAIRING_CODE_LENGTH}}$`);
+
 const EMULATOR_CENTER_COORDINATES: Record<Model, { x: number; y: number }> = {
     [Model.T3T1]: { x: 125, y: 150 },
     [Model.T3W1]: { x: 200, y: 480 },
@@ -117,15 +120,23 @@ export class DeviceFixture {
 
     @step()
     async getTHPPairingCode(): Promise<string[]> {
-        const screenContent = await TrezorUserEnvLink.getScreenContent();
-        const screenContentBody = screenContent.body as string;
+        let code: string[] = [];
 
-        return (
-            screenContentBody
-                .match(/(\d\s*){6}$/)?.[0]
-                .replace(/\s+/g, '')
-                .split('') ?? []
-        );
+        // the device renders the code only once it completes the THP handshake, which lags the host-side confirmation
+        await expect(async () => {
+            const screenContentBody = (await TrezorUserEnvLink.getScreenContent()).body as string;
+            const pairingCode = screenContentBody.match(THP_PAIRING_CODE_REGEX)?.[0];
+
+            if (!pairingCode) {
+                throw new Error(
+                    `expected a ${THP_PAIRING_CODE_LENGTH}-digit THP pairing code on the device display, got: ${screenContentBody}`,
+                );
+            }
+
+            code = pairingCode.replace(/\s+/g, '').split('');
+        }).toPass({ timeout: 10_000 });
+
+        return code;
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -115,6 +115,11 @@ export class OnboardingPage {
 
     @step()
     async enterTHPPairingCode() {
+        await expect(
+            this.thpPairingModal,
+            'expected THP pairing modal to be shown before entering the pairing code',
+        ).toBeVisible({ timeout: 10_000 });
+
         const code = await this.device.getTHPPairingCode();
 
         for (let i = 0; i < code.length; i++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
## test(e2e): fix T3W1 THP pairing race in onboarding

**Problem:** the two THP pairing assertion failures are the #1 and #2 errors in the
desktop e2e project — ~1,900/week across 111+ tests. T3W1 only. Started 2026-07-21.

**Cause:** `enterTHPPairingCode()` read the emulator screen right after `pressYes()`,
before the device rendered the code. `getTHPPairingCode()` then returned `?? []`
silently, the fill loop iterated zero times, and `toBeHidden()` — with no preceding
`toBeVisible()` — passed vacuously. Both error messages are the same bug; which one
fires is a coin flip on a ~30ms window.

**Fix:**
- gate on the pairing modal being visible before reading the device screen
- poll for the code and throw with the raw display content instead of returning `[]`

**Verified locally:** modal gate passes, code parsed, 6 fills, modal closes. A separate
pre-existing failure (`@device-acquire` stays visible after successful pairing)
reproduces on unmodified `develop` and is out of scope. A 30× CI run will confirm the
real rate.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-thp-pairing-in-tests/web/](https://dev.suite.sldev.cz/suite-web/fix-thp-pairing-in-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-thp-pairing-in-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-thp-pairing-in-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-01T11:00:44.879Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-01T11:01:10.091Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->