### PR TITLE
fix(suite): correct date for empty account graph

### DIFF
--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -1,4 +1,4 @@
-import { differenceInMonths, fromUnixTime, isWithinInterval } from 'date-fns';
+import { differenceInMonths, fromUnixTime, getUnixTime, isWithinInterval } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
 import { resetTime } from '@suite-common/suite-utils';
@@ -215,8 +215,11 @@ export const calcXDomain = (
     data: { time: number }[],
     range: GraphRange,
 ): [number, number] => {
-    const start = ticks[0] ?? 0;
-    const lastTick = ticks[ticks.length - 1] ?? 0;
+    // falling back to the unix epoch would render an axis around 1970,
+    // so when there are no ticks yet we center the interval around now instead
+    const now = getUnixTime(new Date());
+    const start = ticks[0] ?? now;
+    const lastTick = ticks[ticks.length - 1] ?? now;
     const lastData = data[data.length - 1];
     // if the last data point is after last tick/label use datapoint's timestamp to mark the end of the interval
     const end = lastData && lastTick < lastData.time ? lastData.time : lastTick;

--- a/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx
@@ -71,12 +71,11 @@ export const TransactionSummary = ({ account }: TransactionSummaryProps) => {
     // Interval shown in InfoCard below the graph
     // For 'all' range pick first and last datapoint's timestamps
     // For other intervals do same date calculation as in calcTicks func
-    const dataInterval: [number, number] =
+    const dataInterval: [number | undefined, number | undefined] =
         selectedRange.label === 'all'
             ? [
-                  intervalGraphData[0]?.data[0]?.time ?? 0,
-                  intervalGraphData[0]?.data[(intervalGraphData[0]?.data.length ?? 1) - 1]?.time ??
-                      0,
+                  intervalGraphData[0]?.data[0]?.time,
+                  intervalGraphData[0]?.data[(intervalGraphData[0]?.data.length ?? 1) - 1]?.time,
               ]
             : [getUnixTime(selectedRange.startDate), getUnixTime(selectedRange.endDate)];
 

--- a/suite-common/suite-utils/src/date.test.ts
+++ b/suite-common/suite-utils/src/date.test.ts
@@ -1,4 +1,6 @@
-import { formatDurationStrict, parseUTCdatetime } from './date';
+import { format, getUnixTime, startOfMonth } from 'date-fns';
+
+import { calcTicksFromData, formatDurationStrict, parseUTCdatetime } from './date';
 
 describe('Date utils', () => {
     test('format duration strict', () => {
@@ -10,6 +12,25 @@ describe('Date utils', () => {
         expect(formatDurationStrict(31556926)).toBe('1 year');
         expect(formatDurationStrict(63671184000)).toBe('2019 years'); // jesus was born
         expect(formatDurationStrict(99999999999)).toBe('3171 years');
+    });
+});
+
+describe(calcTicksFromData.name, () => {
+    it('anchors the axis to the current month when there are no datapoints', () => {
+        expect(calcTicksFromData([])).toEqual([startOfMonth(new Date())]);
+    });
+
+    it('returns monthly ticks spanning the datapoints', () => {
+        const ticks = calcTicksFromData([
+            { time: getUnixTime(new Date(2025, 0, 15)) },
+            { time: getUnixTime(new Date(2025, 2, 15)) },
+        ]);
+
+        expect(ticks.map(tick => format(tick, 'yyyy-MM'))).toEqual([
+            '2025-01',
+            '2025-02',
+            '2025-03',
+        ]);
     });
 });
 

--- a/suite-common/suite-utils/src/date.ts
+++ b/suite-common/suite-utils/src/date.ts
@@ -1,5 +1,5 @@
-import { type Locale } from 'date-fns';
 import {
+    type Locale,
     differenceInCalendarMonths,
     differenceInMonths,
     eachDayOfInterval,
@@ -29,7 +29,11 @@ export const calcTicks = (startDate: Date, endDate: Date) => {
 };
 
 export const calcTicksFromData = (data: { time: number }[]) => {
-    if (!data || data.length < 1) return [];
+    // without datapoints there is no interval to derive ticks from
+    // anchor the axis to the current month so that an empty or still-loading account
+    // does not end up with an axis around the unix epoch
+    if (!data || data.length < 1) return [startOfMonth(new Date())];
+
     const firstTime = data[0]?.time ?? 0;
     const startDate = data.reduce(
         (min, current) => (current.time < min ? current.time : min),


### PR DESCRIPTION
## Description

Show current date in portfolio graph for empty or still loading account.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28512

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-04 at 13 32 11" src="https://github.com/user-attachments/assets/4c963f7c-4c5c-4c38-83ed-79c91cb060b0" />

<img width="100%" alt="Screenshot 2026-08-04 at 13 32 06" src="https://github.com/user-attachments/assets/503c3c3f-e36c-44a7-8f20-310ea3574ff7" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies transaction summary rendering, shared graph utilities, and date formatting. The highest-risk regression surface is the transaction summary graph time-range behavior, which is directly covered by the transactions test. Portfolio graph rendering tests add meaningful coverage for graph utility changes without expanding to the full 133-test static mapping. The date.ts utility is broadly imported, but only the transaction range labels provide specific evidence of date-dependent behavior in this PR.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/utils/wallet/graph/utils.ts`
- `packages/suite/src/views/wallet/transactions/components/TransactionSummary.tsx`
- `suite-common/suite-utils/src/date.test.ts`
- `suite-common/suite-utils/src/date.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the account transaction overview graph and cycles through day/week/month/year/all time range filters, asserting that the corresponding localized date labels update. It is the strongest end-to-end coverage for changes to TransactionSummary.tsx, graph/utils.ts, and date.ts because all three are involved in rendering and labeling the transaction summary graph.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test explicitly asserts that the dashboard portfolio graph becomes visible after discovery completes with custom BTC and LTC Blockbook backends. A change in graph/utils.ts could alter how portfolio graph data is computed or rendered, so this test provides concrete coverage of graph rendering beyond just balance text.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test asserts that the portfolio fiat amount and account balances are correctly hidden and revealed on hover across the dashboard. Portfolio values are derived from graph data, so a regression in graph/utils.ts could affect the values displayed by the dashboard components exercised here.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/suite-utils/src/date.test.ts`

_Updated: 2026-08-04T11:40:25.270Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/empty-account-graph/web/](https://dev.suite.sldev.cz/suite-web/fix/empty-account-graph/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/empty-account-graph&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/empty-account-graph&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/empty-account-graph&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:43:13.712Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T11:42:33.593Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->