### PR TITLE
fix(suite): do not discover when compromised device

### DIFF
--- a/suite/discovery/package.json
+++ b/suite/discovery/package.json
@@ -19,13 +19,16 @@
         "@suite-common/suite-utils": "workspace:*",
         "@suite-common/thp": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
+        "@suite/authenticity-checks": "workspace:*",
         "@suite/locks": "workspace:*",
         "@suite/router": "workspace:*",
         "@suite/router-config": "workspace:*"
     },
     "devDependencies": {
+        "@suite-common/message-system": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite-common/wallet-types": "workspace:*",
+        "@suite/settings": "workspace:*",
         "@trezor/connect-common": "workspace:*",
         "redux": "^5.0.1"
     }

--- a/suite/discovery/src/discoveryMiddleware.test.ts
+++ b/suite/discovery/src/discoveryMiddleware.test.ts
@@ -10,13 +10,25 @@ import {
 } from '@suite/router';
 import { type RouterStateOverrides, createRouterStateMock } from '@suite/router/mocks';
 import {
+    type SuiteSettingsState,
+    prepareSuiteSettingsReducer,
+    suiteSettingsInitialState,
+} from '@suite/settings';
+import {
     type DeviceReducerState,
     deviceActions,
     deviceReducerInitialState,
     prepareDeviceReducer,
 } from '@suite-common/device';
+import {
+    type MessageSystemState,
+    messageSystemInitialState,
+    prepareMessageSystemReducer,
+} from '@suite-common/message-system';
 import { type AnyAction } from '@suite-common/redux-utils';
