### PR TITLE
fix(suite-desktop): disable devtools in production unless CLI flag is set

### DIFF
--- a/packages/suite-desktop-core/src/libs/menu.ts
+++ b/packages/suite-desktop-core/src/libs/menu.ts
@@ -1,11 +1,14 @@
 import { Menu, type MenuItemConstructorOptions, app, shell } from 'electron';
 
-import { isDevEnv } from '@suite-common/suite-utils';
+import { isCodesignBuild } from '@trezor/env-utils';
 
 import { restartApp } from './app-utils';
 import type { MainWindowProxy } from './main-window-proxy';
+import { hasSwitch } from './process-switches';
 
 const isMac = process.platform === 'darwin';
+// DevTools are only available in development, or in production when explicitly enabled via CLI flag.
+const isDevToolsEnabled = !isCodesignBuild() || hasSwitch('open-devtools');
 
 // original MenuItemConstructorOptions is too complex for our purpose.
 // submenu field may be an object or array of objects.
@@ -98,7 +101,7 @@ export const buildMainMenu = (mainWindowProxy: MainWindowProxy) => {
     // { role: 'appMenu' } — macOS "App menu" conditionally prepended below
     const mainMenuTemplate: MenuItem[] = [fileMenu, editMenu, viewMenu, windowMenu, helpMenu];
 
-    if (!isDevEnv) {
+    if (!isDevToolsEnabled) {
         // remove toggleDevTools from "View"
         viewMenu.submenu.splice(2, 1);
     }

--- a/packages/suite-desktop-core/src/modules/shortcuts.ts
+++ b/packages/suite-desktop-core/src/modules/shortcuts.ts
@@ -1,26 +1,38 @@
 import electronLocalshortcut from 'electron-localshortcut';
 
+import { isCodesignBuild } from '@trezor/env-utils';
+
 import type { ModuleInit } from './module';
 import { restartApp } from '../libs/app-utils';
+import { hasSwitch } from '../libs/process-switches';
 
 export const SERVICE_NAME = 'shortcuts';
+
+// DevTools are only available in development, or in production when explicitly enabled via CLI flag.
+const isDevToolsEnabled = !isCodesignBuild() || hasSwitch('open-devtools');
 
 export const init: ModuleInit = ({ mainWindowProxy }) => {
     const { logger } = global;
 
     mainWindowProxy.on('init', mainWindow => {
-        const openDevToolsShortcuts = ['F12', 'CommandOrControl+Shift+I', 'CommandOrControl+Alt+I'];
-        openDevToolsShortcuts.forEach(shortcut => {
-            electronLocalshortcut.register(mainWindow, shortcut, () => {
-                logger.info(SERVICE_NAME, `${shortcut} pressed to open/close DevTools`);
+        if (isDevToolsEnabled) {
+            const openDevToolsShortcuts = [
+                'F12',
+                'CommandOrControl+Shift+I',
+                'CommandOrControl+Alt+I',
+            ];
+            openDevToolsShortcuts.forEach(shortcut => {
+                electronLocalshortcut.register(mainWindow, shortcut, () => {
+                    logger.info(SERVICE_NAME, `${shortcut} pressed to open/close DevTools`);
 
-                if (mainWindow.webContents.isDevToolsOpened()) {
-                    mainWindow.webContents.closeDevTools();
-                } else {
-                    mainWindow.webContents.openDevTools();
-                }
+                    if (mainWindow.webContents.isDevToolsOpened()) {
+                        mainWindow.webContents.closeDevTools();
+                    } else {
+                        mainWindow.webContents.openDevTools();
+                    }
+                });
             });
-        });
+        }
 
         const reloadAppShortcuts = ['F5', 'CommandOrControl+R'];
         reloadAppShortcuts.forEach(shortcut => {


### PR DESCRIPTION
## Description

DevTools could still be opened in production desktop builds via keyboard shortcuts (F12, Cmd/Ctrl+Shift+I, Cmd/Ctrl+Alt+I). 
This change gates both the DevTools shortcuts (`modules/shortcuts.ts`) and the menu item (`libs/menu.ts`) on `isDevEnv || --open-devtools`. As a result DevTools are fully disabled in production unless the app is launched with the `--open-devtools` CLI flag, which restores auto-open, shortcuts, and the menu item.

## Notes for QA

Shall be tested with next Suite Desktop RC:
- In a production build, verify F12 / Cmd+Shift+I / Cmd+Alt+I do nothing and the "Toggle Developer Tools" View menu entry is absent
- Then launch with `--open-devtools` flag and confirm DevTools open on start and all shortcuts/menu work again.
- Development builds should be unaffected (the shortcuts work always).

## Related issue

Part of https://github.com/trezor/trezor-suite/issues/31442

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/disable-devtools-in-prod/web/](https://dev.suite.sldev.cz/suite-web/disable-devtools-in-prod/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=disable-devtools-in-prod&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=disable-devtools-in-prod&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T08:41:28.685Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T08:40:49.682Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are desktop-core infrastructure (application menu and keyboard shortcuts) with no direct static E2E coverage in the candidate set. The most relevant inferred check is a basic Electron app launch smoke test, which would catch critical initialization regressions. Beyond that, there are no tests that exercise menu items or shortcut behavior directly.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/libs/menu.ts`
- `packages/suite-desktop-core/src/modules/shortcuts.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Inferred coverage: this is a desktop-only Electron app launch smoke test that verifies the Suite UI window initializes successfully. The changed files (menu.ts and shortcuts.ts) are desktop-core modules loaded during app startup, so a crash or initialization regression in either would likely surface here as a failed launch.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/libs/menu.ts`
- `packages/suite-desktop-core/src/modules/shortcuts.ts`

_Updated: 2026-08-20T08:40:06.436Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->