### PR TITLE
fix(suite): persist per-network scam tx filter in tx history

### DIFF
--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -491,6 +491,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_NETWORK_RESERVE:
                 case WALLET_SETTINGS.SET_AUTO_EJECT:
                 case WALLET_SETTINGS.SET_ADDRESS_DISPLAY_TYPE:
+                case WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS:
                     api.dispatch(storageActions.saveWalletSettings());
 
                     break;

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 26.8.0.2
+
+- convert `walletSettings.hideSuspiciousTransactions` from a single boolean to a per-network record
+
 ## 26.8.0
 
 - remove inaccurate historic ERC4626 fiat rates from storage

--- a/packages/suite/src/storage/migrations/versions/26.8.0.2.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.2.test.ts
@@ -1,0 +1,88 @@
+import '@suite-common/test-utils/globalOverrides';
+import { type IDBPDatabase, deleteDB, openDB } from 'idb';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+import migration from './26.8.0.2';
+
+const DB_NAME = 'suite-idb-test-26.8.0.2';
+const INITIAL_VERSION = 1;
+
+const runMigration = () =>
+    openDB(DB_NAME, INITIAL_VERSION + 1, {
+        upgrade(db: IDBPDatabase<SuiteDBSchema>, _oldVersion, _newVersion, tx) {
+            migration.migrate(db, tx);
+        },
+    });
+
+const createDBWithWalletSettings = async (walletSettings?: Record<string, unknown>) => {
+    const db = await openDB<SuiteDBSchema>(DB_NAME, INITIAL_VERSION, {
+        upgrade(upgradeDb) {
+            upgradeDb.createObjectStore('walletSettings');
+        },
+    });
+
+    if (walletSettings) {
+        // @ts-expect-error The old shape of the stored settings is intentionally invalid now.
+        await db.put('walletSettings', walletSettings, 'wallet');
+    }
+
+    db.close();
+};
+
+describe('migration 26.8.0.2', () => {
+    beforeEach(async () => {
+        await deleteDB(DB_NAME);
+    });
+
+    test('converts stored `true` to a record of all enabled networks', async () => {
+        await createDBWithWalletSettings({
+            enabledNetworks: ['btc', 'eth', 'op'],
+            hideSuspiciousTransactions: true,
+        });
+
+        const migratedDb = await runMigration();
+        const settings = await migratedDb.get('walletSettings', 'wallet');
+
+        expect(settings?.hideSuspiciousTransactions).toEqual({ btc: true, eth: true, op: true });
+
+        migratedDb.close();
+    });
+
+    test('converts stored `false` to an empty record', async () => {
+        await createDBWithWalletSettings({
+            enabledNetworks: ['btc', 'eth'],
+            hideSuspiciousTransactions: false,
+        });
+
+        const migratedDb = await runMigration();
+        const settings = await migratedDb.get('walletSettings', 'wallet');
+
+        expect(settings?.hideSuspiciousTransactions).toEqual({});
+
+        migratedDb.close();
+    });
+
+    test('leaves settings without the old boolean untouched', async () => {
+        await createDBWithWalletSettings({
+            enabledNetworks: ['btc'],
+        });
+
+        const migratedDb = await runMigration();
+        const settings = await migratedDb.get('walletSettings', 'wallet');
+
+        expect(settings).toEqual({ enabledNetworks: ['btc'] });
+
+        migratedDb.close();
+    });
+
+    test('does nothing when no wallet settings are stored', async () => {
+        await createDBWithWalletSettings();
+
+        const migratedDb = await runMigration();
+
+        expect(await migratedDb.get('walletSettings', 'wallet')).toBeUndefined();
+
+        migratedDb.close();
+    });
+});

