### PR TITLE
feat(requirements): unify bugs and author across the connect closure

### DIFF
--- a/networks/cardano/network-cardano/package.json
+++ b/networks/cardano/network-cardano/package.json
@@ -52,5 +52,9 @@
         "@fivebinaries/coin-selection": "3.0.0",
         "@trezor/utils": "workspace:*",
         "cbor": "^10.0.12"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/ripple/network-ripple/package.json
+++ b/networks/ripple/network-ripple/package.json
@@ -51,5 +51,9 @@
     "dependencies": {
         "@trezor/utils": "workspace:*",
         "xrpl": "4.6.0"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/solana/network-solana/package.json
+++ b/networks/solana/network-solana/package.json
@@ -60,5 +60,9 @@
         "@solana/rpc-types": "^6.9.0",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/stellar/network-stellar/package.json
+++ b/networks/stellar/network-stellar/package.json
@@ -51,5 +51,9 @@
     "dependencies": {
         "@stellar/stellar-sdk": "16.1.0",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/networks/tron/network-tron/package.json
+++ b/networks/tron/network-tron/package.json
@@ -46,5 +46,9 @@
     "dependencies": {
         "@noble/hashes": "^2.0.1",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/blockchain-link-types/package.json
+++ b/packages/blockchain-link-types/package.json
@@ -45,5 +45,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/blockchain-link-utils/package.json
+++ b/packages/blockchain-link-utils/package.json
@@ -45,5 +45,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/connect-mobile/package.json
+++ b/packages/connect-mobile/package.json
@@ -35,5 +35,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/device-utils/package.json
+++ b/packages/device-utils/package.json
@@ -34,5 +34,9 @@
         "@trezor/protobuf": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/env-utils/package.json
+++ b/packages/env-utils/package.json
@@ -51,5 +51,6 @@
         "react-native": {
             "optional": true
         }
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/protobuf/package.json
+++ b/packages/protobuf/package.json
@@ -53,5 +53,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/requirements/README.md
+++ b/packages/requirements/README.md
@@ -23,7 +23,7 @@ Optional flags:
 # Run only one requirement by name
 yarn workspace @trezor/requirements requirements:verify --only=package-json
 
-# Align release-critical package.json fields (version, repository) across
+# Align release-critical package.json fields (version, repository, bugs, author) across
 # every published package in the @trezor/connect release closure
 yarn workspace @trezor/requirements requirements:fix --only=connect-closure-fields
 

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts
@@ -14,6 +14,8 @@ type Workspace = {
 };
 
 const REPO = { type: 'git', url: 'git://github.com/trezor/trezor-suite.git' };
+const BUGS = { url: 'https://github.com/trezor/trezor-suite/issues' };
+const AUTHOR = 'Trezor <info@trezor.io>';
 const CANONICAL = '10.0.0-beta.1';
 
 const setupRepo = (workspaces: ReadonlyArray<Workspace>): RepoContext => {
@@ -48,7 +50,9 @@ const closure = (transportJson: Record<string, unknown>): ReadonlyArray<Workspac
             name: '@trezor/connect',
             version: CANONICAL,
             repository: REPO,
-            license: 'MIT',
+            bugs: BUGS,
+            author: AUTHOR,
+            license: 'SEE LICENSE IN LICENSE.md',
             dependencies: {
                 '@trezor/connect-common': 'workspace:*',
                 '@trezor/transport-web': 'workspace:*',
@@ -62,13 +66,21 @@ const closure = (transportJson: Record<string, unknown>): ReadonlyArray<Workspac
             name: '@trezor/connect-common',
             version: CANONICAL,
             repository: REPO,
-            license: 'See LICENSE.md in repo root', // legitimately different license — must be ignored
+            bugs: BUGS,
+            author: AUTHOR,
+            license: 'MIT', // license legitimately differs across the family — must be ignored
             dependencies: { '@trezor/utils': 'workspace:*' },
         },
     },
     {
         location: 'packages/utils',
-        json: { name: '@trezor/utils', version: CANONICAL, repository: REPO },
+        json: {
+            name: '@trezor/utils',
+            version: CANONICAL,
+            repository: REPO,
+            bugs: BUGS,
+            author: AUTHOR,
+        },
     },
     {
         location: 'packages/transport-web',
@@ -110,8 +122,10 @@ describe(requireConnectClosureUnifiedFields.name, () => {
         expect(requireConnectClosureUnifiedFields.scope).toBe('repo');
     });
 
+    const UNIFIED = { version: CANONICAL, repository: REPO, bugs: BUGS, author: AUTHOR };
+
     it('passes when every field is unified across the closure', async () => {
-        const context = remember(setupRepo(closure({ version: CANONICAL, repository: REPO })));
+        const context = remember(setupRepo(closure(UNIFIED)));
 
         expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
     });
@@ -119,15 +133,13 @@ describe(requireConnectClosureUnifiedFields.name, () => {
     it('treats structurally-equal repository values as unified regardless of key order', async () => {
         // The transport packages carry the same repository object with reordered keys.
         const reordered = { url: REPO.url, type: REPO.type };
-        const context = remember(setupRepo(closure({ version: CANONICAL, repository: reordered })));
+        const context = remember(setupRepo(closure({ ...UNIFIED, repository: reordered })));
 
         expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);
     });
 
     it('flags a version left behind (the #30575 scenario)', async () => {
-        const context = remember(
-            setupRepo(closure({ version: '1.0.0-alpha.1', repository: REPO })),
-        );
+        const context = remember(setupRepo(closure({ ...UNIFIED, version: '1.0.0-alpha.1' })));
 
         const errors = await requireConnectClosureUnifiedFields.verify(context);
         const versionErrors = errors.filter(e => e.includes('"version"'));
@@ -137,23 +149,26 @@ describe(requireConnectClosureUnifiedFields.name, () => {
         expect(versionErrors.join('\n')).toContain(CANONICAL);
     });
 
-    it('flags a missing repository field (the #30591 scenario)', async () => {
+    it('flags missing repository / bugs / author fields (the #30591 scenario)', async () => {
         const context = remember(setupRepo(closure({ version: CANONICAL })));
 
         const errors = await requireConnectClosureUnifiedFields.verify(context);
-        const repoErrors = errors.filter(e => e.includes('no "repository" field'));
 
-        expect(repoErrors).toHaveLength(2);
-        expect(repoErrors.join('\n')).toContain('@trezor/transport-web');
-        expect(repoErrors.join('\n')).toContain('@trezor/transport-common');
+        for (const field of ['repository', 'bugs', 'author']) {
+            const missing = errors.filter(e => e.includes(`no "${field}" field`));
+            expect(missing).toHaveLength(2);
+            expect(missing.join('\n')).toContain('@trezor/transport-web');
+            expect(missing.join('\n')).toContain('@trezor/transport-common');
+        }
     });
 
     it('ignores fields that legitimately vary (license)', async () => {
-        const context = remember(setupRepo(closure({ version: CANONICAL, repository: REPO })));
+        const context = remember(setupRepo(closure(UNIFIED)));
 
         const errors = await requireConnectClosureUnifiedFields.verify(context);
 
-        expect(errors.join('\n')).not.toContain('license');
+        // connect is "SEE LICENSE IN LICENSE.md", connect-common is "MIT" — not flagged.
+        expect(errors).toEqual([]);
     });
 
     it('ignores packages outside the production closure', async () => {
@@ -178,7 +193,7 @@ describe(requireConnectClosureUnifiedFields.name, () => {
     });
 
     describe('fix mode', () => {
-        it('aligns version and fills missing repository in a single write per package', async () => {
+        it('aligns version and fills missing repository / bugs / author per package', async () => {
             const context = remember(setupRepo(closure({ version: '1.0.0-alpha.1' })));
 
             const errors = await requireConnectClosureUnifiedFields.fix!(context);
@@ -188,6 +203,8 @@ describe(requireConnectClosureUnifiedFields.name, () => {
                 const pkg = readJson(context, location);
                 expect(pkg.version).toBe(CANONICAL);
                 expect(pkg.repository).toEqual(REPO);
+                expect(pkg.bugs).toEqual(BUGS);
+                expect(pkg.author).toBe(AUTHOR);
             }
 
             expect(await requireConnectClosureUnifiedFields.verify(context)).toEqual([]);

--- a/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
+++ b/packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts
@@ -96,17 +96,29 @@ type UnifiedField = {
  * share. Each field either shares one value across the closure or is missing on
  * the packages that lag behind; both are treated as drift and aligned on fix.
  *
- * This list is intentionally conservative: it only carries fields that are
- * release-critical and already unified across the closure today. Metadata fields
- * such as `bugs` and `author` are good future additions once the packages that
- * currently lack them are filled in. Fields that legitimately vary per package
- * (`license`, `homepage`, `publishConfig`, `type`, `sideEffects`) are excluded.
+ * A field only belongs here if it (1) is release/publish metadata, (2) has a
+ * single canonical value the whole family should share, and (3) is safe to
+ * rewrite. Deliberately excluded:
+ * - `license` — NOT uniform for a real reason: `@trezor/connect` and several
+ *   others are under the repository's TREZOR REFERENCE SOURCE LICENSE (via
+ *   "SEE LICENSE IN LICENSE.md"), while the utility packages are "MIT". These are
+ *   two different licenses, so unifying to the most common value (MIT) would
+ *   mis-license the restricted packages. License changes need human review.
+ * - `type`, `sideEffects` — build/bundler semantics, not release metadata.
+ * - `homepage`, `main`, `exports`, `publishConfig`, `browser`, `keywords`, … —
+ *   inherently per-package.
+ * - `dependencies` / `devDependencies` versions are covered by
+ *   requireUnifiedDependencyVersions.
  */
 const UNIFIED_FIELDS: ReadonlyArray<UnifiedField> = [
     // Release lockstep — see #30575.
     { name: 'version', pickCanonical: values => pickCanonicalVersion(values.map(String)) },
     // NPM provenance requires a repository field on every published package — see #30591.
     { name: 'repository', pickCanonical: mostCommon },
+    // Issue tracker; every published package should point at the same tracker.
+    { name: 'bugs', pickCanonical: mostCommon },
+    // Package author; uniform across the Trezor-published family.
+    { name: 'author', pickCanonical: mostCommon },
 ];
 
 type FieldDrift = {

--- a/packages/schema-utils/package.json
+++ b/packages/schema-utils/package.json
@@ -43,5 +43,9 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "bugs": {
+        "url": "https://github.com/trezor/trezor-suite/issues"
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/transport-common/package.json
+++ b/packages/transport-common/package.json
@@ -69,5 +69,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/transport-web/package.json
+++ b/packages/transport-web/package.json
@@ -48,5 +48,6 @@
     },
     "peerDependencies": {
         "tslib": "^2.6.2"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }

--- a/packages/type-utils/package.json
+++ b/packages/type-utils/package.json
@@ -32,5 +32,6 @@
         "depcheck": "yarn g:depcheck",
         "type-check": "yarn g:tsc --build",
         "lint:js": "yarn g:eslint '**/*.{ts,tsx,js}'"
-    }
+    },
+    "author": "Trezor <info@trezor.io>"
 }


### PR DESCRIPTION
## Description

Stacked PR **3/3** (on top of #30725). Extends `UNIFIED_FIELDS` with `bugs` and `author` and brings the closure into compliance.

Both fields have a single canonical value across the family and were merely missing on some published packages (`bugs` on 10, `author` on 16). `requirements:fix` fills them, so the whole Connect release family now shares the same issue tracker and author. The 16 touched `package.json` files gain only the canonical `bugs` / `author` values — no version/dependency changes.

## Stack

- #30724 — shared-helpers refactor (merged)
- 2/3 — #30725 — connect-closure-fields requirement ← **base of this PR**
- **3/3 → this PR** — unify bugs + author

## Notes for QA

Metadata only (issue tracker + author). The requirement reports no drift after the fills; full `@trezor/requirements` suite green.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-bugs-author/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-closure-bugs-author/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-closure-bugs-author&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-closure-bugs-author&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:04:00.712Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:03:44.153Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in two risk areas: (1) Connect/transport/protobuf/protocol package configuration and a new Connect closure-fields requirement that governs API response shape, and (2) network-specific package.json updates for Cardano, Solana, Tron, and Stellar. The recommended set prioritizes Connect response-contract tests, a transport session test, and targeted end-to-end flows for the changed networks. Pure utility package changes (type-utils, schema-utils, env-utils, device-utils, connect-mobile) and the static requirements unit tests have no specific end-to-eend coverage and are listed as uncovered.

<details><summary><b>Changed files (19)</b></summary>

- `networks/cardano/network-cardano/package.json`
- `networks/ripple/network-ripple/package.json`
- `networks/solana/network-solana/package.json`
- `networks/stellar/network-stellar/package.json`
- `networks/tron/network-tron/package.json`
- `packages/blockchain-link-types/package.json`
- `packages/blockchain-link-utils/package.json`
- `packages/connect-mobile/package.json`
- `packages/device-utils/package.json`
- `packages/env-utils/package.json`
- `packages/protobuf/package.json`
- `packages/protocol/package.json`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts`
- `packages/schema-utils/package.json`
- `packages/transport-common/package.json`
- `packages/transport-web/package.json`
- `packages/type-utils/package.json`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — This test explicitly asserts the shape of TrezorConnect.selectAccount payloads (e.g., absence of xpub/publicKey), which is exactly the kind of Connect response-field contract that the changed connect-closure-fields requirements enforce. It is the strongest end-to-end signal for the requirements changes and the related connect/transport/protobuf package changes.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Exercises the core TrezorConnect web flow across Bitcoin and Cardano address exports, including response payloads and popup lifecycle. It directly covers Connect runtime behavior that could regress from changes to connect-mobile, transport, protobuf, and protocol packages.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly references @trezor/transport-common BridgeTransport session enumeration and acquisition. A package.json change in transport-common could alter bridge session behavior, making this the most targeted regression test for that file.
- `suite/e2e/tests/wallet/cardano.test.ts` — Validates Cardano account details, public key export, send form, and receive address verification end-to-end. It directly exercises the networks/cardano/network-cardano package and related blockchain-link infrastructure.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Covers the full Solana send flow including fee/reserve calculation and device confirmation. It directly exercises the networks/solana/network-solana package and Solana transaction construction.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Tests TrezorConnect.getAccountInfo account selection and success response, which depends on the same Connect response-field contracts and transport infrastructure affected by the closure-fields requirements and transport/protobuf package changes.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises TrezorConnect.getAddress for single and bundled Bitcoin addresses with forced on-device confirmation. It covers another Connect method whose response shape and popup behavior depend on the changed Connect/transport/protobuf packages.
- `suite/e2e/tests/staking/ada/stake.test.ts` — A deeper Cardano flow that builds and signs a staking transaction through a mocked Cardano backend. It is a strong secondary check that the Cardano network package and blockchain-link integration still work for transaction signing.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — A deeper Solana flow covering staking transaction signing and epoch state updates. It provides additional coverage for the Solana network package beyond the basic send test.
- `suite/e2e/tests/wallet/receive.test.ts` — Includes a Tron (TRX) receive address verification flow among BTC/ETH/SOL. This is the most concrete end-to-end coverage available for the networks/tron/network-tron package change.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Explicitly interacts with the Stellar (XLM) network by enabling it from the receive account picker during a swap. It provides the most direct end-to-end signal for the networks/stellar/network-stellar package change.

</details>

⚠️ **Changes with no test coverage (9)**
- `networks/ripple/network-ripple/package.json`
- `packages/connect-mobile/package.json`
- `packages/device-utils/package.json`
- `packages/env-utils/package.json`
- `packages/requirements/src/requirements/allRequirements.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.test.ts`
- `packages/requirements/src/requirements/connect-closure-fields/requireConnectClosureUnifiedFields.ts`
- `packages/schema-utils/package.json`
- `packages/type-utils/package.json`

_Updated: 2026-09-04T07:04:44.343Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->
