### PR TITLE
refactor(redux): support selective thunk dependencies

### DIFF
--- a/suite-common/redux-utils/src/createThunk.ts
+++ b/suite-common/redux-utils/src/createThunk.ts
@@ -1,4 +1,6 @@
 import {
+    type AsyncThunk,
+    type AsyncThunkConfig,
     type AsyncThunkOptions,
     type AsyncThunkPayloadCreator,
     createAsyncThunk as createAsyncThunkReduxToolkit,
@@ -6,13 +8,18 @@ import {
 
 import { type CustomThunkAPI } from './extraDependenciesType';
 
-export const createThunk = <TParams = void, TPayload = void, TThunkAPI = void>(
+type ResolveThunkAPI<TThunkAPI> = [TThunkAPI] extends [void]
+    ? CustomThunkAPI
+    : Omit<CustomThunkAPI, keyof TThunkAPI> & TThunkAPI;
+
+type CreateThunk = <
+    TReturned = void,
+    TThunkArg = void,
+    TThunkAPI extends AsyncThunkConfig | void = void,
+>(
     typePrefix: string,
-    thunk: AsyncThunkPayloadCreator<TParams, TPayload, TThunkAPI & CustomThunkAPI>,
-    options?: AsyncThunkOptions<TPayload, TThunkAPI & CustomThunkAPI>,
-) =>
-    createAsyncThunkReduxToolkit<TParams, TPayload, TThunkAPI & CustomThunkAPI>(
-        typePrefix,
-        thunk,
-        options,
-    );
+    thunk: AsyncThunkPayloadCreator<TReturned, TThunkArg, ResolveThunkAPI<TThunkAPI>>,
+    options?: AsyncThunkOptions<TThunkArg, ResolveThunkAPI<TThunkAPI>>,
+) => AsyncThunk<TReturned, TThunkArg, ResolveThunkAPI<TThunkAPI>>;
+
+export const createThunk: CreateThunk = createAsyncThunkReduxToolkit;

--- a/suite-common/redux-utils/src/createThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createThunk.type-test.ts
@@ -1,0 +1,40 @@
+import { createThunk } from './createThunk';
+
+type SelectedExtraDependencies = {
+    services: {
+        selectedDependency: () => void;
+    };
+};
+
+type SelectedState = {
+    selected: {
+        value: string;
+    };
+};
+
+type UnselectedState = {
+    unselected: {
+        value: string;
+    };
+};
+
+const selectSelectedValue = (state: SelectedState) => state.selected.value;
+const selectUnselectedValue = (state: UnselectedState) => state.unselected.value;
+
+createThunk<void, void, { state: SelectedState; extra: SelectedExtraDependencies }>(
+    'test/selectiveExtraDependencies',
+    (_, { extra, getState }) => {
+        const selectedValue: string = selectSelectedValue(getState());
+        extra.services.selectedDependency();
+
+        // @ts-expect-error The thunk only has access to its explicitly selected state.
+        const unselectedValue = selectUnselectedValue(getState());
+
+        // @ts-expect-error The thunk only has access to its explicitly selected dependencies.
+        const unselectedAnalytics = extra.services.analytics;
+
+        void selectedValue;
+        void unselectedValue;
+        void unselectedAnalytics;
+    },
+);

--- a/suite/backup/src/backupDeviceThunk.test.ts
+++ b/suite/backup/src/backupDeviceThunk.test.ts
@@ -1,27 +1,53 @@
-import { configureMockStore, testMocks } from '@suite-common/test-utils';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { backupDeviceThunk } from './backupDeviceThunk';
+import {
+    type BackupDeviceThunkDeps,
+    type BackupDeviceThunkState,
+    backupDeviceThunk,
+} from './backupDeviceThunk';
 import { backupActions } from './backupReducer';
 
-const defaultDeviceState = {
-    selectedDevice: {
+const selectedDevice = mockSuiteDevice(
+    {
         connected: true,
-        type: 'acquired' as const,
+        type: 'acquired',
         path: '1',
-        features: {
-            major_version: 2,
-            internal_model: DeviceModelInternal.T2T1,
-        },
     },
-    devices: [],
+    {
+        major_version: 2,
+        internal_model: DeviceModelInternal.T2T1,
+    },
+);
+
+const defaultState: BackupDeviceThunkState = {
+    device: {
+        devices: [],
+        persistentDeviceData: [],
+        selectedDevice,
+    },
 };
 
-const initStore = (deviceState = defaultDeviceState) =>
-    configureMockStore({
-        preloadedState: { device: deviceState },
-    });
+const createThunkDependencies = (
+    state: BackupDeviceThunkState,
+    analyticsReport?: DesktopAnalyticsDep['analytics']['report'],
+): {
+    dispatch: jest.Mock;
+    getState: jest.Mock<BackupDeviceThunkState, []>;
+    extra: BackupDeviceThunkDeps;
+} => ({
+    dispatch: jest.fn(),
+    getState: jest.fn(() => state),
+    extra: {
+        services: {
+            analytics: mockDesktopAnalytics(analyticsReport),
+        },
+    },
+});
 
 describe('Backup Thunks', () => {
     beforeAll(() => {
@@ -33,45 +59,50 @@ describe('Backup Thunks', () => {
 
     it('backup success', async () => {
         testMocks.setTrezorConnectFixtures({ success: true });
+        const report = jest.fn();
+        const { dispatch, getState, extra } = createThunkDependencies(defaultState, report);
 
-        const store = initStore();
+        await backupDeviceThunk({ params: {} })(dispatch, getState, extra);
 
-        await store.dispatch(backupDeviceThunk({ params: {} }));
-
-        const actions = store.getActions();
-        expect(actions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    type: backupActions.setInProgress.type,
-                    payload: true,
-                }),
-                expect.objectContaining({
-                    type: notificationsActions.addToast.type,
-                    payload: expect.objectContaining({ type: 'backup-success' }),
-                }),
-                expect.objectContaining({
-                    type: backupActions.setInProgress.type,
-                    payload: false,
-                }),
-            ]),
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: backupActions.setInProgress.type,
+                payload: true,
+            }),
         );
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: notificationsActions.addToast.type,
+                payload: expect.objectContaining({ type: 'backup-success' }),
+            }),
+        );
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: backupActions.setInProgress.type,
+                payload: false,
+            }),
+        );
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith({
+            type: events.createBackupEvent.name,
+            payload: {
+                status: 'finished',
+                error: '',
+            },
+        });
     });
 
     it('backup success with skipSuccessToast', async () => {
         testMocks.setTrezorConnectFixtures({ success: true });
+        const { dispatch, getState, extra } = createThunkDependencies(defaultState);
 
-        const store = initStore();
+        await backupDeviceThunk({ params: {}, skipSuccessToast: true })(dispatch, getState, extra);
 
-        await store.dispatch(backupDeviceThunk({ params: {}, skipSuccessToast: true }));
-
-        const actions = store.getActions();
-        expect(actions).not.toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    type: notificationsActions.addToast.type,
-                    payload: expect.objectContaining({ type: 'backup-success' }),
-                }),
-            ]),
+        expect(dispatch).not.toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: notificationsActions.addToast.type,
+                payload: expect.objectContaining({ type: 'backup-success' }),
+            }),
         );
     });
 
