### PR TITLE
fix(suite): show full address in sign message select, hide /0 for ethereum

### DIFF
--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -39,6 +39,12 @@ const DropdownWrapper = styled.div<{ $isOpen: boolean }>`
     transition: transform 0.2s ease-in-out;
 `;
 
+// The control can grow beyond its minimum height when the value wraps to multiple lines,
+// so the label is anchored to the middle of the first row instead of the whole control.
+const SelectFloatingLabel = styled(FloatingLabel)<{ $size: InputSize }>`
+    top: ${({ $size }) => mapSizeToHeight($size) / 2}px;
+`;
+
 type ControlComponentProps = ControlProps<OptionType, boolean> & {
     'data-testid'?: string;
     hasError?: boolean;
@@ -71,15 +77,16 @@ export const Control = ({
                 isClean={isClean}
             >
                 {label && !isLoading && !isClean && (
-                    <FloatingLabel
+                    <SelectFloatingLabel
                         $isActive={hasValue || !!placeholder || !!isSearchable}
                         $isDisabled={isDisabled}
+                        $size={size}
                     >
                         {label}
-                    </FloatingLabel>
+                    </SelectFloatingLabel>
                 )}
                 <Row
-                    height={isClean ? undefined : mapSizeToHeight(size)}
+                    minHeight={isClean ? undefined : mapSizeToHeight(size)}
                     gap={4}
                     padding={isClean ? undefined : { horizontal: INPUT_PADDING }}
                     overflow="hidden"

--- a/suite/sign-verify/src/SignAddressInput.tsx
+++ b/suite/sign-verify/src/SignAddressInput.tsx
@@ -1,5 +1,8 @@
+import { type ReactNode } from 'react';
+
 import { Address } from '@suite/address';
 import { type Account, type ReceiveInfo } from '@suite-common/wallet-types';
+import { isUtxoBased } from '@suite-common/wallet-utils';
 import { Box, Row, Select, type SelectProps, Text } from '@trezor/components';
 
 import { type AddressItem, useSignAddressOptions } from './useSignAddressOptions';
@@ -7,14 +10,14 @@ import { type AddressItem, useSignAddressOptions } from './useSignAddressOptions
 const optionToAddress = (option: AddressItem | null) =>
     option ? { address: option.label, path: option.value } : null;
 
-const formatOptionLabel = (option: AddressItem) => (
-    <Row gap={4}>
-        <Box minWidth={36}>
-            <Text isDisabled>/{option.value.split('/').pop()}</Text>
-        </Box>
-        <Address value={option.label} isTruncated />
-    </Row>
+const WrappingSingleValue = ({ children }: { children?: ReactNode }) => (
+    <Text as="div" maxWidth="100%" intent="neutral" priority="primary" padding={{ vertical: 8 }}>
+        {children}
+    </Text>
 );
+
+const wrappedValueComponents = { SingleValue: WrappingSingleValue };
+const singleAddressComponents = { ...wrappedValueComponents, DropdownIndicator: () => null };
 
 type SignAddressInputProps = {
     account?: Account;
@@ -30,14 +33,29 @@ export const SignAddressInput = ({
 }: SignAddressInputProps) => {
     const { getValue, groupedOptions } = useSignAddressOptions(account, touchedAddresses);
 
+    const hasMultipleAddresses = !!account && isUtxoBased(account);
+
+    const formatOptionLabel = (option: AddressItem) => (
+        <Row gap={4}>
+            {hasMultipleAddresses && (
+                <Box minWidth={36}>
+                    <Text isDisabled>/{option.value.split('/').pop()}</Text>
+                </Box>
+            )}
+            <Address value={option.label} />
+        </Row>
+    );
+
     return (
         <Select
+            {...selectProps}
             value={getValue(value)}
             options={groupedOptions}
             onChange={option => onChange?.(optionToAddress(option))}
             formatOptionLabel={formatOptionLabel}
-            isSearchable
-            {...selectProps}
+            isSearchable={hasMultipleAddresses}
+            isMenuOpen={hasMultipleAddresses ? undefined : false}
+            components={hasMultipleAddresses ? wrappedValueComponents : singleAddressComponents}
         />
     );
 };

--- a/suite/sign-verify/src/useSignAddressOptions.ts
+++ b/suite/sign-verify/src/useSignAddressOptions.ts
@@ -111,9 +111,11 @@ export const useSignAddressOptions = (
         );
 
         return Object.entries(groupedAddresses).map(([label, options]) => {
-            const translatedLabel = label
-                ? translationString(label as ExtendedMessageDescriptor['id'])
-                : label;
+            if (!label) {
+                return { label: '', options };
+            }
+
+            const translatedLabel = translationString(label as ExtendedMessageDescriptor['id']);
 
             // @ts-expect-error: indexing with noUncheckedIndexedAccess
             const firstOption: (typeof options)[number] = options[0];


### PR DESCRIPTION


## Description

On the Sign & verify messages page, the address `Select` always displayed a middle-truncated address (e.g. `0x 9eA3 721B ... D597 FAE3`) even when there was enough space for the whole address, and for Ethereum accounts it showed a meaningless `/0` derivation-index prefix (plus an `m/0/i` group header in the opened dropdown) although an Ethereum account has exactly one address.

- The address is now rendered in full (`Address` without `isTruncated`).
- The closed control wraps the address to multiple lines when it doesn't fit on one: the design-system `Select` control now uses `minHeight` instead of a fixed `height` (single-line content keeps the exact same height everywhere), and this select overrides the shared one-line-ellipsis `SingleValue` with a wrapping one. The `Select` floating label is now anchored to the middle of the first row (`mapSizeToHeight(size) / 2`) instead of `top: 50%`, which is identical while the control is at its minimum height but keeps the label above the first line when the control grows.
- The derivation-index chip is only rendered for UTXO-based accounts (`isUtxoBased`), where an account has many addresses; Ethereum accounts have exactly one address, so no chip.
- Groups without a category (Ethereum) get an empty label, so no group header is rendered in the dropdown.
- For non-UTXO-based accounts there is nothing to choose from, so the select is static: no chevron, the dropdown cannot be opened, and it is not searchable.

## Notes for QA

- Sign & verify messages page (account → Sign & verify):
  - Ethereum account: the Address field shows the full address with no `/0` prefix, has no chevron, and cannot be opened or searched.
  - Bitcoin (and Cardano) accounts: options still show the `/index` chip and the group headers (Fresh/Used/Change `m/x/i`), but addresses are no longer shortened.
- On a narrow window, the closed Address field grows and wraps the address to multiple lines instead of cutting it off (both UTXO and Ethereum accounts).
- Because the shared `Select` control height changed from fixed to minimum, please sanity-check that other selects across the app (fee, coin, account type, settings dropdowns…) look unchanged — single-line content should render pixel-identically.
- No functional change to signing/verifying itself.

## Related Issue

Resolve #30696

## Screenshots:

Before:

| Ethereum address select |
| --- |
| shortened address with `/0` prefix (see issue #30696) |

After:
<img width="657" height="702" alt="Screenshot 2026-08-03 at 9 23 42" src="https://github.com/user-attachments/assets/7acb494a-fddc-442d-919b-9d753f3079a5" />

<img width="1081" height="851" alt="Screenshot 2026-08-03 at 10 38 16" src="https://github.com/user-attachments/assets/c6ba63fc-aade-438f-9789-f51cc0a7de8a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the sign-verify address selection UI (useSignAddressOptions hook and SignAddressInput component) plus a shared Select custom-components file. The two sign-and-verify E2E tests directly cover this functionality and should be run first. The Select component is a broad dependency, but without evidence that the modification affects other dropdown flows, a targeted run is preferred over broad regression testing.

<details><summary><b>Changed files (3)</b></summary>

- `packages/components/src/components/form/Select/customComponents.tsx`
- `packages/suite/src/hooks/wallet/sign-verify/useSignAddressOptions.ts`
- `packages/suite/src/views/wallet/sign-verify/components/SignAddressInput.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Directly exercises the SignAddressInput component and useSignAddressOptions hook when selecting an Ethereum address and signing/verifying a message, so any change to address-option logic or the Select UI will be validated here.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Covers Bitcoin sign/verify flows including address selection via SignAddressInput, making it the primary regression test for the changed sign-verify address option behavior and the associated Select rendering.

</details>

_Updated: 2026-08-03T08:41:08.486Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30696-sign-verify-address-select/web/](https://dev.suite.sldev.cz/suite-web/fix/30696-sign-verify-address-select/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30696-sign-verify-address-select&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30696-sign-verify-address-select&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:49:08.725Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:49:47.227Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->



