### PR TITLE
fix(ci): restore install step before EAS build:list check

### DIFF
--- a/.github/workflows/release-suite-native-develop.yml
+++ b/.github/workflows/release-suite-native-develop.yml
@@ -53,6 +53,9 @@ jobs:
         continue-on-error: true
         with:
           version: v0.19.1
+      - name: Install libs
+        run: |
+          yarn workspaces focus @suite-native/app
       - name: Check existing EAS builds for commit
         id: check-existing-builds
         env:
@@ -74,10 +77,6 @@ jobs:
             fi
           done
         working-directory: suite-native/app
-      - name: Install libs
-        if: steps.check-existing-builds.outputs.android-build-exists == 'false' || steps.check-existing-builds.outputs.ios-build-exists == 'false'
-        run: |
-          yarn workspaces focus @suite-native/app
       - name: Build on EAS Android
         if: steps.check-existing-builds.outputs.android-build-exists == 'false'
         run: eas build


### PR DESCRIPTION
## Description

`eas build:list` evaluates `app.config.ts` to resolve the EAS project ID. That file imports from `expo/config`, which is only available after `yarn workspaces focus @suite-native/app` runs.

This restores the install step to before the check, unconditionally — the original order from `503022e9`. The optimization was self-defeating: you need the install to run the check that decides whether to install.

## Notes for QA

CI-only change. No app code affected. The scheduled `[Release] suite-native develop` workflow should stop failing at the "Check existing EAS builds for commit" step.