@@ -80,49 +111,48 @@ describe('Backup Thunks', () => {
             success: false,
             error: { message: 'avadakedavra' },
         });
+        const { dispatch, getState, extra } = createThunkDependencies(defaultState);
 
-        const store = initStore();
+        await backupDeviceThunk({ params: {} })(dispatch, getState, extra);
 
-        await store.dispatch(backupDeviceThunk({ params: {} }));
-
-        const actions = store.getActions();
-        expect(actions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    type: backupActions.setInProgress.type,
-                    payload: true,
-                }),
-                expect.objectContaining({
-                    type: notificationsActions.addToast.type,
-                    payload: expect.objectContaining({ type: 'backup-failed' }),
-                }),
-                expect.objectContaining({
-                    type: backupActions.setError.type,
-                    payload: 'avadakedavra',
-                }),
-            ]),
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: backupActions.setInProgress.type,
+                payload: true,
+            }),
+        );
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: notificationsActions.addToast.type,
+                payload: expect.objectContaining({ type: 'backup-failed' }),
+            }),
+        );
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: backupActions.setError.type,
+                payload: 'avadakedavra',
+            }),
         );
     });
 
     it('backup without device shows error toast', async () => {
-        const store = initStore({
-            selectedDevice: undefined as any,
-            devices: [],
+        const { dispatch, getState, extra } = createThunkDependencies({
+            device: {
+                ...defaultState.device,
+                selectedDevice: undefined,
+            },
         });
 
-        await store.dispatch(backupDeviceThunk({ params: {} }));
+        await backupDeviceThunk({ params: {} })(dispatch, getState, extra);
 
-        const actions = store.getActions();
-        expect(actions).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    type: notificationsActions.addToast.type,
-                    payload: expect.objectContaining({
-                        type: 'error',
-                        error: 'Device not connected',
-                    }),
+        expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: notificationsActions.addToast.type,
+                payload: expect.objectContaining({
+                    type: 'error',
+                    error: 'Device not connected',
                 }),
-            ]),
+            }),
         );
     });
 });

