### PR TITLE
refactor(recovery): pass device to recovery thunks instead of re-selecting

### DIFF
--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -71,7 +71,7 @@ export const RecoveryStep = () => {
                             if (shouldSkipSelection) {
                                 dispatch(recoveryActions.setRecoveryInputType('advanced'));
                                 dispatch(updateAnalytics({ recoveryType: 'advanced' }));
-                                dispatch(recoverDeviceThunk());
+                                dispatch(recoverDeviceThunk({ device }));
                             } else {
                                 dispatch(recoveryActions.setStatus('select-recovery-type'));
                             }
@@ -95,7 +95,7 @@ export const RecoveryStep = () => {
                 innerActions={
                     <OnboardingCard.Button
                         data-testid="@onboarding/recovery/start-button"
-                        onClick={() => dispatch(recoverDeviceThunk())}
+                        onClick={() => dispatch(recoverDeviceThunk({ device }))}
                     >
                         <Translation id="TR_START_RECOVERY" />
                     </OnboardingCard.Button>
@@ -116,7 +116,7 @@ export const RecoveryStep = () => {
         const handleSelect = (type: RecoveryInputType) => {
             dispatch(recoveryActions.setRecoveryInputType(type));
             dispatch(updateAnalytics({ recoveryType: type }));
-            dispatch(recoverDeviceThunk());
+            dispatch(recoverDeviceThunk({ device }));
         };
 
         return (
@@ -265,7 +265,7 @@ export const RecoveryStep = () => {
                         onClick={
                             deviceModelInternal === DeviceModelInternal.T1B1
                                 ? () => dispatch(recoveryActions.resetReducer())
-                                : () => dispatch(recoverDeviceThunk())
+                                : () => dispatch(recoverDeviceThunk({ device }))
                         }
                         intent="critical"
                     >

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -184,7 +184,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                         onClick={() =>
                             isT1B1
                                 ? dispatch(recoveryActions.setStatus('select-word-count'))
-                                : dispatch(checkSeedThunk())
+                                : dispatch(checkSeedThunk({ device }))
                         }
                         isDisabled={!isUnderstood || isLocked()}
                         data-testid="@recovery/start-button"
@@ -211,7 +211,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
                             if (shouldSkipSelection) {
                                 dispatch(recoveryActions.setRecoveryInputType('advanced'));
-                                dispatch(checkSeedThunk());
+                                dispatch(checkSeedThunk({ device }));
                             } else {
                                 dispatch(recoveryActions.setStatus('select-recovery-type'));
                             }
@@ -229,7 +229,7 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
                             if (!recoveryInputType) return;
 
                             dispatch(recoveryActions.setRecoveryInputType(recoveryInputType));
-                            dispatch(checkSeedThunk());
+                            dispatch(checkSeedThunk({ device }));
                         }}
                         data-testid="@recovery/continue-button"
                     >

--- a/suite/recovery/package.json
+++ b/suite/recovery/package.json
@@ -15,6 +15,7 @@
         "@reduxjs/toolkit": "2.12.0",
         "@suite-common/device": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/test-utils": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -1,9 +1,15 @@
+import { events } from '@suite/analytics';
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import type { AcquiredDevice } from '@suite-common/suite-types';
+import { mockDeviceFeatures, mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { createTestStore, testMocks } from '@suite-common/test-utils';
+import TrezorConnect from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { recoveryReducer } from './recoveryReducer';
-import { checkSeedThunk, recoverDeviceThunk } from './recoveryThunks';
+import { checkSeedThunk, recoverDeviceThunk, recoveryRerunThunk } from './recoveryThunks';
+
+const device = mockSuiteDevice({ path: '1' }) as AcquiredDevice;
 
 const getInitialState = (custom?: any): any => ({
     suite: {
@@ -11,12 +17,7 @@ const getInitialState = (custom?: any): any => ({
         locks: [],
     },
     device: {
-        selectedDevice: {
-            features: {
-                major_version: 2,
-                internal_model: DeviceModelInternal.T2T1,
-            },
-        },
+        selectedDevice: device,
     },
     recovery: {
         ...recoveryReducer(undefined, { type: 'foo' }),
@@ -27,18 +28,10 @@ const getInitialState = (custom?: any): any => ({
     },
 });
 
-const device = {
-    features: {
-        major_version: 2,
-        internal_model: DeviceModelInternal.T2T1,
-    },
-    path: '1',
-} as any;
-
-const initStore = (custom?: any) => {
+const initStore = (analytics = mockDesktopAnalytics(), custom?: any) => {
     const preloadedState = getInitialState(custom);
     const store = createTestStore({
-        extra: { services: { analytics: mockDesktopAnalytics() } },
+        extra: { services: { analytics } },
         preloadedState,
         reducer: (state: any, action: any) => ({
             ...state,
@@ -49,12 +42,21 @@ const initStore = (custom?: any) => {
     return store;
 };
 
+// recoveryRerunThunk dispatches its follow-up thunk without awaiting it, so that thunk's side
+// effects settle on a later microtask — flush them before asserting on it.
+const flushAsyncEffects = () => new Promise(resolve => setTimeout(resolve, 0));
+
 describe('Recovery Thunks', () => {
     beforeAll(() => {
         jest.spyOn(console, 'error').mockImplementation();
     });
     afterAll(() => {
         jest.clearAllMocks();
+    });
+    beforeEach(() => {
+        testMocks.setTrezorConnectFixtures(undefined);
+        (TrezorConnect.getFeatures as jest.Mock).mockClear();
+        (TrezorConnect.recoveryDevice as jest.Mock).mockClear();
     });
 
     it('recoverDeviceThunk', async () => {
@@ -65,11 +67,85 @@ describe('Recovery Thunks', () => {
         expect(store.getState().recovery.status).toMatch('finished');
     });
 
-    it('checkSeedThunk', async () => {
+    it('recoverDeviceThunk waits for on-device confirmation on T1B1', async () => {
         const store = initStore();
+        const t1b1Device = mockSuiteDevice(
+            { path: '1' },
+            { internal_model: DeviceModelInternal.T1B1 },
+        ) as AcquiredDevice;
+        const action = store.dispatch(recoverDeviceThunk({ device: t1b1Device }));
+        expect(store.getState().recovery.status).toMatch('waiting-for-confirmation');
+        await action;
+        expect(store.getState().recovery.status).toMatch('finished');
+    });
+
+    it('checkSeedThunk', async () => {
+        const analytics = mockDesktopAnalytics();
+        const store = initStore(analytics);
         const action = store.dispatch(checkSeedThunk({ device }));
         expect(store.getState().recovery.status).toMatch('in-progress');
         await action;
         expect(store.getState().recovery.status).toMatch('finished');
+        expect(analytics.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.settingsDeviceCheckSeedEvent.name,
+                payload: { status: 'finished' },
+            }),
+        );
+    });
+
+    it('recoveryRerunThunk runs recovery against freshly-loaded features when the device is not initialized', async () => {
+        // The store device reports initialized: true, but the fresh getFeatures payload says false.
+        // Selecting the not-initialized branch proves the follow-up runs against the FRESH features
+        // rather than the ones already in the store.
+        const analytics = mockDesktopAnalytics();
+        const store = initStore(analytics);
+        testMocks.setTrezorConnectFixtures([
+            {
+                success: true,
+                payload: mockDeviceFeatures({ recovery_status: 'Recovery', initialized: false }),
+            },
+        ]);
+
+        const result = await store.dispatch(recoveryRerunThunk());
+        await flushAsyncEffects();
+
+        expect(TrezorConnect.getFeatures).toHaveBeenCalledWith({ device: { path: '1' } });
+        // recoverDeviceThunk (real recovery) sets passphrase_protection; checkSeedThunk does not.
+        expect(TrezorConnect.recoveryDevice).toHaveBeenCalledWith(
+            expect.objectContaining({ passphrase_protection: false, device: { path: '1' } }),
+        );
+        // recoverDeviceThunk does not report analytics — checkSeedThunk would.
+        expect(analytics.report).not.toHaveBeenCalled();
+        if (!recoveryRerunThunk.fulfilled.match(result)) throw new Error('expected fulfilled');
+        expect(result.payload).toEqual({ initialized: false });
+    });
+
+    it('recoveryRerunThunk runs seed check against freshly-loaded features when the device is initialized', async () => {
+        const analytics = mockDesktopAnalytics();
+        const store = initStore(analytics);
+        testMocks.setTrezorConnectFixtures([
+            {
+                success: true,
+                payload: mockDeviceFeatures({ recovery_status: 'Recovery', initialized: true }),
+            },
+        ]);
+
+        const result = await store.dispatch(recoveryRerunThunk());
+        await flushAsyncEffects();
+
+        expect(TrezorConnect.getFeatures).toHaveBeenCalledWith({ device: { path: '1' } });
+        // checkSeedThunk (seed check) defaults the recovery type to DryRun.
+        expect(TrezorConnect.recoveryDevice).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'DryRun', device: { path: '1' } }),
+        );
+        expect(analytics.report).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: events.settingsDeviceCheckSeedEvent.name,
+                payload: { status: 'finished' },
+            }),
+        );
+        if (!recoveryRerunThunk.fulfilled.match(result)) throw new Error('expected fulfilled');
+        expect(result.payload).toEqual({ initialized: true });
     });
 });

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -27,6 +27,14 @@ const getInitialState = (custom?: any): any => ({
     },
 });
 
+const device = {
+    features: {
+        major_version: 2,
+        internal_model: DeviceModelInternal.T2T1,
+    },
+    path: '1',
+} as any;
+
 const initStore = (custom?: any) => {
     const preloadedState = getInitialState(custom);
     const store = createTestStore({
@@ -51,7 +59,7 @@ describe('Recovery Thunks', () => {
 
     it('recoverDeviceThunk', async () => {
         const store = initStore();
-        const action = store.dispatch(recoverDeviceThunk());
+        const action = store.dispatch(recoverDeviceThunk({ device }));
         expect(store.getState().recovery.status).toMatch('in-progress');
         await action;
         expect(store.getState().recovery.status).toMatch('finished');
@@ -59,7 +67,7 @@ describe('Recovery Thunks', () => {
 
     it('checkSeedThunk', async () => {
         const store = initStore();
-        const action = store.dispatch(checkSeedThunk());
+        const action = store.dispatch(checkSeedThunk({ device }));
         expect(store.getState().recovery.status).toMatch('in-progress');
         await action;
         expect(store.getState().recovery.status).toMatch('finished');

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -1,6 +1,7 @@
 import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { type WithServices, createThunk } from '@suite-common/redux-utils';
+import type { AcquiredDevice } from '@suite-common/suite-types';
 import TrezorConnect, { PROTO, type RecoveryDevice } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -29,14 +30,11 @@ type CheckSeedThunkDeps = WithServices<DesktopAnalyticsDep>;
 
 export const checkSeedThunk = createThunk<
     void,
-    void,
+    { device: AcquiredDevice },
     { state: CheckSeedThunkState; extra: CheckSeedThunkDeps }
->(`${actionPrefix}/checkSeedThunk`, async (_, { dispatch, getState, extra }) => {
+>(`${actionPrefix}/checkSeedThunk`, async ({ device }, { dispatch, getState, extra }) => {
     const recoveryInputType = selectRecoveryInputType(getState());
     const wordsCount = selectWordsCount(getState());
-    const device = selectSelectedDevice(getState());
-
-    if (!device?.features) return;
 
     dispatch(recoveryActions.setError(undefined));
 
@@ -79,50 +77,47 @@ export const checkSeedThunk = createThunk<
 
 type RecoverDeviceThunkState = DeviceRootState & { recovery: RecoveryState };
 
-export const recoverDeviceThunk = createThunk<void, void, { state: RecoverDeviceThunkState }>(
-    `${actionPrefix}/recoverDeviceThunk`,
-    async (_, { dispatch, getState }) => {
-        const recoveryInputType = selectRecoveryInputType(getState());
-        const wordsCount = selectWordsCount(getState());
-        const device = selectSelectedDevice(getState());
+export const recoverDeviceThunk = createThunk<
+    void,
+    { device: AcquiredDevice },
+    { state: RecoverDeviceThunkState }
+>(`${actionPrefix}/recoverDeviceThunk`, async ({ device }, { dispatch, getState }) => {
+    const recoveryInputType = selectRecoveryInputType(getState());
+    const wordsCount = selectWordsCount(getState());
 
-        if (!device?.features) {
-            return;
-        }
-        dispatch(recoveryActions.setError(undefined));
+    dispatch(recoveryActions.setError(undefined));
 
-        if (device.features.internal_model === DeviceModelInternal.T1B1) {
-            dispatch(recoveryActions.setStatus('waiting-for-confirmation'));
-        } else {
-            dispatch(recoveryActions.setStatus('in-progress'));
-        }
+    if (device.features.internal_model === DeviceModelInternal.T1B1) {
+        dispatch(recoveryActions.setStatus('waiting-for-confirmation'));
+    } else {
+        dispatch(recoveryActions.setStatus('in-progress'));
+    }
 
-        const params: RecoveryDevice = {
-            type: device.features.recovery_type ?? 'NormalRecovery', // For old firmware, we assume NormalRecovery as it was the only option before
-            input_method: recoveryInputTypeToInputMethod[recoveryInputType],
-            word_count: wordsCount,
-            passphrase_protection: DEFAULT_PASSPHRASE_PROTECTION,
-            enforce_wordlist: true,
-        };
+    const params: RecoveryDevice = {
+        type: device.features.recovery_type ?? 'NormalRecovery', // For old firmware, we assume NormalRecovery as it was the only option before
+        input_method: recoveryInputTypeToInputMethod[recoveryInputType],
+        word_count: wordsCount,
+        passphrase_protection: DEFAULT_PASSPHRASE_PROTECTION,
+        enforce_wordlist: true,
+    };
 
-        if (device.features.capabilities?.includes('Capability_U2F')) {
-            params.u2f_counter = Math.floor(Date.now() / 1000);
-        }
+    if (device.features.capabilities?.includes('Capability_U2F')) {
+        params.u2f_counter = Math.floor(Date.now() / 1000);
+    }
 
-        const response = await TrezorConnect.recoveryDevice({
-            ...params,
-            device: {
-                path: device.path,
-            },
-        });
+    const response = await TrezorConnect.recoveryDevice({
+        ...params,
+        device: {
+            path: device.path,
+        },
+    });
 
-        if (!response.success) {
-            dispatch(recoveryActions.setError(response.error.message));
-        }
+    if (!response.success) {
+        dispatch(recoveryActions.setError(response.error.message));
+    }
 
-        dispatch(recoveryActions.setStatus('finished'));
-    },
-);
+    dispatch(recoveryActions.setStatus('finished'));
+});
 
 type RecoveryRerunThunkState = DeviceRootState & { recovery: RecoveryState };
 
@@ -160,12 +155,15 @@ export const recoveryRerunThunk = createThunk<
         return rejectWithValue('recovery not in progress');
     }
 
+    // Pass the device with the freshly-loaded features so the follow-up runs against the current state.
+    const deviceWithFreshFeatures: AcquiredDevice = { ...device, features };
+
     if (!features.initialized) {
-        dispatch(recoverDeviceThunk());
+        dispatch(recoverDeviceThunk({ device: deviceWithFreshFeatures }));
     }
 
     if (features.initialized) {
-        dispatch(checkSeedThunk());
+        dispatch(checkSeedThunk({ device: deviceWithFreshFeatures }));
     }
 
     return { initialized: features.initialized };

--- a/suite/recovery/tsconfig.json
+++ b/suite/recovery/tsconfig.json
@@ -7,6 +7,9 @@
             "path": "../../suite-common/redux-utils"
         },
         {
+            "path": "../../suite-common/suite-types"
+        },
+        {
             "path": "../../suite-common/test-utils"
         },
         { "path": "../analytics" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15742,6 +15742,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/device": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
+    "@suite-common/suite-types": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
     "@suite/analytics": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
## Description

`recoverDeviceThunk` and `checkSeedThunk` previously re-read the selected device from the store (`selectSelectedDevice(getState())`) and early-returned on `if (!device?.features)`. This refactor makes them receive the target `AcquiredDevice` as a parameter instead.

### Rationale

- **The re-read wasn't load-bearing.** `device.path` is stable within a single connection (it's a monotonic counter that only changes on reconnect). For the synchronous `onClick` call sites no device event can fire between the component's render and the thunk dispatch, so `getState()` inside the thunk returns exactly what the component already held. The guard was pure defensive boilerplate duplicated with the callers.
- **The guard is consolidated, not duplicated away.** Every call site already narrows the selected device to `AcquiredDevice` before dispatching (`RecoveryStep` via `!device?.features` → `null`; `views/recovery` via `isDeviceAcquired`). `Unknown`/`Unreadable` devices carry `features?: never`, so the narrowing is guaranteed to yield `AcquiredDevice`. Requiring it in the type removes the redundant runtime check.
- **`recoveryRerunThunk` keeps its own device selection** (it needs `device.path` for `getFeatures`) and forwards the device with the **freshly-loaded** features from that call — i.e. the one place where "fresh state" genuinely mattered is now more correct than the previous `getState()` re-read, not less.

### Result

`recoverDeviceThunk` / `checkSeedThunk` become pure functions of their input — easier to test (no store setup) and explicit about which device they operate on.

## Changes

- `suite/recovery/src/recoveryThunks.ts` — thunks take `{ device: AcquiredDevice }`; guards removed; rerun forwards `{ ...device, features }`.
- Call sites updated in `RecoveryStep/index.tsx` (4×) and `views/recovery/index.tsx` (3×).
- `suite/recovery` gains `@suite-common/suite-types` dependency + tsconfig reference (for `AcquiredDevice`).
- Test updated to pass the device parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the onboarding RecoveryStep UI, the standalone recovery view, and the shared recovery thunks that drive recovery state. Because these are shared across all recovery paths, regressions could affect both onboarding recovery and device-settings dry-runs on multiple device models. The recommended tests focus narrowly on those flows, which provide the highest confidence that the recovery UI and state logic still work correctly.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx`
- `packages/suite/src/views/recovery/index.tsx`
- `suite/recovery/package.json`
- `suite/recovery/src/recoveryThunks.test.ts`
- `suite/recovery/src/recoveryThunks.ts`
- `suite/recovery/tsconfig.json`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — This test walks through the T1B1 onboarding recovery path (advanced recovery, word input, disconnect/retry) and directly renders the RecoveryStep view and recovery thunk-driven state transitions.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — It exercises the T1B1 recovery flow when the device is disconnected mid-recovery and the retry logic is triggered, which depends on the recovery thunk and RecoveryStep state handling.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — Validates the complete T1B1 recovery success path in onboarding, confirming that RecoveryStep UI and recovery thunk interactions complete without errors.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Covers the T2T1 recovery disconnect/retry flow in onboarding, which is a key regression area for changes to recovery thunks and the recovery view.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Tests Shamir recovery persistence across page reload and device reconnect during onboarding, directly exercising recovery thunk reinitialization and the RecoveryStep UI.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Verifies the full T2T1 recovery success path in onboarding, including device prompts and mnemonic entry, which depend on the recovery step component and thunks.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Initiates a recovery dry-run from device settings and tests disconnect/reload recovery behavior, directly using the recovery view and recovery thunk lifecycle.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Runs a T1B1 recovery dry-run from device settings, covering the recovery UI and thunk interactions for standard recovery on this model.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Runs a T2T1 recovery dry-run from device settings and validates reinitialization after disconnect/reload, directly testing recovery thunks and the recovery view.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite/recovery/package.json`
- `suite/recovery/src/recoveryThunks.test.ts`
- `suite/recovery/tsconfig.json`

_Updated: 2026-09-04T07:48:49.336Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/recover-device-thunk-param/web/](https://dev.suite.sldev.cz/suite-web/mroz22/recover-device-thunk-param/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/recover-device-thunk-param&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/recover-device-thunk-param&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-04T07:50:47.252Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T07:50:09.452Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->