### PR TITLE
Message System for Wrap/Unwrap

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx
@@ -2,11 +2,11 @@ import { type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type Variant } from '@suite-common/suite-types';
-import type { YieldFlowType } from '@suite-common/wallet-core';
+import type { WrappedNativeFlowType, YieldFlowType } from '@suite-common/wallet-core';
 import { Banner } from '@trezor/components';
 
 type YieldDisabledBannerProps = {
-    type: YieldFlowType;
+    type: YieldFlowType | WrappedNativeFlowType;
     content?: ReactNode;
     variant?: Variant;
 };
@@ -16,6 +16,8 @@ const yieldDisabledMessageMap = {
     withdraw: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     redeem: 'TR_EARN_YIELD_WITHDRAW_DISABLED',
     claim: 'TR_EARN_YIELD_CLAIM_DISABLED',
+    wrap: 'TR_EARN_YIELD_WRAP_DISABLED',
+    unwrap: 'TR_EARN_YIELD_UNWRAP_DISABLED',
 } as const;
 
 export const YieldDisabledBanner = ({ type, content, variant }: YieldDisabledBannerProps) => (

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -13,6 +13,7 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldDepositContext } from './useYieldDepositContext';
 import { YieldActionStep } from '../common/YieldActionStep';
@@ -20,6 +21,7 @@ import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
 import { YieldApproveModal } from '../common/YieldApproveModal';
 import { YieldApproveStep } from '../common/YieldApproveStep';
 import { YieldApprovedAmountCard } from '../common/YieldApprovedAmountCard';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteDeposit } from '../common/YieldFlowCompleteDeposit';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldWrapStep } from '../common/YieldWrapStep';
@@ -68,6 +70,12 @@ export const YieldDepositForm = () => {
         setMaxAmount,
         flow,
     } = useYieldDepositContext();
+
+    const {
+        isDisabled: isWrapDisabled,
+        content: wrapDisabledContent,
+        variant: wrapDisabledVariant,
+    } = useMessageSystemWrappedNative('wrap');
 
     const { approvalPendingTransaction, actionPendingTransaction: depositPendingTransaction } =
         splitYieldPendingTransaction(pendingTransaction, 'deposit');
@@ -295,28 +303,42 @@ export const YieldDepositForm = () => {
                                     />
                                 ),
                                 onEdit: returnToWrapStep,
