### PR TITLE
feat(connect): add ethereumSignAuth7702 method

### DIFF
--- a/packages/connect-common/src/callableMethods.ts
+++ b/packages/connect-common/src/callableMethods.ts
@@ -84,6 +84,7 @@ const connectPublicCallableMethodGroups = {
         'ethereumSignTransaction',
         'ethereumSignMessage',
         'ethereumSignTypedData',
+        'ethereumSignAuth7702',
         'ethereumVerifyMessage',
     ],
     cardano: [

--- a/packages/connect-common/src/types/api/ethereum.type-test.ts
+++ b/packages/connect-common/src/types/api/ethereum.type-test.ts
@@ -251,3 +251,37 @@ export const signTypedData = async (api: TrezorConnect) => {
         domain_separator_hash: '0x',
     });
 };
+
+export const signAuth7702 = async (api: TrezorConnect) => {
+    const signed = await api.ethereumSignAuth7702({
+        path: "m/44'/60'/0'/0/0",
+        chainId: 1,
+        delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+        nonce: 0,
+        __experimental: true,
+    });
+
+    if (signed.success) {
+        const { payload } = signed;
+        payload.yParity.toFixed();
+        payload.r.toLowerCase();
+        payload.s.toLowerCase();
+    }
+
+    // @ts-expect-error: `__experimental` opt-in is missing
+    await api.ethereumSignAuth7702({
+        path: "m/44'/60'/0'/0/0",
+        chainId: 1,
+        delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+        nonce: 0,
+    });
+
+    await api.ethereumSignAuth7702({
+        path: "m/44'/60'/0'/0/0",
+        chainId: 1,
+        delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+        // @ts-expect-error: nonce is a number
+        nonce: '0x0',
+        __experimental: true,
+    });
+};

--- a/packages/connect-common/src/types/api/ethereum/common.ts
+++ b/packages/connect-common/src/types/api/ethereum/common.ts
@@ -4,6 +4,41 @@ import { Type } from '@trezor/schema-utils';
 
 import { DerivationPath } from '../../params';
 
+// ethereumSignAuth7702
+
+/**
+ * EIP-7702 authorization tuple to be signed by the device.
+ */
+export type EthereumSignAuth7702 = Static<typeof EthereumSignAuth7702>;
+export const EthereumSignAuth7702 = Type.Object({
+    path: DerivationPath,
+    /** Chain id the authorization is valid on. `0` makes it valid on every EVM chain. */
+    chainId: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+    /**
+     * Address of the contract the account delegates to. Authorizing the zero address
+     * revokes an existing delegation.
+     */
+    delegate: Type.String(),
+    /**
+     * Account nonce the authorization is valid for. Both fields are `uint64` on the wire, but
+     * are capped at `Number.MAX_SAFE_INTEGER` so a value JavaScript cannot represent exactly is
+     * rejected instead of being silently rounded into a different authorization.
+     */
+    nonce: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+});
+
+/**
+ * Signature of an EIP-7702 authorization tuple. Together with the `chainId`, `delegate`
+ * and `nonce` that were signed it forms an entry of a transaction `authorizationList`.
+ */
+export type EthereumSignedAuth7702 = Static<typeof EthereumSignedAuth7702>;
+export const EthereumSignedAuth7702 = Type.Object({
+    /** Parity of the signature `y` coordinate, `0` or `1`. Legacy `v` is `yParity + 27`. */
+    yParity: Type.Number(),
+    r: Type.String(),
+    s: Type.String(),
+});
+
 // ethereumSignMessage
 
 export type EthereumSignMessage = Static<typeof EthereumSignMessage>;

--- a/packages/connect-common/src/types/api/ethereum/ethereumSignAuth7702.ts
+++ b/packages/connect-common/src/types/api/ethereum/ethereumSignAuth7702.ts
@@ -1,0 +1,6 @@
+import type { EthereumSignAuth7702, EthereumSignedAuth7702 } from './common';
+import type { ExperimentalMethod, Params, Response } from '../../params';
+
+export declare function ethereumSignAuth7702(
+    params: Params<EthereumSignAuth7702 & ExperimentalMethod>,
+): Response<EthereumSignedAuth7702>;

