### PR TITLE
fix(suite-desktop): better support for stepped clear signing support

### DIFF
--- a/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
+++ b/packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx
@@ -20,6 +20,8 @@ type WrappedNativePageHeaderProps = {
     flow: WrappedNativeFlowType;
     account?: Account;
     contractAddress?: string;
+    /** Once the flow has finished, leaving via the back arrow is not abandoning it. */
+    isFlowComplete?: boolean;
 };
 
 export const WrappedNativePageHeader = ({
@@ -27,6 +29,7 @@ export const WrappedNativePageHeader = ({
     flow,
     account,
     contractAddress,
+    isFlowComplete = false,
 }: WrappedNativePageHeaderProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const navigateToTokenOverview = useNavigateToAccountRoute(account, 'wallet-tokens');
@@ -36,7 +39,7 @@ export const WrappedNativePageHeader = ({
         analytics.report({
             type: events.yieldNavigateEvent.name,
             payload: {
-                action: 'cancel',
+                action: isFlowComplete ? 'continue' : 'cancel',
                 from: flow === 'wrap' ? 'wrap-form' : 'unwrap-form',
                 to: 'account-detail',
                 networkSymbol: account?.symbol,

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -138,6 +138,13 @@ export const UnwrapNativeToken = ({
     });
 
     const handleSubmit = methods.handleSubmit(async ({ amountInput: unwrapAmount }) => {
+        // The form stays mounted while an unwrap is pending so its transaction remains visible,
+        // which leaves this path reachable after the feature has been disabled remotely. Checked
+        // before reporting so a blocked submit is not counted as one.
+        if (isDisabled) {
+            return;
+        }
+
         reportSubmit();
 
         if (!(await ensureDeviceReady())) {
@@ -217,7 +224,7 @@ export const UnwrapNativeToken = ({
                         tokenBalance={tokenBalance}
                         approxFiat={{ symbol: account.symbol, tokenContractAddress }}
                         isSubmitting={unwrapMutation.isPending}
-                        isSubmitDisabled={!isAmountValid}
+                        isSubmitDisabled={!isAmountValid || isDisabled}
                         warning={
                             isAmountTooHigh ? (
                                 <YieldActionStepWarning isInsufficientFunds />

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -37,6 +37,8 @@ type UnwrapNativeTokenProps = {
     tokenDecimals: number;
     tokenBalance: string;
     tokenContractAddress: string;
+    /** Reported upward because the page header lives outside this subtree, in the layout. */
+    onFlowCompleteChange?: (isComplete: boolean) => void;
 };
 
 type BroadcastUnwrap = {
@@ -50,6 +52,7 @@ export const UnwrapNativeToken = ({
     tokenDecimals,
     tokenBalance,
     tokenContractAddress,
+    onFlowCompleteChange,
 }: UnwrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
@@ -74,6 +77,11 @@ export const UnwrapNativeToken = ({
     });
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'unwrap');
+    const isFlowComplete = !!broadcast && pendingTxStatus === 'confirmed';
+
+    useEffect(() => {
+        onFlowCompleteChange?.(isFlowComplete);
+    }, [isFlowComplete, onFlowCompleteChange]);
 
     const { reportSubmit, reportMaxClick } = useWrappedNativeFlowAnalytics({
         flowType: 'unwrap',
@@ -174,7 +182,7 @@ export const UnwrapNativeToken = ({
     };
 
     const renderContent = () => {
-        if (broadcast && pendingTxStatus === 'confirmed') {
+        if (broadcast && isFlowComplete) {
             return (
                 <WrappedNativeFlowComplete
                     account={account}

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -118,6 +118,13 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     });
 
     const handleSubmit = methods.handleSubmit(async ({ amountInput: wrapAmount }) => {
+        // The form stays mounted while a wrap is pending so its transaction remains visible, which
+        // leaves this path reachable after the feature has been disabled remotely. Checked before
+        // reporting so a blocked submit is not counted as one.
+        if (isDisabled) {
+            return;
+        }
+
         reportSubmit();
 
         if (!(await ensureDeviceReady())) {
@@ -216,7 +223,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
                         availableAmount={account.formattedBalance}
                         shouldShowReceivingRow={false}
                         isSubmitting={wrapMutation.isPending}
-                        isSubmitDisabled={!isAmountValid}
+                        isSubmitDisabled={!isAmountValid || isDisabled}
                         warning={renderWrapWarning()}
                         pendingTransaction={
                             broadcast

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -35,6 +35,8 @@ import { useYieldFiatInput } from '../hooks/useYieldFiatInput';
 type WrapNativeTokenProps = {
     account: Account;
     token: YieldFlowDisplayToken & { contractAddress: string };
+    /** Reported upward because the page header lives outside this subtree, in the layout. */
+    onFlowCompleteChange?: (isComplete: boolean) => void;
 };
 
 type BroadcastWrap = {
@@ -42,7 +44,7 @@ type BroadcastWrap = {
     amount: string;
 };
 
-export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
+export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNativeTokenProps) => {
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
     const {
@@ -60,6 +62,11 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     });
 
     const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'wrap');
+    const isFlowComplete = !!broadcast && pendingTxStatus === 'confirmed';
+
+    useEffect(() => {
+        onFlowCompleteChange?.(isFlowComplete);
+    }, [isFlowComplete, onFlowCompleteChange]);
 
     const { reportSubmit, reportMaxClick } = useWrappedNativeFlowAnalytics({
         flowType: 'wrap',
@@ -173,7 +180,7 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
     };
 
     const renderContent = () => {
-        if (broadcast && pendingTxStatus === 'confirmed') {
+        if (broadcast && isFlowComplete) {
             return (
                 <WrappedNativeFlowComplete
                     account={account}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -116,6 +116,10 @@ export const TransactionReviewModalBodyInner = ({
     const tradingToken = useSelector(selectTradingComposedTransactionInfo).composed?.token;
 
     const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
+    // A contract call's single "address" row is the contract, not a payment recipient, so the
+    // step-back heuristic below must not treat its ConfirmOutput as a re-confirmed output. A vault
+    // deposit otherwise matches every condition and walks the review backwards mid-signing.
+    const isContractCall = !!precomposedForm.transactionData;
 
     const totalRecipients = outputs.filter(({ type }) => type === 'address').length;
     const hasOpReturn = outputs.some(output => output.type === 'opreturn');
@@ -151,7 +155,8 @@ export const TransactionReviewModalBodyInner = ({
                 totalRecipients === 1 && // Currently we only support going bak for =1
                 lastButtonRequestCode === 'ButtonRequest_ConfirmOutput' &&
                 !hasOpReturn &&
-                !isApprovalTx
+                !isApprovalTx &&
+                !isContractCall
             ) {
                 setReviewStep(prev => prev - 1);
             } else {
@@ -166,6 +171,7 @@ export const TransactionReviewModalBodyInner = ({
         totalRecipients,
         hasOpReturn,
         isApprovalTx,
+        isContractCall,
     ]);
 
     const isInternalTransfer = useSelector(state =>

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -9,7 +9,11 @@ import {
 import { selectLanguage } from '@suite/settings';
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
 import { type Locale, type TrezorDevice } from '@suite-common/suite-types';
-import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkType,
+    getNetworkDisplaySymbol,
+    getWrappedNativeSymbol,
+} from '@suite-common/wallet-config';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { selectAccounts } from '@suite-common/wallet-core';
 import {
@@ -119,6 +123,19 @@ const isYieldAction = (
 ): evmTxType is keyof typeof yieldStrings =>
     !!evmTxType && Object.keys(yieldStrings).includes(evmTxType);
 
+type WrappedNativeAction = Extract<EvmTransactionPurpose, 'wrap' | 'unwrap'>;
+
+const isWrappedNativeAction = (
+    evmTxType: EvmTransactionPurpose | undefined,
+): evmTxType is WrappedNativeAction => evmTxType === 'wrap' || evmTxType === 'unwrap';
+
+// Mirrors the firmware's clear-signing "Intent" screen, which reads "Wrap ETH to WETH" /
+// "Unwrap WETH to ETH" for a canonical WETH deposit()/withdraw().
+const wrappedNativeIntentStrings: Record<WrappedNativeAction, TranslationKey> = {
+    wrap: 'TR_EARN_YIELD_WRAP_TITLE',
+    unwrap: 'TR_EARN_YIELD_UNWRAP_TITLE',
+};
+
 const getTranslationValues = (
     networkType: NetworkType,
     stakeType?: StakeType,
@@ -223,7 +240,7 @@ const getOutputTitle = (
             return <Translation id={translation ? translation.label : 'TR_RECIPIENT_ADDRESS'} />;
 
         case 'amount':
-            if (isYieldAction(evmTxType)) {
+            if (isYieldAction(evmTxType) || isWrappedNativeAction(evmTxType)) {
                 return <Translation id="AMOUNT" />;
             }
 
@@ -255,6 +272,7 @@ const getOutputTitle = (
         case 'recipient_name':
             return <Translation id="TR_TRADING_PROVIDER" />;
         case 'swap_intent':
+        case 'contract_intent':
             return <Translation id="TR_TRADING_INTENT" />;
         case 'traded_assets':
             return <Translation id={receiveAddress ? 'TR_CONTRACT' : 'TR_MY_ASSETS'} />;
@@ -467,6 +485,19 @@ const getOutputLines = ({
                     value: translationString('TR_TRADING_INTENT_SWAP', {}),
                 },
             ];
+        case 'contract_intent':
+            return [
+                {
+                    id: 'contract_intent',
+                    type: 'data',
+                    value: isWrappedNativeAction(evmTxType)
+                        ? translationString(wrappedNativeIntentStrings[evmTxType], {
+                              nativeSymbol: getNetworkDisplaySymbol(symbol),
+                              tokenSymbol: getWrappedNativeSymbol(symbol),
+                          })
+                        : '',
+                },
+            ];
         case 'amount': {
             if (isYieldAction(evmTxType)) {
                 return [
@@ -489,7 +520,11 @@ const getOutputLines = ({
             const output: OutputElementLine[] = [
                 {
                     id: type,
-                    label: <Translation id="AMOUNT" />,
+                    // The card heading already reads "Amount" for a wrap/unwrap, so labelling
+                    // the line too would print it twice.
+                    label: isWrappedNativeAction(evmTxType) ? undefined : (
+                        <Translation id="AMOUNT" />
+                    ),
                     value,
                     type: 'amount',
                     token: token || nativeToken,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -14,7 +14,7 @@ import type {
 } from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
-    getEvmTransactionTextSignature,
+    getEvmTransactionPurpose,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
 } from '@suite-common/wallet-utils';
@@ -102,7 +102,15 @@ export const TransactionReviewOutputList = ({
 
     const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
 
-    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    // Resolved from the full context, not the calldata alone, so a WETH deposit()/withdraw() is
+    // classified as wrap/unwrap — the review rows for those mirror the device's clear-signing
+    // screens and need to know which of the two it is.
+    const evmTxType = getEvmTransactionPurpose({
+        networkSymbol: symbol,
+        to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
+            ?.address,
+        data: precomposedForm.transactionData,
+    });
 
     const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'claim';
 

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -13,6 +13,7 @@ import {
     getIsUpdatedEthereumSendFlow,
     getIsUpdatedSendFlow,
     isClearSignedEvmTradingSwapTransaction,
+    isClearSignedWrappedNativeTransaction,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
     isTestnet,
@@ -38,6 +39,7 @@ interface GetLinesParams {
     stakeType?: StakeType;
     nativeToken?: TokenInfo;
     isClearSignedTradingSwap: boolean;
+    isClearSignedWrapUnwrap: boolean;
     isTronStakeFreeze: boolean;
     tronResourceLabel: string;
 }
@@ -51,6 +53,7 @@ const getLines = ({
     stakeType,
     nativeToken,
     isClearSignedTradingSwap,
+    isClearSignedWrapUnwrap,
     isTronStakeFreeze,
     tronResourceLabel,
 }: GetLinesParams): OutputElementLine[] => {
@@ -129,7 +132,10 @@ const getLines = ({
         const isFeeOnly =
             isUnknownStakingValue ||
             (isEvmApprovalTx(precomposedForm.transactionData) && isApprovalFlowSupported(device)) ||
-            isYieldOrClaimOperation;
+            isYieldOrClaimOperation ||
+            // A clear-signed wrap/unwrap already confirms the amount on its own row, and the
+            // device leaves it off its summary screen for the same reason.
+            isClearSignedWrapUnwrap;
 
         return isFeeOnly ? [feeLine] : [amountLine, feeLine];
     }
@@ -222,6 +228,12 @@ export const TransactionReviewTotalOutput = ({
         transactionData: precomposedForm.transactionData,
         trading: precomposedForm.trading,
     });
+    const isClearSignedWrapUnwrap = isClearSignedWrappedNativeTransaction({
+        account,
+        device,
+        precomposedTx,
+        transactionData: precomposedForm.transactionData,
+    });
     const lines = getLines({
         device,
         networkType,
@@ -231,12 +243,14 @@ export const TransactionReviewTotalOutput = ({
         stakeType,
         nativeToken,
         isClearSignedTradingSwap,
+        isClearSignedWrapUnwrap,
         isTronStakeFreeze,
         tronResourceLabel,
     });
 
     const titleId = (() => {
-        if (isClearSignedTradingSwap) return 'TR_NETWORK_FEE';
+        // Both list the fee alone, so "Total including fee" would be misleading.
+        if (isClearSignedTradingSwap || isClearSignedWrapUnwrap) return 'TR_NETWORK_FEE';
         if (precomposedForm.trading?.isSlip24Active) return 'TR_SUMMARY';
         if (isTronStakeFreeze) return 'TR_SUMMARY';
 

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -26,6 +26,12 @@ interface UseTxFeesFormProps {
     networkType?: NetworkType;
     networkSymbol?: NetworkSymbol;
     defaultGasLimit?: string;
+    /**
+     * Native value the transaction sends, in wei. A payable call such as a WETH wrap spends it on
+     * top of the fee, so leaving it out lets a full-balance wrap pass validation and then fail on
+     * broadcast with "insufficient funds".
+     */
+    txValue?: string;
 }
 
 export function useEvmTxSimulationFeesForm({
@@ -33,6 +39,7 @@ export function useEvmTxSimulationFeesForm({
     networkType = 'ethereum',
     networkSymbol = 'eth',
     defaultGasLimit = ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+    txValue = '0',
 }: UseTxFeesFormProps) {
     const form = useForm<FeesFormValues>({
         defaultValues: {
@@ -79,13 +86,21 @@ export function useEvmTxSimulationFeesForm({
         const selectedLevel = composedLevels[selectedFee || 'normal'];
         const fee = selectedLevel?.type === 'final' ? selectedLevel.fee : undefined;
 
-        if (!fee || new BigNumber(fee).lte(accountBalance)) return undefined;
+        if (!fee) return undefined;
 
-        return {
-            id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
-            values: { networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol) },
-        } as const;
-    }, [accountBalance, composedLevels, networkSymbol, selectedFee]);
+        if (new BigNumber(fee).gt(accountBalance)) {
+            return {
+                id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
+                values: { networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol) },
+            } as const;
+        }
+
+        if (new BigNumber(fee).plus(txValue).gt(accountBalance)) {
+            return { id: 'AMOUNT_IS_NOT_ENOUGH', values: undefined } as const;
+        }
+
+        return undefined;
+    }, [accountBalance, composedLevels, networkSymbol, selectedFee, txValue]);
 
     function handleTxSimulationResult({ simulation, gas_estimation }: TxSimulationEVMResult) {
         const newFeeLimit =

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx
@@ -20,6 +20,7 @@ import {
 import { type Account, type TxSimulationAction } from '@suite-common/wallet-types';
 import { Banner, Card, Column, Modal } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
+import { BigNumber } from '@trezor/utils';
 
 import { Fees } from 'src/components/wallet/Fees/Fees';
 
@@ -57,6 +58,10 @@ export function EarnYieldTxSimulationModalInner({
             ? action.payload.transaction.gasLimit
             : undefined,
         accountBalance: account.availableBalance,
+        // A wrap is payable, so its value competes with the fee for the same native balance.
+        txValue: areTxSimulationMethods(TX_METHODS_WITH_FEES, action)
+            ? new BigNumber(action.payload.transaction.value || 0).toFixed(0)
+            : undefined,
     });
 
     const [confirming, setConfirming] = useState<boolean>(false);

--- a/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts
@@ -17,6 +17,11 @@ const SIGN_TX_ROUTES = [
     'earn-yield-deposit',
     'earn-yield-withdraw',
     'earn-yield-claim',
+    // The clear-signed wrap/unwrap review needs these too: firmware announces its provider and
+    // intent screens with ButtonRequest_Other (confirm_action's default), which without remapping
+    // would replace the review with ConfirmActionModal midway and reset its step tracking.
+    'earn-yield-wrap',
+    'earn-yield-unwrap',
     'earn-tron-stake',
     'earn-tron-vote',
     'earn-tron-unstake',

--- a/packages/suite/src/views/earn/yield/unwrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/unwrap/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { goto } from '@suite/router';
 import { WRAPPED_NATIVE } from '@suite-common/wallet-config';
@@ -15,6 +15,8 @@ export const EarnUnwrap = () => {
     const dispatch = useDispatch();
     const { account, routeParams } = useEarnRouteAccount();
     const wrappedNative = account ? WRAPPED_NATIVE[account.symbol] : undefined;
+    // Held here rather than in UnwrapNativeToken because useLayout renders the header outside it.
+    const [isFlowComplete, setIsFlowComplete] = useState(false);
 
     useEffect(() => {
         if (!routeParams) {
@@ -29,6 +31,7 @@ export const EarnUnwrap = () => {
             flow="unwrap"
             account={account}
             contractAddress={wrappedNative?.address}
+            isFlowComplete={isFlowComplete}
         />,
     );
 
@@ -53,6 +56,7 @@ export const EarnUnwrap = () => {
             tokenDecimals={wrappedNative.decimals}
             tokenBalance={wrappedToken?.balance ?? '0'}
             tokenContractAddress={wrappedNative.address}
+            onFlowCompleteChange={setIsFlowComplete}
         />
     );
 };

--- a/packages/suite/src/views/earn/yield/wrap/index.tsx
+++ b/packages/suite/src/views/earn/yield/wrap/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { goto } from '@suite/router';
 import { WRAPPED_NATIVE } from '@suite-common/wallet-config';
@@ -14,6 +14,8 @@ export const EarnWrap = () => {
     const dispatch = useDispatch();
     const { account, routeParams } = useEarnRouteAccount();
     const wrappedNative = account ? WRAPPED_NATIVE[account.symbol] : undefined;
+    // Held here rather than in WrapNativeToken because useLayout renders the header outside it.
+    const [isFlowComplete, setIsFlowComplete] = useState(false);
 
     useEffect(() => {
         if (!routeParams) {
@@ -28,6 +30,7 @@ export const EarnWrap = () => {
             flow="wrap"
             account={account}
             contractAddress={wrappedNative?.address}
+            isFlowComplete={isFlowComplete}
         />,
     );
 
@@ -48,5 +51,7 @@ export const EarnWrap = () => {
         contractAddress: wrappedNative.address,
     };
 
-    return <WrapNativeToken account={account} token={token} />;
+    return (
+        <WrapNativeToken account={account} token={token} onFlowCompleteChange={setIsFlowComplete} />
+    );
 };

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -168,6 +168,10 @@ const TokenRowBasicActions = ({
         dispatch(goto(payload));
     };
 
+    // This table renders on both the Tokens and the DeFi tab, so the reported origin has to follow
+    // the tab it was rendered for. Unwrap in particular is offered on the Tokens tab.
+    const analyticsFrom = type === 'defi' ? 'account-defi-tokens' : 'account-tokens';
+
     const navigateToYieldDeposit = () => {
         if (!availableVault || !availableVaultAddress) return;
 
@@ -175,7 +179,7 @@ const TokenRowBasicActions = ({
             type: sharedEvents.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'account-defi-tokens',
+                from: analyticsFrom,
                 to: 'deposit-form',
                 networkSymbol: account.symbol,
                 vaultId: availableVault.id,
@@ -200,7 +204,7 @@ const TokenRowBasicActions = ({
             type: sharedEvents.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'account-defi-tokens',
+                from: analyticsFrom,
                 to: 'withdraw-form',
                 networkSymbol: account.symbol,
                 vaultId: availableVault.id,
@@ -325,7 +329,7 @@ const TokenRowBasicActions = ({
             type: sharedEvents.yieldNavigateEvent.name,
             payload: {
                 action: 'continue',
-                from: 'account-defi-tokens',
+                from: analyticsFrom,
                 to: 'unwrap-form',
                 networkSymbol: account.symbol,
             },

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -484,14 +484,14 @@ const TokenRowBasicActions = ({
                     {
                         label: <Translation id="TR_EARN_YIELD_DEPOSIT" />,
                         icon: PlusIcon,
-                        onClick: () => {},
+                        onClick: navigateToYieldDeposit,
                         isDisabled: type === 'defi' ? isDepositButtonDisabled : true,
                         isHidden: type === 'defi' ? !isBelowTablet : !isErc4626(token),
                     },
                     {
                         label: <Translation id="TR_EARN_YIELD_WITHDRAW" />,
                         icon: MinusIcon,
-                        onClick: () => {},
+                        onClick: navigateToYieldWithdraw,
                         isDisabled: type === 'defi' ? isWithdrawButtonDisabled : true,
                         isHidden: type === 'defi' ? !isBelowTablet : !isErc4626(token),
                     },

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -57,7 +57,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         from: {
             description:
-                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only, `account-defi-tokens`, `claim-select-account-modal`, `wrap-form` and `unwrap-form` are desktop-only; `account-tokens` = yield badge on the account Tokens tab, `account-defi-tokens` also covers the yield badge on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
+                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only as an origin, `account-defi-tokens`, `claim-select-account-modal`, `wrap-form` and `unwrap-form` are desktop-only; `account-tokens` = yield badge on the account Tokens tab or the token row actions there, `account-defi-tokens` also covers the yield badge and token row actions on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -71,7 +71,8 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
             ],
         },
         to: {
-            description: 'Destination of the navigation',
+            description:
+                'Destination of the navigation. Desktop also reports `account-detail` when leaving the wrap/unwrap pages, where it means the account Tokens tab',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -80,7 +81,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
                 },
                 {
                     version: '26.8.0',
-                    notes: 'added `wrap-form` and `unwrap-form` values (desktop)',
+                    notes: 'added `wrap-form` and `unwrap-form` values, and `account-detail` is now also reported (desktop)',
                 },
             ],
         },

--- a/suite-common/wallet-constants/src/earnConstants.ts
+++ b/suite-common/wallet-constants/src/earnConstants.ts
@@ -1,4 +1,16 @@
+import { type VersionArray } from '@trezor/utils';
+
 import { MIN_ETH_BALANCE_FOR_FEE_BUFFER } from './ethereumStakingConstants';
+
+/**
+ * Wrap/unwrap and the wrapped-native (WETH) vault calldata are clear-signed only from this
+ * firmware; older versions would show a raw function signature (trezor/trezor-suite#30848).
+ *
+ * Note this is stricter than the `evmClearSigning` capability, which connect reports from 2.12.1 —
+ * a device on 2.12.1–2.12.3 advertises clear signing but still blind-signs WETH. Anything deciding
+ * how a wrap/unwrap is presented has to gate on this version, not on the capability alone.
+ */
+export const WRAPPED_NATIVE_MIN_FIRMWARE: VersionArray = [2, 12, 4];
 
 // Native balance kept aside when wrapping so the follow-up approve + deposit transactions
 // still have enough to cover their fees — the same buffer staking keeps for its exit fee.

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.ts
@@ -1,15 +1,10 @@
 import type { TrezorDevice } from '@suite-common/suite-types';
+import { WRAPPED_NATIVE_MIN_FIRMWARE } from '@suite-common/wallet-constants';
 import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { DeviceModelInternal, getFirmwareVersionArray } from '@trezor/device-utils';
 import { type VersionArray, versionUtils } from '@trezor/utils';
 
 import type { YieldFlowDisplayToken, YieldFlowType } from './stablecoinYieldTypes';
-
-/**
- * Wrap/unwrap and the wrapped-native (WETH) vault calldata are clear-signed only from this
- * firmware; older versions would show a raw function signature (trezor/trezor-suite#30848).
- */
-const WRAPPED_NATIVE_MIN_FIRMWARE: VersionArray = [2, 12, 4];
 
 const hasMinFirmware = (device: TrezorDevice | undefined, minVersion: VersionArray): boolean => {
     // The firmware gates target the T2+ line only; T1B1 versions its firmware as 1.x.

--- a/suite-common/wallet-types/src/transactionReviewOutput.ts
+++ b/suite-common/wallet-types/src/transactionReviewOutput.ts
@@ -24,6 +24,7 @@ export type ReviewOutput =
               | 'approve_data'
               | 'recipient_name'
               | 'swap_intent'
+              | 'contract_intent'
               | 'tron-vote'
               | 'tron-withdraw'
               | 'tron-claim'

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -92,12 +92,13 @@ const buildEthereumAccount = (overrides: Partial<Account> = {}): Account =>
         ...overrides,
     });
 
-// >= 2.12.1: clear-signing-capable (clear signing is version-gated per selector).
+// Clear signing is version-gated per selector: swaps from 2.12.1, WETH wrap/unwrap from 2.12.4.
+// Use the highest threshold so every clear-signed flow is covered by one fixture.
 const buildUpdatedDevice = () =>
     mockSuiteDevice(undefined, {
         major_version: 2,
         minor_version: 12,
-        patch_version: 2,
+        patch_version: 4,
     });
 
 const buildPrecomposedTransaction = ({
@@ -237,6 +238,25 @@ describe('isClearSignedWrappedNativeTransaction', () => {
 
         expect(result).toBe(false);
     });
+
+    it.each([
+        { version: '2.12.1', firmware: { major_version: 2, minor_version: 12, patch_version: 1 } },
+        { version: '2.12.3', firmware: { major_version: 2, minor_version: 12, patch_version: 3 } },
+    ])(
+        'returns false on fw $version, which advertises clear signing but blind-signs WETH',
+        ({ firmware }) => {
+            const result = isClearSignedWrappedNativeTransaction({
+                // No unavailableCapabilities: evmClearSigning is genuinely available from 2.12.1,
+                // yet the WETH definition only ships in 2.12.4.
+                account,
+                device: mockSuiteDevice(undefined, firmware),
+                precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
+                transactionData: WETH_DEPOSIT_DATA,
+            });
+
+            expect(result).toBe(false);
+        },
+    );
 
     it('returns false for an unrelated contract call to the WETH address', () => {
         const result = isClearSignedWrappedNativeTransaction({

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -14,6 +14,7 @@ import { buildApprovalTransactionData } from './ethUtils';
 import {
     constructTransactionReviewOutputs,
     isClearSignedEvmTradingSwapTransaction,
+    isClearSignedWrappedNativeTransaction,
 } from './reviewTransactionUtils';
 
 const buildPrecomposedTx = (to: string | undefined): GeneralPrecomposedTransactionFinal =>
@@ -118,6 +119,15 @@ const buildPrecomposedTransaction = ({
         isTokenKnown,
     }) as unknown as GeneralPrecomposedTransactionFinal;
 
+const wethToken: TokenInfo = {
+    balance: '1000000',
+    contract: WETH_MAINNET.toLowerCase(),
+    decimals: 18,
+    name: 'Wrapped Ether',
+    standard: 'ERC20',
+    symbol: 'WETH',
+};
+
 const usdcToken: TokenInfo = {
     balance: '1000000',
     contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
@@ -179,6 +189,61 @@ describe('isClearSignedEvmTradingSwapTransaction', () => {
             precomposedTx: buildPrecomposedTx(LIFI_DIAMOND),
             transactionData: LIFI_SWAP_DATA,
             trading: buildTrading(),
+        });
+
+        expect(result).toBe(false);
+    });
+});
+
+describe('isClearSignedWrappedNativeTransaction', () => {
+    const account = buildEthereumAccount();
+    const device = buildUpdatedDevice();
+
+    it.each([
+        { op: 'wrap', transactionData: WETH_DEPOSIT_DATA },
+        { op: 'unwrap', transactionData: WETH_WITHDRAW_DATA },
+    ])('returns true for a canonical WETH $op', ({ transactionData }) => {
+        const result = isClearSignedWrappedNativeTransaction({
+            account,
+            device,
+            precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
+            transactionData,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {
+        const result = isClearSignedWrappedNativeTransaction({
+            account: buildEthereumAccount({ symbol: 'bsc' }),
+            device,
+            precomposedTx: buildPrecomposedTransaction({ to: WBNB_BSC }),
+            transactionData: WETH_DEPOSIT_DATA,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false when the device cannot clear-sign', () => {
+        const result = isClearSignedWrappedNativeTransaction({
+            account,
+            device: mockSuiteDevice(
+                { unavailableCapabilities: { evmClearSigning: 'no-support' } },
+                { major_version: 2, minor_version: 8, patch_version: 0 },
+            ),
+            precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
+            transactionData: WETH_DEPOSIT_DATA,
+        });
+
+        expect(result).toBe(false);
+    });
+
+    it('returns false for an unrelated contract call to the WETH address', () => {
+        const result = isClearSignedWrappedNativeTransaction({
+            account,
+            device,
+            precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
+            transactionData: ERC20_TRANSFER_DATA,
         });
 
         expect(result).toBe(false);
@@ -393,24 +458,51 @@ describe('constructTransactionReviewOutputs', () => {
     it.each([
         { op: 'wrap', transactionData: WETH_DEPOSIT_DATA },
         { op: 'unwrap', transactionData: WETH_WITHDRAW_DATA },
-    ])('suppresses the raw data row for a clear-signed WETH $op', ({ transactionData }) => {
+    ])('mirrors the four device screens for a clear-signed WETH $op', ({ transactionData, op }) => {
         const outputs = constructTransactionReviewOutputs({
             account,
             device,
             decreaseOutputId: undefined,
             precomposedForm: buildFormState({ transactionData }),
+            precomposedTx: buildPrecomposedTransaction({
+                to: WETH_MAINNET,
+                // An unwrap review carries the WETH token; the amount row must still be
+                // native, matching the device's AmountFormatter.
+                token: op === 'unwrap' ? wethToken : undefined,
+            }),
+        });
+
+        // `confirm_ethereum_clear_signing` walks provider → intent → amount → summary. The
+        // summary is the review's own total row, so three outputs precede it.
+        expect(outputs).toEqual([
+            { type: 'recipient_name', value: 'WETH' },
+            { type: 'contract_intent', value: '' },
+            { type: 'amount', value: '1000000' },
+        ]);
+        // No token on the amount row: wrapping is 1:1 and the device prints ETH both ways.
+        expect(outputs[2]).not.toHaveProperty('token');
+    });
+
+    it('renders the blind-signing rows for a WETH wrap on firmware without clear signing', () => {
+        const outputs = constructTransactionReviewOutputs({
+            account,
+            device: mockSuiteDevice(
+                { unavailableCapabilities: { evmClearSigning: 'update-required' } },
+                { major_version: 2, minor_version: 8, patch_version: 0 },
+            ),
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData: WETH_DEPOSIT_DATA }),
             precomposedTx: buildPrecomposedTransaction({ to: WETH_MAINNET }),
         });
 
-        // The device clear-signs the intent + amount, so the raw calldata row is dropped...
-        expect(outputs).not.toEqual(
-            expect.arrayContaining([expect.objectContaining({ type: 'data' })]),
-        );
-        // ...but the contract address (and the fee/total summary) still show.
         expect(outputs).toEqual(
             expect.arrayContaining([
+                expect.objectContaining({ type: 'data', value: WETH_DEPOSIT_DATA }),
                 expect.objectContaining({ type: 'contract', value: WETH_MAINNET }),
             ]),
+        );
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'contract_intent' })]),
         );
     });
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -11,6 +11,7 @@ import {
     getWrappedNativeSymbol,
     networks,
 } from '@suite-common/wallet-config';
+import { WRAPPED_NATIVE_MIN_FIRMWARE } from '@suite-common/wallet-constants';
 import {
     type Account,
     type FormState,
@@ -22,7 +23,7 @@ import {
     type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import type { CardanoOutput } from '@trezor/connect';
-import { getFirmwareVersion } from '@trezor/device-utils';
+import { getFirmwareVersion, getFirmwareVersionArray } from '@trezor/device-utils';
 import { BigNumber, versionUtils } from '@trezor/utils';
 
 import { datetimeToLocktime } from './bitcoinUtils';
@@ -194,9 +195,14 @@ type ClearSignedWrappedNativeParams = {
 
 /**
  * Whether the device will clear-sign this transaction as a canonical WETH wrap/unwrap
- * (deposit()/withdraw(), fw 2.12.4+), which it renders as provider → intent → amount → fee
- * summary. Gated on `isEvmClearSigningTx` so a wrapped native the firmware does not clear-sign
- * (e.g. WBNB on BSC) still falls through to the blind-signing rows.
+ * (deposit()/withdraw()), which it renders as provider → intent → amount → fee summary. Gated on
+ * `isEvmClearSigningTx` so a wrapped native the firmware does not clear-sign (e.g. WBNB on BSC)
+ * still falls through to the blind-signing rows.
+ *
+ * The `evmClearSigning` capability is not sufficient on its own: connect reports it from 2.12.1,
+ * while WETH gained its clear-signing definition in 2.12.4. Without the version gate a device on
+ * 2.12.1–2.12.3 would get the mirrored review while it actually blind-signs — the same
+ * modal/device mismatch this mirroring exists to remove, inverted.
  */
 export const isClearSignedWrappedNativeTransaction = ({
     account,
@@ -205,6 +211,14 @@ export const isClearSignedWrappedNativeTransaction = ({
     transactionData,
 }: ClearSignedWrappedNativeParams): boolean => {
     if (account.networkType !== 'ethereum' || !isEvmClearSigningSupportedByDevice(device)) {
+        return false;
+    }
+
+    const firmwareVersion = getFirmwareVersionArray(device);
+    if (
+        firmwareVersion === null ||
+        !versionUtils.isNewerOrEqual(firmwareVersion, WRAPPED_NATIVE_MIN_FIRMWARE)
+    ) {
         return false;
     }
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -6,7 +6,11 @@ import {
 } from '@suite-common/calldata';
 import { EVM_SPENDER_LABELS } from '@suite-common/suite-constants';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { EARN_YIELD_CLAIM_PROVIDER, networks } from '@suite-common/wallet-config';
+import {
+    EARN_YIELD_CLAIM_PROVIDER,
+    getWrappedNativeSymbol,
+    networks,
+} from '@suite-common/wallet-config';
 import {
     type Account,
     type FormState,
@@ -29,6 +33,7 @@ import {
 } from './deviceUtils';
 import { fromGwei, fromWei } from './ethConverter';
 import {
+    getEvmTransactionPurpose,
     getEvmTransactionTextSignature,
     isEvmApprovalTx,
     isEvmYieldTxByTextSignature,
@@ -179,6 +184,49 @@ export const getClearSignedEvmTradingSwapCoverage = ({
 export const isClearSignedEvmTradingSwapTransaction = (
     params: ClearSignedEvmTradingSwapParams,
 ): boolean => getClearSignedEvmTradingSwapCoverage(params) !== undefined;
+
+type ClearSignedWrappedNativeParams = {
+    account: Account;
+    device: TrezorDevice;
+    precomposedTx: GeneralPrecomposedTransactionFinal;
+    transactionData?: string;
+};
+
+/**
+ * Whether the device will clear-sign this transaction as a canonical WETH wrap/unwrap
+ * (deposit()/withdraw(), fw 2.12.4+), which it renders as provider → intent → amount → fee
+ * summary. Gated on `isEvmClearSigningTx` so a wrapped native the firmware does not clear-sign
+ * (e.g. WBNB on BSC) still falls through to the blind-signing rows.
+ */
+export const isClearSignedWrappedNativeTransaction = ({
+    account,
+    device,
+    precomposedTx,
+    transactionData,
+}: ClearSignedWrappedNativeParams): boolean => {
+    if (account.networkType !== 'ethereum' || !isEvmClearSigningSupportedByDevice(device)) {
+        return false;
+    }
+
+    const network = networks[account.symbol];
+    if (!('chainId' in network)) {
+        return false;
+    }
+
+    const to = precomposedTx.outputs.find(
+        o => 'address' in o && typeof o.address === 'string',
+    )?.address;
+    const wrappedNativeTxParams = {
+        networkSymbol: account.symbol,
+        to,
+        data: transactionData,
+    };
+
+    return (
+        (isWrapNativeTx(wrappedNativeTxParams) || isUnwrapNativeTx(wrappedNativeTxParams)) &&
+        isEvmClearSigningTx(network.chainId, to, transactionData)
+    );
+};
 
 const constructOldFlow = ({
     precomposedTx,
@@ -350,11 +398,13 @@ const constructNewFlow = ({
     availableRewards,
     swapSlippage,
     clearSignedSwapCoverage,
+    isClearSignedWrapUnwrap,
     isApprovalFlowSupported,
     isEvmClearSigningSupported,
     isUpdatedEthereumSendFlow,
     isUpdatedStellarSendFlow,
 }: ConstructOutputsParams & {
+    isClearSignedWrapUnwrap: boolean;
     isUpdatedEthereumSendFlow: boolean;
     isUpdatedStellarSendFlow: boolean;
     isApprovalFlowSupported: boolean;
@@ -378,30 +428,17 @@ const constructNewFlow = ({
     const hasDestinationTag = 'destinationTag' in precomposedForm;
     const trading = precomposedForm?.trading;
 
-    const evmTxType = getEvmTransactionTextSignature(precomposedForm.transactionData);
+    // Resolved from the full context rather than the calldata alone, so that the WETH
+    // deposit()/withdraw() selectors classify as wrap/unwrap instead of 'unknown'.
+    const evmTxType = getEvmTransactionPurpose({
+        networkSymbol: symbol,
+        to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
+            ?.address,
+        data: precomposedForm.transactionData,
+    });
     const isClaimOp = evmTxType === 'claim';
     const isYieldOp = isEvmYieldTxByTextSignature(evmTxType);
     const isEvmClaimClearSign = isUpdatedEthereumSendFlow && isEvmClearSigningSupported;
-
-    // The device clear-signs WETH wrap/unwrap (deposit()/withdraw(), fw 2.12.4+) as a
-    // "Wrap/Unwrap ETH … Amount" screen, so the raw calldata Data row is redundant — suppress
-    // it, mirroring clear-signed swaps. Gated on isEvmClearSigningTx so a wrapped native the
-    // firmware does not clear-sign (e.g. WBNB on BSC) still shows the raw data.
-    const evmNetwork = networks[symbol];
-    const evmChainId = 'chainId' in evmNetwork ? evmNetwork.chainId : undefined;
-    const evmContractAddress = precomposedTx.outputs.find(
-        o => 'address' in o && typeof o.address === 'string',
-    )?.address;
-    const wrappedNativeTxParams = {
-        networkSymbol: symbol,
-        to: evmContractAddress,
-        data: precomposedForm.transactionData,
-    };
-    const isClearSignedWrapUnwrap =
-        isEvmClearSigningSupported &&
-        evmChainId !== undefined &&
-        (isWrapNativeTx(wrappedNativeTxParams) || isUnwrapNativeTx(wrappedNativeTxParams)) &&
-        isEvmClearSigningTx(evmChainId, evmContractAddress, precomposedForm.transactionData);
 
     if (networkType === 'ethereum' && stakeType && isUpdatedEthereumSendFlow) {
         // The firmware clear-signs staking operations as a single confirmation screen followed
@@ -409,6 +446,28 @@ const constructNewFlow = ({
         precomposedTx.outputs.forEach(o => {
             if ('address' in o && typeof o.address === 'string') {
                 outputs.push({ type: 'address', value: o.address });
+            }
+        });
+
+        return outputs;
+    }
+
+    if (isClearSignedWrapUnwrap) {
+        // The firmware walks a clear-signed wrap/unwrap through four screens — provider, intent,
+        // the amount, then the fee summary (`confirm_ethereum_clear_signing`). Mirror them 1:1
+        // (the summary is the review's own total row) so the modal's step pill tracks what is
+        // actually on the device.
+        outputs.push(
+            { type: 'recipient_name', value: getWrappedNativeSymbol(symbol) ?? '' },
+            { type: 'contract_intent', value: '' },
+        );
+
+        precomposedTx.outputs.forEach(o => {
+            if ('address' in o && typeof o.address === 'string') {
+                // Deliberately no `token`: wrapping is 1:1 and the device renders both legs with
+                // the native currency formatter, so passing the WETH token info would make an
+                // unwrap read "WETH" where the device says "ETH".
+                outputs.push({ type: 'amount', value: o.amount.toString() });
             }
         });
 
@@ -503,8 +562,7 @@ const constructNewFlow = ({
             (precomposedForm.transactionData && isEvmApproval && !isApprovalFlowSupported) ||
             (precomposedForm.transactionData && isYieldOp && !isUpdatedEthereumSendFlow) ||
             (precomposedForm.transactionData && isClaimOp && !isEvmClaimClearSign)) &&
-        !isClearSignedTradingSwap &&
-        !isClearSignedWrapUnwrap
+        !isClearSignedTradingSwap
     ) {
         outputs.push({ type: 'data', value: precomposedForm.transactionData });
     }
@@ -754,6 +812,14 @@ export const constructTransactionReviewOutputs = ({
     return constructNewFlow({
         ...params,
         clearSignedSwapCoverage,
+        // Firmware that predates the updated send flow cannot clear-sign at all, so this is
+        // resolved only for the new flow.
+        isClearSignedWrapUnwrap: isClearSignedWrappedNativeTransaction({
+            account: params.account,
+            device,
+            precomposedTx: params.precomposedTx,
+            transactionData: params.precomposedForm.transactionData,
+        }),
         isUpdatedEthereumSendFlow,
         isApprovalFlowSupported: isApprovalSupported(device),
         isEvmClearSigningSupported: isEvmClearSigningSupportedByDevice(device),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Improves support for step-based clear signing flow

## Notes for QA

See attached screenshots

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30792

## Screenshots:


| Deposit 1 | Deposit 2 | Deposit 3 | Deposit 4 |
|--------|--------|--------|--------|
| <img width="1112" height="820" alt="Screenshot 2026-08-04 at 18 17 15" src="https://github.com/user-attachments/assets/ba9a75c6-1b9b-411b-9368-9e9433f78e3f" /> | <img width="1094" height="855" alt="Screenshot 2026-08-04 at 18 17 22" src="https://github.com/user-attachments/assets/209c37c1-7ee9-4e67-a52d-56ce6906d1c0" /> | <img width="1099" height="824" alt="Screenshot 2026-08-04 at 18 17 31" src="https://github.com/user-attachments/assets/7ce6f737-545c-4881-a9b1-5f76804af3fb" /> | <img width="1087" height="792" alt="Screenshot 2026-08-04 at 18 17 35" src="https://github.com/user-attachments/assets/e0dd2c7d-0faf-4922-a568-1c92db33d1b1" /> | 

| Withdraw 1 | Withdraw 2 | Withdraw 3 | Withdraw 4 |
|--------|--------|--------|--------|
| <img width="1075" height="778" alt="Screenshot 2026-08-04 at 18 18 25" src="https://github.com/user-attachments/assets/a49c9b8b-c5ca-4f84-857e-5d53018f2f23" /> | <img width="1073" height="782" alt="Screenshot 2026-08-04 at 18 18 30" src="https://github.com/user-attachments/assets/1dd8cfec-e587-4c42-b2d4-3beb1233259a" /> | <img width="1102" height="828" alt="Screenshot 2026-08-04 at 18 18 34" src="https://github.com/user-attachments/assets/c1474cbf-baec-4dc7-b18c-2514aae73804" /> | <img width="1091" height="796" alt="Screenshot 2026-08-04 at 18 18 39" src="https://github.com/user-attachments/assets/f6131d26-8e2d-4d40-8fee-c388f72c8620" /> | 

| Unwrap 1 | Unwrap 2 | Unwrap 3 |
|--------|--------|--------|
| <img width="1097" height="763" alt="Screenshot 2026-08-04 at 18 19 20" src="https://github.com/user-attachments/assets/d6bb6f27-31f4-4d6a-96ee-134bc749bd6b" /> | <img width="1090" height="752" alt="Screenshot 2026-08-04 at 18 19 25" src="https://github.com/user-attachments/assets/2806b4a7-3a67-4d76-a926-a188a78ff6a9" /> | <img width="1087" height="744" alt="Screenshot 2026-08-04 at 18 19 16" src="https://github.com/user-attachments/assets/3ef515de-3472-4362-a28b-ba0679290697" /> | 


| Wrap 1 | Wrap 2 | Wrap 3 |
|--------|--------|--------|
| <img width="1082" height="761" alt="Screenshot 2026-08-04 at 18 20 53" src="https://github.com/user-attachments/assets/20333cec-0e82-4fe4-ab6d-e5de48c4072d" /> | <img width="1091" height="774" alt="Screenshot 2026-08-04 at 18 20 57" src="https://github.com/user-attachments/assets/4c45ca4b-8fd7-4490-989e-94332290b6b4" /> | <img width="1092" height="771" alt="Screenshot 2026-08-04 at 18 21 01" src="https://github.com/user-attachments/assets/6aede932-8439-413e-b151-51baacf31a5a" /> | 


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/sync-tx-sign-steps/web/](https://dev.suite.sldev.cz/suite-web/feat/sync-tx-sign-steps/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily touches stablecoin yield wrap/unwrap views, EVM yield transaction simulation, transaction review output rendering, and the global button-request middleware. The highest risk is in transaction signing/review flows, so the strategy prioritizes one yield deposit test, representative EVM and non-EVM sends, and two staking confirmation flows. A token-navigation test and a sign-message test are added as medium-risk checks for shared UI/middleware. Wrap/unwrap earn views and the yield analytics event have no E2E coverage in the candidate set.

<details><summary><b>Changed files (19)</b></summary>

- `packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx`
- `packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `packages/suite/src/middlewares/suite/buttonRequestMiddleware.ts`
- `packages/suite/src/views/earn/yield/unwrap/index.tsx`
- `packages/suite/src/views/earn/yield/wrap/index.tsx`
- `packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx`
- `suite-common/analytics/src/events/yieldNavigateEvent.ts`
- `suite-common/wallet-constants/src/earnConstants.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.ts`
- `suite-common/wallet-types/src/transactionReviewOutput.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/yield/deposit.test.ts` — Static coverage maps both changed tx-simulation files (useEvmTxSimulationFeesForm.ts and EarnYieldTxSimulationModalInner.tsx) to this test, and it is the only E2E test known to exercise the stablecoin yield deposit/simulation flow affected by this change set.
- `suite/e2e/tests/staking/ada/stake.test.ts` — This flow confirms a staking transaction on device and verifies the review modal content (deposit, fee, pool details). Changes to TransactionReviewOutputList/Output/TotalOutput and reviewTransactionUtils directly affect how those outputs are rendered.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — It exercises an EVM transaction review with custom staking data, device prompts, and button requests. The changed review-output components, reviewTransactionUtils, and buttonRequestMiddleware are on the critical path for this flow.
- `suite/e2e/tests/wallet/send-eth.test.ts` — A core EVM send flow that relies on the transaction review modal (address, amount, gas limit, max fee) and device signing button requests. It will catch regressions in the changed review-output components and button-request middleware.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This non-EVM send flow uses the same transaction review output components and device confirmation path, providing coverage for output-list changes outside of EVM fee structures.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — TokenRowActions.tsx is statically mapped to this test, and the test navigates buy/sell/swap from token pages. A change to token-row actions could affect how those navigation entry points are exposed.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — The button-request middleware change could alter device signing button prompts. This test signs and verifies messages and confirms multiple device prompts, offering a focused check of the middleware behavior.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/components/earn/yield/common/WrappedNativePageHeader.tsx`
- `packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `packages/suite/src/views/earn/yield/unwrap/index.tsx`
- `packages/suite/src/views/earn/yield/wrap/index.tsx`
- `suite-common/wallet-types/src/transactionReviewOutput.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`

_Updated: 2026-08-05T13:28:24.090Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/sync-tx-sign-steps&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/sync-tx-sign-steps&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/sync-tx-sign-steps&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:30:28.702Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:29:21.879Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->