### PR TITLE
chore(scripts): move async-storage to foundation outdated-deps list

### DIFF
--- a/scripts/list-outdated-dependencies/connect-dependencies.txt
+++ b/scripts/list-outdated-dependencies/connect-dependencies.txt
@@ -9,7 +9,6 @@
 @headlessui/react
 @noble/post-quantum
 @reown/walletkit
-@react-native-async-storage/async-storage
 @scure/base
 @scure/bip39
 @sinclair/typebox

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -17,6 +17,7 @@
 @evolu/web
 @noble/curves
 @pmmmwh/react-refresh-webpack-plugin
+@react-native-async-storage/async-storage
 @sentry/browser
 @sentry/core
 @sentry/electron


### PR DESCRIPTION
## Description

`@react-native-async-storage/async-storage` was listed in `connect-dependencies.txt`, one of the domain lists used to check for outdated dependencies (`scripts/list-outdated-dependencies/`). It is, however, a suite-native (mobile) app dependency, not a `connect` one.

Moving it to `foundation-dependencies.txt` so the outdated-dependency check for it is owned by the right team/domain.

No runtime change — just a reorganization of the domain lists consumed by `list-outdated-dependencies.sh`.

## Related Issue

N/A

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/move-async-storage-foundation-deps/web/](https://dev.suite.sldev.cz/suite-web/mroz22/move-async-storage-foundation-deps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/move-async-storage-foundation-deps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/move-async-storage-foundation-deps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T06:29:15.445Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T06:28:52.244Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->