### PR TITLE
refactor(discovery): discovery when becoming acquired/connected

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -374,7 +374,11 @@ const observeSelectedDevice = [
         action: {
             type: 'foo',
         },
-        changed: false,
+        observeResult: {
+            isDeviceChanged: false,
+            isDeviceBecomingAcquired: false,
+            isDeviceBecomingConnected: false,
+        },
     },
     {
         description: `no selected device in reducer`,
@@ -382,7 +386,11 @@ const observeSelectedDevice = [
         action: {
             type: DEVICE.CONNECT,
         },
-        changed: false,
+        observeResult: {
+            isDeviceChanged: false,
+            isDeviceBecomingAcquired: false,
+            isDeviceBecomingConnected: false,
+        },
     },
     {
         description: `device not changed`,
@@ -396,10 +404,14 @@ const observeSelectedDevice = [
                 devices: [SUITE_DEVICE],
             },
         },
-        changed: false,
+        observeResult: {
+            isDeviceChanged: false,
+            isDeviceBecomingAcquired: false,
+            isDeviceBecomingConnected: false,
+        },
     },
     {
-        description: `device is changed`,
+        description: `device is changed when it becomes connected`,
         action: {
             type: DEVICE.CONNECT,
         },
@@ -414,11 +426,12 @@ const observeSelectedDevice = [
                 ],
             },
         },
-        result: [
-            deviceActions.updateSelectedDevice.type,
-            deviceActions.selectedDeviceBecomingConnected.type,
-        ],
-        changed: true,
+        actions: [deviceActions.updateSelectedDevice.type],
+        observeResult: {
+            isDeviceChanged: true,
+            isDeviceBecomingAcquired: false,
+            isDeviceBecomingConnected: true,
+        },
     },
     {
         description: `device is changed (missing in reducer)`,
@@ -432,7 +445,11 @@ const observeSelectedDevice = [
                 devices: [],
             },
         },
-        changed: true,
+        observeResult: {
+            isDeviceChanged: true,
+            isDeviceBecomingAcquired: false,
+            isDeviceBecomingConnected: false,
+        },
     },
     {
         description: `device is changed and becomes acquired`,
@@ -451,12 +468,39 @@ const observeSelectedDevice = [
                 ],
             },
         },
-        result: [
-            deviceActions.updateSelectedDevice.type,
-            deviceActions.selectedDeviceBecomingAcquired.type,
-            deviceActions.selectedDeviceBecomingConnected.type,
-        ],
-        changed: true,
+        actions: [deviceActions.updateSelectedDevice.type],
+        observeResult: {
+            isDeviceChanged: true,
+            isDeviceBecomingAcquired: true,
+            isDeviceBecomingConnected: true,
+        },
+    },
+    {
+        description: `device is already connected and becomes acquired`,
+        action: {
+            type: DEVICE.CONNECT,
+        },
+        state: {
+            suite: {},
+            device: {
+                selectedDevice: {
+                    ...SUITE_DEVICE_UNACQUIRED,
+                    connected: true,
+                },
+                devices: [
+                    mockSuiteDevice({
+                        path: SUITE_DEVICE_UNACQUIRED.path,
+                        connected: true,
+                    }),
+                ],
+            },
+        },
+        actions: [deviceActions.updateSelectedDevice.type],
+        observeResult: {
+            isDeviceChanged: true,
+            isDeviceBecomingAcquired: true,
+            isDeviceBecomingConnected: false,
+        },
     },
 ];
 

--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -414,7 +414,10 @@ const observeSelectedDevice = [
                 ],
             },
         },
-        result: deviceActions.updateSelectedDevice.type,
+        result: [
+            deviceActions.updateSelectedDevice.type,
+            deviceActions.selectedDeviceBecomingConnected.type,
+        ],
         changed: true,
     },
     {
@@ -429,6 +432,30 @@ const observeSelectedDevice = [
                 devices: [],
             },
         },
