### PR TITLE
feat(suite-desktop): display wrap/unwrap assets breakdown in toast

### DIFF
--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -1,4 +1,5 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -98,5 +99,37 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 flowType: 'redeem',
             }),
         );
+    });
+
+    it('shows an unwrap toast displaying both the wrapped and native assets', async () => {
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+
+        await store
+            .dispatch(submitUnwrapNativeTokenThunk({ account, token, unwrapAmount: '1.5' }))
+            .unwrap();
+
+        const unwrapToast = store.getActions().find(action => action.payload?.type === 'tx-unwrap');
+
+        expect(unwrapToast?.payload).toMatchObject({
+            type: 'tx-unwrap',
+            txid: '0xunwrap',
+            metadata: {
+                send: {
+                    symbol: account.symbol,
+                    displaySymbol: token.symbol,
+                    contractAddress: token.contractAddress,
+                    amount: '1.5',
+                },
+                receive: {
+                    symbol: account.symbol,
+                    displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                    amount: '1.5',
+                },
+            },
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -82,11 +82,24 @@ export const submitUnwrapNativeTokenThunk = createThunk(
             dispatch(
                 notificationsActions.addToast({
                     type: 'tx-unwrap',
-                    // Amount shown in the destination unit — the native coin (e.g. ETH).
-                    formattedAmount: `${unwrapAmount} ${getNetworkDisplaySymbol(account.symbol)}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,
+                    formattedAmount: unwrapAmount,
+                    metadata: {
+                        send: {
+                            symbol: account.symbol,
+                            displaySymbol: token.symbol,
+                            contractAddress: token.contractAddress,
+                            amount: unwrapAmount,
+                        },
+                        receive: {
+                            symbol: account.symbol,
+                            displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            amount: unwrapAmount,
+                        },
+                    },
+                    style: { maxWidth: 'auto' },
                 }),
             );
 

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,4 +1,5 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -98,5 +99,37 @@ describe('submitWrapNativeTokenThunk', () => {
                 flowType: 'deposit',
             }),
         );
+    });
+
+    it('shows a wrap toast displaying both the native and wrapped assets', async () => {
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
+
+        await store
+            .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1.5' }))
+            .unwrap();
+
+        const wrapToast = store.getActions().find(action => action.payload?.type === 'tx-wrap');
+
+        expect(wrapToast?.payload).toMatchObject({
+            type: 'tx-wrap',
+            txid: '0xwrap',
+            metadata: {
+                send: {
+                    symbol: account.symbol,
+                    displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                    amount: '1.5',
+                },
+                receive: {
+                    symbol: account.symbol,
+                    displaySymbol: token.symbol,
+                    contractAddress: token.contractAddress,
+                    amount: '1.5',
+                },
+            },
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -2,11 +2,7 @@ import { openDeferredModal } from '@suite/modal';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import {
-    getNetwork,
-    getNetworkDisplaySymbol,
-    getWrappedNativeSymbol,
-} from '@suite-common/wallet-config';
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     composeYieldWrapTransactionThunk,
@@ -89,17 +85,27 @@ export const submitWrapNativeTokenThunk = createThunk(
                 return undefined;
             }
 
-            const wrappedSymbol =
-                getWrappedNativeSymbol(account.symbol) ?? getNetworkDisplaySymbol(account.symbol);
-
             dispatch(
                 notificationsActions.addToast({
                     type: 'tx-wrap',
-                    // Amount shown in the destination unit — the wrapped-native token (e.g. WETH).
-                    formattedAmount: `${wrapAmount} ${wrappedSymbol}`,
                     descriptor: account.descriptor,
                     symbol: account.symbol,
                     txid: sendResult.txid,
+                    formattedAmount: wrapAmount,
+                    metadata: {
+                        send: {
+                            symbol: account.symbol,
+                            displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            amount: wrapAmount,
+                        },
+                        receive: {
+                            symbol: account.symbol,
+                            displaySymbol: token.symbol,
+                            contractAddress: token.contractAddress,
+                            amount: wrapAmount,
+                        },
+                    },
+                    style: { maxWidth: 'auto' },
                 }),
             );
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -23,6 +23,7 @@ import { AutoEjectRenderer } from './AutoEjectRenderer';
 import { CoinProtocolRenderer } from './CoinProtocolRenderer';
 import { ExchangeInfoRenderer } from './ExchangeInfoRenderer';
 import { TransactionRenderer } from './TransactionRenderer';
+import { WrapInfoRenderer } from './WrapInfoRenderer';
 import { type NotificationViewProps } from '../Notifications/NotificationGroup/NotificationList/NotificationView';
 
 type LocalizedNotificationEntry = NotificationEntry<TranslationKey>;
@@ -502,6 +503,28 @@ export const NotificationRenderer = ({
                 />
             );
 
+        case 'tx-wrap':
+            return (
+                <WrapInfoRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_WRAP_BROADCASTED"
+                />
+            );
+
+        case 'tx-unwrap':
+            return (
+                <WrapInfoRenderer
+                    render={render}
+                    notification={notification}
+                    icon={ArrowUpIcon}
+                    variant="success"
+                    message="TOAST_TX_UNWRAP_BROADCASTED"
+                />
+            );
+
         case 'tx-sent':
             return (
                 <TransactionRenderer
@@ -646,34 +669,6 @@ export const NotificationRenderer = ({
                     icon={ArrowUpIcon}
                     variant="success"
                     message="TOAST_TX_YIELD_CLAIM"
-                    messageValues={{
-                        account: notification.descriptor,
-                    }}
-                />
-            );
-
-        case 'tx-wrap':
-            return (
-                <TransactionRenderer
-                    render={render}
-                    notification={notification}
-                    icon={ArrowUpIcon}
-                    variant="success"
-                    message="TOAST_TX_WRAP"
-                    messageValues={{
-                        account: notification.descriptor,
-                    }}
-                />
-            );
-
-        case 'tx-unwrap':
-            return (
-                <TransactionRenderer
-                    render={render}
-                    notification={notification}
-                    icon={ArrowUpIcon}
-                    variant="success"
-                    message="TOAST_TX_UNWRAP"
                     messageValues={{
                         account: notification.descriptor,
                     }}

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx
@@ -1,0 +1,42 @@
+import { HiddenPlaceholder } from '@suite/discreet-mode';
+import { Translation } from '@suite/intl';
+import { type WrapTransactionAsset } from '@suite-common/toast-notifications';
+import { ExchangeInfoNotification } from '@trezor/product-components';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import type { NotificationRendererProps } from 'src/components/suite/notifications/NotificationRenderer/NotificationRenderer';
+import type { NotificationViewProps } from 'src/components/suite/notifications/Notifications/NotificationGroup/NotificationList/NotificationView';
+
+type WrapInfoRendererProps = Omit<NotificationViewProps, 'messageValues'> &
+    (NotificationRendererProps<'tx-wrap'> | NotificationRendererProps<'tx-unwrap'>);
+
+const withFormattedAmount = (asset: WrapTransactionAsset) => ({
+    ...asset,
+    amount: <FormattedCryptoAmount value={asset.amount} isBalance disableHiddenPlaceholder />,
+});
+
+export const WrapInfoRenderer = ({ render: View, ...props }: WrapInfoRendererProps) => {
+    const { send, receive } = props.notification.metadata;
+
+    return (
+        <View
+            {...props}
+            message="TOAST_TX_COMPOSED"
+            messageValues={{
+                content: (
+                    <ExchangeInfoNotification
+                        data-testid="@toast/tx-wrap"
+                        message={<Translation id={props.message} />}
+                        send={withFormattedAmount(send)}
+                        receive={withFormattedAmount(receive)}
+                        renderAmount={(amount, side) => (
+                            <HiddenPlaceholder data-testid={`@toast/tx-wrap/${side}-amount`}>
+                                {amount}
+                            </HiddenPlaceholder>
+                        )}
+                    />
+                ),
+            }}
+        />
+    );
+};

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -52,6 +52,28 @@ type ExchangeTransactionNotification = {
     metadata: FormStateTradingExchange;
 } & TransactionNotificationPayload;
 
+export type WrapTransactionAsset = {
+    symbol: NetworkSymbol;
+    displaySymbol: string;
+    contractAddress?: string;
+    amount: string;
+};
+
+type WrapTransactionMetadata = {
+    send: WrapTransactionAsset;
+    receive: WrapTransactionAsset;
+};
+
+type WrapTransactionNotification = {
+    type: 'tx-wrap';
+    metadata: WrapTransactionMetadata;
+} & TransactionNotificationPayload;
+
+type UnwrapTransactionNotification = {
+    type: 'tx-unwrap';
+    metadata: WrapTransactionMetadata;
+} & TransactionNotificationPayload;
+
 type ReceivedTransactionNotification = {
     type: 'tx-received' | 'tx-confirmed';
     token?: Pick<TokenInfo, 'contract' | 'name' | 'symbol'>;
@@ -80,17 +102,6 @@ type YieldWithdrawTransactionNotification = {
 type YieldClaimTransactionNotification = {
     type: 'tx-yield-claim';
 } & BaseTransactionNotificationPayload;
-
-// Wrap/unwrap toasts show the amount in the destination unit: the wrapped-native token (WETH) for
-// a wrap, the native coin (ETH) for an unwrap. That destination unit is baked into `formattedAmount`
-// by the dispatcher.
-type WrapNativeTokenTransactionNotification = {
-    type: 'tx-wrap';
-} & TransactionNotificationPayload;
-
-type UnwrapNativeTokenTransactionNotification = {
-    type: 'tx-unwrap';
-} & TransactionNotificationPayload;
 
 export type ErrorToastPayload = {
     type:
@@ -163,6 +174,8 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | ApproveTransactionNotification
     | RevokeTransactionNotification
     | ExchangeTransactionNotification
+    | WrapTransactionNotification
+    | UnwrapTransactionNotification
     | RawSentTransactionNotification
     | ErrorToastPayload
     | {
@@ -218,8 +231,6 @@ export type ToastPayload<TranslationKey extends UnknownTranslationKey = UnknownT
     | YieldDepositTransactionNotification
     | YieldWithdrawTransactionNotification
     | YieldClaimTransactionNotification
-    | WrapNativeTokenTransactionNotification
-    | UnwrapNativeTokenTransactionNotification
     | {
           type: 'cannot-open-bluetooth-settings-error';
       }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -4173,6 +4173,14 @@ export const messages = defineMessages({
         defaultMessage:
             'Swap transaction from {sendAccount} to {receiveAccount} has been broadcast',
     },
+    TOAST_TX_WRAP_BROADCASTED: {
+        id: 'TOAST_TX_WRAP_BROADCASTED',
+        defaultMessage: 'Wrap transaction has been broadcast',
+    },
+    TOAST_TX_UNWRAP_BROADCASTED: {
+        id: 'TOAST_TX_UNWRAP_BROADCASTED',
+        defaultMessage: 'Unwrap transaction has been broadcast',
+    },
     TOAST_TX_RECEIVED: {
         id: 'TOAST_TX_RECEIVED',
         defaultMessage: 'Received to {account}',
@@ -11641,14 +11649,6 @@ export const messages = defineMessages({
     TOAST_TX_YIELD_CLAIM: {
         id: 'TOAST_TX_YIELD_CLAIM',
         defaultMessage: 'Claim transaction from {account} has been broadcast',
-    },
-    TOAST_TX_WRAP: {
-        id: 'TOAST_TX_WRAP',
-        defaultMessage: 'Wrap transaction from {account} has been broadcast',
-    },
-    TOAST_TX_UNWRAP: {
-        id: 'TOAST_TX_UNWRAP',
-        defaultMessage: 'Unwrap transaction from {account} has been broadcast',
     },
     TOAST_SUCCESSFUL_CLAIM: {
         id: 'TOAST_SUCCESSFUL_CLAIM',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Displays both tokens with `...` dots if needed

## Notes for QA

Needs to be checked on:
- wrap
- unwrap
- deposit
- withdraw 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30655

## Screenshots:

<img width="772" height="410" alt="Screenshot 2026-08-03 at 9 50 05" src="https://github.com/user-attachments/assets/01106e96-bc47-4974-a255-221d604eb887" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/improve-weth-titles&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/improve-weth-titles&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/improve-weth-titles&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:14:07.155Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:13:26.366Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/improve-weth-titles/web/](https://dev.suite.sldev.cz/suite-web/feat/improve-weth-titles/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes add wrap/unwrap native token thunks and a new wrap-info notification renderer. The highest-confidence E2E coverage comes from the LI.FI DEX swap test, where native ETH is swapped to an ERC-20 token and likely wraps to WETH. ETH staking tests are included at medium priority as they share transaction and notification infrastructure. No candidate test explicitly covers a dedicated wrap/unwrap feature, and the new WrapInfoRenderer component has no clear direct E2E exercise in the provided list.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx`
- `packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx`
- `suite-common/toast-notifications/src/types.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test performs a native ETH to USDC swap via the LI.FI DEX aggregator. DEX swaps from native ETH to ERC-20 tokens typically route through WETH, which exercises the wrapNativeTokenThunks. Any regression in wrapping logic or the associated wrap-info notification rendering would likely surface here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking flows share wallet transaction composition, signing, and toast notification infrastructure with native token wrapping. If the thunk or notification changes affect shared ETH transaction handling, this test would catch regressions in the end-to-end staking flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Similar to initial-stake, this test exercises additional ETH staking transactions and toast confirmations, sharing the same wallet action and notification renderer infrastructure that could be impacted by wrap/unwrap thunk changes.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstaking/claiming uses the same wallet action layer and notification system as wrapping/unwrapping. This test provides a sanity check that the broader ETH transaction and toast infrastructure still works after the changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/suite/notifications/NotificationRenderer/WrapInfoRenderer.tsx`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-03T11:13:39.315Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->