### PR TITLE
refactor(recovery): drop isAdditionalShamirBackupInProgress re-export

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -34,6 +34,7 @@
         "@suite-common/analytics": "workspace:*",
         "@suite-common/analytics-redux": "workspace:*",
         "@suite-common/assets": "workspace:*",
+        "@suite-common/backup": "workspace:*",
         "@suite-common/bip329": "workspace:*",
         "@suite-common/bip329-types": "workspace:*",
         "@suite-common/bluetooth": "workspace:*",

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
-import { isAdditionalShamirBackupInProgress } from '@suite/recovery';
+import { isAdditionalShamirBackupInProgress } from '@suite-common/backup';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { Modal, type ModalProps } from '@trezor/components';

--- a/packages/suite/src/utils/suite/prerequisites.ts
+++ b/packages/suite/src/utils/suite/prerequisites.ts
@@ -1,5 +1,6 @@
-import { isAdditionalShamirBackupInProgress, isRecoveryInProgress } from '@suite/recovery';
+import { isRecoveryInProgress } from '@suite/recovery';
 import { type RouterState } from '@suite/router';
+import { isAdditionalShamirBackupInProgress } from '@suite-common/backup';
 
 import type { TransportState } from 'src/reducers/suite/suiteReducer';
 import type { AppState, TrezorDevice } from 'src/types/suite';

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -20,6 +20,7 @@
             "path": "../../suite-common/analytics-redux"
         },
         { "path": "../../suite-common/assets" },
