### PR TITLE
feat(suite-native): add trading tx sim to msg system

### DIFF
--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -101,6 +101,7 @@ export const Feature = {
         concierge: 'trading.concierge',
         survey: 'trading.survey',
         slip24: 'trading.slip24',
+        txSimulation: 'trading.txSimulation',
     },
     earn: {
         dashboard: {

--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -14,7 +14,6 @@ export type LaunchArguments = {
     isTradingResidenceCheckEnabled?: boolean;
     isTradingDebugEnabled?: boolean;
     isTradingSlip24Enabled?: boolean;
-    isTradingTxSimulationEnabled?: boolean;
     isN4w1BackupEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.test.ts
@@ -22,7 +22,6 @@ describe('featureFlagsSlice', () => {
                 isTradingResidenceCheckEnabled: true,
                 isTradingDebugEnabled: false,
                 isTradingSlip24Enabled: false,
-                isTradingTxSimulationEnabled: false,
                 isN4w1BackupEnabled: false,
             });
         });
@@ -41,7 +40,6 @@ describe('featureFlagsSlice', () => {
                 isTradingResidenceCheckEnabled: false,
                 isTradingDebugEnabled: false,
                 isTradingSlip24Enabled: false,
-                isTradingTxSimulationEnabled: false,
                 isN4w1BackupEnabled: false,
             });
         });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -10,7 +10,6 @@ export const FeatureFlag = {
     IsTradingResidenceCheckEnabled: 'isTradingResidenceCheckEnabled',
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsTradingSlip24Enabled: 'isTradingSlip24Enabled',
-    IsTradingTxSimulationEnabled: 'isTradingTxSimulationEnabled',
     IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
 } as const;
 
