### PR TITLE
feat(requirements): unify release fields across the connect closure

### DIFF
--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -23,6 +23,10 @@ Optional flags:
 # Run only one requirement by name
 yarn workspace @trezor/requirements requirements:verify --only=package-json
 
+# Align release-critical package.json fields (version, repository) across
+# every published package in the @trezor/connect release closure
+yarn workspace @trezor/requirements requirements:fix --only=connect-closure-fields
+
 # Limit to affected workspaces containing the given text
 yarn workspace @trezor/requirements requirements:verify --filter=@trezor/connect
 

--- a/packages/requirements/src/requirements/allRequirements.ts
+++ b/packages/requirements/src/requirements/allRequirements.ts
@@ -1,5 +1,6 @@
 import type { Requirement, RequirementScope } from './Requirement';
 import { requireAgentsSkills } from './agents-skills/requireAgentsSkills';
+import { requireConnectClosureUnifiedFields } from './connect-closure-fields/requireConnectClosureUnifiedFields';
 import { requireUnifiedDependencyVersions } from './dependency-versions/requireUnifiedDependencyVersions';
 import { requireDocsSummary } from './docs-summary/requireDocsSummary';
 import { requireFirmwareReleaseVersionMonotonicity } from './firmware-releases/requireFirmwareReleaseVersionMonotonicity';
