### PR TITLE
Earn Yield - Add Rewards Tooltips

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -3,9 +3,12 @@ import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
+import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Banner, Row, Skeleton, Tooltip } from '@trezor/components';
 import { HandCoinsIcon, InfoIcon } from '@trezor/icons';
+
+import { useSelector } from 'src/hooks/suite';
 
 type EarnYieldClaimRewardsBannerProps = {
     value: BaseCurrencyAmount;
@@ -26,6 +29,8 @@ export const EarnYieldClaimRewardsBanner = ({
 }: EarnYieldClaimRewardsBannerProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const handleOnClaim = () => {
         analytics.report({
@@ -49,7 +54,7 @@ export const EarnYieldClaimRewardsBanner = ({
                     <span>
                         <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />:
                     </span>
-                    {isValueLoading ? (
+                    {isValueLoading || isDiscoveryRunning ? (
                         <Skeleton width={50} height={16} animate />
                     ) : (
                         <>
@@ -62,7 +67,7 @@ export const EarnYieldClaimRewardsBanner = ({
             rightContent={
                 <Tooltip content={claimDisabledTooltip}>
                     <Banner.Button
-                        isDisabled={isClaimDisabled}
+                        isDisabled={isClaimDisabled || isDiscoveryRunning}
                         iconLeft={claimDisabledTooltip ? InfoIcon : undefined}
                         onClick={handleOnClaim}
                     >

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -4,25 +4,25 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
-import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
-import { Banner, Row, Skeleton, Tooltip } from '@trezor/components';
+import { Banner, Row, Skeleton, Text, Tooltip } from '@trezor/components';
 import { HandCoinsIcon, InfoIcon } from '@trezor/icons';
 
 import { useSelector } from 'src/hooks/suite';
 
+import { EarnYieldClaimRewardsBannerAccountsTooltip } from './EarnYieldClaimRewardsBannerAccountsTooltip';
+import { EarnYieldClaimRewardsBannerTokensTooltip } from './EarnYieldClaimRewardsBannerTokensTooltip';
+import { useYieldClaimRewardsData } from './hooks/useYieldClaimRewardsData';
+import { type useMerklRewards } from '../../yield/claim/hooks';
+
 type EarnYieldClaimRewardsBannerProps = {
-    value: BaseCurrencyAmount;
-    currency: string;
-    isValueLoading?: boolean;
+    rewards: ReturnType<typeof useMerklRewards>['merklRewardsQuery'];
     isClaimDisabled?: boolean;
     claimDisabledTooltip?: React.ReactNode;
     onClaim?: () => void;
 };
 
 export const EarnYieldClaimRewardsBanner = ({
-    value,
-    currency,
-    isValueLoading,
+    rewards,
     isClaimDisabled,
     claimDisabledTooltip,
     onClaim,
@@ -31,6 +31,11 @@ export const EarnYieldClaimRewardsBanner = ({
     const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
+
+    const { value, currency } = rewards.data.totalRewardsToClaim;
+    const { isLoading } = rewards;
+
+    const { accountRewards, tokenRewards } = useYieldClaimRewardsData({ rewards });
 
     const handleOnClaim = () => {
         analytics.report({
@@ -50,16 +55,33 @@ export const EarnYieldClaimRewardsBanner = ({
             intent="neutral"
             icon={HandCoinsIcon}
             description={
-                <Row gap={4} alignItems="center">
-                    <span>
+                <Row gap={12} alignItems="center">
+                    <Text intent="neutral" priority="secondary">
                         <Translation id="TR_EARN_CLAIM_REWARDS_LABEL" />:
-                    </span>
-                    {isValueLoading || isDiscoveryRunning ? (
+                    </Text>
+
+                    {isLoading || isDiscoveryRunning ? (
                         <Skeleton width={50} height={16} animate />
                     ) : (
                         <>
-                            {!isClaimDisabled && '≈ '}
-                            <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                            <Text typographyStyle="body-sm-strong">
+                                {!isClaimDisabled && '≈ '}
+                                <BaseCurrencyAmountFormatter value={value} currency={currency} />
+                            </Text>
+
+                            {tokenRewards.length > 0 && (
+                                <EarnYieldClaimRewardsBannerTokensTooltip
+                                    rewards={tokenRewards}
+                                    currency={currency}
+                                />
+                            )}
+
+                            {accountRewards.length > 1 && (
+                                <EarnYieldClaimRewardsBannerAccountsTooltip
+                                    rewards={accountRewards}
+                                    currency={currency}
+                                />
+                            )}
                         </>
                     )}
                 </Row>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
@@ -1,0 +1,55 @@
+import { AccountLabel } from '@suite/account';
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { Grid, Text, Tooltip } from '@trezor/components';
+
+import { type AccountRewards } from './hooks/useYieldClaimRewardsData';
+
+interface EarnYieldClaimRewardsBannerAccountsTooltipProps {
+    rewards: AccountRewards;
+    currency: BaseCurrencyCode;
+}
+
+export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
+    rewards,
+    currency,
+}: EarnYieldClaimRewardsBannerAccountsTooltipProps) => {
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    if (rewards.length < 2) return null;
+
+    return (
+        <Tooltip
+            width="auto"
+            content={
+                <Grid columns="auto auto" rowGap={4} columnGap={24}>
+                    {rewards.map(({ account, fiat }) => (
+                        <>
+                            <Text>
+                                <AccountLabel account={account} showAccountTypeBadge />
+                            </Text>
+
+                            <Text align="end">
+                                <BaseCurrencyAmountFormatter
+                                    value={asBaseCurrencyAmount(fiat)}
+                                    currency={currency}
+                                />
+                            </Text>
+                        </>
+                    ))}
+                </Grid>
+            }
+        >
+            <Text cursor="default">
+                <Translation
+                    id="TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL"
+                    values={{
+                        accounts: rewards.length,
+                    }}
+                />
+            </Text>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
@@ -1,0 +1,61 @@
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
+import { Grid, Text, Tooltip } from '@trezor/components';
+
+import { FormattedCryptoAmount } from 'src/components/suite';
+
+import { type TokenRewards } from './hooks/useYieldClaimRewardsData';
+
+interface EarnYieldClaimRewardsBannerTokensTooltipProps {
+    rewards: TokenRewards;
+    currency: BaseCurrencyCode;
+}
+
+export const EarnYieldClaimRewardsBannerTokensTooltip = ({
+    rewards,
+    currency,
+}: EarnYieldClaimRewardsBannerTokensTooltipProps) => {
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    if (rewards.length === 0) return null;
+
+    return (
+        <Tooltip
+            width="auto"
+            content={
+                <Grid columns="auto auto" rowGap={4} columnGap={24}>
+                    {rewards.map(({ symbol, crypto, fiat }) => (
+                        <>
+                            <Text>
+                                <FormattedCryptoAmount value={crypto.toString()} symbol={symbol} />
+                            </Text>
+
+                            <Text align="end">
+                                <BaseCurrencyAmountFormatter
+                                    value={asBaseCurrencyAmount(fiat)}
+                                    currency={currency}
+                                />
+                            </Text>
+                        </>
+                    ))}
+                </Grid>
+            }
+        >
+            <Text cursor="default">
+                {rewards.length === 1 ? (
+                    <Translation
+                        id="TR_EARN_CLAIM_REWARDS_TOKEN_LABEL"
+                        values={{ symbol: rewards[0]!.symbol }}
+                    />
+                ) : (
+                    <Translation
+                        id="TR_EARN_CLAIM_REWARDS_TOKENS_LABEL"
+                        values={{ tokens: rewards.length }}
+                    />
+                )}
+            </Text>
+        </Tooltip>
+    );
+};

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx
@@ -30,12 +30,12 @@ import { useMessageSystemYield } from 'src/hooks/suite/useMessageSystemYield';
 import { EarnYieldClaimRewardsBanner } from './EarnYieldClaimRewardsBanner';
 import { EarnYieldClaimSelectAccountModal } from './EarnYieldClaimSelectAccountModal';
 import { EarnYieldTableBody } from './EarnYieldTableBody';
-import { useYieldAccountsVisibility } from './hooks/useYieldAccountsVisibility';
-import { useYieldTableData } from './hooks/useYieldTableData';
 import { PoweredByBadge } from '../../providers/PoweredByBadge';
 import { getYieldOpportunityAnchor } from '../../utils/getYieldOpportunityAnchor';
 import { useMerklRewards } from '../../yield/claim/hooks';
 import { EarnDashboardTableHeader } from '../common/EarnDashboardTableHeader';
+import { useYieldAccountsVisibility } from './hooks/useYieldAccountsVisibility';
+import { useYieldTableData } from './hooks/useYieldTableData';
 
 const emptyVaults: YieldDtoV2[] = [];
 
@@ -183,9 +183,7 @@ export const EarnYieldTable = () => {
                     {(isYieldActive || accountsRewards.length > 0) && (
                         <>
                             <EarnYieldClaimRewardsBanner
-                                value={merklRewardsQuery.data.totalRewardsToClaim.value}
-                                currency={merklRewardsQuery.data.totalRewardsToClaim.currency}
-                                isValueLoading={merklRewardsQuery.isLoading}
+                                rewards={merklRewardsQuery}
                                 isClaimDisabled={isClaimDisabled}
                                 claimDisabledTooltip={
                                     claimMessageSystem.isDisabled

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
@@ -1,0 +1,186 @@
+import { renderHook } from '@testing-library/react';
+
+import {
+    type AccountWithNetworkType,
+    asAccountDescriptor,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { BigNumber } from '@trezor/utils';
+
+import { useYieldClaimRewardsData } from './useYieldClaimRewardsData';
+
+type RewardsQuery = Parameters<typeof useYieldClaimRewardsData>[0]['rewards'];
+type AccountsRewards = RewardsQuery['data']['accountsRewards'];
+type AccountRewards = AccountsRewards[number];
+type Reward = AccountRewards['rewards'][number];
+type RewardToken = Reward['token'];
+
+const USDC: RewardToken = {
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    chainId: 1,
+    symbol: 'USDC',
+    decimals: 6,
+};
+
+const WETH: RewardToken = {
+    address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    chainId: 1,
+    symbol: 'WETH',
+    decimals: 18,
+};
+
+interface CreateRewardProps {
+    token: RewardToken;
+    claimable: string;
+    fiatClaimable: string | null;
+}
+
+const createReward = ({ token, claimable, fiatClaimable }: CreateRewardProps): Reward => ({
+    root: '0x2e7100',
+    amount: claimable,
+    claimed: '0',
+    pending: '0',
+    proofs: [],
+    token,
+    claimable: asBaseCurrencyAmount(new BigNumber(claimable)),
+    fiat: {
+        amount: null,
+        claimed: null,
+        pending: null,
+        claimable:
+            fiatClaimable === null ? null : asBaseCurrencyAmount(new BigNumber(fiatClaimable)),
+    },
+});
+
+const createAccount = (descriptor: string) =>
+    mockWalletAccount({
+        symbol: 'eth',
+        descriptor: asAccountDescriptor(descriptor),
+    }) as AccountWithNetworkType<'ethereum'>;
+
+const createAccountRewards = (
+    account: AccountWithNetworkType<'ethereum'>,
+    rewards: Reward[],
+): AccountRewards => ({
+    account,
+    rewards,
+    totalClaimableFiatAmount: asBaseCurrencyAmount(
+        rewards.reduce(
+            (total, reward) => total.plus(reward.fiat.claimable ?? '0'),
+            new BigNumber(0),
+        ),
+    ),
+});
+
+const createRewardsQuery = (accountsRewards: AccountsRewards) =>
+    ({ data: { accountsRewards } }) as unknown as RewardsQuery;
+
+const renderUseYieldClaimRewardsData = (accountsRewards: AccountsRewards) => {
+    const { result } = renderHook(() =>
+        useYieldClaimRewardsData({ rewards: createRewardsQuery(accountsRewards) }),
+    );
+
+    return {
+        accountRewards: result.current.accountRewards.map(({ account, fiat }) => ({
+            accountKey: account.key,
+            fiat: fiat.toString(),
+        })),
+        tokenRewards: result.current.tokenRewards.map(({ symbol, crypto, fiat }) => ({
+            symbol,
+            crypto: crypto.toString(),
+            fiat: fiat.toString(),
+        })),
+    };
+};
+
+describe(useYieldClaimRewardsData.name, () => {
+    it('returns nothing when no account has rewards', () => {
+        const { accountRewards, tokenRewards } = renderUseYieldClaimRewardsData([]);
+
+        expect(accountRewards).toEqual([]);
+        expect(tokenRewards).toEqual([]);
+    });
+
+    it('converts a single reward of a single account to units', () => {
+        const account = createAccount('0xaccounta');
+
+        const { accountRewards, tokenRewards } = renderUseYieldClaimRewardsData([
+            createAccountRewards(account, [
+                createReward({ token: USDC, claimable: '12500000', fiatClaimable: '12.5' }),
+            ]),
+        ]);
+
+        expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '12.5' }]);
+        expect(tokenRewards).toEqual([{ symbol: 'USDC', crypto: '12.5', fiat: '12.5' }]);
+    });
+
+    it('sums rewards of the same token of a single account and keeps other tokens separate', () => {
+        const account = createAccount('0xaccounta');
+
+        const { accountRewards, tokenRewards } = renderUseYieldClaimRewardsData([
+            createAccountRewards(account, [
+                createReward({ token: USDC, claimable: '10000000', fiatClaimable: '10' }),
+                createReward({ token: USDC, claimable: '2500000', fiatClaimable: '2.5' }),
+                createReward({
+                    token: WETH,
+                    claimable: '500000000000000000',
+                    fiatClaimable: '1500',
+                }),
+            ]),
+        ]);
+
+        expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '1512.5' }]);
+        expect(tokenRewards).toEqual([
+            { symbol: 'USDC', crypto: '12.5', fiat: '12.5' },
+            { symbol: 'WETH', crypto: '0.5', fiat: '1500' },
+        ]);
+    });
+
+    it('counts a reward without a fiat rate as zero fiat while keeping its crypto amount', () => {
+        const account = createAccount('0xaccounta');
+
+        const { accountRewards, tokenRewards } = renderUseYieldClaimRewardsData([
+            createAccountRewards(account, [
+                createReward({ token: USDC, claimable: '10000000', fiatClaimable: '10' }),
+                createReward({ token: USDC, claimable: '2500000', fiatClaimable: null }),
+            ]),
+        ]);
+
+        expect(accountRewards).toEqual([{ accountKey: account.key, fiat: '10' }]);
+        expect(tokenRewards).toEqual([{ symbol: 'USDC', crypto: '12.5', fiat: '10' }]);
+    });
+
+    it('sums rewards per token across accounts and keeps the fiat total per account', () => {
+        const firstAccount = createAccount('0xaccounta');
+        const secondAccount = createAccount('0xaccountb');
+
+        const { accountRewards, tokenRewards } = renderUseYieldClaimRewardsData([
+            createAccountRewards(firstAccount, [
+                createReward({ token: USDC, claimable: '10000000', fiatClaimable: '10' }),
+                createReward({
+                    token: WETH,
+                    claimable: '500000000000000000',
+                    fiatClaimable: '1500',
+                }),
+            ]),
+            createAccountRewards(secondAccount, [
+                createReward({ token: USDC, claimable: '5000000', fiatClaimable: '5' }),
+                createReward({
+                    token: WETH,
+                    claimable: '250000000000000000',
+                    fiatClaimable: '750',
+                }),
+            ]),
+        ]);
+
+        expect(accountRewards).toEqual([
+            { accountKey: firstAccount.key, fiat: '1510' },
+            { accountKey: secondAccount.key, fiat: '755' },
+        ]);
+        expect(tokenRewards).toEqual([
+            { symbol: 'USDC', crypto: '15', fiat: '15' },
+            { symbol: 'WETH', crypto: '0.75', fiat: '2250' },
+        ]);
+    });
+});

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+
+import {
+    type AccountWithNetworkType,
+    type BaseCurrencyAmount,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
+import { type AmountUnit, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { type useMerklRewards } from 'src/components/earn/yield/claim/hooks';
+
+interface UseYieldClaimRewardsDataProps {
+    rewards: ReturnType<typeof useMerklRewards>['merklRewardsQuery'];
+}
+
+interface UseYieldClaimRewardsDataResult {
+    accountRewards: AccountRewards;
+    tokenRewards: TokenRewards;
+}
+
+interface AccountReward {
+    account: AccountWithNetworkType<'ethereum'>;
+    fiat: BigNumber;
+}
+
+export type AccountRewards = AccountReward[];
+
+interface TokenReward {
+    symbol: string;
+    crypto: AmountUnit;
+    fiat: BaseCurrencyAmount;
+}
+
+export type TokenRewards = TokenReward[];
+
+type TokenMap = {
+    [key: string]: { symbol: string; decimals: number; crypto: BigNumber; fiat: BigNumber };
+};
+
+export const useYieldClaimRewardsData = ({
+    rewards,
+}: UseYieldClaimRewardsDataProps): UseYieldClaimRewardsDataResult => {
+    const allRewards = useMemo(
+        () => rewards.data.accountsRewards.flatMap(accountRewards => accountRewards.rewards),
+        [rewards.data.accountsRewards],
+    );
+
+    const accountRewards = useMemo(
+        () =>
+            rewards.data.accountsRewards.map(item => ({
+                account: item.account,
+                fiat: item.totalClaimableFiatAmount,
+            })) satisfies AccountRewards,
+        [rewards.data.accountsRewards],
+    );
+
+    const tokenRewards = useMemo(() => {
+        const tokenMap: TokenMap = {};
+
+        for (const reward of allRewards) {
+            const entry = tokenMap[reward.token.address] ?? {
+                symbol: reward.token.symbol,
+                decimals: reward.token.decimals,
+                crypto: new BigNumber(0),
+                fiat: new BigNumber(0),
+            };
+
+            entry.crypto = entry.crypto.plus(reward.claimable);
+            entry.fiat = entry.fiat.plus(reward.fiat.claimable ?? '0');
+
+            tokenMap[reward.token.address] = { ...entry };
+        }
+
+        return Object.entries(tokenMap).map(([_, { symbol, decimals, ...entry }]) => {
+            const crypto = subunitsToUnits({
+                value: asAmountSubunit(entry.crypto),
+                decimals,
+            });
+
+            const fiat = asBaseCurrencyAmount(entry.fiat);
+
+            return { symbol, crypto, fiat };
+        }) satisfies TokenRewards;
+    }, [allRewards]);
+
+    return { accountRewards, tokenRewards };
+};

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8796,7 +8796,7 @@ export const messages = defineMessages({
     },
     TR_EARN_CLAIM_REWARDS_LABEL: {
         id: 'TR_EARN_CLAIM_REWARDS_LABEL',
-        defaultMessage: 'Available rewards',
+        defaultMessage: 'Available bonus rewards',
     },
     TR_EARN_CLAIM_REWARDS_BUTTON: {
         id: 'TR_EARN_CLAIM_REWARDS_BUTTON',

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -8802,6 +8802,18 @@ export const messages = defineMessages({
         id: 'TR_EARN_CLAIM_REWARDS_BUTTON',
         defaultMessage: 'Claim',
     },
+    TR_EARN_CLAIM_REWARDS_TOKEN_LABEL: {
+        id: 'TR_EARN_CLAIM_REWARDS_TOKEN_LABEL',
+        defaultMessage: 'in {symbol}',
+    },
+    TR_EARN_CLAIM_REWARDS_TOKENS_LABEL: {
+        id: 'TR_EARN_CLAIM_REWARDS_TOKENS_LABEL',
+        defaultMessage: 'in {tokens} tokens',
+    },
+    TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL: {
+        id: 'TR_EARN_CLAIM_REWARDS_ACCOUNTS_LABEL',
+        defaultMessage: 'on {accounts} accounts',
+    },
     TR_EARN_ENTER_AMOUNT_IN: {
         id: 'TR_EARN_ENTER_AMOUNT_IN',
         defaultMessage: 'Enter amount in {currency}',


### PR DESCRIPTION
## Description

Add tooltips for token and account rewards to earn yield table.

Crowdin updated from `Available rewards` to `Available bonus rewards`.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29277

## Screenshots:

No rewards:

<img width="100%" alt="Screenshot 2026-08-04 at 11 42 00" src="https://github.com/user-attachments/assets/6ddcdc3e-bb09-4406-af84-a04b8334cdea" />

One reward on one account:

<img width="100%" alt="Screenshot 2026-08-04 at 11 40 53" src="https://github.com/user-attachments/assets/98f33b32-7938-4ac6-8481-1ad155aada79" />

Multiple rewards on one account:

<img width="100%" alt="Screenshot 2026-08-04 at 11 41 14" src="https://github.com/user-attachments/assets/b426f674-678f-4cf5-adc1-7b78beb82a1e" />

Multiple rewards on multiple accounts:

<img width="100%" alt="Screenshot 2026-08-04 at 11 41 33" src="https://github.com/user-attachments/assets/9fbefd5c-1ed0-40e3-ab13-d4560a8f9c97" />

<img width="100%" alt="Screenshot 2026-08-04 at 11 41 37" src="https://github.com/user-attachments/assets/0c8b2e38-ddfd-4d68-a123-2469a07b5d56" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on the Earn dashboard yield claim-rewards UI (banner, account/token tooltips, yield table, and data hook) plus related intl messages. The highest-confidence E2E coverage comes from the staking claim/unstake tests that directly exercise claim-rewards behavior. A small set of staking dashboard tests provides medium confidence for shared earn/staking UI. No candidate E2E test explicitly targets the /earn/yield route, so the tooltip-only files have no direct E2E coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldTable.tsx`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts`
- `packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises the claim rewards flow for Cardano, including the claim rewards button and modal. The changed EarnYieldClaimRewardsBanner and useYieldClaimRewardsData hook are the UI/data layer that drives claim rewards presentation, so a regression here would be immediately visible.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests the ETH claim flow after unstaking completes, including claimable balance display and the claim transaction. This is a primary code path for the changed claim rewards components and would catch regressions in reward computation or claim UI.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Validates SOL reward claiming after epoch advancement, including the claim card, claim modal, and device confirmation. This directly uses the claim rewards UX that the changed banner and hook support.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Covers the ADA staking dashboard UI where yield and claim-related elements may render. A regression in shared earn/staking layout or reward data formatting could affect this flow even though it does not perform a claim.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates claim rewards button state and staking dashboard transitions for ADA. The changed components may influence whether the claim button is shown as enabled or disabled.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers the ETH staking dashboard and post-stake state where yield progress indicators and reward summaries are displayed. Shared earn/staking UI changes could impact this view.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx`

_Updated: 2026-08-04T10:25:20.210Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/earn-rewards-ui-improvements/web/](https://dev.suite.sldev.cz/suite-web/feat/earn-rewards-ui-improvements/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/earn-rewards-ui-improvements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/earn-rewards-ui-improvements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:25:33.123Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T10:26:32.945Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->