### PR TITLE
[nity nit] refactor(utils): make Cache class generic (Cache<T>)

### DIFF
--- a/packages/blockchain-link/src/workers/state.ts
+++ b/packages/blockchain-link/src/workers/state.ts
@@ -6,7 +6,7 @@ export class WorkerState {
     addresses: string[];
     accounts: SubscriptionAccountInfo[];
     subscription: { [key: string]: unknown };
-    cache: Cache;
+    cache: Cache<Promise<number>>;
     url?: string;
 
     constructor() {

--- a/packages/utils/src/cache.ts
+++ b/packages/utils/src/cache.ts
@@ -1,18 +1,18 @@
 /**
  * Cache class which allows to store Key-Value pairs with a TTL for each key
  */
-export class Cache {
-    store: Map<string, { value: any; ttl: number }>;
+export class Cache<T = unknown> {
+    store: Map<string, { value: T; ttl: number }>;
 
     constructor() {
         this.store = new Map();
     }
 
-    set(key: string, value: any, ttl: number) {
+    set(key: string, value: T, ttl: number) {
         this.store.set(key, { value, ttl: Date.now() + ttl });
     }
 
-    get(key: string) {
+    get(key: string): T | undefined {
         const entry = this.store.get(key);
         if (!entry) return;
         if (entry.ttl < Date.now()) {


### PR DESCRIPTION
Split out of the types-hardening umbrella #27649.

## What
Make `@trezor/utils`' `Cache` class generic — `class Cache<T = unknown>` — instead of typing `store`/`set`/`get` as `any`.

- `get(key)` now returns `T | undefined` (previously `any`).
- The sole non-test consumer, `blockchain-link`'s `WorkerState.cache`, is pinned to `Cache<Promise<number>>`.

## Why
The `any` on `get()` leaked into every caller. This is the one place in the `Cache` API where removing `any` actually improves the type seen by consumers (not just internal hygiene). The `T = unknown` default keeps any existing untyped usage compiling.

## Risk
None — purely a type-level change, no runtime behaviour changes. `type-check` and `lint:js` green for `@trezor/utils` and `@trezor/blockchain-link`.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are broadly imported shared primitives, so the strategy is to run a small, targeted set. The Solana staking tests provide direct coverage of epoch cache expiration and pending-state transitions, which are the most concrete cache/state behaviors in the candidate list. The coins settings test adds coverage for discovery and custom backend worker state. If these pass, the risk of a broad regression is low.

<details><summary><b>Changed files (2)</b></summary>

- `packages/blockchain-link/src/workers/state.ts`
- `packages/utils/src/cache.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test explicitly exercises the Solana epoch cache mechanism (solanaEpochCachePeriod) and pending-state transitions after epoch advancement, so a change to the generic cache utility or blockchain-link worker state could directly break it.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — The test verifies that rewards update only after the Solana epoch cache period expires and the tab is revisited, directly testing cache invalidation behavior that cache.ts and worker state likely underpin.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — This test runs discovery across enabled networks and configures a custom Blockbook backend for ETH, which exercises blockchain-link worker state transitions and network backend handling.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — It shares the same Solana staking backend mock and epoch-advancement flow as the high-priority staking tests, so a regression in cache invalidation or worker state would likely surface here too.

</details>

_Updated: 2026-08-06T13:28:38.022Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/utils-cache-generic/web/](https://dev.suite.sldev.cz/suite-web/mroz22/utils-cache-generic/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/utils-cache-generic&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/utils-cache-generic&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T13:31:23.150Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T13:31:10.092Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->