### PR TITLE
[CI] Respect message-system claim flag on Cardano StakingCard (#30473)

### DIFF
--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -110,8 +110,10 @@ export const StakingCard = ({
     const {
         isStakingDisabled,
         isUnstakingDisabled,
+        isClaimingDisabled,
         stakingMessageContent,
         unstakingMessageContent,
+        claimingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
     const {
@@ -185,7 +187,7 @@ export const StakingCard = ({
     };
 
     const openClaimModal = () => {
-        if (canClaimRewards) {
+        if (canClaimRewards && !isClaimingDisabled) {
             dispatch(openModal({ type: 'claim', account }));
 
             analytics.report({
@@ -392,14 +394,17 @@ export const StakingCard = ({
                             </Button>
                         </Tooltip>
                     ) : (
-                        <Button
-                            onClick={openClaimModal}
-                            isDisabled={!canClaimRewards}
-                            intent="brand"
-                            data-testid="@account/staking/claim-rewards-button"
-                        >
-                            <Translation id="TR_EARN_CLAIM_REWARDS" />
-                        </Button>
+                        <Tooltip content={claimingMessageContent}>
+                            <Button
+                                onClick={openClaimModal}
+                                isDisabled={!canClaimRewards || isClaimingDisabled}
+                                iconLeft={isClaimingDisabled ? InfoIcon : undefined}
+                                intent="brand"
+                                data-testid="@account/staking/claim-rewards-button"
+                            >
+                                <Translation id="TR_EARN_CLAIM_REWARDS" />
+                            </Button>
+                        </Tooltip>
                     )}
                     <Tooltip content={unstakingMessageContent}>
                         <Button


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI run for external PR #30473 (CI does not run for external contributors). This PR will be closed once CI finishes; review happens on #30473.

## Description

CI mirror of #30473 by @myasiura-stack, rebased onto develop, including review fixups.

## Notes for QA

No QA needed — CI-only PR, closed after the checks finish.

## Related Issue

#30473

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-30473/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-30473/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-30473&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-30473&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:07:26.616Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:06:48.030Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->