### PR TITLE
test(suite): replace playwright textContent with innerText method

### DIFF
--- a/packages/eslint/src/index.mjs
+++ b/packages/eslint/src/index.mjs
@@ -4,7 +4,11 @@ import globals from 'globals';
 
 import { areExpensiveChecksEnabled } from './expensiveChecks.mjs';
 import { globalNoExtraneousDependenciesDevDependencies, importConfig } from './importConfig.mjs';
-import { javascriptConfig, noCastedObjectHelpersSyntax } from './javascriptConfig.mjs';
+import {
+    javascriptConfig,
+    noCastedObjectHelpersSyntax,
+    noRestrictedSyntax,
+} from './javascriptConfig.mjs';
 import { javascriptNodejsConfig } from './javascriptNodejsConfig.mjs';
 import { jestConfig } from './jestConfig.mjs';
 import { localRulesConfig } from './localRulesConfig.mjs';
@@ -18,6 +22,7 @@ import { restrictedImportsPatterns, typescriptConfig } from './typescriptConfig.
 export {
     globalNoExtraneousDependenciesDevDependencies,
     noCastedObjectHelpersSyntax,
+    noRestrictedSyntax,
     restrictedImportsPatterns,
 };
 

--- a/packages/eslint/src/javascriptConfig.mjs
+++ b/packages/eslint/src/javascriptConfig.mjs
@@ -29,6 +29,48 @@ export const noCastedObjectHelpersSyntax = [
     },
 ];
 