--- a/packages/connect-common/src/types/api/ethereum/index.ts
+++ b/packages/connect-common/src/types/api/ethereum/index.ts
@@ -3,6 +3,7 @@ import { Type } from '@trezor/schema-utils';
 
 import type { ethereumGetAddress } from './ethereumGetAddress';
 import type { ethereumGetPublicKey } from './ethereumGetPublicKey';
+import type { ethereumSignAuth7702 } from './ethereumSignAuth7702';
 import type { ethereumSignMessage } from './ethereumSignMessage';
 import type { ethereumSignTransaction } from './ethereumSignTransaction';
 import type { ethereumSignTypedData } from './ethereumSignTypedData';
@@ -15,6 +16,7 @@ export const TrezorConnectEthereum = Type.Object({
     ethereumSignTransaction: Type.Unsafe<typeof ethereumSignTransaction>(),
     ethereumSignMessage: Type.Unsafe<typeof ethereumSignMessage>(),
     ethereumSignTypedData: Type.Unsafe<typeof ethereumSignTypedData>(),
+    ethereumSignAuth7702: Type.Unsafe<typeof ethereumSignAuth7702>(),
     ethereumVerifyMessage: Type.Unsafe<typeof ethereumVerifyMessage>(),
 });
 export type TrezorConnectEthereum = Static<typeof TrezorConnectEthereum>;

--- a/packages/connect-explorer/src/data/methods/ethereum/signAuth7702.ts
+++ b/packages/connect-explorer/src/data/methods/ethereum/signAuth7702.ts
@@ -1,0 +1,36 @@
+export default [
+    {
+        name: 'ethereumSignAuth7702',
+        submitButton: 'Sign authorization',
+
+        fields: [
+            {
+                name: 'path',
+                type: 'input',
+                value: `m/44'/60'/0'/0/0`,
+            },
+            {
+                name: 'chainId',
+                type: 'number',
+                value: '1',
+            },
+            {
+                // MetaMask delegate, one of the contracts allowed by firmware. Use the zero
+                // address to revoke an existing delegation instead.
+                name: 'delegate',
+                type: 'input',
+                value: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+            },
+            {
+                name: 'nonce',
+                type: 'number',
+                value: '0',
+            },
+            {
+                name: '__experimental',
+                type: 'checkbox',
+                value: true,
+            },
+        ],
+    },
+];

