### PR TITLE
Chore/random fixes

### DIFF
--- a/packages/suite-desktop-core/src/modules/tray.ts
+++ b/packages/suite-desktop-core/src/modules/tray.ts
@@ -125,7 +125,7 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
         renderTray();
     });
     mainThreadEmitter.on('module/bridge/status', (status: Status) => {
-        logger.debug(SERVICE_NAME, 'Bridge status ' + status);
+        logger.debug(SERVICE_NAME, 'Bridge status ' + JSON.stringify(status));
         state.bridgeStatus = status.process;
         renderTray();
     });

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.test.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.test.ts
@@ -74,6 +74,7 @@ describe('onboardingMiddleware', () => {
             const result = store.getActions();
             expect(result).toEqual([
                 { type: routerAppChanged.type, payload: 'onboarding' },
+                { type: 'recovery/resetReducer', payload: undefined },
                 { type: '@onboarding/enable-onboarding-reducer', payload: true },
             ]);
         });

--- a/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
+++ b/packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts
@@ -16,6 +16,13 @@ const onboardingMiddleware =
             firmwareActions.setStatus.match(action) && action.payload === 'done';
 
         if (
+            action.type === routerAppChanged.type &&
+            (action.payload === 'recovery' || action.payload === 'onboarding')
+        ) {
+            api.dispatch(recoveryActions.resetReducer());
+        }
+
+        if (
             isFwInstallationDone &&
             api.getState().onboarding.isActive &&
             api.getState().firmware.status === 'thp-pairing'

--- a/packages/suite/src/middlewares/suite/suiteMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/suiteMiddleware.ts
@@ -2,8 +2,7 @@ import { isAnyOf } from '@reduxjs/toolkit';
 
 import { disconnectDeviceThunk } from '@suite/device';
 import { METADATA } from '@suite/metadata';
-import { recoveryActions } from '@suite/recovery';
-import { goto, routerAppChanged } from '@suite/router';
+import { goto } from '@suite/router';
 import { deviceActions, isTrezorDeviceWithState } from '@suite-common/device';
 import { type AnyAction, createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { isAnyDeviceEventAction } from '@suite-common/suite-utils';
@@ -47,13 +46,6 @@ const isActionDeviceRelated = (action: AnyAction): boolean => {
 
 export const prepareSuiteMiddleware = createMiddlewareWithExtraDeps(
     (action, { dispatch, next, getState, extra }) => {
-        if (
-            action.type === routerAppChanged.type &&
-            (action.payload === 'recovery' || action.payload === 'onboarding')
-        ) {
-            dispatch(recoveryActions.resetReducer());
-        }
-
         // this action needs to be processed before propagation to deviceReducer
         // otherwise device will not be accessible and related data will not be removed (accounts, txs...)
         if (action.type === DEVICE.DISCONNECT) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some minor things i've found while dismantling the tractor

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/random-fixes/web/](https://dev.suite.sldev.cz/suite-web/chore/random-fixes/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/random-fixes&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/random-fixes&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:33:28.579Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:32:49.284Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set centers on broad, global middleware (onboarding and suite middleware) plus a desktop tray module. Because the two middleware files statically map to 133 tests each, the broad-utility heuristic applies: only a small, targeted subset of onboarding and initial-run tests are recommended. These capture the highest-risk state transitions (analytics consent, initial-run persistence, post-onboarding dashboard behavior) without running the full suite. The desktop tray module has no inferred E2E coverage in the provided candidate list.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite-desktop-core/src/modules/tray.ts`
- `packages/suite/src/middlewares/onboarding/onboardingMiddleware.test.ts`
- `packages/suite/src/middlewares/onboarding/onboardingMiddleware.ts`
- `packages/suite/src/middlewares/suite/suiteMiddleware.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Directly exercises the analytics consent dialog and onboarding completion flow that onboardingMiddleware.ts orchestrates. A regression in onboarding middleware state transitions would be immediately visible here.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests the persistence of onboarding/initial-run state across page reloads, which is a core responsibility of the onboarding and suite middleware. This is the most focused E2E test for middleware-driven initial run behavior.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Covers the end-to-end flow from completing onboarding through device switching to wallet discovery, exercising suite-level state transitions that suiteMiddleware.ts may influence.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Validates post-onboarding dashboard state and asset activation, which depends on onboarding middleware correctly completing the initial run.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Exercises the full onboarding flow plus offline banner and discovery failure handling, which touches suite-level lifecycle/online-offline middleware behavior in suiteMiddleware.ts.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite-desktop-core/src/modules/tray.ts`
- `packages/suite/src/middlewares/onboarding/onboardingMiddleware.test.ts`

_Updated: 2026-08-04T08:32:37.698Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->