### PR TITLE
feat(suite): add recovery source warning

### DIFF
--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -1,3 +1,4 @@
+import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { TrezorLink } from '@suite/external-links';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { selectRecoveryWordRequestInputType } from '@suite/modal';
@@ -10,14 +11,22 @@ import {
     selectRecoveryStatus,
     selectWordsCount,
 } from '@suite/recovery';
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { isDeviceWithButtonOnlyNoTouchscreen } from '@suite-common/suite-utils';
-import { Badge, Column } from '@trezor/components';
+import { Badge, Banner, Column } from '@trezor/components';
 import { DeviceModelInternal } from '@trezor/device-utils';
 import { HELP_CENTER_ADVANCED_RECOVERY_URL } from '@trezor/urls';
 
-import { goToNextStep, updateAnalytics } from 'src/actions/onboarding/onboardingActions';
+import {
+    addPath,
+    goToNextStep,
+    goToPreviousStep,
+    updateAnalytics,
+} from 'src/actions/onboarding/onboardingActions';
 import { SelectRecoveryType, SelectRecoveryWord, SelectWordCount } from 'src/components/recovery';
+import * as STEP from 'src/constants/onboarding/steps';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 import RecoveryStepBox from './RecoveryStepBox';
@@ -28,6 +37,7 @@ export const RecoveryStep = () => {
     const error = useSelector(selectRecoveryError);
     const wordsCount = useSelector(selectWordsCount);
     const recoveryWordRequestInputType = useSelector(selectRecoveryWordRequestInputType);
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
 
     if (!device?.features) {
@@ -38,6 +48,17 @@ export const RecoveryStep = () => {
     const subheadingKey: TranslationKey = isDeviceWithButtonOnlyNoTouchscreen(deviceModelInternal)
         ? 'TR_RECOVER_SUBHEADING_BUTTONS'
         : 'TR_RECOVER_SUBHEADING_TOUCH';
+
+    const handleCreateWallet = () => {
+        analytics.report({
+            type: events.onboardingRecoveryWarningCreateNewWalletEvent.name,
+            payload: { platform: 'desktop' },
+        });
+        dispatch(goToPreviousStep());
+        dispatch(addPath(STEP.PATH_CREATE));
+        dispatch(goToNextStep());
+        dispatch(updateAnalytics({ seed: 'create' }));
+    };
 
     if (status === 'initial') {
         // 1. step where users chooses number of words in case of T1B1.
@@ -98,7 +119,22 @@ export const RecoveryStep = () => {
                         <Translation id="TR_START_RECOVERY" />
                     </OnboardingCard.Button>
                 }
-            />
+            >
+                <Banner
+                    intent="neutral"
+                    icon
+                    title={<Translation id="TR_RECOVERY_SOURCE_WARNING_TITLE" />}
+                    description={<Translation id="TR_RECOVERY_SOURCE_WARNING_DESCRIPTION" />}
+                    rightContent={
+                        <Banner.Button
+                            data-testid="@onboarding/recovery/create-wallet-button"
+                            onClick={handleCreateWallet}
+                        >
+                            <Translation id="TR_NEW_WALLET" />
+                        </Banner.Button>
+                    }
+                />
+            </RecoveryStepBox>
         );
     }
 

--- a/suite-common/analytics/src/constants.ts
+++ b/suite-common/analytics/src/constants.ts
@@ -32,6 +32,7 @@ export enum EventType {
     AccountsBalance = 'accounts/balance',
     OnboardingStepViewed = 'onboarding/step-viewed',
     OnboardingFeedbackBannerClicked = 'onboarding/feedback-banner',
+    OnboardingRecoveryWarningCreateNewWallet = 'onboarding/recovery-warning/create-new-wallet',
     PromoNoDeviceEshopCta = 'promo/no-device-eshop-cta',
     GuideSupportChatOpened = 'guide/support-chat-opened',
     YieldEarnDashboardReady = 'yield/earn-dashboard-ready',

--- a/suite-common/analytics/src/events/index.ts
+++ b/suite-common/analytics/src/events/index.ts
@@ -27,6 +27,7 @@ export {
     onboardingFeedbackBannerClickedEvent,
     type OnboardingFeedbackBannerOrigin,
 } from './onboardingFeedbackBannerClickedEvent';
+export { onboardingRecoveryWarningCreateNewWalletEvent } from './onboardingRecoveryWarningCreateNewWalletEvent';
 export { suiteSyncLabelCreatedEvent } from './suiteSyncLabelCreatedEvent';
 export { walletBalanceEvent } from './walletBalanceEvent';
 export {

--- a/suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts
+++ b/suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts
@@ -1,0 +1,23 @@
+import { EventType } from '../constants';
+import type { AnalyticsPlatform, AttributeDef, EventDef } from '../eventDefinition';
+
+type Attributes = {
+    platform: AttributeDef<AnalyticsPlatform>;
+};
+
+export const onboardingRecoveryWarningCreateNewWalletEvent: EventDef<
+    Attributes,
+    EventType.OnboardingRecoveryWarningCreateNewWallet
+> = {
+    name: EventType.OnboardingRecoveryWarningCreateNewWallet,
+    descriptionTrigger:
+        'User clicks Create a new wallet in the onboarding recovery source warning. Emitted by both desktop and mobile app.',
+    changelog: [{ version: '26.8.0', notes: 'added' }],
+
+    attributes: {
+        platform: {
+            description: '`desktop` or `mobile`, identifying which app emitted the event.',
+            changelog: [{ version: '26.8.0', notes: 'added' }],
+        },
+    },
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -3206,6 +3206,15 @@ export const messages = defineMessages({
         description: 'Subheading in recover page. Basic info about recovery',
         id: 'TR_RECOVER_SUBHEADING_BUTTONS',
     },
+    TR_RECOVERY_SOURCE_WARNING_TITLE: {
+        defaultMessage: 'Was this wallet created on a Trezor?',
+        id: 'TR_RECOVERY_SOURCE_WARNING_TITLE',
+    },
+    TR_RECOVERY_SOURCE_WARNING_DESCRIPTION: {
+        defaultMessage:
+            'A wallet created elsewhere may not have the same security as one created on your Trezor. If you are unsure, we recommend setting up a new wallet here and moving your funds to it.',
+        id: 'TR_RECOVERY_SOURCE_WARNING_DESCRIPTION',
+    },
     TR_RECOVERY_ERROR: {
         defaultMessage: 'Wallet recovery failed: {error}',
         description: 'Error during recovery. For example wrong word retyped or device disconnected',


### PR DESCRIPTION
## Description

- add a neutral safety warning to the existing Desktop onboarding recovery card before wallet-backup entry
- add a banner action that switches to the existing create-wallet path while preserving the current recovery and back actions
- report the shared `onboarding/recovery-warning/create-new-wallet` analytics event with the emitting platform

## Notes for QA

- start Desktop onboarding and select **Recover wallet**
- confirm the warning copy and **Create a new wallet** action appear before recovery begins
- confirm **Start recovery** still starts the existing recovery flow
- confirm **Create a new wallet** enters the normal new-wallet setup path
- confirm Back navigation remains unchanged and long localized copy does not obscure either action

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30728

## Screenshots:
<img width="1021" height="621" alt="image" src="https://github.com/user-attachments/assets/f1003cce-7e78-4557-a34c-b90a24e75867" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set centers on the onboarding RecoveryStep UI and a new analytics event for a recovery 'create new wallet' warning. The highest-risk regressions are in the device-specific recovery onboarding flows, so run all T1B1 and T2T1 recovery tests first. The analytics pipeline changes are lower risk but could break event typing/emission, so the general analytics events test is recommended at medium priority.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx`
- `suite-common/analytics/src/constants.ts`
- `suite-common/analytics/src/events/index.ts`
- `suite-common/analytics/src/events/onboardingRecoveryWarningCreateNewWalletEvent.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — This test directly navigates the T1B1 wallet recovery flow in the RecoveryStep component, which is one of the changed files. If the new 'create new wallet' warning or its analytics event was wired into the recovery UI here, this test will exercise that code path and can surface regressions in the recovery step rendering or event firing.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Exercises the T1B1 recovery flow including retry after device disconnect, which passes through RecoveryStep. Changes to recovery warnings or analytics instrumentation in this step could alter the retry/disconnect behavior or fire unexpected analytics events.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Completes the full T1B1 recovery onboarding path, which is the primary user flow affected by RecoveryStep changes. Any new warning modal, analytics event, or message added to RecoveryStep will be encountered here.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Directly uses the T2T1 recovery flow and RecoveryStep. Device-disconnect handling during recovery is sensitive to UI state changes in RecoveryStep, so this is a good regression test for the changed component.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Covers Shamir recovery and page-reload persistence in RecoveryStep. Because it passes through the recovery step multiple times and across reloads, it can catch issues where the new warning/analytics event interferes with recovery state persistence.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Completes the standard T2T1 recovery onboarding flow. This is the canonical path for RecoveryStep and will hit any new warning or analytics instrumentation added to that step.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Validates the default onboarding analytics event stream and event constants. Changes to analytics event exports (index.ts) or constants could affect how events are typed or emitted; this test intercepts analytics requests during onboarding and can detect regressions in the analytics pipeline.

</details>

_Updated: 2026-08-03T13:43:57.915Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/agent/onboarding-recovery-source-warning/web/](https://dev.suite.sldev.cz/suite-web/agent/onboarding-recovery-source-warning/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=agent/onboarding-recovery-source-warning&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=agent/onboarding-recovery-source-warning&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=agent/onboarding-recovery-source-warning&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:45:48.393Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T13:44:55.274Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->