### PR TITLE
fix(network-solana): confirm pushed transactions by polling signature status

### DIFF
--- a/networks/solana/network-solana/src/runtime/connect.ts
+++ b/networks/solana/network-solana/src/runtime/connect.ts
@@ -21,7 +21,7 @@ import {
     isTransactionMessageWithDurableNonceLifetime,
     lamports,
     prependTransactionMessageInstructions,
-    sendAndConfirmTransactionFactory,
+    sendTransactionWithoutConfirmingFactory,
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
@@ -398,13 +398,46 @@ const getSendErrorMessage = (error: any) => {
     }
 };
 
+const SIGNATURE_CONFIRMATION_TIMEOUT_MS = 60_000;
+const SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS = 2_000;
+
+// Polling instead of kit's `sendAndConfirmTransactionFactory` — its internal timeout strategy
+// reads `e.target.reason` in an abort handler, and on React Native the abort event has no
+// target, so every confirmed transaction ended with an unhandled TypeError rejection.
+const waitForSignatureConfirmation = async (
+    signature: ReturnType<typeof getSignatureFromTransaction>,
+    api: SolanaAPI,
+) => {
+    const deadline = Date.now() + SIGNATURE_CONFIRMATION_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+        const { value } = await api.rpc.getSignatureStatuses([signature]).send();
+        const status = value[0];
+
+        if (status?.err) {
+            throw new Error(`Transaction failed: ${JSON.stringify(status.err)}`);
+        }
+        if (
+            status?.confirmationStatus === 'confirmed' ||
+            status?.confirmationStatus === 'finalized'
+        ) {
+            return;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS));
+    }
+
+    throw new Error('Timeout while waiting for the transaction to be confirmed.');
+};
+
 export const sendAndConfirmTransaction = async (rawTx: string, api: SolanaAPI) => {
     const transaction = await preparePushTransaction(rawTx, api);
 
     try {
         const signature = getSignatureFromTransaction(transaction);
-        const send = sendAndConfirmTransactionFactory(api);
+        const send = sendTransactionWithoutConfirmingFactory({ rpc: api.rpc });
         await send(transaction, { commitment: 'confirmed', skipPreflight: false });
+        await waitForSignatureConfirmation(signature, api);
 
         return signature;
     } catch (error) {


### PR DESCRIPTION
## Description

NOT READY FOR REVIEW

Native Solana staking (and any native SOL push) logged `Uncaught (in promise): TypeError: Cannot read property 'reason' of null` on every successful transaction. Kit's `sendAndConfirmTransactionFactory` races a timeout strategy whose abort handler reads `e.target.reason`; on React Native/Hermes the abort event has no `target`, so when the confirmation wins the race and aborts the timeout, the handler throws an unhandled rejection. Replaced with `sendTransactionWithoutConfirmingFactory` + our own signature-status polling loop (2s interval, 60s deadline, propagates on-chain `err`), avoiding kit's abort machinery entirely.

## Notes for QA

Stake SOL or send SOL from the native app: the transaction confirms as before and no `Cannot read property 'reason' of null` error appears in the logs.

## Related Issue

—

## Screenshots:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the Solana network runtime connection layer and has no static coverage mapping. I inferred coverage from the LLM analysis: the highest-risk paths are Solana transaction sending and live/passthrough trading swaps that use real network connections. The recommended strategy is to run a focused set of Solana send, staking, and trading tests, prioritizing the live and passthrough tests that exercise the actual connect path.

<details><summary><b>Changed files (1)</b></summary>

- `networks/solana/network-solana/src/runtime/connect.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This live SPL-token swap on Solana exercises the actual Solana network connection path end-to-end; a regression in the runtime connect layer would likely surface here because it relies on real RPC/runtime interactions rather than mocks. Inferred coverage (no static mapping was available).
- `suite/e2e/tests/trading-poc/passthru-swap-sol-to-btc.test.ts` — A passthrough/live SOL-to-BTC swap that sends real Solana traffic through a proxy; the runtime connect implementation is directly on the critical path for broadcasting and status polling. Inferred coverage (no static mapping was available).
- `suite/e2e/tests/wallet/send-sol.test.ts` — Directly validates sending a Solana transaction, including fee estimation, address display, and signing/broadcasting—all of which depend on the Solana runtime connection. Inferred coverage (no static mapping was available).

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Solana staking creates and submits stake transactions and polls stake-account state, so it shares the Solana runtime connect infrastructure, though it uses a mocked backend that may insulate it from some connect-layer changes. Inferred coverage (no static mapping was available).
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstake/claim flow exercises the same staking runtime paths as initial staking, including transaction submission and epoch-based state updates. Inferred coverage (no static mapping was available).
- `suite/e2e/tests/trading/sell-solana.test.ts` — Selling SOL requires constructing and sending a Solana transaction to a provider, so it traverses the Solana runtime connection layer within the trading flow. Inferred coverage (no static mapping was available).
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — SOL-to-BTC swap exercises Solana transaction construction, device confirmation, and broadcast through the trading stack, making it a relevant secondary check for connect-layer regressions. Inferred coverage (no static mapping was available).

</details>

_Updated: 2026-08-02T20:19:39.090Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/solana-native-confirm-unhandled-rejection/web/](https://dev.suite.sldev.cz/suite-web/fix/solana-native-confirm-unhandled-rejection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/solana-native-confirm-unhandled-rejection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/solana-native-confirm-unhandled-rejection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-02T20:21:21.525Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-02T20:20:42.605Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->