--- a/packages/suite/src/storage/migrations/versions/26.8.0.2.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.2.ts
@@ -1,0 +1,23 @@
+import { createMigration } from '@suite/idb-migration-utils';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+export default createMigration<SuiteDBSchema>('26.8.0.2', async (_db, tx) => {
+    const store = tx.objectStore('walletSettings');
+    const settings = await store.get('wallet');
+
+    if (!settings) return;
+
+    // The stored value may still have the old shape, hence the widening cast.
+    const { hideSuspiciousTransactions } = settings as { hideSuspiciousTransactions: unknown };
+
+    if (typeof hideSuspiciousTransactions !== 'boolean') return;
+
+    // The setting used to be a single boolean applied to all networks; it is now stored
+    // per network. A stored `true` is preserved for all networks the user has enabled.
+    settings.hideSuspiciousTransactions = hideSuspiciousTransactions
+        ? Object.fromEntries(settings.enabledNetworks.map(symbol => [symbol, true]))
+        : {};
+
+    await store.put(settings, 'wallet');
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -29,3 +29,4 @@ export { default as m26_7_0_1 } from './26.7.0.1';
 export { default as m26_7_0_2 } from './26.7.0.2';
 export { default as m26_8_0 } from './26.8.0';
 export { default as m26_8_0_1 } from './26.8.0.1';
+export { default as m26_8_0_2 } from './26.8.0.2';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -1,9 +1,9 @@
 import { type ReactNode } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { selectHasActiveModal } from '@suite/modal';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectIsHideSuspiciousTransactions,
     toggleHideSuspiciousTransactions,
@@ -25,6 +25,8 @@ import {
 } from '@trezor/components';
 import { FunnelSimpleIcon } from '@trezor/icons';
 import { zIndices } from '@trezor/theme';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 type FilterValue = boolean | string;
 
@@ -59,9 +61,15 @@ const suspiciousTransactionsOptions: readonly FilterOption[] = [
 const getSectionDefaultValue = (section: FilterSection) =>
     section.options.find(option => option.isDefault)?.value;
 
-export const FilterAction = () => {
+type FilterActionProps = {
+    symbol: NetworkSymbol;
+};
+
+export const FilterAction = ({ symbol }: FilterActionProps) => {
     const { suspiciousTransactionsTooltipClosed } = useSelector(selectFlags);
-    const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
+    const suspiciousTransactionsHidden = useSelector(state =>
+        selectIsHideSuspiciousTransactions(state, symbol),
+    );
     const hasActiveModal = useSelector(selectHasActiveModal);
     const dispatch = useDispatch();
 
@@ -73,8 +81,8 @@ export const FilterAction = () => {
     const dataTest = '@wallet/accounts/hide-scam-transactions';
 
     const handleToggleSuspiciousTransactionsRequest = (requestedHidden: FilterValue) => {
-        if (requestedHidden === Boolean(suspiciousTransactionsHidden)) return;
-        dispatch(toggleHideSuspiciousTransactions());
+        if (requestedHidden === suspiciousTransactionsHidden) return;
+        dispatch(toggleHideSuspiciousTransactions(symbol));
     };
 
     const filterSections: FilterSection[] = [
@@ -82,7 +90,7 @@ export const FilterAction = () => {
             key: 'suspiciousTransactions',
             title: <Translation id="TR_SUSPICIOUS_TRANSACTIONS" />,
             options: suspiciousTransactionsOptions,
-            value: Boolean(suspiciousTransactionsHidden),
+            value: suspiciousTransactionsHidden,
             onChange: handleToggleSuspiciousTransactionsRequest,
         },
     ];

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
@@ -104,7 +104,7 @@ export const TransactionListActions = ({
                 }
             />
             {isTxFilteringEnabled && hasNetworkPotentialFraudTransactions(account.symbol) && (
-                <FilterAction />
+                <FilterAction symbol={account.symbol} />
             )}
             {isExportable && <ExportAction account={account} searchQuery={searchQuery} />}
         </Row>

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -38,7 +38,9 @@ export const WalletTransactionList = ({
     isExportable = true,
 }: TransactionListProps) => {
     // NOTE: The number of the displayed pages may be different from the number of the pages for all transactions
-    const suspiciousTransactionsHidden = useSelector(selectIsHideSuspiciousTransactions);
+    const suspiciousTransactionsHidden = useSelector(state =>
+        selectIsHideSuspiciousTransactions(state, symbol),
+    );
     const fraudTransactionPossible =
         suspiciousTransactionsHidden && hasNetworkPotentialFraudTransactions(symbol);
     const [visiblePages, setVisiblePages] = useState(1);

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -37,6 +37,7 @@ export const setNetworkReserve = createAction(
 
 export const toggleHideSuspiciousTransactions = createAction(
     WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
+    (symbol: NetworkSymbol) => ({ payload: symbol }),
 );
 
 export const setAutoEjectEnabled = createAction(

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
@@ -1,12 +1,14 @@
 import { deviceInitialState } from '@suite-common/device';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { FirmwareType } from '@trezor/device-utils';
 
 import * as walletSettingsActions from './walletSettingsActions';
 import {
     initialWalletSettingsState,
     prepareWalletSettingsReducer,
+    selectIsHideSuspiciousTransactions,
     selectIsNetworkReserveSettingsVisible,
 } from './walletSettingsReducer';
 
@@ -56,6 +58,51 @@ describe('settings reducer', () => {
             ...initialState,
             enabledNetworks: ['eth'],
         });
+    });
+
+    it('TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS toggles the setting only for the given network', () => {
+        const toggledOn = reducer(
+            undefined,
+            walletSettingsActions.toggleHideSuspiciousTransactions('op'),
+        );
+
+        expect(toggledOn).toEqual({
+            ...initialState,
+            hideSuspiciousTransactions: { op: true },
+        });
+
+        const toggledOff = reducer(
+            toggledOn,
+            walletSettingsActions.toggleHideSuspiciousTransactions('op'),
+        );
+
+        expect(toggledOff).toEqual({
+            ...initialState,
+            hideSuspiciousTransactions: { op: false },
+        });
+    });
+});
+
+describe('selectIsHideSuspiciousTransactions', () => {
+    const getState = (hideSuspiciousTransactions: Partial<Record<NetworkSymbol, boolean>>) => ({
+        wallet: {
+            settings: {
+                ...initialState,
+                hideSuspiciousTransactions,
+            },
+        },
+    });
+
+    it('returns true only for networks with the setting enabled', () => {
+        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'op')).toBe(
+            true,
+        );
+        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'eth')).toBe(
+            false,
+        );
+        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'btc')).toBe(
+            false,
+        );
     });
 });
 

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -31,7 +31,7 @@ export const createMemoizedSelector = createWeakMapSelector.withTypes<WalletSett
 const initialState: WalletSettingsState = {
     localCurrency: 'usd',
     enabledNetworks: [],
-    hideSuspiciousTransactions: false,
+    hideSuspiciousTransactions: {},
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,
     networkReserve: true,
@@ -89,9 +89,17 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
                 state.networkReserve = action.payload;
             },
         );
