### PR TITLE
fix(trading): use Hyperliquid crypto ID for HyperEVM

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -330,7 +330,7 @@ export const networks = {
             },
         },
         coingeckoId: 'hyperevm',
-        tradeCryptoId: 'hyperevm',
+        tradeCryptoId: 'hyperliquid',
         caipId: 'eip155:999',
         isDebugOnlyNetwork: true,
         yieldXyzId: null,


### PR DESCRIPTION
## Description

Use `hyperliquid` as HyperEVM's native `tradeCryptoId`, matching the canonical trade API mapping.

Reference: https://github.com/trezor/trezor-trade-api/issues/702#issuecomment-5091975016

## Notes for QA

No manual QA required. Configuration-only correction covered by wallet-config unit tests.

## Related Issue

Related to https://github.com/trezor/trezor-trade-api/issues/702

## Screenshots:

Not applicable.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad network configuration source used by 133 tests, so the recommendation focuses on tests that directly exercise network config-derived behavior: coin enablement, custom backends, multi-network discovery, and network-specific wallet features. These six tests provide high confidence for the most common regressions while avoiding indiscriminate full-suite execution.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests configuring custom Blockbook backend URLs for BTC and ETH, which are defined and validated against network configuration in networksConfig.ts. A change to backend defaults, network symbols, or backend types would directly break this flow.
- `suite/e2e/tests/settings/coins.test.ts` — Tests enabling mainnet/testnet networks and setting a custom ETH backend. Network enablement UI, testnet visibility, and backend indicators depend directly on properties defined in networksConfig.ts.
- `suite/e2e/tests/wallet/discovery.test.ts` — Tests multi-coin discovery for eight networks (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC). Discovery relies on network configuration to map symbols to backends, account types, and derivation paths.
- `suite/e2e/tests/wallet/cardano.test.ts` — Tests Cardano-specific account details, xpub display, public key reveal, and send/receive flows. ADA network config including account type descriptions and derivation paths is sourced from networksConfig.ts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — Tests adding accounts with different derivation paths and types across BTC, LTC, ETH, Base, and ADA. Account type mappings and coin-specific paths come from networksConfig.ts.
- `suite/e2e/tests/wallet/receive.test.ts` — Tests address reveal and validation for BTC, ETH, SOL, and TRX. Address format regexes and network-specific receive behavior depend on network configuration.

</details>

_Updated: 2026-08-03T11:16:10.293Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/hyperevm-trade-crypto-id/web/](https://dev.suite.sldev.cz/suite-web/fix/hyperevm-trade-crypto-id/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/hyperevm-trade-crypto-id&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/hyperevm-trade-crypto-id&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/hyperevm-trade-crypto-id&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:23:45.647Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:18:40.981Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->