### PR TITLE
fix(suite): do not show insufficient funds banner when pending tx

### DIFF
--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
@@ -17,7 +17,7 @@ import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteForm = () => {
     const { account, form, actions, fees } = useTronStakeContext();
-    const { error } = actions;
+    const { error, pendingTxid } = actions;
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
@@ -50,7 +50,7 @@ export const TronVoteForm = () => {
 
                 <TronStakeFees />
 
-                {hasInsufficientFunds && (
+                {hasInsufficientFunds && pendingTxid === null && (
                     <Banner
                         intent="warning"
                         description={

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
@@ -15,7 +15,7 @@ import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteStep = () => {
     const { form, actions, account, fees } = useTronStakeContext();
-    const { error } = actions;
+    const { error, pendingTxid } = actions;
 
     const { isVotingDisabled, votingMessageContent } = useMessageSystemStaking(account.symbol);
 
@@ -32,7 +32,7 @@ export const TronVoteStep = () => {
 
                 <TronStakeFees />
 
-                {hasInsufficientFunds && (
+                {hasInsufficientFunds && pendingTxid === null && (
                     <Banner
                         intent="warning"
                         description={


### PR DESCRIPTION
## Description

Don't show insufficient funds banner when transaction is pending.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30705

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are isolated to Tron staking vote UI components (TronVoteForm and TronVoteStep). Static coverage reports 133 matches per file, but the identical lists of broadly unrelated tests (analytics, backup, browser checks) indicate these are treated as global/shared dependencies rather than meaningful coverage of Tron vote behavior. No analyzed E2E test specifically exercises Tron staking/voting; the only concrete link is check-links.test.ts, which loads /earn/tron/vote as a smoke test. Risk is moderate because the actual vote flow is uncovered—run check-links for a basic render/routing check, and consider adding a dedicated Tron vote E2E test.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx`

</details>

**Recommended tests (1)**

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to /earn/tron/vote as part of its exhaustive route coverage and verifies the page content attaches and links return HTTP 200. A render crash or broken routing in the changed Tron vote components could be caught, but it does not exercise vote submission or step logic.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx`
- `packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx`

_Updated: 2026-08-03T16:08:00.726Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-insufficient-funds-banner/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-insufficient-funds-banner/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-insufficient-funds-banner&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-insufficient-funds-banner&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-03T16:10:57.330Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Recovery - dry run > Recovery with device reconnection | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-03T16:10:24.404Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->