### PR TITLE
feat(suite-desktop): definitions for clear signing

### DIFF
--- a/suite-common/calldata/src/clearSigning.test.ts
+++ b/suite-common/calldata/src/clearSigning.test.ts
@@ -13,6 +13,18 @@ const APPROVE_DATA = '0x095ea7b3000000000000000000000000000000000000000000000000
 // transfer(address,uint256)
 const TRANSFER_DATA = '0xa9059cbb000000000000000000000000000000000000000000000000000000000000dead';
 
+// Canonical WETH contracts firmware clear-signs (mirror of sc_constants.py weth_deployments)
+const WETH_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const WETH_BASE = '0x4200000000000000000000000000000000000006';
+const WETH_ARBITRUM = '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1';
+const WETH_SEPOLIA = '0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9';
+// A wrapped-native token that firmware does NOT clear-sign (WBNB on BSC, chain 56)
+const WBNB_BSC = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c';
+// deposit() — wrap (no args, bare selector)
+const DEPOSIT_DATA = '0xd0e30db0';
+// withdraw(uint256) — unwrap
+const WITHDRAW_DATA = '0x2e1a7d4d000000000000000000000000000000000000000000000000000000000000dead';
+
 describe(isEvmClearSigningTx.name, () => {
     describe('no data', () => {
         it('returns false for undefined data', () => {
@@ -136,6 +148,49 @@ describe(isEvmClearSigningTx.name, () => {
 
         it('does not match the chain-specific address on a chain it is not deployed on', () => {
             expect(isEvmClearSigningTx(1, ZKSYNC_ALT_ADDRESS, LIFI_DATA)).toBe(false);
+        });
+    });
+
+    describe('WETH wrap/unwrap (deposit/withdraw)', () => {
+        it('recognises deposit() (wrap) on mainnet WETH', () => {
+            expect(isEvmClearSigningTx(1, WETH_MAINNET, DEPOSIT_DATA)).toBe(true);
+        });
+
+        it('recognises withdraw(uint256) (unwrap) on mainnet WETH', () => {
+            expect(isEvmClearSigningTx(1, WETH_MAINNET, WITHDRAW_DATA)).toBe(true);
+        });
+
+        it.each([
+            ['Base', 8453, WETH_BASE],
+            ['Arbitrum', 42161, WETH_ARBITRUM],
+            ['Sepolia testnet', 11155111, WETH_SEPOLIA],
+        ])('recognises deposit() on %s WETH', (_name, chainId, address) => {
+            expect(isEvmClearSigningTx(chainId, address, DEPOSIT_DATA)).toBe(true);
+        });
+
+        it('returns false for a wrapped-native that firmware does not cover (WBNB on BSC)', () => {
+            expect(isEvmClearSigningTx(56, WBNB_BSC, DEPOSIT_DATA)).toBe(false);
+        });
+
+        it('returns false for a WETH address on a chain it is not deployed on', () => {
+            // Polygon (137) is not a WETH deployment
+            expect(isEvmClearSigningTx(137, WETH_MAINNET, DEPOSIT_DATA)).toBe(false);
+        });
+
+        it('returns false for deposit() on a non-WETH contract', () => {
+            expect(isEvmClearSigningTx(1, RANDOM_ADDRESS, DEPOSIT_DATA)).toBe(false);
+        });
+
+        it('returns false for an unrelated selector on a WETH contract', () => {
+            expect(isEvmClearSigningTx(1, WETH_MAINNET, '0xdeadbeef')).toBe(false);
+        });
+
+        it('handles a mixed-case to address', () => {
+            expect(isEvmClearSigningTx(1, WETH_MAINNET.toLowerCase(), DEPOSIT_DATA)).toBe(true);
+        });
+
+        it('handles uppercase hex in data', () => {
+            expect(isEvmClearSigningTx(1, WETH_MAINNET, DEPOSIT_DATA.toUpperCase())).toBe(true);
         });
     });
 });

--- a/suite-common/calldata/src/clearSigning.ts
+++ b/suite-common/calldata/src/clearSigning.ts
@@ -84,6 +84,38 @@ const LIFI_MOVED_DEPLOYMENTS: ReadonlyArray<Deployment> = [
 const UNISWAP_V3_ROUTER_ADDRESS = '68b3465833fb72a70ecdf485e0e4c7bd8665fc45';
 const UNISWAP_V3_ROUTER_CHAINS = [1];
 
+// Canonical WETH (Wrapped Ether) deposit()/withdraw() — "Wrap ETH to WETH" / "Unwrap WETH
+// to ETH". Mirrors firmware's WETH definition set (trezor-firmware#7252, its
+// sc_constants.py `weth_deployments` + clear_signing_definitions.py). Shipped in firmware
+// 2.12.4. Firmware clear-signs ONLY these canonical WETH contracts — NOT other wrapped-native
+// tokens (WBNB / WPOL / WAVAX / WETC), so do not add those here. Unlike the swap
+// CONTRACT_DEFINITIONS below, wrap/unwrap is not a swap (no receive leg / coverage), so it
+// lives in its own table consulted only by the version-agnostic isEvmClearSigningTx — no
+// minFirmware gate is applied (matching how swaps are matched in that predicate; device-version
+// gating lives in getEvmClearSignedSwapCoverage, which wrap/unwrap deliberately does not feed,
+// nor the swap decoder drift guards). Addresses lowercase & 0x-stripped, mirroring firmware.
+const WETH_WRAP_UNWRAP_SELECTORS: ReadonlySet<string> = new Set([
+    'd0e30db0', // deposit() — wrap
+    '2e1a7d4d', // withdraw(uint256) — unwrap
+]);
+
+const WETH_DEPLOYMENTS: ReadonlyArray<Deployment> = [
+    { chainId: 1, address: 'c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' }, // ethereum
+    { chainId: 10, address: '4200000000000000000000000000000000000006' }, // optimism
+    { chainId: 42161, address: '82af49447d8a07e3bd95bd0d56f35241523fbab1' }, // arbitrum
+    { chainId: 8453, address: '4200000000000000000000000000000000000006' }, // base
+    { chainId: 11155111, address: '7b79995e5f793a07bc00c21412e50ecae098e7f9' }, // sepolia (testnet)
+    { chainId: 17000, address: '94373a4919b3240d86ea41593d5eba789fef3848' }, // holesky (testnet)
+];
+
+const isWethWrapUnwrapClearSigningTx = (
+    chainId: number,
+    toAddr: string,
+    funcSig: string,
+): boolean =>
+    WETH_WRAP_UNWRAP_SELECTORS.has(funcSig) &&
+    WETH_DEPLOYMENTS.some(d => d.chainId === chainId && d.address === toAddr);
+
 const deploymentsFor = (
     address: string,
     chains: ReadonlyArray<number>,
@@ -226,6 +258,10 @@ export const isEvmClearSigningTx = (
     }
 
     if (GLOBAL_SELECTORS.has(parsed.funcSig)) {
+        return true;
+    }
+
+    if (isWethWrapUnwrapClearSigningTx(chainId, parsed.toAddr, parsed.funcSig)) {
         return true;
     }
 

--- a/suite-common/calldata/src/clearSigningCoverage.test.ts
+++ b/suite-common/calldata/src/clearSigningCoverage.test.ts
@@ -84,6 +84,18 @@ describe(getEvmClearSignedSwapCoverage.name, () => {
             ).toBeUndefined();
         });
 
+        it('returns undefined for wrapped-native wrap/unwrap (clear-signed, but not a swap)', () => {
+            const WETH_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+            // deposit() / withdraw(uint256) are recognised by isEvmClearSigningTx but are
+            // deliberately not swap coverage.
+            expect(
+                getEvmClearSignedSwapCoverage(1, WETH_MAINNET, '0xd0e30db0', '2.13.0'),
+            ).toBeUndefined();
+            expect(
+                getEvmClearSignedSwapCoverage(1, WETH_MAINNET, '0x2e1a7d4ddead', '2.13.0'),
+            ).toBeUndefined();
+        });
+
         it('returns undefined (does not throw) for an empty firmware version', () => {
             expect(
                 getEvmClearSignedSwapCoverage(1, ONEINCH, ONEINCH_FIXTURES.swap, ''),

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -44,6 +44,13 @@ const ERC20_REVOKE_DATA = buildApprovalTransactionData({
     spender: ERC20_APPROVE_SPENDER,
 });
 
+// Canonical WETH (Wrapped Ether) — clear-signed wrap/unwrap (deposit/withdraw) on mainnet
+const WETH_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const WETH_DEPOSIT_DATA = '0xd0e30db0'; // deposit() — wrap
+const WETH_WITHDRAW_DATA = `0x2e1a7d4d${'00'.repeat(32)}`; // withdraw(uint256) — unwrap
+// WBNB on BSC — a wrapped native the firmware does NOT clear-sign
+const WBNB_BSC = '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c';
+
 const buildTrading = (overrides: Partial<FormStateTrading> = {}): FormStateTrading => ({
     activeSection: 'exchange',
     isSlip24Active: false,
@@ -382,4 +389,44 @@ describe('constructTransactionReviewOutputs', () => {
             );
         },
     );
+
+    it.each([
+        { op: 'wrap', transactionData: WETH_DEPOSIT_DATA },
+        { op: 'unwrap', transactionData: WETH_WITHDRAW_DATA },
+    ])('suppresses the raw data row for a clear-signed WETH $op', ({ transactionData }) => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData }),
+            precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
+        });
+
+        // The device clear-signs the intent + amount, so the raw calldata row is dropped...
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'data' })]),
+        );
+        // ...but the contract address (and the fee/total summary) still show.
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'contract', value: WETH_MAINNET }),
+            ]),
+        );
+    });
+
+    it('keeps the raw data row for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {
+        const outputs = constructTransactionReviewOutputs({
+            account: buildEthereumAccount({ symbol: 'bsc' }),
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData: WETH_DEPOSIT_DATA }),
+            precomposedTx: buildPrecomposedTransaction({ to: WBNB_BSC }),
+        });
+
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'data', value: WETH_DEPOSIT_DATA }),
+            ]),
+        );
+    });
 });

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -2,6 +2,7 @@ import {
     Calldata,
     type ClearSigningCoverage,
     getEvmClearSignedSwapCoverage,
+    isEvmClearSigningTx,
 } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