+/**
+ * Base `no-restricted-syntax` selectors. Exported so configs that add their own selectors can
+ * spread these back in — the rule's options are replaced, not merged, when it is re-declared.
+ */
+export const noRestrictedSyntax = [
+    {
+        message:
+            "Please don't use createAsyncThunk. Use createThunk from @suite-common/redux-utils instead.",
+        selector: "CallExpression[callee.name='createAsyncThunk']",
+    },
+    {
+        message:
+            'Please don\'t use getState directly. Always use strongly typed selector, because geState is typed as "any" and it\'s dangerous to use it directly.',
+        selector:
+            'MemberExpression[property.type="Identifier"]:matches([object.callee.name="getState"])',
+    },
+    {
+        message:
+            'Do not assign "getState" directly. Always use strongly typed selector, because getState is typed as "any" and it\'s dangerous to use it directly.',
+        selector:
+            "VariableDeclarator[init.type='CallExpression']:matches([init.callee.name='getState'])",
+    },
+    {
+        message:
+            'Please don\'t use "state" directly because it\'s typed as "any". Always use it only as parameter for strongly typed selector function.',
+        selector:
+            "CallExpression[callee.name='useSelector'] MemberExpression[object.name='state']:matches([property.type='Identifier'])",
+    },
+    {
+        message:
+            'Use Array/String .includes() instead of .indexOf() comparison (e.g. `arr.indexOf(x) >= 0` → `arr.includes(x)`, `arr.indexOf(x) === -1` → `!arr.includes(x)`).',
+        selector:
+            "BinaryExpression[left.type='CallExpression'][left.callee.type='MemberExpression'][left.callee.property.name='indexOf']:matches([operator='>='][right.value=0], [operator='<'][right.value=0], [operator='>'][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='==='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1])",
+    },
+    {
+        selector: "TSTypeQuery > Identifier[name='undefined']",
+        message:
+            'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
+    },
+    ...noCastedObjectHelpersSyntax,
+];
+
 /** @type {Config[]} */
 export const javascriptConfig = [
     pluginJs.configs.recommended,
@@ -57,44 +99,7 @@ export const javascriptConfig = [
             ],
             'no-label-var': 'error', // Disallow labels that share a name with a variable
             'no-undef-init': 'error', // Disallow initializing variables to undefined
-            'no-restricted-syntax': [
-                'error',
-                {
-                    message:
-                        "Please don't use createAsyncThunk. Use createThunk from @suite-common/redux-utils instead.",
-                    selector: "CallExpression[callee.name='createAsyncThunk']",
-                },
-                {
-                    message:
-                        'Please don\'t use getState directly. Always use strongly typed selector, because geState is typed as "any" and it\'s dangerous to use it directly.',
-                    selector:
-                        'MemberExpression[property.type="Identifier"]:matches([object.callee.name="getState"])',
-                },
-                {
-                    message:
-                        'Do not assign "getState" directly. Always use strongly typed selector, because geState is typed as "any" and it\'s dangerous to use it directly.',
-                    selector:
-                        "VariableDeclarator[init.type='CallExpression']:matches([init.callee.name='getState'])",
-                },
-                {
-                    message:
-                        'Please don\'t use "state" directly because it\'s typed as "any". Always use it only as parameter for strongly typed selector function.',
-                    selector:
-                        "CallExpression[callee.name='useSelector'] MemberExpression[object.name='state']:matches([property.type='Identifier'])",
-                },
-                {
-                    message:
-                        'Use Array/String .includes() instead of .indexOf() comparison (e.g. `arr.indexOf(x) >= 0` → `arr.includes(x)`, `arr.indexOf(x) === -1` → `!arr.includes(x)`).',
-                    selector:
-                        "BinaryExpression[left.type='CallExpression'][left.callee.type='MemberExpression'][left.callee.property.name='indexOf']:matches([operator='>='][right.value=0], [operator='<'][right.value=0], [operator='>'][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='==='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='=='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1], [operator='!='][right.type='UnaryExpression'][right.operator='-'][right.argument.value=1])",
-                },
-                {
-                    selector: "TSTypeQuery > Identifier[name='undefined']",
-                    message:
-                        'Use `undefined` (or `never` in discriminated unions) instead of `typeof undefined` in type position.',
-                },
-                ...noCastedObjectHelpersSyntax,
-            ],
+            'no-restricted-syntax': ['error', ...noRestrictedSyntax],
             'object-shorthand': [
                 'error',
                 'always',

--- a/suite/e2e/eslint.config.mjs
+++ b/suite/e2e/eslint.config.mjs
@@ -1,4 +1,4 @@
-import { eslint, playwrightEslintFlat } from '@trezor/eslint';
+import { eslint, noRestrictedSyntax, playwrightEslintFlat } from '@trezor/eslint';
 
 export default [
     ...eslint,
@@ -13,6 +13,20 @@ export default [
         },
     },
     playwrightEslintFlat,
+    {
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                ...noRestrictedSyntax,
+                {
+                    selector:
+                        "CallExpression[callee.type='MemberExpression'][callee.property.name=/^(textContent|allTextContents)$/]",
+                    message:
+                        'To assert text prefer the auto-retrying expect(locator).toHaveText(), otherwise use innerText()/allInnerTexts().',
+                },
+            ],
+        },
+    },
     {
         files: ['**/tests/manual/**'],
         rules: {

--- a/suite/e2e/skills/locators.md
+++ b/suite/e2e/skills/locators.md
@@ -13,6 +13,7 @@ MUST_NOT: Use CSS classes, XPath indices, or hardcoded text selectors
 MUST_NOT: Select an element by its position among siblings
 MUST_NOT: Scatter locators in tests—only in Page Objects
 MUST_NOT: Use implicit waits or hardcoded timeouts
+MUST_NOT: Read text with `textContent()`/`allTextContents()`—use `innerText()`/`allInnerTexts()`
 
 ## Decision Tree for Locator Selection
 
@@ -54,6 +55,7 @@ When the testid contains a dynamic segment (token, currency, code), declare a me
 ❌ Narrowing a positional locator – a tighter parent or a different index is the same bug, not a fix: add the missing testid instead
 ❌ Text-only selectors – fragile to copy/i18n: `this.page.getByText('Claim Rewards')`
 ❌ Hardcoded timeouts: `await page.waitForTimeout(2000)`
+❌ `textContent()`/`allTextContents()` – returns `string | null` and unrendered text, forcing null guards: `await locator.innerText()`
 
 ---
 

--- a/suite/e2e/support/common.ts
+++ b/suite/e2e/support/common.ts
@@ -1,6 +1,6 @@
 import { createIntl, createIntlCache } from 'react-intl';
 
-import test, { Locator, Page, TestInfo } from '@playwright/test';
+import test, { Locator, Page, TestInfo, expect } from '@playwright/test';
 import { isEqual, omit } from 'lodash';
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
@@ -132,9 +132,6 @@ export const getCountryLabel = (country: TradingCountryCode) => {
 };
 
 export const calculatePercentageOfBalance = (params: PercentageOfBalanceParams) => {
-    if (params.balance === null) {
-        throw new Error('Account balance is null');
-    }
     const fraction = (parseFloat(params.balance) * params.percentage) / 100;
     const maxDecimals = getAccountDecimals(params.symbol);
 
@@ -150,12 +147,9 @@ export const countDecimalPlaces = (value: string | number) => {
 };
 
 export const getBigNumberFromBalance = async (locator: Locator) => {
-    let originalBalanceText = await locator.textContent();
-    if (!originalBalanceText) {
-        throw new Error('Balance text content is empty');
-    }
-
-    const hasEllipsis = originalBalanceText?.includes('…');
+    await expect(locator).toHaveText(/\d/);
+    let originalBalanceText = await locator.innerText();
+    const hasEllipsis = originalBalanceText.includes('…');
     if (hasEllipsis) {
         originalBalanceText = originalBalanceText.slice(0, -1);
     }

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -166,14 +166,13 @@ export class DevicePrompt {
         if (!isSeparatorVisible) {
             return false;
         }
-        const separatorText = await this.paginatedTextSeparator.textContent();
 
-        return typeof separatorText === 'string' ? separatorText : false;
+        return await this.paginatedTextSeparator.innerText();
     }
 
     @step()
     async combinedPaginatedText() {
-        let textsArray = await this.paginatedText.allTextContents();
+        let textsArray = await this.paginatedText.allInnerTexts();
         const separatorText = await this.getPaginatedTextSeparator();
         if (separatorText) {
             textsArray = textsArray.map(text => text.replace(separatorText, ''));
@@ -186,11 +185,7 @@ export class DevicePrompt {
     @step()
     async getFeeRate() {
         // Element format is: Bitcoin #1 \n+ ≈ 10 minutes \n+ 4.00 sat/vB
-        const fullText = await this.headerParagraph.textContent();
-        if (!fullText) {
-            throw new Error('No text found in header paragraph of device prompt');
-        }
-
+        const fullText = await this.headerParagraph.innerText();
         const lines = fullText
             .split('\n')
             .map(line => line.trim())

--- a/suite/e2e/support/pageObjects/trading/feeSection.ts
+++ b/suite/e2e/support/pageObjects/trading/feeSection.ts
@@ -80,11 +80,7 @@ export class FeeSection {
     @step()
     async getSolanaFee() {
         await expect(this.maxFee).toBeVisible();
-        const feeWithSymbol = await this.maxFee.textContent();
-        if (!feeWithSymbol) {
-            throw new Error('Fee amount is undefined or null');
-        }
-
+        const feeWithSymbol = await this.maxFee.innerText();
         const feeParts = feeWithSymbol.split(' ');
         const feeValue = feeParts[0];
         if (!feeValue || isNaN(parseFloat(feeValue))) {
@@ -116,14 +112,14 @@ export class FeeSection {
 
     @step()
     async getBitcoinFeeRate(type: FeeTypes | 'custom') {
-        let feeRateText: string | null;
+        let feeRateText: string;
         const nonBreakingSpace = '\u00A0';
         const suffixForDustPreventionFee = `${nonBreakingSpace}sat/vB`;
         const suffixForCustomFee = `.00${nonBreakingSpace}sat/vB`;
 
         if (type !== 'custom') {
             await this.expectBitcoinFeeCalculated();
-            feeRateText = await this.rateOnCard(type).textContent();
+            feeRateText = await this.rateOnCard(type).innerText();
         } else {
             feeRateText = (await this.customInput.inputValue()) + suffixForCustomFee;
         }
@@ -131,10 +127,6 @@ export class FeeSection {
         const isDustPreventionRateApplied = await this.dustPreventionNotice.isVisible();
         if (isDustPreventionRateApplied) {
             feeRateText = (await this.getDustPreventionFeeRate()) + suffixForDustPreventionFee;
-        }
-
-        if (!feeRateText) {
-            throw new Error('Fee amount is undefined or null');
         }
 
         return feeRateText;
@@ -168,11 +160,7 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
 
     @step()
     async getDustPreventionFeeRate() {
-        const dustPreventionText = await this.dustPreventionNotice.textContent();
-        if (!dustPreventionText) {
-            throw new Error('Dust prevention text is undefined or null');
-        }
-
+        const dustPreventionText = await this.dustPreventionNotice.innerText();
         const regex = /has been adjusted to (?<value>\d+\.\d+) sat\/vB/;
         const match = dustPreventionText.match(regex);
 
@@ -208,11 +196,7 @@ before rounding: ${maxFeeInEthereum} ETH, after rounding: ${maxFeeRounded} ETH`;
 
     @step()
     async getNetworkReserveAmount() {
-        const bannerText = await this.networkReserveBanner.textContent();
-        if (!bannerText) {
-            throw new Error('Network reserve banner text is undefined or null');
-        }
-
+        const bannerText = await this.networkReserveBanner.innerText();
         const regex = /(\d+(?:\.\d+)?)(?=\s*SOL)/;
         const match = bannerText.match(regex);
 

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -68,8 +68,8 @@ export class TradingFormInputs {
 
     @step()
     async selectCountryOfResidence(countryCode: TradingCountryCode) {
-        const currentCountry = await this.countryValue.textContent();
-        if (currentCountry?.includes(countryCode)) {
+        const currentCountry = await this.countryValue.innerText();
+        if (currentCountry.includes(countryCode)) {
             return;
         }
         await this.countrySelect.click();

--- a/suite/e2e/support/pageObjects/trading/quotesSection.ts
+++ b/suite/e2e/support/pageObjects/trading/quotesSection.ts
@@ -34,12 +34,8 @@ export class TradingQuotesSection {
     @step()
     async getBestOfferAmount(): Promise<string> {
         await expect(this.bestOfferAmount).toHaveText(/^(?=[\d,.]*[1-9])[\d,]+(\.\d+)?\s+\w+$/);
-        const rawText = await this.bestOfferAmount.textContent();
-        if (!rawText) {
-            throw new Error('Best offer amount did not have any text content');
-        }
-
-        const [amount] = rawText.trim().split(/\s+/);
+        const rawText = await this.bestOfferAmount.innerText();
+        const [amount] = rawText.split(/\s+/);
         if (!amount) {
             throw new Error(`Best offer amount could not be parsed from "${rawText}"`);
         }
@@ -58,16 +54,14 @@ export class TradingQuotesSection {
 
     @step()
     async chooseDifferentOfferIfAvailable(provider?: string): Promise<void> {
-        const initialProvider = (await this.selectedProviderName.textContent())?.trim();
-        if (!initialProvider) {
-            throw new Error('Cannot get text content from the initial provider.');
-        }
+        await expect(this.selectedProviderName).not.toBeEmpty();
+        const initialProvider = (await this.selectedProviderName.innerText()).trim();
 
         await this.selectedProvider.click();
         await expect(this.list.first()).toBeVisible();
 
         const offerProviderNames = (
-            await this.list.getByTestId('@trading/offers/quote/provider').allTextContents()
+            await this.list.getByTestId('@trading/offers/quote/provider').allInnerTexts()
         ).map(name => name.trim());
 
         let differentProvider: string | undefined;

--- a/suite/e2e/support/pageObjects/trading/receiveAccount.ts
+++ b/suite/e2e/support/pageObjects/trading/receiveAccount.ts
@@ -75,12 +75,11 @@ export class TradingReceiveAccount {
 
         const selectedOption = this.receiveAccountModalSuiteOption.nth(index);
         // Capture the option's account name (not the balance/address)
-        const selectedAccountName =
-            (
-                await selectedOption
-                    .getByTestId('@trading/receive-account-modal/option/suite/name')
-                    .textContent()
-            )?.trim() ?? '';
+        const selectedOptionName = selectedOption.getByTestId(
+            '@trading/receive-account-modal/option/suite/name',
+        );
+        await expect(selectedOptionName).not.toBeEmpty();
+        const selectedAccountName = await selectedOptionName.innerText();
         await selectedOption.click();
 
         if (symbol === 'btc') {

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -35,10 +35,10 @@ const compareTextAndNumber = async (
     compareFnName: string,
 ) => {
     await baseExpect(locator).toBeVisible();
-    const text = await locator.textContent();
-    const textWithoutEllipsis = text?.endsWith('…') ? text.slice(0, -1) : text;
+    const text = await locator.innerText();
+    const textWithoutEllipsis = text.endsWith('…') ? text.slice(0, -1) : text;
     const numericValue = Number(textWithoutEllipsis);
-    const isNumber = Number.isFinite(numericValue);
+    const isNumber = textWithoutEllipsis.trim() !== '' && Number.isFinite(numericValue);
 
     return {
         pass: isNumber && compareFn(numericValue, expectedValue),
@@ -330,8 +330,8 @@ export const expect = baseExpect.extend({
 
     async toHaveValidAddress(locator: Locator, symbol: Account['symbol']) {
         await baseExpect(locator).toBeVisible();
-        const text = await locator.textContent();
-        const stripped = text?.replace(/\s/g, '') ?? '';
+        const text = await locator.innerText();
+        const stripped = text.replace(/\s/g, '');
 
         return {
             pass: addressValidator.isAddressValid(stripped, symbol),

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -33,7 +33,7 @@ export type PaymentMethods =
 
 export type PercentageOfBalanceParams = {
     percentage: number;
-    balance: string | null;
+    balance: string;
     symbol: NetworkSymbol;
 };
 

--- a/suite/e2e/tests/settings/application-log.test.ts
+++ b/suite/e2e/tests/settings/application-log.test.ts
@@ -18,7 +18,7 @@ test.describe('Application Logs', { tag: ['@T3W1', '@T3T1'] }, () => {
                 await expect(page.getByTestId('@modal/application-log')).toBeVisible();
                 await expect(page.getByTestId('@log/content')).not.toBeEmpty();
 
-                return page.getByTestId('@log/content').textContent();
+                return page.getByTestId('@log/content').innerText();
             });
 
             const exportedLogPath =

--- a/suite/e2e/tests/staking/staking-form.test.ts
+++ b/suite/e2e/tests/staking/staking-form.test.ts
@@ -6,7 +6,7 @@ import { calculatePercentageOfBalance } from '../../support/common';
 import { expect, test } from '../../support/fixtures';
 import { createTestAnnotation } from '../../support/reporters/annotations';
 
-let ethereumStakingBalance: string | null;
+let ethereumStakingBalance: string;
 const WITHDRAWAL_BUFFER = 0.005;
 
 test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
@@ -42,11 +42,11 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
         async ({ walletPage, stakingSection }) => {
             await test.step('Identify possible staking balance', async () => {
                 await walletPage.openAccount({ symbol: 'eth', type: 'normal', atIndex: 0 });
-                ethereumStakingBalance = await walletPage.topPanelBalance.textContent();
-                if (!ethereumStakingBalance) {
-                    throw new Error('Ethereum staking balance is undefined or null');
-                }
-                ethereumStakingBalance = ethereumStakingBalance?.replace(/,/g, '');
+                await expect(walletPage.topPanelBalance).toHaveText(/\d/);
+                ethereumStakingBalance = (await walletPage.topPanelBalance.innerText()).replace(
+                    /,/g,
+                    '',
+                );
                 await stakingSection.stakingTabButton.click();
                 await stakingSection.stakeMoreButton.click();
             });
@@ -105,7 +105,7 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
                             .click();
                         const expectedValue = calculatePercentageOfBalance({
                             percentage,
-                            balance: ethereumStakingBalance!,
+                            balance: ethereumStakingBalance,
                             symbol: 'eth',
                         });
                         await expect.soft(stakingSection.cryptoInput).toHaveValue(expectedValue);
@@ -121,7 +121,7 @@ test.describe('ETH staking form', { tag: ['@T3W1', '@T3T1'] }, () => {
                         .toHaveTranslation('TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL', {
                             values: { amount: '0.005', networkDisplaySymbol: 'ETH' },
                         });
-                    const expectedMax = new BigNumber(ethereumStakingBalance!).minus(
+                    const expectedMax = new BigNumber(ethereumStakingBalance).minus(
                         WITHDRAWAL_BUFFER,
                     );
                     const formattedExpectedMax = localizeNumber(expectedMax);

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -5,8 +5,8 @@ import { expect, test } from '../../support/fixtures';
 
 const solanaBalanceAddress = '41baq3croaLZEj8dPWZnXn8e6xdAtvtWu2h941vm3Ngw';
 const customFeeRate = 1;
-let bitcoinBalance: string | null;
-let solanaBalance: string | null;
+let bitcoinBalance: string;
+let solanaBalance: string;
 
 test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({
@@ -33,9 +33,11 @@ test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
     test('Sell form % inputs and limits', async ({ page, walletPage, tradingPage }) => {
         await test.step('Find out btc and sol balances', async () => {
             await walletPage.openAccount({ symbol: 'btc' });
-            bitcoinBalance = await walletPage.topPanelBalance.textContent();
+            await expect(walletPage.topPanelBalance).toHaveText(/\d/);
+            bitcoinBalance = await walletPage.topPanelBalance.innerText();
             await walletPage.openAccount({ symbol: 'sol' });
-            solanaBalance = await walletPage.topPanelBalance.textContent();
+            await expect(walletPage.topPanelBalance).toHaveText(/\d/);
+            solanaBalance = await walletPage.topPanelBalance.innerText();
             await walletPage.openTrading();
             await tradingPage.sellTabButton.click();
             const worldwideOption = messages['TR_TRADING_COUNTRY_WORLD'].defaultMessage;
@@ -88,12 +90,9 @@ test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
                     .click();
                 await expect
                     .soft(async () => {
-                        const resultingFee = await tradingPage.fees.maxFee.textContent();
-                        if (!resultingFee) {
-                            throw new Error('Custom Fee amount is undefined or null');
-                        }
+                        const resultingFee = await tradingPage.fees.maxFee.innerText();
                         const maxValue = (
-                            parseFloat(bitcoinBalance!) - parseFloat(resultingFee)
+                            parseFloat(bitcoinBalance) - parseFloat(resultingFee)
                         ).toString();
                         await expect(tradingPage.inputs.cryptoAmount).toHaveValue(
                             localizeNumber(maxValue, 'en-US', 0, 8),

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -60,10 +60,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@webOnly', '@T3T1', '@T3W1
         });
 
         await test.step('Verify fees on modal and emulator', async () => {
-            const feeFromDeviceModal = await devicePrompt.cryptoAmountOf('fee').textContent();
-            if (!feeFromDeviceModal) {
-                throw new Error('"Including fee" is not displayed on the device prompt modal');
-            }
+            const feeFromDeviceModal = await devicePrompt.cryptoAmountOf('fee').innerText();
             const totalAmount = new BigNumber(feeFromDeviceModal).plus(sendAmount).toString();
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 `${totalAmount} BTC`,

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -43,12 +43,7 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
                 values: { networkName: 'Ethereum', index: '3' },
             });
             await walletPage.revealAddressButton.click();
-            const addressDisplayedInSuite = await devicePrompt
-                .outputValueOf('address')
-                .textContent();
-            if (!addressDisplayedInSuite) {
-                throw new Error('Address is missing in receive modal');
-            }
+            const addressDisplayedInSuite = await devicePrompt.outputValueOf('address').innerText();
             expect.soft(addressDisplayedInSuite.replace(/\s/g, '')).toEqual(ETHEREUM_ADDRESS_3);
             const addressDisplayedOnDevice = await devicePrompt.getAddressFromDisplay();
             expect.soft(addressDisplayedOnDevice).toEqual(DEVICE_ETHEREUM_ADDRESS_3);

--- a/suite/e2e/tests/wallet/pending-transactions.test.ts
+++ b/suite/e2e/tests/wallet/pending-transactions.test.ts
@@ -96,11 +96,9 @@ test.describe(
                         .getByTestId('@transaction-item/0/heading')
                         .click();
 
-                    const txid = await page.getByTestId('@tx-detail/txid-value').textContent();
-                    if (!txid) {
-                        throw new Error('Transaction ID not found');
-                    }
-                    transaction.txid = txid;
+                    const txidValue = page.getByTestId('@tx-detail/txid-value');
+                    await expect(txidValue).not.toBeEmpty();
+                    transaction.txid = await txidValue.innerText();
 
                     await devicePrompt.closeModal();
                 }

--- a/suite/e2e/tests/wallet/public-keys.test.ts
+++ b/suite/e2e/tests/wallet/public-keys.test.ts
@@ -44,18 +44,18 @@ test.describe('Public Keys', { tag: ['@T3W1', '@T3T1'] }, () => {
                     await walletPage.accountDetailsTabButton.click();
                     await walletPage.showPublicKeyButton.click();
                     await expect(async () => {
-                        const value = await devicePrompt.outputValue.textContent();
+                        const value = await devicePrompt.outputValue.innerText();
 
-                        expect(value?.replace(/\s+/g, '')).toBe(xpub);
+                        expect(value.replace(/\s+/g, '')).toBe(xpub);
                     }).toPass({ timeout: 25000 });
                 });
 
                 await test.step('Display and Verify Public key again', async () => {
                     await devicePrompt.waitForPromptAndConfirm();
 
-                    const value = await devicePrompt.outputValue.textContent();
+                    const value = await devicePrompt.outputValue.innerText();
 
-                    expect(value?.replace(/\s+/g, '')).toBe(xpub);
+                    expect(value.replace(/\s+/g, '')).toBe(xpub);
                 });
             },
         );

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -56,9 +56,10 @@ test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
                 await tradingPage.setMax.click();
 
                 await expect(tradingPage.fees.maxFee).not.toBeEmpty();
+                await expect(tradingPage.sendBalance).toHaveText(/\d/);
 
-                const balance = Number(await tradingPage.sendBalance.textContent());
-                maxFee = Number(await tradingPage.fees.maxFee.textContent());
+                const balance = Number(await tradingPage.sendBalance.innerText());
+                maxFee = Number(await tradingPage.fees.maxFee.innerText());
                 const reservedAmount = await tradingPage.fees.getNetworkReserveAmount();
                 sendMaxAmountWithReserve = localizeNumber(
                     new BigNumber(balance - maxFee - reservedAmount),

--- a/suite/e2e/tests/wallet/transactions.test.ts
+++ b/suite/e2e/tests/wallet/transactions.test.ts
@@ -32,14 +32,13 @@ test.describe('Account transactions overview', { tag: ['@T3W1', '@T3T1'] }, () =
             }
         });
 
-        const latestTransactionAddress = await test.step('Find the latest transaction', async () =>
-            (await walletPage.transactionAddress.first().textContent())
-                ?.replace(/\s/g, '')
-                .slice(-4));
+        const latestTransactionAddress =
+            await test.step('Find the latest transaction', async () => {
+                const address = walletPage.transactionAddress.first();
+                await expect(address).not.toBeEmpty();
 
-        if (!latestTransactionAddress) {
-            throw new Error('No latest transaction found');
-        }
+                return (await address.innerText()).replace(/\s/g, '').slice(-4);
+            });
 
         await test.step('Search for latest transaction by its address', async () => {
             await walletPage.transactionSearch.fill(latestTransactionAddress);

--- a/suite/e2e/tests/yield/deposit.test.ts
+++ b/suite/e2e/tests/yield/deposit.test.ts
@@ -45,12 +45,12 @@ test.describe('stablecoin yield', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () =>
 
             const ethAccountName = await walletPage
                 .accountLabel({ symbol: 'eth', type: 'normal', atIndex: 0 })
-                .textContent();
+                .innerText();
 
             await expect(yieldSection.yieldTitle).toHaveTranslation('TR_EARN_DEFI_YIELD_TITLE');
 
             for (const expectedRow of EXPECT_YIELD_DASHBOARD_ROWS) {
-                await expect(yieldSection.accountLabel(expectedRow.id)).toHaveText(ethAccountName!);
+                await expect(yieldSection.accountLabel(expectedRow.id)).toHaveText(ethAccountName);
                 await expect(yieldSection.vaultSubtitle(expectedRow.id)).toHaveText(
                     expectedRow.name,
                 );


### PR DESCRIPTION
introduces eslint rule to prohibi textContent

<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR improves how we in our test access text from page and work with it. Playwright offers few posibilities and its community agrees on using innerText over textContent. InnerText represents the string in the way how user sees it and it does not inherit `| null` baggage from DOM

So in this PR I have replaced all occurences of textContent and added eslint rule. I also had to extract one global eslint rule to a variable so I would not lose it on the suite/e2e level

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/innerText-cneaup/web/](https://dev.suite.sldev.cz/suite-web/innerText-cneaup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=innerText-cneaup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=innerText-cneaup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:38:24.053Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:39:46.239Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->