### PR TITLE
fix(suite-native): do not discover when compromised device

### DIFF
--- a/suite-native/discovery/src/discoveryMiddleware.ts
+++ b/suite-native/discovery/src/discoveryMiddleware.ts
@@ -16,6 +16,7 @@ import {
 import {
     createAndBackupWalletThunk,
     recoverWalletThunk,
+    selectCompromisedDeviceFailedCheck,
     selectIsDeviceFirmwareSupported,
 } from '@suite-native/device';
 import { isPassphraseDiscoveryFailure } from '@suite-native/passphrase';
@@ -41,10 +42,16 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // We need to wait until `authorizeDeviceThunk` action is fulfilled, because we need
         // to know the device state when starting discovery of newly authorized device.
         next(action);
+        const device = selectSelectedDevice(getState());
+        if (!device) return action;
 
         const isDeviceFirmwareVersionSupported = selectIsDeviceFirmwareSupported(getState());
         const isAnyNetworkEnabled = selectIsAnyNetworkEnabled(getState());
         const isBitcoinEnabled = selectIsBitcoinEnabled(getState());
+
+        // Discovery must be blocked while the compromised device warning is shown.
+        const failedCheck = selectCompromisedDeviceFailedCheck(getState(), device);
+        if (failedCheck !== null) return action;
 
         // Clear pending coins on discovery success, revert on passphrase failure
         if (discoveryActions.updateDiscovery.match(action)) {
@@ -68,8 +75,8 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         // ensure that BTC is enabled when device with BTC-only firmware is connected
         // (it could have been disabled via some other device with universal firmware)
         if (deviceActions.selectDevice.match(action)) {
-            const device = action.payload;
-            if (device?.connected && hasBitcoinOnlyFirmware(device)) {
+            const newDevice = action.payload;
+            if (newDevice?.connected && hasBitcoinOnlyFirmware(newDevice)) {
                 if (!isBitcoinEnabled) {
                     dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: true }));
                 }
@@ -85,16 +92,15 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
             action.type === DEVICE.CONNECT ||
             deviceActions.selectDevice.match(action) ||
             changeCoinVisibility.fulfilled.match(action) ||
+            deviceActions.dismissFirmwareAuthenticityCheck.match(action) || // may no longer be device compromised
             accountsActions.updateAccount.match(action) || // empty account can become nonempty
             accountsActions.changeAccountVisibility.match(action) ||
             createAndBackupWalletThunk.fulfilled.match(action) ||
             recoverWalletThunk.fulfilled.match(action)
         ) {
-            const device = selectSelectedDevice(getState());
             if (
                 isAnyNetworkEnabled &&
                 isDeviceFirmwareVersionSupported &&
-                device &&
                 device.connected &&
                 isDeviceAcquired(device)
             ) {


### PR DESCRIPTION
## Description

Analogically to #30747, block discovery during compromised device.

It's simpler than on Desktop because we are not allowing you to go to Settings with Device Compromised screen, you have to really disconnect the device.

- Entropy check, FW Authenticity Checks (revision, meta):
  - `deviceConnectionMiddleware` navigates to `DeviceCompromisedModalScreen` via `selectCompromisedDeviceFailedCheck` → must use the same selector in discovery
- Device Authenticity Check: already OK :heavy_check_mark:  Only relevant in onboarding, so Discovery runs after finishing it whole

Restart discovery when no longer device compromised **during the same session** – these scenarios can happen:
- Dismiss button – available only for FW Authenticity checks
- Disabling the checks in settings – N/A on mobile
- Message system – extremely improbable, see description [in desktop PR](https://github.com/trezor/trezor-suite/pull/30747)

## Notes for QA

Test with trezor-user-env with `2-main`, which always fails revision check.

In no flows should you land on Device compromised modal with discovery running. But I don't really know how to verify that, sorry :disappointed: 
I had to do local console logs to verify that during development.
Maybe it's enough to check that after dismissing the modal, discovery is visibly progressing from zero (i.e. not done already).

## Related Issue

Resolve #30765

## Screenshots:

### Before

<img width="800" alt="Image" src="https://github.com/user-attachments/assets/2f60322b-883b-4a04-a76a-a8237ac9f63d" />

### After

[after - dismiss on mobile.webm](https://github.com/user-attachments/assets/ab0f5a40-2f93-4926-a23f-dad349109b7c)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/no-discovery-when-device-compro-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->