### PR TITLE
refactor(recovery): rename to isRecoveryInputTypeDisabled with switch + exhaustive guard

### DIFF
--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -5,7 +5,7 @@ import { selectRecoveryWordRequestInputType } from '@suite/modal';
 import { OnboardingCard } from '@suite/onboarding-components';
 import {
     type RecoveryInputType,
-    isStandardRecoveryDisabled,
+    isRecoveryInputTypeDisabled,
     recoverDeviceThunk,
     recoveryActions,
     selectRecoveryError,
@@ -82,7 +82,7 @@ export const RecoveryStep = () => {
                             dispatch(recoveryActions.setWordsCount(number));
                             // For T1B1 with 12 or 18 words, skip recovery type selection and use Advanced recovery
                             // For 24 words, show the recovery type selection
-                            const shouldSkipSelection = isStandardRecoveryDisabled(
+                            const shouldSkipSelection = isRecoveryInputTypeDisabled(
                                 deviceModelInternal,
                                 number,
                                 'standard',

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -9,7 +9,7 @@ import {
     type SeedInputStatus,
     type WordCount,
     checkSeedThunk,
-    isStandardRecoveryDisabled,
+    isRecoveryInputTypeDisabled,
     recoveryActions,
     selectRecovery,
 } from '@suite/recovery';
@@ -202,7 +202,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
                             // For T1B1 with 12 or 18 words, skip recovery type selection and use Advanced recovery
                             // For 24 words, show the recovery type selection
-                            const shouldSkipSelection = isStandardRecoveryDisabled(
+                            const shouldSkipSelection = isRecoveryInputTypeDisabled(
                                 deviceModelInternal,
                                 wordCount,
                                 'standard',

--- a/suite/recovery/package.json
+++ b/suite/recovery/package.json
@@ -19,6 +19,7 @@
         "@suite-common/test-utils": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@trezor/connect": "workspace:*",
-        "@trezor/device-utils": "workspace:*"
+        "@trezor/device-utils": "workspace:*",
+        "@trezor/type-utils": "workspace:*"
     }
 }

--- a/suite/recovery/src/recoveryUtils.test.ts
+++ b/suite/recovery/src/recoveryUtils.test.ts
@@ -1,0 +1,45 @@
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { isRecoveryInputTypeDisabled } from './recoveryUtils';
+import { type WordCount } from './types';
+
+const NON_T1B1_MODELS = [
+    DeviceModelInternal.T2T1,
+    DeviceModelInternal.T2B1,
+    DeviceModelInternal.T3B1,
+    DeviceModelInternal.T3T1,
+    DeviceModelInternal.T3W1,
+] as const;
+
+const ALL_MODELS = [DeviceModelInternal.T1B1, ...NON_T1B1_MODELS] as const;
+const ALL_WORD_COUNTS: WordCount[] = [12, 18, 24];
+
+describe('isRecoveryInputTypeDisabled', () => {
+    it.each(ALL_MODELS)('advanced input type is never disabled (%s)', model => {
+        ALL_WORD_COUNTS.forEach(wordCount => {
+            expect(isRecoveryInputTypeDisabled(model, wordCount, 'advanced')).toBe(false);
+        });
+    });
+
+    it.each([12, 18] as const)(
+        'standard input type is disabled for T1B1 with %i words (lower entropy)',
+        wordCount => {
+            expect(
+                isRecoveryInputTypeDisabled(DeviceModelInternal.T1B1, wordCount, 'standard'),
+            ).toBe(true);
+        },
+    );
+
+    it('standard input type is enabled for T1B1 with 24 words (sufficient entropy)', () => {
+        expect(isRecoveryInputTypeDisabled(DeviceModelInternal.T1B1, 24, 'standard')).toBe(false);
+    });
+
+    it.each(NON_T1B1_MODELS)(
+        'standard input type is never disabled on non-T1B1 devices (%s)',
+        model => {
+            ALL_WORD_COUNTS.forEach(wordCount => {
+                expect(isRecoveryInputTypeDisabled(model, wordCount, 'standard')).toBe(false);
+            });
+        },
+    );
+});

--- a/suite/recovery/src/recoveryUtils.ts
+++ b/suite/recovery/src/recoveryUtils.ts
@@ -1,4 +1,5 @@
 import { DeviceModelInternal } from '@trezor/device-utils';
+import { exhaustive } from '@trezor/type-utils';
 
 import { type RecoveryInputType, type WordCount } from './types';
 
@@ -13,20 +14,22 @@ const WORD_COUNT_18 = 18 as const;
  * - Standard recovery is enabled for 24-word seeds (sufficient entropy)
  * - Advanced recovery is always available for all word counts
  */
-export const isStandardRecoveryDisabled = (
+export const isRecoveryInputTypeDisabled = (
     deviceModelInternal: DeviceModelInternal,
     wordCount: WordCount,
     recoveryInputType: RecoveryInputType,
 ): boolean => {
-    // Advanced recovery is never disabled
-    if (recoveryInputType === 'advanced') {
-        return false;
+    switch (recoveryInputType) {
+        // Advanced recovery is never disabled
+        case 'advanced':
+            return false;
+        // Only disable Standard recovery for T1B1 with 12 or 18-word seeds
+        case 'standard':
+            return (
+                deviceModelInternal === DeviceModelInternal.T1B1 &&
+                (wordCount === WORD_COUNT_12 || wordCount === WORD_COUNT_18)
+            );
+        default:
+            return exhaustive(recoveryInputType);
     }
-
-    // Only disable Standard recovery for T1B1 with 12 or 18-word seeds
-    return (
-        recoveryInputType === 'standard' &&
-        deviceModelInternal === DeviceModelInternal.T1B1 &&
-        (wordCount === WORD_COUNT_12 || wordCount === WORD_COUNT_18)
-    );
 };

--- a/suite/recovery/tsconfig.json
+++ b/suite/recovery/tsconfig.json
@@ -12,6 +12,7 @@
         },
         { "path": "../analytics" },
         { "path": "../../packages/connect" },
-        { "path": "../../packages/device-utils" }
+        { "path": "../../packages/device-utils" },
+        { "path": "../../packages/type-utils" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15194,6 +15194,7 @@ __metadata:
     "@suite/analytics": "workspace:*"
     "@trezor/connect": "workspace:*"
     "@trezor/device-utils": "workspace:*"
+    "@trezor/type-utils": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Rename `isStandardRecoveryDisabled` → `isRecoveryInputTypeDisabled` in `@suite/recovery` and refactor it to use a `switch` over `recoveryInputType` with an `exhaustive()` guard instead of an `if` + compound boolean condition.

### Why

- **Better name**: the function decides whether *any* recovery input type should be disabled (it takes `recoveryInputType` and handles both `standard` and `advanced`), not only the standard one.
- **Compile-time safety**: `exhaustive(recoveryInputType)` (from `@trezor/type-utils`) takes a `never` argument. If a new `RecoveryInputType` is ever added to `types.ts`, the `default` branch stops type-checking, forcing the case to be handled — today an unhandled type would silently return `false`.
- Drops the now-redundant `recoveryInputType === 'standard' && …` check (the type is already narrowed inside each `case`).

### Behavior

Unchanged:
- `advanced` → never disabled
- `standard` → disabled only for T1B1 with 12/18-word seeds

### Changes

- `recoveryUtils.ts` — rename + `if` → `switch`/`case` + `exhaustive`
- call sites `views/recovery/index.tsx`, `views/onboarding/steps/RecoveryStep/index.tsx` — updated to new name
- `package.json` — add `@trezor/type-utils` dependency
- `tsconfig.json` — add `packages/type-utils` project reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are tightly scoped to recovery UI and shared recovery utilities: onboarding RecoveryStep, the standalone recovery view, and suite/recovery utility code. Risk is concentrated in recovery flows (both onboarding wallet recovery and settings seed-check/dry-run). The recommended set focuses on the direct recovery paths and their disconnect/reload edge cases, avoiding the broad 133-test mapping which reflects generic transitive imports rather than real functional overlap.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx`
- `packages/suite/src/views/recovery/index.tsx`
- `suite/recovery/package.json`
- `suite/recovery/src/recoveryUtils.test.ts`
- `suite/recovery/src/recoveryUtils.ts`
- `suite/recovery/tsconfig.json`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Directly exercises the RecoveryStep component in the onboarding flow for T1B1, covering 24-word standard recovery, device prompts, and onboarding completion. A change to RecoveryStep or recoveryUtils could break this core recovery path.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Tests RecoveryStep behavior when the device disconnects mid-recovery, verifying reconnect/retry prompts. Changes to recovery state management or UI in RecoveryStep could regress this user-visible error path.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Covers the standard 12-word recovery path through the onboarding RecoveryStep for T2T1, including device confirmation prompts and completion. A likely direct consumer of the changed recovery components.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Directly tests the recovery view (packages/suite/src/views/recovery/index.tsx) via the device-settings seed check/dry-run flow, including disconnect and page-reload recovery scenarios. This is the main regression surface for the changed recovery view.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Exercises advanced recovery mode and device-disconnect handling in the onboarding RecoveryStep, sharing the same recovery state/UI as the standard success path and validating resilience of recoveryUtils integration.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — Validates retry behavior after device disconnection during T1B1 onboarding recovery, a related edge case to t2t1-recovery-fail that ensures recovery error handling works across device models.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests recovery state persistence across page reloads and device reconnects during onboarding Shamir recovery, which relies on recovery state management that could be affected by changes in RecoveryStep or recoveryUtils.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Device-specific dry-run path for T1B1 that exercises the recovery view and its integration with device input (blind matrix PIN/mnemonic), providing model-specific coverage of the changed recovery UI.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Device-specific dry-run path for T2T1, including disconnect and reload recovery, directly targeting the changed recovery view and its error/persistence handling on a different model.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite/recovery/package.json`
- `suite/recovery/src/recoveryUtils.test.ts`
- `suite/recovery/tsconfig.json`

_Updated: 2026-08-04T14:08:06.158Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/recovery-disabled-switch/web/](https://dev.suite.sldev.cz/suite-web/mroz22/recovery-disabled-switch/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/recovery-disabled-switch&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/recovery-disabled-switch&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:09:00.615Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:08:35.238Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->