### PR TITLE
Move HyperEVM out of debug mode

### DIFF
--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -332,7 +332,6 @@ export const networks = {
         coingeckoId: 'hyperevm',
         tradeCryptoId: 'hyperliquid',
         caipId: 'eip155:999',
-        isDebugOnlyNetwork: true,
         yieldXyzId: null,
     },
     avax: {


### PR DESCRIPTION
## Description

Move HyperEVM out of debug mode.

## Related issue

Resolve https://github.com/trezor/trezor-suite/issues/30781

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** suite-common/wallet-config/src/networksConfig.ts is a global dependency referenced by 133 tests, so broad coverage would be wasteful. The change most directly affects coin enablement, custom backend configuration, and multi-coin discovery. I recommend a focused set of tests covering settings/coins, blockbook backends, discovery, and a few network-activation flows. These will catch user-visible regressions like missing coins, failed discovery, or broken backend URLs without running the entire suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-config/src/networksConfig.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises enabling coins and configuring custom Blockbook backend URLs, which are defined in networksConfig.ts. A regression here would be immediately visible as broken discovery or backend errors.
- `suite/e2e/tests/settings/coins.test.ts` — The test covers enabling/disabling mainnet and testnet networks, toggling testnet visibility, and setting a custom ETH backend — all behaviors driven by the network configuration in networksConfig.ts.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes. It directly depends on the backend and coin definitions in networksConfig.ts.
- `suite/e2e/tests/wallet/discovery.test.ts` — The test activates eight different coins and verifies multi-coin discovery completes, including recovery after reload. Network availability and discovery behavior are governed by networksConfig.ts.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — This test uses the Activate Assets modal to enable ETH and verifies assets appear in dashboard views. It relies on network enablement flows configured in networksConfig.ts.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — The test enables multiple networks (BTC, ETH, POL, BSC, ARB) via the post-onboarding Activate Assets modal, which uses network configuration from networksConfig.ts.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds accounts across multiple coins (BTC, LTC, ETH, Base, ADA) and checks account type/path metadata. Changes to coin definitions in networksConfig.ts could affect supported account types and paths.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — The test enables the regtest network and verifies account discovery and balance display. Regtest/testnet network availability is configured in networksConfig.ts.

</details>

_Updated: 2026-08-03T15:40:41.451Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/hype-out-of-debug/web/](https://dev.suite.sldev.cz/suite-web/chore/hype-out-of-debug/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/hype-out-of-debug&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/hype-out-of-debug&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/hype-out-of-debug&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T15:43:21.176Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T15:43:06.954Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->