### PR TITLE
[CI] Track Cardano staking completions, failures, and vote-change modal steps (#30555)

### DIFF
--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,6 +1,8 @@
+import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { closeModal, openDeferredModal, openModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -87,7 +89,8 @@ export const cancelSignTx =
 
 // private, called from signTransaction only
 const pushTransaction =
-    (stakeType: StakeType) => async (dispatch: Dispatch, getState: GetState) => {
+    (stakeType: StakeType) =>
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { serializedTx, precomposedTx } = getState().wallet.stake;
         const { account } = getState().wallet.selectedAccount;
         const device = selectSelectedDevice(getState());
@@ -192,6 +195,11 @@ const pushTransaction =
                         cardanoSpecific,
                     }),
                 );
+
+                asTypedDesktopAnalytics(extra.services.analytics).report({
+                    type: events.stakingConfirmEvent.name,
+                    payload: { action: stakeType, networkSymbol: account.symbol },
+                });
             }
 
             // notification from the backend may be delayed.
@@ -208,6 +216,11 @@ const pushTransaction =
                     error: sentTx.error.message,
                 }),
             );
+
+            asTypedDesktopAnalytics(extra.services.analytics).report({
+                type: events.stakingConfirmEvent.name,
+                payload: { action: stakeType, networkSymbol: account.symbol, success: false },
+            });
         }
 
         dispatch(cancelSignTx(sentTx.success, account));

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { FormProvider } from 'react-hook-form';
 
