### PR TITLE
refactor(suite): narrow vanilla thunk dependencies

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -69,6 +69,7 @@
         "@suite-common/suite-config": "workspace:*",
         "@suite-common/suite-constants": "workspace:*",
         "@suite-common/suite-rbf-labels-migrations": "workspace:*",
+        "@suite-common/suite-rbf-labels-migrations-types": "workspace:*",
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-sync-quota-manager": "workspace:*",
         "@suite-common/suite-sync-storage": "workspace:*",

--- a/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
+++ b/packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts
@@ -1,6 +1,6 @@
 import { moveLabelsForRbfOldMetadataThunk } from '@suite/metadata';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { findLabelsToBeMovedOrDeleted } from '@suite-common/suite-rbf-labels-migrations';
+import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
 import { selectTransactions } from '@suite-common/wallet-core';
 import { type StaticSessionId } from '@trezor/connect';
@@ -21,9 +21,13 @@ type MoveLabelsForRbfThunkParams = {
     stateBeforePush: StateBeforePush;
 };
 
+type MoveLabelsForRbfThunkDeps = {
+    services: MigrateSuiteSyncLabelsForRbfTransactionDep;
+};
+
 export const moveLabelsForRbfThunk =
     ({ newTxId, prevTxId, deviceStaticSessionId, stateBeforePush }: MoveLabelsForRbfThunkParams) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: MoveLabelsForRbfThunkDeps) => {
         const toBeMovedOrDeletedList = findLabelsToBeMovedOrDeleted({
             prevTxId,
             // NOTE: beware of stateBeforePush, this has to be passed here which is a state

--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -1,4 +1,4 @@
-import { type OnboardingAnalytics, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, type OnboardingAnalytics, events } from '@suite/analytics';
 import { initialRunCompleted } from '@suite/flags';
 import { closeModal } from '@suite/modal';
 import { recoveryRerunThunk } from '@suite/recovery';
@@ -8,7 +8,6 @@ import {
     selectIsUnlockedBootloaderAllowed,
 } from '@suite/settings';
 import { selectHasBitcoinOnlyFirmware, selectSelectedDevice } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { type BackupType } from '@suite-common/suite-types';
 import {
     changeCoinVisibility,
@@ -126,7 +125,9 @@ const resetOnboarding = (): OnboardingAction => ({
     type: ONBOARDING.RESET_ONBOARDING,
 });
 
-const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+type GoToSuiteDeps = { services: DesktopAnalyticsDep };
+
+const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: GoToSuiteDeps) => {
     const device = selectSelectedDevice(getState());
     const onboardingAnalytics = selectOnboardingAnalytics(getState());
     // Clear modals that might block navigation. They aren't relevant anyway, as there is no <ModalSwitcher /> in onboarding.
@@ -175,7 +176,7 @@ const goToSuite = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDep
                   unitPackaging: fullPayload.unitPackaging,
               };
 
-        asTypedDesktopAnalytics(analytics).report(
+        analytics.report(
             {
                 type: events.deviceSetupCompletedEvent.name,
                 payload,

--- a/packages/suite/src/actions/suite/analyticsActions.ts
+++ b/packages/suite/src/actions/suite/analyticsActions.ts
@@ -3,7 +3,7 @@
  * @docs docs/misc/analytics.md
  */
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import {
     analyticsActions,
     selectAnalyticsInstanceId,
@@ -13,7 +13,6 @@ import {
     selectIsAnalyticsEnabled,
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
 import { getCommitHash, getEnvironment, isCodesignBuild } from '@trezor/env-utils';
 
@@ -24,11 +23,13 @@ type SendReportProps = {
     sendReport: boolean;
 };
 
+type EnableAnalyticsThunkDeps = { services: DesktopAnalyticsDep };
+
 export const enableAnalyticsThunk =
     ({ sendReport }: SendReportProps) =>
-    (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
+    (dispatch: Dispatch, _getState: GetState, extra: EnableAnalyticsThunkDeps) => {
         if (sendReport) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.settingsAnalyticsEvent.name,
                 payload: { value: true },
             });
@@ -38,11 +39,13 @@ export const enableAnalyticsThunk =
         dispatch(analyticsActions.enableAnalytics());
     };
 
+type DisableAnalyticsThunkDeps = { services: DesktopAnalyticsDep };
+
 export const disableAnalyticsThunk =
     ({ sendReport }: SendReportProps) =>
-    (dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
+    (dispatch: Dispatch, _getState: GetState, extra: DisableAnalyticsThunkDeps) => {
         if (sendReport) {
-            asTypedDesktopAnalytics(extra.services.analytics).report(
+            extra.services.analytics.report(
                 { type: events.settingsAnalyticsEvent.name, payload: { value: false } },
                 { force: true },
             );
@@ -52,13 +55,15 @@ export const disableAnalyticsThunk =
         dispatch(analyticsActions.disableAnalytics());
     };
 
+type InitDeps = { services: DesktopAnalyticsDep };
+
 /**
  * Init analytics, should be always run on application start (see suiteMiddleware). It:
  * - sets common analytics variables based on what was loaded from storage
  * - set sentry user id
  * @param state - tracking state loaded from storage
  */
-export const init = () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+export const init = () => (dispatch: Dispatch, getState: GetState, extra: InitDeps) => {
     const sessionId = getTrackingRandomId();
     // if instanceId does not exist yet (was not loaded from storage), create a new one
     const instanceId = selectAnalyticsInstanceId(getState()) ?? getTrackingRandomId();

--- a/packages/suite/src/actions/suite/suiteActions.ts
+++ b/packages/suite/src/actions/suite/suiteActions.ts
@@ -1,12 +1,11 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { openDeferredModal } from '@suite/modal';
 import { selectRouterUrl } from '@suite/router';
 import { suiteSettingsActions } from '@suite/settings';
 import { type TorBootstrap, TorStatus, isOnionUrl, selectTorState, torActions } from '@suite/tor';
 import { type deviceActions } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getCustomBackends } from '@suite-common/wallet-utils';
 import { type HandshakeElectron, desktopApi } from '@trezor/suite-desktop-api';
@@ -88,9 +87,11 @@ export const updateOnlineStatus = (payload: boolean): SuiteAction => ({
 
 export const updateTorStatus = (payload: TorStatus) => torActions.setTorStatus(payload);
 
+type ToggleTorDeps = { services: DesktopAnalyticsDep };
+
 export const toggleTor =
     (shouldEnable: boolean, modal: string | undefined) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: ToggleTorDeps) => {
         const { torBootstrap } = selectTorState(getState());
 
         const backends = getCustomBackends(getState().wallet.blockchain);
@@ -118,7 +119,7 @@ export const toggleTor =
         const ipcResponse = await desktopApi.toggleTor(shouldEnable);
 
         if (ipcResponse.success) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.settingsTorEvent.name,
                 payload: {
                     value: shouldEnable,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx
@@ -1,16 +1,18 @@
 import { useEffect } from 'react';
 
+import { type ThunkAction } from 'redux-thunk';
+
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { H3, Modal, Paragraph, Tooltip } from '@trezor/components';
 import { ShieldWarningIcon } from '@trezor/icons';
 
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { type Dispatch, type GetState } from 'src/types/suite';
+import { type SuiteExtra } from 'src/support/extraDependencies';
+import { type Action, type AppState, type Dispatch } from 'src/types/suite';
 
 interface ConfirmUnverifiedModalProps {
     action: {
@@ -18,11 +20,7 @@ interface ConfirmUnverifiedModalProps {
         title: TranslationKey;
         closeAfterEventTriggered?: boolean;
     };
-    verifyProcess?: () => (
-        dispatch: Dispatch,
-        getState: GetState,
-        extra: ExtraDependencies,
-    ) => Promise<void>;
+    verifyProcess?: () => ThunkAction<Promise<void>, AppState, SuiteExtra, Action>;
     warningText: TranslationKey;
 }
 

--- a/packages/suite/src/hooks/suite/useDispatch.ts
+++ b/packages/suite/src/hooks/suite/useDispatch.ts
@@ -1,7 +1,18 @@
 import { useDispatch as useReduxDispatch } from 'react-redux';
 
+import { type AsyncThunkAction } from '@reduxjs/toolkit';
 import { type ThunkDispatch } from 'redux-thunk';
 
-import { type Action, type AppState } from 'src/types/suite';
+import { type ExtraDependencies } from '@suite-common/redux-utils';
 
-export const useDispatch: () => ThunkDispatch<AppState, any, Action> = useReduxDispatch;
+import { type SuiteExtra } from 'src/support/extraDependencies';
+import { type Action, type AppState, type Dispatch, type GetState } from 'src/types/suite';
+
+type SuiteDispatch = {
+    <T extends AsyncThunkAction<any, any, any>>(asyncThunkAction: T): ReturnType<T>;
+    <T>(thunkAction: (dispatch: Dispatch, getState: GetState, extra: SuiteExtra) => T): T;
+    <T>(thunkAction: (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => T): T;
+} & Dispatch &
+    ThunkDispatch<AppState, SuiteExtra, Action>;
+
+export const useDispatch: () => SuiteDispatch = useReduxDispatch;

--- a/packages/suite/src/reducers/store.ts
+++ b/packages/suite/src/reducers/store.ts
@@ -25,7 +25,6 @@ import { type PlatformEncryptionDep } from '@suite-common/platform-encryption';
 import { type ReceiveState, prepareReceiveReducer } from '@suite-common/receive';
 import {
     type ExtraDependencies,
-    type ExtraDependenciesStatic,
     type GetTransportsFactoriesDep,
     type ThpHostNameDep,
     castExtraStore,
@@ -66,6 +65,7 @@ import {
 } from '../actions/bluetooth/desktopBluetoothReducer';
 import { type CreateConnectLoggerFactoryDep } from '../support/createConnectLoggerFactory';
 import {
+    type SuiteExtra,
     type SuiteServices,
     createSuiteServicesCompositionRoot,
     extraDependencies,
@@ -174,8 +174,6 @@ export type SuiteStoreDeps = HistoryDep &
     ReloadAppDep &
     ThpHostNameDep &
     GetTransportsFactoriesDep;
-
-type SuiteExtra = ExtraDependenciesStatic & { services: SuiteServices };
 
 export type SuiteStore = ReturnType<
     typeof castExtraStore<SuiteExtra, EnhancedStore<AppState, Action | UnknownAction>>

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -118,6 +118,8 @@ export type SuiteServices = CommonServices &
     SuiteRouterHistoryDep &
     TransportsDep;
 
+export type SuiteExtra = ExtraDependenciesStatic & { services: SuiteServices };
+
 export const selectSuiteServices = (services: any): SuiteServices => services;
 
 export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {

--- a/packages/suite/src/types/suite/index.ts
+++ b/packages/suite/src/types/suite/index.ts
@@ -1,3 +1,4 @@
+import type { AsyncThunkAction } from '@reduxjs/toolkit';
 import type { Store as ReduxStore } from 'redux';
 import type { ThunkAction as TAction, ThunkDispatch } from 'redux-thunk';
 
@@ -23,6 +24,7 @@ import { type firmwareActions } from '@suite-common/firmware';
 import { type geolocationActions } from '@suite-common/geolocation';
 import { type addLog } from '@suite-common/logger';
 import { type messageSystemActions } from '@suite-common/message-system';
+import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { type suiteSyncActions, type suiteSyncDataActions } from '@suite-common/suite-sync';
 import { type suiteSyncQuotaManagerActions } from '@suite-common/suite-sync-quota-manager';
 import { type thpActions } from '@suite-common/thp';
@@ -178,7 +180,10 @@ export type Action =
 
 export type ThunkAction = TAction<any, AppState, any, Action>;
 
-export type Dispatch = ThunkDispatch<AppState, any, Action>;
+export type Dispatch = {
+    <T>(thunkAction: (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => T): T;
+    <T extends AsyncThunkAction<any, any, any>>(asyncThunkAction: T): ReturnType<T>;
+} & ThunkDispatch<AppState, any, Action>;
 
 export type GetState = () => AppState;
 

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -102,6 +102,9 @@
             "path": "../../suite-common/suite-rbf-labels-migrations"
         },
         {
+            "path": "../../suite-common/suite-rbf-labels-migrations-types"
+        },
+        {
             "path": "../../suite-common/suite-sync"
         },
         {

--- a/suite/desktop-update/package.json
+++ b/suite/desktop-update/package.json
@@ -31,7 +31,6 @@
         "@trezor/utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0"
+        "redux": "^5.0.1"
     }
 }

--- a/suite/desktop-update/src/desktopUpdateActionsThunks.ts
+++ b/suite/desktop-update/src/desktopUpdateActionsThunks.ts
@@ -1,8 +1,6 @@
-import { type AnyAction } from 'redux';
-import { type ThunkDispatch } from 'redux-thunk';
+import { type Dispatch } from 'redux';
 
-import { AppUpdateEventStatus, asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
+import { AppUpdateEventStatus, type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type UpdateInfo, desktopApi } from '@trezor/suite-desktop-api';
 
@@ -13,11 +11,12 @@ import {
     desktopUpdateActions,
 } from './desktopUpdateReducer';
 
-type Dispatch = ThunkDispatch<DesktopUpdateRootState, ExtraDependencies, AnyAction>;
 type GetState = () => DesktopUpdateRootState;
 
+type AvailableThunkDeps = { services: DesktopAnalyticsDep };
+
 export const availableThunk =
-    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: AvailableThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { allowPrerelease } = getState().desktopUpdate;
 
@@ -26,7 +25,7 @@ export const availableThunk =
             earlyAccessProgram: allowPrerelease,
             updateInfo: info,
         });
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.appUpdateEvent.name,
             payload,
         });
@@ -42,8 +41,10 @@ export const notAvailableThunk = (info: UpdateInfo) => (dispatch: Dispatch) => {
     dispatch(desktopUpdateActions.notAvailable(info));
 };
 
+type DownloadThunkDeps = { services: DesktopAnalyticsDep };
+
 export const downloadThunk =
-    () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    () => (dispatch: Dispatch, getState: GetState, extra: DownloadThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { latest, allowPrerelease } = getState().desktopUpdate;
 
@@ -52,7 +53,7 @@ export const downloadThunk =
             earlyAccessProgram: allowPrerelease,
             updateInfo: latest,
         });
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.appUpdateEvent.name,
             payload,
         });
@@ -60,8 +61,10 @@ export const downloadThunk =
         dispatch(desktopUpdateActions.download());
     };
 
+type ReadyThunkDeps = { services: DesktopAnalyticsDep };
+
 export const readyThunk =
-    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    (info: UpdateInfo) => (dispatch: Dispatch, getState: GetState, extra: ReadyThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { latest, allowPrerelease } = getState().desktopUpdate;
 
@@ -72,7 +75,7 @@ export const readyThunk =
             earlyAccessProgram: allowPrerelease,
             updateInfo: latest,
         });
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.appUpdateEvent.name,
             payload,
         });
@@ -80,9 +83,11 @@ export const readyThunk =
         dispatch(desktopUpdateActions.ready(info));
     };
 
+type InstallUpdateThunkDeps = { services: DesktopAnalyticsDep };
+
 export const installUpdateThunk =
     ({ installNow }: { installNow: boolean }) =>
-    (_: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    (_: Dispatch, getState: GetState, extra: InstallUpdateThunkDeps) => {
         // eslint-disable-next-line no-restricted-syntax
         const { desktopUpdate } = getState();
 
@@ -95,7 +100,7 @@ export const installUpdateThunk =
             isAutoUpdated: desktopUpdate.isAutomaticUpdateEnabled,
         });
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.appUpdateEvent.name,
             payload,
         });
@@ -110,25 +115,26 @@ export const installUpdateThunk =
         }
     };
 
-export const errorThunk =
-    () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
-        // eslint-disable-next-line no-restricted-syntax
-        const { state, latest, allowPrerelease } = getState().desktopUpdate;
+type ErrorThunkDeps = { services: DesktopAnalyticsDep };
 
-        // Ignore displaying errors while checking
-        if (state !== UpdateState.Checking) {
-            dispatch(notificationsActions.addToast({ type: 'auto-updater-error', state }));
+export const errorThunk = () => (dispatch: Dispatch, getState: GetState, extra: ErrorThunkDeps) => {
+    // eslint-disable-next-line no-restricted-syntax
+    const { state, latest, allowPrerelease } = getState().desktopUpdate;
 
-            const payload = getAppUpdatePayload({
-                status: AppUpdateEventStatus.Error,
-                earlyAccessProgram: allowPrerelease,
-                updateInfo: latest,
-            });
-            asTypedDesktopAnalytics(extra.services.analytics).report({
-                type: events.appUpdateEvent.name,
-                payload,
-            });
-        }
+    // Ignore displaying errors while checking
+    if (state !== UpdateState.Checking) {
+        dispatch(notificationsActions.addToast({ type: 'auto-updater-error', state }));
 
-        dispatch(desktopUpdateActions.notAvailable());
-    };
+        const payload = getAppUpdatePayload({
+            status: AppUpdateEventStatus.Error,
+            earlyAccessProgram: allowPrerelease,
+            updateInfo: latest,
+        });
+        extra.services.analytics.report({
+            type: events.appUpdateEvent.name,
+            payload,
+        });
+    }
+
+    dispatch(desktopUpdateActions.notAvailable());
+};

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -1,6 +1,6 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { selectOAuthServerEnvironment } from '@suite/settings';
 import {
     type DataType,
@@ -103,9 +103,15 @@ type DisconnectProviderParams = {
     removeMetadata?: boolean;
 };
 
+type DisconnectProviderDeps = { services: DesktopAnalyticsDep };
+
 export const disconnectProvider =
     ({ clientId, dataType, removeMetadata = true }: DisconnectProviderParams) =>
-    async (dispatch: Dispatch, _getState: () => MetadataRootState, extra: ExtraDependencies) => {
+    async (
+        dispatch: Dispatch,
+        _getState: () => MetadataRootState,
+        extra: DisconnectProviderDeps,
+    ) => {
         typedObjectKeys(fetchIntervals).forEach((id: FetchIntervalTrackingId) => {
             const [trackedDataType, trackedClientId] = id.split('-');
             if (trackedDataType === dataType && trackedClientId === clientId) {
@@ -135,7 +141,7 @@ export const disconnectProvider =
                 payload: { dataType, clientId: undefined },
             });
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.settingsGeneralLabelingProviderEvent.name,
                 payload: {
                     provider: '',

--- a/suite/receive/package.json
+++ b/suite/receive/package.json
@@ -15,7 +15,6 @@
         "@suite-common/address": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/receive": "workspace:*",
-        "@suite-common/redux-utils": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite/receive/src/showAddressThunk.ts
+++ b/suite/receive/src/showAddressThunk.ts
@@ -1,10 +1,9 @@
 import { type Dispatch } from '@reduxjs/toolkit';
 
 import { type SelectedAccountRootState, selectSelectedAccount } from '@suite/account';
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { closeModal, openModal, preserveModal, removePreserveModal } from '@suite/modal';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     type WalletSettingsRootState,
@@ -15,12 +14,14 @@ import { AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { openAddressModal } from './openAddressModal';
 
+type ShowAddressThunkDeps = { services: DesktopAnalyticsDep };
+
 export const showAddressThunk =
     ({ path, address }: { path: string; address: string }) =>
     async (
         dispatch: Dispatch,
         getState: () => DeviceRootState & WalletSettingsRootState & SelectedAccountRootState,
-        extra: ExtraDependencies,
+        extra: ShowAddressThunkDeps,
     ) => {
         const device = selectSelectedDevice(getState());
         const account = selectSelectedAccount(getState());
@@ -45,7 +46,7 @@ export const showAddressThunk =
                 }),
             );
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.createReceiveAddressShowAddressEvent.name,
                 payload: {
                     assetSymbol: account.symbol,
@@ -58,7 +59,7 @@ export const showAddressThunk =
 
         dispatch(preserveModal());
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
+        extra.services.analytics.report({
             type: events.createReceiveAddressShowAddressEvent.name,
             payload: {
                 assetSymbol: account.symbol,
@@ -77,7 +78,7 @@ export const showAddressThunk =
             // Show second part of the confirm address modal.
             dispatch(openAddressModal({ ...modalPayload, isConfirmed: true }));
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.createReceiveAddressConfirmOnTrezorEvent.name,
                 payload: { assetSymbol: account.symbol },
             });

--- a/suite/receive/tsconfig.json
+++ b/suite/receive/tsconfig.json
@@ -6,9 +6,6 @@
         { "path": "../../suite-common/device" },
         { "path": "../../suite-common/receive" },
         {
-            "path": "../../suite-common/redux-utils"
-        },
-        {
             "path": "../../suite-common/suite-types"
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14747,7 +14747,6 @@ __metadata:
     react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
     redux: "npm:^5.0.1"
-    redux-thunk: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -15159,7 +15158,6 @@ __metadata:
     "@suite-common/address": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/receive": "workspace:*"
-    "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -17299,6 +17297,7 @@ __metadata:
     "@suite-common/suite-config": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-rbf-labels-migrations": "workspace:*"
+    "@suite-common/suite-rbf-labels-migrations-types": "workspace:*"
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-sync-quota-manager": "workspace:*"
     "@suite-common/suite-sync-storage": "workspace:*"


### PR DESCRIPTION
## Description

Vanilla thunks were typed against the complete global ExtraDependencies object even though each consumed only one service. This gives every thunk a named <ThunkName>Deps contract composed from the existing service dependency types and removes redundant desktop analytics casts; behavior is unchanged. The metadata wrapper also declares the nested init thunk's extra type so dispatch remains type-safe.\n\n- Updated: **19 thunks across 12 implementation files**\n- Analytics thunks: **18**, typed with DesktopAnalyticsDep\n- RBF labels thunk: **1**, typed with MigrateSuiteSyncLabelsForRbfTransactionDep

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/narrow-vanilla-thunk-extra-deps/web/](https://dev.suite.sldev.cz/suite-web/refactor/narrow-vanilla-thunk-extra-deps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The highest-risk changes are the new receive-address thunk and the metadata/Suite Sync provider thunks, so the recommended set focuses heavily on receive flows and metadata label tests. Global Redux/store files are broad dependencies and are only covered indirectly through these targeted scenarios. Desktop-update and configuration files have no clear E2E coverage.

<details><summary><b>Changed files (17)</b></summary>

- `packages/suite/package.json`
- `packages/suite/src/actions/labels/moveLabelsForRbfThunk.ts`
- `packages/suite/src/actions/onboarding/onboardingActions.ts`
- `packages/suite/src/actions/suite/analyticsActions.ts`
- `packages/suite/src/actions/suite/suiteActions.ts`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConfirmUnverifiedModal.tsx`
- `packages/suite/src/hooks/suite/useDispatch.ts`
- `packages/suite/src/reducers/store.ts`
- `packages/suite/src/support/extraDependencies.ts`
- `packages/suite/src/types/suite/index.ts`
- `packages/suite/tsconfig.json`
- `suite/desktop-update/package.json`
- `suite/desktop-update/src/desktopUpdateActionsThunks.ts`
- `suite/metadata/src/metadataProviderThunks.ts`
- `suite/receive/package.json`
- `suite/receive/src/showAddressThunk.ts`
- `suite/receive/tsconfig.json`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/metadata/legacy/dropbox-api-errors.test.ts` — Directly exercises Dropbox metadata provider save/fetch error handling paths that are implemented in the changed suite/metadata/src/metadataProviderThunks.ts. A regression here would break labeling persistence and error surfacing.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Covers provider connect/disconnect cycles and label restore for remembered devices, which are core responsibilities of metadataProviderThunks. Changed provider thunk logic could corrupt label state on disconnect/reconnect.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Validates switching between metadata providers (Dropbox ↔ Google), which relies on the provider initialization and teardown logic in the changed metadataProviderThunks.
- `suite/e2e/tests/metadata/suite-sync/sync-from-relay.test.ts` — Exercises the Suite Sync label-download path backed by Evolu, a new code path in the changed metadataProviderThunks. Regression would prevent labels from syncing to local UI.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Tests updating and deleting account/wallet/address/output labels via Suite Sync, directly invoking the metadata provider thunk changes for CRUD and sync to the relay.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Reveals and verifies a Cardano receive address behind a passphrase wallet, directly exercising the changed suite/receive/src/showAddressThunk.ts for an altcoin path.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — Uses the global receive flow to reveal an ETH address and compare it with the device display, directly covering showAddressThunk.ts and the receive modal/address verification path.
- `suite/e2e/tests/wallet/receive.test.ts` — Core receive-address reveal flow for BTC/ETH/SOL/TRX; the changed showAddressThunk.ts is the thunk that drives this flow. A regression would break address display/copy/device verification.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Validates analytics event emission and consent state, which is influenced by the changed packages/suite/src/actions/suite/analyticsActions.ts. Good sanity check that analytics dispatching still works.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Edits transaction output labels, the closest existing coverage to the changed moveLabelsForRbfThunk.ts label-moving logic, even though it does not perform an RBF bump.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Hits the onboarding flow entry point where packages/suite/src/actions/onboarding/onboardingActions.ts drives state; verifies that analytics consent and post-onboarding navigation still function.
- `suite/e2e/tests/wallet/cardano.test.ts` — Reveals a Cardano address and public key with device confirmation, sharing the receive/verification flow with showAddressThunk and the ConfirmUnverifiedModal path.
- `suite/e2e/tests/wallet/public-keys.test.ts` — Shows public keys (XPUBs) with device prompts, a flow that can surface the changed ConfirmUnverifiedModal when keys have not yet been verified.
- `suite/e2e/tests/wallet/without-device.test.ts` — Tests send/receive behavior when the device is disconnected, a scenario where the changed ConfirmUnverifiedModal may be triggered for unverified actions.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/package.json`
- `packages/suite/src/types/suite/index.ts`
- `packages/suite/tsconfig.json`
- `suite/desktop-update/package.json`
- `suite/desktop-update/src/desktopUpdateActionsThunks.ts`
- `suite/receive/package.json`
- `suite/receive/tsconfig.json`

_Updated: 2026-08-03T20:46:36.235Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/narrow-vanilla-thunk-extra-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/narrow-vanilla-thunk-extra-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T20:49:20.893Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T20:48:12.210Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->