### PR TITLE
feat(suite): remove beta tag from Czech firmware language

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -1,6 +1,7 @@
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
+import { NON_BETA_DEVICE_LANGUAGES } from '@suite-common/device';
 import { LANGUAGES, type Locale } from '@suite-common/suite-types';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
@@ -31,9 +32,13 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
                 return null;
             }
 
+            const isBeta = !NON_BETA_DEVICE_LANGUAGES.includes(it as Locale);
+
             return {
                 value: it,
-                label: `${LANGUAGES[it as Locale].name} (beta)`,
+                label: isBeta
+                    ? `${LANGUAGES[it as Locale].name} (beta)`
+                    : LANGUAGES[it as Locale].name,
             };
         })
         .filter((lang): lang is { value: string; label: string } => Boolean(lang));

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -159,6 +159,8 @@ const selectAvailableDeviceTranslations = createMemoizedSelector(
     device => device?.availableTranslations ?? {},
 );
 
+export const NON_BETA_DEVICE_LANGUAGES: Locale[] = ['en-US', 'cs-CZ'];
+
 export const selectSupportedDeviceLanguages = createMemoizedSelector(
     [selectAvailableDeviceTranslations],
     availableDeviceTranslations => {
@@ -168,7 +170,7 @@ export const selectSupportedDeviceLanguages = createMemoizedSelector(
                 value: code as Locale,
                 icon,
                 label: name,
-                isBeta: true, // TODO: This will need tweaking in the future.
+                isBeta: !NON_BETA_DEVICE_LANGUAGES.includes(code as Locale), // TODO: This will need tweaking in the future.
             }))
             .sort((a, b) => a.label.localeCompare(b.label));
 


### PR DESCRIPTION
- applies to desktop/web/mobile

<!--- Provide a general summary of your changes in the Title above -->

## Description

Czech translation of Trezor FW is moving out of beta (for all models). This needs to be reflected in Suite by removing the `(beta)` tag from the firmware language dropdown.

## Notes for QA

Check that drop down for changing firmware language lists Czech without the `(beta)` tag in Desktop, Web and Mobile.

## Screenshots:

before
<img width="198" height="274" alt="image" src="https://github.com/user-attachments/assets/79887d11-1ff1-46c1-ad55-95b66d70bf30" />

after
<img width="227" height="281" alt="image" src="https://github.com/user-attachments/assets/b821bcde-87d6-4880-aa55-49a7aba37317" />