### PR TITLE
fix(suite-desktop): display total available for wrap amount excluding min fees

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
@@ -63,7 +63,7 @@ const usdcVault = createMockVault('ethereum-usdc-vault', {
 
 describe(getYieldOpportunityData.name, () => {
     describe('wrapped-native (WETH) vault', () => {
-        it('combines the token balance with the native balance minus the gas reserve', () => {
+        it('combines the token balance with the full native balance', () => {
             const account = mockWalletAccount({
                 symbol: 'eth',
                 formattedBalance: '1',
@@ -83,7 +83,7 @@ describe(getYieldOpportunityData.name, () => {
                 vault: wethVault,
             });
 
-            expect(data.additionalDepositAmount).toBe('1.495');
+            expect(data.additionalDepositAmount).toBe('1.5');
         });
 
         it('counts a native-only account (no WETH token) as depositable', () => {
@@ -96,11 +96,11 @@ describe(getYieldOpportunityData.name, () => {
             });
 
             expect(data.matchedInputToken).toBeUndefined();
-            expect(data.additionalDepositAmount).toBe('0.995');
+            expect(data.additionalDepositAmount).toBe('1');
             expect(data.hasRewardsData).toBe(true);
         });
 
-        it('does not count a native balance below the gas reserve', () => {
+        it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {
             const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
 
             const data = getYieldOpportunityData({
@@ -109,8 +109,8 @@ describe(getYieldOpportunityData.name, () => {
                 vault: wethVault,
             });
 
-            expect(data.additionalDepositAmount).toBe('0');
-            expect(data.hasRewardsData).toBe(false);
+            expect(data.additionalDepositAmount).toBe('0.003');
+            expect(data.hasRewardsData).toBe(true);
         });
 
         it('denominates amounts in the native symbol without a token contract', () => {
@@ -180,11 +180,11 @@ describe(getYieldOpportunityData.name, () => {
 });
 
 describe(useYieldTableData.name, () => {
-    it('classifies a native-only account as depositable, ahead of below-reserve accounts', () => {
-        const belowReserveAccount = mockWalletAccount({
+    it('classifies a native-only account as depositable, ahead of empty accounts', () => {
+        const emptyAccount = mockWalletAccount({
             symbol: 'eth',
             descriptor: asAccountDescriptor('0xbe1030e5e50e5e0'),
-            formattedBalance: '0.001',
+            formattedBalance: '0',
         });
         const nativeOnlyAccount = mockWalletAccount({
             symbol: 'eth',
@@ -195,7 +195,7 @@ describe(useYieldTableData.name, () => {
         const { result } = renderHook(() =>
             useYieldTableData({
                 availableVaults: [wethVault],
-                visibleAccounts: [belowReserveAccount, nativeOnlyAccount],
+                visibleAccounts: [emptyAccount, nativeOnlyAccount],
                 visibleAccountSymbols: new Set<NetworkSymbol>(['eth']),
             }),
         );
@@ -209,8 +209,8 @@ describe(useYieldTableData.name, () => {
                 additionalDepositAmount,
             })),
         ).toEqual([
-            { key: nativeOnlyAccount.key, additionalDepositAmount: '0.995' },
-            { key: belowReserveAccount.key, additionalDepositAmount: '0' },
+            { key: nativeOnlyAccount.key, additionalDepositAmount: '1' },
+            { key: emptyAccount.key, additionalDepositAmount: '0' },
         ]);
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -364,7 +364,7 @@ describe('stablecoinYieldUtils', () => {
             ).toBe('100');
         });
 
-        it('adds the native balance minus the gas reserve for a wrapped-native vault', () => {
+        it('adds the full native balance for a wrapped-native vault', () => {
             expect(
                 getYieldDepositableBalance({
                     networkSymbol: 'eth',
@@ -372,10 +372,10 @@ describe('stablecoinYieldUtils', () => {
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: '1.5',
                 }),
-            ).toBe('1.695');
+            ).toBe('1.7');
         });
 
-        it('ignores native balance below the gas reserve', () => {
+        it('counts the full native balance even below the gas reserve', () => {
             expect(
                 getYieldDepositableBalance({
                     networkSymbol: 'eth',
@@ -383,10 +383,10 @@ describe('stablecoinYieldUtils', () => {
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: '1',
                 }),
-            ).toBe('1');
+            ).toBe('1.003');
         });
 
-        it('returns the spendable native balance when no token is matched', () => {
+        it('returns the full native balance when no token is matched', () => {
             expect(
                 getYieldDepositableBalance({
                     networkSymbol: 'eth',
@@ -394,7 +394,7 @@ describe('stablecoinYieldUtils', () => {
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: undefined,
                 }),
-            ).toBe('0.995');
+            ).toBe('1');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -408,8 +408,10 @@ export const shouldRecommendWrapReserve = (
 
 /**
  * Balance available for a yield deposit. For a wrapped-native (WETH) vault the native balance can
- * be wrapped, so it counts in after keeping `WETH_WRAP_GAS_RESERVE` aside to cover the follow-up
- * wrap + approve + deposit (+ exit) fees.
+ * be wrapped, so the full native balance counts in on top of the already-held wrapped token. The
+ * `WETH_WRAP_GAS_RESERVE` is intentionally NOT deducted here — the summary shows the user's full
+ * depositable amount (native + wrapped); the fee reserve is a concern of the deposit flow, not the
+ * headline figure.
  */
 export const getYieldDepositableBalance = ({
     networkSymbol,
@@ -424,10 +426,8 @@ export const getYieldDepositableBalance = ({
         return tokenDepositBalance;
     }
 
-    // Native-asset deposit: the wrappable native balance also counts in.
-    return new BigNumber(tokenDepositBalance)
-        .plus(getWrappableNativeBalance(nativeFormattedBalance))
-        .toString();
+    // Native-asset deposit: the full native balance can be wrapped and counts in.
+    return new BigNumber(tokenDepositBalance).plus(nativeFormattedBalance || '0').toString();
 };
 
 type GetYieldWrapAmountParams = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- the fee reserve is a concern of the deposit flow

## Notes for QA

Deposit flow min fees are unaffected.

## Related Issue

Resolve #30541 

## Screenshots:


| Total amount | To wrap - fees | Available WETH |
|--------|--------|--------|
| <img width="1259" height="697" alt="Screenshot 2026-08-04 at 10 03 03" src="https://github.com/user-attachments/assets/a1258515-775c-4986-877d-d0ca4555ad59" /> | <img width="964" height="792" alt="Screenshot 2026-08-04 at 10 02 54" src="https://github.com/user-attachments/assets/f1612464-54e5-4c9a-8e4e-048769186912" /> | <img width="1076" height="714" alt="Screenshot 2026-08-04 at 10 06 47" src="https://github.com/user-attachments/assets/80581075-fe48-4382-956e-4ba87d07f86e" /> | 


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/display-full-balance/web/](https://dev.suite.sldev.cz/suite-web/fix/display-full-balance/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/display-full-balance&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/display-full-balance&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/display-full-balance&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are focused on stablecoin yield utilities (`stablecoinYieldUtils.ts`) and their associated unit tests. No E2E tests in the provided candidate list directly exercise stablecoin yield or earn-dashboard yield functionality; the 133 static mappings for `stablecoinYieldUtils.ts` appear to be transitive broad-utility imports rather than behavior-specific coverage. The appropriate validation for these changes is the existing unit tests, not the E2E suite.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`

_Updated: 2026-08-04T08:13:28.588Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:14:50.319Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T08:13:33.880Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->