### PR TITLE
feat(suite-native-30720): support transaction simulation for cross-chain swaps

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -9,7 +9,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import {
     type TradingType,
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     getUnusedAddressFromAccount,
     selectTradingBuyReceiveAccountKey,
     selectTradingBuyReceiveAddress,
@@ -79,7 +79,7 @@ export const useTradingReceiveAddress = ({
 
     const isDebug = useSelector(selectIsDebugModeActive);
 
-    const symbol = cryptoId && cryptoIdToSymbol(cryptoId);
+    const symbol = cryptoId && cryptoIdToNetworkSymbol(cryptoId);
     const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
     const methods = useForm<TradingVerifyFormProps>({

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -5,7 +5,7 @@ import { selectIsDebugModeActive } from '@suite/debug';
 import { openModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import {
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     getUnusedAddressFromAccount,
     parseCryptoId,
     selectTradingAccountKeyByTradeType,
@@ -72,7 +72,7 @@ const useTradingVerifyAccount = ({
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
 
     const networkId = cryptoId && parseCryptoId(cryptoId).networkId;
-    const symbol = cryptoId && cryptoIdToSymbol(cryptoId);
+    const symbol = cryptoId && cryptoIdToNetworkSymbol(cryptoId);
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
@@ -1,7 +1,7 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
-import { cryptoIdToSymbol, parseCryptoId, useTradingUtils } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol, parseCryptoId, useTradingUtils } from '@suite-common/trading';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { IconCircle, Row } from '@trezor/components';
 import { PlusIcon } from '@trezor/icons';
@@ -21,7 +21,7 @@ export const TradingReceiveAccountAddSuiteOption = () => {
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const { cryptoIdToPlatformName, cryptoIdToCoinName } = useTradingUtils();
 
-    const symbol = cryptoIdToSymbol(cryptoId);
+    const symbol = cryptoIdToNetworkSymbol(cryptoId);
 
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
     const networkName = contractAddress

--- a/suite-common/trading/src/utils.test.ts
+++ b/suite-common/trading/src/utils.test.ts
@@ -19,7 +19,7 @@ import {
     addIdsToQuotes,
     cryptoIdToNetwork,
     cryptoIdToNetworkAndContractAddress,
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     filterQuotesAccordingTags,
     getDefaultCountry,
     getDefaultCountrySubdivision,
@@ -176,7 +176,7 @@ describe('getTradingQuotesDedupedByProvider', () => {
     });
 });
 
-describe('cryptoIdToSymbol', () => {
+describe('cryptoIdToNetworkSymbol', () => {
     it.each([
         ['bitcoin', 'btc'],
         ['ethereum', 'eth'],
@@ -184,7 +184,7 @@ describe('cryptoIdToSymbol', () => {
     ] as [CryptoId, NetworkSymbol][])(
         'should return correct symbol for %s',
         (cryptoId, expectedSymbol) => {
-            expect(cryptoIdToSymbol(cryptoId)).toBe(expectedSymbol);
+            expect(cryptoIdToNetworkSymbol(cryptoId)).toBe(expectedSymbol);
         },
     );
 });

--- a/suite-common/trading/src/utils.test.ts
+++ b/suite-common/trading/src/utils.test.ts
@@ -27,6 +27,7 @@ import {
     getTradingQuotesByPaymentMethod,
     getTradingQuotesDedupedByProvider,
     getUnusedAddressFromAccount,
+    isCrossChainTrade,
     isCryptoIdForNativeToken,
     isFinalStatus,
     mapTestnetSymbol,
@@ -222,6 +223,12 @@ describe('cryptoIdToNetwork', () => {
             expect(cryptoIdToNetwork(cryptoId)?.symbol).toBe(expectedSymbol);
         },
     );
+});
+
+describe('isCrossChainTrade', () => {
+    it('should return true when send and receive assets are on different networks', () => {
+        expect(isCrossChainTrade('ethereum' as CryptoId, 'bitcoin' as CryptoId)).toBe(true);
+    });
 });
 
 describe('toTokenCryptoId', () => {

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -413,3 +413,14 @@ export const getStatusUrl = (provider?: TradingProviderInfo, trade?: TradingTrad
 
     return tradeStatusUrl || provider?.statusUrl;
 };
+
+export const isCrossChainTrade = (sendCryptoId?: CryptoId, receiveCryptoId?: CryptoId) => {
+    const sendNetwork = cryptoIdToNetwork(sendCryptoId);
+    const receiveNetwork = cryptoIdToNetwork(receiveCryptoId);
+
+    if (!sendNetwork || !receiveNetwork) {
+        return false;
+    }
+
+    return sendNetwork.symbol !== receiveNetwork.symbol;
+};

--- a/suite-common/trading/src/utils.ts
+++ b/suite-common/trading/src/utils.ts
@@ -154,8 +154,9 @@ export const cryptoIdToNetworkAndContractAddress = (
 export const cryptoIdToNetwork = (cryptoId: CryptoId | undefined): Network | undefined =>
     cryptoIdToNetworkAndContractAddress(cryptoId)?.network;
 
-export const cryptoIdToSymbol = (cryptoId: CryptoId | undefined): NetworkSymbol | undefined =>
-    cryptoIdToNetwork(cryptoId)?.symbol;
+export const cryptoIdToNetworkSymbol = (
+    cryptoId: CryptoId | undefined,
+): NetworkSymbol | undefined => cryptoIdToNetwork(cryptoId)?.symbol;
 
 export const cryptoIdToNetworkSymbolAndContractAddress = (cryptoId: CryptoId | undefined) => {
     const { network, contractAddress } = cryptoIdToNetworkAndContractAddress(cryptoId);
@@ -415,12 +416,12 @@ export const getStatusUrl = (provider?: TradingProviderInfo, trade?: TradingTrad
 };
 
 export const isCrossChainTrade = (sendCryptoId?: CryptoId, receiveCryptoId?: CryptoId) => {
-    const sendNetwork = cryptoIdToNetwork(sendCryptoId);
-    const receiveNetwork = cryptoIdToNetwork(receiveCryptoId);
+    const sendNetworkSymbol = cryptoIdToNetworkSymbol(sendCryptoId);
+    const receiveNetworkSymbol = cryptoIdToNetworkSymbol(receiveCryptoId);
 
-    if (!sendNetwork || !receiveNetwork) {
+    if (!sendNetworkSymbol || !receiveNetworkSymbol) {
         return false;
     }
 
-    return sendNetwork.symbol !== receiveNetwork.symbol;
+    return sendNetworkSymbol !== receiveNetworkSymbol;
 };

--- a/suite-common/trading/src/utils/exchange/receiveAddressCoherence.ts
+++ b/suite-common/trading/src/utils/exchange/receiveAddressCoherence.ts
@@ -3,7 +3,7 @@ import { type CryptoId } from 'invity-api';
 import { type AddressValidator } from '@suite-common/address';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 
-import { cryptoIdToSymbol } from '../../utils';
+import { cryptoIdToNetworkSymbol } from '../../utils';
 
 export const isReceiveAddressValid = (
     addressValidator: AddressValidator,
@@ -36,7 +36,7 @@ export const isReceiveAddressCoherent = ({
         return true;
     }
 
-    const receiveSymbol = receiveCryptoId ? cryptoIdToSymbol(receiveCryptoId) : undefined;
+    const receiveSymbol = receiveCryptoId ? cryptoIdToNetworkSymbol(receiveCryptoId) : undefined;
     if (!receiveSymbol) {
         return false;
     }

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx
@@ -1,14 +1,18 @@
 import { getTranslation } from '@suite-native/intl';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { oneInchFusionPlusWithoutEip712SignDataQuote } from '@suite-native/trading-fixtures';
 
 import { ExchangePreviewScreenHeader } from './ExchangePreviewScreenHeader';
 import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
+import { renderWithTradingProvider } from '../../../test-utils/tradingTestUtils';
 
 jest.mock('../../../hooks/exchange/useDexExchangeTxSimulation', () => ({
     useDexExchangeTxSimulation: jest.fn(),
 }));
 
 const mockUseDexExchangeTxSimulation = jest.mocked(useDexExchangeTxSimulation);
+
+const renderExchangePreviewScreenHeader = () =>
+    renderWithTradingProvider(<ExchangePreviewScreenHeader />, { tradeType: 'exchange' });
 
 describe('ExchangePreviewScreenHeader', () => {
     beforeEach(() => {
@@ -22,7 +26,7 @@ describe('ExchangePreviewScreenHeader', () => {
     });
 
     it('renders only the exchange preview title when simulation is disabled', () => {
-        const { getByText, queryByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+        const { getByText, queryByText } = renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
@@ -38,7 +42,7 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+        const { getByText } = renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.simulating')),
@@ -53,7 +57,7 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+        const { getByText } = renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.transactionSimulation.title')),
@@ -68,7 +72,7 @@ describe('ExchangePreviewScreenHeader', () => {
             data: undefined,
         });
 
-        const { getByText, queryByText } = renderWithBasicProvider(<ExchangePreviewScreenHeader />);
+        const { getByText, queryByText } = renderExchangePreviewScreenHeader();
 
         expect(
             getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
@@ -77,5 +81,35 @@ describe('ExchangePreviewScreenHeader', () => {
         expect(
             queryByText(getTranslation('moduleTrading.transactionSimulation.simulating')),
         ).toBeNull();
+    });
+
+    it('renders only the exchange preview title for a cross-chain trade', () => {
+        mockUseDexExchangeTxSimulation.mockReturnValue({
+            isEnabled: true,
+            isLoading: false,
+            error: null,
+            data: undefined,
+        });
+
+        const { getByText, queryByText } = renderWithTradingProvider(
+            <ExchangePreviewScreenHeader />,
+            {
+                tradeType: 'exchange',
+                overrides: {
+                    wallet: {
+                        trading: {
+                            exchange: {
+                                selectedQuote: oneInchFusionPlusWithoutEip712SignDataQuote,
+                            },
+                        },
+                    },
+                },
+            },
+        );
+
+        expect(
+            getByText(getTranslation('moduleTrading.tradingExchangePreviewScreen.title')),
+        ).toBeOnTheScreen();
+        expect(queryByText(getTranslation('moduleTrading.transactionSimulation.title'))).toBeNull();
     });
 });

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
 import { FadeIn } from 'react-native-reanimated';
+import { useSelector } from 'react-redux';
 
+import { isCrossChainTrade, selectTradingExchangeSelectedQuote } from '@suite-common/trading';
 import { AnimatedText, HStack, Loader, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { ScreenHeader } from '@suite-native/navigation';
@@ -8,9 +10,13 @@ import { ScreenHeader } from '@suite-native/navigation';
 import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
 
 const HeaderTitle = () => {
+    const quote = useSelector(selectTradingExchangeSelectedQuote);
+
     const { isLoading, isEnabled, error } = useDexExchangeTxSimulation();
 
-    if (!isEnabled || error) {
+    const isCrossChain = isCrossChainTrade(quote?.send, quote?.receive);
+
+    if (!isEnabled || error || isCrossChain) {
         return (
             <Text variant="body-md-strong">
                 <Translation id="moduleTrading.tradingExchangePreviewScreen.title" />

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { cryptoIdToSymbol, tradingExchangeActions } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol, tradingExchangeActions } from '@suite-common/trading';
 import { type AccountsRootState, selectAccounts } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Button, Text } from '@suite-native/atoms';
@@ -54,8 +54,8 @@ export const ExchangeUsdcPresetButton = () => {
     }
 
     const handlePress = () => {
-        const previousReceiveSymbol = cryptoIdToSymbol(getValues('receiveAsset')?.cryptoId);
-        const receiveSymbol = cryptoIdToSymbol(USDT_ETH.cryptoId);
+        const previousReceiveSymbol = cryptoIdToNetworkSymbol(getValues('receiveAsset')?.cryptoId);
+        const receiveSymbol = cryptoIdToNetworkSymbol(USDT_ETH.cryptoId);
 
         setValue('sendAsset', USDC_ETH);
         setValue('sendAccount', debugAccount);

--- a/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
+++ b/suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { HStack } from '@suite-native/atoms';
@@ -52,7 +52,7 @@ export const ExchangeSendContent = () => {
     const { control } = useExchangeFormContext();
 
     const asset = useWatch({ name: 'sendAsset', control });
-    const symbol = cryptoIdToSymbol(asset?.cryptoId);
+    const symbol = cryptoIdToNetworkSymbol(asset?.cryptoId);
 
     return (
         <>

--- a/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx
@@ -1,5 +1,5 @@
 import { invariant } from '@suite-common/suite-utils';
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { getNetwork } from '@suite-common/wallet-config';
 import { Box, HStack, Text } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
@@ -18,7 +18,7 @@ export const TradeableAssetNetworkInfo = ({ asset }: TradeableAssetNetworkInfoPr
     }
 
     const { cryptoId, contractAddress } = asset;
-    const symbol = cryptoIdToSymbol(cryptoId);
+    const symbol = cryptoIdToNetworkSymbol(cryptoId);
     invariant(symbol, 'Symbol should be defined');
 
     const { displaySymbol, name } = getNetwork(symbol);

--- a/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { invariant } from '@suite-common/suite-utils';
 import {
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     selectIsTradingFavouriteAssetByCryptoId,
     tradingActions,
 } from '@suite-common/trading';
@@ -25,7 +25,7 @@ export const TradeableAssetListItem = ({ asset, onPress }: TradeableAssetListIte
     );
     const { symbol, name, contractAddress, cryptoId } = asset;
 
-    const networkSymbol = cryptoIdToSymbol(cryptoId);
+    const networkSymbol = cryptoIdToNetworkSymbol(cryptoId);
     invariant(networkSymbol, `Network symbol not found for cryptoId: ${cryptoId}`);
 
     const onFavouritePress = () => {

--- a/suite-native/module-trading/src/components/sell/SellCard.tsx
+++ b/suite-native/module-trading/src/components/sell/SellCard.tsx
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { type AccountsRootState, selectAccountFormattedBalance } from '@suite-common/wallet-core';
 import { Box, HStack } from '@suite-native/atoms';
 import { useWatch } from '@suite-native/forms';
@@ -32,7 +32,7 @@ export const SellCard = ({ isAmountInputActive, shouldAnimateEntering }: SellCar
         control,
         name: ['sendAsset', 'cryptoStringAmount', 'sendAccount'],
     });
-    const symbol = asset ? cryptoIdToSymbol(asset.cryptoId) : undefined;
+    const symbol = asset ? cryptoIdToNetworkSymbol(asset.cryptoId) : undefined;
 
     const formattedBalance = useSelector((state: AccountsRootState) =>
         selectAccountFormattedBalance(state, sendAccount?.key),

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
@@ -4,7 +4,7 @@ import { useDispatch } from 'react-redux';
 import { type UnknownAction } from '@reduxjs/toolkit';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { type TradingType, cryptoIdToSymbol } from '@suite-common/trading';
+import { type TradingType, cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type FieldValues, type Path, type UseFormReturn } from '@suite-native/forms';
@@ -86,7 +86,8 @@ export const useTradeableAssetChange = <TFieldValues extends FieldValues>({
             }
 
             const isTokenChange =
-                cryptoIdToSymbol(selectedValue?.cryptoId) === cryptoIdToSymbol(asset.cryptoId);
+                cryptoIdToNetworkSymbol(selectedValue?.cryptoId) ===
+                cryptoIdToNetworkSymbol(asset.cryptoId);
 
             setSelectedValue(asset);
 

--- a/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { type CryptoId } from 'invity-api';
 
 import { normalizeForSearch } from '@suite-common/suite-utils';
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkByCoingeckoId } from '@suite-common/wallet-config';
 import { type TradeableAsset } from '@suite-native/trading-types';
 
@@ -94,7 +94,7 @@ export const useTradeableAssetsFilteredData = ({ assets }: { assets: TradeableAs
             return assets;
         }
 
-        return assets.filter(a => filterSymbol === cryptoIdToSymbol(a.cryptoId));
+        return assets.filter(a => filterSymbol === cryptoIdToNetworkSymbol(a.cryptoId));
     }, [assets, filterSymbol]);
 
     const filteredData = useMemo(() => {

--- a/suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts
+++ b/suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts
@@ -1,6 +1,10 @@
 import type { CoinInfo, CryptoId } from 'invity-api';
 
-import { cryptoIdToSymbol, isCryptoIdForNativeToken, parseCryptoId } from '@suite-common/trading';
+import {
+    cryptoIdToNetworkSymbol,
+    isCryptoIdForNativeToken,
+    parseCryptoId,
+} from '@suite-common/trading';
 import { getDisplaySymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { type TradeableAsset } from '@suite-native/trading-types';
@@ -25,4 +29,4 @@ export const coinInfoToTradeableAsset = (
 };
 
 export const getSymbolFromTradeableAsset = (asset: TradeableAsset | undefined) =>
-    asset?.cryptoId ? cryptoIdToSymbol(asset.cryptoId) : undefined;
+    asset?.cryptoId ? cryptoIdToNetworkSymbol(asset.cryptoId) : undefined;

--- a/suite-native/trading-quote-utils/src/hooks/useTradingFiatValues.ts
+++ b/suite-native/trading-quote-utils/src/hooks/useTradingFiatValues.ts
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import type { CryptoId } from 'invity-api';
 
 import {
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     useTradingFiatValues as useCommonTradingFiatValues,
 } from '@suite-common/trading';
 import {
@@ -18,7 +18,7 @@ export const useTradingFiatValues = (
     amount: string | undefined,
     cryptoId: CryptoId | undefined,
 ) => {
-    const symbol = cryptoIdToSymbol(cryptoId);
+    const symbol = cryptoIdToNetworkSymbol(cryptoId);
     const shouldSendInSats = useSelector((state: WalletSettingsRootState) =>
         selectIsAmountInSats(state, symbol),
     );

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -18,7 +18,7 @@ import {
     type TradingTransaction,
     type TradingType,
     type TradingTypeWithConcierge,
-    cryptoIdToSymbol,
+    cryptoIdToNetworkSymbol,
     isFinalStatus,
     selectDeviceTradingTrades,
     selectTradingIsSlip24Allowed,
@@ -468,7 +468,7 @@ export const selectAccountLabelWithNetworkFallback = (
     }
 
     if (cryptoId) {
-        const networkSymbol = cryptoIdToSymbol(cryptoId);
+        const networkSymbol = cryptoIdToNetworkSymbol(cryptoId);
         if (networkSymbol) {
             return getNetwork(networkSymbol).name;
         }

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -1,5 +1,5 @@
 import { messages } from '@suite/intl';
-import { cryptoIdToSymbol } from '@suite-common/trading';
+import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
@@ -70,8 +70,8 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
                 type StatusKey = keyof typeof statusTranslationKeys;
                 const row = tradingPage.transactions.swapTransactionRow(trade.orderId);
                 const receiveSymbol = (
-                    cryptoIdToSymbol(
-                        trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0],
+                    cryptoIdToNetworkSymbol(
+                        trade.data.receive as Parameters<typeof cryptoIdToNetworkSymbol>[0],
                     ) ?? trade.data.receive
                 ).toUpperCase();
 
@@ -117,8 +117,9 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
 
         for (const trade of SEEDED_TRADES) {
             const receiveSymbol = (
-                cryptoIdToSymbol(trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0]) ??
-                trade.data.receive
+                cryptoIdToNetworkSymbol(
+                    trade.data.receive as Parameters<typeof cryptoIdToNetworkSymbol>[0],
+                ) ?? trade.data.receive
             ).toUpperCase();
 
             await test.step(`Open detail for trade ${trade.orderId}`, async () => {


### PR DESCRIPTION
## Description

- Add cross-chain trade detection based on send and receive networks.

## Notes for QA

- Confirm transaction simulation is not shown for cross-chain

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/30720

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/30720-transaction-simulation---cross-chain-swaps/web/](https://dev.suite.sldev.cz/suite-web/feat/30720-transaction-simulation---cross-chain-swaps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/30720-transaction-simulation---cross-chain-swaps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/30720-transaction-simulation---cross-chain-swaps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/30720-transaction-simulation---cross-chain-swaps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:58:30.093Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:58:36.132Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily touches receive address selection, account verification, and common trading utilities in both desktop and mobile trading flows. The highest regression risk is in cross-chain swap and buy flows where receive addresses are selected, added, and verified. The recommended tests focus on these paths in the web E2E suite; suite-native mobile changes are not covered by web E2E tests and should be validated by their own test suite.

<details><summary><b>Changed files (19)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts`
- `packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx`
- `suite-common/trading/src/utils.test.ts`
- `suite-common/trading/src/utils.ts`
- `suite-common/trading/src/utils/exchange/receiveAddressCoherence.ts`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx`
- `suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx`
- `suite-native/module-trading/src/components/sell/SellCard.tsx`
- `suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts`
- `suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts`
- `suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts`
- `suite-native/trading-quote-utils/src/hooks/useTradingFiatValues.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`
- `suite/e2e/tests/trading/swap-history.test.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Directly exercises receive address selection in the BTC buy flow and verifies the buy trade payload; changes to useTradingReceiveAddress and TradingReceiveAccountAddSuiteOption affect how receive addresses are chosen and validated.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests adding a new Suite receive account during the Ethereum buy flow, directly touching the TradingReceiveAccountAddSuiteOption component and useTradingReceiveAddress hook.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Fills a buy form for a Solana token and relies on receive account selection; changes to receive address hooks and common trading utils can alter address/account resolution.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Cross-chain SOL-to-USDC swap requires selecting a receive address and verifying it on device; receive address coherence logic is directly on the critical path.
- `suite/e2e/tests/trading/swap-coins.test.ts` — SOL-to-BTC swap with receive address selection and device prompt address verification; affected by receive address and account verification changes.
- `suite/e2e/tests/trading/swap-history.test.ts` — This test file was modified in the PR, so it must be run to validate the changes and detect regressions in swap history behavior.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — SOL-to-BTC swap verifies the recipient/send address on the device prompt; receive address coherence and account verification changes can affect displayed addresses.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — USDT-to-BTC cross-chain swap with receive address selection and device address verification; directly uses receive address logic.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — SPL token-to-token swap (USDT-to-USDC) requires receive address selection on the same network; affected by receive address hook changes.

</details>

<details><summary>🟡 <b>Medium priority (8)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live SOL-to-USDC swap uses receive address selection and provider address verification; shares receive address infrastructure with mocked swap tests but runs against live quotes.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live USDT-to-SOL swap uses receive address selection and device prompt verification; shares receive address infrastructure with mocked swap tests.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow confirms the provider destination address on the device prompt; changes to account verification and trading utils may affect address display and validation.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Ethereum sell flow displays destination address and account label; account verification hook changes may affect how the sell account is resolved.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — ERC-20 token sell flow shows destination address and account name; shares sell account verification logic affected by the changes.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Solana sell flow verifies destination address and account on device; account verification changes may affect sell account resolution.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form inputs including selecting a Suite receive account for buy assets; receive address selection path is exercised.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Swap form with a buy asset on a disabled network still renders provider info; receive address/account selection for disabled networks may be affected by common utils changes.

</details>

⚠️ **Changes with no test coverage (13)**
- `suite-common/trading/src/utils.test.ts`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.test.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewScreenHeader.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.tsx`
- `suite-native/module-trading/src/components/exchange/send/ExchangeSendContent.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx`
- `suite-native/module-trading/src/components/general/TradeableAssetSheet/TradeableAssetListItem.tsx`
- `suite-native/module-trading/src/components/sell/SellCard.tsx`
- `suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts`
- `suite-native/module-trading/src/hooks/general/useTradeableAssetsFilteredData.ts`
- `suite-native/trading-atoms/src/utils/general/tradeableAssetUtils.ts`
- `suite-native/trading-quote-utils/src/hooks/useTradingFiatValues.ts`
- `suite-native/trading-state/src/selectors/commonSelectors.ts`

_Updated: 2026-08-04T10:57:39.257Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->