### PR TITLE
feat(suite-desktop): ensure auto-tracked wrapped native assets

### DIFF
--- a/packages/suite/src/actions/wallet/tokenActions.ts
+++ b/packages/suite/src/actions/wallet/tokenActions.ts
@@ -6,17 +6,23 @@ import { type TokenInfo } from '@trezor/connect';
 import { type Dispatch } from 'src/types/suite';
 import { type Account } from 'src/types/wallet';
 
-export const addToken = (account: Account, tokenInfo: TokenInfo[]) => (dispatch: Dispatch) => {
-    dispatch(
-        accountsActions.updateAccount({
-            ...account,
-            tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
-        }),
-    );
+export const addToken =
+    (account: Account, tokenInfo: TokenInfo[], options?: { showSuccessToast?: boolean }) =>
+    (dispatch: Dispatch) => {
+        dispatch(
+            accountsActions.updateAccount({
+                ...account,
+                tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
+            }),
+        );
 
-    dispatch(
-        notificationsActions.addToast({
-            type: 'add-token-success',
-        }),
-    );
-};
+        // Auto-tracking flows (e.g. wrapping a native token) add a token as a side effect and show
+        // their own toast, so the generic success toast can be suppressed to avoid double toasts.
+        if (options?.showSuccessToast ?? true) {
+            dispatch(
+                notificationsActions.addToast({
+                    type: 'add-token-success',
+                }),
+            );
+        }
+    };

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,6 +1,6 @@
 import { configureMockStore } from '@suite-common/test-utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
+import { type YieldFlowDisplayToken, accountsActions } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -101,12 +101,27 @@ describe('submitWrapNativeTokenThunk', () => {
         );
     });
 
-    it('shows a wrap toast displaying both the native and wrapped assets', async () => {
-        const store = configureMockStore({ extra: {}, preloadedState: {} });
+    const getTrackedTokenUpdates = (store: ReturnType<typeof configureMockStore>) =>
+        store
+            .getActions()
+            .filter(action => action.type === accountsActions.updateAccount.type)
+            .filter(action =>
+                action.payload.tokens?.some(
+                    (accountToken: { contract: string }) =>
+                        accountToken.contract.toLowerCase() === token.contractAddress.toLowerCase(),
+                ),
+            );
+
+    const acceptModalAndSucceed = () => {
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
         mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
+    };
+
+    it('shows a wrap toast displaying both the native and wrapped assets', async () => {
+        acceptModalAndSucceed();
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
 
         await store
             .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1.5' }))
@@ -131,5 +146,60 @@ describe('submitWrapNativeTokenThunk', () => {
                 },
             },
         });
+    });
+
+    it('starts tracking the wrapped native token after a successful wrap', async () => {
+        acceptModalAndSucceed();
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+        await store
+            .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
+            .unwrap();
+
+        const trackedTokenUpdates = getTrackedTokenUpdates(store);
+        expect(trackedTokenUpdates).toHaveLength(1);
+    });
+
+    it('does not track the wrapped native token when it is already tracked', async () => {
+        acceptModalAndSucceed();
+        const accountWithTrackedToken = mockWalletAccount({
+            symbol: 'eth',
+            tokens: [
+                {
+                    standard: 'ERC20',
+                    // stored in a different case to prove the dedupe is case-insensitive
+                    contract: token.contractAddress.toLowerCase(),
+                    symbol: 'WETH',
+                    decimals: 18,
+                },
+            ],
+        }) as Account;
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+        await store
+            .dispatch(
+                submitWrapNativeTokenThunk({
+                    account: accountWithTrackedToken,
+                    token,
+                    wrapAmount: '1',
+                }),
+            )
+            .unwrap();
+
+        expect(getTrackedTokenUpdates(store)).toHaveLength(0);
+    });
+
+    it('does not track the wrapped native token when the send fails', async () => {
+        mockOpenDeferredModal.mockImplementation(
+            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+        );
+        mockSendYieldTransaction.mockResolvedValue(undefined);
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+        await store
+            .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
+            .unwrap();
+
+        expect(getTrackedTokenUpdates(store)).toHaveLength(0);
     });
 });

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -8,8 +8,10 @@ import {
     composeYieldWrapTransactionThunk,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
+import { type TokenInfo } from '@trezor/connect';
 
 import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
+import { addToken } from './tokenActions';
 
 const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
 
@@ -83,6 +85,27 @@ export const submitWrapNativeTokenThunk = createThunk(
 
             if (!sendResult) {
                 return undefined;
+            }
+
+            // Make sure re-wrapping doesn't create a duplicate
+            const isAlreadyTracked = account.tokens?.some(
+                accountToken =>
+                    accountToken.contract.toLowerCase() === token.contractAddress.toLowerCase(),
+            );
+
+            if (!isAlreadyTracked) {
+                const wrappedTokenInfo: TokenInfo = {
+                    // Only affects symbol casing (both ERC20 and BEP20 preserve it); the real
+                    // standard/balance are filled in by the next backend account refresh.
+                    standard: 'ERC20',
+                    contract: token.contractAddress,
+                    symbol: token.symbol,
+                    name: token.symbol,
+                    decimals: token.decimals,
+                    balance: '0',
+                };
+
+                dispatch(addToken(account, [wrappedTokenInfo], { showSuccessToast: false }));
             }
 
             dispatch(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Silently adds wrapped asset for tracking after a successful wrapping

## Notes for QA

1) By default on BNB we're not tracking WBNB, so flow can be tested there. Shouldn't affect existing logic to add tokens

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30648

## Screenshots:

https://github.com/user-attachments/assets/0e49e9a9-d343-4d48-b4f4-41aa5fc8f9ac


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/ensure-wrapped-token-list/web/](https://dev.suite.sldev.cz/suite-web/feat/ensure-wrapped-token-list/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/ensure-wrapped-token-list&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/ensure-wrapped-token-list&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:08:39.653Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:08:11.232Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to wallet token actions and native-token wrapping thunks. The static coverage maps are extremely broad (133 tests each), almost certainly due to transitive barrel imports, so they were ignored in favor of inference. The highest-confidence E2E coverage comes from token-trading and DEX-swap flows, with the ETH→USDC LI.FI swap being the most plausible exerciser of the wrapping thunk. Run the short list above rather than the full mapped set.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/actions/wallet/tokenActions.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This test swaps native ETH to USDC via the LI.FI DEX aggregator, a flow that typically requires wrapping ETH to WETH under the hood. It is the most likely E2E scenario in the analyzed set to exercise the wrapNativeTokenThunks path and token action state changes.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — The test buys a Solana SPL token (JUP) and therefore touches token account state, balance fetching, and token-aware trading infrastructure that tokenActions likely coordinates.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Selling an ERC-20 token (USDC) on Ethereum exercises token balance tracking, token send composition, and token-specific trading flows that depend on the wallet token actions.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swapping a Solana SPL token (USDT) to a native coin touches token holding and swap composition logic, sharing the token state management code affected by tokenActions.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — This SPL token-to-token swap (USDT to USDC) relies on token account discovery and balance handling, making it a representative check that token-related wallet actions still work.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`

_Updated: 2026-08-04T14:08:45.663Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->