@@ -13,6 +14,7 @@ import { requireTypeDeclarationSize } from './type-declarations/requireTypeDecla
 export const requirements: ReadonlyArray<Requirement<RequirementScope>> = [
     requireAgentsSkills,
     requireUnifiedDependencyVersions,
+    requireConnectClosureUnifiedFields,
     requireConnectPublicDependencies,
     requireDocsSummary,
     requireFirmwareReleaseVersionMonotonicity,

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
@@ -1,0 +1,368 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+jest.mock('node:child_process');
+
+import type { RepoContext } from '../Requirement';
+import { requireConnectClosureUnifiedFields } from './requireConnectClosureUnifiedFields';
+
+type Workspace = {
+    readonly location: string;
+    readonly json: Record<string, unknown>;
+};
+
+const REPO = { type: 'git', url: 'git://github.com/trezor/trezor-suite.git' };
+const CANONICAL = '10.0.0-beta.1';
+
+const setupRepo = (workspaces: ReadonlyArray<Workspace>): RepoContext => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'connect-closure-fields-'));
+
+    const write = (location: string, json: Record<string, unknown>) => {
+        const dir = join(repoRoot, location);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, 'package.json'), `${JSON.stringify(json, null, 4)}\n`);
+    };
+
+    write('.', { name: 'trezor-suite', private: true });
+    for (const ws of workspaces) write(ws.location, ws.json);
+
+    const list = [
+        { location: '.', name: 'trezor-suite' },
+        ...workspaces.map(w => ({ location: w.location, name: w.json.name })),
+    ]
+        .map(w => JSON.stringify(w))
+        .join('\n');
+
+    jest.mocked(execFileSync).mockReturnValue(list);
+
+    return { repoRoot };
+};
+
+// connect -> {connect-common -> utils} (canonical) + {transport-web -> transport-common} (lagging).
+const closure = (transportJson: Record<string, unknown>): ReadonlyArray<Workspace> => [
+    {
+        location: 'packages/connect',
+        json: {
+            name: '@trezor/connect',
+            version: CANONICAL,
+            repository: REPO,
+            license: 'MIT',
+            dependencies: {
+                '@trezor/connect-common': 'workspace:*',
+                '@trezor/transport-web': 'workspace:*',
+            },
+            devDependencies: { '@trezor/unrelated': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/connect-common',
+        json: {
+            name: '@trezor/connect-common',
+            version: CANONICAL,
+            repository: REPO,
+            license: 'See LICENSE.md in repo root', // legitimately different license — must be ignored
+            dependencies: { '@trezor/utils': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/utils',
+        json: { name: '@trezor/utils', version: CANONICAL, repository: REPO },
+    },
+    {
+        location: 'packages/transport-web',
+        json: {
+            name: '@trezor/transport-web',
+            ...transportJson,
+            dependencies: { '@trezor/transport-common': 'workspace:*' },
+        },
+    },
+    {
+        location: 'packages/transport-common',
+        json: { name: '@trezor/transport-common', ...transportJson },
+    },
+    // Only a devDependency of connect — outside the prod closure, ignored.
+    {
+        location: 'packages/unrelated',
+        json: { name: '@trezor/unrelated', version: '1.2.3' },
+    },
+];
+
+const readJson = (context: RepoContext, location: string) =>
+    JSON.parse(readFileSync(join(context.repoRoot, location, 'package.json'), 'utf-8'));
+
+const tempRoots: string[] = [];
+const remember = (context: RepoContext): RepoContext => {
+    tempRoots.push(context.repoRoot);
+
+    return context;
+};
+
+afterEach(() => {
+    for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+    tempRoots.length = 0;
+    jest.clearAllMocks();
+});
+
+describe(requireConnectClosureUnifiedFields.name, () => {
+    it('has repo scope', () => {
+        expect(requireConnectClosureUnifiedFields.scope).toBe('repo');
+    });
+
+    it('passes when every field is unified across the closure', async () => {
+        const context = remember(setupRepo(closure({ version: CANONICAL, repository: REPO })));
+
+        expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+    });
+
+    it('treats structurally-equal repository values as unified regardless of key order', async () => {
+        // The transport packages carry the same repository object with reordered keys.
+        const reordered = { url: REPO.url, type: REPO.type };
+        const context = remember(setupRepo(closure({ version: CANONICAL, repository: reordered })));
+
+        expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+    });
+
+    it('flags a version left behind (the #30575 scenario)', async () => {
+        const context = remember(
+            setupRepo(closure({ version: '1.0.0-alpha.1', repository: REPO })),
+        );
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+        const versionErrors = errors.filter(e => e.includes('"version"'));
+
+        expect(versionErrors).toHaveLength(2);
+        expect(versionErrors.join('\n')).toContain('@trezor/transport-web');
+        expect(versionErrors.join('\n')).toContain(CANONICAL);
+    });
+
+    it('flags a missing repository field (the #30591 scenario)', async () => {
+        const context = remember(setupRepo(closure({ version: CANONICAL })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+        const repoErrors = errors.filter(e => e.includes('no "repository" field'));
+
+        expect(repoErrors).toHaveLength(2);
+        expect(repoErrors.join('\n')).toContain('@trezor/transport-web');
+        expect(repoErrors.join('\n')).toContain('@trezor/transport-common');
+    });
+
+    it('ignores fields that legitimately vary (license)', async () => {
+        const context = remember(setupRepo(closure({ version: CANONICAL, repository: REPO })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        expect(errors.join('\n')).not.toContain('license');
+    });
+
+    it('ignores packages outside the production closure', async () => {
+        const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        expect(errors.join('\n')).not.toContain('@trezor/unrelated');
+    });
+
+    it('errors when no Connect closure root is present', async () => {
+        const context = remember(
+            setupRepo([
+                { location: 'packages/utils', json: { name: '@trezor/utils', version: CANONICAL } },
+            ]),
+        );
+
+        const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('No Connect closure packages found');
+    });
+
+    describe('fix mode', () => {
+        it('aligns version and fills missing repository in a single write per package', async () => {
+            const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+            const errors = await requireConnectClosureUnifiedFields.fix!(context);
+            expect(errors).toEqual([]);
+
+            for (const location of ['packages/transport-web', 'packages/transport-common']) {
+                const pkg = readJson(context, location);
+                expect(pkg.version).toBe(CANONICAL);
+                expect(pkg.repository).toEqual(REPO);
+            }
+
+            expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+        });
+
+        it('does not touch packages outside the closure', async () => {
+            const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
+
+            await requireConnectClosureUnifiedFields.fix!(context);
+
+            expect(readJson(context, 'packages/unrelated').version).toBe('1.2.3');
+        });
+    });
+
+    describe('most-common canonical selection', () => {
+        const REPO_ALT = { type: 'git', url: 'git://github.com/trezor/fork.git' };
+
+        it('picks the majority value and flags the minority (repository)', async () => {
+            // connect + connect-common + utils carry REPO (3); the two transport packages
+            // carry REPO_ALT (2). The majority (REPO) must win.
+            const context = remember(
+                setupRepo(closure({ version: CANONICAL, repository: REPO_ALT })),
+            );
+
+            const repoErrors = (await requireConnectClosureUnifiedFields.verify(context)).filter(
+                e => e.includes('"repository"'),
+            );
+
+            expect(repoErrors).toHaveLength(2);
+            expect(repoErrors.join('\n')).toContain('@trezor/transport-web');
+            expect(repoErrors.join('\n')).toContain('@trezor/transport-common');
+            expect(repoErrors.join('\n')).toContain(`uses ${JSON.stringify(REPO)}`);
+        });
+
+        it('rewrites the minority to the majority value on fix (repository)', async () => {
+            const context = remember(
+                setupRepo(closure({ version: CANONICAL, repository: REPO_ALT })),
+            );
+
+            await requireConnectClosureUnifiedFields.fix!(context);
+
+            for (const location of ['packages/transport-web', 'packages/transport-common']) {
+                expect(readJson(context, location).repository).toEqual(REPO);
+            }
+            // The majority holders keep their value untouched.
+            expect(readJson(context, 'packages/connect').repository).toEqual(REPO);
+            expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
+        });
+
+        it('breaks ties deterministically by canonical key regardless of input order', async () => {
+            // Equal frequency (2 vs 2). The winner is the value whose canonical
+            // (sorted-key) serialization sorts first — REPO_A, because its url sorts
+            // before REPO_B's — independent of the order packages are discovered in.
+            const REPO_A = { type: 'git', url: 'git://github.com/trezor/aaa.git' };
+            const REPO_B = { type: 'git', url: 'git://github.com/trezor/zzz.git' };
+
+            const tiedClosure = (
+                repos: ReadonlyArray<Record<string, string>>,
+            ): ReadonlyArray<Workspace> => [
+                {
+                    location: 'packages/connect',
+                    json: {
+                        name: '@trezor/connect',
+                        version: CANONICAL,
+                        repository: repos[0],
+                        dependencies: {
+                            '@trezor/a': 'workspace:*',
+                            '@trezor/b': 'workspace:*',
+                            '@trezor/c': 'workspace:*',
+                        },
+                    },
+                },
+                {
+                    location: 'packages/a',
+                    json: { name: '@trezor/a', version: CANONICAL, repository: repos[1] },
+                },
+                {
+                    location: 'packages/b',
+                    json: { name: '@trezor/b', version: CANONICAL, repository: repos[2] },
+                },
+                {
+                    location: 'packages/c',
+                    json: { name: '@trezor/c', version: CANONICAL, repository: repos[3] },
+                },
+            ];
+
+            for (const repos of [
+                [REPO_A, REPO_A, REPO_B, REPO_B],
+                [REPO_B, REPO_B, REPO_A, REPO_A],
+            ]) {
+                const context = remember(setupRepo(tiedClosure(repos)));
+
+                const repoErrors = (
+                    await requireConnectClosureUnifiedFields.verify(context)
+                ).filter(e => e.includes('"repository"'));
+
+                // REPO_A is canonical either way → the two REPO_B holders are the drift.
+                expect(repoErrors).toHaveLength(2);
+                expect(repoErrors.join('\n')).toContain(`uses ${JSON.stringify(REPO_A)}`);
+                expect(repoErrors.join('\n')).not.toContain(`uses ${JSON.stringify(REPO_B)}`);
+            }
+        });
+    });
+
+    describe('private package exclusion', () => {
+        it('errors when every closure package is private', async () => {
+            const context = remember(
+                setupRepo([
+                    {
+                        location: 'packages/connect',
+                        json: {
+                            name: '@trezor/connect',
+                            version: CANONICAL,
+                            repository: REPO,
+                            private: true,
+                            dependencies: { '@trezor/utils': 'workspace:*' },
+                        },
+                    },
+                    {
+                        location: 'packages/utils',
+                        json: {
+                            name: '@trezor/utils',
+                            version: CANONICAL,
+                            repository: REPO,
+                            private: true,
+                        },
+                    },
+                ]),
+            );
+
+            const errors = await requireConnectClosureUnifiedFields.verify(context);
+
+            expect(errors).toEqual(['No published Connect closure packages found.']);
+        });
+
+        it('ignores a private package inside the closure (neither flagged nor rewritten)', async () => {
+            const REPO_ALT = { type: 'git', url: 'git://github.com/trezor/fork.git' };
+            const context = remember(
+                setupRepo([
+                    {
+                        location: 'packages/connect',
+                        json: {
+                            name: '@trezor/connect',
+                            version: CANONICAL,
+                            repository: REPO,
+                            dependencies: {
+                                '@trezor/utils': 'workspace:*',
+                                '@trezor/internal': 'workspace:*',
+                            },
+                        },
+                    },
+                    {
+                        location: 'packages/utils',
+                        json: { name: '@trezor/utils', version: CANONICAL, repository: REPO },
+                    },
+                    // Divergent repository, but private — excluded from the published closure.
+                    {
+                        location: 'packages/internal',
+                        json: {
+                            name: '@trezor/internal',
+                            version: CANONICAL,
+                            repository: REPO_ALT,
+                            private: true,
+                        },
+                    },
+                ]),
+            );
+
+            const errors = await requireConnectClosureUnifiedFields.verify(context);
+            expect(errors.filter(e => e.includes('"repository"'))).toEqual([]);
+            expect(errors.join('\n')).not.toContain('@trezor/internal');
+
+            await requireConnectClosureUnifiedFields.fix!(context);
+            // The private package keeps its divergent value — fix must not touch it.
+            expect(readJson(context, 'packages/internal').repository).toEqual(REPO_ALT);
+        });
+    });
+});

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
@@ -1,0 +1,219 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { arrayToDictionary, deepEqual, typedObjectEntries } from '@trezor/utils';
+
+import { pickCanonicalVersion } from '../../versions';
+import type { Requirement } from '../Requirement';
+import {
+    type WorkspacePackage,
+    collectProdWorkspaceClosure,
+    collectWorkspacePackages,
+} from '../connectClosure';
+
+/**
+ * Canonical, order-insensitive serialization: object keys are sorted recursively
+ * so structurally-equal values (e.g. `{ type, url }` and `{ url, type }`) map to
+ * the same key.
+ */
+const canonicalKey = (value: unknown): string => {
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value) ?? 'undefined';
+    }
+
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalKey).join(',')}]`;
+    }
+
+    const entries = Object.keys(value)
+        .sort()
+        .map(
+            key =>
+                `${JSON.stringify(key)}:${canonicalKey((value as Record<string, unknown>)[key])}`,
+        );
+
+    return `{${entries.join(',')}}`;
+};
+
+/**
+ * Pick the most common value among the given values, compared structurally
+ * (order-insensitively). Ties are broken deterministically by the canonical key,
+ * so the result is stable regardless of input order. Returns `undefined` for
+ * empty input.
+ *
+ * Lives here rather than in the shared `versions.ts` because this requirement is
+ * its only consumer.
+ */
+const mostCommon = (values: ReadonlyArray<unknown>): unknown => {
+    const counts = new Map<string, { readonly value: unknown; count: number }>();
+
+    for (const value of values) {
+        const key = canonicalKey(value);
+        const entry = counts.get(key);
+
+        if (entry) {
+            entry.count += 1;
+        } else {
+            counts.set(key, { value, count: 1 });
+        }
+    }
+
+    const sorted = [...counts.entries()].sort((a, b) => {
+        if (b[1].count !== a[1].count) return b[1].count - a[1].count; // higher frequency first
+
+        return a[0].localeCompare(b[0]); // deterministic tie-break
+    });
+
+    return sorted[0]?.[1].value;
+};
+
+/**
+ * Entry packages of the Trezor Connect family. Every internal workspace package
+ * reachable from these through production dependencies (`dependencies` and
+ * `optionalDependencies`) is published together as part of a Connect release.
+ *
+ * `@trezor/connect` (the core) is included on purpose: the public entry points
+ * (`connect-web`/`connect-mobile`/`connect-webextension`) are thin and do not
+ * reach deeper packages such as `@trezor/transport-*`, which nevertheless ship
+ * with every Connect release.
+ */
+const CONNECT_CLOSURE_ROOTS = [
+    '@trezor/connect',
+    '@trezor/connect-web',
+    '@trezor/connect-mobile',
+    '@trezor/connect-webextension',
+] as const;
+
+type UnifiedField = {
+    readonly name: string;
+    /** Chooses the value the whole closure should agree on. */
+    readonly pickCanonical: (values: ReadonlyArray<unknown>) => unknown;
+};
+
+/**
+ * package.json fields that every published package in the Connect closure must
+ * share. Each field either shares one value across the closure or is missing on
+ * the packages that lag behind; both are treated as drift and aligned on fix.
+ *
+ * This list is intentionally conservative: it only carries fields that are
+ * release-critical and already unified across the closure today. Metadata fields
+ * such as `bugs` and `author` are good future additions once the packages that
+ * currently lack them are filled in. Fields that legitimately vary per package
+ * (`license`, `homepage`, `publishConfig`, `type`, `sideEffects`) are excluded.
+ */
+const UNIFIED_FIELDS: ReadonlyArray<UnifiedField> = [
+    // Release lockstep — see #30575.
+    { name: 'version', pickCanonical: values => pickCanonicalVersion(values.map(String)) },
+    // NPM provenance requires a repository field on every published package — see #30591.
+    { name: 'repository', pickCanonical: mostCommon },
+];
+
+type FieldDrift = {
+    readonly field: string;
+    readonly packageName: string;
+    readonly dir: string;
+    readonly actual: unknown;
+    readonly canonical: unknown;
+};
+
+const analyzeClosure = (
+    repoRoot: string,
+): { readonly drifts: ReadonlyArray<FieldDrift> } | { readonly error: string } => {
+    const packages = collectWorkspacePackages(repoRoot);
+    const closureNames = [...collectProdWorkspaceClosure(CONNECT_CLOSURE_ROOTS, packages)].sort();
+
+    if (closureNames.length === 0) {
+        return {
+            error: `No Connect closure packages found. Expected at least one of: ${CONNECT_CLOSURE_ROOTS.join(', ')}.`,
+        };
+    }
+
+    const publicPackages = closureNames
+        .map(name => packages.get(name))
+        .filter(
+            (pkg): pkg is WorkspacePackage => pkg !== undefined && pkg.packageJson.private !== true,
+        );
+
+    if (publicPackages.length === 0) {
+        return { error: 'No published Connect closure packages found.' };
+    }
+
+    const drifts: FieldDrift[] = [];
+
+    for (const field of UNIFIED_FIELDS) {
+        const presentValues = publicPackages
+            .map(pkg => pkg.packageJson[field.name])
+            .filter(value => value !== undefined);
+
+        if (presentValues.length === 0) continue;
+
+        const canonical = field.pickCanonical(presentValues);
+
+        for (const pkg of publicPackages) {
+            const actual = pkg.packageJson[field.name];
+
+            if (deepEqual(actual, canonical)) continue;
+
+            drifts.push({
+                field: field.name,
+                packageName: pkg.name,
+                dir: pkg.dir,
+                actual,
+                canonical,
+            });
+        }
+    }
+
+    return { drifts };
+};
+
+const formatDriftError = ({ field, packageName, actual, canonical }: FieldDrift): string => {
+    const current =
+        actual === undefined
+            ? `has no "${field}" field`
+            : `has "${field}" = ${JSON.stringify(actual)}`;
+
+    return `"${packageName}" ${current} but the Connect closure uses ${JSON.stringify(canonical)}. Run requirements:fix --only=connect-closure-fields.`;
+};
+
+/**
+ * Verifies that every published package in the `@trezor/connect` production
+ * closure shares the same value for a set of release-critical package.json fields
+ * (see UNIFIED_FIELDS), so the whole family is published in lockstep and no
+ * package is released with stale or missing metadata.
+ */
+export const requireConnectClosureUnifiedFields: Requirement<'repo'> = {
+    name: 'connect-closure-fields',
+    scope: 'repo',
+    verify: ({ repoRoot }) => {
+        const analysis = analyzeClosure(repoRoot);
+
+        if ('error' in analysis) {
+            return Promise.resolve([analysis.error]);
+        }
+
+        return Promise.resolve(analysis.drifts.map(formatDriftError));
+    },
+    fix: ({ repoRoot }) => {
+        const analysis = analyzeClosure(repoRoot);
+
+        if ('error' in analysis) {
+            return Promise.resolve([analysis.error]);
+        }
+
+        const driftsByDir = arrayToDictionary([...analysis.drifts], drift => drift.dir, true);
+
+        for (const [dir, drifts] of typedObjectEntries(driftsByDir)) {
+            const pkgPath = join(dir, 'package.json');
+            const parsed = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+
+            for (const drift of drifts) {
+                parsed[drift.field] = drift.canonical;
+            }
+
+            writeFileSync(pkgPath, JSON.stringify(parsed, null, 4) + '\n', 'utf-8');
+        }
+
+        return Promise.resolve([]);
+    },
+};

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
@@ -1,6 +1,7 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { readPackageJson } from '@trezor/node-utils';
 import { arrayToDictionary, deepEqual, typedObjectEntries } from '@trezor/utils';
 
 import { pickCanonicalVersion } from '../../versions';
@@ -205,7 +206,7 @@ export const requireConnectClosureUnifiedFields: Requirement<'repo'> = {
 
         for (const [dir, drifts] of typedObjectEntries(driftsByDir)) {
             const pkgPath = join(dir, 'package.json');
-            const parsed = JSON.parse(readFileSync(pkgPath, 'utf-8')) as Record<string, unknown>;
+            const parsed = readPackageJson<Record<string, unknown>>(dir);
 
             for (const drift of drifts) {
                 parsed[drift.field] = drift.canonical;


### PR DESCRIPTION
## Description

Builds on #30724 (already merged); this PR targets `develop`. Adds the `connect-closure-fields` requirement.

It verifies that every published package in the production closure of the Trezor Connect family (`@trezor/connect` + its public entry points, traversed via `dependencies` + `optionalDependencies`; only non-`private` packages) shares the same value for a set of release-critical `package.json` fields, so the family is published in lockstep with no stale or missing metadata.

`UNIFIED_FIELDS` in this PR: `version` (release lockstep — #30575) and `repository` (NPM provenance — #30591). Both are already unified across the closure today, so this ships **green with no `package.json` changes**. The canonical value is derived from the packages themselves (most common; `version` breaks ties by higher semver); a package that diverges from — or is missing — the field is drift, which `verify()` reports and `fix()` writes.

This PR adds a local `mostCommon` helper directly in `requireConnectClosureUnifiedFields.ts` — the canonical picker for the `repository` field. It is deliberately kept in the requirement file rather than the shared `src/versions.ts` because this requirement is its only consumer. The `version` field reuses the existing `pickCanonicalVersion` helper from `src/versions.ts` (added in #30724).

`license` is deliberately excluded: `@trezor/connect` and several others are under the repository's **TREZOR REFERENCE SOURCE LICENSE** (via `"SEE LICENSE IN LICENSE.md"`) while the utility packages are `"MIT"` — two different licenses, so unifying to the most common value would mis-license the restricted packages.

## Stack

- #30724 — shared-helpers refactor (merged)
- **2/3 → this PR** — connect-closure-fields requirement
- 3/3 — #30726 — unify bugs + author

## Notes for QA

Dev-tooling only; no metadata churn in this PR. The requirement reports no drift against the repo.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are in the requirements package and specifically govern Connect closure/unified fields, with no static E2E coverage available. The highest-confidence inferred coverage comes from the TrezorConnect E2E suite. Running a broad Connect popup test plus a permissions-focused test catches regressions in method metadata, permission grants, and popup behavior while keeping the run small. The associated unit test file already provides direct coverage of the requirement implementation.

<details><summary><b>Changed files (3)</b></summary>

- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the broadest Connect API surface area covered by the candidate list, including getAddress, cardanoGetAddress, permissions grants, cancellation flows, and popup lifecycle. Because the changed files define requirements for Connect closure/unified fields, any change that alters how Connect methods declare or validate their metadata, permissions, or popup behavior is most likely to surface here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — This test focuses on the Connect permissions lifecycle (grant, remember, revoke, and re-request). Changes to closure-field requirements could affect how methods declare their required permissions or how remembered permissions are matched, making this a targeted secondary check.

</details>

_Updated: 2026-09-04T07:03:03.383Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-fields/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-fields/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-closure-fields&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-closure-fields&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:04:31.240Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:03:23.343Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->


