### PR TITLE
refactor(requirements): extract shared closure and version helpers

### DIFF
--- a/packages/node-utils/src/index.ts
+++ b/packages/node-utils/src/index.ts
@@ -15,3 +15,5 @@ export { checkSocks5Proxy } from './checkSocks5Proxy';
 export { validateJsonSchema } from './validateJsonSchema';
 export { findProcessFromIncomingPort, type ProcessInfo } from './findProcessFromIncomingPort';
 export { parseRequestUrl, formatRequestUrl, type ParsedRequestUrl } from './parseRequestUrl';
+export { readJson } from './readJson';
+export { readPackageJson, type PackageJson } from './packageJson';

--- a/packages/node-utils/src/packageJson.ts
+++ b/packages/node-utils/src/packageJson.ts
@@ -1,0 +1,29 @@
+import { join } from 'node:path';
+
+import { readJson } from './readJson';
+
+/**
+ * Structural view of a `package.json`. Only the commonly-read fields are typed
+ * explicitly; the trailing index signature keeps arbitrary metadata
+ * (`repository`, `bugs`, `author`, …) accessible as `unknown` without every
+ * consumer redeclaring its own subset.
+ */
+export type PackageJson = {
+    readonly name?: string;
+    readonly version?: string;
+    readonly private?: boolean;
+    readonly type?: string;
+    readonly scripts?: Record<string, string | undefined>;
+    readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
+    readonly resolutions?: Record<string, string>;
+    readonly dependencies?: Record<string, string>;
+    readonly devDependencies?: Record<string, string>;
+    readonly optionalDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
+    readonly [field: string]: unknown;
+};
+
+/** Read and parse the `package.json` located directly inside `directory`. */
+export const readPackageJson = <T = PackageJson>(directory: string): T =>
+    readJson<T>(join(directory, 'package.json'));

