### PR TITLE
refactor(recovery): remove unused submitThunk

### DIFF
--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -1,7 +1,7 @@
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import TrezorConnect, { PROTO, type RecoveryDevice, UI_RESPONSE } from '@trezor/connect';
+import TrezorConnect, { PROTO, type RecoveryDevice } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { isRecoveryInProgress } from './isRecoveryInProgress';
@@ -11,13 +11,6 @@ import { selectAdvancedRecovery, selectWordsCount } from './recoverySelectors';
 const DEFAULT_PASSPHRASE_PROTECTION = false;
 
 const actionPrefix = '@suite/recovery';
-
-export const submitThunk = createThunk(
-    `${actionPrefix}/submitThunk`,
-    ({ word, requestId }: { word: string; requestId?: string }) => {
-        TrezorConnect.uiResponse({ type: UI_RESPONSE.RECEIVE_WORD, payload: word, requestId });
-    },
-);
 
 export const checkSeedThunk = createThunk(
     `${actionPrefix}/checkSeedThunk`,


### PR DESCRIPTION
## Description

`submitThunk` in `suite/recovery/src/recoveryThunks.ts` was defined and exported (via `export * from './recoveryThunks'` in the package index), but a repo-wide search found no consumer — it is never imported or dispatched anywhere.

Actual word submission during recovery happens directly through `TrezorConnect.uiResponse({ type: UI_RESPONSE.RECEIVE_WORD, ... })` in:
- `packages/suite/src/components/suite/WordInput.tsx`
- `packages/suite/src/components/suite/WordInputAdvanced.tsx`

So `submitThunk` is dead code. This PR removes it and the now-orphaned `UI_RESPONSE` import.

## Verification

```
grep -rn "submitThunk" --exclude-dir=node_modules .
# only the definition line before this change; nothing after removal
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file suite/recovery/src/recoveryThunks.ts is central to device recovery flows. No static coverage mapping was available, so recommendations are inferred from test descriptions. The highest confidence comes from the three recovery dry-run tests, which directly exercise recovery start, progress, and reinitialization. Onboarding recovery success tests add integrated regression coverage. The risk profile is moderate because recovery is a critical user path, but the targeted dry-run tests should catch thunk-level regressions quickly.

<details><summary><b>Changed files (1)</b></summary>

- `suite/recovery/src/recoveryThunks.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/recovery/dry-run.test.ts` — This test directly exercises the recovery dry-run flow from device settings, including start, device disconnect/reconnect, and page reload scenarios. Since recoveryThunks.ts likely implements the core recovery thunk logic, this is the most direct end-to-end validation.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Tests recovery dry-run specifically on the T1B1 device model, including PIN entry, mnemonic input, and success confirmation. Changes to recovery thunks could affect device-specific recovery behavior, making this a high-value targeted test.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Tests recovery dry-run on the T2T1 device model with disconnect and page reload recovery paths. It directly validates recovery thunk behavior under interruption and reinitialization, matching the likely scope of recoveryThunks.ts.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — This test covers the full wallet recovery flow during onboarding for T1B1. Recovery thunks are likely invoked as part of this integrated flow, so it provides broader regression coverage beyond standalone dry-run.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — This test covers the full wallet recovery flow during onboarding for T2T1. It validates that recovery thunk behavior integrates correctly with the onboarding state machine and device prompts.

</details>

_Updated: 2026-08-04T12:22:51.609Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-unused-recovery-submitthunk/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-unused-recovery-submitthunk/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-unused-recovery-submitthunk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/remove-unused-recovery-submitthunk&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T12:25:24.655Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T12:24:43.509Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->