+import { type AcquiredDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { isDeviceAcquired } from '@suite-common/suite-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type ThpState, initialThpState, prepareThpReducer, thpActions } from '@suite-common/thp';
 import * as walletCore from '@suite-common/wallet-core';
@@ -39,12 +51,16 @@ const mockedStartOrRestartDiscoveryThunk = jest.mocked(walletCore.startOrRestart
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const discoveryReducer = prepareDiscoveryReducer(extraDependenciesCommonMock);
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+const suiteSettingsReducer = prepareSuiteSettingsReducer(extraDependenciesCommonMock);
 const thpReducer = prepareThpReducer(extraDependenciesCommonMock);
 
 type State = {
     device: DeviceReducerState;
     locks: LocksState;
+    messageSystem: MessageSystemState;
     router: RouterState;
+    suiteSettings: SuiteSettingsState;
     thp: ThpState;
     wallet: { discovery: Discovery };
 };
@@ -86,6 +102,17 @@ const selectedDevice = mockSuiteDevice({
     state: { staticSessionId: 'device@selected:1' },
 });
 
+if (!isDeviceAcquired(selectedDevice)) {
+    throw `${mockSuiteDevice.name}() must return an AcquiredDevice here.`;
+}
+const compromisedDevice: AcquiredDevice = {
+    ...selectedDevice,
+    authenticityChecks: {
+        firmwareRevision: { success: false, error: 'revision-mismatch' },
+        firmwareHash: { success: false, error: 'hash-mismatch' },
+    },
+};
+
 const unacquiredDevice = mockSuiteDevice({
     type: 'unacquired',
     path,
@@ -118,6 +145,18 @@ const fixtures: Fixture[] = [
             {
                 action: deviceActions.selectDevice(selectedDevice),
                 expectedCallCount: 1,
+            },
+        ],
+    },
+    {
+        description: 'does not start discovery when compromised device warning should be displayed',
+        state: {
+            router: { app: 'dashboard' },
+        },
+        steps: [
+            {
+                action: deviceActions.selectDevice(compromisedDevice),
+                expectedCallCount: 0,
             },
         ],
     },
@@ -259,7 +298,9 @@ const getInitialState = (state: FixtureState = {}): State => ({
         ...locksInitialState,
         ...state.locks,
     },
+    messageSystem: messageSystemInitialState,
     router: createRouterStateMock(state.router),
+    suiteSettings: suiteSettingsInitialState,
     thp: {
         ...initialThpState,
         ...state.thp,
@@ -273,7 +314,9 @@ const initStore = (state?: FixtureState) =>
         reducer: {
             device: deviceReducer,
             locks: locksReducer,
+            messageSystem: messageSystemReducer,
             router: routerReducer,
+            suiteSettings: suiteSettingsReducer,
             thp: thpReducer,
             wallet: combineReducers({ discovery: discoveryReducer }),
         },

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -1,3 +1,4 @@
+import { selectShouldDisplayDeviceCompromised } from '@suite/authenticity-checks';
 import { routerAppChanged } from '@suite/router';
 import { connectPopupCallThunkInner } from '@suite-common/connect-popup';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
@@ -44,7 +45,10 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         );
         if (!isDeviceReady) return action;
 
-        // 3. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place
+        // 3. Discovery must be blocked while the compromised device warning is shown.
+        if (selectShouldDisplayDeviceCompromised(getState())) return action;
+
+        // 4. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place
         //    *after* device acquisition, and also needs device interaction to complete (would block discovery).
         const isTHPAutoconnectModal = selectThpAutoconnectStep(getState()) === 'AutoconnectInfo';
         const isTHPAutoconnectFinished = thpActions.finishAutoconnectFlow.match(action);
@@ -58,13 +62,14 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             isDeviceBecomingConnected ||
             isTHPAutoconnectFinished || // now that the THP Autoconnect was finished, resume the delayed discovery
             routerAppChanged.match(action) || // may no longer be one of the apps where discovery is disabled
+            deviceActions.dismissFirmwareAuthenticityCheck.match(action) || // may no longer be device compromised
             connectPopupCallThunkInner.fulfilled.match(action) ||
             deviceActions.selectDevice.match(action) ||
             changeNetworks.match(action) ||
             accountsActions.updateAccount.match(action) || // empty account can become nonempty
             accountsActions.changeAccountVisibility.match(action)
         ) {
-            // 4. Nothing to discover (discovery would be no-op). It's intentionally inside the action matcher condition
+            // 5. Nothing to discover (discovery would be no-op). It's intentionally inside the action matcher condition
             // so it won't be called on every action, because the selector is expensive and not viable for memoization.
             const shouldRediscover = selectShouldRediscover(getState(), device);
             if (!shouldRediscover) return action;

--- a/suite/discovery/tsconfig.json
+++ b/suite/discovery/tsconfig.json
@@ -19,15 +19,20 @@
         {
             "path": "../../suite-common/wallet-core"
         },
+        { "path": "../authenticity-checks" },
         { "path": "../locks" },
         { "path": "../router" },
         { "path": "../router-config" },
+        {
+            "path": "../../suite-common/message-system"
+        },
         {
             "path": "../../suite-common/test-utils"
         },
         {
             "path": "../../suite-common/wallet-types"
         },
+        { "path": "../settings" },
         {
             "path": "../../packages/connect-common"
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14779,6 +14779,7 @@ __metadata:
   dependencies:
     "@suite-common/connect-popup": "workspace:*"
     "@suite-common/device": "workspace:*"
+    "@suite-common/message-system": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
@@ -14786,9 +14787,11 @@ __metadata:
     "@suite-common/thp": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
+    "@suite/authenticity-checks": "workspace:*"
     "@suite/locks": "workspace:*"
     "@suite/router": "workspace:*"
     "@suite/router-config": "workspace:*"
+    "@suite/settings": "workspace:*"
     "@trezor/connect-common": "workspace:*"
     redux: "npm:^5.0.1"
   languageName: unknown


### PR DESCRIPTION
## Description

Block discovery during compromised device.
- FW Authenticity Checks (revision, hash, meta):
  - blocked in `Preloader` via `selectShouldDisplayDeviceCompromised` → must use the same selector in discovery
- Entropy check: same
- Device Authenticity Check: already OK :heavy_check_mark:  Only relevant in onboarding, so Discovery runs after finishing it whole

Restart discovery when no longer device compromised **during the same session** – these scenarios can happen:
- Dismiss button – available only for FW Authenticity checks
- Disabling the checks in settings – available for Entropy as well as FW Authenticity checks
- Message system – extremely improbable, the king of all edge cases = not worth solving: we'd have to release msg system that disables a security check right during the users' session, which would refresh it mid-session. I did not handle this, so currently if that happens, discovery doesn't start, but clicking through tabs will fix it (routerApp change will trigger it)  

## Notes for QA

Test with trezor-user-env, which always fails hash check.

In no flows should you land on Device compromised modal with discovery running (that's accurately indicated in redux, and also by noticable by the account skeletons and global green loader on top of page).

## Related Issue

Resolve #26830

## Screenshots:

### Before

[before.webm](https://github.com/user-attachments/assets/7953fc96-d1c4-49c8-a2d1-ca57dd854464)

### After

**Via dismiss button**

[after - dismiss.webm](https://github.com/user-attachments/assets/c6ad32f9-f123-4e17-8089-9f052d3089e5)

**Via settings**

[after - settings.webm](https://github.com/user-attachments/assets/4eae35d2-bd81-40ed-a0e7-6773fb6419dd)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the discovery middleware and its unit tests, so risk is concentrated on account discovery flows. The recommended set targets direct discovery scenarios (multi-coin, reload recovery, custom backends) plus two tests where asset/network activation triggers discovery, providing high confidence with minimal runtime.

<details><summary><b>Changed files (4)</b></summary>

- `suite/discovery/package.json`
- `suite/discovery/src/discoveryMiddleware.test.ts`
- `suite/discovery/src/discoveryMiddleware.ts`
- `suite/discovery/tsconfig.json`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test directly validates standard wallet discovery after ejecting and re-adding a wallet, which is a core path exercised by the discovery middleware.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies discovery completes successfully when using custom Blockbook backends for BTC and LTC, directly stressing backend-specific discovery orchestration in the middleware.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test explicitly asserts discovery status transitions, recovery after page reload mid-discovery, and completion across eight activated coins, making it the most direct E2E coverage of the middleware behavior.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Enabling a new asset (ETH) through the Activate Assets modal triggers account discovery; a regression in the middleware could prevent the new asset from appearing in dashboard views.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates networks from both the coins settings page and the dashboard modal, relying on discovery to finish before balances and asset lists update.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite/discovery/package.json`
- `suite/discovery/tsconfig.json`

_Updated: 2026-08-03T16:49:36.328Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/no-discovery-when-device-compro/web/](https://dev.suite.sldev.cz/suite-web/fix/no-discovery-when-device-compro/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/no-discovery-when-device-compro&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/no-discovery-when-device-compro&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T16:52:53.626Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T16:51:48.326Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->