### PR TITLE
refactor(suite-common): move notification utils to suite-common

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -10,13 +10,13 @@ import {
 import { type Route, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
+import { isTransactionNotification } from '@suite-common/toast-notifications';
 import { Column } from '@trezor/components';
 import { BellIcon, GearSixIcon, HouseIcon, PiggyBankIcon, RepeatIcon } from '@trezor/icons';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { type AppState } from 'src/reducers/store';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
-import { isTransactionNotification } from 'src/utils/suite/notification';
 
 import { NavigationItem, type NavigationItemProps } from './NavigationItem';
 

--- a/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
+++ b/packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx
@@ -1,9 +1,9 @@
 import { Translation, type TranslationKey } from '@suite/intl';
+import { getSeenAndUnseenNotifications } from '@suite-common/toast-notifications';
 import { Column, H2, H4, IconCircle, Paragraph } from '@trezor/components';
 import { BellZIcon } from '@trezor/icons';
 
 import { type AppState } from 'src/types/suite';
-import { getSeenAndUnseenNotifications } from 'src/utils/suite/notification';
 
 import { NotificationList } from './NotificationList/NotificationList';
 

--- a/packages/suite/src/utils/suite/notification.ts
+++ b/packages/suite/src/utils/suite/notification.ts
@@ -1,5 +1,3 @@
-import { type TranslationKey } from '@suite/intl';
-import { type NotificationsState } from '@suite-common/toast-notifications';
 import { CheckIcon, InfoIcon, WarningIcon } from '@trezor/icons';
 
 import { type ToastNotificationVariant } from 'src/types/suite';
@@ -15,39 +13,4 @@ export const getNotificationIcon = (variant: ToastNotificationVariant) => {
             return CheckIcon;
         // no default
     }
-};
-
-// Filters notifications which should not be visible in the notifications popup.
-export const filterNonActivityNotifications = (
-    notifications: NotificationsState<TranslationKey>,
-): NotificationsState<TranslationKey> =>
-    notifications.filter(notification => notification.type !== 'coin-scheme-protocol');
-
-// transaction-related notifications (sent/received/confirmed, staking, yield, exchange, claims)
-export const isTransactionNotification = (
-    notification: NotificationsState<TranslationKey>[number],
-) =>
-    notification.type.startsWith('tx-') ||
-    notification.type === 'raw-tx-sent' ||
-    notification.type === 'successful-claim';
-
-export const getSeenAndUnseenNotifications = (
-    notifications: NotificationsState<TranslationKey>,
-): {
-    seenNotifications: NotificationsState<TranslationKey>;
-    unseenNotifications: NotificationsState<TranslationKey>;
-} => {
-    const seen: NotificationsState<TranslationKey> = [];
-    const unseen: NotificationsState<TranslationKey> = [];
-
-    // Splits notifications based on whether they were seen.
-    filterNonActivityNotifications(notifications).forEach(notification => {
-        if (notification.seen) {
-            seen.push(notification);
-        } else {
-            unseen.push(notification);
-        }
-    });
-
-    return { seenNotifications: seen, unseenNotifications: unseen };
 };

--- a/packages/suite/src/views/suite/notifications/index.tsx
+++ b/packages/suite/src/views/suite/notifications/index.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
 import { Card, CollapsibleBox, Column, Dot, Row } from '@trezor/components';
+import { isTransactionNotification } from '@suite-common/toast-notifications';
+import { Card, CollapsibleBox, Column, Dot, Row } from '@trezor/components';
 
 import {
     type NavigationItem,
@@ -13,7 +15,6 @@ import { NotificationGroup } from 'src/components/suite/notifications/Notificati
 import { ReleaseNotes } from 'src/components/suite/notifications/ReleaseNotes/ReleaseNotes';
 import { TriggerActivityNotification } from 'src/components/suite/notifications/TriggerActivityNotification/TriggerActivityNotification';
 import { useLayout, useSelector } from 'src/hooks/suite';
-import { isTransactionNotification } from 'src/utils/suite/notification';
 
 type ActivityTab = 'transactions' | 'release-notes' | 'all';
 

--- a/packages/suite/src/views/suite/notifications/index.tsx
+++ b/packages/suite/src/views/suite/notifications/index.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
-import { Card, CollapsibleBox, Column, Dot, Row } from '@trezor/components';
 import { isTransactionNotification } from '@suite-common/toast-notifications';
 import { Card, CollapsibleBox, Column, Dot, Row } from '@trezor/components';
 

--- a/suite-common/toast-notifications/src/index.ts
+++ b/suite-common/toast-notifications/src/index.ts
@@ -1,7 +1,6 @@
-// This package consists only of few types now. In future we will move rest of notifications related logic here
-// because we will need that in mobile as well.
 export * from './types';
 export * from './notificationsReducer';
 export * from './notificationsActions';
 export * from './notificationsThunks';
 export * from './notificationsSelectors';
+export * from './notificationsUtils';

--- a/suite-common/toast-notifications/src/notificationsThunks.ts
+++ b/suite-common/toast-notifications/src/notificationsThunks.ts
@@ -2,14 +2,15 @@ import { createThunk } from '@suite-common/redux-utils';
 
 import { ACTION_PREFIX, notificationsActions } from './notificationsActions';
 import { selectNotifications } from './notificationsSelectors';
+import { isTransactionNotification } from './notificationsUtils';
 import { type NotificationEntry } from './types';
 
+type TransactionEntry = NotificationEntry & { descriptor?: string; txid?: string };
+
 const findTransactionEvents = (descriptor: string, notifications: NotificationEntry[]) =>
-    notifications.filter(
-        n =>
-            (n.type === 'tx-sent' || n.type === 'tx-received' || n.type === 'tx-confirmed') &&
-            (n.descriptor === descriptor || n.txid === descriptor),
-    );
+    notifications
+        .filter((n): n is TransactionEntry => isTransactionNotification(n))
+        .filter(n => n.descriptor === descriptor || n.txid === descriptor);
 
 export const removeAccountEventsThunk = createThunk(
     `${ACTION_PREFIX}/removeAccountEventsThunk`,

--- a/suite-common/toast-notifications/src/notificationsUtils.ts
+++ b/suite-common/toast-notifications/src/notificationsUtils.ts
@@ -1,0 +1,31 @@
+import { type NotificationsState, type UnknownTranslationKey } from './types';
+
+export const filterNonActivityNotifications = <TKey extends string = UnknownTranslationKey>(
+    notifications: NotificationsState<TKey>,
+): NotificationsState<TKey> =>
+    notifications.filter(notification => notification.type !== 'coin-scheme-protocol');
+
+export const isTransactionNotification = (notification: NotificationsState[number]): boolean =>
+    notification.type.startsWith('tx-') ||
+    notification.type === 'raw-tx-sent' ||
+    notification.type === 'successful-claim';
+
+export const getSeenAndUnseenNotifications = <TKey extends string = UnknownTranslationKey>(
+    notifications: NotificationsState<TKey>,
+): {
+    seenNotifications: NotificationsState<TKey>;
+    unseenNotifications: NotificationsState<TKey>;
+} => {
+    const seen: NotificationsState<TKey> = [];
+    const unseen: NotificationsState<TKey> = [];
+
+    filterNonActivityNotifications(notifications).forEach(notification => {
+        if (notification.seen) {
+            seen.push(notification);
+        } else {
+            unseen.push(notification);
+        }
+    });
+
+    return { seenNotifications: seen, unseenNotifications: unseen };
+};


### PR DESCRIPTION
## Description

- Move `filterNonActivityNotifications`, `isTransactionNotification`, and `getSeenAndUnseenNotifications` from `packages/suite/src/utils/suite/notification.ts` into`suite-common/toast-notifications/src/notificationsUtils.ts`
- Export all three from the `@suite-common/toast-notifications` package index
- Update all callers in `packages/suite` to import from `@suite-common/toast-notifications`
- Fix `findTransactionEvents` in `notificationsThunks.ts` which only matched 3 of 10+ transaction types — `tx-staked`, `tx-unstaked`, `tx-exchange`, `tx-yield-*`, and `raw-tx-sent` notifications were left as orphans when an account was removed

## Notes for QA

- No visible behavior change on desktop — imports moved, logic unchanged
- test the desktop transaction notifications if it works as before

## Related Issue

  Resolve #30750

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch core notification/toast infrastructure and the notifications page/navigation, which are used pervasively. Rather than running the full 133-test static mapping, a small targeted set is recommended: four high-priority tests that assert specific toasts (backup failed, settings applied, feedback sent, tx sent) plus three medium-priority tests covering the /notifications route, guide feedback toast, and a banner notification. This combination gives high confidence that toast creation, grouping, rendering, and dismissal still work, while validating the notifications page renders correctly.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `packages/suite/src/components/suite/notifications/Notifications/NotificationGroup/NotificationGroup.tsx`
- `packages/suite/src/utils/suite/notification.ts`
- `packages/suite/src/views/suite/notifications/index.tsx`
- `suite-common/toast-notifications/src/index.ts`
- `suite-common/toast-notifications/src/notificationsThunks.ts`
- `suite-common/toast-notifications/src/notificationsUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test directly asserts the '@toast/backup-failed' toast notification after a failed backup, so it exercises the toast creation, grouping, and dismissal logic in the changed notification files end-to-end.
- `suite/e2e/tests/settings/passphrase.test.ts` — It verifies the '@toast/settings-applied' toast appears and auto-dismisses after toggling passphrase protection, covering toast lifecycle and rendering from the changed notification infrastructure.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — The test waits for '@toast/user-feedback-send-success' after submitting a bug report, directly validating that the notification system successfully displays a success toast.
- `suite/e2e/tests/wallet/send-base.test.ts` — It asserts '@toast/tx-sent' appears after broadcasting a Base transaction, so it exercises the toast path triggered by transaction completion.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This route-coverage test navigates to /notifications, which is rendered by the changed notifications/index.tsx view, providing a sanity check that the notifications page still loads and its links are valid. (Inferred, not statically mapped to that file.)
- `suite/e2e/tests/general/suite-guide.test.ts` — It verifies the guide-panel feedback success toast (TR_GUIDE_FEEDBACK_SENT), which shares the same toast rendering and notification state as the changed files.
- `suite/e2e/tests/suite/safety-checks-warning.test.ts` — It checks the safety-checks warning banner visibility and dismissal; banner notifications are likely composed via the changed NotificationGroup and notification utilities.

</details>

_Updated: 2026-08-04T06:43:11.503Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite-common/extract-notification-utils-to-toast-notifications/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite-common/extract-notification-utils-to-toast-notifications/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite-common/extract-notification-utils-to-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite-common/extract-notification-utils-to-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/suite-common/extract-notification-utils-to-toast-notifications&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T06:45:23.328Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T06:44:39.455Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->