### PR TITLE
fix(suite): show LI.FI as clear-signing provider name to match device

### DIFF
--- a/suite-common/suite-constants/src/evm.ts
+++ b/suite-common/suite-constants/src/evm.ts
@@ -8,7 +8,7 @@ export const EVM_SPENDER_LABELS: Record<string, string> = {
     // 1inch
     '0x111111125421ca6dc452d289314280a0f8842a65': '1inch Aggregation Router V6',
     // LI.FI
-    '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LiFI Diamond',
+    '0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae': 'LI.FI',
     // Uniswap
     '0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45': 'Uniswap V3 Router',
     '0xe592427a0aece92de3edee1f18e0157c05861564': 'Uniswap V3 Router',

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -29,10 +29,14 @@ const dexGasLimit = '26250';
 const dexMaximumFee = '0.00003161748342375 ETH';
 const gasLimitWithLabel = `${messages.TR_GAS_LIMIT.defaultMessage}: ${dexGasLimit}`;
 const accountLabel = 'Ethereum #1';
+// Provider name rendered by Suite in the confirm-on-device prompt.
+const suiteProviderName = 'LI.FI';
 
 // Firmware strings on the DEX review pages.
 const deviceReview = {
     providerTitle: 'Provider',
+    // The emulator still runs the previous FW release, which renders 'LiFI Diamond'.
+    // TODO: change to 'LI.FI' once trezor-user-env ships the firmware with the renamed provider.
     providerName: 'LiFI Diamond',
     intentTitle: 'Intent',
     intentValue: 'Swap',
@@ -152,7 +156,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             await devicePrompt.confirmOnDevicePromptIsShown();
 
             await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(
-                deviceReview.providerName,
+                suiteProviderName,
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
@@ -215,7 +219,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
 
         await test.step('Re-verify the fully revealed review form', async () => {
             await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(
-                deviceReview.providerName,
+                suiteProviderName,
             );
             await expect(devicePrompt.outputValueOf('swap_intent')).toHaveTranslation(
                 'TR_TRADING_INTENT_SWAP',


### PR DESCRIPTION
## Description

During clear-signed LI.FI swaps, Suite's confirmation showed the provider as **LiFI Diamond** while the device shows **LI.FI**. This aligns the Suite-side spender label for the LI.FI Diamond contract (`0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae`) in `EVM_SPENDER_LABELS` so both UIs display the same provider name.

The label lives in `@suite-common/suite-constants` and is consumed by `constructTransactionReviewOutputs` in `@suite-common/wallet-utils`, so the fix applies to both the web/desktop app and the mobile app (suite-native). The LI.FI DEX swap e2e test expectation was updated to match.

## Notes for QA

- Start a LI.FI DEX swap (e.g. ETH on Ethereum or BNB Smart Chain), proceed to device confirmation, and verify the Provider field in Suite matches the Provider screen on the device — both should show **LI.FI**.
- Sanity-check that other spender labels (1inch, Uniswap, etc.) are unaffected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30723

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches a broadly-shared EVM constants module and a single DEX-swap test file. The highest-confidence test is the modified swap-dex-lifi test, which directly exercises the affected DEX gas-buffer behavior. Because evm.ts maps to 134 tests, I narrowly supplement with three EVM transaction tests that assert concrete gas/fee values rather than broad coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/suite-constants/src/evm.ts`
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test file was directly modified in the PR and exercises the exact DEX swap flow (LI.FI ETH→USDC) that depends on EVM gas-limit buffer constants such as ETHEREUM_ADJUST_GAS_LIMIT. Running it confirms the modified test passes and that the changed EVM constants still produce correct gas/fee displays and device prompts.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly asserts Ethereum gas limit, max fee per gas, and max priority fee per gas values on both the app device prompt and the hardware device emulator. Changes to EVM constants are highly likely to alter these displayed values or fee calculations.
- `suite/e2e/tests/wallet/send-base.test.ts` — Validates EVM L2 (Base) send flows with the same gas-limit, max-fee, and priority-fee parameters. The Base path reuses the EVM constant infrastructure, so a regression here would be user-visible on an EVM-compatible network.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests Ethereum swap fee handling with custom gas parameters and compares device-prompt fee values. EVM constant changes could shift the calculated maximum fee or gas-limit display in the swap confirmation flow.

</details>

_Updated: 2026-08-05T07:10:18.578Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/lifi-clear-signing-provider-name/web/](https://dev.suite.sldev.cz/suite-web/fix/lifi-clear-signing-provider-name/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/lifi-clear-signing-provider-name&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/lifi-clear-signing-provider-name&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/lifi-clear-signing-provider-name&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:11:24.411Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:11:40.076Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->