+                                // Wrapping may be disabled remotely; skipping it stays available so a
+                                // user with a wrapped-token balance can still finish the deposit.
                                 content: () => (
-                                    <YieldWrapStep
-                                        token={token}
-                                        nativeSymbol={nativeSymbol}
-                                        availableAmount={account.formattedBalance}
-                                        receivingAmount={liveAmount || '0'}
-                                        isSubmitting={isSubmittingAction}
-                                        isSubmitDisabled={
-                                            isAmountEmpty ||
-                                            isAmountTooHigh ||
-                                            isAmountInvalidDecimals
-                                        }
-                                        warning={renderWrapWarning()}
-                                        pendingTransaction={wrapPendingTransaction}
-                                        fiatToggle={fiatToggle}
-                                        onMaxClick={handleMaxClick}
-                                        onSubmit={handleOnWrap}
-                                        onSkip={
-                                            hasWrappedTokenBalance ? handleOnSkipWrap : undefined
-                                        }
-                                        onPendingTxClick={openPendingTransaction}
-                                    />
+                                    <Column gap={16}>
+                                        {isWrapDisabled && (
+                                            <YieldDisabledBanner
+                                                type="wrap"
+                                                content={wrapDisabledContent}
+                                                variant={wrapDisabledVariant}
+                                            />
+                                        )}
+                                        <YieldWrapStep
+                                            token={token}
+                                            nativeSymbol={nativeSymbol}
+                                            availableAmount={account.formattedBalance}
+                                            receivingAmount={liveAmount || '0'}
+                                            isSubmitting={isSubmittingAction}
+                                            isSubmitDisabled={
+                                                isWrapDisabled ||
+                                                isAmountEmpty ||
+                                                isAmountTooHigh ||
+                                                isAmountInvalidDecimals
+                                            }
+                                            warning={renderWrapWarning()}
+                                            pendingTransaction={wrapPendingTransaction}
+                                            fiatToggle={fiatToggle}
+                                            onMaxClick={handleMaxClick}
+                                            onSubmit={handleOnWrap}
+                                            onSkip={
+                                                hasWrappedTokenBalance
+                                                    ? handleOnSkipWrap
+                                                    : undefined
+                                            }
+                                            onPendingTxClick={openPendingTransaction}
+                                        />
+                                    </Column>
                                 ),
                             },
                             approve: {

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -19,9 +19,11 @@ import { BigNumber } from '@trezor/utils';
 
 import { submitUnwrapNativeTokenThunk } from 'src/actions/wallet/unwrapNativeTokenThunks';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { WrappedNativeFlowComplete } from '../common/WrappedNativeFlowComplete';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
@@ -50,6 +52,11 @@ export const UnwrapNativeToken = ({
 }: UnwrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
+    const {
+        isDisabled,
+        content: disabledContent,
+        variant: disabledVariant,
+    } = useMessageSystemWrappedNative('unwrap');
     const [broadcast, setBroadcast] = useState<BroadcastUnwrap | null>(null);
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',
@@ -163,6 +170,17 @@ export const UnwrapNativeToken = ({
                         output={{ token: nativeToken, amount: broadcast.amount }}
                     />
                 </WrappedNativeFlowComplete>
+            );
+        }
+
+        // An unwrap already broadcast keeps rendering the form, so its pending transaction stays visible.
+        if (isDisabled && !broadcast) {
+            return (
+                <YieldDisabledBanner
+                    type="unwrap"
+                    content={disabledContent}
+                    variant={disabledVariant}
+                />
             );
         }
 

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -10,10 +10,12 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldWithdrawContext } from './useYieldWithdrawContext';
 import { YieldActionStep } from '../common/YieldActionStep';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
@@ -50,6 +52,12 @@ export const YieldWithdrawForm = () => {
         setMaxAmount,
         flow,
     } = useYieldWithdrawContext();
+
+    const {
+        isDisabled: isUnwrapDisabled,
+        content: unwrapDisabledContent,
+        variant: unwrapDisabledVariant,
+    } = useMessageSystemWrappedNative('unwrap');
 
     const { actionPendingTransaction: withdrawPendingTransaction } = splitYieldPendingTransaction(
         pendingTransaction,
@@ -273,28 +281,42 @@ export const YieldWithdrawForm = () => {
                                     }}
                                 />
                             ),
+                            // Unwrapping may be disabled remotely; skipping it stays available so the
+                            // user can finish the flow and keep the wrapped token.
                             content: () => (
-                                <YieldUnwrapStep
-                                    tokenSymbol={token.symbol}
-                                    tokenDecimals={token.decimals}
-                                    tokenBalance={token.balance}
-                                    approxFiat={unwrapApproxFiat}
-                                    fiatToggle={fiatToggle}
-                                    onMaxClick={() => setMaxAmount(token.balance)}
-                                    isSubmitting={isSubmittingAction}
-                                    isSubmitDisabled={
-                                        isAmountEmpty || isAmountTooHigh || isAmountInvalidDecimals
-                                    }
-                                    warning={
-                                        !isAmountInvalidDecimals && isAmountTooHigh ? (
-                                            <YieldActionStepWarning isInsufficientFunds />
-                                        ) : undefined
-                                    }
-                                    pendingTransaction={unwrapPendingTransaction}
-                                    onSubmit={handleOnUnwrap}
-                                    onSkip={handleOnSkipUnwrap}
-                                    onPendingTxClick={openPendingTransaction}
-                                />
+                                <Column gap={16}>
+                                    {isUnwrapDisabled && (
+                                        <YieldDisabledBanner
+                                            type="unwrap"
+                                            content={unwrapDisabledContent}
+                                            variant={unwrapDisabledVariant}
+                                        />
+                                    )}
+                                    <YieldUnwrapStep
+                                        tokenSymbol={token.symbol}
+                                        tokenDecimals={token.decimals}
+                                        tokenBalance={token.balance}
+                                        approxFiat={unwrapApproxFiat}
+                                        fiatToggle={fiatToggle}
+                                        onMaxClick={() => setMaxAmount(token.balance)}
+                                        isSubmitting={isSubmittingAction}
+                                        isSubmitDisabled={
+                                            isUnwrapDisabled ||
+                                            isAmountEmpty ||
+                                            isAmountTooHigh ||
+                                            isAmountInvalidDecimals
+                                        }
+                                        warning={
+                                            !isAmountInvalidDecimals && isAmountTooHigh ? (
+                                                <YieldActionStepWarning isInsufficientFunds />
+                                            ) : undefined
+                                        }
+                                        pendingTransaction={unwrapPendingTransaction}
+                                        onSubmit={handleOnUnwrap}
+                                        onSkip={handleOnSkipUnwrap}
+                                        onPendingTxClick={openPendingTransaction}
+                                    />
+                                </Column>
                             ),
                         },
                         complete: {

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -20,9 +20,11 @@ import { BigNumber } from '@trezor/utils';
 
 import { submitWrapNativeTokenThunk } from 'src/actions/wallet/wrapNativeTokenThunks';
 import { useDispatch } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { WrappedNativeFlowComplete } from '../common/WrappedNativeFlowComplete';
 import { YieldActionStepWarning } from '../common/YieldActionStepWarning';
+import { YieldDisabledBanner } from '../common/YieldDisabledBanner';
 import { YieldFlowTransferRow } from '../common/YieldFlowTransferRow';
 import { YieldWrapStep } from '../common/YieldWrapStep';
 import { useWrappedNativeDeviceGuard } from '../common/useWrappedNativeDeviceGuard';
@@ -42,6 +44,11 @@ type BroadcastWrap = {
 export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
+    const {
+        isDisabled,
+        content: disabledContent,
+        variant: disabledVariant,
+    } = useMessageSystemWrappedNative('wrap');
     const [broadcast, setBroadcast] = useState<BroadcastWrap | null>(null);
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',
@@ -161,6 +168,17 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                         output={{ token, amount: broadcast.amount }}
                     />
                 </WrappedNativeFlowComplete>
+            );
+        }
+
+        // A wrap already broadcast keeps rendering the form, so its pending transaction stays visible.
+        if (isDisabled && !broadcast) {
+            return (
+                <YieldDisabledBanner
+                    type="wrap"
+                    content={disabledContent}
+                    variant={disabledVariant}
+                />
             );
         }
 

