### PR TITLE
[CI] Share stake max reserve policy across desktop and native (#29721)

### DIFF
--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -17,6 +17,7 @@ import {
     fromWei,
     getConvertedOrDefaultFeeInfo,
     getFiatRateKey,
+    getMaxStakeAmount,
     getStakingLimitsByNetworkSymbol,
     toFiatCurrency,
 } from '@suite-common/wallet-utils';
@@ -286,27 +287,24 @@ export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues
     );
 
     const setMax = useCallback(async () => {
-        if (amountLimits == null || stakingLimits == null) {
+        if (stakingLimits == null) {
             return;
         }
 
         setValue('setMaxOutputId', 0, { shouldDirty: true });
         clearErrors([FIAT_INPUT, CRYPTO_INPUT]);
 
-        let amount = new BigNumber(amountLimits.maxCrypto ?? '');
+        const amount = getMaxStakeAmount({
+            balance: account.formattedBalance,
+            symbol: account.symbol,
+        });
 
-        if (amount.gt(stakingLimits.MIN_BALANCE_FOR_STAKING)) {
-            amount = new BigNumber(account.formattedBalance).minus(
-                stakingLimits.MIN_FOR_WITHDRAWALS,
-            );
-        }
+        setValue(CRYPTO_INPUT, amount, { shouldDirty: true, shouldValidate: true });
 
-        setValue(CRYPTO_INPUT, amount.toString(), { shouldDirty: true, shouldValidate: true });
-
-        await onCryptoAmountChange(amount.toString(), 'max');
+        await onCryptoAmountChange(amount, 'max');
     }, [
         account.formattedBalance,
-        amountLimits,
+        account.symbol,
         clearErrors,
         onCryptoAmountChange,
         setValue,

--- a/suite-common/wallet-utils/src/__fixtures__/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/stakingUtils.ts
@@ -1,4 +1,4 @@
-import { type NetworkType } from '@suite-common/wallet-config';
+import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 import { UNSTAKING_ETH_PERIOD } from '@suite-common/wallet-constants';
 import { SOLANA_EPOCH_DAYS } from '@trezor/network-solana/constants';
 
@@ -77,5 +77,86 @@ export const getUnstakingPeriodInDaysFixture: GetUnstakingPeriodInDaysFixture[] 
             exitTime: 0,
         },
         result: 0,
+    },
+];
+
+type GetMaxStakeAmountFixture = {
+    description: string;
+    args: {
+        balance: string;
+        symbol: NetworkSymbol | undefined;
+    };
+    result: string;
+};
+
+export const getMaxStakeAmountFixture: GetMaxStakeAmountFixture[] = [
+    {
+        description:
+            'SOL: reserves the withdrawal amount (0.02), not just the fee buffer, when the balance is well above the staking minimum',
+        args: { balance: '5', symbol: 'sol' },
+        result: '4.98',
+    },
+    {
+        description:
+            'SOL: takes the fee-buffer-only branch because balance minus the fee buffer (0.005) does not exceed MIN_BALANCE_FOR_STAKING (1.02)',
+        args: { balance: '1.01', symbol: 'sol' },
+        result: '1.005',
+    },
+    {
+        description:
+            'SOL: at the exact fee-buffer branch boundary (balance minus the fee buffer equals MIN_BALANCE_FOR_STAKING), still takes the fee-buffer-only branch',
+        args: { balance: '1.025', symbol: 'sol' },
+        result: '1.02',
+    },
+    {
+        description:
+            'SOL: one cent above the boundary, switches to the withdrawal-reserve branch; this is a known non-monotonic step inherited from desktop (max amount drops from 1.02 to 1.006 as balance rises), not something this shared helper introduces',
+        args: { balance: '1.026', symbol: 'sol' },
+        result: '1.006',
+    },
+    {
+        description: 'SOL: caps the result at the protocol maximum stake amount',
+        args: { balance: '10000005', symbol: 'sol' },
+        result: '10000000',
+    },
+    {
+        description:
+            'SOL: never returns a negative amount when the balance is below the fee buffer',
+        args: { balance: '0.001', symbol: 'sol' },
+        result: '0',
+    },
+    {
+        description:
+            'ETH: withdrawal reserve equals the fee buffer (both 0.005), so max leaves 0.005 regardless of the branch',
+        args: { balance: '5', symbol: 'eth' },
+        result: '4.995',
+    },
+    {
+        description: 'returns 0 (fails safe, reserves everything) for a non-staking network symbol',
+        args: { balance: '5', symbol: 'btc' },
+        result: '0',
+    },
+    {
+        description: 'TRX: below the withdrawal-branch threshold, reserves the full fee buffer (5)',
+        args: { balance: '6', symbol: 'trx' },
+        result: '1',
+    },
+    {
+        description:
+            'TRX: just above the threshold, reserves only the withdrawal amount (0.01) instead of the 5 TRX fee buffer, a steep cliff inherited from desktop',
+        args: { balance: '6.02', symbol: 'trx' },
+        result: '6.01',
+    },
+    {
+        description:
+            'ADA: withdrawal reserve is 0, so once above the fee buffer the max amount is the full balance',
+        args: { balance: '5', symbol: 'ada' },
+        result: '5',
+    },
+    {
+        description:
+            'ADA: never returns a negative amount when the balance is below the fee buffer',
+        args: { balance: '0.001', symbol: 'ada' },
+        result: '0',
     },
 ];

