### PR TITLE
[CI] Add message-system kill switch for Cardano change-delegate action (#30269)

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx
@@ -16,6 +16,7 @@ import { Card, Column, Modal, Tooltip } from '@trezor/components';
 import { VotingDelegationsOptions } from 'src/components/earn';
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 import {
     ChangeDelegateFormContext,
     useChangeDelegateForm,
@@ -36,6 +37,8 @@ export const StakeChangeDelegateModalLoaded = ({
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const { account } = selectedAccount;
+
+    const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
     const changeDelegateContextValues = useChangeDelegateForm({ selectedAccount });
 
@@ -62,7 +65,7 @@ export const StakeChangeDelegateModalLoaded = ({
         onCancel?.();
     };
 
-    const { isDisabled, errorType } = useMemo(() => {
+    const { isDisabled: isSelectionInvalid, errorType } = useMemo(() => {
         switch (selectedVotingDelegation.type) {
             case 'everstake': {
                 if (isEverstake) {
@@ -89,6 +92,20 @@ export const StakeChangeDelegateModalLoaded = ({
         return { isDisabled: false };
     }, [selectedVotingDelegation, currentDrepId, isEverstake]);
 
+    const isDisabled = isSelectionInvalid || isVotingDisabled;
+
+    const tooltipContent = useMemo(() => {
+        if (isVotingDisabled) {
+            return votingMessageContent;
+        }
+
+        if (isSelectionInvalid && errorType === 'current_delegate') {
+            return <Translation id="TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP" />;
+        }
+
+        return undefined;
+    }, [isVotingDisabled, votingMessageContent, isSelectionInvalid, errorType]);
+
     return (
         <ChangeDelegateFormContext.Provider value={changeDelegateContextValues}>
             <FormProvider {...methods}>
@@ -96,10 +113,7 @@ export const StakeChangeDelegateModalLoaded = ({
                     heading={<Translation id="TR_STAKE_CHANGE_DELEGATE" />}
                     onCancel={handleCancel}
                     bottomContent={
-                        <Tooltip
-                            isActive={isDisabled && errorType === 'current_delegate'}
-                            content={<Translation id="TR_STAKE_CHANGE_DELEGATE_DISABLED_TOOLTIP" />}
-                        >
+                        <Tooltip content={tooltipContent}>
                             <Modal.Button
                                 isDisabled={isDisabled}
                                 onClick={() => handleSubmit(signTx)()}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -110,8 +110,10 @@ export const StakingCard = ({
     const {
         isStakingDisabled,
         isUnstakingDisabled,
+        isVotingDisabled,
         stakingMessageContent,
         unstakingMessageContent,
+        votingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
     const {
@@ -215,7 +217,8 @@ export const StakingCard = ({
     };
 
     const openChangeDelegateModal = () => {
-        if (!isCardanoNetworkType || !isStakingActive || isStakeConfirming) return;
+        if (!isCardanoNetworkType || !isStakingActive || isStakeConfirming || isVotingDisabled)
+            return;
 
         dispatch(openModal({ type: 'change-delegate' }));
 
@@ -420,14 +423,19 @@ export const StakingCard = ({
                         </Button>
                     </Tooltip>
                     {isCardanoNetworkType && (
-                        <Button
-                            onClick={openChangeDelegateModal}
-                            isDisabled={!isStakingActive || isStakeConfirming}
-                            intent="neutral"
-                            priority="secondary"
-                        >
-                            <Translation id="TR_STAKE_CHANGE_DELEGATE" />
-                        </Button>
+                        <Tooltip content={votingMessageContent}>
+                            <Button
+                                onClick={openChangeDelegateModal}
+                                isDisabled={
+                                    !isStakingActive || isStakeConfirming || isVotingDisabled
+                                }
+                                iconLeft={isVotingDisabled ? InfoIcon : undefined}
+                                intent="neutral"
+                                priority="secondary"
+                            >
+                                <Translation id="TR_STAKE_CHANGE_DELEGATE" />
+                            </Button>
+                        </Tooltip>
                     )}
                 </Row>
             </Column>

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -55,6 +55,7 @@ export const Feature = {
         trx: 'trx.staking.claim',
     },
     vote: {
+        ada: 'ada.staking.vote',
         trx: 'trx.staking.vote',
     },
     withdraw: {

--- a/suite-common/message-system/src/useMessageSystemStaking.test.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.test.ts
@@ -42,6 +42,16 @@ const stateWithDisabledFeatures = {
                     feature: [{ domain: 'eth.staking.claim', flag: false }],
                 },
             },
+            {
+                message: {
+                    id: 'adaVoteDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    content: { en: 'Change delegate disabled' },
+                    feature: [{ domain: 'ada.staking.vote', flag: false }],
+                },
+            },
         ],
         experiments: [],
     },
@@ -49,7 +59,7 @@ const stateWithDisabledFeatures = {
         banner: [],
         context: [],
         modal: [],
-        feature: ['stakeDisabledMsg', 'claimDisabledMsg'],
+        feature: ['stakeDisabledMsg', 'claimDisabledMsg', 'adaVoteDisabledMsg'],
     },
 } as unknown as MessageSystemState;
 
@@ -80,6 +90,22 @@ describe('useMessageSystemStaking', () => {
             unstakingMessageContent: 'Staking disabled',
             claimingMessageContent: 'Claiming disabled',
         });
+    });
+
+    it('returns disabled state and message for ada change-delegate (vote) feature', () => {
+        const { result } = renderHook('ada');
+
+        expect(result.current).toMatchObject({
+            isVotingDisabled: true,
+            votingMessageContent: 'Change delegate disabled',
+        });
+    });
+
+    it('returns undefined voting state for networks without a vote feature key', () => {
+        const { result } = renderHook('eth');
+
+        expect(result.current.isVotingDisabled).toBeUndefined();
+        expect(result.current.votingMessageContent).toBeUndefined();
     });
 
     it('returns localized message content', () => {

--- a/suite-common/message-system/src/useMessageSystemStaking.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.ts
@@ -29,7 +29,7 @@ export const useMessageSystemStaking = ({
     const stake = isStaking ? Feature.stake[key] : undefined;
     const unstake = isStaking ? Feature.unstake[key] : undefined;
     const claim = isStaking ? Feature.claim[key] : undefined;
-    const vote = isStaking && key === 'trx' ? Feature.vote[key] : undefined;
+    const vote = isStaking && (key === 'trx' || key === 'ada') ? Feature.vote[key] : undefined;
     const withdraw = isStaking && key === 'trx' ? Feature.withdraw[key] : undefined;
 
     const isStakingDisabled = useSelector((state: MessageSystemRootState) =>


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI run for external PR #30269 (CI does not run for external contributors). This PR will be closed once CI finishes; review happens on #30269.

## Description

CI mirror of #30269 by @myasiura-stack, rebased onto develop, including review fixups.

## Notes for QA

No QA needed — CI-only PR, closed after the checks finish.

## Related Issue

#30269

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-30269/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-30269/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-30269&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-30269&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pr-30269&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:07:45.412Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T07:07:03.842Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on staking UI (StakeChangeDelegateModal, StakingCard) and message-system staking hooks/types. Highest risk lies in Cardano delegation flows that exercise the delegate-change modal, and in the StakingCard used across ETH and SOL dashboards. The recommended set targets ADA delegation plus initial ETH/SOL staking for maximum coverage with a small number of tests.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StakeChangeDelegateModal/StakeChangeDelegateModal.tsx`
- `packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemStaking.test.ts`
- `suite-common/message-system/src/useMessageSystemStaking.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test initiates Cardano staking/delegation, which is the most likely flow to render the changed StakeChangeDelegateModal and interact with the StakingCard and message-system staking integration.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstaking changes delegation state and uses the staking dashboard card and related modals, providing direct coverage of the changed delegate-change UI and message-system-aware StakingCard.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The initial ETH staking flow renders the StakingCard in its empty and active states and opens staking nutshell/stake modals, exercising the changed dashboard card and any message-system banners.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — The initial SOL staking flow renders the StakingCard and progress indicators, validating the changed card component and message-system integration on a different staking network.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/staking-events.test.ts` — This test navigates to staking from the account menu and dashboard assets, touching the same staking entry points and StakingCard surface that the message-system changes could influence.
- `suite/e2e/tests/staking/ada/claim.test.ts` — Claiming Cardano rewards uses the staking dashboard and its action buttons, giving additional coverage of the StakingCard and related staking UI after delegation is active.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This flow exercises the StakingCard with an already-staked account, ensuring the changed card and message-system behavior still work in the non-empty staking state.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking transitions the StakingCard through pending/claimable states and verifies modal interactions, catching regressions in the changed staking UI components.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — SOL unstake and claim flows rely on the staking dashboard card and modals, adding cross-network coverage for the changed StakingCard and message-system integration.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test opens the ETH staking form and checks validation/amount inputs, which is adjacent to the StakingCard entry point and could be affected by message-system staking banners or state changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/src/useMessageSystemStaking.test.ts`

_Updated: 2026-08-02T07:07:13.260Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->