### PR TITLE
test(connect): extend test-matrix-generator

### DIFF
--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -150,7 +150,7 @@ args.forEach(arg => {
     const argName = key.replace(/^--/, '');
 
     // Check if the value contains commas to create an array
-    parsedArgs[argName] = value.includes(',') ? value.split(',') : value;
+    parsedArgs[argName] = value.includes(',') ? value.split(',') : [value];
 });
 
 log('parsedArgs', parsedArgs);
@@ -166,6 +166,22 @@ const validateArgs = () => {
 };
 
 validateArgs();
+
+const addExplicitFirmware = firmware => {
+    if (!firmware || firmware === 'all') {
+        return;
+    }
+
+    if (firmware.startsWith('1') && !firmwares1.includes(firmware)) {
+        firmwares1.push(firmware);
+    }
+
+    if (firmware.startsWith('2') && !firmwares2.includes(firmware)) {
+        firmwares2.push(firmware);
+    }
+};
+
+[...parsedArgs.firmware].forEach(addExplicitFirmware);
 
 log('validated args', parsedArgs);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I want to be able to run any FW version using [connect custom e2e setup](https://github.com/trezor/trezor-suite/actions/workflows/test-connect-custom.yml) - not only defined in the matrix ('2.3.0', '2-latest', '2-main')

The proof that it is working:
 - testing 2.10.0: https://github.com/trezor/trezor-suite/actions/runs/30894587422/job/91944369735
 - testing default (*-latest): https://github.com/trezor/trezor-suite/actions/runs/30894816499

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is CI infrastructure (a Connect test matrix generator), so no application code is directly exercised by E2E tests. With no static coverage available, I infer that a small set of representative TrezorConnect E2E tests is the most relevant smoke test to confirm the generator still produces a runnable Connect test selection. No broad Suite coverage is needed.

<details><summary><b>Changed files (1)</b></summary>

- `scripts/ci/connect-test-matrix-generator.js`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Inferred coverage: the changed file is a CI matrix generator for Connect tests, so running a representative Connect E2E smoke test validates that the generated test selection/orchestration path still executes connect flows end-to-end. This test covers getAddress, permissions, cancellation, and popup lifecycle paths.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Inferred coverage: this focused Connect permissions test exercises a central Connect flow that the matrix generator is responsible for scheduling, making it a good targeted validation that Connect E2E tests remain correctly selected and runnable.

</details>

_Updated: 2026-08-04T09:13:12.716Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/connect-matrix-generator/web/](https://dev.suite.sldev.cz/suite-web/test/connect-matrix-generator/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/connect-matrix-generator&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/connect-matrix-generator&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:15:07.800Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:15:04.723Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->