### PR TITLE
test(suite): narrow db-migration tests to not be run on canary test runs

### DIFF
--- a/suite/e2e/tests/suite/db-locale-migration.test.ts
+++ b/suite/e2e/tests/suite/db-locale-migration.test.ts
@@ -12,9 +12,9 @@ const suiteDevInstance = 'https://dev.suite.sldev.cz/suite-web';
 test.describe(
     'Database migration',
     // This test is run only on web nightly builds, it works with web instances of 25.7 and develop branch
-    // On PR and release CI run it would provide no value and potentially false failures
+    // On PR and release CI run it would provide no value and potentially false failures, same goes for canary firmware runs
     // Note: Trezor user env doesn't support legacy bridge versions on macOs, which is needed to connect the device to the old Suite version. Use linux or only run in CI.
-    { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] },
+    { tag: ['@webOnly', '@nightlyOnly', '@T3T1', '@specificFirmware'] },
     () => {
         test.use({
             deviceSetup: { passphrase_protection: true, mnemonic: 'mnemonic_all' },

--- a/suite/e2e/tests/suite/db-migration.test.ts
+++ b/suite/e2e/tests/suite/db-migration.test.ts
@@ -11,10 +11,10 @@ const suiteDevInstance = 'https://dev.suite.sldev.cz/suite-web';
 test.describe(
     'Database migration',
     // This test is run only on web nightly builds, it works with web instances of 25.10 and develop branch
-    // On PR and release CI run it would provide no value and potentially false failures
+    // On PR and release CI run it would provide no value and potentially false failures, same goes for canary firmware runs
     // Note: Trezor user env doesn't support legacy bridge versions on macOs, which is needed to connect the device to the old Suite version. Use linux or only run in CI.
     // Additionally, 25.10 does not support T3W1 yet
-    { tag: ['@webOnly', '@nightlyOnly', '@T3T1'] },
+    { tag: ['@webOnly', '@nightlyOnly', '@T3T1', '@specificFirmware'] },
     () => {
         test.use({
             deviceSetup: { passphrase_protection: true, mnemonic: 'mnemonic_all' },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

narrow db-migration tests to not be run on canary test runs. They have no value on canary runs and cause only environment / config failures

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-db-migration-not-on-canary/web/](https://dev.suite.sldev.cz/suite-web/test-db-migration-not-on-canary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-db-migration-not-on-canary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-db-migration-not-on-canary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T07:30:05.979Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T07:30:02.676Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->