--- a/suite/backup/src/backupDeviceThunk.ts
+++ b/suite/backup/src/backupDeviceThunk.ts
@@ -1,5 +1,5 @@
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { selectSelectedDevice } from '@suite-common/device';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import TrezorConnect from '@trezor/connect';
@@ -7,18 +7,24 @@ import TrezorConnect from '@trezor/connect';
 import { actionPrefix, backupActions } from './backupReducer';
 import type { BackupDeviceParams } from './types';
 
-export const backupDeviceThunk = createThunk(
+type BackupDeviceThunkParams = {
+    params?: BackupDeviceParams;
+    skipSuccessToast?: boolean;
+};
+
+export type BackupDeviceThunkDeps = {
+    services: DesktopAnalyticsDep;
+};
+
+export type BackupDeviceThunkState = DeviceRootState;
+
+export const backupDeviceThunk = createThunk<
+    void,
+    BackupDeviceThunkParams,
+    { state: BackupDeviceThunkState; extra: BackupDeviceThunkDeps }
+>(
     `${actionPrefix}/backupDeviceThunk`,
-    async (
-        {
-            params = {},
-            skipSuccessToast,
-        }: {
-            params?: BackupDeviceParams;
-            skipSuccessToast?: boolean;
-        },
-        { dispatch, getState, extra },
-    ) => {
+    async ({ params = {}, skipSuccessToast }, { dispatch, getState, extra }) => {
         const device = selectSelectedDevice(getState());
         if (!device) {
             dispatch(
@@ -46,7 +52,7 @@ export const backupDeviceThunk = createThunk(
 
             dispatch(notificationsActions.addToast({ type: 'backup-failed' }));
             dispatch(backupActions.setError(result.error.message));
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.createBackupEvent.name,
                 payload: {
                     status: 'error',
@@ -58,7 +64,7 @@ export const backupDeviceThunk = createThunk(
                 dispatch(notificationsActions.addToast({ type: 'backup-success' }));
             }
             dispatch(backupActions.setInProgress(false));
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.createBackupEvent.name,
                 payload: {
                     status: 'finished',


### PR DESCRIPTION
## Description

RTK thunks created through createThunk always inherited the complete CustomThunkAPI, because custom config was intersected with the defaults. Explicit state and extra fields now override their defaults, while omitted fields retain the existing API.\n\nbackupDeviceThunk demonstrates the pattern with DeviceRootState and BackupDeviceThunkDeps. Its test now invokes the thunk with only the required analytics service; the affected type-check validates backward compatibility across about 120 existing createThunk call sites.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set centers on the backup device thunk and the shared createThunk utility. While createThunk is a broad dependency, the concrete risk is to backup flows, so the highest-value tests are the four backup-specific E2E specs. Onboarding wallet-creation tests provide medium-value regression coverage because they invoke backup during the create-wallet flow. The changed type-test and unit-test files are test artifacts and do not need E2E coverage.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/redux-utils/src/createThunk.ts`
- `suite-common/redux-utils/src/createThunk.type-test.ts`
- `suite/backup/src/backupDeviceThunk.test.ts`
- `suite/backup/src/backupDeviceThunk.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — Directly exercises the backup failure path (disconnect mid-backup, failed backup state) implemented by backupDeviceThunk.ts. A regression in the backup thunk would be immediately visible here.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Tests backup modal state and the no-device backup path, both of which depend on the backup thunk orchestrating the flow correctly.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — Covers the happy-path backup flow including pre/post-backup checkboxes and analytics createBackupEvent, which is produced by the backup thunk.
- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — Validates multi-share/Shamir backup creation from device settings, a flow driven by the backup thunk and sensitive to thunk lifecycle changes.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — Onboarding wallet creation for T1B1 includes a full seed backup phase; this indirectly exercises backup thunk integration within the onboarding flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — Creates a wallet with Shamir backup during onboarding, so backup thunk changes could affect the backup step or its completion.
- `suite/e2e/tests/onboarding/t3b1/t3b1-create-wallet.test.ts` — Onboarding with Shamir backup on T3B1 relies on the same backup thunk machinery as the standalone backup tests.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — T3T1 onboarding wallet creation includes Shamir backup; useful for detecting backup thunk regressions on this device model.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Covers wallet creation with selectable Shamir/single-share backup types, exercising backup thunk behavior during onboarding for T3W1.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/redux-utils/src/createThunk.type-test.ts`
- `suite/backup/src/backupDeviceThunk.test.ts`

_Updated: 2026-08-04T14:39:26.779Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/selective-rtk-thunk-dependencies/web/](https://dev.suite.sldev.cz/suite-web/selective-rtk-thunk-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=selective-rtk-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=selective-rtk-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=selective-rtk-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:41:05.097Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:41:17.099Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->