### PR TITLE
chore(e2e-utils): tighten fix agent locator and comment rules

### DIFF
--- a/packages/e2e-utils/src/fixBot/FIX_AGENT.md
+++ b/packages/e2e-utils/src/fixBot/FIX_AGENT.md
@@ -28,6 +28,9 @@ Your change surface is exactly two things — nothing else, no exceptions:
 1. Any file inside `suite/e2e/`.
 2. Adding a `data-testid` attribute in a product source file.
 
+Adding a `data-testid` is an ordinary, expected fix — not a last resort to be avoided. It is
+almost always the right remedy when a test cannot reliably reach an element (see Step 3).
+
 Everything else in product code is off-limits.
 This holds even when a product change is the only way to make a test pass — in that case the
 failure is not yours to fix (see Step 2, "Bail when it is not yours to fix").
@@ -67,6 +70,10 @@ Then read the source files mentioned in the analysis — spec files, page object
 (if a locator is involved) the product component that renders the target element. **Expand the
 analysis with your own product-code analysis and the preflight results (Step 2)** before
 deciding the fix.
+
+Read `suite/e2e/CLAUDE.md` and the skills it lists — they are mandatory for every change under
+`suite/e2e/`. `skills/locators.md` (testid convention and naming) and `skills/page-objects.md`
+(where locators and methods belong) govern most fixes you will make.
 
 The test name and each `test.step()` label are the specification of intended behavior — read
 them as the source of truth for what the test verifies. A correct fix restores the test's
@@ -131,16 +138,31 @@ _Cost marker: at the start of each iteration, run `echo fixagent-stage-iteration
 
 **1. Make changes** within the allowed surface (see Fix Constraints).
 
-**Missing / mismatched locator.** When a locator the test uses is not found, do not reflexively
-add it to the product. Inspect the target element in the trace (see _Reading traces_) to see what
-it actually exposes — don't guess. If it already exposes a `data-testid` (possibly renamed from what
-the test expects), point the test/page-object at the current one. Add a new `data-testid` only if
-the element genuinely has none.
+**Locators: a testid, or you add one.** This covers both a locator that finds nothing and one
+that finds the wrong element. Inspect the target in the trace (see _Reading traces_) to see what
+it actually exposes — don't guess — then:
 
-**Readability lives in clear code, not comments.** Any test file or page object you touch should
-read on its own through precise naming and obvious structure — that is the primary tool. A comment
-is the last resort, reserved for intent the code genuinely cannot carry (a non-obvious wait, a
-workaround for a known bug). When you do add one, keep it to a single line.
+- It already exposes a `data-testid`, possibly renamed from what the test expects → point the
+  test/page object at the current one.
+- It exposes none → add one in the product component, following the naming convention in
+  `suite/e2e/skills/locators.md`, and use it.
+
+That skill also forbids reaching an element by its position among siblings — `.first()`,
+`.nth(n)`, `.last()`, or a role/text chain that resolves only by DOM order. Narrowing a
+positional locator you inherited does not count as fixing it: delete it and add the testid.
+
+**No narrating comments.** Do not explain the DOM you discovered, why the old locator broke, or
+what your change does. That belongs in the commit message and `pr-description.md`, which is where
+reviewers look for it. A comment describing structure (`// the row's last cell holds the actions`)
+is worse than noise: it hard-codes an assumption that nothing verifies and that goes stale the
+moment the component changes. Carry the meaning in the name instead — `tokenRowMoreButton(tokenName)`
+explains itself. Add a comment only for intent the code genuinely cannot express: a non-obvious
+wait, a workaround for a known product bug. Keep it to one line.
+
+**An existing workaround may only go when its cause goes.** If the test wraps a step in a retry
+(`toPass`, a re-query loop) or carries a comment about known instability, remove it only if your
+change eliminates what it was masking, and say so in the PR description. If you are working
+around the same instability by other means, leave it in place.
 
 **2. Run all validations that are still failing:**
 

--- a/suite/e2e/skills/locators.md
+++ b/suite/e2e/skills/locators.md
@@ -10,6 +10,7 @@ PRIORITY_3: MUST chain to parent if multiple instances exist
 PRIORITY_4: MUST use parameterized methods for dynamic values
 
 MUST_NOT: Use CSS classes, XPath indices, or hardcoded text selectors
+MUST_NOT: Select an element by its position among siblings
 MUST_NOT: Scatter locators in tests—only in Page Objects
 MUST_NOT: Use implicit waits or hardcoded timeouts
 
@@ -35,6 +36,8 @@ Does element have data-testid?
 
 When multiple elements share the same testid pattern, get the parent first and query the child within it.
 
+The parent must be addressable on its own—when many rows or cards repeat the same testid pattern, the row carries a testid identifying which one it is (e.g. keyed by its name), and the child is chained from it. Never index into the list instead.
+
 **Do not use** if a unique testid exists without a parent—use PRIMARY directly.
 
 ### TERTIARY: Parameterized Locators
@@ -47,6 +50,8 @@ When the testid contains a dynamic segment (token, currency, code), declare a me
 
 ❌ CSS class selectors – breaks on CSS refactor: `this.page.locator('.button-primary')`
 ❌ XPath with indices – brittle, breaks on DOM changes: `this.page.locator('//button[3]')`
+❌ Position among siblings – silently points at the wrong element when the DOM gains one: `row.getByRole('button').first()`, `.nth(1)`, `.last()`
+❌ Narrowing a positional locator – a tighter parent or a different index is the same bug, not a fix: add the missing testid instead
 ❌ Text-only selectors – fragile to copy/i18n: `this.page.getByText('Claim Rewards')`
 ❌ Hardcoded timeouts: `await page.waitForTimeout(2000)`
 


### PR DESCRIPTION
## Fix agent — locator rules and no narrating comments

Split out of #30618, which mixed the actual test fix with these guidance changes.

While fixing `tests/trading/navigation.test.ts`, the fix agent produced a positional locator
(`row.getByRole('button').first()`) plus a comment narrating the DOM it had discovered. Both
are things it should never emit. This tightens the rules so it doesn't.

**`packages/e2e-utils/src/fixBot/FIX_AGENT.md`**

- Points at `suite/e2e/CLAUDE.md` and its skills as mandatory reading — `locators.md` and
  `page-objects.md` govern most fixes the agent makes.
- States that adding a `data-testid` is an ordinary, expected fix, not a last resort.
- Rewrites the locator section to cover *resolves to the wrong element*, not just *not found*,
  and bans narrowing an inherited positional locator instead of replacing it.
- Bans narrating comments (the DOM, why the old locator broke, what the change does) — that
  belongs in the commit message and `pr-description.md`.
- Adds: an existing workaround (`toPass`, retry loop) may only be removed when the change
  eliminates what it was masking, and the PR description must say so.

**`suite/e2e/skills/locators.md`** — the positional-locator ban now lives here, where every
e2e change reads it: a `MUST_NOT`, the requirement that a repeated-pattern parent be
addressable on its own, and two anti-pattern examples.

Docs only — no runtime code changed.