+import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { CARDANO_EVERSTAKE_DREP } from '@suite-common/wallet-constants';
 import {
     DEFAULT_VOTING_OPTION,
@@ -34,6 +36,7 @@ export const StakeChangeDelegateModalLoaded = ({
     selectedAccount,
 }: StakeChangeDelegateModalProps) => {
     const dispatch = useDispatch();
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const { account } = selectedAccount;
@@ -63,6 +66,30 @@ export const StakeChangeDelegateModalLoaded = ({
         dispatch(stakeActions.setVotingDelegationOption(DEFAULT_VOTING_OPTION));
 
         onCancel?.();
+
+        analytics.report({
+            type: events.stakingChangeDelegateEvent.name,
+            payload: {
+                action: 'cancel',
+                step: 'change-delegate-form-modal',
+                networkSymbol: account.symbol,
+            },
+        });
+    };
+
+    const handleContinue = () => {
+        handleSubmit(() => {
+            analytics.report({
+                type: events.stakingChangeDelegateEvent.name,
+                payload: {
+                    action: 'continue',
+                    step: 'change-delegate-form-modal',
+                    networkSymbol: account.symbol,
+                },
+            });
+
+            signTx();
+        })();
     };
 
     const { isDisabled: isSelectionInvalid, errorType } = useMemo(() => {
@@ -114,10 +141,7 @@ export const StakeChangeDelegateModalLoaded = ({
                     onCancel={handleCancel}
                     bottomContent={
                         <Tooltip content={tooltipContent}>
-                            <Modal.Button
-                                isDisabled={isDisabled}
-                                onClick={() => handleSubmit(signTx)()}
-                            >
+                            <Modal.Button isDisabled={isDisabled} onClick={handleContinue}>
                                 <Translation id="TR_CONTINUE" />
                             </Modal.Button>
                         </Tooltip>

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -19,6 +19,7 @@ export type EarnYieldContext = {
 export type EarnModalAction = 'continue' | 'cancel' | 'close';
 
 export type EarnAnalyticsStep =
+    | 'change-delegate-form-modal'
     | 'claim-form-modal'
     | 'earn-dashboard'
     | 'entry-period-stake-modal'

--- a/suite/analytics/src/events/stakingChangeDelegateEvent.ts
+++ b/suite/analytics/src/events/stakingChangeDelegateEvent.ts
@@ -5,7 +5,9 @@ import { EventType } from '../constants';
 
 type Attributes = {
     action: AttributeDef<EarnModalAction>;
-    step: AttributeDef<Extract<EarnAnalyticsStep, 'staking-dashboard'>>;
+    step: AttributeDef<
+        Extract<EarnAnalyticsStep, 'staking-dashboard' | 'change-delegate-form-modal'>
+    >;
     networkSymbol?: AttributeDef<string>;
     currency?: AttributeDef<'crypto' | 'fiat'>;
 };
@@ -29,9 +31,15 @@ export const stakingChangeDelegateEvent: EventDef<Attributes, EventType.StakingC
                 'The action taken by the user: `continue` to proceed with changing delegate, `cancel` to abort the process, `close` to dismiss the modal',
         },
         step: {
-            changelog: [{ version: '25.4.0', notes: 'added' }],
+            changelog: [
+                { version: '25.4.0', notes: 'added' },
+                {
+                    version: '26.8.0',
+                    notes: 'added `change-delegate-form-modal` value for the change delegate/vote form modal',
+                },
+            ],
             description:
-                'The current step in the change delegate flow: `staking-dashboard` when initiated from the staking dashboard',
+                'The current step in the change delegate flow: `staking-dashboard` when initiated from the staking dashboard, `change-delegate-form-modal` when in the change delegate form',
         },
         networkSymbol: {
             changelog: [{ version: '25.4.0', notes: 'added' }],

--- a/suite/analytics/src/events/stakingConfirmEvent.ts
+++ b/suite/analytics/src/events/stakingConfirmEvent.ts
@@ -5,6 +5,7 @@ import { EventType } from '../constants';
 type Attributes = {
     action: AttributeDef<'stake' | 'unstake' | 'claim' | 'change-delegate' | 'withdraw'>;
     networkSymbol?: AttributeDef<string>;
+    success?: AttributeDef<boolean>;
 };
 
 export const stakingConfirmEvent: EventDef<Attributes, EventType.StakingConfirm> = {
@@ -24,6 +25,11 @@ export const stakingConfirmEvent: EventDef<Attributes, EventType.StakingConfirm>
         },
         networkSymbol: {
             changelog: [{ version: '25.12.0', notes: 'added' }],
+        },
+        success: {
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+            description:
+                'Set to `false` when the signed staking transaction fails to broadcast to the blockchain; absent otherwise',
         },
     },
 };


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI run for external PR #30555 (CI does not run for external contributors). This PR will be closed once CI finishes; review happens on #30555.

## Description

CI mirror of #30555 by @myasiura-stack, rebased onto develop, including review fixups.

## Notes for QA

No QA needed — CI-only PR, closed after the checks finish.

## Related Issue

#30555

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-30555&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-30555&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pr-30555&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-30555/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-30555/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T15:09:38.068Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T15:08:57.212Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is narrowly focused on Cardano/ADA staking delegation changes (StakeChangeDelegateModal, stakeActions, staking types, and two staking analytics events). The highest-confidence coverage comes from the ADA staking tests, which directly exercise delegation and stake-key flows. Analytics and generic ETH/SOL staking tests provide medium confidence that shared confirmation/action plumbing is not broken. The new analytics events for delegate change and confirmation have no direct E2E test coverage.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/wallet/stakeActions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `suite-common/suite-types/src/staking.ts`
- `suite/analytics/src/events/stakingChangeDelegateEvent.ts`
- `suite/analytics/src/events/stakingConfirmEvent.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests Cardano reward claiming, which is part of the ADA staking lifecycle that the delegate-change modal and stakeActions support. A regression in delegation state or staking actions would be visible here.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Directly exercises ADA stake delegation and vote delegation on the device, the functional area most likely to use the StakeChangeDelegateModal and stakingChangeDelegateEvent analytics. This is the closest end-to-end coverage for the changed delegate flow.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates ADA stake key deregistration and depends on the same staking actions/types as the changed files. Issues in staking state management would likely surface during unstaking.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — Covers staking analytics event infrastructure. While it currently tests StakingNavigate, changes to staking analytics events (stakingChangeDelegateEvent, stakingConfirmEvent) share the same instrumentation layer and could affect event dispatching.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the generic staking confirmation flow where stakingConfirmEvent and stakeActions are used. A regression in shared staking confirmation logic could affect ETH staking success toasts and progress updates.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Validates Solana staking confirmation and progress tracking, which relies on the same staking actions and confirmation event plumbing as the changed code.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite/analytics/src/events/stakingChangeDelegateEvent.ts`
- `suite/analytics/src/events/stakingConfirmEvent.ts`

_Updated: 2026-08-02T15:07:52.387Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->