--- a/packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts
+++ b/packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts
@@ -1,0 +1,11 @@
+import { selectLanguage } from '@suite/settings';
+import { useMessageSystemWrappedNative as useMessageSystemWrappedNativeCore } from '@suite-common/message-system';
+import type { WrappedNativeFlowType } from '@suite-common/wallet-core';
+
+import { useSelector } from './useSelector';
+
+export const useMessageSystemWrappedNative = (type: WrappedNativeFlowType) => {
+    const locale = useSelector(selectLanguage);
+
+    return useMessageSystemWrappedNativeCore({ type, locale });
+};

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -72,6 +72,7 @@ import { SUITE } from 'src/actions/suite/constants';
 import { setSendFormPrefill } from 'src/actions/suite/suiteActions';
 import { getEarnRouteParams } from 'src/components/earn/utils/getEarnRouteParams';
 import { useDispatch, useLayoutSize, useSelector } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 import { getTokenAddressTranslationId } from 'src/utils/wallet/tokenUtils';
 
 import type { TokensTableType } from './types';
@@ -144,6 +145,8 @@ const TokenRowBasicActions = ({
 
     const isDepositButtonDisabled = !availableVault?.status.enter;
     const isWithdrawButtonDisabled = !availableVault?.status.exit;
+
+    const { isDisabled: isUnwrapDisabled } = useMessageSystemWrappedNative('unwrap');
 
     if (!unusedAddress || !device) return null;
 
@@ -436,7 +439,7 @@ const TokenRowBasicActions = ({
                                     },
                                 }),
                             ),
