### PR TITLE
chore(suite): cleanup authenticityChecks selectors

### DIFF
--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,6 +1,6 @@
 import { type FC, type PropsWithChildren, memo, useEffect } from 'react';
 
-import { selectShouldDisplayDeviceCompromisedOnRoute } from '@suite/authenticity-checks';
+import { selectShouldDisplayDeviceCompromised } from '@suite/authenticity-checks';
 import { useDevice } from '@suite/device';
 import { KillswitchMessageScreen } from '@suite/message-system';
 import {
@@ -65,9 +65,7 @@ export const Preloader = memo(function Preloader({ children }: PropsWithChildren
     const isForegroundApp = useSelector(selectIsForegroundApp);
     const hasRoute = useSelector(selectHasRoute);
     const prerequisite = useSelector(selectPrerequisite);
-    const shouldDisplayDeviceCompromisedOnRoute = useSelector(
-        selectShouldDisplayDeviceCompromisedOnRoute,
-    );
+    const shouldDisplayDeviceCompromisedOnRoute = useSelector(selectShouldDisplayDeviceCompromised);
     const killswitch = useSelector(selectActiveKillswitchMessage);
 
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { selectShouldDisplayDeviceCompromised } from '@suite/authenticity-checks';
+import { selectIsDeviceCompromised } from '@suite/authenticity-checks';
 import { TrafficLightOffset } from '@suite/macos';
 import { suiteSettingsActions } from '@suite/settings';
 import { selectIsAnyDeviceSelected, selectSelectedDevice } from '@suite-common/device';
@@ -105,7 +105,7 @@ export const Sidebar = ({ showAccounts = true }: SidebarProps) => {
     const [maxResizableSidebarWidth, setMaxResizableSidebarWidth] =
         useState<number>(SIDEBAR_MAX_WIDTH);
 
-    const shouldDisplayDeviceCompromised = useSelector(selectShouldDisplayDeviceCompromised);
+    const shouldDisplayDeviceCompromised = useSelector(selectIsDeviceCompromised);
     const selectedDevice = useSelector(selectSelectedDevice);
 
     const handleSidebarWidthChanged = (width: number) => {

--- a/suite/authenticity-checks/src/authenticityChecksSelectors.ts
+++ b/suite/authenticity-checks/src/authenticityChecksSelectors.ts
@@ -83,13 +83,6 @@ export const selectFirmwareHashCheckErrorIfEnabled = (state: AuthenticityChecksR
     return hashCheckError;
 };
 
-export function selectIsDeviceCompromised(state: AuthenticityChecksRootState): boolean {
-    const revisionError = selectFirmwareRevisionCheckErrorIfEnabled(state);
-    const hashError = selectFirmwareHashCheckErrorIfEnabled(state);
-
-    return revisionError !== null || hashError !== null;
-}
-
 /**
  * Determine hard failure of either of firmware authenticity checks to block access to device.
  */
@@ -142,9 +135,7 @@ export const selectIsDeviceInvariabilityEnabledAndFailed = (state: AuthenticityC
     );
 };
 
-export const selectShouldDisplayDeviceCompromised = (
-    state: AuthenticityChecksRootState,
-): boolean => {
+export const selectIsDeviceCompromised = (state: AuthenticityChecksRootState): boolean => {
     // Entropy check won't be performed if disabled but we must also check it here to avoid showing the UI when the failed state is stored in database.
     const isEntropyCheckEnabledAndFailed = selectIsEntropyCheckEnabledAndFailed(state);
     // Entropy check is not dismissible.
@@ -171,8 +162,5 @@ export const selectShouldDisplayDeviceCompromised = (
 export const selectShouldRouterAppSkipAuthenticityCheck = (state: RouterRootState): boolean =>
     SHOULD_ROUTER_APP_SKIP_AUTHENTICITY_CHECKS[selectRouterApp(state)];
 
-export const selectShouldDisplayDeviceCompromisedOnRoute = (
-    state: AuthenticityChecksRootState,
-): boolean =>
-    !selectShouldRouterAppSkipAuthenticityCheck(state) &&
-    selectShouldDisplayDeviceCompromised(state);
+export const selectShouldDisplayDeviceCompromised = (state: AuthenticityChecksRootState): boolean =>
+    !selectShouldRouterAppSkipAuthenticityCheck(state) && selectIsDeviceCompromised(state);

--- a/suite/authenticity-checks/src/index.ts
+++ b/suite/authenticity-checks/src/index.ts
@@ -1,13 +1,12 @@
 export {
     selectFirmwareHashCheckErrorIfEnabled,
     selectFirmwareRevisionCheckErrorIfEnabled,
-    selectIsDeviceCompromised,
     selectIsDeviceIdCheckEnabledAndFailed,
     selectIsDeviceInvariabilityEnabledAndFailed,
     selectIsEntropyCheckEnabledAndFailed,
     selectIsFirmwareAuthenticityCheckEnabledAndHardFailed,
+    selectIsDeviceCompromised,
     selectShouldDisplayDeviceCompromised,
-    selectShouldDisplayDeviceCompromisedOnRoute,
     selectShouldRetryFirmwareRevisionCheckError,
     type AuthenticityChecksRootState,
 } from './authenticityChecksSelectors';

--- a/suite/authenticity-checks/src/selectIsDeviceCompromised.test.ts
+++ b/suite/authenticity-checks/src/selectIsDeviceCompromised.test.ts
@@ -9,7 +9,7 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import {
     type AuthenticityChecksRootState,
-    selectShouldDisplayDeviceCompromised,
+    selectIsDeviceCompromised,
 } from './authenticityChecksSelectors';
 
 type Fixture = {
@@ -190,10 +190,10 @@ const fixtures: Fixture[] = [
     },
 ];
 
-describe(selectShouldDisplayDeviceCompromised.name, () => {
+describe(selectIsDeviceCompromised.name, () => {
     fixtures.forEach(f => {
         it(f.description, () => {
-            expect(selectShouldDisplayDeviceCompromised(f.state)).toBe(f.result);
+            expect(selectIsDeviceCompromised(f.state)).toBe(f.result);
         });
     });
 });

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -2,7 +2,7 @@ import { type UnknownAction } from 'redux';
 
 import {
     type AuthenticityChecksRootState,
-    selectShouldDisplayDeviceCompromised,
+    selectIsDeviceCompromised,
 } from '@suite/authenticity-checks';
 import { type LocksRootState } from '@suite/locks';
 import { type RouterRootState, routerAppChanged } from '@suite/router';
@@ -59,7 +59,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps<
     if (!isDeviceReady) return action;
 
     // 3. Discovery must be blocked while the compromised device warning is shown.
-    if (selectShouldDisplayDeviceCompromised(getState())) return action;
+    if (selectIsDeviceCompromised(getState())) return action;
 
     // 4. Discovery must be delayed if THP Autoconnect modal is open, because it is the only THP step that takes place
     //    *after* device acquisition, and also needs device interaction to complete (would block discovery).


### PR DESCRIPTION
## Description

In `@suite/authenticity-checks`, remove one useless selector, and rename others to be clearer:

- delete old `selectIsDeviceCompromised`
- rename `selectShouldDisplayDeviceCompromised`  → `selectIsDeviceCompromised`
- rename `selectShouldDisplayDeviceCompromisedOnRoute` → `selectShouldDisplayDeviceCompromised`

IMO that makes sense:
- "is compromised" = just gets the facts about authenticity check results
- "should display compromised" = whether the fact should be displayed – depends on router (can vary with the UI state)

## Notes for QA

The only real change is in the removed selector, now replaced by a similar one, so check that these functions are still disabled, when you have a compromised device:
- Sell Form
- Exchange Form
- Buy form
- Concierge
- Token recieve

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set spans authenticity-check selectors, discovery middleware, and two very broadly used layout/loading components. The highest regression risk is in onboarding authenticity/entropy handling and multi-coin wallet discovery, so run those targeted tests first. The Preloader and Sidebar changes are global, but only a small smoke subset that directly exercises initial load, sidebar account list, and route rendering is recommended; avoid running all 139 mapped tests.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/suite/Preloader/Preloader.tsx`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Sidebar.tsx`
- `suite/authenticity-checks/src/authenticityChecksSelectors.ts`
- `suite/authenticity-checks/src/index.ts`
- `suite/authenticity-checks/src/selectIsDeviceCompromised.test.ts`
- `suite/discovery/src/discoveryMiddleware.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This test verifies the full device authenticity-check path during onboarding; changes to authenticityChecksSelectors and selectIsDeviceCompromised directly control whether the flow passes or blocks onboarding.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Asserts the device-compromised modal appears on entropy-check failures and is suppressed for transport errors; this behavior is governed by the changed authenticity-checks selectors.
- `suite/e2e/tests/wallet/discovery.test.ts` — Directly exercises multi-coin discovery lifecycle, page-reload recovery, and Redux discovery status transitions that are handled by discoveryMiddleware.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Covers adding a standard wallet and discovering a BTC account, a core discovery flow that shares the middleware path with the changed discoveryMiddleware.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Runs through onboarding firmware readiness checks; authenticity-checks selectors influence how firmware-hash/revision errors are handled during this flow.
- `suite/e2e/tests/onboarding/initial-run.test.ts` — Validates initial app load, onboarding rendering, and reload behavior, which depend on Preloader rendering decisions.
- `suite/e2e/tests/wallet/account-search.test.ts` — Exercises the account search field and account buttons rendered in the Suite sidebar; Sidebar.tsx changes could break these interactions.
- `suite/e2e/tests/wallet/add-account-types.test.ts` — Adds accounts and verifies the account list/sidebar UI; Sidebar.tsx layout changes may affect account rendering.
- `suite/e2e/tests/wallet/multi-account-discovery-perf.test.ts` — Triggers full multi-account discovery across BTC/ETH/LTC; changes to discovery middleware could affect completion or performance of this flow.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — Navigates every route and asserts the bundle loader is hidden and layout content attaches; a broken Preloader or Sidebar could fail this broad smoke test, but coverage is indirect.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/authenticity-checks/src/selectIsDeviceCompromised.test.ts`

_Updated: 2026-09-07T07:29:10.243Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/cleanup-desktop-authenticity-selectors/web/](https://dev.suite.sldev.cz/suite-web/chore/cleanup-desktop-authenticity-selectors/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/cleanup-desktop-authenticity-selectors&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/cleanup-desktop-authenticity-selectors&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T07:28:28.577Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T07:28:44.682Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->