### PR TITLE
fix(suite): forget device when switching firmware type

### DIFF
--- a/packages/connect-common/src/events/ui-request.ts
+++ b/packages/connect-common/src/events/ui-request.ts
@@ -26,6 +26,7 @@ export const UI_REQUEST = {
     FIRMWARE_NOT_INSTALLED: 'ui-device_firmware_not_installed',
     FIRMWARE_PROGRESS: 'ui-firmware-progress',
     FIRMWARE_PROGRESS_UNEXPECTED_DELAY: 'ui-firmware-progress-unexpected-delay',
+    FIRMWARE_TYPE_CHANGED: 'ui-firmware_type_changed',
 
     /** connect is waiting for device to be automatically reconnected */
     FIRMWARE_RECONNECT: 'ui-firmware_reconnect',
@@ -250,6 +251,13 @@ export interface FirmwareProgressUnexpectedDelay {
     payload: Record<string, never>;
 }
 
+export interface FirmwareTypeChanged {
+    type: typeof UI_REQUEST.FIRMWARE_TYPE_CHANGED;
+    payload: {
+        device: Device;
+    };
+}
+
 /**
  * Prompt user to reconnect device during firmware installation.
  */
@@ -291,6 +299,7 @@ export type UiEvent =
     | BundleProgress<any>
     | FirmwareProgress
     | FirmwareProgressUnexpectedDelay
+    | FirmwareTypeChanged
     | FirmwareException
     | FirmwareReconnect
     | FirmwareDisconnect

--- a/packages/connect/src/api/firmware/uploadFirmware.ts
+++ b/packages/connect/src/api/firmware/uploadFirmware.ts
@@ -34,6 +34,17 @@ const postProgressMessage = (
     );
 };
 
+const postFirmwareTypeChangedMessage = (
+    device: IDevice,
+    postMessage: (message: CoreEventMessage) => void,
+) => {
+    postMessage(
+        createUiMessage(UI_REQUEST.FIRMWARE_TYPE_CHANGED, {
+            device: device.toMessageObject(),
+        }),
+    );
+};
+
 const FIRMWARE_ERASE_TIMEOUT_MILLISECONDS = 15_000;
 const TIMEOUT_MIN_FW_VERSION = '1.12.1';
 const TIMEOUT_MAX_FW_VERSION = '1.13.0';