--- a/packages/node-utils/src/packageJson.ts
+++ b/packages/node-utils/src/packageJson.ts
@@ -13,6 +13,8 @@ export type PackageJson = {
     readonly version?: string;
     readonly private?: boolean;
     readonly type?: string;
+    readonly main?: string;
+    readonly files?: ReadonlyArray<string>;
     readonly scripts?: Record<string, string | undefined>;
     readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
     readonly resolutions?: Record<string, string>;

--- a/packages/node-utils/src/readJson.ts
+++ b/packages/node-utils/src/readJson.ts
@@ -1,0 +1,5 @@
+import { readFileSync } from 'node:fs';
+
+/** Read and parse a JSON file. Throws if the file is missing or contains invalid JSON. */
+export const readJson = <T>(filePath: string): T =>
+    JSON.parse(readFileSync(filePath, 'utf-8')) as T;

--- a/packages/requirements/package.json
+++ b/packages/requirements/package.json
@@ -14,6 +14,7 @@
         "requirements:fix": "tsx src/run.ts fix"
     },
     "dependencies": {
+        "@trezor/node-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
         "chalk": "^5.6.2",
         "semver": "^7.7.1"

--- a/packages/requirements/src/fileSystem.ts
+++ b/packages/requirements/src/fileSystem.ts
@@ -1,4 +1,4 @@
-import { type Dirent, readFileSync, readdirSync } from 'node:fs';
+import { type Dirent, readdirSync } from 'node:fs';
 import { join, sep } from 'node:path';
 
 export type WalkDirectoryEntry = {
@@ -41,7 +41,3 @@ export function* walkDirectory(
 }
 
 export const normalizePath = (filePath: string): string => filePath.split(sep).join('/');
-
-/** Read and parse a JSON file. Throws if the file is missing or contains invalid JSON. */
-export const readJson = <T>(filePath: string): T =>
-    JSON.parse(readFileSync(filePath, 'utf-8')) as T;

--- a/packages/requirements/src/fileSystem.ts
+++ b/packages/requirements/src/fileSystem.ts
@@ -1,4 +1,4 @@
-import { type Dirent, readdirSync } from 'node:fs';
+import { type Dirent, readFileSync, readdirSync } from 'node:fs';
 import { join, sep } from 'node:path';
 
 export type WalkDirectoryEntry = {
@@ -41,3 +41,7 @@ export function* walkDirectory(
 }
 
 export const normalizePath = (filePath: string): string => filePath.split(sep).join('/');
+
+/** Read and parse a JSON file. Throws if the file is missing or contains invalid JSON. */
+export const readJson = <T>(filePath: string): T =>
+    JSON.parse(readFileSync(filePath, 'utf-8')) as T;

--- a/packages/requirements/src/requirements/connectClosure.ts
+++ b/packages/requirements/src/requirements/connectClosure.ts
@@ -1,17 +1,4 @@
-import { listAllWorkspaces, readPackageJson } from '../workspaces';
-
-export type PackageJson = {
-    readonly name?: string;
-    readonly version?: string;
-    readonly private?: boolean;
-    readonly dependencies?: Record<string, string>;
-    readonly optionalDependencies?: Record<string, string>;
-    readonly peerDependencies?: Record<string, string>;
-    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
-    readonly devDependencies?: Record<string, string>;
-    // package.json carries arbitrary metadata fields (repository, bugs, author, …).
-    readonly [field: string]: unknown;
-};
+import { type PackageJson, listAllWorkspaces, readPackageJson } from '../workspaces';
 
 export type WorkspacePackage = {
     readonly name: string;

--- a/packages/requirements/src/requirements/connectClosure.ts
+++ b/packages/requirements/src/requirements/connectClosure.ts
@@ -1,4 +1,6 @@
-import { type PackageJson, listAllWorkspaces, readPackageJson } from '../workspaces';
+import { type PackageJson, readPackageJson } from '@trezor/node-utils';
+
+import { listAllWorkspaces } from '../workspaces';
 
 export type WorkspacePackage = {
     readonly name: string;

--- a/packages/requirements/src/requirements/connectClosure.ts
+++ b/packages/requirements/src/requirements/connectClosure.ts
@@ -1,0 +1,89 @@
+import { listAllWorkspaces, readPackageJson } from '../workspaces';
+
+export type PackageJson = {
+    readonly name?: string;
+    readonly version?: string;
+    readonly private?: boolean;
+    readonly dependencies?: Record<string, string>;
+    readonly optionalDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
+    readonly devDependencies?: Record<string, string>;
+    // package.json carries arbitrary metadata fields (repository, bugs, author, …).
+    readonly [field: string]: unknown;
+};
+
+export type WorkspacePackage = {
+    readonly name: string;
+    readonly dir: string;
+    readonly packageJson: PackageJson;
+};
+
+/**
+ * Read every workspace's package.json into a name-keyed map. Packages without a
+ * `name` are skipped; version-less packages are kept so a closure traversal can
+ * still walk through them.
+ */
+export const collectWorkspacePackages = (repoRoot: string): Map<string, WorkspacePackage> => {
+    const packages = new Map<string, WorkspacePackage>();
+
+    for (const workspace of listAllWorkspaces(repoRoot)) {
+        const packageJson = readPackageJson<PackageJson>(workspace.dir);
+        if (!packageJson.name) continue;
+
+        packages.set(packageJson.name, {
+            name: packageJson.name,
+            dir: workspace.dir,
+            packageJson,
+        });
+    }
+
+    return packages;
+};
+
+/**
+ * Compute the production closure of the given root packages: every internal
+ * workspace package reachable through `dependencies` and `optionalDependencies`
+ * (i.e. what actually ships when the roots are published). `devDependencies` and
+ * `peerDependencies` are intentionally not traversed.
+ */
+export const collectProdWorkspaceClosure = (
+    roots: ReadonlyArray<string>,
+    packages: ReadonlyMap<string, WorkspacePackage>,
+): ReadonlySet<string> => {
+    const getProdWorkspaceDeps = (
+        deps: Record<string, string> | undefined,
+    ): ReadonlyArray<string> =>
+        Object.entries(deps ?? {})
+            .filter(([name, version]) => version.startsWith('workspace:') && packages.has(name))
+            .map(([name]) => name);
+
+    const closure = new Set<string>();
+    const queue: string[] = roots.filter(root => packages.has(root));
+
+    for (const root of queue) {
+        closure.add(root);
+    }
+
+    while (queue.length > 0) {
+        const name = queue.shift();
+        if (name === undefined) continue;
+
+        const pkg = packages.get(name);
+        if (pkg === undefined) continue;
+
+        const nextDeps = [
+            ...getProdWorkspaceDeps(pkg.packageJson.dependencies),
+            ...getProdWorkspaceDeps(pkg.packageJson.optionalDependencies),
+        ];
+
+        for (const dep of nextDeps) {
+            if (closure.has(dep)) continue;
+
+            closure.add(dep);
+            queue.push(dep);
+        }
+    }
+
+    return closure;
+};

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { pickCanonicalVersion } from '../../versions';
-import { listAllWorkspaces, readPackageJson } from '../../workspaces';
+import { type PackageJson, listAllWorkspaces, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 /**
@@ -15,14 +15,6 @@ import type { Requirement } from '../Requirement';
 export const ALLOWED_DRIFTS = new Set([
     'babel-jest', // waiting for suite-native who are waiting for expo to update babel-jest
 ]);
-
-type PackageJson = {
-    readonly name?: string;
-    readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
-    readonly resolutions?: Record<string, string>;
-    readonly dependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-};
 
 type VersionOccurrence = {
     readonly version: string;

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import * as semver from 'semver';
 
+import { pickCanonicalVersion } from '../../versions';
 import { listAllWorkspaces, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
@@ -123,34 +123,6 @@ const formatDriftError = (depName: string, occurrences: VersionOccurrence[]): st
 };
 
 /**
- * Strip common version range prefixes (^, ~, >=, <=, >, <, =) so that the
- * bare version string can be compared numerically.
- */
-const stripRangePrefix = (specifier: string): string => specifier.replace(/^[~^]|^[><=]+\s*/g, '');
-
-/**
- * Pick the canonical version for a drifted dependency.
- * Strategy: most frequent version wins; ties broken by the numerically higher
- * version specifier (e.g. "^10.2.0" wins over "^9.5.0").
- */
-const pickCanonicalVersion = (occurrences: VersionOccurrence[]): string => {
-    const frequencyMap = new Map<string, number>();
-
-    for (const o of occurrences) {
-        frequencyMap.set(o.version, (frequencyMap.get(o.version) ?? 0) + 1);
-    }
-
-    const sorted = [...frequencyMap.entries()].sort((a, b) => {
-        if (b[1] !== a[1]) return b[1] - a[1]; // higher frequency first
-
-        // later versions first
-        return semver.rcompare(stripRangePrefix(a[0]), stripRangePrefix(b[0]), { loose: true });
-    });
-
-    return sorted[0]?.[0] ?? '';
-};
-
-/**
  * Verifies that every external (non-workspace) dependency uses the same version specifier
  * across all workspaces in the monorepo.
  */
@@ -189,7 +161,10 @@ export const requireUnifiedDependencyVersions: Requirement<'repo'> = {
         const canonicalVersions = new Map<string, string>();
 
         for (const [depName, occurrences] of drifts) {
-            canonicalVersions.set(depName, pickCanonicalVersion(occurrences));
+            canonicalVersions.set(
+                depName,
+                pickCanonicalVersion(occurrences.map(occurrence => occurrence.version)),
+            );
         }
 
         // Apply fixes to workspace package.json files

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -1,8 +1,10 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { type PackageJson, readPackageJson } from '@trezor/node-utils';
+
 import { pickCanonicalVersion } from '../../versions';
-import { type PackageJson, listAllWorkspaces, readPackageJson } from '../../workspaces';
+import { listAllWorkspaces } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 /**

--- a/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
+++ b/packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { pickCanonicalVersion } from '../../versions';
@@ -166,10 +166,7 @@ export const requireUnifiedDependencyVersions: Requirement<'repo'> = {
 
         for (const dir of workspaceDirs) {
             const pkgPath = join(dir, 'package.json');
-
-            const rawContent = readFileSync(pkgPath, 'utf-8');
-
-            const pkg: PackageJson = JSON.parse(rawContent) as PackageJson;
+            const pkg = readPackageJson<PackageJson>(dir);
             let modified = false;
 
             for (const depType of ['dependencies', 'devDependencies'] as const) {

--- a/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts
+++ b/packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts
@@ -1,6 +1,7 @@
-import { readFileSync, readdirSync } from 'node:fs';
+import { readdirSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
+import { readJson } from '@trezor/node-utils';
 import { type VersionArray, versionUtils } from '@trezor/utils';
 
 import { normalizePath } from '../../fileSystem';
@@ -53,7 +54,7 @@ const readChannelReleases = (channelDir: string): FirmwareRelease[] => {
         }
 
         const file = join(channelDir, entry.name);
-        const data = JSON.parse(readFileSync(file, 'utf-8')) as FirmwareReleaseFile;
+        const data = readJson<FirmwareReleaseFile>(file);
 
         releases.push({ file, data });
     }

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
@@ -2,10 +2,11 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { type PackageJson, readPackageJson } from '@trezor/node-utils';
 import { typedObjectKeys } from '@trezor/utils';
 
 import type { AllowedOnlyInRule, ForbiddenDepsConfig } from './forbiddenDepsTypes';
-import { type PackageJson, getWorkspaceDirectoryMap, readPackageJson } from '../../workspaces';
+import { getWorkspaceDirectoryMap } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const FORBIDDEN_DEPS_CONFIG_FILE = 'forbiddenDeps.config.ts';

--- a/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
+++ b/packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { typedObjectKeys } from '@trezor/utils';
 
 import type { AllowedOnlyInRule, ForbiddenDepsConfig } from './forbiddenDepsTypes';
-import { getWorkspaceDirectoryMap, readPackageJson } from '../../workspaces';
+import { type PackageJson, getWorkspaceDirectoryMap, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const FORBIDDEN_DEPS_CONFIG_FILE = 'forbiddenDeps.config.ts';
@@ -20,13 +20,6 @@ const DEPENDENCY_FIELDS = [
 ] as const;
 
 type DependencyField = (typeof DEPENDENCY_FIELDS)[number];
-
-type PackageJson = {
-    readonly dependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-    readonly optionalDependencies?: Record<string, string>;
-    readonly peerDependencies?: Record<string, string>;
-};
 
 type DependencyOccurrence = {
     readonly field: DependencyField;

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { typedObjectEntries } from '@trezor/utils';
 
 import { walkDirectory } from '../../fileSystem';
+import type { PackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';
@@ -61,10 +62,6 @@ const REQUIRED_SCRIPTS: Record<string, RequiredScriptConfig> = {
         ignoredPackages: ['@trezor/suite-e2e'],
         isRequired: hasUnitTestFile,
     },
-};
-
-type PackageJson = {
-    readonly scripts?: Record<string, string | undefined>;
 };
 
 const matchesScriptCommand = (

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -1,7 +1,7 @@
+import { type PackageJson, readPackageJson } from '@trezor/node-utils';
 import { typedObjectEntries } from '@trezor/utils';
 
 import { walkDirectory } from '../../fileSystem';
-import { type PackageJson, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';

--- a/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
+++ b/packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts
@@ -1,10 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
 import { typedObjectEntries } from '@trezor/utils';
 
 import { walkDirectory } from '../../fileSystem';
-import type { PackageJson } from '../../workspaces';
+import { type PackageJson, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';
@@ -92,12 +89,10 @@ export const requirePackageJsonScripts: Requirement<'workspace'> = {
     name: 'package-json-scripts',
     scope: 'workspace',
     verify: context => {
-        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
-
         let parsed: PackageJson;
 
         try {
-            parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+            parsed = readPackageJson<PackageJson>(context.workspaceDir);
         } catch {
             return Promise.resolve([
                 `${context.workspaceName}: ${PACKAGE_JSON_FILE} is missing or contains invalid JSON.`,

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -1,4 +1,4 @@
-import { readPackageJson } from '@trezor/node-utils';
+import { type PackageJson, readPackageJson } from '@trezor/node-utils';
 
 import type { Requirement } from '../Requirement';
 
@@ -13,18 +13,16 @@ interface ExportValueMap {
     [key: string]: ExportValue;
 }
 
-type PackageJson = {
-    readonly name?: string;
+type PublishConfig = {
     readonly main?: string;
+    readonly types?: string;
     readonly type?: string;
-    readonly files?: ReadonlyArray<string>;
-    readonly publishConfig?: {
-        readonly main?: string;
-        readonly types?: string;
-        readonly type?: string;
-        readonly exports?: ExportValueMap;
-    };
+    readonly exports?: ExportValueMap;
 };
+
+// The shared PackageJson intentionally doesn't model `publishConfig`; extend it
+// with the publish-specific shape this requirement validates.
+type PublishablePackageJson = PackageJson & { readonly publishConfig?: PublishConfig };
 
 const getExpectedExport = (exportKey: string): ExportValue | null => {
     if (exportKey === '.') {
@@ -50,7 +48,7 @@ const getExpectedExport = (exportKey: string): ExportValue | null => {
     return `${basePath}*`;
 };
 
-const validatePublicPackage = (packageJson: PackageJson): ReadonlyArray<string> => {
+const validatePublicPackage = (packageJson: PublishablePackageJson): ReadonlyArray<string> => {
     const errors: string[] = [];
     const { publishConfig } = packageJson;
 
@@ -122,7 +120,7 @@ const validateKeyOrder = (obj: ExportValue, context: string): ReadonlyArray<stri
 };
 
 const validateExports = (
-    exportsConfig: NonNullable<PackageJson['publishConfig']>['exports'],
+    exportsConfig: NonNullable<PublishablePackageJson['publishConfig']>['exports'],
 ): ReadonlyArray<string> => {
     const errors: string[] = [];
     if (!exportsConfig) {
@@ -164,9 +162,9 @@ export const requirePublishConfig: Requirement<'workspace'> = {
     name: 'package-json-publishConfig',
     scope: 'workspace',
     applies: context => {
-        let parsed: PackageJson;
+        let parsed: PublishablePackageJson;
         try {
-            parsed = readPackageJson<PackageJson>(context.workspaceDir);
+            parsed = readPackageJson<PublishablePackageJson>(context.workspaceDir);
         } catch {
             return false;
         }
@@ -174,9 +172,9 @@ export const requirePublishConfig: Requirement<'workspace'> = {
         return parsed.publishConfig !== undefined;
     },
     verify: context => {
-        let parsed: PackageJson;
+        let parsed: PublishablePackageJson;
         try {
-            parsed = readPackageJson<PackageJson>(context.workspaceDir);
+            parsed = readPackageJson<PublishablePackageJson>(context.workspaceDir);
         } catch {
             return Promise.resolve([
                 `${context.workspaceName}: ${PACKAGE_JSON_FILE} is missing or contains invalid JSON`,

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -1,4 +1,5 @@
-import { readPackageJson } from '../../workspaces';
+import { readPackageJson } from '@trezor/node-utils';
+
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';

--- a/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
+++ b/packages/requirements/src/requirements/package-json/requirePublishConfig.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
+import { readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 
 const PACKAGE_JSON_FILE = 'package.json';
@@ -165,11 +163,9 @@ export const requirePublishConfig: Requirement<'workspace'> = {
     name: 'package-json-publishConfig',
     scope: 'workspace',
     applies: context => {
-        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
-
         let parsed: PackageJson;
         try {
-            parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+            parsed = readPackageJson<PackageJson>(context.workspaceDir);
         } catch {
             return false;
         }
@@ -177,11 +173,9 @@ export const requirePublishConfig: Requirement<'workspace'> = {
         return parsed.publishConfig !== undefined;
     },
     verify: context => {
-        const packageJsonPath = join(context.workspaceDir, PACKAGE_JSON_FILE);
-
         let parsed: PackageJson;
         try {
-            parsed = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as PackageJson;
+            parsed = readPackageJson<PackageJson>(context.workspaceDir);
         } catch {
             return Promise.resolve([
                 `${context.workspaceName}: ${PACKAGE_JSON_FILE} is missing or contains invalid JSON`,

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { readJson } from '../../fileSystem';
-import type { PackageJson } from '../../workspaces';
+import { type PackageJson, readJson } from '@trezor/node-utils';
+
 import type { Requirement } from '../Requirement';
 import {
     type WorkspacePackage,

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -1,22 +1,13 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { listAllWorkspaces, readPackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
-
-type PackageJson = {
-    readonly name?: string;
-    readonly dependencies?: Record<string, string>;
-    readonly optionalDependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-    readonly peerDependencies?: Record<string, string>;
-    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
-};
-
-type WorkspacePackage = {
-    readonly name: string;
-    readonly packageJson: PackageJson;
-};
+import {
+    type PackageJson,
+    type WorkspacePackage,
+    collectProdWorkspaceClosure,
+    collectWorkspacePackages,
+} from '../connectClosure';
 
 type Snapshot = {
     readonly prod: ReadonlyArray<string>;
@@ -40,32 +31,6 @@ const SNAPSHOT_DIR = join(
 
 const readJson = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, 'utf8')) as T;
 
-const collectWorkspacePackages = (repoRoot: string) => {
-    const pkgMap = new Map<string, WorkspacePackage>();
-
-    for (const workspace of listAllWorkspaces(repoRoot)) {
-        const packageJson = readPackageJson<PackageJson>(workspace.dir);
-        if (!packageJson.name) continue;
-
-        pkgMap.set(packageJson.name, {
-            name: packageJson.name,
-            packageJson,
-        });
-    }
-
-    return pkgMap;
-};
-
-const getWorkspaceDeps = (
-    deps: Record<string, string> | undefined,
-    workspacePackages: Map<string, WorkspacePackage>,
-) =>
-    Object.entries(deps ?? {})
-        .filter(
-            ([name, version]) => version.startsWith('workspace:') && workspacePackages.has(name),
-        )
-        .map(([name]) => name);
-
 const collectDependencyNames = (
     collector: Set<string>,
     deps: Record<string, string> | undefined,
@@ -88,38 +53,18 @@ const createSnapshot = (
     target: string,
     workspacePackages: Map<string, WorkspacePackage>,
 ): Snapshot => {
-    const prodClosure = new Set<string>([target]);
-    const prodQueue = [target];
-
-    while (prodQueue.length > 0) {
-        const packageName = prodQueue.shift();
-        if (!packageName) continue;
-
-        const pkg = workspacePackages.get(packageName);
-        if (!pkg) continue;
-
-        const nextWorkspaceDeps = [
-            ...getWorkspaceDeps(pkg.packageJson.dependencies, workspacePackages),
-            ...getWorkspaceDeps(pkg.packageJson.optionalDependencies, workspacePackages),
-        ];
-
-        for (const depName of nextWorkspaceDeps) {
-            if (prodClosure.has(depName)) continue;
-
-            prodClosure.add(depName);
-            prodQueue.push(depName);
-        }
-    }
-
+    const prodClosure = collectProdWorkspaceClosure([target], workspacePackages);
     const prodDependencies = new Set<string>(prodClosure);
 
     for (const packageName of prodClosure) {
         const pkg = workspacePackages.get(packageName);
         if (!pkg) continue;
 
-        collectDependencyNames(prodDependencies, pkg.packageJson.dependencies);
-        collectDependencyNames(prodDependencies, pkg.packageJson.optionalDependencies);
-        collectDependencyNames(prodDependencies, getRequiredPeerDependencies(pkg.packageJson));
+        const { packageJson } = pkg;
+
+        collectDependencyNames(prodDependencies, packageJson.dependencies);
+        collectDependencyNames(prodDependencies, packageJson.optionalDependencies);
+        collectDependencyNames(prodDependencies, getRequiredPeerDependencies(packageJson));
     }
 
     return {

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { readJson } from '../../fileSystem';
 import type { PackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 import {
@@ -28,8 +29,6 @@ const SNAPSHOT_DIR = join(
     'public-package-dependencies',
     '__snapshots__',
 );
-
-const readJson = <T>(filePath: string): T => JSON.parse(readFileSync(filePath, 'utf8')) as T;
 
 const collectDependencyNames = (
     collector: Set<string>,

--- a/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
+++ b/packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import type { PackageJson } from '../../workspaces';
 import type { Requirement } from '../Requirement';
 import {
-    type PackageJson,
     type WorkspacePackage,
     collectProdWorkspaceClosure,
     collectWorkspacePackages,

--- a/packages/requirements/src/versions.ts
+++ b/packages/requirements/src/versions.ts
@@ -1,0 +1,31 @@
+import * as semver from 'semver';
+
+/**
+ * Strip common version range prefixes (^, ~, >=, <=, >, <, =) so that the bare
+ * version string can be compared numerically. Exact versions pass through
+ * unchanged.
+ */
+export const stripRangePrefix = (specifier: string): string =>
+    specifier.replace(/^[~^]|^[><=]+\s*/g, '');
+
+/**
+ * Pick the canonical version among the given version specifiers.
+ * Strategy: the most frequent version wins; ties are broken by the numerically
+ * higher (later) version (e.g. "^10.2.0" wins over "^9.5.0").
+ */
+export const pickCanonicalVersion = (versions: ReadonlyArray<string>): string => {
+    const frequency = new Map<string, number>();
+
+    for (const version of versions) {
+        frequency.set(version, (frequency.get(version) ?? 0) + 1);
+    }
+
+    const sorted = [...frequency.entries()].sort((a, b) => {
+        if (b[1] !== a[1]) return b[1] - a[1]; // higher frequency first
+
+        // later version first
+        return semver.rcompare(stripRangePrefix(a[0]), stripRangePrefix(b[0]), { loose: true });
+    });
+
+    return sorted[0]?.[0] ?? '';
+};

--- a/packages/requirements/src/workspaces.ts
+++ b/packages/requirements/src/workspaces.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+
+import { readJson } from './fileSystem';
 
 type YarnWorkspaceInfo = {
     readonly name: string;
@@ -91,4 +92,4 @@ export type PackageJson = {
 };
 
 export const readPackageJson = <T = PackageJson>(workspaceDir: string): T =>
-    JSON.parse(readFileSync(join(workspaceDir, 'package.json'), 'utf-8')) as T;
+    readJson<T>(join(workspaceDir, 'package.json'));

--- a/packages/requirements/src/workspaces.ts
+++ b/packages/requirements/src/workspaces.ts
@@ -1,7 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { join, resolve } from 'node:path';
-
-import { readJson } from './fileSystem';
+import { resolve } from 'node:path';
 
 type YarnWorkspaceInfo = {
     readonly name: string;
@@ -68,28 +66,3 @@ export const getWorkspaceDirectoryMap = (repoRoot: string): ReadonlyMap<string, 
 
     return map;
 };
-
-/**
- * Structural view of a `package.json`. Only the fields the requirements actually
- * read are typed explicitly; the trailing index signature keeps arbitrary
- * metadata (`repository`, `bugs`, `author`, …) accessible as `unknown` without
- * every consumer redeclaring its own subset.
- */
-export type PackageJson = {
-    readonly name?: string;
-    readonly version?: string;
-    readonly private?: boolean;
-    readonly type?: string;
-    readonly scripts?: Record<string, string | undefined>;
-    readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
-    readonly resolutions?: Record<string, string>;
-    readonly dependencies?: Record<string, string>;
-    readonly devDependencies?: Record<string, string>;
-    readonly optionalDependencies?: Record<string, string>;
-    readonly peerDependencies?: Record<string, string>;
-    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
-    readonly [field: string]: unknown;
-};
-
-export const readPackageJson = <T = PackageJson>(workspaceDir: string): T =>
-    readJson<T>(join(workspaceDir, 'package.json'));

--- a/packages/requirements/src/workspaces.ts
+++ b/packages/requirements/src/workspaces.ts
@@ -68,5 +68,27 @@ export const getWorkspaceDirectoryMap = (repoRoot: string): ReadonlyMap<string, 
     return map;
 };
 
-export const readPackageJson = <T>(workspaceDir: string): T =>
+/**
+ * Structural view of a `package.json`. Only the fields the requirements actually
+ * read are typed explicitly; the trailing index signature keeps arbitrary
+ * metadata (`repository`, `bugs`, `author`, …) accessible as `unknown` without
+ * every consumer redeclaring its own subset.
+ */
+export type PackageJson = {
+    readonly name?: string;
+    readonly version?: string;
+    readonly private?: boolean;
+    readonly type?: string;
+    readonly scripts?: Record<string, string | undefined>;
+    readonly workspaces?: { readonly packages?: ReadonlyArray<string> } | ReadonlyArray<string>;
+    readonly resolutions?: Record<string, string>;
+    readonly dependencies?: Record<string, string>;
+    readonly devDependencies?: Record<string, string>;
+    readonly optionalDependencies?: Record<string, string>;
+    readonly peerDependencies?: Record<string, string>;
+    readonly peerDependenciesMeta?: Record<string, { readonly optional?: boolean }>;
+    readonly [field: string]: unknown;
+};
+
+export const readPackageJson = <T = PackageJson>(workspaceDir: string): T =>
     JSON.parse(readFileSync(join(workspaceDir, 'package.json'), 'utf-8')) as T;

--- a/packages/requirements/tsconfig.json
+++ b/packages/requirements/tsconfig.json
@@ -1,5 +1,8 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
-    "references": [{ "path": "../utils" }]
+    "references": [
+        { "path": "../node-utils" },
+        { "path": "../utils" }
+    ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16969,6 +16969,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/requirements@workspace:packages/requirements"
   dependencies:
+    "@trezor/node-utils": "workspace:*"
     "@trezor/utils": "workspace:*"
     chalk: "npm:^5.6.2"
     semver: "npm:^7.7.1"


### PR DESCRIPTION
## Description

Stacked PR **1/3**. Pure, behavior-preserving refactor that extracts tooling duplicated across two requirements into shared modules.

Two requirements independently carried the same logic:
- `requireConnectPublicDependencies` — its own workspace-package collector + prod-closure BFS.
- `requireUnifiedDependencyVersions` — its own most-frequent / semver canonical-version picker.

Extracted into shared modules:
- `src/requirements/connectClosure.ts` — `collectWorkspacePackages` + `collectProdWorkspaceClosure` (dependencies + optionalDependencies traversal).
- `src/versions.ts` — `stripRangePrefix` + `pickCanonicalVersion`.

Behavior is preserved: the `connect-public-dependencies` snapshots (including the required-vs-optional peer-dependency filtering) regenerate byte-for-byte, and the `unified-dependency-versions` tests are unchanged.

## Stack

- **1/3 → this PR** — shared-helpers refactor (base `develop`)
- 2/3 — #30725 — connect-closure-fields requirement
- 3/3 — #30726 — unify bugs + author

## Notes for QA

Dev-tooling only; no runtime/app behavior is affected. `type-check`, `lint:js`, and the full `@trezor/requirements` suite are green.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are build-time/development tooling under packages/node-utils and packages/requirements (package.json linting, dependency/version enforcement, workspace utilities). They do not ship to the runtime Trezor Suite application and static coverage found no E2E references. No user-facing E2E behavior is directly exercised by these files, so no Playwright E2E tests are required; validation should happen at the unit/integration level of the requirements/node-utils packages and through the normal build pipeline.

<details><summary><b>Changed files (14)</b></summary>

- `packages/node-utils/src/index.ts`
- `packages/node-utils/src/packageJson.ts`
- `packages/node-utils/src/readJson.ts`
- `packages/requirements/package.json`
- `packages/requirements/src/requirements/connectClosure.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`
- `packages/requirements/src/versions.ts`
- `packages/requirements/src/workspaces.ts`
- `packages/requirements/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (14)**
- `packages/node-utils/src/index.ts`
- `packages/node-utils/src/packageJson.ts`
- `packages/node-utils/src/readJson.ts`
- `packages/requirements/package.json`
- `packages/requirements/src/requirements/connectClosure.ts`
- `packages/requirements/src/requirements/dependency-versions/requireUnifiedDependencyVersions.ts`
- `packages/requirements/src/requirements/firmware-releases/requireFirmwareReleaseVersionMonotonicity.ts`
- `packages/requirements/src/requirements/forbidden-deps/requireForbiddenDeps.ts`
- `packages/requirements/src/requirements/package-json/requirePackageJsonScripts.ts`
- `packages/requirements/src/requirements/package-json/requirePublishConfig.ts`
- `packages/requirements/src/requirements/public-package-dependencies/requireConnectPublicDependencies.ts`
- `packages/requirements/src/versions.ts`
- `packages/requirements/src/workspaces.ts`
- `packages/requirements/tsconfig.json`

_Updated: 2026-08-07T12:11:18.631Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-refactor/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-refactor/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-closure-refactor&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-closure-refactor&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T12:14:13.341Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T12:14:44.695Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