+        { "path": "../../suite-common/backup" },
         { "path": "../../suite-common/bip329" },
         {
             "path": "../../suite-common/bip329-types"

--- a/suite/backup/package.json
+++ b/suite/backup/package.json
@@ -23,7 +23,6 @@
         "@suite/external-links": "workspace:*",
         "@suite/intl": "workspace:*",
         "@suite/nfc": "workspace:*",
-        "@suite/recovery": "workspace:*",
         "@suite/router": "workspace:*",
         "@suite/settings": "workspace:*",
         "@trezor/components": "workspace:*",

--- a/suite/backup/src/CreateWalletBackupModal.tsx
+++ b/suite/backup/src/CreateWalletBackupModal.tsx
@@ -8,8 +8,8 @@ import {
     AdditionalBackupSteps,
     AdditionalBackupSuccess,
 } from '@suite/nfc';
-import { isAdditionalShamirBackupInProgress } from '@suite/recovery';
 import { selectIsN4w1BackupEnabled } from '@suite/settings';
+import { isAdditionalShamirBackupInProgress } from '@suite-common/backup';
 import { selectSelectedDevice } from '@suite-common/device';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { Modal } from '@trezor/components';

--- a/suite/backup/tsconfig.json
+++ b/suite/backup/tsconfig.json
@@ -20,7 +20,6 @@
         { "path": "../external-links" },
         { "path": "../intl" },
         { "path": "../nfc" },
-        { "path": "../recovery" },
         { "path": "../router" },
         { "path": "../settings" },
         { "path": "../../packages/components" },

--- a/suite/recovery/package.json
+++ b/suite/recovery/package.json
@@ -13,7 +13,6 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
-        "@suite-common/backup": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
         "@suite-common/test-utils": "workspace:*",

--- a/suite/recovery/src/isRecoveryInProgress.ts
+++ b/suite/recovery/src/isRecoveryInProgress.ts
@@ -1,7 +1,5 @@
 import { type PROTO } from '@trezor/connect';
 
-export { isAdditionalShamirBackupInProgress } from '@suite-common/backup';
-
 export const isRecoveryInProgress = (features: PROTO.Features) => {
     const { recovery_status, backup_availability } = features;
 

--- a/suite/recovery/tsconfig.json
+++ b/suite/recovery/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../suite-common/backup" },
         { "path": "../../suite-common/device" },
         {
             "path": "../../suite-common/redux-utils"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15187,7 +15187,6 @@ __metadata:
   resolution: "@suite/recovery@workspace:suite/recovery"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
-    "@suite-common/backup": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
@@ -17266,6 +17265,7 @@ __metadata:
     "@suite-common/analytics": "workspace:*"
     "@suite-common/analytics-redux": "workspace:*"
     "@suite-common/assets": "workspace:*"
+    "@suite-common/backup": "workspace:*"
     "@suite-common/bip329": "workspace:*"
     "@suite-common/bip329-types": "workspace:*"
     "@suite-common/bluetooth": "workspace:*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14650,7 +14650,6 @@ __metadata:
     "@suite/external-links": "workspace:*"
     "@suite/intl": "workspace:*"
     "@suite/nfc": "workspace:*"
-    "@suite/recovery": "workspace:*"
     "@suite/router": "workspace:*"
     "@suite/settings": "workspace:*"
     "@trezor/components": "workspace:*"


### PR DESCRIPTION
## Description

`isAdditionalShamirBackupInProgress` is defined in `@suite-common/backup` but was re-exported through `@suite/recovery` (in `isRecoveryInProgress.ts`), which never used it itself — a pure pass-through re-export of a *backup* concept living inside a *recovery* module.

This switches all three call sites to import it directly from `@suite-common/backup`:
- `packages/suite/src/utils/suite/prerequisites.ts`
- `packages/suite/src/components/.../MultiShareBackupModal.tsx`
- `suite/backup/src/CreateWalletBackupModal.tsx`

and adjusts dependencies + tsconfig references:
- **add** `@suite-common/backup` to `packages/suite` (new direct import)
- **drop** `@suite-common/backup` from `@suite/recovery` (orphaned after removing the re-export)

Aligns with how `suite/backup` already imports other backup helpers (`doesSupportMultiShare`, `hasSlip39Backup`) directly from `@suite-common/backup`. No behavior change.

## Related Issue

N/A — code hygiene / re-export cleanup.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/remove-recovery-reexport/web/](https://dev.suite.sldev.cz/suite-web/mroz22/remove-recovery-reexport/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set extracts backup and recovery functionality into dedicated suite/backup and suite/recovery packages and modifies the shared MultiShareBackupModal and prerequisites utilities. The highest regression risk is in backup/recovery flows and modal behavior. Run the targeted backup/recovery tests first, then a few onboarding wallet-creation variants as integration smoke tests. Config/package files have no direct E2E coverage but are validated indirectly by any passing flow.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/package.json`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/MultiShareBackupModal/MultiShareBackupModal.tsx`
- `packages/suite/src/utils/suite/prerequisites.ts`
- `packages/suite/tsconfig.json`
- `suite/backup/package.json`
- `suite/backup/src/CreateWalletBackupModal.tsx`
- `suite/backup/tsconfig.json`
- `suite/recovery/package.json`
- `suite/recovery/src/isRecoveryInProgress.ts`
- `suite/recovery/tsconfig.json`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — This test validates backup error handling when the device disconnects mid-process, exercising backup state management and failure notifications that depend on the backup modal components being extracted to suite/backup.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — This test directly covers backup modal checkbox state reset and disabled states when the device is disconnected, making it a focused regression test for backup modal behavior after the package extraction.
- `suite/e2e/tests/backup/t2t1-success.test.ts` — This test covers the standard backup creation happy path initiated from the dashboard, including pre/post-backup checkboxes and analytics, which likely flows through the extracted CreateWalletBackupModal.
- `suite/e2e/tests/backup/t3t1-t2t1-create-additional-share.test.ts` — This is the only test that directly exercises the MultiShareBackupModal flow for creating additional Shamir backup shares from device settings; changes to MultiShareBackupModal.tsx could break this flow.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — This test verifies that recovery state persists across page reloads and device reconnections, directly exercising the new suite/recovery isRecoveryInProgress logic and recovery middleware.
- `suite/e2e/tests/recovery/dry-run.test.ts` — This test performs a recovery dry run from device settings, relying on recovery state detection and the extracted suite/recovery package; it also validates reconnection and reload resilience.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-create-wallet.test.ts` — This test exercises Shamir backup creation during the onboarding wallet creation flow, providing integration coverage of the extracted backup modal and prerequisite checks on T2T1.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet.test.ts` — This test covers wallet creation with Shamir backup during onboarding, ensuring the extracted backup components and modal interactions work end-to-end on T3T1.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test covers backup type selection and PIN setup during onboarding, validating the extracted backup components in the wallet creation flow on T3W1.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — This is a variant of the recovery dry run on T1B1, ensuring recovery state detection and the extracted recovery package work across device models.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — This is a variant of the recovery dry run on T2T1, providing additional coverage of recovery state detection and the extracted recovery package.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/package.json`
- `packages/suite/tsconfig.json`
- `suite/backup/package.json`
- `suite/backup/tsconfig.json`
- `suite/recovery/package.json`
- `suite/recovery/tsconfig.json`

_Updated: 2026-08-04T13:33:03.885Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/remove-recovery-reexport&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/remove-recovery-reexport&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:33:58.720Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:34:32.133Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->