### PR TITLE
fix(suite-common-icons): correct vault icons for network native tokens

### DIFF
--- a/suite-common/icons/scripts/constants/index.ts
+++ b/suite-common/icons/scripts/constants/index.ts
@@ -5,6 +5,9 @@ import { ICONS_URL_BASE } from '../../src/coinImages';
 export const PACKAGE_ROOT = resolve(__dirname, '..', '..');
 
 export const FILES_CRYPTOICONS_PATH = join(PACKAGE_ROOT, 'files', 'cryptoIcons');
+// Bundled coin discs the apps render for native coins, keyed by network symbol. Read directly
+// instead of through `src/cryptoIcons`, whose `require` calls only resolve in a bundler.
+export const CRYPTO_ICONS_SVG_PATH = join(PACKAGE_ROOT, 'cryptoAssets', 'cryptoIcons');
 export const UPDATED_ICONS_LIST_FILE = join(FILES_CRYPTOICONS_PATH, 'icons.json');
 export const UPDATED_ICONS_LIST_URL = join(ICONS_URL_BASE, 'icons.json');
 

--- a/suite-common/icons/scripts/downloadCryptoIcons.ts
+++ b/suite-common/icons/scripts/downloadCryptoIcons.ts
@@ -2,8 +2,6 @@
 import { createHash } from 'crypto';
 import fs from 'fs/promises';
 import { join } from 'path';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import sharp from 'sharp';
 
 import {
     FILES_CRYPTOICONS_PATH,
@@ -24,24 +22,13 @@ import {
     getCoinData,
     getCoinMarketImageUrls,
 } from './utils/fetchCoins';
+import { resizeImage } from './utils/images';
 import { sleep } from './utils/sleep';
 
 async function writeImage(fileName: string, imageBuffer: Buffer) {
     const destinationFile = join(FILES_CRYPTOICONS_PATH, fileName);
 
     await fs.writeFile(destinationFile, Buffer.from(imageBuffer));
-}
-
-async function resizeImage(imageBuffer: ArrayBuffer, size: number) {
-    const resizedImage = sharp(imageBuffer).resize(size, size);
-
-    const fullQualityImageBuffer = await resizedImage.webp({ quality: 100 }).toBuffer();
-    const lossLessImageBuffer = await resizedImage.clone().webp({ lossless: true }).toBuffer();
-
-    // sometimes lossless image is much smaller than 100 quality compressed image
-    return fullQualityImageBuffer.byteLength < lossLessImageBuffer.byteLength
-        ? fullQualityImageBuffer
-        : lossLessImageBuffer;
 }
 
 function isValidUrl(url: string): boolean {

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.test.ts
@@ -1,10 +1,15 @@
 import fs from 'fs/promises';
 import { join } from 'path';
+import sharp from 'sharp';
 
 import { COIN_IMAGE_SIZES, ICONS_URL_BASE, createCoinImageName } from '../../src/coinImages';
-import { FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
+import { CRYPTO_ICONS_SVG_PATH, FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
+import { rasterizeSvg } from './images';
 
+// `readFile` stays real so the bundled-icon path actually rasterizes the design-system SVG, while
+// `writeFile` is mocked to keep the run off the disk.
 jest.mock('fs/promises', () => ({
+    ...jest.requireActual('fs/promises'),
     writeFile: jest.fn(),
 }));
 
@@ -20,12 +25,14 @@ const { downloadVaultIcons } = require('./downloadVaultIcons') as {
 
 const ETH_WETH_VAULT = '0x704cfb08969048a8dff298b214f959791d8da509';
 const ETH_USDT_VAULT = '0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829';
+const ETH_USDC_VAULT = '0x8cb3649114051ca5119141a34c200d65dc0faa73';
 const BASE_WETH_VAULT = '0x4edc6ab1964e25eb2c202ab9f201e9548baa53df';
 const BASE_USDC_VAULT = '0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e';
 
 // Underlying tokens; the WETH ones are the wrapped-native contracts from @suite-common/wallet-config.
 const ETH_WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const BASE_WETH = '0x4200000000000000000000000000000000000006';
+const ETH_USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const BASE_USDC = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 const ETH_USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7';
 
@@ -85,7 +92,19 @@ const mockFetchRoutes = (routes: Record<string, Response>) => {
 
 const writtenFiles = () => (fs.writeFile as jest.Mock).mock.calls.map(([path]) => String(path));
 
+const writtenIcon = (fileName: string): Buffer | undefined =>
+    (fs.writeFile as jest.Mock).mock.calls.find(
+        ([path]) => String(path) === join(FILES_CRYPTOICONS_PATH, fileName),
+    )?.[1];
+
 const requestedUrls = () => fetchMock.mock.calls.map(([input]) => urlOf(input));
+
+// What the app itself renders for a native coin, i.e. what the published vault icon has to equal.
+const bundledIcon = async (networkSymbol: string, size: (typeof COIN_IMAGE_SIZES)[number]) =>
+    await rasterizeSvg(
+        await fs.readFile(join(CRYPTO_ICONS_SVG_PATH, `${networkSymbol}.svg`)),
+        size,
+    );
 
 describe('downloadVaultIcons', () => {
     let consoleErrorSpy: jest.SpyInstance;
@@ -127,7 +146,7 @@ describe('downloadVaultIcons', () => {
         expect(fs.writeFile).toHaveBeenCalledTimes(COIN_IMAGE_SIZES.length);
     });
 
-    it('substitutes the native coin icon when the underlying is the wrapped native token', async () => {
+    it('renders the bundled native coin disc when the underlying is the wrapped native token', async () => {
         mockFetchRoutes({
             ...vaultListRoute({
                 ethereum: [
@@ -143,12 +162,41 @@ describe('downloadVaultIcons', () => {
 
         await downloadVaultIcons();
 
-        // The WETH icon must never be requested — the vault reads as ETH.
-        expect(requestedUrls()).toContain(iconUrl('ethereum', 24));
-        expect(requestedUrls()).not.toContain(iconUrl('weth', 24));
-        expect(writtenFiles()).toContain(
-            join(FILES_CRYPTOICONS_PATH, `ethereum--${ETH_WETH_VAULT}@24.webp`),
+        // A WETH vault reads as an ETH vault, and the app renders native ETH from the bundled disc
+        // rather than from CoinGecko — so neither the WETH nor the CoinGecko ETH rendition is used.
+        expect(requestedUrls()).toEqual([YIELD_VAULTS_URL]);
+        for (const size of COIN_IMAGE_SIZES) {
+            expect(writtenIcon(`ethereum--${ETH_WETH_VAULT}@${size}.webp`)).toEqual(
+                await bundledIcon('eth', size),
+            );
+        }
+    });
+
+    it('renders each size of the bundled disc at its own pixel dimensions', async () => {
+        mockFetchRoutes(
+            vaultListRoute({
+                ethereum: [
+                    vault({
+                        address: ETH_WETH_VAULT,
+                        underlyingToken: ETH_WETH,
+                        coingeckoId: 'weth',
+                    }),
+                ],
+            }),
         );
+
+        await downloadVaultIcons();
+
+        for (const size of COIN_IMAGE_SIZES) {
+            const icon = writtenIcon(`ethereum--${ETH_WETH_VAULT}@${size}.webp`);
+            const { format, width, height } = await sharp(icon).metadata();
+
+            expect({ format, width, height }).toEqual({
+                format: 'webp',
+                width: size,
+                height: size,
+            });
+        }
     });
 
     it('resolves an L2 wrapped-native underlying to the settlement layer native coin', async () => {
@@ -167,10 +215,13 @@ describe('downloadVaultIcons', () => {
 
         await downloadVaultIcons();
 
-        expect(requestedUrls()).toContain(iconUrl('ethereum', 24));
-        expect(requestedUrls()).not.toContain(iconUrl('l2-standard-bridged-weth-base', 24));
-        expect(writtenFiles()).toContain(
-            join(FILES_CRYPTOICONS_PATH, `base--${BASE_WETH_VAULT}@24.webp`),
+        // Base settles on Ethereum, so its native coin — and hence its disc — is ETH, not BASE.
+        expect(requestedUrls()).toEqual([YIELD_VAULTS_URL]);
+        expect(writtenIcon(`base--${BASE_WETH_VAULT}@24.webp`)).toEqual(
+            await bundledIcon('eth', 24),
+        );
+        expect(writtenIcon(`base--${BASE_WETH_VAULT}@24.webp`)).not.toEqual(
+            await bundledIcon('base', 24),
         );
     });
 
@@ -279,6 +330,34 @@ describe('downloadVaultIcons', () => {
             ...vaultListRoute({
                 ethereum: [
                     vault({
+                        address: ETH_USDC_VAULT,
+                        underlyingToken: ETH_USDC,
+                        coingeckoId: 'usd-coin',
+                    }),
+                ],
+                base: [
+                    vault({
+                        address: BASE_USDC_VAULT,
+                        underlyingToken: BASE_USDC,
+                        coingeckoId: 'usd-coin',
+                    }),
+                ],
+            }),
+            ...sourceIconRoutes('usd-coin'),
+        });
+
+        await downloadVaultIcons();
+
+        // Both vaults resolve to usd-coin: one vault-list request plus one per source size.
+        expect(fetchMock).toHaveBeenCalledTimes(1 + COIN_IMAGE_SIZES.length);
+        expect(fs.writeFile).toHaveBeenCalledTimes(2 * COIN_IMAGE_SIZES.length);
+    });
+
+    it('renders a shared bundled disc once for vaults across platforms', async () => {
+        mockFetchRoutes(
+            vaultListRoute({
+                ethereum: [
+                    vault({
                         address: ETH_WETH_VAULT,
                         underlyingToken: ETH_WETH,
                         coingeckoId: 'weth',
@@ -292,14 +371,17 @@ describe('downloadVaultIcons', () => {
                     }),
                 ],
             }),
-            ...sourceIconRoutes('ethereum'),
-        });
+        );
 
         await downloadVaultIcons();
 
-        // Both vaults resolve to native ETH: one vault-list request plus one per source size.
-        expect(fetchMock).toHaveBeenCalledTimes(1 + COIN_IMAGE_SIZES.length);
+        // Both vaults read as native ETH, so nothing beyond the vault list is fetched and the two
+        // vault addresses end up with byte-identical renditions.
+        expect(requestedUrls()).toEqual([YIELD_VAULTS_URL]);
         expect(fs.writeFile).toHaveBeenCalledTimes(2 * COIN_IMAGE_SIZES.length);
+        expect(writtenIcon(`base--${BASE_WETH_VAULT}@80.webp`)).toEqual(
+            writtenIcon(`ethereum--${ETH_WETH_VAULT}@80.webp`),
+        );
     });
 
     it('throws when the vault list cannot be fetched', async () => {

--- a/suite-common/icons/scripts/utils/downloadVaultIcons.ts
+++ b/suite-common/icons/scripts/utils/downloadVaultIcons.ts
@@ -11,13 +11,16 @@ import {
     isWrappedNativeToken,
 } from '@suite-common/wallet-config';
 
+import { rasterizeSvg } from './images';
 import {
     COIN_IMAGE_SIZES,
     type CoinImageSize,
     ICONS_URL_BASE,
     createCoinImageName,
 } from '../../src/coinImages';
-import { FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
+import { type NetworkIconSymbol } from '../../src/iconSymbols';
+import { isCryptoIconSymbol } from '../../src/iconUtils';
+import { CRYPTO_ICONS_SVG_PATH, FILES_CRYPTOICONS_PATH, YIELD_VAULTS_URL } from '../constants';
 import { type YieldVault, yieldVaultsSchema } from '../schemas';
 
 const earnYieldApi = createHttpClient({
@@ -50,20 +53,40 @@ const fetchPublishedIcon = (fileName: string) =>
     })();
 
 /**
- * A vault-position token renders as the asset the vault is denominated in — except that a
- * wrapped-native underlying reads as the native coin: a WETH vault is an ETH vault.
- * On an L2 the native coin is the settlement layer's, so ETH is
- * resolved through `settlementLayer` rather than from the L2 itself.
+ * Where the icon of the asset a vault is denominated in comes from: either an already published
+ * CoinGecko rendition, or — for a native coin — the bundled design-system disc the apps render
+ * themselves instead of the CoinGecko one.
  */
-const resolveSourceCoingeckoId = (network: Network, vault: YieldVault) => {
+type VaultIconSource =
+    | { kind: 'published'; coingeckoId: string }
+    | { kind: 'bundled'; networkSymbol: NetworkIconSymbol };
+
+/**
+ * A vault-position token renders as the asset the vault is denominated in — except that a
+ * wrapped-native underlying reads as the native coin: a WETH vault is an ETH vault. On an L2 the
+ * native coin is the settlement layer's, so ETH is resolved through `settlementLayer` rather than
+ * from the L2 itself.
+ */
+const resolveIconSource = (network: Network, vault: YieldVault): VaultIconSource | undefined => {
     if (!isWrappedNativeToken(network.symbol, vault.underlyingToken)) {
-        return vault.coingeckoId;
+        return { kind: 'published', coingeckoId: vault.coingeckoId };
     }
 
-    return getNetwork(network.settlementLayer ?? network.symbol).tradeCryptoId;
+    const nativeSymbol = network.settlementLayer ?? network.symbol;
+
+    // `TokenIcon` resolves a native coin the same way and renders it through `NativeTokenIcon`, so
+    // deriving the vault icon from any other source would make it differ from the coin it stands
+    // for everywhere else in the app.
+    if (isCryptoIconSymbol(nativeSymbol)) {
+        return { kind: 'bundled', networkSymbol: nativeSymbol };
+    }
+
+    const coingeckoId = getNetwork(nativeSymbol).tradeCryptoId;
+
+    return coingeckoId ? { kind: 'published', coingeckoId } : undefined;
 };
 
-const fetchSourceIcon = async (
+const fetchPublishedSourceIcon = async (
     coingeckoId: string,
     size: CoinImageSize,
 ): Promise<Buffer | undefined> => {
@@ -82,16 +105,41 @@ const fetchSourceIcon = async (
     }
 };
 
+const renderBundledSourceIcon = async (
+    networkSymbol: NetworkIconSymbol,
+    size: CoinImageSize,
+): Promise<Buffer | undefined> => {
+    const svgPath = join(CRYPTO_ICONS_SVG_PATH, `${networkSymbol}.svg`);
+
+    try {
+        return await rasterizeSvg(await fs.readFile(svgPath), size);
+    } catch (error) {
+        console.error('Vault icons: failed to render the bundled icon:', svgPath, error);
+
+        return undefined;
+    }
+};
+
+const loadSourceIcon = (source: VaultIconSource, size: CoinImageSize) =>
+    source.kind === 'bundled'
+        ? renderBundledSourceIcon(source.networkSymbol, size)
+        : fetchPublishedSourceIcon(source.coingeckoId, size);
+
+const sourceIconKey = (source: VaultIconSource, size: CoinImageSize) =>
+    source.kind === 'bundled'
+        ? `bundled:${source.networkSymbol}@${size}`
+        : createCoinImageName({ coingeckoId: source.coingeckoId, size });
+
 /**
  * Derives icons for yield-vault position tokens. The vault contracts are not listed on CoinGecko
  * (and even if they were, they would carry the vault operator's branding), so the main
- * CoinGecko-driven pipeline never produces them — instead, copy the underlying asset's already
- * published renditions under each vault-address file name.
+ * CoinGecko-driven pipeline never produces them — instead, write the icon of the asset the vault is
+ * denominated in under each vault-address file name.
  */
 export const downloadVaultIcons = async (): Promise<void> => {
     const vaults = await fetchYieldVaults();
 
-    // The same underlying backs vaults on several platforms, so fetch each source rendition once.
+    // The same underlying backs vaults on several platforms, so load each source rendition once.
     const sourceIconCache = new Map<string, Buffer | undefined>();
     const savedIcons: string[] = [];
 
@@ -110,8 +158,8 @@ export const downloadVaultIcons = async (): Promise<void> => {
         }
 
         for (const vault of platformVaults) {
-            const sourceCoingeckoId = resolveSourceCoingeckoId(network, vault);
-            if (!sourceCoingeckoId) {
+            const source = resolveIconSource(network, vault);
+            if (!source) {
                 console.error(
                     `Vault icons: no source coin resolved for "${vault.yieldId}", skipping it:`,
                     vault.address,
@@ -120,9 +168,9 @@ export const downloadVaultIcons = async (): Promise<void> => {
             }
 
             for (const size of COIN_IMAGE_SIZES) {
-                const cacheKey = createCoinImageName({ coingeckoId: sourceCoingeckoId, size });
+                const cacheKey = sourceIconKey(source, size);
                 if (!sourceIconCache.has(cacheKey)) {
-                    sourceIconCache.set(cacheKey, await fetchSourceIcon(sourceCoingeckoId, size));
+                    sourceIconCache.set(cacheKey, await loadSourceIcon(source, size));
                 }
 
                 const imageBuffer = sourceIconCache.get(cacheKey);

--- a/suite-common/icons/scripts/utils/images.ts
+++ b/suite-common/icons/scripts/utils/images.ts
@@ -1,0 +1,34 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import sharp from 'sharp';
+
+export async function resizeImage(imageBuffer: ArrayBuffer | Buffer, size: number) {
+    const resizedImage = sharp(imageBuffer).resize(size, size);
+
+    const fullQualityImageBuffer = await resizedImage.webp({ quality: 100 }).toBuffer();
+    const lossLessImageBuffer = await resizedImage.clone().webp({ lossless: true }).toBuffer();
+
+    // sometimes lossless image is much smaller than 100 quality compressed image
+    return fullQualityImageBuffer.byteLength < lossLessImageBuffer.byteLength
+        ? fullQualityImageBuffer
+        : lossLessImageBuffer;
+}
+
+// The density at which sharp takes an SVG's intrinsic dimensions literally, i.e. the one it
+// rasterizes at when none is given.
+const SVG_DEFAULT_DENSITY = 72;
+
+/**
+ * Renders an SVG into a webp of the given size.
+ *
+ * sharp rasterizes a vector at its intrinsic size before applying any resize, which would upscale a
+ * 24px design-system icon into a blurry 80px one — hence the density, which makes it rasterize at
+ * the target size in the first place.
+ */
+export async function rasterizeSvg(svgBuffer: Buffer, size: number) {
+    const { width } = await sharp(svgBuffer).metadata();
+    const density = width ? Math.ceil((SVG_DEFAULT_DENSITY * size) / width) : SVG_DEFAULT_DENSITY;
+
+    const raster = await sharp(svgBuffer, { density }).resize(size, size).png().toBuffer();
+
+    return await resizeImage(raster, size);
+}


### PR DESCRIPTION
## Description

Don't display coingecko network native tokens. Use existing SVG images from codebase for that, convert them to webp and upload them with the rest of icons.

## Related Issue

Resolve #30553

## Screenshots:

### Currently
https://data.trezor.io/suite/icons/coins/ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@80.webp:
<img src="https://data.trezor.io/suite/icons/coins/ethereum--0xe4db1c5a1b709ce4d2ada6985d9d506e58f73829@80.webp"/>

https://data.trezor.io/suite/icons/coins/ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@80.webp:
<img src="https://data.trezor.io/suite/icons/coins/ethereum--0xde6c23e561f3e55846207ec45a91b777e0f7c889@80.webp"/>

https://data.trezor.io/suite/icons/coins/ethereum--0x704cfb08969048a8dff298b214f959791d8da509@80.webp:
<img src="https://data.trezor.io/suite/icons/coins/ethereum--0x704cfb08969048a8dff298b214f959791d8da509@80.webp"/>

https://data.trezor.io/suite/icons/coins/base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@80.webp:
<img src="https://data.trezor.io/suite/icons/coins/base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@80.webp"/>

https://data.trezor.io/suite/icons/coins/base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@80.webp:
<img src="https://data.trezor.io/suite/icons/coins/base--0x5e6fc406960a1c2d9ab6813ff1c914c6836bc53e@80.webp"/>


### After
After running it locally, these (`ethereum--0x704cfb08969048a8dff298b214f959791d8da509@{size}.webp`, `base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@{size}.webp`)  changed as expected to:
<img width="80" height="80" alt="base--0x4edc6ab1964e25eb2c202ab9f201e9548baa53df@80" src="https://github.com/user-attachments/assets/7f8d4272-2f8f-48b9-97cf-854e35260bcc" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are build-time icon download and processing scripts under `suite-common/icons/scripts/` (crypto/vault icon downloaders, image utilities, and their unit test). They do not implement runtime application logic and are not statically referenced by any Playwright E2E test. None of the analyzed E2E tests assert on icon assets or icon-download behavior, so the risk of user-facing regression is negligible. No E2E tests are recommended; validation should happen at the build-script/unit-test level instead.

<details><summary><b>Changed files (5)</b></summary>

- `suite-common/icons/scripts/constants/index.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.test.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.ts`
- `suite-common/icons/scripts/utils/images.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `suite-common/icons/scripts/constants/index.ts`
- `suite-common/icons/scripts/downloadCryptoIcons.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.test.ts`
- `suite-common/icons/scripts/utils/downloadVaultIcons.ts`
- `suite-common/icons/scripts/utils/images.ts`

_Updated: 2026-08-04T09:36:26.038Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29862-network-native-icons&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29862-network-native-icons&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/29862-network-native-icons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29862-network-native-icons/web/](https://dev.suite.sldev.cz/suite-web/fix/29862-network-native-icons/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T09:38:42.472Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->