+        changed: true,
+    },
+    {
+        description: `device is changed and becomes acquired`,
+        action: {
+            type: DEVICE.CONNECT,
+        },
+        state: {
+            suite: {},
+            device: {
+                selectedDevice: SUITE_DEVICE_UNACQUIRED,
+                devices: [
+                    mockSuiteDevice({
+                        path: SUITE_DEVICE_UNACQUIRED.path,
+                        connected: true,
+                    }),
+                ],
+            },
+        },
+        result: [
+            deviceActions.updateSelectedDevice.type,
+            deviceActions.selectedDeviceBecomingAcquired.type,
+            deviceActions.selectedDeviceBecomingConnected.type,
+        ],
         changed: true,
     },
 ];

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -157,14 +157,14 @@ describe('Suite Actions', () => {
         it(`observeSelectedDevice: ${f.description}`, async () => {
             const state = getInitialState(f.state.suite, f.state.device);
             const store = mockStore(state);
-            const changed = await store.dispatch(observeSelectedDevice()).unwrap();
-            expect(changed).toEqual(f.changed);
+            const observeResult = await store.dispatch(observeSelectedDevice()).unwrap();
+            expect(observeResult).toEqual(f.observeResult);
 
             const actionTypes = filterThunkActionTypes(store.getActions()).map(
                 action => action.type,
             );
 
-            expect(actionTypes).toEqual(f.result ?? []);
+            expect(actionTypes).toEqual(f.actions ?? []);
         });
     });
 

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -159,12 +159,12 @@ describe('Suite Actions', () => {
             const store = mockStore(state);
             const changed = store.dispatch(observeSelectedDevice());
             expect(changed).toEqual(f.changed);
-            if (!f.result) {
-                expect(filterThunkActionTypes(store.getActions()).length).toEqual(0);
-            } else {
-                const action = filterThunkActionTypes(store.getActions()).pop();
-                expect(action?.type).toEqual(f.result);
-            }
+
+            const actionTypes = filterThunkActionTypes(store.getActions()).map(
+                action => action.type,
+            );
+
+            expect(actionTypes).toEqual(f.result ?? []);
         });
     });
 

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -154,10 +154,10 @@ describe('Suite Actions', () => {
     });
 
     fixtures.observeSelectedDevice.forEach(f => {
-        it(`observeSelectedDevice: ${f.description}`, () => {
+        it(`observeSelectedDevice: ${f.description}`, async () => {
             const state = getInitialState(f.state.suite, f.state.device);
             const store = mockStore(state);
-            const changed = store.dispatch(observeSelectedDevice());
+            const changed = await store.dispatch(observeSelectedDevice()).unwrap();
             expect(changed).toEqual(f.changed);
 
             const actionTypes = filterThunkActionTypes(store.getActions()).map(

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts
@@ -11,7 +11,7 @@ import {
     extraDependenciesCommonMock,
     testMocks,
 } from '@suite-common/test-utils';
-import { defaultTrezorUIEventHandlerThunk } from '@suite-common/wallet-core';
+import { defaultTrezorUIEventHandlerThunk, observeSelectedDevice } from '@suite-common/wallet-core';
 import { UI_EVENT, UI_REQUEST } from '@trezor/connect';
 
 import * as deviceSettingsActions from 'src/actions/settings/deviceSettingsActions';
@@ -78,9 +78,19 @@ describe('buttonRequest middleware', () => {
 
         await call;
 
+        // Not interested in noisy lifecycle actions from reduxJS toolkit
+        const unrelatedActionTypes = [
+            observeSelectedDevice.pending.type,
+            observeSelectedDevice.fulfilled.type,
+        ];
+        const actions = store
+            .getActions()
+            .filter(action => !unrelatedActionTypes.includes(action.type));
+
         // not interested in the last action (its from changePin mock);
-        store.getActions().pop();
-        expect(store.getActions()).toMatchObject([
+        actions.pop();
+
+        expect(actions).toMatchObject([
             { type: connectInitThunk.pending.type, payload: undefined },
             { type: connectInitThunk.fulfilled.type, payload: undefined },
             { type: lockDevice.type, payload: true },

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -113,6 +113,14 @@ const updateSelectedDevice = createAction(
     (payload: TrezorDevice) => ({ payload }),
 );
 
+const selectedDeviceBecomingAcquired = createAction(
+    `${DEVICE_MODULE_PREFIX}/selectedDeviceBecomingAcquired`,
+);
+
+const selectedDeviceBecomingConnected = createAction(
+    `${DEVICE_MODULE_PREFIX}/selectedDeviceBecomingConnected`,
+);
+
 // Remove button requests for specific device by button request code or all button requests if no code is provided.
 const removeButtonRequests = createAction(
     `${DEVICE_MODULE_PREFIX}/removeButtonRequests`,
@@ -187,6 +195,8 @@ export const deviceActions = {
     requestDeviceReconnect,
     selectDevice,
     updateSelectedDevice,
+    selectedDeviceBecomingAcquired,
+    selectedDeviceBecomingConnected,
     removeButtonRequests,
     setEntropyCheckResult,
     setDelegatedIdentityKey,

--- a/suite-common/device/src/deviceActions.ts
+++ b/suite-common/device/src/deviceActions.ts
@@ -113,14 +113,6 @@ const updateSelectedDevice = createAction(
     (payload: TrezorDevice) => ({ payload }),
 );
 
-const selectedDeviceBecomingAcquired = createAction(
-    `${DEVICE_MODULE_PREFIX}/selectedDeviceBecomingAcquired`,
-);
-
-const selectedDeviceBecomingConnected = createAction(
-    `${DEVICE_MODULE_PREFIX}/selectedDeviceBecomingConnected`,
-);
-
 // Remove button requests for specific device by button request code or all button requests if no code is provided.
 const removeButtonRequests = createAction(
     `${DEVICE_MODULE_PREFIX}/removeButtonRequests`,
@@ -195,8 +187,6 @@ export const deviceActions = {
     requestDeviceReconnect,
     selectDevice,
     updateSelectedDevice,
-    selectedDeviceBecomingAcquired,
-    selectedDeviceBecomingConnected,
     removeButtonRequests,
     setEntropyCheckResult,
     setDelegatedIdentityKey,

--- a/suite-common/suite-utils/src/device.ts
+++ b/suite-common/suite-utils/src/device.ts
@@ -542,3 +542,11 @@ export const getDeviceLanguage = (device?: TrezorDevice): string | null =>
     device?.features?.language ?? null;
 
 export const getDeviceMode = (device?: TrezorDevice): DeviceMode | null => device?.mode ?? null;
+
+type DeviceComparisonParams = { prevDevice: TrezorDevice; nextDevice: TrezorDevice };
+
+export const getIsDeviceBecomingAcquired = ({ prevDevice, nextDevice }: DeviceComparisonParams) =>
+    !isDeviceAcquired(prevDevice) && isDeviceAcquired(nextDevice);
+
+export const getIsDeviceBecomingConnected = ({ prevDevice, nextDevice }: DeviceComparisonParams) =>
+    !prevDevice.connected && nextDevice.connected;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -109,39 +109,56 @@ export const forgetDisconnectedDevices = createThunk(
     },
 );
 
+type ObserveSelectedDeviceResult = {
+    isDeviceChanged: boolean;
+    isDeviceBecomingAcquired: boolean;
+    isDeviceBecomingConnected: boolean;
+};
+
 /**
  * Keep selected device synchronized with the `devices` reducer, because selected device is a copy
  * of one of the `devices` (and those are updated via DEVICE.CHANGED. etc.).
  * Called from `suiteMiddleware` (Desktop) or `deviceMiddleware` (Mobile).
  */
-export const observeSelectedDevice = createThunk<boolean, void>(
+export const observeSelectedDevice = createThunk<ObserveSelectedDeviceResult, void>(
     `${DEVICE_MODULE_PREFIX}/observeSelectedDevice`,
-    (_, { dispatch, getState }) => {
+    (_, { dispatch, getState, fulfillWithValue }) => {
         const devices = selectDevices(getState());
 
         const selectedDevice = selectSelectedDevice(getState());
-        if (!selectedDevice) return false;
+        if (!selectedDevice)
+            return fulfillWithValue({
+                isDeviceChanged: false,
+                isDeviceBecomingAcquired: false,
+                isDeviceBecomingConnected: false,
+            });
 
         // Device in `devices` may have been already updated via DEVICE.CHANGED action
         const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
-        if (!deviceFromReducer) return true;
+        if (!deviceFromReducer)
+            return fulfillWithValue({
+                isDeviceChanged: true,
+                isDeviceBecomingAcquired: false,
+                isDeviceBecomingConnected: false,
+            });
 
-        const changed = isChanged(selectedDevice, deviceFromReducer);
-        if (changed) {
+        const isDeviceChanged = isChanged(selectedDevice, deviceFromReducer);
+        if (isDeviceChanged) {
             dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
-
-            // This lives here, because currently we only care about selected device updating.
-            // TBD: maybe this would be cleaner in connectInitThunk – if we care about all devices?
-            const deviceComparison = { prevDevice: selectedDevice, nextDevice: deviceFromReducer };
-            if (getIsDeviceBecomingAcquired(deviceComparison)) {
-                dispatch(deviceActions.selectedDeviceBecomingAcquired());
-            }
-            if (getIsDeviceBecomingConnected(deviceComparison)) {
-                dispatch(deviceActions.selectedDeviceBecomingConnected());
-            }
         }
 
-        return changed;
+        // The "Is becoming acquired/connect" logic lives here, because currently we only care about
+        // that for the selected device updates.
+        // TBD: maybe this would be cleaner in connectInitThunk – if we care about all devices?
+        const deviceComparison = { prevDevice: selectedDevice, nextDevice: deviceFromReducer };
+        const isDeviceBecomingAcquired = getIsDeviceBecomingAcquired(deviceComparison);
+        const isDeviceBecomingConnected = getIsDeviceBecomingConnected(deviceComparison);
+
+        return fulfillWithValue({
+            isDeviceChanged,
+            isDeviceBecomingAcquired,
+            isDeviceBecomingConnected,
+        });
     },
 );
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -18,6 +18,8 @@ import { type AcquiredDevice, type TrezorDevice } from '@suite-common/suite-type
 import {
     getDeviceInstances,
     getFirstDeviceInstance,
+    getIsDeviceBecomingAcquired,
+    getIsDeviceBecomingConnected,
     getIsThpDevice,
     getSelectedDevice,
 } from '@suite-common/suite-utils';
@@ -108,22 +110,33 @@ export const forgetDisconnectedDevices = createThunk(
 );
 
 /**
- * Called from `suiteMiddleware`
- * Keep `suite` reducer synchronized with `devices` reducer
+ * Keep selected device synchronized with the `devices` reducer, because selected device is a copy
+ * of one of the `devices` (and those are updated via DEVICE.CHANGED. etc.).
+ * Called from `suiteMiddleware` (Desktop) or `deviceMiddleware` (Mobile).
  */
 export const observeSelectedDevice = () => (dispatch: any, getState: any) => {
     const devices = selectDevices(getState());
 
     const selectedDevice = selectSelectedDevice(getState());
-
     if (!selectedDevice) return false;
 
+    // Device in `devices` may have been already updated via DEVICE.CHANGED action
     const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
     if (!deviceFromReducer) return true;
 
     const changed = isChanged(selectedDevice, deviceFromReducer);
     if (changed) {
         dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
+
+        // This lives here, because currently we only care about selected device updating.
+        // TBD: maybe this would be cleaner in connectInitThunk – if we care about all devices?
+        const deviceComparison = { prevDevice: selectedDevice, nextDevice: deviceFromReducer };
+        if (getIsDeviceBecomingAcquired(deviceComparison)) {
+            dispatch(deviceActions.selectedDeviceBecomingAcquired());
+        }
+        if (getIsDeviceBecomingConnected(deviceComparison)) {
+            dispatch(deviceActions.selectedDeviceBecomingConnected());
+        }
     }
 
     return changed;

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -114,33 +114,36 @@ export const forgetDisconnectedDevices = createThunk(
  * of one of the `devices` (and those are updated via DEVICE.CHANGED. etc.).
  * Called from `suiteMiddleware` (Desktop) or `deviceMiddleware` (Mobile).
  */
-export const observeSelectedDevice = () => (dispatch: any, getState: any) => {
-    const devices = selectDevices(getState());
+export const observeSelectedDevice = createThunk<boolean, void>(
+    `${DEVICE_MODULE_PREFIX}/observeSelectedDevice`,
+    (_, { dispatch, getState }) => {
+        const devices = selectDevices(getState());
 
-    const selectedDevice = selectSelectedDevice(getState());
-    if (!selectedDevice) return false;
+        const selectedDevice = selectSelectedDevice(getState());
+        if (!selectedDevice) return false;
 
-    // Device in `devices` may have been already updated via DEVICE.CHANGED action
-    const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
-    if (!deviceFromReducer) return true;
+        // Device in `devices` may have been already updated via DEVICE.CHANGED action
+        const deviceFromReducer = getSelectedDevice(selectedDevice, devices);
+        if (!deviceFromReducer) return true;
 
-    const changed = isChanged(selectedDevice, deviceFromReducer);
-    if (changed) {
-        dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
+        const changed = isChanged(selectedDevice, deviceFromReducer);
+        if (changed) {
+            dispatch(deviceActions.updateSelectedDevice(deviceFromReducer));
 
-        // This lives here, because currently we only care about selected device updating.
-        // TBD: maybe this would be cleaner in connectInitThunk – if we care about all devices?
-        const deviceComparison = { prevDevice: selectedDevice, nextDevice: deviceFromReducer };
-        if (getIsDeviceBecomingAcquired(deviceComparison)) {
-            dispatch(deviceActions.selectedDeviceBecomingAcquired());
+            // This lives here, because currently we only care about selected device updating.
+            // TBD: maybe this would be cleaner in connectInitThunk – if we care about all devices?
+            const deviceComparison = { prevDevice: selectedDevice, nextDevice: deviceFromReducer };
+            if (getIsDeviceBecomingAcquired(deviceComparison)) {
+                dispatch(deviceActions.selectedDeviceBecomingAcquired());
+            }
+            if (getIsDeviceBecomingConnected(deviceComparison)) {
+                dispatch(deviceActions.selectedDeviceBecomingConnected());
+            }
         }
-        if (getIsDeviceBecomingConnected(deviceComparison)) {
-            dispatch(deviceActions.selectedDeviceBecomingConnected());
-        }
-    }
 
-    return changed;
-};
+        return changed;
+    },
+);
 
 /**
  * Called from <AcquireDevice /> component

--- a/suite/discovery/src/conditions.ts
+++ b/suite/discovery/src/conditions.ts
@@ -1,6 +1,34 @@
+import { type LocksRootState, selectIsDeviceLocked } from '@suite/locks';
 import { type RouterRootState, selectRouterApp } from '@suite/router';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 
 import { SHOULD_ROUTER_APP_START_DISCOVERY } from './config';
 
+/**
+ * Determines if current router app is one of those, where discovery should start.
+ */
 export const selectShouldRouterAppStartDiscovery = (state: RouterRootState) =>
     SHOULD_ROUTER_APP_START_DISCOVERY[selectRouterApp(state)];
+
+type DeviceReadyRootState = DeviceRootState & LocksRootState;
+
+/**
+ * Determines if device is ready for discovery, either:
+ * - unlocked
+ * - edge case: locked, and just has been acquired. In that case, device-change is emitted right before acquireDevice ends (and unlocks the device).
+ *   TODO investigate if the lock state can be synced sooner, so that this case can be removed.
+ */
+export const selectIsDeviceReadyToStartDiscovery = (
+    state: DeviceReadyRootState,
+    becomesAcquired: boolean,
+): boolean => {
+    const device = selectSelectedDevice(state);
+    const isDeviceLocked = selectIsDeviceLocked(state);
+
+    return (
+        device?.connected == true &&
+        isDeviceAcquired(device) &&
+        (!isDeviceLocked || becomesAcquired)
+    );
+};

--- a/suite/discovery/src/conditions.ts
+++ b/suite/discovery/src/conditions.ts
@@ -1,17 +1,6 @@
 import { type RouterRootState, selectRouterApp } from '@suite/router';
-import type { TrezorDevice } from '@suite-common/suite-types';
 
 import { SHOULD_ROUTER_APP_START_DISCOVERY } from './config';
-
-type IsDeviceBecomingAcquiredParams = {
-    prevDevice: TrezorDevice;
-    device: TrezorDevice;
-};
-export const isDeviceBecomingAcquired = ({ prevDevice, device }: IsDeviceBecomingAcquiredParams) =>
-    prevDevice.features === undefined && device.features !== undefined;
-
-export const isDeviceBecomingConnected = ({ prevDevice, device }: IsDeviceBecomingAcquiredParams) =>
-    !prevDevice.connected && device.connected;
 
 export const selectShouldRouterAppStartDiscovery = (state: RouterRootState) =>
     SHOULD_ROUTER_APP_START_DISCOVERY[selectRouterApp(state)];

--- a/suite/discovery/src/discoveryMiddleware.test.ts
+++ b/suite/discovery/src/discoveryMiddleware.test.ts
@@ -145,6 +145,10 @@ const fixtures: Fixture[] = [
         steps: [
             {
                 action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: deviceActions.selectedDeviceBecomingAcquired(),
                 expectedCallCount: 1,
             },
         ],
@@ -158,6 +162,10 @@ const fixtures: Fixture[] = [
         steps: [
             {
                 action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: deviceActions.selectedDeviceBecomingConnected(),
                 expectedCallCount: 1,
             },
         ],
@@ -174,6 +182,10 @@ const fixtures: Fixture[] = [
         steps: [
             {
                 action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: deviceActions.selectedDeviceBecomingConnected(),
                 expectedCallCount: 0,
             },
         ],
@@ -202,6 +214,10 @@ const fixtures: Fixture[] = [
         steps: [
             {
                 action: deviceActions.updateSelectedDevice(selectedDevice),
+                expectedCallCount: 0,
+            },
+            {
+                action: deviceActions.selectedDeviceBecomingAcquired(),
                 expectedCallCount: 0,
             },
             {

--- a/suite/discovery/src/discoveryMiddleware.test.ts
+++ b/suite/discovery/src/discoveryMiddleware.test.ts
@@ -102,6 +102,12 @@ const disconnectedDevice = mockSuiteDevice({
     state: { staticSessionId: 'device@selected:1' },
 });
 
+const createObserveSelectedDeviceFulfilledAction = (payload: {
+    isDeviceChanged: boolean;
+    isDeviceBecomingAcquired: boolean;
+    isDeviceBecomingConnected: boolean;
+}) => walletCore.observeSelectedDevice.fulfilled(payload, 'request-id', undefined);
+
 const fixtures: Fixture[] = [
     {
         description: 'starts discovery when device is selected',
@@ -148,7 +154,11 @@ const fixtures: Fixture[] = [
                 expectedCallCount: 0,
             },
             {
-                action: deviceActions.selectedDeviceBecomingAcquired(),
+                action: createObserveSelectedDeviceFulfilledAction({
+                    isDeviceChanged: true,
+                    isDeviceBecomingAcquired: true,
+                    isDeviceBecomingConnected: true,
+                }),
                 expectedCallCount: 1,
             },
         ],
@@ -165,7 +175,11 @@ const fixtures: Fixture[] = [
                 expectedCallCount: 0,
             },
             {
-                action: deviceActions.selectedDeviceBecomingConnected(),
+                action: createObserveSelectedDeviceFulfilledAction({
+                    isDeviceChanged: true,
+                    isDeviceBecomingAcquired: false,
+                    isDeviceBecomingConnected: true,
+                }),
                 expectedCallCount: 1,
             },
         ],
@@ -185,7 +199,11 @@ const fixtures: Fixture[] = [
                 expectedCallCount: 0,
             },
             {
-                action: deviceActions.selectedDeviceBecomingConnected(),
+                action: createObserveSelectedDeviceFulfilledAction({
+                    isDeviceChanged: true,
+                    isDeviceBecomingAcquired: false,
+                    isDeviceBecomingConnected: true,
+                }),
                 expectedCallCount: 0,
             },
         ],
@@ -217,7 +235,11 @@ const fixtures: Fixture[] = [
                 expectedCallCount: 0,
             },
             {
-                action: deviceActions.selectedDeviceBecomingAcquired(),
+                action: createObserveSelectedDeviceFulfilledAction({
+                    isDeviceChanged: true,
+                    isDeviceBecomingAcquired: true,
+                    isDeviceBecomingConnected: true,
+                }),
                 expectedCallCount: 0,
             },
             {

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -1,9 +1,7 @@
-import { selectIsDeviceLocked } from '@suite/locks';
 import { routerAppChanged } from '@suite/router';
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { type AnyAction, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
-import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { selectThpAutoconnectStep, thpActions } from '@suite-common/thp';
 import {
     accountsActions,
@@ -12,7 +10,10 @@ import {
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
-import { selectShouldRouterAppStartDiscovery } from './conditions';
+import {
+    selectIsDeviceReadyToStartDiscovery,
+    selectShouldRouterAppStartDiscovery,
+} from './conditions';
 
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, getState }): Promise<AnyAction> => {
@@ -21,7 +22,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         await next(action);
 
         const device = selectSelectedDevice(getState());
-        const isDeviceLocked = selectIsDeviceLocked(getState());
+        if (!device) return action;
         const becomesAcquired = deviceActions.selectedDeviceBecomingAcquired.match(action);
         const becomesConnected = deviceActions.selectedDeviceBecomingConnected.match(action);
 
@@ -32,10 +33,8 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // 1. Discovery should only start on certain apps
         if (!selectShouldRouterAppStartDiscovery(getState())) return action;
 
-        // 2. Device must be unlocked. The only exception is, when it is locked and just has been acquired.
-        //    In that case, device-change is emitted right before acquireDevice ends (and unlocks the device).
-        const isDeviceReady =
-            device?.connected && isDeviceAcquired(device) && (!isDeviceLocked || becomesAcquired);
+        // 2. Device must be idle, not locked.
+        const isDeviceReady = selectIsDeviceReadyToStartDiscovery(getState(), becomesAcquired);
         if (!isDeviceReady) return action;
 
         // 3. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -12,42 +12,25 @@ import {
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
 
-import {
-    isDeviceBecomingAcquired,
-    isDeviceBecomingConnected,
-    selectShouldRouterAppStartDiscovery,
-} from './conditions';
+import { selectShouldRouterAppStartDiscovery } from './conditions';
 
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
     async (action, { dispatch, next, getState }): Promise<AnyAction> => {
-        // We are only taking a snapshot, but yes, the same rules shall apply: prevState and nextState MUST NOT be used without a selector.
-        // eslint-disable-next-line no-restricted-syntax
-        const prevState: any = getState();
-
         // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
         // Note: TS says next(action) generally isn't async, but the action may return anything; sometimes it's a Promise → needs to be awaited
         await next(action);
 
-        // eslint-disable-next-line no-restricted-syntax
-        const nextState: any = getState();
-
-        const prevDevice = selectSelectedDevice(prevState);
-        const device = selectSelectedDevice(nextState);
-        const isDeviceLocked = selectIsDeviceLocked(nextState);
-
-        const wasDeviceUpdated =
-            !!prevDevice && !!device && deviceActions.updateSelectedDevice.match(action);
-        const becomesAcquired =
-            wasDeviceUpdated && isDeviceBecomingAcquired({ prevDevice, device });
-        const becomesConnected =
-            wasDeviceUpdated && isDeviceBecomingConnected({ prevDevice, device });
+        const device = selectSelectedDevice(getState());
+        const isDeviceLocked = selectIsDeviceLocked(getState());
+        const becomesAcquired = deviceActions.selectedDeviceBecomingAcquired.match(action);
+        const becomesConnected = deviceActions.selectedDeviceBecomingConnected.match(action);
 
         /*
          The following conditions always block discovery:
         */
 
         // 1. Discovery should only start on certain apps
-        if (!selectShouldRouterAppStartDiscovery(nextState)) return action;
+        if (!selectShouldRouterAppStartDiscovery(getState())) return action;
 
         // 2. Device must be unlocked. The only exception is, when it is locked and just has been acquired.
         //    In that case, device-change is emitted right before acquireDevice ends (and unlocks the device).

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -6,6 +6,7 @@ import { selectThpAutoconnectStep, thpActions } from '@suite-common/thp';
 import {
     accountsActions,
     changeNetworks,
+    observeSelectedDevice,
     selectShouldRediscover,
     startOrRestartDiscoveryThunk,
 } from '@suite-common/wallet-core';
@@ -23,8 +24,11 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
 
         const device = selectSelectedDevice(getState());
         if (!device) return action;
-        const becomesAcquired = deviceActions.selectedDeviceBecomingAcquired.match(action);
-        const becomesConnected = deviceActions.selectedDeviceBecomingConnected.match(action);
+
+        const isObserveSelectedDeviceMatch = observeSelectedDevice.fulfilled.match(action);
+        const { isDeviceBecomingAcquired, isDeviceBecomingConnected } = isObserveSelectedDeviceMatch
+            ? action.payload
+            : { isDeviceBecomingAcquired: false, isDeviceBecomingConnected: false };
 
         /*
          The following conditions always block discovery:
@@ -34,7 +38,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         if (!selectShouldRouterAppStartDiscovery(getState())) return action;
 
         // 2. Device must be idle, not locked.
-        const isDeviceReady = selectIsDeviceReadyToStartDiscovery(getState(), becomesAcquired);
+        const isDeviceReady = selectIsDeviceReadyToStartDiscovery(
+            getState(),
+            isDeviceBecomingAcquired,
+        );
         if (!isDeviceReady) return action;
 
         // 3. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place
@@ -47,8 +54,8 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
          Start discovery only on the following actions:
         */
         if (
-            becomesAcquired ||
-            becomesConnected ||
+            isDeviceBecomingAcquired ||
+            isDeviceBecomingConnected ||
             isTHPAutoconnectFinished || // now that the THP Autoconnect was finished, resume the delayed discovery
             routerAppChanged.match(action) || // may no longer be one of the apps where discovery is disabled
             connectPopupCallThunkInner.fulfilled.match(action) ||


### PR DESCRIPTION
## Description

Followup to #30546:
- most importantly, untangle the hot mess of prevState/nextState comparison in `deviceMiddleware` in bd40a69137a78bd0a8f6aff78ffb7fc25108f5ff
- small nit for readability: extract one condition from middleware in 8771abe074ccc87192864724e9f5a7e041714bbc

## Notes for QA

Part of #30546 QA. This is refactoring of the becoming connected / becoming acquired flows, so those should still work the same. 

## Screenshots:

From  #30546 (I again tested these two flows myself):

- [start when acquiring](https://github.com/user-attachments/assets/7456b3c3-e1f7-4358-90cd-4e9d34810899)
- [restart when becoming connected](https://github.com/user-attachments/assets/d5e9ab5d-30b7-421f-a90e-39f9dba26fe0)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily touch broad device-state and discovery infrastructure (device.ts, deviceThunks.ts, discoveryMiddleware.ts, conditions.ts). Because these are global utilities mapped to over 100 tests, only a targeted subset that directly exercises discovery flows and device session state is recommended. The remaining changed files are unit tests and fixtures with no direct E2E coverage.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts`
- `suite-common/suite-utils/src/device.ts`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite/discovery/src/conditions.ts`
- `suite/discovery/src/discoveryMiddleware.test.ts`
- `suite/discovery/src/discoveryMiddleware.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Directly exercises the discovery process across multiple coins and recovery after a page reload, which is the primary behavior controlled by discoveryMiddleware.ts and conditions.ts. A regression here would be immediately visible to users enabling networks.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Tests wallet discovery after ejecting and re-adding a standard wallet, directly covering device state transitions and the discovery integration path that the changed device utilities and thunks support.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Tests custom Blockbook backend discovery, exercising discovery conditions and middleware paths with non-default backend configuration that could be affected by changes to discovery logic.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session acquisition, release, and takeover behavior, which depends on device state utilities and thunks in the changed files. A regression would manifest as incorrect 'Use Here' / 'Connected' states.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Tests device disconnect/reconnect and cached passphrase wallet behavior, covering device state management helpers and thunks that may be affected by the changed device files.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `packages/suite/src/middlewares/suite/buttonRequestMiddleware.test.ts`
- `suite/discovery/src/discoveryMiddleware.test.ts`

_Updated: 2026-08-03T12:41:07.584Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/discovery-becoming-acquired/web/](https://dev.suite.sldev.cz/suite-web/refactor/discovery-becoming-acquired/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/discovery-becoming-acquired&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/discovery-becoming-acquired&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/discovery-becoming-acquired&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T12:43:21.749Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T12:43:09.378Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->