@@ -31,6 +32,8 @@ import {
     getEvmTransactionTextSignature,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
+    isUnwrapNativeTx,
+    isWrapNativeTx,
 } from './ethUtils';
 import { getStakeType } from './ethereumStakingUtils';
 import { isExchangeTradingForm } from './sendFormUtils';
@@ -380,6 +383,26 @@ const constructNewFlow = ({
     const isYieldOp = isEvmYieldTxByTextSignature(evmTxType);
     const isEvmClaimClearSign = isUpdatedEthereumSendFlow && isEvmClearSigningSupported;
 
+    // The device clear-signs WETH wrap/unwrap (deposit()/withdraw(), fw 2.12.4+) as a
+    // "Wrap/Unwrap ETH … Amount" screen, so the raw calldata Data row is redundant — suppress
+    // it, mirroring clear-signed swaps. Gated on isEvmClearSigningTx so a wrapped native the
+    // firmware does not clear-sign (e.g. WBNB on BSC) still shows the raw data.
+    const evmNetwork = networks[symbol];
+    const evmChainId = 'chainId' in evmNetwork ? evmNetwork.chainId : undefined;
+    const evmContractAddress = precomposedTx.outputs.find(
+        o => 'address' in o && typeof o.address === 'string',
+    )?.address;
+    const wrappedNativeTxParams = {
+        networkSymbol: symbol,
+        to: evmContractAddress,
+        data: precomposedForm.transactionData,
+    };
+    const isClearSignedWrapUnwrap =
+        isEvmClearSigningSupported &&
+        evmChainId !== undefined &&
+        (isWrapNativeTx(wrappedNativeTxParams) || isUnwrapNativeTx(wrappedNativeTxParams)) &&
+        isEvmClearSigningTx(evmChainId, evmContractAddress, precomposedForm.transactionData);
+
     if (networkType === 'ethereum' && stakeType && isUpdatedEthereumSendFlow) {
         // The firmware clear-signs staking operations as a single confirmation screen followed
         // by the amount/fee summary, so the review consists of one output only.
@@ -480,7 +503,8 @@ const constructNewFlow = ({
             (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
             (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
             (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)) &&
-        !isClearSignedTradingSwap
+        !isClearSignedTradingSwap &&
+        !isClearSignedWrapUnwrap
     ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enables clear signing of flows for weth deposit 

## Notes for QA

1) Test old and new firmware. On the old one we'd display a function signature

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30550
Resolve https://github.com/trezor/trezor-suite/issues/30560

## Screenshots:

<img width="1148" height="649" alt="Screenshot 2026-08-03 at 14 45 13" src="https://github.com/user-attachments/assets/fead15e8-fc96-44ac-b114-664d22f50838" />

| Wrap eth | Wrap eth | Wrap eth |
|--------|--------|--------|
| <img width="369" height="536" alt="Screenshot 2026-08-03 at 14 45 35" src="https://github.com/user-attachments/assets/7809090c-4ad9-436e-bcc5-6f3f184cb29c" /> | <img width="394" height="453" alt="Screenshot 2026-08-03 at 14 45 39" src="https://github.com/user-attachments/assets/be00aa84-7ada-4b4a-a0cb-25e548bacf78" /> | <img width="412" height="416" alt="Screenshot 2026-08-03 at 14 45 44" src="https://github.com/user-attachments/assets/2243addf-d2a7-45e7-b698-19a10c168177" /> |


| Unwrap eth | Unwrap eth | Unwrap eth |
|--------|--------|--------|
| <img width="391" height="459" alt="Screenshot 2026-08-03 at 14 46 55" src="https://github.com/user-attachments/assets/80b35216-e3c8-4b0d-812e-c3a799473f8e" /> | <img width="477" height="435" alt="Screenshot 2026-08-03 at 14 47 01" src="https://github.com/user-attachments/assets/0d134415-ac8a-41f7-9417-4a88e12b44b4" /> | <img width="732" height="661" alt="Screenshot 2026-08-03 at 14 47 13" src="https://github.com/user-attachments/assets/b10bf364-b8bd-45f5-bdd4-e917315ff1c2" /> | 

| Revoke | Approvals |
|--------|--------|
| <img width="415" height="416" alt="Screenshot 2026-08-03 at 14 48 39" src="https://github.com/user-attachments/assets/6f25b0ab-5dd1-46e4-bf78-e0582f7533e4" /> | <img width="470" height="485" alt="Screenshot 2026-08-03 at 14 48 35" src="https://github.com/user-attachments/assets/17ccdc05-22ec-471e-bcfd-61f5f1ee486d" /> | 


| Create | approval |
|--------|--------|
| <img width="420" height="459" alt="Screenshot 2026-08-03 at 14 49 27" src="https://github.com/user-attachments/assets/ffe7ac8d-2175-4b4a-ab1a-c8c924772941" /> | <img width="441" height="494" alt="Screenshot 2026-08-03 at 14 50 05" src="https://github.com/user-attachments/assets/f2091d0c-97b4-471a-9dec-b0f259e0ea67" /> | 

| Deposit | WETH |
|--------|--------|
| <img width="441" height="455" alt="Screenshot 2026-08-03 at 14 50 32" src="https://github.com/user-attachments/assets/7cdb072b-f158-4fd5-9cef-54d3bbd2f4e6" /> | <img width="446" height="463" alt="Screenshot 2026-08-03 at 14 50 36" src="https://github.com/user-attachments/assets/23f00266-e1c4-4ac9-964c-09bbfdaa7214" /> | 




<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect two broad shared utilities for transaction review (reviewTransactionUtils) and EVM calldata clear-signing (clearSigning). Because these utilities are imported transitively by many tests, the broad-utility heuristic applies. The highest-risk flows are EVM transaction reviews—sends on Ethereum/Base, DEX swaps, and ETH staking—where decoded calldata and composed transaction details are shown to users and on device screens. The recommended tests focus on these flows to catch regressions in device prompt rendering, fee display, and decoded contract interaction data without running the entire suite.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/calldata/src/clearSigning.test.ts`
- `suite-common/calldata/src/clearSigning.ts`
- `suite-common/calldata/src/clearSigningCoverage.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — DEX swaps decode contract calldata into human-readable review fields (provider, intent, slippage, minimum received, gas limit, receive address). This is the clearest end-to-end exercise of the clearSigning and reviewTransactionUtils changes.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — TrezorConnect ETH transaction signing in desktop core mode triggers Suite's transaction review/approval flow, which depends on reviewTransactionUtils for composing transaction info and clearSigning for EVM data decoding.
- `suite/e2e/tests/wallet/send-base.test.ts` — Base is an EVM L2, so its send flow uses the same review/clear-signing path as Ethereum. The test asserts device prompts show the correct address, amount, gas limit, max/priority fees, and max fee.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Changed reviewTransactionUtils and clearSigning directly shape how ETH transaction review screens and device prompts compose/display recipient, amount, gas limit, and fee details. This test exercises the full ETH send flow with custom EIP-1559 fees and device-display assertions.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking transaction review shows staking amount, fee, and Everstake contract data; changes to clearSigning/review utils could affect how these EVM contract-interaction details are rendered on device prompts.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim transactions are EVM contract interactions whose review details (amounts, fees, contract calls) depend on the changed utilities.
- `suite/e2e/tests/trading/passthru-swap-eth-to-btc.test.ts` — Live ETH→BTC swap verifies the device prompt shows the correct recipient address, amount, and fee for an EVM send transaction composed by the trading flow, exercising reviewTransactionUtils end-to-end.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH swap with custom gas fees exercises reviewTransactionUtils for composing swap transaction details and verifying gas limit, max fee per gas, and max priority fee per gas on device prompts.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/calldata/src/clearSigning.test.ts`
- `suite-common/calldata/src/clearSigningCoverage.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`

_Updated: 2026-08-03T13:38:49.825Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/clear-sign-wrap-unwrap/web/](https://dev.suite.sldev.cz/suite-web/feat/clear-sign-wrap-unwrap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/clear-sign-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/clear-sign-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/clear-sign-wrap-unwrap&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:39:59.932Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:39:50.836Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->