### PR TITLE
fix(sign-verify): wrap Address and Format on narrow viewports

### DIFF
--- a/suite/sign-verify/src/SignVerify.tsx
+++ b/suite/sign-verify/src/SignVerify.tsx
@@ -202,7 +202,7 @@ export const SignVerify = ({ account, network, renderShell }: SignVerifyProps) =
                         />
                         {isSignPage ? (
                             <>
-                                <Row gap={40} alignItems="flex-start">
+                                <Row gap={40} alignItems="flex-start" flexWrap="wrap">
                                     <Box flex="1" minWidth={0}>
                                         <SignAddressInput
                                             name="path"


### PR DESCRIPTION
Fixes #30794

## Problem
On Sign & verify for Bitcoin, the Address shares a row with Format. Around ~900px width, the Address is squeezed to ~116px, making the Bitcoin address unreadable (each group stacks one-per-line).

## Solution
Add `flexWrap="wrap"` to the `Row` component so that when the viewport is narrow, the Format selector wraps below the Address input instead of squeezing it.

## Testing
- Resize window to ~900px while on Bitcoin Sign & Verify
- Address should stay readable and Format should wrap below
- Ethereum (no Format) should be unaffected