### PR TITLE
fix(suite): open explorer from empty account view via button href

### DIFF
--- a/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx
@@ -1,10 +1,10 @@
-import { TrezorLink } from '@suite/external-links';
+import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { type Explorer } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { isUtxoBased } from '@suite-common/wallet-utils';
-import { ArrowUpRightIcon, CloudIcon } from '@trezor/icons';
+import { CloudIcon } from '@trezor/icons';
 
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite';
@@ -16,6 +16,7 @@ interface NoTransactionsProps {
 export const NoTransactions = ({ account }: NoTransactionsProps) => {
     const explorer = useSelector(state => selectExplorer(state, account.symbol)) as Explorer;
     const explorerUrl = `${getExplorerUrl(explorer, 'address')}${account.descriptor}${explorer.queryString ?? ''}`;
+    const href = useExternalLink(explorerUrl);
 
     return (
         <AccountExceptionLayout
@@ -27,12 +28,8 @@ export const NoTransactions = ({ account }: NoTransactionsProps) => {
                     ? [
                           {
                               key: '1',
-                              iconLeft: ArrowUpRightIcon,
-                              children: (
-                                  <TrezorLink href={explorerUrl}>
-                                      <Translation id="TR_SHOW_DETAILS_IN_BLOCK_EXPLORER" />
-                                  </TrezorLink>
-                              ),
+                              href,
+                              children: <Translation id="TR_SHOW_DETAILS_IN_BLOCK_EXPLORER" />,
                           },
                       ]
                     : undefined


### PR DESCRIPTION
## Description

The **Show details in blockchain explorer** button on the empty-account view did nothing when clicked. A `TrezorLink` anchor was nested inside the `Button`'s children, and since 987e9c4aab9 every `Button` calls `setPointerCapture` on pointerdown, which retargets the follow-up click to the button element — the nested anchor never receives it, and the button has no `onClick` of its own.

The action now passes `href` directly to the `Button` (`ButtonProps` supports it and renders the button `as="a"` with `target="_blank"` + `rel="noreferrer noopener"`), matching the existing `Button href` usages (`LearnMoreButton`, Contact support, custom-firmware GitHub button). `useExternalLink` keeps the Tor onion-URL swap that `TrezorLink` provided. The redundant left arrow icon was dropped because `Button` automatically appends the external-link arrow on the right for `target="_blank"`; the text is not underlined, consistent with all other link-behaving buttons.

## Notes for QA

- Open an account with no transaction history so the `Transactions not available` view shows (e.g. a fresh or dormant account on a non-UTXO network such as Ethereum or Stellar; originally reported on a dormant Stellar account in #30674).
- Clicking **Show details in blockchain explorer** now opens the account in the explorer in the browser; with Tor enabled the onion URL is used when available.
- The button shows the external-link arrow on the right and the label is not underlined, like other link buttons (e.g. Learn more).

## Related Issue

Resolve #30702

## Screenshots:
<img width="1149" height="515" alt="Screenshot 2026-08-03 at 12 06 03" src="https://github.com/user-attachments/assets/7fd8a9b2-b83e-4d55-8e6b-49cc20e39514" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared empty-state component in the transactions view, statically referenced by many suites but mostly as a transitive dependency. The targeted risk is regressions in how empty/no-transaction accounts are displayed. Running the empty-account assertion in coins-custom-backend and the transactions-view smoke test in wallet/transactions provides high confidence with minimal overhead.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/wallet/transactions/components/NoTransactions.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test explicitly asserts that an empty account page shows 'TR_ACCOUNT_IS_EMPTY_TITLE', which is the exact no-transactions state rendered by NoTransactions.tsx. Any regression in the empty-state component (visibility, layout, or copy) would be caught here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — It exercises the transaction overview page where NoTransactions.tsx lives; while it tests accounts that have transactions, a regression causing the empty-state component to render incorrectly or overlay real data would be visible on this view.

</details>

_Updated: 2026-08-03T09:47:18.783Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30702-no-transactions-explorer-button/web/](https://dev.suite.sldev.cz/suite-web/fix/30702-no-transactions-explorer-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30702-no-transactions-explorer-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30702-no-transactions-explorer-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T09:49:50.451Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T09:49:46.488Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->