--- a/suite-common/wallet-utils/src/stakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.test.ts
@@ -1,5 +1,8 @@
-import { getUnstakingPeriodInDaysFixture } from './__fixtures__/stakingUtils';
-import { getUnstakingPeriodInDays } from './stakingUtils';
+import {
+    getMaxStakeAmountFixture,
+    getUnstakingPeriodInDaysFixture,
+} from './__fixtures__/stakingUtils';
+import { getMaxStakeAmount, getUnstakingPeriodInDays } from './stakingUtils';
 
 describe('getUnstakingPeriodInDays', () => {
     getUnstakingPeriodInDaysFixture.forEach(test => {
@@ -7,6 +10,18 @@ describe('getUnstakingPeriodInDays', () => {
             const result = getUnstakingPeriodInDays(test.args.networkType, {
                 withdrawTime: test.args.withdrawTime,
                 exitTime: test.args.exitTime,
+            });
+            expect(result).toEqual(test.result);
+        });
+    });
+});
+
+describe('getMaxStakeAmount', () => {
+    getMaxStakeAmountFixture.forEach(test => {
+        it(test.description, () => {
+            const result = getMaxStakeAmount({
+                balance: test.args.balance,
+                symbol: test.args.symbol,
             });
             expect(result).toEqual(test.result);
         });

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -162,6 +162,29 @@ export const getStakingLimitsByNetworkSymbol = (
     }
 };
 
+interface GetMaxStakeAmount {
+    balance: string;
+    symbol: NetworkSymbol | undefined;
+}
+
+export const getMaxStakeAmount = ({ balance, symbol }: GetMaxStakeAmount): string => {
+    const limits = getStakingLimitsByNetworkSymbol(symbol);
+    if (!limits) return '0';
+
+    const balanceBN = new BigNumber(balance);
+
+    const balanceMinusFeeBuffer = BigNumber.max(
+        balanceBN.minus(limits.MIN_BALANCE_FOR_FEE_BUFFER),
+        0,
+    );
+
+    const maxAmount = balanceMinusFeeBuffer.gt(limits.MIN_BALANCE_FOR_STAKING)
+        ? BigNumber.max(balanceBN.minus(limits.MIN_FOR_WITHDRAWALS), 0)
+        : balanceMinusFeeBuffer;
+
+    return BigNumber.min(maxAmount, limits.MAX_AMOUNT_FOR_STAKING).toFixed();
+};
+
 export const getStakingDataForNetwork = (
     account?: Account,
 ): Omit<StakingPoolExtended, 'contract' | 'name'> | undefined => {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2665,8 +2665,8 @@ export const messages = {
             amountLabel: 'Amount',
             stakeMaxButton: 'Stake max',
             unstakeMaxButton: 'Unstake max',
-            withdrawalFeesBanner:
-                "We've left {amount} {displaySymbol} in your account so you can pay withdrawal fees.",
+            withdrawalFeesRecommendation:
+                "It's recommended to leave {amount} {displaySymbol} so you can pay for withdrawal fees.",
             insufficientBalanceBanner:
                 'Not enough {displaySymbol}. Staking requires at least {minAmount} {displaySymbol} plus network fees.',
             insufficientBalanceBannerButton: 'Buy {displaySymbol}',

--- a/suite-native/module-earn/src/components/EarnMaxButton.tsx
+++ b/suite-native/module-earn/src/components/EarnMaxButton.tsx
@@ -11,7 +11,7 @@ import { type AccountKey, type StakeType } from '@suite-common/wallet-types';
 import {
     formatNetworkAmount,
     getDecimalsForBaseCurrency,
-    getStakingLimitsByNetworkSymbol,
+    getMaxStakeAmount,
 } from '@suite-common/wallet-utils';
 import { HStack, Switch, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
@@ -64,20 +64,9 @@ export const EarnMaxButton = ({
             return stakedBalance ?? '0';
         }
 
-        const limits = getStakingLimitsByNetworkSymbol(symbol);
         const availableAmount = formatNetworkAmount(account!.availableBalance, symbol);
-        const buffer = limits?.MIN_BALANCE_FOR_FEE_BUFFER ?? 0;
 
-        const balanceMinusBuffer = BigNumber.max(new BigNumber(availableAmount).minus(buffer), 0);
-
-        if (
-            limits?.MAX_AMOUNT_FOR_STAKING &&
-            balanceMinusBuffer.gt(limits.MAX_AMOUNT_FOR_STAKING)
-        ) {
-            return limits.MAX_AMOUNT_FOR_STAKING.toFixed();
-        }
-
-        return balanceMinusBuffer.toFixed();
+        return getMaxStakeAmount({ balance: availableAmount, symbol });
     };
 
     const setMaxAmount = () => {

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
@@ -26,24 +26,22 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
 
     const { displaySymbol } = getNetwork(symbol);
     const formattedBalance = formatNetworkAmount(account.availableBalance, symbol);
-    const maxStakeAmount = new BigNumber(formattedBalance).minus(limits.MIN_BALANCE_FOR_FEE_BUFFER);
 
     const isVisible =
         !hasError &&
         !!amountValue &&
-        new BigNumber(amountValue).gte(maxStakeAmount) &&
-        maxStakeAmount.gt(0);
+        new BigNumber(formattedBalance).minus(amountValue).lt(limits.MIN_FOR_WITHDRAWALS);
 
     if (!isVisible) return null;
 
     return (
         <InlineAlertBox
-            intent="info"
+            intent="warning"
             title={
                 <Translation
-                    id="earn.earnFormScreen.withdrawalFeesBanner"
+                    id="earn.earnFormScreen.withdrawalFeesRecommendation"
                     values={{
-                        amount: limits.MIN_BALANCE_FOR_FEE_BUFFER.toString(),
+                        amount: limits.MIN_FOR_WITHDRAWALS.toString(),
                         displaySymbol,
                     }}
                 />


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI run for external PR #29721 (CI does not run for external contributors). This PR will be closed once CI finishes; review happens on #29721.

## Description

CI mirror of #29721 by @myasiura-stack, rebased onto develop, including review fixups.

## Notes for QA

No QA needed — CI-only PR, closed after the checks finish.

## Related Issue

#29721

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ci/pr-29721/web/](https://dev.suite.sldev.cz/suite-web/ci/pr-29721/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ci/pr-29721&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ci/pr-29721&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pr-29721&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T19:16:45.495Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T19:17:21.311Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily affects staking form logic in the web Suite app (useStakeForm.ts, stakingUtils.ts) and native earn components. The highest-confidence web E2E coverage comes from the staking-form validation test, supplemented by ETH and SOL end-to-end stake flows. The native mobile changes are not covered by the available web/desktop E2E test suite and require separate native testing.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/hooks/earn/useStakeForm.ts`
- `suite-common/wallet-utils/src/__fixtures__/stakingUtils.ts`
- `suite-common/wallet-utils/src/stakingUtils.test.ts`
- `suite-common/wallet-utils/src/stakingUtils.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnMaxButton.tsx`
- `suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Directly validates ETH staking form behaviors including minimum/maximum amounts, decimal validation, percentage buttons, Max button with withdrawal buffer, and fiat/crypto switching—functionality implemented in useStakeForm.ts and stakingUtils.ts. A regression here would be immediately user-visible.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the complete first-time ETH staking flow, including opening the staking form, entering an amount, and submitting the transaction. This shares the staking form infrastructure and amount validation logic with the changed files.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests staking additional ETH from an already-staked account, reusing the staking form and amount validation paths affected by the hook and utility changes.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Covers the first-time SOL staking flow including form input, amount entry, and confirmation, which relies on the same staking form hook infrastructure.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests adding more stake to an existing SOL staking account, exercising the staking form and validation paths that depend on the changed utilities.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/src/components/EarnMaxButton.tsx`
- `suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx`

_Updated: 2026-08-02T19:15:51.742Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->