-                        isDisabled: token.balance === '0',
+                        isDisabled: token.balance === '0' || isUnwrapDisabled,
                         isHidden: !isWrappedNativeToken(account.symbol, token.contract),
                     },
                     {

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx
@@ -25,6 +25,11 @@ jest.mock('@suite/debug', () => ({
     selectIsDebugModeActive: () => mockSelectIsDebugModeActive(),
 }));
 
+const mockIsWrapDisabled = jest.fn();
+jest.mock('src/hooks/suite/useMessageSystemWrappedNative', () => ({
+    useMessageSystemWrappedNative: () => ({ isDisabled: mockIsWrapDisabled() }),
+}));
+
 const mockGetNetworkType = jest.fn();
 const mockGetWrappedNativeAddress = jest.fn();
 const mockGetWrappedNativeSymbol = jest.fn();
@@ -59,6 +64,7 @@ describe('WrapNativeTokenButton', () => {
         mockGetNetworkType.mockReturnValue('ethereum');
         mockGetWrappedNativeAddress.mockReturnValue('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
         mockGetWrappedNativeSymbol.mockReturnValue('WETH');
+        mockIsWrapDisabled.mockReturnValue(false);
     });
 
     it('renders nothing when debug mode is off', () => {
@@ -78,6 +84,13 @@ describe('WrapNativeTokenButton', () => {
         mockGetWrappedNativeSymbol.mockReturnValue(undefined);
         renderButton();
         expect(screen.queryByTestId(WRAP_BUTTON_TESTID)).not.toBeInTheDocument();
+    });
+
+    it('disables the button when wrapping is disabled by the message system', () => {
+        mockIsWrapDisabled.mockReturnValue(true);
+        renderButton();
+
+        expect(screen.getByTestId(WRAP_BUTTON_TESTID)).toBeDisabled();
     });
 
     it('navigates to the standalone wrap page when all conditions are met', () => {

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -8,9 +8,10 @@ import {
     getWrappedNativeAddress,
     getWrappedNativeSymbol,
 } from '@suite-common/wallet-config';
-import { Button } from '@trezor/components';
+import { Button, Tooltip } from '@trezor/components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 import { type Account } from 'src/types/wallet';
 
 type WrapNativeTokenButtonProps = {
@@ -25,6 +26,8 @@ type WrapNativeTokenButtonProps = {
 export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
     const dispatch = useDispatch();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
+    const { isDisabled: isWrapDisabled, content: wrapDisabledContent } =
+        useMessageSystemWrappedNative('wrap');
 
     const { symbol } = account;
     const wrappedAddress = getWrappedNativeAddress(symbol);
@@ -55,13 +58,16 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
     };
 
     return (
-        <Button
-            intent="accentViolet"
-            size="small"
-            onClick={onClick}
-            data-testid="@trading/menu/wrap-native-token"
-        >
-            <Translation id="TR_WRAP_NATIVE_TOKEN" />
-        </Button>
+        <Tooltip content={wrapDisabledContent} isActive={isWrapDisabled}>
+            <Button
+                intent="accentViolet"
+                size="small"
+                isDisabled={isWrapDisabled}
+                onClick={onClick}
+                data-testid="@trading/menu/wrap-native-token"
+            >
+                <Translation id="TR_WRAP_NATIVE_TOKEN" />
+            </Button>
+        </Tooltip>
     );
 };

--- a/suite-common/message-system/schema/config.schema.v1.json
+++ b/suite-common/message-system/schema/config.schema.v1.json
@@ -792,6 +792,10 @@
         "yieldFlowType": {
             "type": "string",
             "enum": ["deposit", "withdraw", "redeem", "claim"]
+        },
+        "wrappedNativeFlowType": {
+            "type": "string",
+            "enum": ["wrap", "unwrap"]
         }
     }
 }

--- a/suite-common/message-system/src/index.ts
+++ b/suite-common/message-system/src/index.ts
@@ -16,4 +16,5 @@ export * from './useExperiment';
 export * from './useMessageSystemEarnDashboard';
 export * from './useMessageSystemMessageForm';
 export * from './useMessageSystemStaking';
+export * from './useMessageSystemWrappedNative';
 export * from './useMessageSystemYield';

--- a/suite-common/message-system/src/messageSystemTypes.ts
+++ b/suite-common/message-system/src/messageSystemTypes.ts
@@ -3,6 +3,7 @@ import type {
     ExperimentsItem,
     MessageSystem,
     TradingType,
+    WrappedNativeFlowType,
     YieldFlowType,
 } from '@suite-common/suite-types';
 import type { AccountType, NetworkSymbol, StakingNetworkSymbol } from '@suite-common/wallet-config';
@@ -114,6 +115,13 @@ export const Feature = {
             redeem: 'earn.yield.redeem',
             claim: 'earn.yield.claim',
         } as const satisfies Record<YieldFlowType, string>,
+        // Wrapping the native coin into its wrapped-native token (e.g. ETH → WETH) and back. It is
+        // a step of the yield deposit/withdraw flows, but also a standalone flow, so it is gated
+        // separately from the yield flow types.
+        wrappedNative: {
+            wrap: 'earn.wrappedNative.wrap',
+            unwrap: 'earn.wrappedNative.unwrap',
+        } as const satisfies Record<WrappedNativeFlowType, string>,
     },
     mevProtection: 'settings.mevProtection',
     suiteSync: 'settings.suiteSync',

--- a/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
+++ b/suite-common/message-system/src/useMessageSystemWrappedNative.test.ts
@@ -1,0 +1,96 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import {
+    configureMockStore,
+    extraDependenciesCommonMock,
+    renderHookWithStoreProvider,
+} from '@suite-common/test-utils';
+
+import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
+import { type MessageSystemState } from './messageSystemTypes';
+import { useMessageSystemWrappedNative } from './useMessageSystemWrappedNative';
+
+const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
+
+const stateWithDisabledWrap = {
+    ...messageSystemInitialState,
+    config: {
+        version: 1,
+        timestamp: '2023-01-01',
+        sequence: 1,
+        actions: [
+            {
+                message: {
+                    id: 'wrapDisabledMsg',
+                    priority: 1,
+                    dismissible: false,
+                    category: ['feature'],
+                    variant: 'critical',
+                    content: { en: 'Wrapping disabled', cs: 'Wrapování vypnuté' },
+                    feature: [{ domain: 'earn.wrappedNative.wrap', flag: false }],
+                },
+            },
+        ],
+        experiments: [],
+    },
+    validMessages: {
+        banner: [],
+        context: [],
+        modal: [],
+        feature: ['wrapDisabledMsg'],
+    },
+} as unknown as MessageSystemState;
+
+const createStore = (state: MessageSystemState = stateWithDisabledWrap) =>
+    configureMockStore({
+        extra: {},
+        reducer: combineReducers({ messageSystem: messageSystemReducer }),
+        preloadedState: { messageSystem: state } as { messageSystem: MessageSystemState },
+    });
+
+const renderHook = (props: Parameters<typeof useMessageSystemWrappedNative>[0]) =>
+    renderHookWithStoreProvider(() => useMessageSystemWrappedNative(props), {
+        store: createStore(),
+    });
+
+describe('useMessageSystemWrappedNative', () => {
+    it('returns disabled state, message content and variant when wrapping is disabled', () => {
+        const { result } = renderHook({ type: 'wrap', locale: 'en' });
+
+        expect(result.current).toMatchObject({
+            isDisabled: true,
+            content: 'Wrapping disabled',
+            variant: 'critical',
+        });
+    });
+
+    it('returns localized message content', () => {
+        const { result } = renderHook({ type: 'wrap', locale: 'cs' });
+
+        expect(result.current.content).toBe('Wrapování vypnuté');
+    });
+
+    it('does not disable unwrapping when only wrapping is disabled', () => {
+        const { result } = renderHook({ type: 'unwrap', locale: 'en' });
+
+        expect(result.current).toMatchObject({
+            isDisabled: false,
+            content: undefined,
+            variant: undefined,
+        });
+    });
+
+    it('returns not disabled when no feature messages are configured', () => {
+        const store = createStore(messageSystemInitialState);
+        const { result } = renderHookWithStoreProvider(
+            () => useMessageSystemWrappedNative({ type: 'wrap', locale: 'en' }),
+            { store },
+        );
+
+        expect(result.current).toMatchObject({
+            isDisabled: false,
+            content: undefined,
+            variant: undefined,
+        });
+    });
+});

--- a/suite-common/message-system/src/useMessageSystemWrappedNative.ts
+++ b/suite-common/message-system/src/useMessageSystemWrappedNative.ts
@@ -1,0 +1,40 @@
+import { useSelector } from 'react-redux';
+
+import { type WrappedNativeFlowType } from '@suite-common/suite-types';
+
+import {
+    selectFeatureMessage,
+    selectFeatureMessageContent,
+    selectIsFeatureDisabled,
+} from './messageSystemSelectors';
+import { Feature, type MessageSystemRootState } from './messageSystemTypes';
+
+interface UseMessageSystemWrappedNativeProps {
+    type: WrappedNativeFlowType;
+    locale: string;
+}
+
+export const useMessageSystemWrappedNative = ({
+    type,
+    locale,
+}: UseMessageSystemWrappedNativeProps) => {
+    const domain = Feature.earn.wrappedNative[type];
+
+    const isDisabled = useSelector((state: MessageSystemRootState) =>
+        selectIsFeatureDisabled(state, domain),
+    );
+
+    const content = useSelector((state: MessageSystemRootState) =>
+        selectFeatureMessageContent(state, domain, locale),
+    );
+
+    const variant = useSelector(
+        (state: MessageSystemRootState) => selectFeatureMessage(state, domain)?.variant,
+    );
+
+    return {
+        isDisabled,
+        content,
+        variant,
+    };
+};

--- a/suite-common/suite-types/src/messageSystem.ts
+++ b/suite-common/suite-types/src/messageSystem.ts
@@ -308,6 +308,11 @@ export type TradingType = 'buy' | 'sell' | 'exchange' | 'concierge';
  * via the `definition` "yieldFlowType".
  */
 export type YieldFlowType = 'deposit' | 'withdraw' | 'redeem' | 'claim';
+/**
+ * This interface was referenced by `MessageSystem`'s JSON-Schema
+ * via the `definition` "wrappedNativeFlowType".
+ */
+export type WrappedNativeFlowType = 'wrap' | 'unwrap';
 
 /**
  * JSON schema of the Trezor Suite messaging system.

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10312,6 +10312,14 @@ export const messages = defineMessages({
         id: 'TR_EARN_YIELD_CLAIM_DISABLED',
         defaultMessage: 'Claim is currently disabled.',
     },
+    TR_EARN_YIELD_WRAP_DISABLED: {
+        id: 'TR_EARN_YIELD_WRAP_DISABLED',
+        defaultMessage: 'Wrapping is currently disabled.',
+    },
+    TR_EARN_YIELD_UNWRAP_DISABLED: {
+        id: 'TR_EARN_YIELD_UNWRAP_DISABLED',
+        defaultMessage: 'Unwrapping is currently disabled.',
+    },
     TR_EARN_DEFI_YIELD_TITLE: {
         id: 'TR_EARN_DEFI_YIELD_TITLE',
         defaultMessage: 'DeFi Yield',


### PR DESCRIPTION
## Description

Introduce message system for wrap/unwrap.

## Messages for testing

```json
[
  {
    "conditions": [
      { "environment": { "desktop": "*", "web": "*", "mobile": "!" } }
    ],
    "message": {
      "id": "5b3d1c9e-3f2a-4a71-9c3e-1f7b0d9e0001",
      "priority": 100,
      "dismissible": false,
      "variant": "warning",
      "category": "feature",
      "content": {
        "en": "Wrapping ETH into WETH is temporarily unavailable. Please try again later.",
        "cs": "Wrapování ETH na WETH je momentálně nedostupné. Zkuste to prosím později.",
        "es": "El envoltorio de ETH a WETH no está disponible temporalmente.",
        "de": "Das Wrappen von ETH in WETH ist vorübergehend nicht verfügbar.",
        "fr": "L'encapsulation d'ETH en WETH est temporairement indisponible.",
        "pt": "O empacotamento de ETH para WETH está temporariamente indisponível."
      },
      "feature": [{ "domain": "earn.wrappedNative.wrap", "flag": false }]
    }
  },
  {
    "conditions": [
      { "environment": { "desktop": "*", "web": "*", "mobile": "!" } }
    ],
    "message": {
      "id": "5b3d1c9e-3f2a-4a71-9c3e-1f7b0d9e0002",
      "priority": 100,
      "dismissible": false,
      "variant": "critical",
      "category": "feature",
      "content": {
        "en": "Unwrapping WETH back into ETH is temporarily unavailable.",
        "cs": "Unwrapování WETH na ETH je momentálně nedostupné.",
        "es": "El desenvoltorio de WETH a ETH no está disponible temporalmente.",
        "de": "Das Unwrappen von WETH in ETH ist vorübergehend nicht verfügbar.",
        "fr": "La désencapsulation de WETH en ETH est temporairement indisponible.",
        "pt": "O desempacotamento de WETH para ETH está temporariamente indisponível."
      },
      "feature": [{ "domain": "earn.wrappedNative.unwrap", "flag": false }]
    }
  },
  {
    "conditions": [
      { "environment": { "desktop": "*", "web": "*", "mobile": "!" } }
    ],
    "message": {
      "id": "5b3d1c9e-3f2a-4a71-9c3e-1f7b0d9e0003",
      "priority": 100,
      "dismissible": false,
      "variant": "critical",
      "category": "feature",
      "content": {
        "en": "Wrapped-token conversions are paused while we investigate an issue.",
        "cs": "Konverze wrapped tokenů jsou pozastaveny, prošetřujeme problém.",
        "es": "Las conversiones de tokens envueltos están pausadas.",
        "de": "Wrapped-Token-Konvertierungen sind vorübergehend pausiert.",
        "fr": "Les conversions de jetons encapsulés sont suspendues.",
        "pt": "As conversões de tokens empacotados estão pausadas."
      },
      "feature": [
        { "domain": "earn.wrappedNative.wrap", "flag": false },
        { "domain": "earn.wrappedNative.unwrap", "flag": false }
      ]
    }
  }
]
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29860

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-04 at 16 19 35" src="https://github.com/user-attachments/assets/32b7a099-9d4b-46d4-b307-6c6557c81434" />

<img width="100%" alt="Screenshot 2026-08-04 at 16 20 22" src="https://github.com/user-attachments/assets/d155026d-9105-4ea7-bbd0-e09aada4ace6" />

<img width="100%" alt="Screenshot 2026-08-04 at 16 20 34" src="https://github.com/user-attachments/assets/ab63a6f0-79bc-473a-a8de-f1752674aba4" />

<img width="100%" alt="Screenshot 2026-08-04 at 16 20 50" src="https://github.com/user-attachments/assets/5c783d6f-46d4-4add-9d9a-15ebcc3109b5" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrap-unwrap-message-system/web/](https://dev.suite.sldev.cz/suite-web/feat/wrap-unwrap-message-system/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily affects earn/yield staking UI (deposit/withdraw forms, disabled banner, wrap/unwrap helpers) and token-related wallet UI (TokenRowActions, WrapNativeTokenButton, message-system wrapped-native hook). The highest-risk regressions are in the staking deposit/withdraw flows and token row actions. The recommended strategy is to run the targeted staking ETH/SOL tests plus the live token-swap trading tests that statically reference TokenRowActions. ADA staking and trading navigation provide medium-value shared-infrastructure coverage. The wrapped-native-token and message-system changes lack dedicated E2E coverage in the existing suite.

<details><summary><b>Changed files (16)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldDisabledBanner.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx`
- `suite-common/message-system/schema/config.schema.v1.json`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.test.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.ts`
- `suite-common/suite-types/src/messageSystem.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the full ETH staking deposit flow, including opening the staking form, entering an amount, and confirming on device. It directly renders the changed YieldDepositForm component and related earn/yield infrastructure.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test covers the ETH unstaking flow, including the unstaking form and confirmation modal. It directly exercises the changed YieldWithdrawForm component.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test walks through the Solana first-time staking flow, including the staking form and amount entry. It renders the changed YieldDepositForm and related yield components.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test covers Solana unstaking and claiming, interacting with the yield withdrawal/claim flow. It exercises the changed YieldWithdrawForm and related yield components.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Statically mapped to TokenRowActions.tsx. This test swaps SOL to a USDC token and likely interacts with token row action UI in the wallet, making it a direct regression check for TokenRowActions changes.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Statically mapped to TokenRowActions.tsx. This test swaps an SPL token (USDT) to SOL, exercising token action UI in the wallet.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — ADA staking uses the same earn/yield staking infrastructure (staking nutshell modal, deposit/confirmation flow) as the changed yield components, though with Cardano-specific behavior.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — ADA unstaking uses the same earn/yield withdrawal infrastructure as the changed YieldWithdrawForm, providing coverage of the shared unstake flow.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test performs additional ETH staking from an already-staked account, reusing the same YieldDepositForm and staking form components as the initial stake flow.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — This test performs additional SOL staking, reusing the same yield deposit form and staking dashboard components changed in this PR.
- `suite/e2e/tests/trading/navigation.test.ts` — Statically mapped to TokenRowActions.tsx. This test navigates to trading forms from token pages, exercising token-level UI that shares the TokenRowActions component.

</details>

⚠️ **Changes with no test coverage (12)**
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/hooks/suite/useMessageSystemWrappedNative.ts`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.test.tsx`
- `packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx`
- `suite-common/message-system/schema/config.schema.v1.json`
- `suite-common/message-system/src/index.ts`
- `suite-common/message-system/src/messageSystemTypes.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.test.ts`
- `suite-common/message-system/src/useMessageSystemWrappedNative.ts`
- `suite-common/suite-types/src/messageSystem.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-04T14:39:20.079Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrap-unwrap-message-system&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrap-unwrap-message-system&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrap-unwrap-message-system&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap fees > Swap custom fees for Ethereum | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:40:42.161Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T14:40:29.780Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->