### PR TITLE
feat(suite): add copy button to tx id in tx detail modal

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/BasicTxDetails.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { useExternalLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
+import { notificationsActions } from '@suite-common/toast-notifications';
 import { type Network } from '@suite-common/wallet-config';
 import {
     type PendingEvmNonceStatus,
@@ -16,6 +17,7 @@ import {
     Grid,
     H3,
     Icon,
+    IconButton,
     InfoItem,
     type InfoItemProps,
     InfoSegments,
@@ -24,8 +26,10 @@ import {
     Text,
     Tooltip,
 } from '@trezor/components';
+import { copyToClipboard } from '@trezor/dom-utils';
 import {
     CalendarIcon,
+    CopyIcon,
     FingerprintIcon,
     GasPumpIcon,
     PencilIcon,
@@ -38,6 +42,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { FormattedDateWithBullet } from 'src/components/suite/FormattedDateWithBullet';
 import { TransactionHeader } from 'src/components/wallet/TransactionItem/TransactionHeader';
+import { useDispatch } from 'src/hooks/suite';
 import { useLayoutSize } from 'src/hooks/suite/useLayoutSize';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 import { getTransactionIcon } from 'src/utils/wallet/transactionIconUtils';
@@ -95,10 +100,17 @@ export const BasicTxDetails = ({
     nonceStatus,
     nextNonce,
 }: BasicTxDetailsProps) => {
+    const dispatch = useDispatch();
+
     const { isBelowTablet } = useLayoutSize();
     const explorerLink = useExternalLink(`${explorerUrl}${tx.txid}${explorerUrlQueryString ?? ''}`);
     // all solana txs which are fetched are already confirmed
     const isConfirmed = confirmations > 0 || tx.solanaSpecific?.status === 'confirmed';
+
+    const onTxIdCopy = () => {
+        copyToClipboard(tx.txid);
+        dispatch(notificationsActions.addToast({ type: 'copy-to-clipboard' }));
+    };
 
     return (
         <Card>
@@ -320,13 +332,29 @@ export const BasicTxDetails = ({
 
                 {/* TX ID */}
                 <Item label={<Translation id="TR_TXID" />} icon={FingerprintIcon}>
-                    <Link
-                        href={explorerLink}
-                        data-testid="@tx-detail/txid-value"
-                        overflowWrap="anywhere"
+                    <Tooltip
+                        content={
+                            <Row gap={8}>
+                                {tx.txid}
+                                <IconButton
+                                    icon={CopyIcon}
+                                    size="small"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    onClick={onTxIdCopy}
+                                    tooltip={{ isActive: false }}
+                                />
+                            </Row>
+                        }
                     >
-                        {tx.txid}
-                    </Link>
+                        <Link
+                            href={explorerLink}
+                            data-testid="@tx-detail/txid-value"
+                            overflowWrap="anywhere"
+                        >
+                            {tx.txid}
+                        </Link>
+                    </Tooltip>
                 </Item>
 
                 {tx.tronSpecific?.energyUsage && (


### PR DESCRIPTION
## Description

Add copy button to tx id in tx detail modal.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29055

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-03 at 11 32 53" src="https://github.com/user-attachments/assets/023759aa-d9a6-4d06-8344-28b6662e029e" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/txid-copy-button/web/](https://dev.suite.sldev.cz/suite-web/feat/txid-copy-button/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/txid-copy-button&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/txid-copy-button&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:45:52.345Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:45:59.184Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->