### PR TITLE
chore(message-system): wallet recovering info message

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-07-22T00:00:00+00:00",
-    "sequence": 150,
+    "timestamp": "2026-08-04T17:00:00+00:00",
+    "sequence": 151,
     "actions": [
         {
             "conditions": [
@@ -1113,6 +1113,36 @@
                     }
                 },
                 "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "duration": {
+                        "from": "2026-08-04T00:00:00.000Z",
+                        "to": "2026-08-25T22:00:00.000Z"
+                    },
+                    "environment": {
+                        "desktop": "*",
+                        "mobile": "*",
+                        "web": "*"
+                    }
+                }
+            ],
+            "message": {
+                "id": "1ae436e7-bb03-41a0-b173-86d40b9f112c",
+                "priority": 92,
+                "dismissible": true,
+                "variant": "info",
+                "category": "banner",
+                "content": {
+                    "en": "Recovered your wallet? A wallet created elsewhere may not have the same security as one created on your Trezor. If you are unsure, we recommend setting up a new wallet here and moving your funds to it.",
+                    "cs": "Obnovili jste svou peněženku? Peněženka vytvořená jinde nemusí mít stejné zabezpečení jako peněženka vytvořená na vašem Trezoru. Pokud si nejste jisti, doporučujeme zde nastavit novou peněženku a převést do ní své prostředky.",
+                    "es": "¿Has recuperado tu cartera? Una cartera creada en otro lugar puede no tener la misma seguridad que una creada en tu Trezor. Si tienes dudas, te recomendamos configurar una nueva cartera aquí y transferir tus fondos a ella.",
+                    "de": "Wallet wiederhergestellt? Eine anderswo erstellte Wallet bietet möglicherweise nicht dieselbe Sicherheit wie eine auf deinem Trezor erstellte. Wenn du unsicher bist, empfehlen wir, hier eine neue Wallet einzurichten und deine Gelder darauf zu übertragen.",
+                    "fr": "Vous avez récupéré votre portefeuille ? Un portefeuille créé ailleurs peut ne pas offrir la même sécurité qu'un portefeuille créé sur votre Trezor. En cas de doute, nous vous recommandons de configurer un nouveau portefeuille ici et d'y transférer vos fonds.",
+                    "pt": "Recuperou a sua carteira? Uma carteira criada noutro local pode não ter a mesma segurança que uma criada no seu Trezor. Se não tiver a certeza, recomendamos configurar uma nova carteira aqui e transferir os seus fundos para ela."
+                }
             }
         },
         {


### PR DESCRIPTION
## Description

Adding a global info banner recommending wallet recreation if the user did not created wallet using Trezor or is unsure. Scheduled visibility is 3 weeks from today on all platforms (web/desktop/mobile).

## Notes for QA

Check the global banner.

## Screenshots:
<img width="1592" height="721" alt="image" src="https://github.com/user-attachments/assets/768abf0a-8524-46fd-a71b-1fd37b015bed" />
<img width="1590" height="600" alt="image" src="https://github.com/user-attachments/assets/819b7cd6-8e70-4623-a556-63ecbd5fadbc" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file `suite-common/message-system/config/config.v1.json` is a remote message-system configuration JSON. None of the 123 candidate E2E tests statically reference it, and the LLM analysis does not identify any test whose behavior is directly driven by this config. The risk is therefore low for the existing E2E suite, but the impact depends on what the config change enables/disables (e.g., feature flags, banners). No E2E tests are recommended; consider validating the config change with unit/integration tests for the message-system loader or a targeted smoke test if one exists.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-08-04T16:03:09.658Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-wallet-recovering/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-wallet-recovering/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-wallet-recovering&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-wallet-recovering&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-wallet-recovering&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:06:12.268Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:05:08.599Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->