-        builder.addCase(WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS, state => {
-            state.hideSuspiciousTransactions = !state.hideSuspiciousTransactions;
-        });
+        builder.addCase(
+            WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
+            (
+                state,
+                action: ReturnType<typeof walletSettingsActions.toggleHideSuspiciousTransactions>,
+            ) => {
+                const symbol = action.payload;
+                state.hideSuspiciousTransactions[symbol] =
+                    !state.hideSuspiciousTransactions[symbol];
+            },
+        );
         builder.addCase(
             WALLET_SETTINGS.SET_AUTO_EJECT,
             (state, action: ReturnType<typeof walletSettingsActions.setAutoEjectEnabled>) => {
@@ -111,8 +119,10 @@ export const selectEnabledNetworks = (state: WalletSettingsRootState) =>
     returnStableArrayIfEmpty(state.wallet.settings.enabledNetworks);
 export const selectBaseCurrency = (state: WalletSettingsRootState) =>
     state.wallet.settings.localCurrency;
-export const selectIsHideSuspiciousTransactions = (state: WalletSettingsRootState) =>
-    state.wallet.settings.hideSuspiciousTransactions;
+export const selectIsHideSuspiciousTransactions = (
+    state: WalletSettingsRootState,
+    symbol: NetworkSymbol,
+) => Boolean(state.wallet.settings.hideSuspiciousTransactions[symbol]);
 export const selectBitcoinAmountUnit = (state: WalletSettingsRootState) =>
     state.wallet.settings.bitcoinAmountUnit;
 export const selectIsDeviceAutoEjectEnabled = (state: WalletSettingsRootState) =>

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -20,7 +20,7 @@ export type WalletType = (typeof WalletType)[keyof typeof WalletType];
 export interface WalletSettings {
     localCurrency: BaseCurrencyCode;
     enabledNetworks: NetworkSymbol[];
-    hideSuspiciousTransactions: boolean;
+    hideSuspiciousTransactions: Partial<Record<NetworkSymbol, boolean>>;
     bitcoinAmountUnit: PROTO.AmountUnit;
     mevProtection: boolean;
     networkReserve: boolean;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -206,7 +206,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         reducer: walletSettingsReducer,
         persistedKeys: walletSettingsPersistedWhitelist,
         key: 'walletSettings',
-        version: 3,
+        version: 4,
         migrations: {
             1: initialMigrateAppSettingsAndDiscoveryConfig({
                 mmkvStorage: deps.mmkvStorage,
@@ -222,6 +222,19 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
                 const { discreetMode: _, ...rest } = oldState;
 
                 return rest;
+            },
+            4: (oldState: any /* FIXME */) => {
+                if (!oldState) return oldState;
+
+                // hideSuspiciousTransactions changed from a single boolean to a per-network
+                // record. Mobile has no UI for it, so the stored boolean is just dropped.
+                if (typeof oldState.hideSuspiciousTransactions === 'boolean') {
+                    const { hideSuspiciousTransactions: _, ...rest } = oldState;
+
+                    return rest;
+                }
+
+                return oldState;
             },
         },
         storage: deps.mmkvStorage,


### PR DESCRIPTION
## Description

Persist scam tx filter per network.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30610

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-03 at 16 33 28" src="https://github.com/user-attachments/assets/00af396f-6d82-47ef-8105-b2204e4fcb7d" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set mixes two distinct risk areas: (1) a new IndexedDB migration for wallet settings and (2) refactor/updates to the wallet transaction list UI. The highest-value tests are the migration test that validates persisted settings and the transactions test that exercises the changed filter/search components. Settings-general and locale-migration tests add confidence around shared storage/settings infrastructure, while export-transactions covers the TransactionListActions export path. Several changed files are unit-test-only or native-only and have no E2E coverage.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/src/middlewares/wallet/storageMiddleware.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.2.test.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.2.ts`
- `packages/suite/src/storage/migrations/versions/index.ts`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx`
- `packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx`
- `suite-common/wallet-core/src/settings/walletSettingsActions.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`
- `suite-common/wallet-types/src/settings.ts`
- `suite-native/state/src/reducers.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This test directly validates IndexedDB migration between Suite versions and asserts that the auto-eject wallet setting is preserved in walletSettings. The changed migration files (26.8.0.2), walletSettings reducer/actions/types, and storage middleware are the exact code paths this test exercises.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test cycles through transaction graph range filters and searches transactions by address. It directly uses the changed TransactionList action/filter components and WalletTransactionList rendering logic, making it the best regression guard for visible transaction list behavior.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — The test changes fiat, theme, language, and analytics toggles, all of which are stored via walletSettings actions/reducer. Modifications to walletSettingsActions or walletSettingsReducer could alter how these settings persist or emit analytics events.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies cross-version IndexedDB migration for locale/language settings. The changed storage migration infrastructure and storage middleware are shared with the new 26.8.0.2 migration, so this catches broad migration regressions.
- `suite/e2e/tests/wallet/export-transactions.test.ts` — Transaction export actions live in the changed TransactionListActions component. If the refactor altered export buttons or their data wiring, this test would catch a visible regression for PDF/CSV/JSON exports across multiple coins.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/storage/migrations/versions/26.8.0.2.test.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts`
- `suite-native/state/src/reducers.ts`

_Updated: 2026-08-03T14:39:33.951Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/persist-scam-txs-filter/web/](https://dev.suite.sldev.cz/suite-web/fix/persist-scam-txs-filter/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/persist-scam-txs-filter&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/persist-scam-txs-filter&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/persist-scam-txs-filter&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T14:41:52.810Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T14:41:20.496Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->