### PR TITLE
fix(suite-native): AlertBox cleanup

### DIFF
--- a/suite-native/atoms/src/FullAlertBox/FullAlertBox.tsx
+++ b/suite-native/atoms/src/FullAlertBox/FullAlertBox.tsx
@@ -14,7 +14,7 @@ const containerStyle = prepareNativeStyle<Pick<AlertBoxStyles, 'backgroundColor'
         borderWidth: utils.borders.widths.small,
         borderColor: utils.colors[borderColor],
         borderRadius: utils.borders.radii.r12,
-        padding: utils.spacings.sp16,
+        padding: utils.spacings.sp12,
     }),
 );
 
@@ -56,13 +56,13 @@ export const FullAlertBox = ({
                     <Icon
                         name={iconName ?? intentToIconName[intent]}
                         color={textColor}
-                        size="large"
+                        size="mediumLarge"
                     />
                     <VStack spacing="sp12" flex={1}>
                         <VStack spacing="sp2">
                             <Text color={textColor}>{title}</Text>
                             {description && (
-                                <Text color={textColor} priority="secondary" variant="body-sm">
+                                <Text color={textColor} variant="body-sm">
                                     {description}
                                 </Text>
                             )}

--- a/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
+++ b/suite-native/atoms/src/InlineAlertBox/InlineAlertBox.tsx
@@ -22,8 +22,8 @@ const alertWrapperStyle = prepareNativeStyle<
     borderColor: utils.colors[borderColor],
     backgroundColor: utils.colors[backgroundColor],
     paddingVertical: isButtonDisplayed ? utils.spacings.sp8 : utils.spacings.sp10,
-    paddingRight: isButtonDisplayed ? utils.spacings.sp8 : utils.spacings.sp16,
-    paddingLeft: utils.spacings.sp16,
+    paddingRight: isButtonDisplayed ? utils.spacings.sp8 : utils.spacings.sp12,
+    paddingLeft: utils.spacings.sp12,
 }));
 
 const textStyle = prepareNativeStyle(utils => ({


### PR DESCRIPTION
## Description

  - `FullAlertBox`: icon size 24 → 20px, uniform padding 16 → 12px, removed `priority="secondary"` from description text (was adding 26% alpha to subtitle color)
  - `InlineAlertBox`: left/right padding 16 → 12px
  - 
## Notes for QA

  - Check all 5 intent variants (brand, neutral, critical, warning, info) of both `FullAlertBox` and `InlineAlertBox` against the Figma spec

## Related Issue

  Closes #30501

 ## Screenshots:
<img width="386" height="135" alt="Screenshot 2026-08-03 at 15 02 17" src="https://github.com/user-attachments/assets/fae11d27-2fce-490b-8419-e1bf8f570d66" />
<img width="386" height="77" alt="Screenshot 2026-08-03 at 15 02 40" src="https://github.com/user-attachments/assets/c56c82b4-ca31-47c5-9ca2-156de9461289" />
<img width="386" height="77" alt="Screenshot 2026-08-03 at 15 02 31" src="https://github.com/user-attachments/assets/0a9c05a3-0dcc-4fc9-a924-591c4b3755de" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/alertbox-sizing-padding&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->