### PR TITLE
refactor(suite): store recoveryType instead of advancedRecovery boolean

### DIFF
--- a/packages/suite/mocks/mockInitialAppState.ts
+++ b/packages/suite/mocks/mockInitialAppState.ts
@@ -98,7 +98,7 @@ export const mockInitialAppState: AppState = {
         },
     } as RouterState, // TODO: this is state copied from actual app runtime, so how can there be type error???
     recovery: {
-        advancedRecovery: false,
+        recoveryInputType: 'standard',
         wordsCount: 12,
         status: 'initial',
     },

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -4,6 +4,7 @@ import { Translation, type TranslationKey } from '@suite/intl';
 import { selectRecoveryWordRequestInputType } from '@suite/modal';
 import { OnboardingCard } from '@suite/onboarding-components';
 import {
+    type RecoveryInputType,
     isStandardRecoveryDisabled,
     recoverDeviceThunk,
     recoveryActions,
@@ -88,7 +89,7 @@ export const RecoveryStep = () => {
                             );
 
                             if (shouldSkipSelection) {
-                                dispatch(recoveryActions.setAdvancedRecovery(true));
+                                dispatch(recoveryActions.setRecoveryInputType('advanced'));
                                 dispatch(updateAnalytics({ recoveryType: 'advanced' }));
                                 dispatch(recoverDeviceThunk());
                             } else {
@@ -140,8 +141,8 @@ export const RecoveryStep = () => {
 
     if (status === 'select-recovery-type') {
         // 2. step: Standard recovery (user enters recovery seed word by word on host) or Advanced recovery (user types words on a device)
-        const handleSelect = (type: 'standard' | 'advanced') => {
-            dispatch(recoveryActions.setAdvancedRecovery(type === 'advanced'));
+        const handleSelect = (type: RecoveryInputType) => {
+            dispatch(recoveryActions.setRecoveryInputType(type));
             dispatch(updateAnalytics({ recoveryType: type }));
             dispatch(recoverDeviceThunk());
         };

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -5,7 +5,7 @@ import { useDevice } from '@suite/device';
 import { Translation, messages } from '@suite/intl';
 import { MODAL_CONTEXT_DEVICE, selectModalRequestId } from '@suite/modal';
 import {
-    type RecoveryType,
+    type RecoveryInputType,
     type SeedInputStatus,
     type WordCount,
     checkSeedThunk,
@@ -39,7 +39,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     const { device, isLocked } = useDevice();
     const [isUnderstood, setIsUnderstood] = useState(false);
     const [wordCount, setWordCount] = useState<WordCount | undefined>();
-    const [recoveryType, setRecoveryType] = useState<RecoveryType | undefined>();
+    const [recoveryInputType, setRecoveryInputType] = useState<RecoveryInputType | undefined>();
     const intl = useIntl();
     const pinRequestId = useSelector(selectModalRequestId);
     const { pin, setPin, handlePinSubmit } = usePin(device?.buttonRequests ?? [], pinRequestId);
@@ -98,8 +98,8 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             case 'select-recovery-type':
                 return (
                     <SelectRecoveryTypeStep
-                        setRecoveryType={setRecoveryType}
-                        recoveryType={recoveryType}
+                        setRecoveryInputType={setRecoveryInputType}
+                        recoveryInputType={recoveryInputType}
                     />
                 );
             case 'waiting-for-confirmation':
@@ -209,7 +209,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                             );
 
                             if (shouldSkipSelection) {
-                                dispatch(recoveryActions.setAdvancedRecovery(true));
+                                dispatch(recoveryActions.setRecoveryInputType('advanced'));
                                 dispatch(checkSeedThunk());
                             } else {
                                 dispatch(recoveryActions.setStatus('select-recovery-type'));
@@ -223,11 +223,11 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
             case 'select-recovery-type':
                 return (
                     <Modal.Button
-                        isDisabled={!recoveryType}
+                        isDisabled={!recoveryInputType}
                         onClick={() => {
-                            dispatch(
-                                recoveryActions.setAdvancedRecovery(recoveryType === 'advanced'),
-                            );
+                            if (!recoveryInputType) return;
+
+                            dispatch(recoveryActions.setRecoveryInputType(recoveryInputType));
                             dispatch(checkSeedThunk());
                         }}
                         data-testid="@recovery/continue-button"

--- a/packages/suite/src/views/recovery/steps/SelectRecoveryTypeStep.tsx
+++ b/packages/suite/src/views/recovery/steps/SelectRecoveryTypeStep.tsx
@@ -1,15 +1,15 @@
 import { Translation } from '@suite/intl';
-import { type RecoveryType, recoveryTypes } from '@suite/recovery';
+import { type RecoveryInputType, recoveryInputTypes } from '@suite/recovery';
 import { Card, Column, Grid, H4, Icon, Paragraph, RadioCard, Row } from '@trezor/components';
 import { RecoverySeedFilledIcon, TrezorModelOneFilledIcon } from '@trezor/icons';
 type SelectRecoveryTypeStepProps = {
-    setRecoveryType: (type: RecoveryType) => void;
-    recoveryType?: RecoveryType;
+    setRecoveryInputType: (type: RecoveryInputType) => void;
+    recoveryInputType?: RecoveryInputType;
 };
 
 export const SelectRecoveryTypeStep = ({
-    setRecoveryType,
-    recoveryType,
+    setRecoveryInputType,
+    recoveryInputType,
 }: SelectRecoveryTypeStepProps) => (
     <Card margin={{ top: 8 }}>
         <Column gap={16}>
@@ -17,11 +17,11 @@ export const SelectRecoveryTypeStep = ({
                 <Translation id="TR_CHOOSE_RECOVERY_TYPE" />
             </H4>
             <Grid columns={2} gap={16}>
-                {recoveryTypes.map(type => (
+                {recoveryInputTypes.map(type => (
                     <RadioCard
                         key={type}
-                        isSelected={recoveryType === type}
-                        onClick={() => setRecoveryType(type)}
+                        isSelected={recoveryInputType === type}
+                        onClick={() => setRecoveryInputType(type)}
                         dataTestId={`@recovery/select-type/${type}`}
                     >
                         <Row gap={16} padding={{ left: 4 }}>

--- a/suite/recovery/src/recoveryReducer.ts
+++ b/suite/recovery/src/recoveryReducer.ts
@@ -1,16 +1,16 @@
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { type SeedInputStatus, type WordCount } from './types';
+import { type RecoveryInputType, type SeedInputStatus, type WordCount } from './types';
 
 export interface RecoveryState {
-    advancedRecovery: boolean;
+    recoveryInputType: RecoveryInputType;
     wordsCount: WordCount;
     status: SeedInputStatus;
     error?: string;
 }
 
 const initialState: RecoveryState = {
-    advancedRecovery: false,
+    recoveryInputType: 'standard',
     wordsCount: 12,
     error: undefined,
     status: 'initial',
@@ -23,8 +23,8 @@ export const recoverySlice = createSlice({
         setWordsCount: (state, { payload }: PayloadAction<WordCount>) => {
             state.wordsCount = payload;
         },
-        setAdvancedRecovery: (state, { payload }: PayloadAction<boolean>) => {
-            state.advancedRecovery = payload;
+        setRecoveryInputType: (state, { payload }: PayloadAction<RecoveryInputType>) => {
+            state.recoveryInputType = payload;
         },
         setError: (state, { payload }: PayloadAction<string | undefined>) => {
             state.error = payload;

--- a/suite/recovery/src/recoverySelectors.ts
+++ b/suite/recovery/src/recoverySelectors.ts
@@ -3,7 +3,8 @@ import { type RecoveryState } from './recoveryReducer';
 type RecoveryRootState = { recovery: RecoveryState };
 
 export const selectRecovery = (state: RecoveryRootState) => state.recovery;
-export const selectAdvancedRecovery = (state: RecoveryRootState) => state.recovery.advancedRecovery;
+export const selectRecoveryInputType = (state: RecoveryRootState) =>
+    state.recovery.recoveryInputType;
 export const selectWordsCount = (state: RecoveryRootState) => state.recovery.wordsCount;
 export const selectRecoveryStatus = (state: RecoveryRootState) => state.recovery.status;
 export const selectRecoveryError = (state: RecoveryRootState) => state.recovery.error;

--- a/suite/recovery/src/recoverySlice.test.ts
+++ b/suite/recovery/src/recoverySlice.test.ts
@@ -30,17 +30,17 @@ describe('Recovery Slice', () => {
         expect(store.getActions().length).toEqual(1);
     });
 
-    it('setAdvancedRecovery', () => {
+    it('setRecoveryInputType', () => {
         const store = initStore();
 
         // default state
         const stateBefore = store.getState().recovery;
-        expect(stateBefore.advancedRecovery).toEqual(false);
+        expect(stateBefore.recoveryInputType).toEqual('standard');
 
-        store.dispatch(recoveryActions.setAdvancedRecovery(true));
+        store.dispatch(recoveryActions.setRecoveryInputType('advanced'));
 
         const stateAfter = store.getState().recovery;
-        expect(stateAfter.advancedRecovery).toEqual(true);
+        expect(stateAfter.recoveryInputType).toEqual('advanced');
 
         // should not trigger side-effect actions
         expect(store.getActions().length).toEqual(1);

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -6,16 +6,27 @@ import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { isRecoveryInProgress } from './isRecoveryInProgress';
 import { recoveryActions } from './recoveryReducer';
-import { selectAdvancedRecovery, selectWordsCount } from './recoverySelectors';
+import { selectRecoveryInputType, selectWordsCount } from './recoverySelectors';
+import { type RecoveryInputType } from './types';
 
 const DEFAULT_PASSPHRASE_PROTECTION = false;
 
 const actionPrefix = '@suite/recovery';
 
+/**
+ * Maps the product-level recovery type to the firmware seed input method.
+ * - standard → ScrambledWords: user re-enters the seed word by word on the host
+ * - advanced → Matrix: user enters each letter directly on the device via the matrix keypad
+ */
+const recoveryInputTypeToInputMethod: Record<RecoveryInputType, PROTO.RecoveryDeviceInputMethod> = {
+    standard: PROTO.RecoveryDeviceInputMethod.ScrambledWords,
+    advanced: PROTO.RecoveryDeviceInputMethod.Matrix,
+};
+
 export const checkSeedThunk = createThunk(
     `${actionPrefix}/checkSeedThunk`,
     async (_, { dispatch, getState, extra }) => {
-        const advancedRecovery = selectAdvancedRecovery(getState());
+        const recoveryInputType = selectRecoveryInputType(getState());
         const wordsCount = selectWordsCount(getState());
         const device = selectSelectedDevice(getState());
 
@@ -31,9 +42,7 @@ export const checkSeedThunk = createThunk(
 
         const response = await TrezorConnect.recoveryDevice({
             type: device.features.recovery_type ?? 'DryRun', // For old firmware, we assume DryRun as it was the only option before
-            input_method: advancedRecovery
-                ? PROTO.RecoveryDeviceInputMethod.Matrix
-                : PROTO.RecoveryDeviceInputMethod.ScrambledWords,
+            input_method: recoveryInputTypeToInputMethod[recoveryInputType],
             word_count: wordsCount,
             enforce_wordlist: true,
             device: {
@@ -66,7 +75,7 @@ export const checkSeedThunk = createThunk(
 export const recoverDeviceThunk = createThunk(
     `${actionPrefix}/recoverDeviceThunk`,
     async (_, { dispatch, getState }) => {
-        const advancedRecovery = selectAdvancedRecovery(getState());
+        const recoveryInputType = selectRecoveryInputType(getState());
         const wordsCount = selectWordsCount(getState());
         const device = selectSelectedDevice(getState());
 
@@ -83,9 +92,7 @@ export const recoverDeviceThunk = createThunk(
 
         const params: RecoveryDevice = {
             type: device.features.recovery_type ?? 'NormalRecovery', // For old firmware, we assume NormalRecovery as it was the only option before
-            input_method: advancedRecovery
-                ? PROTO.RecoveryDeviceInputMethod.Matrix
-                : PROTO.RecoveryDeviceInputMethod.ScrambledWords,
+            input_method: recoveryInputTypeToInputMethod[recoveryInputType],
             word_count: wordsCount,
             passphrase_protection: DEFAULT_PASSPHRASE_PROTECTION,
             enforce_wordlist: true,

--- a/suite/recovery/src/recoveryUtils.ts
+++ b/suite/recovery/src/recoveryUtils.ts
@@ -1,6 +1,6 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
 
-import { type RecoveryType, type WordCount } from './types';
+import { type RecoveryInputType, type WordCount } from './types';
 
 const WORD_COUNT_12 = 12 as const;
 const WORD_COUNT_18 = 18 as const;
@@ -16,16 +16,16 @@ const WORD_COUNT_18 = 18 as const;
 export const isStandardRecoveryDisabled = (
     deviceModelInternal: DeviceModelInternal,
     wordCount: WordCount,
-    recoveryType: RecoveryType,
+    recoveryInputType: RecoveryInputType,
 ): boolean => {
     // Advanced recovery is never disabled
-    if (recoveryType === 'advanced') {
+    if (recoveryInputType === 'advanced') {
         return false;
     }
 
     // Only disable Standard recovery for T1B1 with 12 or 18-word seeds
     return (
-        recoveryType === 'standard' &&
+        recoveryInputType === 'standard' &&
         deviceModelInternal === DeviceModelInternal.T1B1 &&
         (wordCount === WORD_COUNT_12 || wordCount === WORD_COUNT_18)
     );

--- a/suite/recovery/src/types.ts
+++ b/suite/recovery/src/types.ts
@@ -1,8 +1,8 @@
 export const wordCounts = [12, 18, 24] as const;
 export type WordCount = (typeof wordCounts)[number];
 
-export const recoveryTypes = ['standard', 'advanced'] as const;
-export type RecoveryType = (typeof recoveryTypes)[number];
+export const recoveryInputTypes = ['standard', 'advanced'] as const;
+export type RecoveryInputType = (typeof recoveryInputTypes)[number];
 
 export type SeedInputStatus =
     | 'initial'


### PR DESCRIPTION
## Description

The recovery reducer used to hold `advancedRecovery: boolean`, which each thunk then translated with a ternary into the firmware `input_method` (`Matrix` / `ScrambledWords`). This PR stores the product-level type `recoveryInputType: 'standard' | 'advanced'` directly instead.

Motivation: the reducer now speaks the same language as the UI (`Basic` / `Advanced recovery`) and analytics, and the single domain→wire translation (recovery input type → firmware seed input method) lives in one named, documented map at the `TrezorConnect` boundary, where it belongs.

## Changes

- `@suite/recovery` reducer: `advancedRecovery: boolean` → `recoveryInputType: RecoveryInputType`; action `setAdvancedRecovery` → `setRecoveryInputType`
- selector `selectAdvancedRecovery` → `selectRecoveryInputType`
- thunks (`checkSeedThunk`, `recoverDeviceThunk`): the duplicated ternary is replaced by a single named map `recoveryInputTypeToInputMethod`, with a comment explaining why `advanced → Matrix` and `standard → ScrambledWords`
- UI dispatches in `views/recovery` and `onboarding/RecoveryStep` (the `=== 'advanced'` translation is gone; added an early-return guard following the neighbouring pattern)
- updated mock and unit test

## Naming: `RecoveryInputType`, not `RecoveryType`

The type is deliberately named `RecoveryInputType` to avoid clashing with the protobuf `PROTO.RecoveryType` (`NormalRecovery` / `DryRun` / `UnlockRepeatedBackup`) — that is a different, orthogonal axis (the *kind* of recovery operation), whereas our type describes *how the seed is entered*. Without the distinction, one file (`views/recovery/index.tsx`) would import two types both named `RecoveryType`.

Deliberately **left unchanged** (separate product / telemetry / test contracts): the analytics field `recoveryType`, the e2e test id `@recovery/select-type/*`, the component name `SelectRecoveryType`, and the status `select-recovery-type`.

## No behavior change

`standard` → `ScrambledWords`, `advanced` → `Matrix`, including the default — exactly as before.

## Notes for QA

Pure refactor, no behavior change. Blast radius is the recovery / seed-check flow (onboarding "recover wallet" and settings → device → "check seed", standard vs. advanced). No dedicated QA needed; a smoke check of a standard and an advanced dry-run recovery is more than enough if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