@@ -37,8 +36,6 @@ export const featureFlagsInitialState: FeatureFlagsState = {
         process.env.EXPO_PUBLIC_FF_IS_TRADING_DEBUG_ENABLED === 'true',
     [FeatureFlag.IsTradingSlip24Enabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SLIP24_ENABLED === 'true',
-    [FeatureFlag.IsTradingTxSimulationEnabled]:
-        process.env.EXPO_PUBLIC_FF_IS_TRADING_TX_SIMULATION_ENABLED === 'true',
     [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
 };
 
@@ -49,7 +46,6 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingResidenceCheckEnabled,
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsTradingSlip24Enabled,
-    FeatureFlag.IsTradingTxSimulationEnabled,
     FeatureFlag.IsN4w1BackupEnabled,
 ];
 

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -14,7 +14,6 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingResidenceCheckEnabled]: '💰 Trading Residence Check',
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsTradingSlip24Enabled]: '💰 Trading SLIP-24',
-    [FeatureFlagEnum.IsTradingTxSimulationEnabled]: '💰 Trading Tx Simulation',
     [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
 } as const satisfies Record<FeatureFlagEnum, string>;
 

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
@@ -1,0 +1,81 @@
+import { getTranslation } from '@suite-native/intl';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { ExchangePreviewScreenHeader } from './ExchangePreviewScreenHeader';
+import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
+
+jest.mock('../../../hooks/exchange/useDexExchangeTxSimulation', () => ({
+    useDexExchangeTxSimulation: jest.fn(),
+}));
+
+const mockUseDexExchangeTxSimulation = jest.mocked(useDexExchangeTxSimulation);
+
+describe('ExchangePreviewScreenHeader', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: false,
+            isLoading: false,
+            error: null,
+            data: undefined,
+        });
+    });
+
+    it('renders only the exchange preview title when simulation is disabled', () => {
+        const { getByText, queryByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.transactionSimulation.title'))).toBeNull();
+    });
+
+    it('renders the loading status while the simulation is loading', () => {
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: true,
+            error: null,
+            data: undefined,
+        });
+
+        const { getByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+
+        expect(
+            getByText(getTranslation('moduleTrading.transactionSimulation.simulating')),
+        ).toBeOnTheScreen();
+    });
+
+    it('renders the simulation title after a successful simulation', () => {
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: false,
+            error: null,
+            data: undefined,
+        });
+
+        const { getByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+
+        expect(
+            getByText(getTranslation('moduleTrading.transactionSimulation.title')),
+        ).toBeOnTheScreen();
+    });
+
+    it('renders only the exchange preview title when simulation fails', () => {
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: false,
+            error: new Error('Simulation failed'),
+            data: undefined,
+        });
+
+        const { getByText, queryByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.transactionSimulation.title'))).toBeNull();
+        expect(
+            queryByText(getTranslation('moduleTrading.transactionSimulation.simulating')),
+        ).toBeNull();
+    });
+});

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
@@ -8,9 +8,9 @@ import { ScreenHeader } from '@suite-native/navigation';
 import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
 
 const HeaderTitle = () => {
-    const { isLoading, isEnabled } = useDexExchangeTxSimulation();
+    const { isLoading, isEnabled, error } = useDexExchangeTxSimulation();
 
-    if (!isEnabled) {
+    if (!isEnabled || error) {
         return (
             <Text variant="body-md-strong">
                 <Translation id="moduleTrading.tradingExchangePreviewScreen.title" />

--- a/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts
@@ -1,33 +1,33 @@
 import { mockMessageSystemStateWithFeatureFlags } from '@suite-common/message-system/mocks';
-import { useExchangeIssue as useCommonExchangeIssue } from '@suite-common/trading';
+import { useDexExchangeTxSimulation as useCommonDexExchangeTxSimulation } from '@suite-common/trading';
 import { btc1NormalAccount } from '@suite-native/trading-fixtures';
 
-import { useExchangeIssue } from './useExchangeIssue';
+import { useDexExchangeTxSimulation } from './useDexExchangeTxSimulation';
 import { TRADING_DEX_SOURCE_ORIGIN } from '../../constants';
 import { renderHookWithTradingProvider } from '../../test-utils/tradingTestUtils';
 
 jest.mock('@suite-common/trading', () => ({
     ...jest.requireActual('@suite-common/trading'),
-    useExchangeIssue: jest.fn(),
+    useDexExchangeTxSimulation: jest.fn(),
 }));
 
-const mockUseCommonExchangeIssue = jest.mocked(useCommonExchangeIssue);
+const mockUseCommonDexExchangeTxSimulation = jest.mocked(useCommonDexExchangeTxSimulation);
 
-describe('useExchangeIssue', () => {
-    const exchangeIssue = {
-        isSimulationEnabled: true,
-        isSimulationLoading: false,
-        isSimulation: false,
-        issue: null,
+describe('useDexExchangeTxSimulation', () => {
+    const simulation = {
+        isEnabled: true,
+        isLoading: false,
+        error: null,
+        data: undefined,
     };
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockUseCommonExchangeIssue.mockReturnValue(exchangeIssue);
+        mockUseCommonDexExchangeTxSimulation.mockReturnValue(simulation);
     });
 
-    const renderUseExchangeIssue = (isRemoteFeatureEnabled?: boolean) =>
-        renderHookWithTradingProvider(() => useExchangeIssue(), {
+    const renderUseDexExchangeTxSimulation = (isRemoteFeatureEnabled?: boolean) =>
+        renderHookWithTradingProvider(() => useDexExchangeTxSimulation(), {
             tradeType: 'exchange',
             overrides: {
                 ...(isRemoteFeatureEnabled === undefined
@@ -49,20 +49,20 @@ describe('useExchangeIssue', () => {
         });
 
     it('passes the enabled native exchange context to the common hook', () => {
-        const { result } = renderUseExchangeIssue();
+        const { result } = renderUseDexExchangeTxSimulation();
 
-        expect(mockUseCommonExchangeIssue).toHaveBeenCalledWith({
+        expect(mockUseCommonDexExchangeTxSimulation).toHaveBeenCalledWith({
             account: btc1NormalAccount,
             isEnabled: true,
             sourceOrigin: TRADING_DEX_SOURCE_ORIGIN,
         });
-        expect(result.current).toBe(exchangeIssue);
+        expect(result.current).toBe(simulation);
     });
 
     it('passes a disabled state when the message-system feature is disabled', () => {
-        renderUseExchangeIssue(false);
+        renderUseDexExchangeTxSimulation(false);
 
-        expect(mockUseCommonExchangeIssue).toHaveBeenCalledWith({
+        expect(mockUseCommonDexExchangeTxSimulation).toHaveBeenCalledWith({
             account: btc1NormalAccount,
             isEnabled: false,
             sourceOrigin: TRADING_DEX_SOURCE_ORIGIN,

--- a/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.ts
@@ -1,13 +1,15 @@
 import { useSelector } from 'react-redux';
 
 import { useDexExchangeTxSimulation as useCommonDexExchangeTxSimulation } from '@suite-common/trading';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
-import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+import {
+    selectExchangeSelectedSendAccount,
+    selectIsTradingTxSimulationEnabled,
+} from '@suite-native/trading-state';
 
 import { TRADING_DEX_SOURCE_ORIGIN } from '../../constants';
 
 export const useDexExchangeTxSimulation = () => {
-    const isFeatureEnabled = useFeatureFlag(FeatureFlag.IsTradingTxSimulationEnabled);
+    const isFeatureEnabled = useSelector(selectIsTradingTxSimulationEnabled);
     const account = useSelector(selectExchangeSelectedSendAccount);
 
     return useCommonDexExchangeTxSimulation({

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeIssue.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeIssue.ts
@@ -1,13 +1,15 @@
 import { useSelector } from 'react-redux';
 
 import { useExchangeIssue as useCommonExchangeIssue } from '@suite-common/trading';
-import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
-import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+import {
+    selectExchangeSelectedSendAccount,
+    selectIsTradingTxSimulationEnabled,
+} from '@suite-native/trading-state';
 
 import { TRADING_DEX_SOURCE_ORIGIN } from '../../constants';
 
 export const useExchangeIssue = () => {
-    const isFeatureEnabled = useFeatureFlag(FeatureFlag.IsTradingTxSimulationEnabled);
+    const isFeatureEnabled = useSelector(selectIsTradingTxSimulationEnabled);
     const account = useSelector(selectExchangeSelectedSendAccount);
 
     return useCommonExchangeIssue({

--- a/suite-native/trading-state/src/selectors/commonSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.test.ts
@@ -50,6 +50,7 @@ import {
     selectIsTradingExchangeEnabled,
     selectIsTradingSellEnabled,
     selectIsTradingSlip24Enabled,
+    selectIsTradingTxSimulationEnabled,
     selectTradeToBeOpened,
     selectTradesToWatchByAccount,
     selectTradingEnvironment,
@@ -84,6 +85,7 @@ const getPreloadedState = ({
     sell,
     exchange,
     concierge,
+    txSimulation,
     blacklist,
     slip24,
     residence,
@@ -93,6 +95,7 @@ const getPreloadedState = ({
     sell?: boolean;
     exchange?: boolean;
     concierge?: boolean;
+    txSimulation?: boolean;
     blacklist?: boolean;
     slip24?: boolean;
     residence?: boolean;
@@ -121,6 +124,12 @@ const getPreloadedState = ({
         features.push({
             domain: 'trading.concierge',
             flag: concierge,
+        });
+    }
+    if (txSimulation !== undefined) {
+        features.push({
+            domain: 'trading.txSimulation',
+            flag: txSimulation,
         });
     }
     if (blacklist !== undefined) {
@@ -269,6 +278,32 @@ describe('commonSelectors', () => {
 
         it('should correctly select that concierge is enabled if remote feature is not set', () => {
             expect(selectIsTradingConciergeEnabled(getPreloadedState({}))).toBe(true);
+        });
+    });
+
+    describe('selectIsTradingTxSimulationEnabled', () => {
+        it('should be enabled when the remote feature is enabled', () => {
+            expect(
+                selectIsTradingTxSimulationEnabled(
+                    getPreloadedState({
+                        txSimulation: true,
+                    }),
+                ),
+            ).toBe(true);
+        });
+
+        it('should be disabled when the remote feature is disabled', () => {
+            expect(
+                selectIsTradingTxSimulationEnabled(
+                    getPreloadedState({
+                        txSimulation: false,
+                    }),
+                ),
+            ).toBe(false);
+        });
+
+        it('should default the remote feature to enabled', () => {
+            expect(selectIsTradingTxSimulationEnabled(getPreloadedState({}))).toBe(true);
         });
     });
 

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -133,11 +133,8 @@ export const selectIsTradingConciergeEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState,
 ) => selectIsFeatureEnabled(state, Feature.trading.concierge, true);
 
-export const selectIsTradingTxSimulationEnabled = (
-    state: MessageSystemRootState & FeatureFlagsRootState,
-) =>
-    selectIsFeatureEnabled(state, Feature.trading.txSimulation, true) &&
-    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingTxSimulationEnabled);
+export const selectIsTradingTxSimulationEnabled = (state: MessageSystemRootState) =>
+    selectIsFeatureEnabled(state, Feature.trading.txSimulation, true);
 
 export const selectIsTradingSlip24Enabled = (
     state: MessageSystemRootState & FeatureFlagsRootState & TradingRootStateWithDeviceAndAccounts,

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -133,6 +133,12 @@ export const selectIsTradingConciergeEnabled = (
     state: MessageSystemRootState & FeatureFlagsRootState,
 ) => selectIsFeatureEnabled(state, Feature.trading.concierge, true);
 
+export const selectIsTradingTxSimulationEnabled = (
+    state: MessageSystemRootState & FeatureFlagsRootState,
+) =>
+    selectIsFeatureEnabled(state, Feature.trading.txSimulation, true) &&
+    selectIsFeatureFlagEnabled(state, FeatureFlag.IsTradingTxSimulationEnabled);
+
 export const selectIsTradingSlip24Enabled = (
     state: MessageSystemRootState & FeatureFlagsRootState & TradingRootStateWithDeviceAndAccounts,
     account: Account | undefined | null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* add tx sim for dex swaps as ff to  msg system

## Notes for QA
* Can be managed from msg system

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/29950

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are almost entirely in `suite-native` (mobile) modules—trading hooks/components, feature flags, and config types—while the available E2E tests all target the web/desktop `suite` application. There is no code-path overlap, so none of these web/desktop E2E tests would exercise the native changes. The only file with static mappings is `suite-common/message-system/src/messageSystemTypes.ts`, a broad shared types file; per the broad-utility heuristic, no specific E2E test behavior is shown to depend directly on it. Therefore no E2E tests from this list are recommended; confidence in these changes must come from native/mobile test coverage instead.

<details><summary><b>Changed files (13)</b></summary>

- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-native/config/src/types.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.test.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.ts`
- `suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx`
- `suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeIssue.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeIssue.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.test.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (13)**
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-native/config/src/types.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.test.ts`
- `suite-native/feature-flags/src/featureFlagsSlice.ts`
- `suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx`
- `suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useDexExchangeTxSimulation.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeIssue.test.ts`
- `suite-native/module-trading/src/hooks/exchange/useExchangeIssue.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.test.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`

_Updated: 2026-08-04T05:49:17.725Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/29950-add-tx-simulation-feature-to-message-system/web/](https://dev.suite.sldev.cz/suite-web/feat/29950-add-tx-simulation-feature-to-message-system/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/29950-add-tx-simulation-feature-to-message-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/29950-add-tx-simulation-feature-to-message-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/29950-add-tx-simulation-feature-to-message-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T05:51:40.659Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T05:51:03.121Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->