### PR TITLE
fix(trading): refresh compose address placeholder when the send account changes

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
@@ -1,0 +1,160 @@
+import { useForm } from 'react-hook-form';
+
+import { act, waitFor } from '@testing-library/react';
+
+import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { type TradingSellFormProps } from '@suite-common/trading';
+import { networks } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+
+import { getComposeAddressPlaceholder } from 'src/utils/wallet/trading/tradingUtils';
+
+import { useTradingComposeTransaction } from './useTradingComposeTransaction';
+
+const STALE_ADDRESS = 'stale-btc-placeholder';
+const BTC_PLACEHOLDER = 'btc-placeholder-address';
+const SOL_PLACEHOLDER = 'sol-placeholder-address';
+const EXTERNAL_ADDRESS = 'external-address-set-meanwhile';
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    useTranslation: () => ({ translationString: (id: string) => id }),
+}));
+
+jest.mock('src/hooks/wallet/form/useCompose', () => ({
+    useCompose: () => ({
+        isLoading: false,
+        composeRequest: jest.fn(),
+        composedLevels: undefined,
+        onFeeLevelChange: jest.fn(),
+        setComposedLevels: jest.fn(),
+    }),
+}));
+
+jest.mock('src/hooks/wallet/form/useFees', () => ({
+    useFees: () => ({ changeFeeLevel: jest.fn(), selectedFee: 'normal' }),
+}));
+
+jest.mock('src/utils/wallet/trading/tradingUtils', () => ({
+    ...jest.requireActual('src/utils/wallet/trading/tradingUtils'),
+    getComposeAddressPlaceholder: jest.fn(),
+}));
+
+const mockGetComposeAddressPlaceholder = getComposeAddressPlaceholder as jest.Mock;
+
+const BTC_ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
+const SOL_ACCOUNT = mockWalletAccount({ symbol: 'sol', formattedBalance: '0.4' });
+
+const feeData = (blockTime: number) => ({
+    blockHeight: 0,
+    blockTime,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: -1,
+    dustLimit: -1,
+    levels: [{ label: 'normal' as const, feePerUnit: '2', blocks: 2 }],
+});
+
+const buildDefaults = (): TradingSellFormProps =>
+    ({
+        outputs: [
+            {
+                type: 'payment',
+                address: STALE_ADDRESS,
+                amount: '',
+                fiat: '',
+                currency: { value: 'usd', label: 'USD' },
+                token: null,
+                label: '',
+            },
+        ],
+        amountInCrypto: true,
+        options: ['broadcast'],
+        feePerUnit: '',
+        feeLimit: '',
+        transactionData: '',
+        destinationTag: '',
+    }) as unknown as TradingSellFormProps;
+
+const renderComposeTransaction = () => {
+    const store = configureMockStore({
+        preloadedState: {
+            wallet: {
+                accounts: [BTC_ACCOUNT, SOL_ACCOUNT],
+                fees: {
+                    btc: { status: 'preloaded', data: feeData(600) },
+                    sol: { status: 'preloaded', data: feeData(-1) },
+                },
+                settings: { addressDisplayType: 'original' },
+            },
+            device: { devices: [], selectedDevice: undefined },
+        } as any,
+    });
+
+    return renderHookWithStoreProvider(
+        ({ account }: { account: Account }) => {
+            const methods = useForm<TradingSellFormProps>({
+                mode: 'onChange',
+                defaultValues: buildDefaults(),
+            });
+            const compose = useTradingComposeTransaction({
+                type: 'sell',
+                account,
+                network: networks[account.symbol],
+                methods,
+                setShowReserveBanner: jest.fn(),
+            });
+
+            return { methods, compose };
+        },
+        { store, initialProps: { account: BTC_ACCOUNT } },
+    );
+};
+
+describe('useTradingComposeTransaction', () => {
+    beforeEach(() => {
+        mockGetComposeAddressPlaceholder.mockImplementation((account: Account) =>
+            Promise.resolve(account.symbol === 'sol' ? SOL_PLACEHOLDER : BTC_PLACEHOLDER),
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('refreshes the compose address placeholder when the send account changes', async () => {
+        const { result, rerender } = renderComposeTransaction();
+
+        expect(result.current.methods.getValues('outputs.0.address')).toBe(STALE_ADDRESS);
+
+        rerender({ account: SOL_ACCOUNT });
+
+        await waitFor(() =>
+            expect(result.current.methods.getValues('outputs.0.address')).toBe(SOL_PLACEHOLDER),
+        );
+    });
+
+    it('keeps an address set while the placeholder request was in flight', async () => {
+        let resolvePlaceholder: (address: string) => void = () => {};
+        const pendingPlaceholder = new Promise<string>(resolve => {
+            resolvePlaceholder = resolve;
+        });
+        mockGetComposeAddressPlaceholder.mockReturnValueOnce(pendingPlaceholder);
+
+        const { result, rerender } = renderComposeTransaction();
+
+        rerender({ account: SOL_ACCOUNT });
+
+        act(() => {
+            result.current.methods.setValue('outputs.0.address', EXTERNAL_ADDRESS);
+        });
+
+        await act(async () => {
+            resolvePlaceholder(SOL_PLACEHOLDER);
+            await pendingPlaceholder;
+        });
+
+        expect(result.current.methods.getValues('outputs.0.address')).toBe(EXTERNAL_ADDRESS);
+    });
+});

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts
@@ -64,6 +64,7 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
     const initState = useMemo(() => ({ account, network, feeInfo }), [account, network, feeInfo]);
     const outputAddress = useWatch({ control, name: TRADING_FORM_OUTPUT_ADDRESS });
     const [state, setState] = useState<TradingUseComposeTransactionStateProps>(initState);
+    const replaceablePlaceholderRef = useRef<{ accountKey?: string; address?: string }>({});
 
     // Tron: derive a cold recipient for the offers fee estimate, passed via compose context.
     // Keyed on device?.state (not the device object) so signing doesn't re-fire the device call.
@@ -148,6 +149,20 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             return;
         }
 
+        const hasAccountChanged = !(
+            state.account?.descriptor === initState.account?.descriptor &&
+            state.account?.symbol === initState.account?.symbol
+        );
+
+        const accountKey =
+            initState.account && `${initState.account.symbol}:${initState.account.descriptor}`;
+        if (replaceablePlaceholderRef.current.accountKey !== accountKey) {
+            replaceablePlaceholderRef.current = {
+                accountKey,
+                address: getValues('outputs')?.[0]?.address,
+            };
+        }
+
         const setStateAsync = async () => {
             const address: string = await getComposeAddressPlaceholder(
                 account,
@@ -164,16 +179,16 @@ export const useTradingComposeTransaction = <T extends TradingSellExchangeFormPr
             const currentOutput = getValues('outputs')?.[0];
 
             if (currentOutput && typeof address === 'string') {
-                if (!currentOutput.address) {
+                const isReplaceable =
+                    currentOutput.address !== address &&
+                    (!currentOutput.address ||
+                        currentOutput.address === replaceablePlaceholderRef.current.address);
+                if (isReplaceable) {
                     setValue(TRADING_FORM_OUTPUT_ADDRESS, address);
                 }
                 setState(initState);
             }
         };
-        const hasAccountChanged = !(
-            state.account?.descriptor === initState.account?.descriptor &&
-            state.account?.symbol === initState.account?.symbol
-        );
 
         // update fee info only if the block height has increased.
         // note: This approach may not be ideal for Bitcoin, as fees can change within the same block


### PR DESCRIPTION
## Description

Switching the send asset in the sell/swap form kept the previous network's compose address placeholder in `outputs.0.address` — `useTradingComposeTransaction` only set it when empty. That stale address was fed to the new network's compose, which fails silently on Solana/Tron (invalid `toAddress`), so Max never filled the amount and no quotes loaded. Only SOL/TRX after an asset switch broke (ETH/XRP ignore the placeholder, default asset starts empty), and revisiting the form worked around it.

Fix: refresh the placeholder on account change, not just when empty. Done in the shared compose hook so it covers all account-change paths (picker, redirect, sync effect).

## Notes for QA
test against issue

## Related Issue

Resolve #30749

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/resolve-issue-30749/web/](https://dev.suite.sldev.cz/suite-web/resolve-issue-30749/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=resolve-issue-30749&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=resolve-issue-30749&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:53:27.025Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:53:35.032Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change touches a shared trading compose-transaction hook used across sell and swap flows. The highest risk is in fee calculation and composedTransactionInfo propagation, so prioritize the fee-specific swap tests and the Solana sell flow. A couple of broader swap flows provide regression coverage without over-testing the broad utility surface.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — The sell flow composes a send transaction to the provider and asserts fee calculation, provider quotes, and device prompt amounts. A change to useTradingComposeTransaction directly affects how the sell transaction is composed and how fees are computed before signing.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test explicitly asserts that Redux 'wallet.trading.composedTransactionInfo' is populated after selecting a swap offer and verifies custom BTC fee rates propagate to the device prompt. It is one of the most direct E2E validations of the compose-transaction hook's output.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This test explicitly asserts that 'wallet.trading.composedTransactionInfo' is populated and validates custom Ethereum gas parameters (gas limit, max fee, max priority fee) on the device prompt. Changes to transaction composition logic are highly likely to break this flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-coins.test.ts` — A full cross-chain SOL-to-BTC swap flow that depends on the compose hook to build the send transaction, display fees, and advance status. It shares the same compose infrastructure as the fee-specific tests and provides regression coverage for non-fee swap composition.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — A DEX swap path that composes an Ethereum transaction with slippage, minimum received, and gas limit adjustments. This exercises compose-transaction behavior for DEX-specific parameters that differ from standard CEX swaps.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx`

_Updated: 2026-08-04T21:51:35.247Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->