### PR TITLE
feat(suite-desktop): add fiat indicator to weth deposit earn flows

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldActionStep.tsx
@@ -8,7 +8,11 @@ import type {
 } from '@suite-common/wallet-core';
 import { Button, Column } from '@trezor/components';
 
-import { YieldAmountCard, type YieldAmountCardUnitToggleProps } from './YieldAmountCard';
+import {
+    YieldAmountCard,
+    type YieldAmountCardUnitToggleProps,
+    type YieldApproxFiat,
+} from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 const actionStepTranslationMap = {
@@ -33,6 +37,7 @@ export type YieldActionStepProps = {
     flowType: YieldPositionFlowType;
     token: YieldFlowDisplayToken;
     summaryValue: ReactNode;
+    approxFiat?: YieldApproxFiat;
     isDisabled?: boolean;
     isPending?: boolean;
     warning?: ReactNode;
@@ -47,6 +52,7 @@ export const YieldActionStep = ({
     flowType,
     token,
     summaryValue,
+    approxFiat,
     isDisabled = false,
     isPending = false,
     warning,
@@ -64,6 +70,7 @@ export const YieldActionStep = ({
             <YieldAmountCard
                 tokenSymbol={token.symbol}
                 decimals={token.decimals}
+                approxFiat={approxFiat}
                 summary={{
                     labelTranslationId: balanceLabelTranslationId,
                     value: summaryValue,

--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -5,16 +5,19 @@ import { Translation, useTranslation } from '@suite/intl';
 import type { TranslationKey } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { formInputsMaxLength } from '@suite-common/validators';
+import type { NetworkSymbol } from '@suite-common/wallet-config';
 import type { YieldFlowFormValues } from '@suite-common/wallet-core';
+import { toTokenAddress } from '@suite-common/wallet-types';
 import { Banner, Button, Card, Column, Row, Text, TextButton } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
 
+import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useSelector } from 'src/hooks/suite';
 import { validateDecimals } from 'src/utils/suite/validation';
 
 type YieldAmountCardSummaryProps = {
     value: ReactNode;
-    labelTranslationId?: TranslationKey;
+    labelTranslationId: TranslationKey;
     onMaxClick?: () => void;
 };
 
@@ -27,6 +30,11 @@ export type YieldAmountCardUnitToggleProps = {
     onClick: () => void;
 };
 
+export type YieldApproxFiat = {
+    symbol: NetworkSymbol;
+    tokenContractAddress?: string | null;
+};
+
 type YieldAmountCardProps = {
     tokenSymbol: string;
     decimals?: number;
@@ -35,6 +43,7 @@ type YieldAmountCardProps = {
     unitToggle?: YieldAmountCardUnitToggleProps;
     warning?: ReactNode;
     isDisabled?: boolean;
+    approxFiat?: YieldApproxFiat;
 };
 
 export const YieldAmountCard = ({
@@ -45,6 +54,7 @@ export const YieldAmountCard = ({
     unitToggle,
     warning,
     isDisabled = false,
+    approxFiat,
 }: YieldAmountCardProps) => {
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
@@ -107,22 +117,48 @@ export const YieldAmountCard = ({
                 />
 
                 {summary && (
-                    <Row alignItems="center" gap={8} flexWrap="wrap">
-                        <Text typographyStyle="body-md" intent="neutral" priority="secondary">
-                            <Translation id={summary.labelTranslationId ?? 'TR_STAKE_AVAILABLE'} />
-                            {': '}
-                            {summary.value}
-                        </Text>
-                        {summary.onMaxClick && (
-                            <Button
-                                type="button"
-                                size="small"
-                                intent="neutral"
-                                priority="secondary"
-                                onClick={() => summary.onMaxClick?.()}
+                    <Row justifyContent="space-between" alignItems="center" gap={8} width="100%">
+                        <Row alignItems="center" gap={8}>
+                            <Text typographyStyle="body-md" intent="neutral" priority="secondary">
+                                <Translation id={summary.labelTranslationId} />
+                                {': '}
+                                {summary.value}
+                            </Text>
+                            {summary.onMaxClick && (
+                                <Button
+                                    type="button"
+                                    size="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={() => summary.onMaxClick?.()}
+                                >
+                                    <Translation id="TR_FRACTION_BUTTONS_MAX" />
+                                </Button>
+                            )}
+                        </Row>
+                        {approxFiat && (
+                            <BaseCurrencyValue
+                                amount={amountInput ?? ''}
+                                symbol={approxFiat.symbol}
+                                tokenAddress={
+                                    approxFiat.tokenContractAddress
+                                        ? toTokenAddress(approxFiat.tokenContractAddress)
+                                        : undefined
+                                }
+                                showApproximationIndicator
                             >
-                                <Translation id="TR_FRACTION_BUTTONS_MAX" />
-                            </Button>
+                                {({ value }) =>
+                                    value ? (
+                                        <Text
+                                            typographyStyle="body-xs"
+                                            intent="neutral"
+                                            priority="secondary"
+                                        >
+                                            {value}
+                                        </Text>
+                                    ) : null
+                                }
+                            </BaseCurrencyValue>
                         )}
                     </Row>
                 )}

--- a/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx
@@ -9,7 +9,7 @@ import { Banner, Button, Column } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
-import { YieldAmountCard } from './YieldAmountCard';
+import { YieldAmountCard, type YieldApproxFiat } from './YieldAmountCard';
 import { YieldApprovedAmountCard } from './YieldApprovedAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 import type { YieldApprovalAction } from '../yieldFlowUtils';
@@ -32,6 +32,7 @@ const getApproveButtonTranslationId = (approvalAction: YieldApprovalAction) => {
 export type YieldApproveStepProps = {
     token: YieldFlowDisplayToken;
     summaryValue: ReactNode;
+    approxFiat?: YieldApproxFiat;
     isDisabled?: boolean;
     isLoading?: boolean;
     /** Current on-chain allowance amount fetched by RPC. */
@@ -51,6 +52,7 @@ export type YieldApproveStepProps = {
 export const YieldApproveStep = ({
     token,
     summaryValue,
+    approxFiat,
     isDisabled = false,
     isLoading = false,
     approvedAmount,
@@ -83,6 +85,7 @@ export const YieldApproveStep = ({
             <YieldAmountCard
                 tokenSymbol={token.symbol}
                 decimals={token.decimals}
+                approxFiat={approxFiat}
                 summary={{
                     labelTranslationId: 'TR_BALANCE',
                     value: summaryValue,

--- a/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx
@@ -6,13 +6,14 @@ import { Button, Column, Row } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 
-import { YieldAmountCard } from './YieldAmountCard';
+import { YieldAmountCard, type YieldApproxFiat } from './YieldAmountCard';
 import { YieldPendingTransaction } from './YieldPendingTransaction';
 
 type YieldUnwrapStepProps = {
     tokenSymbol: string;
     tokenDecimals: number;
     tokenBalance: string;
+    approxFiat?: YieldApproxFiat;
     onMaxClick: () => void;
     onSubmit: () => void;
     onSkip?: () => void;
@@ -27,6 +28,7 @@ export const YieldUnwrapStep = ({
     tokenSymbol,
     tokenDecimals,
     tokenBalance,
+    approxFiat,
     onMaxClick,
     onSubmit,
     onSkip,
@@ -41,12 +43,15 @@ export const YieldUnwrapStep = ({
             tokenSymbol={tokenSymbol}
             decimals={tokenDecimals}
             isDisabled={!!pendingTransaction}
+            approxFiat={approxFiat}
             heading={{
                 amountLabelTranslationId: 'TR_EARN_YIELD_UNWRAP_AMOUNT',
             }}
             summary={{
                 labelTranslationId: 'TR_BALANCE',
-                value: <FormattedCryptoAmount value={tokenBalance} symbol={tokenSymbol} />,
+                value: (
+                    <FormattedCryptoAmount value={tokenBalance} symbol={tokenSymbol} isBalance />
+                ),
                 onMaxClick: pendingTransaction ? undefined : onMaxClick,
             }}
             warning={warning}

--- a/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx
@@ -49,12 +49,20 @@ export const YieldWrapStep = ({
             tokenSymbol={nativeSymbol}
             decimals={token.decimals}
             isDisabled={!!pendingTransaction}
+            // The wrap amount is the native coin, so no token contract address.
+            approxFiat={{ symbol: token.networkSymbol }}
             heading={{
                 amountLabelTranslationId: 'TR_EARN_YIELD_WRAP_AMOUNT',
             }}
             summary={{
                 labelTranslationId: 'TR_EARN_YIELD_AVAILABLE_TO_WRAP',
-                value: <FormattedCryptoAmount value={availableAmount} symbol={nativeSymbol} />,
+                value: (
+                    <FormattedCryptoAmount
+                        value={availableAmount}
+                        symbol={nativeSymbol}
+                        isBalance
+                    />
+                ),
                 onMaxClick: pendingTransaction ? undefined : onMaxClick,
             }}
             warning={warning}

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -66,6 +66,11 @@ export const YieldDepositForm = () => {
         pendingTransaction?.type === 'wrap' ? pendingTransaction : undefined;
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    // Approximate fiat value shown under the amount input, from the token's own rate.
+    const approxFiat = {
+        symbol: token.networkSymbol,
+        tokenContractAddress: token.contractAddress,
+    };
     const sequence = getYieldFlowStepSequence({
         flowType: 'deposit',
         isWrappedNativeVault: flow.isWrappedNativeVault,
@@ -267,10 +272,12 @@ export const YieldDepositForm = () => {
                                 content: () => (
                                     <YieldApproveStep
                                         token={token}
+                                        approxFiat={approxFiat}
                                         summaryValue={
                                             <FormattedCryptoAmount
                                                 value={maxAmount}
                                                 symbol={token.symbol}
+                                                isBalance
                                             />
                                         }
                                         approvedAmount={allowanceAmount || undefined}
@@ -316,10 +323,12 @@ export const YieldDepositForm = () => {
                                     <YieldActionStep
                                         flowType="deposit"
                                         token={token}
+                                        approxFiat={approxFiat}
                                         summaryValue={
                                             <FormattedCryptoAmount
                                                 value={maxAmount}
                                                 symbol={token.symbol}
+                                                isBalance
                                             />
                                         }
                                         warning={

--- a/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
@@ -9,10 +9,14 @@ import {
     doTokensMatch,
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getStablecoinYieldFlowKey,
+    selectBaseCurrency,
+    useMissingRateTickersQuery,
 } from '@suite-common/wallet-core';
-import type { Account, TokenInfoBranded } from '@suite-common/wallet-types';
+import { type Account, type TokenInfoBranded, toTokenAddress } from '@suite-common/wallet-types';
 import { getApyPercent, getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import type { TokenInfo } from '@trezor/connect';
+
+import { useSelector } from 'src/hooks/suite';
 
 const hasTokenSymbol = (
     accountToken: NonNullable<Account['tokens']>[number],
@@ -143,6 +147,16 @@ export const useResolvedYieldFlowData = ({
     });
 
     const apy = vault.rewardRate.total != null ? getApyPercent(vault.rewardRate.total) : null;
+
+    const baseCurrency = useSelector(selectBaseCurrency);
+    // The deposited token (e.g. WETH) is often not held by the user, so the balance-driven fiat
+    // rate fetch skips it. Force-fetch the token's rate so the approximate fiat value can render.
+    useMissingRateTickersQuery({
+        baseCurrencyCode: baseCurrency,
+        missingRateTickers: token?.contractAddress
+            ? [{ symbol: token.networkSymbol, tokenAddress: toTokenAddress(token.contractAddress) }]
+            : [],
+    });
 
     return {
         account,

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -7,13 +7,18 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { type YieldFlowDisplayToken, type YieldFlowFormValues } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import {
+    type YieldFlowDisplayToken,
+    type YieldFlowFormValues,
+    selectBaseCurrency,
+    useMissingRateTickersQuery,
+} from '@suite-common/wallet-core';
+import { type Account, toTokenAddress } from '@suite-common/wallet-types';
 import { Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
 import { submitUnwrapNativeTokenThunk } from 'src/actions/wallet/unwrapNativeTokenThunks';
-import { useDispatch } from 'src/hooks/suite';
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import { WrappedNativeFlowComplete } from '../common/WrappedNativeFlowComplete';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
@@ -60,6 +65,16 @@ export const UnwrapNativeToken = ({
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+
+    const baseCurrency = useSelector(selectBaseCurrency);
+    // The wrapped-native token (WETH) is not held as a balance, so its fiat rate is not fetched by
+    // the balance-driven path. Force-fetch it so the approximate fiat value can render.
+    useMissingRateTickersQuery({
+        baseCurrencyCode: baseCurrency,
+        missingRateTickers: [
+            { symbol: account.symbol, tokenAddress: toTokenAddress(tokenContractAddress) },
+        ],
+    });
     const wrappedToken: YieldFlowDisplayToken & { contractAddress: string } = {
         networkSymbol: account.symbol,
         symbol: tokenSymbol,
@@ -157,6 +172,7 @@ export const UnwrapNativeToken = ({
                         tokenSymbol={tokenSymbol}
                         tokenDecimals={tokenDecimals}
                         tokenBalance={tokenBalance}
+                        approxFiat={{ symbol: account.symbol, tokenContractAddress }}
                         isSubmitting={unwrapMutation.isPending}
                         isSubmitDisabled={!isAmountValid}
                         warning={

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -59,6 +59,16 @@ export const YieldWithdrawForm = () => {
     const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
 
     const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const withdrawActionToken = flowType === 'redeem' ? receiptToken : token;
+    // Approximate fiat value shown under the amount input, from the token's own rate.
+    const actionApproxFiat = {
+        symbol: withdrawActionToken.networkSymbol,
+        tokenContractAddress: withdrawActionToken.contractAddress,
+    };
+    const unwrapApproxFiat = {
+        symbol: token.networkSymbol,
+        tokenContractAddress: token.contractAddress,
+    };
     const sequence = getYieldFlowStepSequence({
         flowType,
         isWrappedNativeVault: flow.isWrappedNativeVault,
@@ -212,11 +222,13 @@ export const YieldWithdrawForm = () => {
                             content: () => (
                                 <YieldActionStep
                                     flowType={flowType}
-                                    token={flowType === 'redeem' ? receiptToken : token}
+                                    token={withdrawActionToken}
+                                    approxFiat={actionApproxFiat}
                                     summaryValue={
                                         <FormattedCryptoAmount
                                             value={maxAmount}
                                             symbol={inputTokenSymbol}
+                                            isBalance
                                         />
                                     }
                                     warning={getWithdrawWarning()}
@@ -264,6 +276,7 @@ export const YieldWithdrawForm = () => {
                                     tokenSymbol={token.symbol}
                                     tokenDecimals={token.decimals}
                                     tokenBalance={token.balance}
+                                    approxFiat={unwrapApproxFiat}
                                     onMaxClick={() => setAmountInput(token.balance)}
                                     isSubmitting={isSubmittingAction}
                                     isSubmitDisabled={


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds displaying of currently typed amount

## Notes for QA

1) As specified in the issue make sure to check all the yield flows (except staking)

## Related Issue

Resolve #30576

## Screenshots:

| wrap | unwrap |
|--------|--------|
| <img width="651" height="411" alt="Screenshot 2026-08-04 at 10 25 44" src="https://github.com/user-attachments/assets/b9fa1780-e524-41b0-a6a6-bbc3fb8cafea" /> | <img width="641" height="350" alt="Screenshot 2026-08-04 at 10 25 55" src="https://github.com/user-attachments/assets/3c274cad-dfcf-43fa-84ff-e0c156bc9601" /> | 

| withdraw | unwrap |
|--------|--------|
| <img width="625" height="524" alt="Screenshot 2026-08-04 at 10 22 00" src="https://github.com/user-attachments/assets/db8e3b46-5210-4d42-a98d-352878abba30" /> | <img width="601" height="631" alt="Screenshot 2026-08-04 at 10 21 46" src="https://github.com/user-attachments/assets/b51aa26d-bc87-431f-a2cd-71a306634478" /> |



| wrap | approve | desposit |
|--------|--------|--------|
| <img width="630" height="703" alt="Screenshot 2026-08-04 at 10 20 26" src="https://github.com/user-attachments/assets/2337a588-133a-4243-8ce4-e2274ad39763" /> | <img width="606" height="604" alt="Screenshot 2026-08-04 at 10 20 28" src="https://github.com/user-attachments/assets/9e183bf6-c3b0-4c78-88db-55bbd6529a51" /> |  <img width="584" height="610" alt="Screenshot 2026-08-04 at 10 21 09" src="https://github.com/user-attachments/assets/064ea6a1-1d70-4e08-8209-6f04b89dbd23" /> |


USD deposit:

<img width="593" height="660" alt="Screenshot 2026-08-04 at 10 20 18" src="https://github.com/user-attachments/assets/04dbf36a-bd0b-491d-b1bb-0e8b6f67a2fa" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/approx-fiat-indicator/web/](https://dev.suite.sldev.cz/suite-web/feat/approx-fiat-indicator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/approx-fiat-indicator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/approx-fiat-indicator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:32:15.885Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:31:18.190Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the earn/yield deposit and withdraw UI layer, so the highest-value tests are the ETH staking deposit, unstake/claim, and staking-form validation flows that exercise those components directly. A SOL initial-stake test and the general route link-check provide cross-coin and route-load coverage. Wrap, unwrap, and token-approval components are not exercised by any available E2E tests, so they remain uncovered and should be verified manually or via unit tests.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldActionStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking deposit flow, which is the primary user-facing flow rendered by the changed yield deposit/amount components and the useResolvedYieldFlowData hook. A regression here would be immediately visible to users trying to stake ETH.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers ETH unstaking and claim, the withdraw side of the earn/yield flow that is likely built on the changed YieldWithdrawForm and step components. It verifies amounts, device prompts, and post-action balances that depend on the changed UI.
- `suite/e2e/tests/staking/staking-form.test.ts` — Directly tests staking form validation, amount input behavior, fraction/max buttons, and crypto/fiat switching. These inputs and validation rules are implemented in the changed yield deposit/amount components, so this is the most targeted regression test for the form changes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — Navigates to all /earn/yield/* routes and verifies that page content loads. If the changed yield components crash on render or break route initialization, this smoke test will catch it across deposit, withdraw, wrap, and unwrap pages.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — SOL staking is another major earn flow that likely reuses the same yield deposit form and resolution hook. Running it adds confidence that the generic yield changes work correctly for a different coin/network without running the entire staking suite.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/components/earn/yield/common/YieldApproveStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldWrapStep.tsx`
- `packages/suite/src/components/earn/yield/common/YieldUnwrapStep.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`

_Updated: 2026-08-04T08:32:35.003Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->