### PR TITLE
chore(suite): improve earn table ui

### DIFF
--- a/packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx
@@ -47,12 +47,13 @@ const LogoWrapper = styled.div<{ $size: number; $isBordered: boolean }>`
         `}
 `;
 
-const Logo = styled.img<{ $size: number }>`
+const Logo = styled.img<{ $size: number; $isTransparent: boolean }>`
     display: block;
     width: ${({ $size }) => $size}px;
     height: ${({ $size }) => $size}px;
     border-radius: calc(infinity * 1px);
-    background-color: ${({ theme }) => theme.elementFillElevated};
+    background-color: ${({ theme, $isTransparent }) =>
+        $isTransparent ? 'transparent' : theme.elementFillElevated};
 `;
 
 type NonNativeTokenIconProps = TokenIconProps & {
@@ -70,6 +71,7 @@ export const NonNativeTokenIcon = ({
     placeholder = '',
     customLogoUrl,
     isBordered = true,
+    isTransparent = false,
     'data-testid': dataTestId,
     ...rest
 }: NonNativeTokenIconProps) => {
@@ -233,6 +235,7 @@ export const NonNativeTokenIcon = ({
                         loading="lazy"
                         decoding="async"
                         $size={size}
+                        $isTransparent={isTransparent}
                         data-testid={dataTestId}
                         alt={placeholder}
                         onLoad={handleOnLoad}

--- a/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/TokenIcon.tsx
@@ -21,6 +21,7 @@ export const TokenIcon = ({
     placeholder = '',
     customLogoUrl,
     isBordered = true,
+    isTransparent = false,
     wrappedTokenIcon = 'token',
     'data-testid': dataTestId,
 }: TokenIconProps) => {
@@ -79,6 +80,7 @@ export const TokenIcon = ({
             placeholder={placeholder}
             customLogoUrl={customLogoUrl}
             isBordered={isBordered}
+            isTransparent={isTransparent}
             coingeckoId={coingeckoId}
             data-testid={dataTestId}
         />

--- a/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
+++ b/packages/product-components/src/components/TokenIcon/tokenIconTypes.ts
@@ -18,6 +18,7 @@ export interface TokenIconProps extends AllowedFrameProps {
     'data-testid'?: string;
     customLogoUrl?: string;
     isBordered?: boolean;
+    isTransparent?: boolean;
     /**
      * If the token is a wrapped native token (e.g. WETH), this prop determines whether to show the icon of the token itself or its network icon.
      */

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -41,10 +41,11 @@ export const EarnAccountCell = ({
                         showNetworkIcon={showAssetNetworkIcon}
                         size={32}
                         isBordered={false}
+                        isTransparent={true}
                         wrappedTokenIcon="network"
                     />
                 ) : (
-                    <TokenIcon symbol={networkSymbol} size={32} />
+                    <TokenIcon symbol={networkSymbol} size={32} isTransparent={true} />
                 )}
             </Column>
 

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx
@@ -48,7 +48,7 @@ export const EarnAccountCell = ({
                 )}
             </Column>
 
-            <Column flex="1" overflow="hidden" gap={2}>
+            <Column flex="1" overflow="hidden" gap={4}>
                 <EarnAccountCellDetails
                     account={account}
                     networkSymbol={networkSymbol}

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
@@ -26,7 +26,7 @@ export const EarnAccountCellDetails = ({
         return (
             <>
                 <Text
-                    typographyStyle="body-sm"
+                    typographyStyle="body-sm-strong"
                     intent="neutral"
                     priority="primary"
                     ellipsisLineCount={1}
@@ -52,7 +52,7 @@ export const EarnAccountCellDetails = ({
                 accountTypeBadgeSize="small"
                 intent="neutral"
                 priority="primary"
-                typographyStyle="body-sm"
+                typographyStyle="body-sm-strong"
                 data-testid="@earn/dashboard/account-label"
             />
 

--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -23,7 +23,7 @@ export const EarnInactiveNetworkOpportunity = ({
     const networkType = getNetworkType(symbol);
 
     const noteParagraph = note && (
-        <Paragraph typographyStyle="body-md" intent="neutral">
+        <Paragraph typographyStyle="body-sm" intent="neutral">
             {note}
         </Paragraph>
     );

--- a/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx
@@ -3,7 +3,7 @@ import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenSymbol } from '@suite-common/wallet-types';
-import { H4, type TextProps } from '@trezor/components';
+import { Text, type TextProps } from '@trezor/components';
 
 type EarnRewardsAmountProps = {
     symbol: NetworkSymbol | TokenSymbol;
@@ -28,13 +28,24 @@ export const EarnRewardsAmount = ({
 
     if (!apy)
         return (
-            <H4 intent={intent} priority={priority} isDisabled={isDisabled}>
+            <Text
+                typographyStyle="body-sm-strong"
+                intent={intent}
+                priority={priority}
+                isDisabled={isDisabled}
+            >
                 <Translation id="TR_EARN_APY_REQUIRED" />
-            </H4>
+            </Text>
         );
 
     return (
-        <H4 data-testid={dataTestId} intent={intent} priority={priority} isDisabled={isDisabled}>
+        <Text
+            typographyStyle="body-sm-strong"
+            data-testid={dataTestId}
+            intent={intent}
+            priority={priority}
+            isDisabled={isDisabled}
+        >
             <HiddenPlaceholder>
                 <CryptoAmountFormatter
                     value={rewards}
@@ -45,6 +56,6 @@ export const EarnRewardsAmount = ({
                     maxDisplayedDecimals={8}
                 />
             </HiddenPlaceholder>
-        </H4>
+        </Text>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -21,7 +21,7 @@ import {
     getStakingLimitsByNetworkSymbol,
     isPending,
 } from '@suite-common/wallet-utils';
-import { Card, Column, Icon, Paragraph, Row, Table } from '@trezor/components';
+import { Card, Column, Icon, Paragraph, Row, Table, Text } from '@trezor/components';
 import { ArrowDownIcon, ArrowRightIcon } from '@trezor/icons';
 import { BigNumber } from '@trezor/utils';
 
@@ -224,7 +224,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     } as const;
 
     const minStakeParagraph = (
-        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+        <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
             <Translation
                 id="TR_EARN_STAKING_DASHBOARD_MINIMUM_STAKE"
                 values={{ amount: minStakingAmount?.toString(), displaySymbol }}
@@ -233,7 +233,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     );
 
     const maxStakeParagraph = (
-        <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+        <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
             <Translation id="TR_EARN_STAKING_DASHBOARD_MAXIMUM_STAKE" />
         </Paragraph>
     );
@@ -325,7 +325,9 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
                         {apyAvailable ? (
                             <EarnStakingRateTooltip networkType={account.networkType} rate={rate} />
                         ) : (
-                            <Translation id="TR_EARN_NOT_AVAILABLE" />
+                            <Text typographyStyle="body-sm">
+                                <Translation id="TR_EARN_NOT_AVAILABLE" />
+                            </Text>
                         )}
                     </Row>
 
@@ -422,7 +424,9 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
                 {apyAvailable ? (
                     <EarnStakingRateTooltip networkType={account.networkType} rate={rate} />
                 ) : (
-                    <Translation id="TR_EARN_NOT_AVAILABLE" />
+                    <Text typographyStyle="body-sm">
+                        <Translation id="TR_EARN_NOT_AVAILABLE" />
+                    </Text>
                 )}
             </Table.Cell>
 

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingCurrentRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingCurrentRewards.tsx
@@ -22,7 +22,7 @@ export const EarnStakingCurrentRewards = ({
     formattedStakingBalance,
     displaySymbol,
 }: EarnStakingCurrentRewardsProps) => (
-    <Column alignItems="flex-start">
+    <Column alignItems="flex-start" gap={4}>
         <EarnRewardsAmount symbol={symbol} rewards={isStakingActive ? rewards : '0'} apy={apy} />
 
         {isStakingActive && (

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingOutdatedProvider.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingOutdatedProvider.tsx
@@ -10,8 +10,8 @@ type EarnStakingOutdatedProviderProps = {
 
 export const EarnStakingOutdatedProvider = ({ apy }: EarnStakingOutdatedProviderProps) => (
     <Row gap={4}>
-        <Icon as={WarningIcon} size={24} intent="warning" />
-        <Paragraph typographyStyle="body-md" intent="warning">
+        <Icon as={WarningIcon} size={20} intent="warning" />
+        <Paragraph typographyStyle="body-sm" intent="warning">
             <Translation
                 id="TR_EARN_STAKING_DASHBOARD_OUTDATED_PROVIDER"
                 values={{ apy: formatApyValue(apy) }}

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingPotentialRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingPotentialRewards.tsx
@@ -22,7 +22,7 @@ export const EarnStakingPotentialRewards = ({
     formattedAccountBalance,
     displaySymbol,
 }: EarnStakingPotentialRewardsProps) => (
-    <Column>
+    <Column gap={4}>
         {apy && <EarnRewardsAmount symbol={symbol} rewards={rewards} apy={apy} intent="brand" />}
 
         {!isCardanoNetworkType && apy && (

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { type NetworkType } from '@suite-common/wallet-config';
-import { Tooltip } from '@trezor/components';
+import { Text, Tooltip } from '@trezor/components';
 
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
@@ -37,9 +37,11 @@ export const EarnStakingRateTooltip = ({ networkType, rate }: EarnStakingRateToo
             tooltipMaxWidth={280}
             placement="top"
         >
-            <Abbr>
-                <ApyValue apy={rate} />
-            </Abbr>
+            <Text typographyStyle="body-sm-strong" intent="neutral" priority="primary">
+                <Abbr>
+                    <ApyValue apy={rate} />
+                </Abbr>
+            </Text>
         </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingRemainingVotes.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingRemainingVotes.tsx
@@ -9,8 +9,8 @@ type EarnStakingRemainingVotesProps = {
 
 export const EarnStakingRemainingVotes = ({ apr }: EarnStakingRemainingVotesProps) => (
     <Row gap={4}>
-        <Icon as={WarningIcon} size={24} intent="warning" />
-        <Paragraph typographyStyle="body-md" intent="warning">
+        <Icon as={WarningIcon} size={20} intent="warning" />
+        <Paragraph typographyStyle="body-sm" intent="warning">
             <Translation
                 id="TR_EARN_STAKING_DASHBOARD_REMAINING_VOTES"
                 values={{ apr: formatTronApr(apr) }}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx
@@ -7,7 +7,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { Tooltip } from '@trezor/components';
+import { Text, Tooltip } from '@trezor/components';
 
 import { ApyValue } from 'src/views/wallet/staking/components/ApyValue';
 
@@ -48,7 +48,11 @@ export const EarnYieldApyTooltip = ({
     );
 
     if (!children && !apyPercentage) {
-        return <ApyValue apy={apyPercentage} />;
+        return (
+            <Text typographyStyle="body-sm-strong" intent="neutral" priority="primary">
+                <ApyValue apy={apyPercentage} />
+            </Text>
+        );
     }
 
     const handleMouseEnter = () => {
@@ -87,13 +91,15 @@ export const EarnYieldApyTooltip = ({
             maxWidth={600}
             placement="top"
         >
-            <Abbr
-                data-testid="@earn/dashboard/apy-percentage"
-                onMouseEnter={handleMouseEnter}
-                onMouseLeave={handleMouseLeave}
-            >
-                {children ?? <ApyValue apy={apyPercentage} />}
-            </Abbr>
+            <Text typographyStyle="body-sm-strong" intent="neutral" priority="primary">
+                <Abbr
+                    data-testid="@earn/dashboard/apy-percentage"
+                    onMouseEnter={handleMouseEnter}
+                    onMouseLeave={handleMouseLeave}
+                >
+                    {children ?? <ApyValue apy={apyPercentage} />}
+                </Abbr>
+            </Text>
         </Tooltip>
     );
 };

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx
@@ -26,7 +26,7 @@ export const EarnYieldPotentialRewards = ({
 }: EarnYieldPotentialRewardsProps) => {
     if (hasMaximumDeposited) {
         return (
-            <Paragraph typographyStyle="body-md" intent="neutral" priority="secondary">
+            <Paragraph typographyStyle="body-sm" intent="neutral" priority="secondary">
                 <Translation id="TR_EARN_YIELD_MAXIMUM_DEPOSITED" />
             </Paragraph>
         );
@@ -37,7 +37,7 @@ export const EarnYieldPotentialRewards = ({
     }
 
     return (
-        <Column>
+        <Column gap={4}>
             <EarnRewardsAmount
                 data-testid="@earn/dashboard/potential-rewards/amount"
                 symbol={symbol}

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx
@@ -22,7 +22,7 @@ export const EarnYieldYearlyRewards = ({
     formattedDepositedAmount,
     displaySymbol,
 }: EarnYieldYearlyRewardsProps) => (
-    <Column>
+    <Column gap={4}>
         <EarnRewardsAmount
             data-testid="@earn/dashboard/yearly-rewards/amount"
             symbol={symbol}


### PR DESCRIPTION
## Description

Update spacings and text sizes and weights in earn tables:

- all texts are of size `body-sm`
- upper texts in a row are `body-sm-strong`
- lower texts in a row are `body-sm`
- added `4px` gap between upper and lower texts in a row
- changed `outdated provider` and `remaining votes` icons size from `24px` to `20px`, as the text is now also smaller
- make token icon in yield table transparent

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30661

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-03 at 08 33 24" src="https://github.com/user-attachments/assets/64205ed1-1c78-47df-8425-75ef201271ae" />

<img width="100%" alt="Screenshot 2026-08-03 at 08 33 35" src="https://github.com/user-attachments/assets/928bfc85-2afb-4ab8-9c4f-99daf9c3fd8e" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/improve-earn-table-ui/web/](https://dev.suite.sldev.cz/suite-web/chore/improve-earn-table-ui/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/improve-earn-table-ui&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/improve-earn-table-ui&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T08:07:24.990Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T08:03:29.325Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch Earn dashboard UI components (staking/yield rewards, account rows, tooltips) and TokenIcon rendering for non-native tokens. Highest risk lies in staking dashboard regressions, so run focused staking E2E tests for ETH, ADA, and SOL. Token icon changes have broad blast radius but low behavioral risk; representative token trading tests (swap and buy token flows) provide adequate smoke coverage without running the full suite.

<details><summary><b>Changed files (16)</b></summary>

- `packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx`
- `packages/product-components/src/components/TokenIcon/TokenIcon.tsx`
- `packages/product-components/src/components/TokenIcon/tokenIconTypes.ts`
- `packages/suite/src/components/earn/dashboard/common/EarnAccountCell.tsx`
- `packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx`
- `packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx`
- `packages/suite/src/components/earn/dashboard/common/EarnRewardsAmount.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingCurrentRewards.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingOutdatedProvider.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingPotentialRewards.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingRateTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/staking/EarnStakingRemainingVotes.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldApyTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldPotentialRewards.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldYearlyRewards.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test navigates to the Cardano account Staking tab and verifies staking dashboard elements including reward amounts, buttons, and staking status indicators that are rendered by the changed Earn dashboard components (EarnStakingAccountRow, EarnStakingCurrentRewards, EarnRewardsAmount). A regression in these components would be directly visible here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the Ethereum staking dashboard from an empty state through pending and active staking, asserting on dashboard cards, amounts, progress indicators, and buttons rendered by the changed Earn components. Directly covers the staking dashboard rendering path.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Verifies the Solana staking dashboard rendering including empty state, staking form, pending amounts, progress indicators, and post-stake dashboard state. The changed Earn dashboard components are directly involved in displaying these staking states.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Focuses on the Solana staking dashboard rewards display and staking account balance text, which are rendered by Earn dashboard components like EarnRewardsAmount and EarnStakingAccountRow. A regression in reward amount rendering would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Tests asset display in grid/table views after enabling networks like ETH. Token icons are likely rendered in asset cards/rows, so changes to TokenIcon/NonNativeTokenIcon could affect visual rendering or layout here.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Involves selecting a Solana SPL token (Jupiter/JUP) in the buy form and verifying quote/confirmation amounts. Token icon changes could affect the asset picker and token display in the trading flow.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Swaps SOL to USDC token across networks and verifies offer details and device prompts. Token icon rendering for USDC in the swap form could be impacted by TokenIcon changes.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swaps a Solana USDT token to Bitcoin. Exercises token selection and display in the swap form, which relies on TokenIcon for rendering token assets.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swaps Solana SPL tokens (USDT to USDC) and verifies swap form and confirmation details. Token icon rendering for both send and receive tokens is exercised by this test.

</details>

_Updated: 2026-08-03T08:10:40.642Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->