### PR TITLE
[CI] Align staking progress-modal copy with design (#30162)

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2581,6 +2581,14 @@ export const messages = {
                 stepWithdrawalPeriod:
                     'Withdrawal period (~{days, plural, one {# day} other {# days}})',
                 stepReadyToClaim: 'Ready to claim',
+                sol: {
+                    stepWarmUpPeriod:
+                        'Warm-up period (~{days, plural, one {# day} other {# days}})',
+                    stepStakedReceivingRewards: 'Staked & receiving rewards',
+                    stepCoolDownPeriod:
+                        'Cool-down period (~{days, plural, one {# day} other {# days}})',
+                    stepUnstakedReadyToClaim: 'Unstaked and ready to claim',
+                },
             },
         },
         yieldInsufficientBalance: {

--- a/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementPendingStakeModal.tsx
@@ -7,6 +7,7 @@ import {
     useAccountsSelector,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -81,14 +82,23 @@ export const StakingManagementPendingStakeModal = ({
         return StakingDetailModalStep.Completed;
     })();
 
-    const inProgressLabel = (
+    const isSolanaStaking = !!symbol && isSupportedSolStakingNetworkSymbol(symbol);
+
+    const inProgressLabel = isSolanaStaking ? (
+        <Translation
+            id="earn.stakingManagementScreen.pendingItemModal.sol.stepWarmUpPeriod"
+            values={{ days: entryPeriodEstimateInDays }}
+        />
+    ) : (
         <Translation
             id="earn.stakingManagementScreen.pendingItemModal.stepEntryPeriod"
             values={{ days: entryPeriodEstimateInDays }}
         />
     );
 
-    const completedLabel = (
+    const completedLabel = isSolanaStaking ? (
+        <Translation id="earn.stakingManagementScreen.pendingItemModal.sol.stepStakedReceivingRewards" />
+    ) : (
         <Translation id="earn.stakingManagementScreen.pendingItemModal.stepStakedReceivingRewards" />
     );
 

--- a/suite-native/module-earn/src/components/StakingManagementUnstakingModal.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementUnstakingModal.tsx
@@ -1,7 +1,7 @@
 import { BASE_CRYPTO_MAX_DISPLAYED_DECIMALS } from '@suite-common/formatters';
 import { selectAccountNetworkSymbol, useAccountsSelector } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { isPositiveBalance } from '@suite-common/wallet-utils';
+import { isPositiveBalance, isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -68,20 +68,29 @@ export const StakingManagementUnstakingModal = ({
     );
 
     const currentStep: StakingDetailModalStep = (() => {
-        if (isPositiveBalance(claimableAmount)) return StakingDetailModalStep.Completed;
         if (isPositiveBalance(unstakingBalance)) return StakingDetailModalStep.InProgress;
+        if (isPositiveBalance(claimableAmount)) return StakingDetailModalStep.Completed;
 
         return StakingDetailModalStep.TransactionConfirmed;
     })();
 
-    const inProgressLabel = (
+    const isSolanaStaking = !!symbol && isSupportedSolStakingNetworkSymbol(symbol);
+
+    const inProgressLabel = isSolanaStaking ? (
+        <Translation
+            id="earn.stakingManagementScreen.pendingItemModal.sol.stepCoolDownPeriod"
+            values={{ days: unstakingPeriodInDays }}
+        />
+    ) : (
         <Translation
             id="earn.stakingManagementScreen.pendingItemModal.stepWithdrawalPeriod"
             values={{ days: unstakingPeriodInDays }}
         />
     );
 
-    const completedLabel = (
+    const completedLabel = isSolanaStaking ? (
+        <Translation id="earn.stakingManagementScreen.pendingItemModal.sol.stepUnstakedReadyToClaim" />
+    ) : (
         <Translation id="earn.stakingManagementScreen.pendingItemModal.stepReadyToClaim" />
     );
 


### PR DESCRIPTION
> [!IMPORTANT]
> **NOT READY FOR REVIEW** — throwaway CI run for external PR #30162 (CI does not run for external contributors). This PR will be closed once CI finishes; review happens on #30162.

## Description

CI mirror of #30162 by @myasiura-stack, rebased onto develop, including review fixups (SOL-specific strings via new keys, step-order fix in the unstaking modal).

## Notes for QA

No QA needed — CI-only PR, closed after the checks finish.

## Related Issue

#30162

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ci/pr-30162&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->