### PR TITLE
chore(deps): migrate usb to v3 (node-usb-rs)

### DIFF
--- a/packages/suite-desktop/package.json
+++ b/packages/suite-desktop/package.json
@@ -29,7 +29,7 @@
     },
     "dependencies": {
         "openpgp": "^6.3.1",
-        "usb": "^2.17.0"
+        "usb": "^3.0.1"
     },
     "devDependencies": {
         "electron": "42.5.0",

--- a/packages/transport-bridge/package.json
+++ b/packages/transport-bridge/package.json
@@ -43,6 +43,6 @@
         "react-dom": "19.2.3",
         "react-intl": "^8.1.3",
         "styled-components": "^6.3.9",
-        "usb": "^2.17.0"
+        "usb": "^3.0.1"
     }
 }

--- a/packages/transport-bridge/src/core.ts
+++ b/packages/transport-bridge/src/core.ts
@@ -1,4 +1,4 @@
-import { WebUSB, usb } from 'usb';
+import { WebUSB } from 'usb';
 
 import {
     type TransportProtocol,
@@ -20,6 +20,7 @@ import {
     SessionsBackground,
     SessionsClient,
     UsbApi,
+    type UsbInterfaceApi,
     callThpMessage,
     createChunks,
     createProtocolMessage,
@@ -39,10 +40,9 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
     const sessionsBackground = new SessionsBackground();
     const sessionsClient = new SessionsClient(sessionsBackground);
 
-    if (apiArg === 'usb' && logger?.enabled) {
-        // https://libusb.sourceforge.io/api-1.0/group__libusb__lib.html#ga2d6144203f0fc6d373677f6e2e89d2d2
-        usb.setDebugLevel(1); // Level 3 would probably be ok as well (doesn't seem too spammy). For full debugging use 4.
-    }
+    // Note: the `usb` package v3 (node-usb-rs, a Rust rewrite) no longer exposes the
+    // legacy libusb `setDebugLevel` control. Its native logging is configured via the
+    // `RUST_LOG` environment variable instead, so there is nothing to toggle here.
 
     if (typeof apiArg === 'string') {
         api =
@@ -50,9 +50,13 @@ export const createCore = (apiArg: 'usb' | 'udp' | AbstractApi, logger?: Log) =>
                 ? new UdpApi({ logger })
                 : new UsbApi({
                       logger,
+                      // `usb` v3 (node-usb-rs) attaches `transferIn`/`transferOut` to the
+                      // device prototype at runtime but hides them from the published
+                      // `.d.ts`; WebUSB still satisfies `UsbInterfaceApi` structurally, so
+                      // cast to keep `@trezor/transport-common` free of DOM USB types.
                       usbInterface: new WebUSB({
                           allowAllDevices: true, // return all devices, not only authorized
-                      }),
+                      }) as unknown as UsbInterfaceApi,
 
                       // todo: possibly only for windows
                       forceReadSerialOnConnect: true,

--- a/packages/transport-common/src/api/usb.ts
+++ b/packages/transport-common/src/api/usb.ts
@@ -333,6 +333,17 @@ export class UsbApi extends AbstractApi {
             this.logger?.debug(`usb: device.open done. device: ${this.formatDeviceForLog(device)}`);
         } catch (err) {
             this.logger?.error(`usb: device.open error ${err}`);
+            // TODO(usb-v3): the `usb` v3 rewrite (node-usb-rs / nusb) no longer throws
+            // libusb-style messages, so this `LIBUSB_ERROR_ACCESS` match (used on Linux to
+            // surface the "missing udev rules" hint) will not fire on v3. Capture the real
+            // error shape from a device, then replace the string below with the v3 equivalent.
+            // The console.log is temporary migration instrumentation — remove before merge.
+            // eslint-disable-next-line no-console
+            console.log('[usb-v3-migration] device.open error:', {
+                name: err.name,
+                message: err.message,
+                ctor: err?.constructor?.name,
+            });
             if (err.message.includes('LIBUSB_ERROR_ACCESS')) {
                 return error({ code: ERRORS.LIBUSB_ERROR_ACCESS });
             }
@@ -577,9 +588,22 @@ export class UsbApi extends AbstractApi {
     }
     // https://github.com/trezor/trezord-go/blob/db03d99230f5b609a354e3586f1dfc0ad6da16f7/usb/libusb.go#L545
     private handleReadWriteError(err: Error) {
+        // TODO(usb-v3): the `LIBUSB_*` entries below match messages from the v2 libusb
+        // bindings. usb v3 (node-usb-rs / nusb) emits different, Rust-side error strings,
+        // so a mid-transfer disconnect on v3 may fall through to `unknownError` instead of
+        // `DEVICE_DISCONNECTED_DURING_ACTION`. The WebUSB-spec branch
+        // ("The device was disconnected.") should still catch spec-compliant disconnects,
+        // but confirm against a device and add the v3 read/write error strings here.
+        // The console.log is temporary migration instrumentation — remove before merge.
+        // eslint-disable-next-line no-console
+        console.log('[usb-v3-migration] read/write error:', {
+            name: err.name,
+            message: err.message,
+            ctor: err?.constructor?.name,
+        });
         if (
             [
-                // node usb
+                // node usb (v2 libusb bindings — see TODO above re: v3)
                 'LIBUSB_TRANSFER_ERROR',
                 'LIBUSB_ERROR_PIPE',
                 'LIBUSB_ERROR_IO',

--- a/packages/transport-test/e2e/api/api.test.ts
+++ b/packages/transport-test/e2e/api/api.test.ts
@@ -21,7 +21,12 @@ const setupApisUnderTest = async () => {
         // type so `transport-common` consumers stay free of DOM lib refs.
         usbInterface = (window.navigator as unknown as { usb: UsbInterfaceApi }).usb;
     } else {
-        usbInterface = await import('usb').then(lib => new lib.WebUSB({ allowAllDevices: true }));
+        // `usb` v3 (node-usb-rs) hides `transferIn`/`transferOut` from its `.d.ts`
+        // (they are attached to the device prototype at runtime), so WebUSB no longer
+        // matches `UsbInterfaceApi` nominally; cast to keep transport-common DOM-free.
+        usbInterface = await import('usb').then(
+            lib => new lib.WebUSB({ allowAllDevices: true }) as unknown as UsbInterfaceApi,
+        );
     }
 
     type ApiTestFixture = {

--- a/packages/transport-test/package.json
+++ b/packages/transport-test/package.json
@@ -30,7 +30,7 @@
         "jest-extended": "^4.0.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
-        "usb": "^2.17.0"
+        "usb": "^3.0.1"
     },
     "dependencies": {
         "@trezor/transport-common": "workspace:*"

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -50,7 +50,7 @@
         "@trezor/transport-common": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",
-        "usb": "^2.17.0"
+        "usb": "^3.0.1"
     },
     "peerDependencies": {
         "tslib": "^2.6.2"

--- a/packages/transport/src/transports/nodeusb.ts
+++ b/packages/transport/src/transports/nodeusb.ts
@@ -4,6 +4,7 @@ import {
     AbstractApiTransport,
     type AbstractTransportParams,
     UsbApi,
+    type UsbInterfaceApi,
 } from '@trezor/transport-common';
 
 // notes:
@@ -18,9 +19,14 @@ export class NodeUsbTransport extends AbstractApiTransport {
 
         super({
             api: new UsbApi({
+                // `usb` v3 (node-usb-rs) attaches `transferIn`/`transferOut` to the device
+                // prototype at runtime, but marks them "hidden" so they are absent from the
+                // published `.d.ts` unless the DOM `USBDevice` lib is loaded. WebUSB still
+                // satisfies `UsbInterfaceApi` structurally at runtime, so cast to keep the
+                // DOM-free typing of `@trezor/transport-common`.
                 usbInterface: new WebUSB({
                     allowAllDevices: true, // return all devices, not only authorized
-                }),
+                }) as unknown as UsbInterfaceApi,
                 logger,
                 debugLink,
             }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5889,6 +5889,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@node-usb/usb-darwin-arm64@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-darwin-arm64@npm:3.0.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-darwin-x64@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-darwin-x64@npm:3.0.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-linux-arm-gnueabihf@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-linux-arm-gnueabihf@npm:3.0.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-linux-arm64-gnu@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-linux-arm64-gnu@npm:3.0.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-linux-arm64-musl@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-linux-arm64-musl@npm:3.0.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-linux-x64-gnu@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-linux-x64-gnu@npm:3.0.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-linux-x64-musl@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-linux-x64-musl@npm:3.0.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-win32-arm64-msvc@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-win32-arm64-msvc@npm:3.0.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-win32-ia32-msvc@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-win32-ia32-msvc@npm:3.0.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@node-usb/usb-win32-x64-msvc@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@node-usb/usb-win32-x64-msvc@npm:3.0.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -17138,7 +17208,7 @@ __metadata:
     electron: "npm:42.5.0"
     electron-builder: "npm:26.15.3"
     openpgp: "npm:^6.3.1"
-    usb: "npm:^2.17.0"
+    usb: "npm:^3.0.1"
   languageName: unknown
   linkType: soft
 
@@ -17492,7 +17562,7 @@ __metadata:
     react-intl: "npm:^8.1.3"
     rimraf: "npm:^6.1.2"
     styled-components: "npm:^6.3.9"
-    usb: "npm:^2.17.0"
+    usb: "npm:^3.0.1"
     webpack: "npm:5.108.1"
     webpack-cli: "npm:^7.0.3"
   languageName: unknown
@@ -17553,7 +17623,7 @@ __metadata:
     jest-extended: "npm:^4.0.2"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
-    usb: "npm:^2.17.0"
+    usb: "npm:^3.0.1"
   languageName: unknown
   linkType: soft
 
@@ -17580,7 +17650,7 @@ __metadata:
     "@types/bytebuffer": "npm:^5.0.49"
     "@types/node": "npm:22.13.10"
     jest: "npm:29.7.0"
-    usb: "npm:^2.17.0"
+    usb: "npm:^3.0.1"
   peerDependencies:
     tslib: ^2.6.2
   languageName: unknown
@@ -18714,7 +18784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/w3c-web-usb@npm:^1.0.14, @types/w3c-web-usb@npm:^1.0.6":
+"@types/w3c-web-usb@npm:^1.0.14":
   version: 1.0.14
   resolution: "@types/w3c-web-usb@npm:1.0.14"
   checksum: 10/53f04db6969fd859a3f7cf62b699060e97f39f6da30fe292c9c5e74ed3f3a8acf50c7574dcadfc1a1a6860558905e78f0de11eaf26b1905edf822e44c6dfef26
@@ -37355,17 +37425,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.5.0":
-  version: 4.8.4
-  resolution: "node-gyp-build@npm:4.8.4"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10/6a7d62289d1afc419fc8fc9bd00aa4e554369e50ca0acbc215cb91446148b75ff7e2a3b53c2c5b2c09a39d416d69f3d3237937860373104b5fe429bf30ad9ac5
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:12.2.0":
   version: 12.2.0
   resolution: "node-gyp@npm:12.2.0"
@@ -46175,15 +46234,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"usb@npm:^2.17.0":
-  version: 2.17.0
-  resolution: "usb@npm:2.17.0"
+"usb@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "usb@npm:3.0.1"
   dependencies:
-    "@types/w3c-web-usb": "npm:^1.0.6"
-    node-addon-api: "npm:^8.0.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.5.0"
-  checksum: 10/464585012a384fc0a199d0401e1f4966256afb807c1dd09b0f30b829f46516a9529cf0724961193cf4f13f2e9622f349544503e7e830340c8234eb67524a7e21
+    "@node-usb/usb-darwin-arm64": "npm:3.0.1"
+    "@node-usb/usb-darwin-x64": "npm:3.0.1"
+    "@node-usb/usb-linux-arm-gnueabihf": "npm:3.0.1"
+    "@node-usb/usb-linux-arm64-gnu": "npm:3.0.1"
+    "@node-usb/usb-linux-arm64-musl": "npm:3.0.1"
+    "@node-usb/usb-linux-x64-gnu": "npm:3.0.1"
+    "@node-usb/usb-linux-x64-musl": "npm:3.0.1"
+    "@node-usb/usb-win32-arm64-msvc": "npm:3.0.1"
+    "@node-usb/usb-win32-ia32-msvc": "npm:3.0.1"
+    "@node-usb/usb-win32-x64-msvc": "npm:3.0.1"
+    "@types/w3c-web-usb": "npm:^1.0.14"
+  dependenciesMeta:
+    "@node-usb/usb-darwin-arm64":
+      optional: true
+    "@node-usb/usb-darwin-x64":
+      optional: true
+    "@node-usb/usb-linux-arm-gnueabihf":
+      optional: true
+    "@node-usb/usb-linux-arm64-gnu":
+      optional: true
+    "@node-usb/usb-linux-arm64-musl":
+      optional: true
+    "@node-usb/usb-linux-x64-gnu":
+      optional: true
+    "@node-usb/usb-linux-x64-musl":
+      optional: true
+    "@node-usb/usb-win32-arm64-msvc":
+      optional: true
+    "@node-usb/usb-win32-ia32-msvc":
+      optional: true
+    "@node-usb/usb-win32-x64-msvc":
+      optional: true
+  checksum: 10/a562ca95184398a333d25299a17f84a757fc901e7c23ff29784f18b754035cde767a73a008664b187d84b43143a206316eb274c207b7b2f442bc009e79ab866e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Migrates the `usb` dependency from `^2.17.0` to **`^3.0.1`** (npm `latest`) across all packages that use it:

- `@trezor/transport`
- `@trezor/transport-bridge`
- `@trezor/transport-test`
- `@trezor/suite-desktop`

`usb` v3 is a **ground-up Rust rewrite** ([`node-usb/node-usb-rs`](https://github.com/node-usb/node-usb-rs)) that implements the **WebUSB spec only** and is **not a drop-in replacement** for the v2 libusb bindings, so it needs code changes.

### Code changes

- **`transport-bridge/core.ts`** — dropped the legacy `usb.setDebugLevel(1)` call; v3 no longer exposes it (native logging is configured via the `RUST_LOG` env var).
- **`transport/nodeusb.ts`, `transport-bridge/core.ts`, `transport-test` api e2e** — cast `new WebUSB(...)` to `UsbInterfaceApi`. v3 attaches `transferIn`/`transferOut` to the device prototype **at runtime** but hides them from its published `.d.ts` (they resolve only with the DOM `USBDevice` lib), so WebUSB no longer matches the structural interface nominally. The cast keeps `@trezor/transport-common` free of DOM USB types.

### Native binaries

v3 ships prebuilt **napi-rs platform packages** (`@node-usb/usb-*`) via `optionalDependencies` for all 10 targets (win/mac/linux × x64/arm64/…), replacing the v2 node-gyp / prebuild-install flow. All are pinned in `yarn.lock`.

### Verification

- ✅ `type-check` — transport, transport-bridge, transport-common, transport-test, suite-desktop
- ✅ `test:unit` — transport-common (269) + transport-bridge (19)
- ✅ `lint:js` — transport, transport-bridge, transport-test

### ⚠️ Needs hardware verification

v3 (nusb) does **not** emit `LIBUSB_ERROR_*` messages, so the string-matched error classification in `transport-common/api/usb.ts` (`LIBUSB_ERROR_ACCESS` → Linux udev hint; retryable transfer errors) will no longer match on v3. Behaviour degrades gracefully (generic error / the WebUSB-spec `"The device was disconnected."` branch still applies), but the exact nusb error strings should be checked against a real Trezor before merge. USB is not exercised by the emulator-based e2e suite (that path is UDP), so this needs a device.

## Related Issue

N/A

## Screenshots

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set focuses on low-level transport/bridge infrastructure (node USB transport, bridge core, and package dependencies). The highest regression risk is in bridge lifecycle, session management, and device connection state propagation. The recommended tests target the bridge spawning and session-handling suites first, plus a small set of device-disconnect scenarios that exercise the same transport surface indirectly.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite-desktop/package.json`
- `packages/transport-bridge/package.json`
- `packages/transport-bridge/src/core.ts`
- `packages/transport-common/src/api/usb.ts`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport-test/package.json`
- `packages/transport/package.json`
- `packages/transport/src/transports/nodeusb.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Directly exercises the node-bridge daemon spawning logic and bridge lifecycle (start/stop) that is implemented in the changed transport-bridge core and nodeusb transport packages. A regression here would mean the desktop app cannot start or stop the bridge correctly.
- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Validates that the bundled bridge process spawns on app startup, survives renderer reload, returns a version, and reconnects after an external bridge restart. This directly covers the bridge core and transport package changes.
- `suite/e2e/tests/suite/bridge.test.ts` — Tests the /bridge page flow and the WebUSB transport option. Since packages/transport-common/src/api/usb.ts is part of the WebUSB API implementation, changes there could affect whether the connect-device prompt appears after exiting the bridge page.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly exercises BridgeTransport session enumerate/acquire behavior, session stealing, and reclaiming across tabs and reloads. This is precisely the transport/bridge session management surface touched by the changes.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — Simulates device disconnect and reconnect by stopping and starting the bridge mid-recovery-dry-run. Changes to bridge core or USB transport could alter how the app reinitializes the dry run after bridge restart.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Uses trezorUserEnv stopBridge/startBridge to simulate device disconnection and reconnection during a T2T1 recovery dry run. Transport-bridge and USB API changes could affect the reinitialization behavior observed after reconnect.
- `suite/e2e/tests/wallet/without-device.test.ts` — Covers device disconnection status, connection modal behavior when sending while disconnected, and the disconnected-device banner in settings. These flows depend on the transport layer reporting device state correctly.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/suite-desktop/package.json`
- `packages/transport-bridge/package.json`
- `packages/transport-test/e2e/api/api.test.ts`
- `packages/transport-test/package.json`
- `packages/transport/package.json`

_Updated: 2026-08-04T08:59:06.893Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/update-usb-latest/web/](https://dev.suite.sldev.cz/suite-web/mroz22/update-usb-latest/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/update-usb-latest&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/update-usb-latest&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:59:39.041Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:59:20.093Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->