### PR TITLE
feat(suite): use vault address instead of yield id and token address in url

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -185,6 +185,7 @@ export const EarnYieldAccountOpportunity = ({
                 analyticsStep: 'earn-dashboard',
                 yieldContext: {
                     id: opportunity.vault.id,
+                    vaultAddress: vaultContractAddress ?? undefined,
                     tokenContractAddress: opportunity.vault.token.address ?? undefined,
                 },
             }),
@@ -192,7 +193,7 @@ export const EarnYieldAccountOpportunity = ({
     };
 
     const navigateToYieldDeposit = () => {
-        if (!opportunity.account) {
+        if (!opportunity.account || !vaultContractAddress) {
             return;
         }
 
@@ -227,15 +228,14 @@ export const EarnYieldAccountOpportunity = ({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
                     account: opportunity.account,
-                    yieldId: opportunity.vault.id,
-                    contractAddress: opportunity.vault.token.address ?? undefined,
+                    vaultAddress: vaultContractAddress,
                 }),
             }),
         );
     };
 
     const navigateToYieldWithdraw = () => {
-        if (!opportunity.account) {
+        if (!opportunity.account || !vaultContractAddress) {
             return;
         }
 
@@ -270,8 +270,7 @@ export const EarnYieldAccountOpportunity = ({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
                     account: opportunity.account,
-                    yieldId: opportunity.vault.id,
-                    contractAddress: opportunity.vault.token.address ?? undefined,
+                    vaultAddress: vaultContractAddress,
                 }),
             }),
         );

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -62,14 +62,13 @@ export const useEarnProviderConsentActions = ({
 
         switch (flow) {
             case EarnFlow.Yield:
-                if (yieldContext) {
+                if (yieldContext?.vaultAddress) {
                     dispatch(
                         goto({
                             routeName: 'earn-yield-deposit',
                             params: getEarnRouteParams({
                                 account,
-                                yieldId: yieldContext.id,
-                                contractAddress: yieldContext.tokenContractAddress,
+                                vaultAddress: yieldContext.vaultAddress,
                             }),
                         }),
                     );

--- a/packages/suite/src/components/earn/utils/getEarnRouteParams.ts
+++ b/packages/suite/src/components/earn/utils/getEarnRouteParams.ts
@@ -1,20 +1,24 @@
 import { type RouteParams } from '@suite/router';
 import { type Account } from '@suite-common/wallet-types';
+import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
 type GetEarnRouteParamsProps = {
     account: Account;
-    yieldId: string;
-    contractAddress?: string;
+    vaultAddress: string;
 };
 
+/**
+ * Params of a vault-scoped Earn route, e.g. `#/eth/0/normal/0x704cfb08…`. The vault address is
+ * normalized so the same vault always yields the same URL, whatever casing the API reports.
+ */
 export const getEarnRouteParams = ({
     account,
-    yieldId,
-    contractAddress,
+    vaultAddress,
 }: GetEarnRouteParamsProps): RouteParams => ({
     symbol: account.symbol,
     accountIndex: account.index,
     accountType: account.accountType,
-    yieldId: encodeURIComponent(yieldId),
-    contractAddress: contractAddress ? encodeURIComponent(contractAddress) : undefined,
+    vaultAddress: encodeURIComponent(
+        getContractAddressForNetworkSymbol(account.symbol, vaultAddress),
+    ),
 });

--- a/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx
@@ -11,6 +11,7 @@ import {
     EarnFlow,
     EarnProvider,
 } from '@suite-common/suite-types/src/staking';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Box, Button, Column, IconButton, Row, Text } from '@trezor/components';
 import { CaretLeftIcon, InfoIcon } from '@trezor/icons';
@@ -61,7 +62,7 @@ export const YieldPageHeader = ({
                 })(),
                 to: 'earn-dashboard',
                 networkSymbol: account?.symbol,
-                vaultId: routeParams?.yieldId,
+                vaultId: vault?.id,
             },
         });
 
@@ -69,7 +70,7 @@ export const YieldPageHeader = ({
     };
 
     const onHowItWorksClick = () => {
-        if (!account || !routeParams) {
+        if (!account || !vault) {
             return;
         }
 
@@ -79,7 +80,7 @@ export const YieldPageHeader = ({
                 element: 'how-it-works',
                 value: analyticsStep,
                 networkSymbol: account.symbol,
-                vaultId: routeParams.yieldId,
+                vaultId: vault.id,
             },
         });
 
@@ -92,8 +93,9 @@ export const YieldPageHeader = ({
                 analyticsStep,
                 actionType: 'close',
                 yieldContext: {
-                    id: routeParams.yieldId,
-                    tokenContractAddress: vault?.token.address ?? undefined,
+                    id: vault.id,
+                    vaultAddress: getYieldVaultContractAddress(vault) ?? undefined,
+                    tokenContractAddress: vault.token.address ?? undefined,
                 },
             }),
         );
@@ -179,7 +181,7 @@ export const YieldPageHeader = ({
                                 size="large"
                                 aria-label={translationString('TR_EARN_HOW_IT_WORKS')}
                                 onClick={onHowItWorksClick}
-                                isDisabled={!account || !routeParams}
+                                isDisabled={!account || !vault}
                                 tooltip={{ content: <Translation id="TR_EARN_HOW_IT_WORKS" /> }}
                             />
                         ) : (
@@ -187,7 +189,7 @@ export const YieldPageHeader = ({
                                 intent="neutral"
                                 priority="secondary"
                                 onClick={onHowItWorksClick}
-                                isDisabled={!account || !routeParams}
+                                isDisabled={!account || !vault}
                             >
                                 <Translation id="TR_EARN_HOW_IT_WORKS" />
                             </Button>

--- a/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
@@ -1,7 +1,6 @@
 import { FormProvider } from 'react-hook-form';
 
 import { ContextMessage } from '@suite/message-system';
-import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
@@ -19,13 +18,12 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 
 type YieldDepositProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
 };
 
-export const YieldDeposit = ({ account, routeParams, vault }: YieldDepositProps) => {
+export const YieldDeposit = ({ account, vault }: YieldDepositProps) => {
     const allowanceContextValue = useAllowance({ account });
-    const yieldDepositContextValues = useYieldDeposit({ account, routeParams, vault });
+    const yieldDepositContextValues = useYieldDeposit({ account, vault });
     const vaultContractAddress = yieldDepositContextValues
         ? getYieldVaultContractAddress(yieldDepositContextValues.vault)
         : undefined;

--- a/packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts
+++ b/packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts
@@ -1,4 +1,3 @@
-import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account } from '@suite-common/wallet-types';
 
@@ -6,18 +5,15 @@ import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow
 
 type UseYieldDepositProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
 };
 
 export const useYieldDeposit = ({
     account,
-    routeParams,
     vault,
 }: UseYieldDepositProps): YieldFlowContextValues | null => {
     const flowResult = useYieldFlow({
         account,
-        routeParams,
         vault,
         flowType: 'deposit',
     });

--- a/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import { type EarnParams } from '@suite/router';
 import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
@@ -60,16 +59,14 @@ type UseResolvedYieldFlowDataResult = {
 
 type UseResolvedYieldFlowDataProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
 };
 
 export const useResolvedYieldFlowData = ({
     account,
-    routeParams,
     vault,
 }: UseResolvedYieldFlowDataProps): UseResolvedYieldFlowDataResult => {
-    const resolvedContractAddress = routeParams.contractAddress ?? vault.token.address;
+    const resolvedContractAddress = vault.token.address;
 
     const matchedToken = useMemo(() => {
         if (resolvedContractAddress) {
@@ -143,7 +140,7 @@ export const useResolvedYieldFlowData = ({
     const flowKey = getStablecoinYieldFlowKey({
         accountKey: account.key,
         tokenContract: resolvedContractAddress,
-        yieldId: routeParams.yieldId,
+        yieldId: vault.id,
     });
 
     const apy = vault.rewardRate.total != null ? getApyPercent(vault.rewardRate.total) : null;

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -5,7 +5,6 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { setConnectionModal, setConnectionMode, useDevice } from '@suite/device';
 import { type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { type EarnParams } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
@@ -53,7 +52,6 @@ import {
 
 type UseYieldFlowProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
     flowType: YieldPositionFlowType;
 };
@@ -128,7 +126,6 @@ export type YieldFlowContextValues = Omit<
 
 export const useYieldFlow = ({
     account,
-    routeParams,
     vault,
     flowType,
 }: UseYieldFlowProps): UseYieldFlowResult => {
@@ -148,7 +145,6 @@ export const useYieldFlow = ({
     const { token, receiptToken, apy, depositedAmount, depositedSharesAmount, flowKey } =
         useResolvedYieldFlowData({
             account,
-            routeParams,
             vault,
         });
     const allowanceFlowDataRef = useCurrentRef({

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx
@@ -1,7 +1,6 @@
 import { FormProvider } from 'react-hook-form';
 
 import { ContextMessage } from '@suite/message-system';
-import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { Context } from '@suite-common/message-system';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
@@ -19,13 +18,12 @@ import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 
 type YieldWithdrawProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
 };
 
-export const YieldWithdraw = ({ account, routeParams, vault }: YieldWithdrawProps) => {
+export const YieldWithdraw = ({ account, vault }: YieldWithdrawProps) => {
     const allowanceContextValue = useAllowance({ account });
-    const yieldWithdrawContextValues = useYieldWithdraw({ account, routeParams, vault });
+    const yieldWithdrawContextValues = useYieldWithdraw({ account, vault });
     const vaultContractAddress = yieldWithdrawContextValues
         ? getYieldVaultContractAddress(yieldWithdrawContextValues.vault)
         : undefined;

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type YieldFlowCompleteValue, type YieldWithdrawFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -10,7 +9,6 @@ import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow
 
 type UseYieldWithdrawProps = {
     account: Account;
-    routeParams: EarnParams;
     vault: YieldDtoV2;
 };
 
@@ -25,7 +23,6 @@ export type YieldWithdrawContextValues = Omit<YieldFlowContextValues, 'flowType'
 
 export const useYieldWithdraw = ({
     account,
-    routeParams,
     vault,
 }: UseYieldWithdrawProps): YieldWithdrawContextValues | null => {
     const [flowType, setFlowType] = useState<YieldWithdrawFlowType>('withdraw');
@@ -34,7 +31,6 @@ export const useYieldWithdraw = ({
 
     const flowResult = useYieldFlow({
         account,
-        routeParams,
         vault,
         flowType,
     });

--- a/packages/suite/src/types/earn/earnLayout.ts
+++ b/packages/suite/src/types/earn/earnLayout.ts
@@ -1,4 +1,3 @@
-import { type EarnParams } from '@suite/router';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type Account } from '@suite-common/wallet-types';
 
@@ -14,6 +13,6 @@ export type EarnLayoutInvalidReason =
 export type EarnLayoutState =
     | { status: 'loading' }
     | { status: 'invalid'; reason: EarnLayoutInvalidReason }
-    | { status: 'valid'; account: Account; routeParams: EarnParams; vault: YieldDtoV2 };
+    | { status: 'valid'; account: Account; vault: YieldDtoV2 };
 
 export type EarnLayoutFallbackState = Exclude<EarnLayoutState, { status: 'valid' }>;

--- a/packages/suite/src/views/earn/yield/deposit/index.tsx
+++ b/packages/suite/src/views/earn/yield/deposit/index.tsx
@@ -13,11 +13,5 @@ export const EarnDeposit = () => {
         return <EarnLayoutFallback layoutState={result} />;
     }
 
-    return (
-        <YieldDeposit
-            account={result.account}
-            routeParams={result.routeParams}
-            vault={result.vault}
-        />
-    );
+    return <YieldDeposit account={result.account} vault={result.vault} />;
 };

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -3,12 +3,15 @@ import { useEffect } from 'react';
 import { type TranslationKey } from '@suite/intl';
 import { type EarnParams, goto } from '@suite/router';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
+import { type YieldDtoV2, useGetVaultByAddress } from '@suite-common/earn-stablecoin-api';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type EarnAnalyticsStep } from '@suite-common/suite-types/src/staking';
-import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
-import { type YieldPositionFlowType, isStablecoinYieldSupported } from '@suite-common/wallet-core';
+import { getNetworkByYieldXyzId, getNetworkOptional } from '@suite-common/wallet-config';
+import {
+    type YieldPositionFlowType,
+    getYieldVaultContractAddress,
+    isStablecoinYieldSupported,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
@@ -40,7 +43,7 @@ type VaultValidationParams = {
     vault?: YieldDtoV2;
 };
 
-type VaultTokenValidationParams = VaultValidationParams & {
+type VaultAddressValidationParams = VaultValidationParams & {
     routeParams: EarnParams;
 };
 
@@ -64,22 +67,26 @@ const isVaultNetworkMismatch = ({ account, vault }: VaultValidationParams): bool
     return vaultNetwork?.symbol !== account.symbol;
 };
 
-const isVaultTokenMismatch = ({
+// The vault is looked up by the address in the route, so this only guards against a backend
+// returning something other than what was asked for.
+const isVaultAddressMismatch = ({
     account,
     routeParams,
     vault,
-}: VaultTokenValidationParams): boolean => {
-    if (!vault?.token.address) {
+}: VaultAddressValidationParams): boolean => {
+    if (!vault) {
         return false;
     }
 
-    if (!routeParams.contractAddress) {
+    const vaultAddress = getYieldVaultContractAddress(vault);
+
+    if (!vaultAddress || !routeParams.vaultAddress) {
         return true;
     }
 
     return (
-        getContractAddressForNetworkSymbol(account.symbol, vault.token.address) !==
-        getContractAddressForNetworkSymbol(account.symbol, routeParams.contractAddress)
+        getContractAddressForNetworkSymbol(account.symbol, vaultAddress) !==
+        getContractAddressForNetworkSymbol(account.symbol, routeParams.vaultAddress)
     );
 };
 
@@ -121,15 +128,15 @@ const getEarnLayoutResult = ({
         return { status: 'invalid', reason: 'network-mismatch' };
     }
 
-    if (isVaultTokenMismatch({ account, routeParams, vault })) {
-        return { status: 'invalid', reason: 'token-mismatch' };
+    if (isVaultAddressMismatch({ account, routeParams, vault })) {
+        return { status: 'invalid', reason: 'missing-vault' };
     }
 
     if (device && !isStablecoinYieldSupported(device, type)) {
         return { status: 'invalid', reason: 'firmware-not-supported' };
     }
 
-    return { status: 'valid', account, routeParams, vault };
+    return { status: 'valid', account, vault };
 };
 
 export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): EarnLayoutState => {
@@ -137,12 +144,20 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
     const dispatch = useDispatch();
     const { account, routeParams } = useEarnRouteAccount();
     const selectedDevice = useSelector(selectSelectedDevice);
+    // Normalized so a hand-written URL resolves the same vault as one the app produced.
+    const vaultAddress = routeParams?.vaultAddress
+        ? getContractAddressForNetworkSymbol(routeParams.symbol, routeParams.vaultAddress)
+        : undefined;
     const {
         data: vault,
         isLoading,
         isSuccess,
         isError,
-    } = useYieldOpportunity(routeParams?.yieldId);
+    } = useGetVaultByAddress({
+        enabled: true,
+        outputToken: vaultAddress,
+        network: getNetworkOptional(routeParams?.symbol)?.yieldXyzId ?? undefined,
+    });
 
     useEffect(() => {
         if (!routeParams) {
@@ -154,7 +169,7 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
         account,
         device: selectedDevice,
         routeParams,
-        vault,
+        vault: vault ?? undefined,
         type,
         isYieldOpportunitiesLoading: isLoading,
         isYieldOpportunitiesSuccess: isSuccess,

--- a/packages/suite/src/views/earn/yield/withdraw/index.tsx
+++ b/packages/suite/src/views/earn/yield/withdraw/index.tsx
@@ -13,11 +13,5 @@ export const EarnWithdraw = () => {
         return <EarnLayoutFallback layoutState={result} />;
     }
 
-    return (
-        <YieldWithdraw
-            account={result.account}
-            routeParams={result.routeParams}
-            vault={result.vault}
-        />
-    );
+    return <YieldWithdraw account={result.account} vault={result.vault} />;
 };

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -30,6 +30,7 @@ import {
 } from '@suite-common/trading';
 import { type Explorer, type Network } from '@suite-common/wallet-config';
 import {
+    getYieldVaultContractAddress,
     getYieldVaultForOutputToken,
     selectExplorer,
     sendFormActions,
@@ -137,6 +138,9 @@ const TokenRowBasicActions = ({
             }),
         [yieldOpportunities, account.symbol, token.contract, token.symbol, token.decimals],
     );
+    const availableVaultAddress = availableVault
+        ? getYieldVaultContractAddress(availableVault)
+        : null;
 
     const isDepositButtonDisabled = !availableVault?.status.enter;
     const isWithdrawButtonDisabled = !availableVault?.status.exit;
@@ -154,10 +158,7 @@ const TokenRowBasicActions = ({
     };
 
     const navigateToYieldDeposit = () => {
-        if (!availableVault) return;
-
-        const yieldId = availableVault.id;
-        const contractAddress = availableVault.token.address;
+        if (!availableVault || !availableVaultAddress) return;
 
         analytics.report({
             type: sharedEvents.yieldNavigateEvent.name,
@@ -166,7 +167,7 @@ const TokenRowBasicActions = ({
                 from: 'account-defi-tokens',
                 to: 'deposit-form',
                 networkSymbol: account.symbol,
-                vaultId: yieldId,
+                vaultId: availableVault.id,
             },
         });
 
@@ -175,18 +176,14 @@ const TokenRowBasicActions = ({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
                     account,
-                    yieldId,
-                    contractAddress,
+                    vaultAddress: availableVaultAddress,
                 }),
             }),
         );
     };
 
     const navigateToYieldWithdraw = () => {
-        if (!availableVault) return;
-
-        const yieldId = availableVault.id;
-        const contractAddress = availableVault.token.address;
+        if (!availableVault || !availableVaultAddress) return;
 
         analytics.report({
             type: sharedEvents.yieldNavigateEvent.name,
@@ -195,7 +192,7 @@ const TokenRowBasicActions = ({
                 from: 'account-defi-tokens',
                 to: 'withdraw-form',
                 networkSymbol: account.symbol,
-                vaultId: yieldId,
+                vaultId: availableVault.id,
             },
         });
 
@@ -204,8 +201,7 @@ const TokenRowBasicActions = ({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
                     account,
-                    yieldId,
-                    contractAddress,
+                    vaultAddress: availableVaultAddress,
                 }),
             }),
         );

--- a/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts
@@ -1,27 +1,33 @@
-import { type YieldDtoV2Output } from '@suite-common/earn-stablecoin-defs';
+import { type YieldDtoV2, type YieldDtoV2Output } from '@suite-common/earn-stablecoin-defs';
 import { type UseQueryResult, commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { getYields } from '../services';
 
 interface GetVaultByAddressProps {
     enabled?: boolean;
+    /** vault (share token) contract address — the vault's own on-chain identity */
     outputToken: string | undefined;
+    /** scopes the lookup to one network, as the same address can exist on several of them */
+    network?: YieldDtoV2['network'];
 }
 
 export function useGetVaultByAddress({
     enabled,
     outputToken,
+    network,
 }: GetVaultByAddressProps): UseQueryResult<YieldDtoV2Output | null, Error> {
     return useQuery({
         enabled: Boolean(enabled && outputToken),
-        queryKey: commonQueryKeys.yieldOpportunitiesByAddress(outputToken),
-        async queryFn() {
+        queryKey: commonQueryKeys.yieldOpportunitiesByAddress({ outputToken, network }),
+        async queryFn({ signal }) {
             const { items } = await getYields({
                 params: {
                     offset: 0,
                     limit: 1,
                     outputTokens: [outputToken!],
+                    network,
                 },
+                signal,
             });
 
             return items?.[0] ?? null;

--- a/suite-common/react-query/src/constants/queryKeys.ts
+++ b/suite-common/react-query/src/constants/queryKeys.ts
@@ -14,10 +14,10 @@ export const commonQueryKeys = {
     tronStakingStats: () => ['tron-staking-stats'],
     yieldOpportunity: (vaultId: string | undefined) => ['yield-opportunities', 'single', vaultId],
     yieldOpportunitiesList: (params: { limit: number }) => ['yield-opportunities', 'list', params],
-    yieldOpportunitiesByAddress: (outputToken: string | undefined) => [
+    yieldOpportunitiesByAddress: (params: { outputToken?: string; network?: string }) => [
         'yield-opportunities',
         'by-address',
-        outputToken,
+        params,
     ],
     yieldOpportunitiesPages: (params: { limit: number; sort: string }) => [
         'yield-opportunities',

--- a/suite-common/suite-types/src/staking.ts
+++ b/suite-common/suite-types/src/staking.ts
@@ -13,6 +13,8 @@ export enum EarnProvider {
 
 export type EarnYieldContext = {
     id: string;
+    /** vault (share token) contract address — how vault-scoped Earn routes address the vault */
+    vaultAddress?: string;
     tokenContractAddress?: string;
 };
 

--- a/suite/router-config/src/routeConfig.ts
+++ b/suite/router-config/src/routeConfig.ts
@@ -12,13 +12,7 @@ import type { RouterApp } from './routerApps';
 export const walletParams = ['symbol', 'accountIndex', 'accountType'] as const;
 export const modalAppParams = ['cancelable', 'variant'] as const;
 export const dashboardParams = ['modal', 'networkSymbol'] as const;
-export const earnParams = [
-    'symbol',
-    'accountIndex',
-    'accountType',
-    'yieldId',
-    'contractAddress',
-] as const;
+export const earnParams = ['symbol', 'accountIndex', 'accountType', 'vaultAddress'] as const;
 
 // Do not export, only for type-checking `routes` itself, instead use the inferred `Route` in @suite/router.
 type RouteDefinition = {

--- a/suite/router/src/router.test.ts
+++ b/suite/router/src/router.test.ts
@@ -48,18 +48,17 @@ describe('router', () => {
                     symbol: 'eth',
                     accountIndex: 0,
                     accountType: 'normal',
-                    yieldId: 'vault-1',
-                    contractAddress: '0xabc',
+                    vaultAddress: '0xvault',
                 }),
-            ).toEqual('/earn/yield/deposit#/eth/0/normal/vault-1/0xabc');
+            ).toEqual('/earn/yield/deposit#/eth/0/normal/0xvault');
             expect(
                 test('earn-yield-withdraw', {
                     symbol: 'eth',
                     accountIndex: 0,
                     accountType: 'normal',
-                    yieldId: 'vault-1',
+                    vaultAddress: '0xvault',
                 }),
-            ).toEqual('/earn/yield/withdraw#/eth/0/normal/vault-1');
+            ).toEqual('/earn/yield/withdraw#/eth/0/normal/0xvault');
             expect(
                 test('earn-yield-claim', {
                     symbol: 'eth',
@@ -195,7 +194,7 @@ describe('router', () => {
             expect(
                 getAppWithParams({
                     pathname: '/earn/yield/deposit',
-                    hash: '#/eth/0/normal/vault-1/0xabc',
+                    hash: '#/eth/0/normal/0xvault',
                 }),
             ).toEqual({
                 app: 'earn-yield',
@@ -203,8 +202,7 @@ describe('router', () => {
                     symbol: 'eth',
                     accountIndex: 0,
                     accountType: 'normal',
-                    yieldId: 'vault-1',
-                    contractAddress: '0xabc',
+                    vaultAddress: '0xvault',
                 },
                 route: getRoute('earn-yield-deposit'),
             });
@@ -212,7 +210,7 @@ describe('router', () => {
             expect(
                 getAppWithParams({
                     pathname: '/earn/yield/withdraw',
-                    hash: '#/eth/0/normal/vault-1',
+                    hash: '#/eth/0/normal/0xvault',
                 }),
             ).toEqual({
                 app: 'earn-yield',
@@ -220,8 +218,7 @@ describe('router', () => {
                     symbol: 'eth',
                     accountIndex: 0,
                     accountType: 'normal',
-                    yieldId: 'vault-1',
-                    contractAddress: undefined,
+                    vaultAddress: '0xvault',
                 },
                 route: getRoute('earn-yield-withdraw'),
             });

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -3,7 +3,7 @@ import { type WalletParams as CommonWalletParams } from '@suite-common/wallet-ty
 import { type Route } from './route';
 import {
     type DashboardParams,
-    decodeEarnRouteParams,
+    decodeEarnVaultAddress,
     parseDashboardParams,
     parseEarnParams,
     validateAccountRouteParams,
@@ -105,16 +105,12 @@ const accountScopedEarnYieldRoutes: Route['name'][] = [
 ];
 
 const validateEarnYieldParams = (route: Route, hash: HashString) => {
-    const [symbol, index, rawAccountType, rawYieldId, rawContractAddress] = parseHash(hash);
+    const [symbol, index, rawAccountType, rawVaultAddress] = parseHash(hash);
 
     const accountRouteParams = validateAccountRouteParams({
         symbol,
         index,
         rawAccountType,
-    });
-    const decodedEarnRouteParams = decodeEarnRouteParams({
-        rawYieldId,
-        rawContractAddress,
     });
 
     if (!accountRouteParams) {
@@ -125,13 +121,15 @@ const validateEarnYieldParams = (route: Route, hash: HashString) => {
         return accountRouteParams;
     }
 
-    if (!rawYieldId) {
+    const vaultAddress = decodeEarnVaultAddress(rawVaultAddress);
+
+    if (!vaultAddress) {
         return;
     }
 
     return parseEarnParams({
         ...accountRouteParams,
-        ...decodedEarnRouteParams,
+        vaultAddress,
     });
 };
 

--- a/suite/router/src/routerParams.ts
+++ b/suite/router/src/routerParams.ts
@@ -25,8 +25,7 @@ const earnParamsSchema = yup.object({
     symbol: yup.mixed<NetworkSymbol>().required(),
     accountIndex: yup.number().required(),
     accountType: yup.mixed<AccountType>().oneOf(accountTypes).required(),
-    yieldId: yup.string().default('no-yield-id'),
-    contractAddress: yup.string().notRequired(),
+    vaultAddress: yup.string().optional(),
 });
 
 export type EarnParams = yup.InferType<typeof earnParamsSchema>;
@@ -54,25 +53,15 @@ export function parseDashboardParams(params: unknown): DashboardParams | undefin
     }
 }
 
-export const decodeEarnRouteParams = ({
-    rawYieldId,
-    rawContractAddress,
-}: {
-    rawYieldId?: string;
-    rawContractAddress?: string;
-}) => {
-    try {
-        const yieldId = rawYieldId ? decodeURIComponent(rawYieldId) : undefined;
-        const contractAddress = rawContractAddress
-            ? decodeURIComponent(rawContractAddress)
-            : undefined;
+export const decodeEarnVaultAddress = (rawVaultAddress?: string): string | undefined => {
+    if (!rawVaultAddress) {
+        return undefined;
+    }
 
-        return {
-            yieldId,
-            contractAddress,
-        };
+    try {
+        return decodeURIComponent(rawVaultAddress);
     } catch {
-        return;
+        return undefined;
     }
 };
 

--- a/suite/router/src/routes.ts
+++ b/suite/router/src/routes.ts
@@ -16,8 +16,7 @@ type AppParamsTypes = {
     accountIndex: number;
     accountType: NonNullable<AccountType>;
     cancelable: boolean;
-    yieldId: string;
-    contractAddress?: string;
+    vaultAddress?: string;
 };
 
 type ExtractType<T extends keyof AppParamsTypes> = {


### PR DESCRIPTION
## Description

Use vault address in deposit/withdraw route URLs instead of yield ID and token address.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30545

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-04 at 14 57 29" src="https://github.com/user-attachments/assets/63e98342-bd94-4bbf-aa74-c32acf3f440b" />

<img width="100%" alt="Screenshot 2026-08-04 at 14 57 36" src="https://github.com/user-attachments/assets/ff7d9e33-2c3e-4e87-a82a-cda8f59d8b2f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is focused on the Earn/Yield feature (deposit/withdraw flows and related hooks/components) with secondary touches to routing and staking types. The highest-value test is the dedicated yield deposit E2E, which should be run unconditionally. Add the route link-check test as a medium-priority guard against router regressions, and one representative ADA staking test to cover the earn-stablecoin hook and staking type changes. Omit broad globally-mapped dependencies like react-query queryKeys unless direct behavioural evidence emerges.

<details><summary><b>Changed files (23)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx`
- `packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts`
- `packages/suite/src/components/earn/utils/getEarnRouteParams.ts`
- `packages/suite/src/components/earn/yield/common/YieldPageHeader.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx`
- `packages/suite/src/components/earn/yield/deposit/useYieldDeposit.ts`
- `packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdraw.tsx`
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `packages/suite/src/types/earn/earnLayout.ts`
- `packages/suite/src/views/earn/yield/deposit/index.tsx`
- `packages/suite/src/views/earn/yield/useEarnLayout.tsx`
- `packages/suite/src/views/earn/yield/withdraw/index.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `suite-common/earn-stablecoin-api/src/hooks/useGetVaultByAddress.ts`
- `suite-common/react-query/src/constants/queryKeys.ts`
- `suite-common/suite-types/src/staking.ts`
- `suite/router-config/src/routeConfig.ts`
- `suite/router/src/router.test.ts`
- `suite/router/src/router.ts`
- `suite/router/src/routerParams.ts`
- `suite/router/src/routes.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/yield/deposit.test.ts` — This is the only E2E test statically mapped to the changed earn/yield views (deposit/index.tsx, useEarnLayout.tsx) and directly exercises the yield deposit flow that the bulk of the changed components implement (YieldDeposit, useYieldDeposit, useYieldFlow, YieldPageHeader, getEarnRouteParams, EarnYieldAccountOpportunity, EarnProviderConsent).

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — The change set modifies several router files (routeConfig.ts, router.ts, routerParams.ts, routes.ts) and adds/updates earn routes. This test enumerates every application route and verifies they load without broken links, making it the best integration check for routing regressions.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Static coverage maps the changed useGetVaultByAddress hook and staking types to the staking test suite, and the ADA stake flow is representative of staking/earn integration paths that could be affected by changes to shared earn components or staking type definitions.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/types/earn/earnLayout.ts`
- `packages/suite/src/views/earn/yield/withdraw/index.tsx`
- `suite-common/suite-types/src/staking.ts`
- `suite/router/src/router.test.ts`
- `suite/router/src/router.ts`
- `suite/router/src/routerParams.ts`
- `suite/router/src/routes.ts`

_Updated: 2026-08-04T13:02:36.816Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-vault-address-url/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-vault-address-url/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-vault-address-url&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-vault-address-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-vault-address-url&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:04:21.253Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T13:04:19.075Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->