--- a/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignAuth7702.mdx
+++ b/packages/connect-explorer/src/pages/methods/ethereum/ethereumSignAuth7702.mdx
@@ -1,0 +1,117 @@
+import { Callout } from 'nextra/components';
+
+import {
+    EthereumSignAuth7702,
+    EthereumSignedAuth7702,
+} from '@trezor/connect-common/src/types/api/ethereum/common';
+
+import { ApiPlayground } from '../../../components/ApiPlayground';
+import { CommonParamsLink } from '../../../components/CommonParamsLink';
+import { ParamsTable } from '../../../components/ParamsTable';
+import signAuth7702 from '../../../data/methods/ethereum/signAuth7702.ts';
+
+<ApiPlayground options={[{ title: 'Sign authorization', legacyConfig: signAuth7702[0] }]} />
+
+export const paramDescriptions = {
+    path: 'minimum length is `3`. [read more](/details/path)',
+    chainId: 'chain id the authorization is valid on. `0` makes it valid on every EVM chain.',
+    delegate:
+        'address of the contract the account delegates to. Use `0x0000000000000000000000000000000000000000` to revoke an existing delegation. A mixed-case address must carry a valid [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksum.',
+    nonce: 'account nonce the authorization is valid for.',
+};
+
+## Ethereum: sign EIP-7702 authorization
+
+Asks device to sign an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) authorization tuple,
+delegating the account derived from the given BIP32 path to a smart contract. Signing an
+authorization for the zero address revokes an existing delegation instead.
+
+```javascript
+const result = await TrezorConnect.ethereumSignAuth7702(params);
+```
+
+<Callout type="warning">
+    **Experimental method**, opted into by passing `__experimental: true`. It may change without a
+    major version bump.
+</Callout>
+
+### Device requirements
+
+Available since firmware 2.12.4; T1B1 does not support it at all. The device also has to be
+configured up front, using [trezorctl](https://trezor.io/guides/trezorctl):
+
+```bash
+# Required for every call - the underlying protobuf message is experimental.
+trezorctl set experimental-features on
+
+# Required to authorize a delegate. Revocation works under the default strict checks.
+trezorctl set safety-checks prompt
+```
+
+Firmware accepts only a
+[short allowlist of delegate contracts](https://github.com/trezor/trezor-firmware/blob/core/v2.12.4/core/src/apps/ethereum/sc_constants.py#L76)
+— currently Ambire and MetaMask. Any other delegate is rejected with
+`Unknown EIP-7702 delegate address`.
+
+### Params
+
+<CommonParamsLink />
+
+#### EthereumSignAuth7702
+
+<ParamsTable schema={EthereumSignAuth7702} descriptions={paramDescriptions} />
+
+### Example
+
+Delegate the first Ethereum account to a smart contract:
+
+```javascript
+TrezorConnect.ethereumSignAuth7702({
+    path: "m/44'/60'/0'/0/0",
+    chainId: 1,
+    delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+    nonce: 0,
+    __experimental: true,
+});
+```
+
+Revoke the delegation:
+
+```javascript
+TrezorConnect.ethereumSignAuth7702({
+    path: "m/44'/60'/0'/0/0",
+    chainId: 1,
+    delegate: '0x0000000000000000000000000000000000000000',
+    nonce: 1,
+    __experimental: true,
+});
+```
+
+### Result
+
+<ParamsTable schema={EthereumSignedAuth7702} />
+
+```javascript
+{
+    success: true,
+    payload: {
+        yParity: number, // 0 or 1, legacy `v` is `yParity + 27`
+        r: string, // hexadecimal string with "0x" prefix
+        s: string, // hexadecimal string with "0x" prefix
+    }
+}
+```
+
+Together with the signed `chainId`, `delegate` and `nonce` this forms one entry of a transaction
+`authorizationList`.
+
+Error
+
+```javascript
+{
+    success: false,
+    error: {
+        message: string // error message
+    }
+}
+```

--- a/packages/connect/e2e/__fixtures__/ethereumSignAuth7702.ts
+++ b/packages/connect/e2e/__fixtures__/ethereumSignAuth7702.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-ignore
+import commonFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_auth_eip7702.json';
+// @ts-ignore
+import errorFixtures from '../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_auth_eip7702_errors.json';
+
+// EIP-7702 is an experimental message not implemented on T1B1 and added to firmware in 2.12.4,
+// so it is skipped on T1B1 and on older firmware.
+const skip = ['1', '<2.12.4'];
+
+// The signed digest covers only chain id, delegate and nonce, so the upstream signatures hold
+// whether or not network definitions are downloaded - definitions only change what the device
+// displays. That includes the `_defs` fixtures, where the firmware test suite injects fake
+// definitions we have no equivalent for.
+const ethereumSignAuth7702: TestCase = {
+    method: 'ethereumSignAuth7702',
+    setup: {
+        mnemonic: commonFixtures.setup.mnemonic,
+        settings: {
+            experimental_features: true,
+            // Authorizing a delegate is refused under strict safety checks. Revocation is not,
+            // but the whole test case shares one emulator setup.
+            safety_checks: 2,
+        },
+    },
+    tests: [
+        ...commonFixtures.tests.map(({ name, parameters, result }) => ({
+            description: name,
+            params: {
+                __experimental: true,
+                path: parameters.path,
+                chainId: parameters.chain_id,
+                delegate: parameters.delegate,
+                nonce: parameters.nonce,
+            },
+            result: {
+                yParity: result.sig_v,
+                r: `0x${result.sig_r}`,
+                s: `0x${result.sig_s}`,
+            },
+            skip,
+        })),
+        ...errorFixtures.tests.map(({ name, parameters }) => ({
+            description: `${name} => rejected`,
+            params: {
+                __experimental: true,
+                path: parameters.path,
+                chainId: parameters.chain_id,
+                delegate: parameters.delegate,
+                nonce: parameters.nonce,
+            },
+            result: false,
+            skip,
+        })),
+        {
+            description: 'missing __experimental opt-in',
+            params: {
+                path: "m/44'/60'/0'/0/0",
+                chainId: 1,
+                delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+                nonce: 1,
+            },
+            result: false,
+            skip,
+        },
+        {
+            description: 'delegate is not an address',
+            params: {
+                __experimental: true,
+                path: "m/44'/60'/0'/0/0",
+                chainId: 1,
+                delegate: 'not-an-address',
+                nonce: 1,
+            },
+            result: false,
+            skip,
+        },
+    ],
+};
+
+export default ethereumSignAuth7702;

--- a/packages/connect/e2e/__fixtures__/index.ts
+++ b/packages/connect/e2e/__fixtures__/index.ts
@@ -10,6 +10,7 @@ export { default as changeLanguage } from './changeLanguage';
 export { default as composeTransaction } from './composeTransaction';
 export { default as ethereumGetAddress } from './ethereumGetAddress';
 export { default as ethereumGetPublicKey } from './ethereumGetPublicKey';
+export { default as ethereumSignAuth7702 } from './ethereumSignAuth7702';
 export { default as ethereumSignMessage } from './ethereumSignMessage';
 export { default as ethereumSignTransaction } from './ethereumSignTransaction';
 export { default as ethereumSignTransactionEip155 } from './ethereumSignTransactionEip155';

--- a/packages/connect/src/api/ethereum/api/ethereumSignAuth7702.test.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignAuth7702.test.ts
@@ -1,0 +1,157 @@
+import EthereumSignAuth7702 from './ethereumSignAuth7702';
+import {
+    decodeEthereumDefinition,
+    ethereumNetworkInfoFromDefinition,
+    getEthereumDefinitions,
+} from '../ethereumDefinitions';
+
+jest.mock('../ethereumDefinitions', () => ({
+    getEthereumDefinitions: jest.fn(),
+    decodeEthereumDefinition: jest.fn(),
+    ethereumNetworkInfoFromDefinition: jest.fn(),
+}));
+
+type Payload = Record<string, unknown>;
+
+const VALID_PAYLOAD: Payload = {
+    method: 'ethereumSignAuth7702',
+    path: "m/44'/60'/0'/0/0",
+    chainId: 1,
+    // Lowercase on purpose - firmware displays what we send, so it has to be checksummed first.
+    delegate: '0x63c0c19a282a1b52b07dd5a65b58948a07dae32b',
+    nonce: 7,
+    __experimental: true,
+};
+
+const REVOKE_DELEGATE = '0x0000000000000000000000000000000000000000';
+
+const createMethod = (payload: Payload = VALID_PAYLOAD) =>
+    new EthereumSignAuth7702({ payload } as any);
+
+describe('ethereumSignAuth7702', () => {
+    beforeEach(() => {
+        jest.mocked(getEthereumDefinitions).mockResolvedValue({});
+        jest.mocked(decodeEthereumDefinition).mockReturnValue({
+            network: undefined,
+            token: undefined,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('maps params onto the protobuf message and checksums the delegate', () => {
+        const { params } = createMethod() as any;
+
+        expect(params.proto).toEqual({
+            address_n: [2147483692, 2147483708, 2147483648, 0, 0],
+            chain_id: 1,
+            delegate: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            nonce: 7,
+        });
+    });
+
+    it('accepts the zero delegate used for revocation', () => {
+        const method = createMethod({ ...VALID_PAYLOAD, delegate: REVOKE_DELEGATE }) as any;
+
+        expect(method.params.proto.delegate).toBe(REVOKE_DELEGATE);
+        expect(method.info).toBe('Revoke Ethereum EIP-7702 delegation');
+    });
+
+    it('describes an authorization as signing, not revoking', () => {
+        expect((createMethod() as any).info).toBe('Sign Ethereum EIP-7702 authorization');
+    });
+
+    it('accepts chainId 0, which makes the authorization valid on every EVM chain', () => {
+        const method = createMethod({ ...VALID_PAYLOAD, chainId: 0 }) as any;
+
+        expect(method.params.proto.chain_id).toBe(0);
+    });
+
+    it('rejects params without the experimental opt-in', () => {
+        const { __experimental, ...payload } = VALID_PAYLOAD;
+
+        expect(() => createMethod(payload)).toThrow();
+    });
+
+    it('accepts an already checksummed delegate', () => {
+        const delegate = '0x5A7FC11397E9a8AD41BF10bf13F22B0a63f96f6d';
+        const method = createMethod({ ...VALID_PAYLOAD, delegate }) as any;
+
+        expect(method.params.proto.delegate).toBe(delegate);
+    });
+
+    it.each([
+        ['too short', '0x63c0c19a282a1b52b07dd5a65b58948a07dae32'],
+        ['not hexadecimal', '0xzzc0c19a282a1b52b07dd5a65b58948a07dae32b'],
+        ['missing the 0x prefix', '63c0c19a282a1b52b07dd5a65b58948a07dae32b'],
+        // Mixed case that does not match EIP-55 is most likely a mistyped address.
+        ['a broken checksum', '0x63c0C19a282a1B52b07dD5a65b58948A07DAE32B'],
+        ['empty', ''],
+    ])('rejects a delegate address that is %s', (_description, delegate) => {
+        expect(() => createMethod({ ...VALID_PAYLOAD, delegate })).toThrow(
+            'Parameter "delegate" is not a valid Ethereum address.',
+        );
+    });
+
+    it.each([
+        ['negative', -1],
+        ['fractional', 1.5],
+        ['above Number.MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
+        // The wire type is uint64, but JavaScript cannot represent its maximum exactly, so it
+        // must be refused rather than rounded into a different authorization.
+        ['the uint64 maximum', 2 ** 64 - 1],
+    ])('rejects a nonce that is %s', (_description, nonce) => {
+        expect(() => createMethod({ ...VALID_PAYLOAD, nonce })).toThrow();
+    });
+
+    it('attaches network definitions and names the network from them', async () => {
+        const definitions = { encoded_network: new ArrayBuffer(4) };
+        jest.mocked(getEthereumDefinitions).mockResolvedValue(definitions);
+        jest.mocked(decodeEthereumDefinition).mockReturnValue({
+            network: { chain_id: 137, name: 'Polygon', slip44: 966, symbol: 'MATIC' },
+            token: undefined,
+        });
+        jest.mocked(ethereumNetworkInfoFromDefinition).mockReturnValue({ name: 'Polygon' } as any);
+
+        const method = createMethod({ ...VALID_PAYLOAD, chainId: 137 }) as any;
+        await method.initAsync();
+
+        expect(getEthereumDefinitions).toHaveBeenCalledWith({ chainId: 137 });
+        expect(method.params.proto.definitions).toBe(definitions);
+        expect(method.info).toBe('Sign Polygon EIP-7702 authorization');
+    });
+
+    it('does not download definitions when the authorization is valid on every chain', async () => {
+        const method = createMethod({ ...VALID_PAYLOAD, chainId: 0 }) as any;
+        await method.initAsync();
+
+        expect(getEthereumDefinitions).not.toHaveBeenCalled();
+        expect(method.params.proto.definitions).toBeUndefined();
+    });
+
+    it('returns the signature split into yParity, r and s', async () => {
+        const method = createMethod() as any;
+        const typedCall = jest.fn().mockResolvedValue({
+            type: 'EthereumAuth7702Signature',
+            message: {
+                signature_v: 1,
+                signature_r: 'aa'.repeat(32),
+                signature_s: 'bb'.repeat(32),
+            },
+        });
+        method.getDevice = () => ({ getCommands: () => ({ typedCall }) });
+
+        await expect(method.run()).resolves.toEqual({
+            yParity: 1,
+            r: `0x${'aa'.repeat(32)}`,
+            s: `0x${'bb'.repeat(32)}`,
+        });
+        expect(typedCall).toHaveBeenCalledWith(
+            'EthereumSignAuth7702',
+            'EthereumAuth7702Signature',
+            method.params.proto,
+        );
+    });
+});

--- a/packages/connect/src/api/ethereum/api/ethereumSignAuth7702.ts
+++ b/packages/connect/src/api/ethereum/api/ethereumSignAuth7702.ts
@@ -1,0 +1,142 @@
+import { getAddress, isAddress } from 'viem';
+
+import {
+    EthereumSignAuth7702 as EthereumSignAuth7702Schema,
+    ExperimentalMethod,
+} from '@trezor/connect-common';
+import type {
+    EthereumNetworkInfoDefinitionValues,
+    PermissionRequest,
+} from '@trezor/connect-common';
+import { ERRORS } from '@trezor/connect-common/src/constants';
+import type { MessagesSchema as PROTO } from '@trezor/protobuf';
+import { Assert } from '@trezor/schema-utils';
+
+import type { MethodMessage } from '../../../core/AbstractMethod';
+import { AbstractMethod } from '../../../core/AbstractMethod';
+import { getEthereumNetwork } from '../../../data/coinInfo';
+import { getNetworkLabel } from '../../../utils/ethereumUtils';
+import { addHexPrefix } from '../../../utils/formatUtils';
+import { getSerializedPath, validatePath } from '../../../utils/pathUtils';
+import {
+    decodeEthereumDefinition,
+    ethereumNetworkInfoFromDefinition,
+    getEthereumDefinitions,
+} from '../ethereumDefinitions';
+
+// Delegating to the zero address clears an existing delegation, see EIP-7702.
+const REVOKE_DELEGATE = '0x0000000000000000000000000000000000000000';
+
+// `chain_id: 0` makes the authorization valid on every EVM chain, so there is no network to resolve.
+const ALL_CHAINS = 0;
+
+type Params = {
+    proto: PROTO.EthereumSignAuth7702;
+    network?: EthereumNetworkInfoDefinitionValues;
+};
+
+// Delegating an account is expensive to get wrong, so a mixed-case address has to carry a valid
+// EIP-55 checksum; an all-lowercase address is accepted as-is. The device renders `delegate`
+// exactly as it was received, hence the normalization to the checksummed form.
+const normalizeDelegate = (delegate: string) => {
+    if (!isAddress(delegate, { strict: true })) {
+        throw ERRORS.TypedError(
+            'Method_InvalidParameter',
+            'Parameter "delegate" is not a valid Ethereum address.',
+        );
+    }
+
+    return getAddress(delegate);
+};
+
+export default class EthereumSignAuth7702 extends AbstractMethod<'ethereumSignAuth7702', Params> {
+    constructor(message: MethodMessage<'ethereumSignAuth7702'>) {
+        const { payload } = message;
+
+        // validate incoming parameters
+        Assert(EthereumSignAuth7702Schema, payload);
+        Assert(ExperimentalMethod, payload);
+
+        const address_n = validatePath(payload.path, 3);
+        const network = getEthereumNetwork(address_n);
+
+        const params = {
+            proto: {
+                address_n,
+                chain_id: payload.chainId,
+                delegate: normalizeDelegate(payload.delegate),
+                nonce: payload.nonce,
+            },
+            network,
+        };
+
+        super(message, params);
+        this.requiredFirmwareCoins = [network];
+        this.requiredDeviceCapabilities = ['Capability_Ethereum'];
+    }
+
+    get requiredPermissions(): PermissionRequest[] {
+        return this.coinPerms('sign', this.requiredFirmwareCoins);
+    }
+
+    async initAsync() {
+        const { chain_id } = this.params.proto;
+        if (chain_id === ALL_CHAINS) return;
+
+        // The path only tells us the slip44 coin, while the authorization is bound to `chainId`.
+        // Definitions let the device name the chain instead of showing a raw chain id.
+        const definitions = await getEthereumDefinitions({ chainId: chain_id });
+        this.params.proto.definitions = definitions;
+
+        const decoded = decodeEthereumDefinition(definitions);
+        if (decoded.network) {
+            this.params.network = ethereumNetworkInfoFromDefinition(decoded.network);
+        }
+    }
+
+    get info() {
+        const label =
+            this.params.proto.delegate === REVOKE_DELEGATE
+                ? 'Revoke #NETWORK EIP-7702 delegation'
+                : 'Sign #NETWORK EIP-7702 authorization';
+
+        return getNetworkLabel(label, this.params.network);
+    }
+
+    getButtonRequestData(code: string) {
+        if (code === 'ButtonRequest_SignTx') {
+            return {
+                type: 'message' as const,
+                coin: this.params.network?.shortcut ?? 'ETH',
+                serializedPath: getSerializedPath(this.params.proto.address_n),
+                message: JSON.stringify(
+                    {
+                        chainId: this.params.proto.chain_id,
+                        delegate: this.params.proto.delegate,
+                        nonce: this.params.proto.nonce,
+                    },
+                    null,
+                    2,
+                ),
+            };
+        }
+    }
+
+    async run() {
+        const cmd = this.getDevice().getCommands();
+
+        const response = await cmd.typedCall(
+            'EthereumSignAuth7702',
+            'EthereumAuth7702Signature',
+            this.params.proto,
+        );
+
+        const { signature_v, signature_r, signature_s } = response.message;
+
+        return {
+            yParity: signature_v,
+            r: addHexPrefix(signature_r),
+            s: addHexPrefix(signature_s),
+        };
+    }
+}

--- a/packages/connect/src/api/ethereum/api/index.ts
+++ b/packages/connect/src/api/ethereum/api/index.ts
@@ -1,5 +1,6 @@
 export { default as ethereumGetAddress } from './ethereumGetAddress';
 export { default as ethereumGetPublicKey } from './ethereumGetPublicKey';
+export { default as ethereumSignAuth7702 } from './ethereumSignAuth7702';
 export { default as ethereumSignMessage } from './ethereumSignMessage';
 export { default as ethereumSignTransaction } from './ethereumSignTransaction';
 export { default as ethereumSignTypedData } from './ethereumSignTypedData';

--- a/packages/connect/src/data/config.ts
+++ b/packages/connect/src/data/config.ts
@@ -267,5 +267,21 @@ export const config: Config = {
             },
             comment: ['Ethereum clear signing for known contracts/function selectors since 2.12.1'],
         },
+        {
+            methods: ['ethereumSignAuth7702'],
+            min: {
+                T1B1: '0',
+                T2T1: '2.12.4',
+                T2B1: '2.12.4',
+                T3B1: '2.12.4',
+                T3T1: '2.12.4',
+                T3W1: '2.12.4',
+            },
+            comment: [
+                'EIP-7702 authorization/revocation since 2.12.4, T1B1 does not support it at all.',
+                'The message is experimental - the device additionally requires experimental features',
+                'to be enabled, and authorization (unlike revocation) requires safety checks to be lowered.',
+            ],
+        },
     ],
 };

--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -87,7 +87,7 @@ const groups = {
     experimental: {
         name: 'experimental',
         pattern: 'methods',
-        includeFilter: 'nostrGetPublicKey,nostrSignEvent',
+        includeFilter: 'nostrGetPublicKey,nostrSignEvent,ethereumSignAuth7702',
     },
 };
 


### PR DESCRIPTION
## Description

Adds `TrezorConnect.ethereumSignAuth7702`, the host side of EIP-7702 authorization/revocation signing shipped in firmware 2.12.4 by trezor/trezor-firmware#7340. 

Callers pass `path`, `chainId`, `delegate` and `nonce` and get back the `{ yParity, r, s }` signature that forms one entry of a transaction `authorizationList`; authorizing the zero address revokes an existing delegation instead. 

The method is gated behind `__experimental: true` (same pattern as the nostr methods), because the protobuf message is marked experimental and the device additionally requires experimental features to be enabled. 

[E2E run](https://github.com/trezor/trezor-suite/actions/runs/31008789178)

## Notes for QA

FW 2.12.4+ required

Device setup (via [trezorctl](https://trezor.io/guides/trezorctl)):

```bash
trezorctl set experimental-features on   # required for every call
trezorctl set safety-checks prompt       # required to authorize; revocation works under strict
```

- Easiest surface is the new Connect Explorer page: **Ethereum → sign EIP-7702 authorization**.
- Firmware only accepts Ambire (`0x5A7FC11397E9a8AD41BF10bf13F22B0a63f96f6d`) and MetaMask (`0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B`) as delegates; anything else must fail with `Unknown EIP-7702 delegate address`.

## Related Issue

Related to trezor/trezor-firmware#6394

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set introduces a brand-new TrezorConnect method, ethereumSignAuth7702 (EIP-7702 authorization signing), across method registration, types, implementation, fixtures, and CI matrix. No Suite E2E test directly covers the new method, so the recommended strategy is to run the existing Ethereum signing and TrezorConnect integration tests as regression smoke tests. The highest-value tests are those that exercise ethereum transaction/message signing and TrezorConnect init, where registration or type changes could surface failures.

<details><summary><b>Changed files (13)</b></summary>

- `packages/connect-common/src/callableMethods.ts`
- `packages/connect-common/src/types/api/ethereum.type-test.ts`
- `packages/connect-common/src/types/api/ethereum/common.ts`
- `packages/connect-common/src/types/api/ethereum/ethereumSignAuth7702.ts`
- `packages/connect-common/src/types/api/ethereum/index.ts`
- `packages/connect-explorer/src/data/methods/ethereum/signAuth7702.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignAuth7702.ts`
- `packages/connect/e2e/__fixtures__/index.ts`
- `packages/connect/src/api/ethereum/api/ethereumSignAuth7702.test.ts`
- `packages/connect/src/api/ethereum/api/ethereumSignAuth7702.ts`
- `packages/connect/src/api/ethereum/api/index.ts`
- `packages/connect/src/data/config.ts`
- `scripts/ci/connect-test-matrix-generator.js`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Directly exercises TrezorConnect Ethereum signing (ethereumSignTransaction), which lives in the same connect Ethereum API family as the new ethereumSignAuth7702 method. This is the strongest Suite E2E proxy for catching regressions in ethereum method registration, shared types, and device signing flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Validates the Suite Ethereum send flow end-to-end, including custom fee handling and device confirmation of ethereum transaction data. Changes to ethereum common types and method config could affect how Suite composes or confirms Ethereum transactions.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Tests another Ethereum signing method through TrezorConnect (ethereumSignMessage) and shares the connect permissions, init, and ethereum API infrastructure that the new method was wired into. Useful for detecting registration or type-export regressions.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Covers TrezorConnect.init in suite-desktop core mode and ethereumGetAddress error handling. Adding a new ethereum method to callableMethods/config changes the global method table, so this is a good smoke test for connect initialization remaining healthy.
- `suite/e2e/tests/wallet/sign-and-verify-eth.test.ts` — Exercises Ethereum message signing inside the Suite wallet and verifies device prompts/toasts. Shares the underlying ethereum signing stack with the new method, though it does not touch the new API directly.

</details>

⚠️ **Changes with no test coverage (10)**
- `packages/connect-common/src/types/api/ethereum.type-test.ts`
- `packages/connect-common/src/types/api/ethereum/ethereumSignAuth7702.ts`
- `packages/connect-common/src/types/api/ethereum/index.ts`
- `packages/connect-explorer/src/data/methods/ethereum/signAuth7702.ts`
- `packages/connect/e2e/__fixtures__/ethereumSignAuth7702.ts`
- `packages/connect/e2e/__fixtures__/index.ts`
- `packages/connect/src/api/ethereum/api/ethereumSignAuth7702.test.ts`
- `packages/connect/src/api/ethereum/api/ethereumSignAuth7702.ts`
- `packages/connect/src/api/ethereum/api/index.ts`
- `scripts/ci/connect-test-matrix-generator.js`

_Updated: 2026-08-05T12:51:19.008Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/connect-eip7702-sign-auth/web/](https://dev.suite.sldev.cz/suite-web/feat/connect-eip7702-sign-auth/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/connect-eip7702-sign-auth&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/connect-eip7702-sign-auth&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/connect-eip7702-sign-auth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T12:54:06.316Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T12:53:50.806Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->