### PR TITLE
fix(suite-desktop): rename deposit weth approval step

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1162,6 +1162,7 @@
   "TR_EARN_YIELD_ALLOWANCE_FETCH_FAILED": "Failed to fetch the approved amount.",
   "TR_EARN_YIELD_AMOUNT_TO_WITHDRAW": "Withdrawal amount",
   "TR_EARN_YIELD_APPROVAL_TOO_LOW": "Approval is too low. Change approval or lower amount.",
+  "TR_EARN_YIELD_APPROVE": "Approve",
   "TR_EARN_YIELD_APPROVED_AMOUNT": "Approved amount",
   "TR_EARN_YIELD_APPROVE_SPENDING_TRANSACTION": "Approve spending transaction",
   "TR_EARN_YIELD_APPROVE_TOKEN_BUTTON": "Approve {tokenSymbol}",

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -262,7 +262,18 @@ export const YieldDepositForm = () => {
                                 ),
                             },
                             approve: {
-                                title: <Translation id="TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE" />,
+                                // For wrapped-native (WETH) vaults the amount is entered in the
+                                // preceding wrap step, so the approve step is just "Approve".
+                                // Non-wrapped vaults have no wrap step and select the amount here.
+                                title: (
+                                    <Translation
+                                        id={
+                                            flow.isWrappedNativeVault
+                                                ? 'TR_EARN_YIELD_APPROVE'
+                                                : 'TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE'
+                                        }
+                                    />
+                                ),
                                 onEdit: handleOnModify,
                                 content: () => (
                                     <YieldApproveStep

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10149,6 +10149,10 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_SELECT_AMOUNT_AND_APPROVE',
         defaultMessage: 'Select amount & approve',
     },
+    TR_EARN_YIELD_APPROVE: {
+        id: 'TR_EARN_YIELD_APPROVE',
+        defaultMessage: 'Approve',
+    },
     TR_EARN_YIELD_DEPOSIT: {
         id: 'TR_EARN_YIELD_DEPOSIT',
         defaultMessage: 'Deposit',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

as simple as it is

## Notes for QA

Check on weth and stablecoin flows

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30543

## Screenshots:

<img width="613" height="625" alt="Screenshot 2026-08-03 at 13 12 02" src="https://github.com/user-attachments/assets/9c598cb5-8dac-4fd9-8212-c5244254b966" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/fix-approval-step-rename/web/](https://dev.suite.sldev.cz/suite-web/feat/fix-approval-step-rename/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fix-approval-step-rename&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fix-approval-step-rename&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:23:17.034Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T11:22:58.467Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->