@@ -44,6 +55,7 @@ type UploadFirmwareProps = {
     device: IDevice;
     firmwareUploadRequest: PROTO.FirmwareUpload;
     updateFlowType: FirmwareUpdateFlowType;
+    firmwareTypeChanged?: boolean;
 };
 
 export const uploadFirmware = async ({
@@ -52,6 +64,7 @@ export const uploadFirmware = async ({
     device,
     firmwareUploadRequest: { payload },
     updateFlowType,
+    firmwareTypeChanged,
 }: UploadFirmwareProps) => {
     if (device.features.major_version === 1) {
         postConfirmationMessage(device, updateFlowType);
@@ -83,6 +96,10 @@ export const uploadFirmware = async ({
             clearInterval(progressTimer);
         });
 
+        if (firmwareTypeChanged) {
+            postFirmwareTypeChangedMessage(device, postMessage);
+        }
+
         postProgressMessage(device, 100, postMessage);
 
         return message;
@@ -101,6 +118,7 @@ export const uploadFirmware = async ({
                 progress,
             }),
         );
+
         while (response.type !== 'Success') {
             // NOTE: offset and message are present in T2
             const start = response.message.offset;
@@ -126,6 +144,10 @@ export const uploadFirmware = async ({
             }).finally(() => {
                 device.transport.removeAllListeners(TRANSPORT.SEND_MESSAGE_PROGRESS);
             });
+
+            if (start === 0 && firmwareTypeChanged) {
+                postFirmwareTypeChangedMessage(device, postMessage);
+            }
         }
         postProgressMessage(device, 100, postMessage);
 

--- a/packages/connect/src/core/onCallFirmwareUpdate.ts
+++ b/packages/connect/src/core/onCallFirmwareUpdate.ts
@@ -509,6 +509,7 @@ export const onCallFirmwareUpdate = async ({
     }
 
     const deviceInitiallyConnectedInBootloader = device.features.bootloader_mode;
+    const firmwareTypeChanged = device.firmwareType && device.firmwareType !== firmwareType;
 
     let reconnectedDevice: Device = device;
 
@@ -582,6 +583,7 @@ export const onCallFirmwareUpdate = async ({
         device: reconnectedDevice,
         firmwareUploadRequest: { payload },
         updateFlowType,
+        firmwareTypeChanged,
     });
 
     log.info('onCallFirmwareUpdate', 'firmware uploaded');
@@ -604,6 +606,7 @@ export const onCallFirmwareUpdate = async ({
             device: reconnectedDevice,
             firmwareUploadRequest: { payload: stripped },
             updateFlowType,
+            firmwareTypeChanged,
         });
     }
 

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -4,6 +4,8 @@ import { isRecoveryInProgress, recoveryActions, selectRecoveryStatus } from '@su
 import { routerAppChanged } from '@suite/router';
 import { deviceActions } from '@suite-common/device';
 import { firmwareActions } from '@suite-common/firmware';
+import { forgetDisconnectedDevices } from '@suite-common/wallet-core';
+import { UI_REQUEST } from '@trezor/connect';
 
 import * as onboardingActions from 'src/actions/onboarding/onboardingActions';
 import { type Action, type AppState, type Dispatch } from 'src/types/suite';
@@ -15,11 +17,9 @@ const onboardingMiddleware =
         const isFwInstallationDone =
             firmwareActions.setStatus.match(action) && action.payload === 'done';
 
-        if (
-            isFwInstallationDone &&
-            api.getState().onboarding.isActive &&
-            api.getState().firmware.status === 'thp-pairing'
-        ) {
+        const { firmware, onboarding } = api.getState();
+
+        if (isFwInstallationDone && onboarding.isActive && firmware.status === 'thp-pairing') {
             // After the THP pairing is finished we want to jump to the next step automatically.
             // User already drifted away from the installation flow and is not aware that THP is actually in the middle
             // of the Firmware installation.
@@ -28,6 +28,16 @@ const onboardingMiddleware =
         } else {
             // pass action
             next(action);
+        }
+
+        // seed is wiped when switching firmware type so we need to forget all device instances as well
+        if (action.type === UI_REQUEST.FIRMWARE_TYPE_CHANGED) {
+            api.dispatch(
+                forgetDisconnectedDevices({
+                    device: firmware.cachedDevice || action.payload.device,
+                    forceForget: true,
+                }),
+            );
         }
 
         if (action.type === routerAppChanged.type) {

--- a/suite/device/src/deviceThunks.ts
+++ b/suite/device/src/deviceThunks.ts
@@ -1,8 +1,7 @@
-import { selectRouterApp } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import type { TrezorDevice } from '@suite-common/suite-types';
-import { handleDeviceDisconnect, selectDeviceThunk } from '@suite-common/wallet-core';
+import { handleDeviceDisconnect } from '@suite-common/wallet-core';
 import type { Device } from '@trezor/connect';
 
 const DEVICE_MODULE_PREFIX = '@suite';
@@ -13,18 +12,6 @@ export const disconnectDeviceThunk = createThunk(
         const selectedDevice = selectSelectedDevice(getState());
         if (!selectedDevice) return;
         if (selectedDevice.path !== device.path) return;
-
-        const routerApp = selectRouterApp(getState());
-
-        /**
-         * Under normal circumstances, after device is disconnected we want suite to select another existing device (either remembered or physically connected)
-         * This is not the case in firmware update and onboarding; In this case we simply wan't suite.device to be empty until user reconnects a device again
-         */
-        if (['onboarding', 'firmware', 'firmware-type'].includes(routerApp)) {
-            dispatch(selectDeviceThunk({ device: undefined }));
-
-            return;
-        }
 
         dispatch(handleDeviceDisconnect(device));
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When switching FW type (from universal to BTC-only and vice-versa) you need to confirm that the seed will be wiped.
Wiping seed also wipes `device.id` so after successful installation **device-A becomes device-B**, however discovered and remembered device-A remains in the suite.

This has few side effects:
- suite sees 2 devices: device-A **disconnected and selected**, device-B **connected but not selected**
- device-A will never be accessible as there is no device-A anymore
- FW installation process hangs up in unexpected state as reconnected device-B is never "autoselected" and the process waits for the device (the selected one) which is `connected: false` forever 


## Additional changes

Removing misleading code and comment in `disconnectDeviceThunk`

- First of all this action is not called after device disconnection as the name imply but after `forgetDevice` action (see suiteMiddleware) - i will clean this up later in some followup PR 
- Secondly, `forgetDevice` was never explicitly called from the listed routes (until now) - as forgetDevice is mainly called manually (remember wallet is a default behavior, not initialized devices in onboarding are not remembered etc.)
- And lastly - setting `selectedDevice: undefined` leads to serious UI glitches and definitely didnt act as described in removed comment  

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** suiteMiddleware.ts is a global root middleware, so it appears in many static mappings. The highest-risk behaviors are app initialization, analytics consent, theme/locale autodetect, settings-change side-effects, and device/transport session handling. Running the targeted high-priority tests for analytics, onboarding consent, initial-run persistence, autodetect, general settings, bridge, multiple sessions, and safety-checks banner will catch the most likely regressions. The medium-priority tests extend coverage to wallet discovery and metadata lifecycle, which also rely on middleware-driven state transitions.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/middlewares/suite/suiteMiddleware.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies the SuiteReady, DeviceConnect, TransportType, and settings-change analytics events that are typically dispatched during suite initialization and after settings mutations handled by suiteMiddleware.
- `suite/e2e/tests/analytics/toggle.test.ts` — It exercises analytics enable/disable consent during onboarding and in settings, plus the analytics dispose/re-enable event flow that suiteMiddleware likely coordinates through SUITE/ANALYTICS actions.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The analytics consent dialog and the transition from onboarding to the dashboard depend on the initial-run and analytics state managed by suiteMiddleware.
- `suite/e2e/tests/settings/autodetect.test.ts` — Detecting and applying the browser's preferred color scheme and locale on first load is a middleware responsibility that directly affects the onboarding screen rendered in this test.
- `suite/e2e/tests/settings/general.test.ts` — Changing fiat, theme, language, and the analytics toggle triggers the corresponding analytics events and settings state transitions that suiteMiddleware processes.
- `suite/e2e/tests/suite/bridge.test.ts` — Navigating from the Bridge page and choosing WebUSB exercises the transport/bridge session handling that suiteMiddleware typically wires to device connection state.
- `suite/e2e/tests/suite/initial-run.test.ts` — This test specifically checks initial-run/onboarding persistence across reloads, which is one of the core responsibilities of suiteMiddleware.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Session stealing and reclaiming flows validate device/transport enumeration state transitions that suiteMiddleware likely handles when Bridge sessions change.
- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — The banner visibility and navigation to device settings on safety-checks changes depend on suite-level state and side-effects that suiteMiddleware coordinates.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejecting a wallet and discovering a standard wallet after onboarding exercises device/wallet state and discovery orchestration that flows through the suite middleware.
- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — Enabling/disabling labeling across wallet sessions, device resets, and reloads relies on metadata initialization and device state side-effects that suiteMiddleware can trigger on SUITE.READY.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — The post-onboarding dashboard state, asset activation modal, and discovery completion are driven by suite-level initialization logic handled by suiteMiddleware.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgetting devices and managing discovery state during the forget flow involves device state transitions and session handling that pass through the suite middleware.

</details>

_Updated: 2026-08-04T11:28:26.738Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/forget-device-when-switching-fw-type/web/](https://dev.suite.sldev.cz/suite-web/fix/forget-device-when-switching-fw-type/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/forget-device-when-switching-fw-type&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/forget-device-when-switching-fw-type&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/forget-device-when-switching-fw-type&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:30:29.516Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:30:09.122Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->