### PR TITLE
Fix fee selection errors in connect popup send flow

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx
@@ -76,45 +76,38 @@ interface SelectAccountModalProps {
 }
 
 const getSelectFeeData = ({ coinInfo, feeLevels }: UiRequestSelectFee['payload']) => {
-    const minFee = coinInfo.minFeeSatoshiKb / 1000;
-    const maxFee = coinInfo.maxFeeSatoshiKb / 1000;
-    const account = {
-        networkType: 'bitcoin' as const,
-        symbol: coinInfo.shortcut.toLowerCase() as NetworkSymbol,
-        tokens: [],
-    };
-    const feeInfo = {
-        levels: feeLevels
-            .filter(({ label }) => label !== 'low') // this option is hidden in Suite
-            .sort(sortLevels),
+    const { shortcut, blockTime, minFeeSatoshiKb, maxFeeSatoshiKb } = coinInfo;
+    const minFee = minFeeSatoshiKb / 1000;
+    const maxFee = maxFeeSatoshiKb / 1000;
+    const symbol = shortcut.toLowerCase() as NetworkSymbol;
 
-        minFee,
-        maxFee,
-        minPriorityFee: -1,
-        blockHeight: 0,
-        blockTime: coinInfo.blockTime,
-    };
+    const levels = feeLevels.filter(({ label }) => label !== 'low').sort(sortLevels); // 'low' option is hidden in Suite
+    const defaultLevel = levels.find(l => l.label === 'normal') ?? levels[0]; // use preferably normal level as default, fall back to any other
+    const selectedFee = defaultLevel?.label ?? 'normal';
+    const feePerUnit = selectedFee === 'custom' ? defaultLevel?.feePerUnit : undefined;
 
-    return { account, feeInfo };
+    return {
+        account: { networkType: 'bitcoin' as const, symbol, tokens: [] },
+        feeInfo: { levels, minFee, maxFee, minPriorityFee: -1, blockHeight: 0, blockTime },
+        defaultValues: { outputs: [], selectedFee, feePerUnit },
+    };
 };
 
 export const SelectFeeModal = ({ data }: SelectAccountModalProps) => {
     const dispatch = useDispatch();
     const popupCall = useSelector(selectConnectPopupCall);
 
-    const { account, feeInfo } = useMemo(() => getSelectFeeData(data), [data]);
+    const { account, feeInfo, defaultValues } = useMemo(() => getSelectFeeData(data), [data]);
 
-    const methods = useForm<FormState>({
-        defaultValues: {
-            outputs: [],
-        },
-    });
+    const methods = useForm<FormState>({ defaultValues });
+
     const { changeFeeLevel } = useFees({
         ...methods,
-        defaultValue: 'normal',
+        defaultValue: defaultValues.selectedFee,
         feeInfo,
         composeRequest: () => {},
     });
+
     const {
         handleSubmit,
         formState: { errors },

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx
@@ -38,10 +38,7 @@ export function CollapsibleFees({
     isOpen,
     tronResources,
 }: CollapsibleFeesProps) {
-    const selectedFee = useWatch<FormState, 'selectedFee'>({
-        name: 'selectedFee',
-        defaultValue: 'normal',
-    });
+    const selectedFee = useWatch<FormState, 'selectedFee'>({ name: 'selectedFee' }) ?? 'normal';
 
     const isTrc20Transfer = useMemo(() => {
         if (networkType !== 'tron' || composedLevels == null) return false;
@@ -56,9 +53,11 @@ export function CollapsibleFees({
         networkType !== 'solana' && (networkType !== 'tron' || isTrc20Transfer);
     const isCustomFee = supportsAdjustableFees && selectedFee === 'custom';
 
-    // when fees are loading, feeInfo.levels = [], but CustomFee requires at least the 'normal' level to have some default
-    const hasNormalFeeLevel = useMemo(
-        () => feeInfo.levels.some(level => level.label === 'normal'),
+    // get default non-custom fee level, preferably normal
+    const defaultFeeLevel = useMemo(
+        () =>
+            feeInfo.levels.find(level => level.label === 'normal')?.label ??
+            feeInfo.levels.find(level => level.label !== 'custom')?.label,
         [feeInfo.levels],
     );
 
@@ -107,17 +106,19 @@ export function CollapsibleFees({
                                     </Column>
 
                                     <Row justifyContent="center" margin={{ bottom: 8 }}>
-                                        {isCustomFee && (
+                                        {/* allow switching to non-custom fee only when there is some */}
+                                        {isCustomFee && !!defaultFeeLevel && (
                                             <Button
                                                 intent="neutral"
                                                 priority="secondary"
-                                                onClick={() => changeFeeLevel('normal')}
+                                                onClick={() => changeFeeLevel(defaultFeeLevel)}
                                                 data-testid="@wallet/fees/select-standard-fee"
                                             >
                                                 <Translation id="FEE_LEVEL_STANDARD" />
                                             </Button>
                                         )}
-                                        {!isCustomFee && hasNormalFeeLevel && (
+                                        {/* in order to have sensible default for custom fee, selected fee level must exist (see useFees hook) */}
+                                        {!isCustomFee && !!selectedFeeLevel && (
                                             <TextButton
                                                 onClick={() => changeFeeLevel('custom')}
                                                 data-testid="@wallet/fees/select-custom-fee"


### PR DESCRIPTION
## Description

3rd party send flow (`composeTransaction` call without account/fees) had some corner cases in fee selection. I've tried to resolve them without changing much of the Suite-only logic:

- when `normal` fee level was missing, nothing was selected
  - fixed by falling back to any other fee level as a default in `SelectFeeModal` (both `useForm` and `useFees`)
  - removed `defaultValue: 'normal'` from `CollapsibleFees` as it had beaten the form defaults somehow
- when `normal` fee level was missing, it wasn't possible to set custom fees
  - fixed by allowing custom fees in `CollapsibleFees` even when `normal` level isn't there
  -  it should be enough that the currently selected fee level exists to get default value for custom fee, see `useFees` hook
- when only `custom` fee level was present, nothing was shown at all
  - fixed by using `custom` level as a default in this case
  - switching to standard fee is allowed only when there's at least one standard fee level

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files affect fee selection and display: CollapsibleFees in send/swap/stake forms and SelectFeeModal in device confirmation prompts. The highest-risk regressions are incorrect custom fee behavior, miscalculated totals, or broken fee rendering on the device. A small set of tests covering custom fees and device fee assertions across send, swap, stake, and sell flows provides strong confidence without running the full suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/DeviceConfirmationModal/SelectFeeModal.tsx`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CollapsibleFees.tsx`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the ETH staking form's fee handling (CollapsibleFees) and asserts the device confirmation prompt shows the correct staking amount and fee, directly covering both changed components in a staking flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Validates SOL staking fee/rent display on the staking form and the device prompt, including model-specific fee screens, so it directly tests fee rendering in CollapsibleFees and SelectFeeModal.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Explicitly tests custom fee selection, fraction buttons, max amount accounting for custom fees, and fee validation for both BTC and SOL sell forms, hitting CollapsibleFees behavior and downstream fee display.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Sets a custom BTC fee rate in the swap form, asserts the device prompt total equals fee plus send amount and shows the custom fee rate, directly testing both CollapsibleFees and SelectFeeModal.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Configures custom Ethereum gas limit, max fee per gas, and priority fee in the swap form and verifies all gas/fee values on the device prompt, covering both fee components end-to-end.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Verifies the device confirmation prompt shows the correct send amount, total, and fee for a Dogecoin transaction, so a regression in SelectFeeModal fee rendering would be caught.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Fills custom Ethereum gas parameters in the send form and asserts detailed fee breakdown (gas limit, max fee, priority fee, total) on both the UI device prompt and the hardware emulator, directly touching both changed files.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Uses Send Max and verifies max fee, total sent, and device prompt fee/amount for a Solana transaction, making it a strong end-to-end check of CollapsibleFees calculations and SelectFeeModal display.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Covers the Cardano staking flow where deposit and fee amounts are displayed and confirmed on the device, sharing fee infrastructure with the changed components.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Validates sell form fee calculation and device prompt fee/amount for a BTC sell, providing additional coverage of fee rendering beyond the custom-fee-focused sell-inputs test.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests custom Ethereum fee parameters in the sell flow and verifies the device prompt, complementing swap-fees-ethereum and send-eth for sell-specific fee handling.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Executes a SOL-to-BTC swap and checks device prompt fee and total, helping ensure cross-chain swap fee display in SelectFeeModal remains correct.

</details>

_Updated: 2026-08-04T16:07:39.061Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/fee-level-modal/web/](https://dev.suite.sldev.cz/suite-web/fix/fee-level-modal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fee-level-modal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fee-level-modal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:08:39.646Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T16:08:18.355Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->