### PR TITLE
feat(suite-native): add native receive copy menu

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,6 +23,7 @@ npmPreapprovedPackages:
   - "@types/invity-api@*"
   # To fix a bug with @sentry/react-native AppStart integration (we want to have more time for QA). Can be removed after 20.8.2026
   - "@sentry/*@*"
+  - "@expo/ui@56.0.24"
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281

--- a/scripts/list-outdated-dependencies/wallet-dependencies.txt
+++ b/scripts/list-outdated-dependencies/wallet-dependencies.txt
@@ -1,4 +1,5 @@
 @exodus/patch-broken-hermes-typed-arrays
+@expo/ui
 @fivebinaries/coin-selection
 @hookform/resolvers
 @noble/hashes
@@ -28,6 +29,7 @@ ajv
 bignumber.js
 cashaddrjs
 event-target-shim
+expo-media-library
 golomb
 immer
 json-schema-to-typescript
@@ -43,6 +45,7 @@ redux-logger
 redux-mock-store
 react-native-quick-crypto
 react-native-tcp-socket
+react-native-view-shot
 redux-persist
 redux-thunk
 reselect

--- a/suite-native/analytics/src/constants.ts
+++ b/suite-native/analytics/src/constants.ts
@@ -92,6 +92,7 @@ export enum EventType {
     ReceiveFlowEntered = 'receive/flow_entered',
     ReceiveOpenNonFreshAddress = 'receive/open-non-fresh-address',
     ReceiveOptionsScreen = 'receive/options-screen',
+    ReceiveQRCodeAction = 'receive/qr-code-action',
     ReceiveShareAddress = 'receive/share-address',
     ReceiveStartVerification = 'receive/start-verification',
     // eslint-disable-next-line local-rules/analytics-event-name

--- a/suite-native/analytics/src/events/index.ts
+++ b/suite-native/analytics/src/events/index.ts
@@ -49,6 +49,7 @@ export { receiveCopyAddressEvent } from './receiveCopyAddressEvent';
 export { receiveFlowEnteredEvent } from './receiveFlowEnteredEvent';
 export { receiveOpenNonFreshAddressEvent } from './receiveOpenNonFreshAddressEvent';
 export { receiveOptionsScreenEvent } from './receiveOptionsScreenEvent';
+export { receiveQRCodeActionEvent } from './receiveQRCodeActionEvent';
 export { receiveShareAddressEvent } from './receiveShareAddressEvent';
 export { receiveStartVerificationEvent } from './receiveStartVerificationEvent';
 export { referralButtonPressEvent } from './referralButtonPressEvent';

--- a/suite-native/analytics/src/events/receiveQRCodeActionEvent.ts
+++ b/suite-native/analytics/src/events/receiveQRCodeActionEvent.ts
@@ -1,0 +1,21 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+type ReceiveQRCodeAction = 'copy' | 'save' | 'share';
+
+type Attributes = {
+    action: AttributeDef<ReceiveQRCodeAction>;
+};
+
+export const receiveQRCodeActionEvent: EventDef<Attributes, EventType.ReceiveQRCodeAction> = {
+    name: EventType.ReceiveQRCodeAction,
+    descriptionTrigger: 'User copies, saves, or shares a receive address QR code image',
+    changelog: [{ version: '26.8.1', notes: 'added' }],
+    attributes: {
+        action: {
+            description: 'The QR code image action: `copy`, `save`, or `share`',
+            changelog: [{ version: '26.8.1', notes: 'added' }],
+        },
+    },
+};

--- a/suite-native/app/app.config.ts
+++ b/suite-native/app/app.config.ts
@@ -301,6 +301,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
                 NSFaceIDUsageDescription:
                     '$(PRODUCT_NAME) needs Face ID and Touch ID to keep sensitive data about your portfolio private.',
                 NSMicrophoneUsageDescription: 'This app does not require access to the microphone.',
+                NSPhotoLibraryAddUsageDescription:
+                    'Allow $(PRODUCT_NAME) to save QR code images to your photos.',
                 ITSAppUsesNonExemptEncryption: false,
                 NSAppTransportSecurity: {
                     NSAllowsArbitraryLoads: true,

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -3,6 +3,17 @@
     "version": "1.0.0",
     "suiteNativeVersion": "26.9.1",
     "main": "index.js",
+    "expo": {
+        "autolinking": {
+            "android": {
+                "exclude": [
+                    "@expo/ui",
+                    "expo-media-library",
+                    "react-native-view-shot"
+                ]
+            }
+        }
+    },
     "scripts": {
         "depcheck": "yarn g:depcheck",
         "android": "expo run:android",

--- a/suite-native/clipboard/package.json
+++ b/suite-native/clipboard/package.json
@@ -11,9 +11,12 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
+        "@expo/ui": "56.0.24",
         "@suite-native/intl": "workspace:*",
         "@suite-native/toasts": "workspace:*",
         "expo-clipboard": "~57.0.1",
-        "react": "19.2.3"
+        "expo-haptics": "~57.0.1",
+        "react": "19.2.3",
+        "react-native": "0.86.0"
     }
 }

--- a/suite-native/clipboard/src/components/ClipboardCopyMenu.ios.tsx
+++ b/suite-native/clipboard/src/components/ClipboardCopyMenu.ios.tsx
@@ -1,0 +1,65 @@
+// This is the iOS implementation selected by Metro through the `.ios` filename suffix.
+import { Button, ContextMenu, Host, RNHostView } from '@expo/ui/swift-ui';
+import * as Haptics from 'expo-haptics';
+
+import { useTranslate } from '@suite-native/intl';
+
+import type { ClipboardCopyMenuProps } from './ClipboardCopyMenu.types';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
+
+export const ClipboardCopyMenu = ({
+    value,
+    children,
+    copyMessage,
+    copyLabel,
+    menuActions,
+    additionalActions,
+    onCopy,
+    style,
+}: ClipboardCopyMenuProps) => {
+    const copyToClipboard = useCopyToClipboard();
+    const { translate } = useTranslate();
+
+    const handleCopy = () => {
+        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+        if (onCopy) {
+            void onCopy();
+
+            return;
+        }
+
+        if (value !== undefined) {
+            void copyToClipboard(value, copyMessage);
+        }
+    };
+
+    const actions = menuActions ?? [
+        {
+            label: copyLabel ?? translate('generic.buttons.copy'),
+            systemImage: 'doc.on.doc',
+            onPress: handleCopy,
+        },
+        ...(additionalActions ?? []),
+    ];
+
+    return (
+        <Host matchContents style={style}>
+            <ContextMenu>
+                <ContextMenu.Items>
+                    {actions.map(({ label, systemImage, onPress }) => (
+                        <Button
+                            key={label}
+                            label={label}
+                            systemImage={systemImage}
+                            onPress={() => void onPress()}
+                        />
+                    ))}
+                </ContextMenu.Items>
+                <ContextMenu.Trigger>
+                    <RNHostView matchContents>{children}</RNHostView>
+                </ContextMenu.Trigger>
+            </ContextMenu>
+        </Host>
+    );
+};

--- a/suite-native/clipboard/src/components/ClipboardCopyMenu.tsx
+++ b/suite-native/clipboard/src/components/ClipboardCopyMenu.tsx
@@ -1,0 +1,37 @@
+// This is the Android implementation selected by Metro as the unsuffixed fallback.
+import { Pressable } from 'react-native';
+
+import * as Haptics from 'expo-haptics';
+
+import type { ClipboardCopyMenuProps } from './ClipboardCopyMenu.types';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
+
+export const ClipboardCopyMenu = ({
+    value,
+    children,
+    copyMessage,
+    onCopy,
+    style,
+}: ClipboardCopyMenuProps) => {
+    const copyToClipboard = useCopyToClipboard();
+
+    const handleLongPress = () => {
+        void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+        if (onCopy) {
+            void onCopy();
+
+            return;
+        }
+
+        if (value !== undefined) {
+            void copyToClipboard(value, copyMessage);
+        }
+    };
+
+    return (
+        <Pressable onLongPress={handleLongPress} style={style}>
+            {children}
+        </Pressable>
+    );
+};

--- a/suite-native/clipboard/src/components/ClipboardCopyMenu.types.ts
+++ b/suite-native/clipboard/src/components/ClipboardCopyMenu.types.ts
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+import type { ButtonProps } from '@expo/ui/swift-ui';
+
+export type ClipboardCopyMenuAction = {
+    label: string;
+    systemImage?: ButtonProps['systemImage'];
+    onPress: () => void | Promise<void>;
+};
+
+export type ClipboardCopyMenuProps = {
+    value?: string;
+    children: ReactElement;
+    copyMessage?: string;
+    copyLabel?: string;
+    menuActions?: ClipboardCopyMenuAction[];
+    additionalActions?: ClipboardCopyMenuAction[];
+    onCopy?: () => void | Promise<void>;
+    style?: StyleProp<ViewStyle>;
+};

--- a/suite-native/clipboard/src/hooks/useCopyToClipboard.ts
+++ b/suite-native/clipboard/src/hooks/useCopyToClipboard.ts
@@ -5,19 +5,29 @@ import * as Clipboard from 'expo-clipboard';
 import { useTranslate } from '@suite-native/intl';
 import { useToast } from '@suite-native/toasts';
 
+type CopyToClipboardOptions = {
+    shouldShowToast?: boolean;
+};
+
 export function useCopyToClipboard() {
     const { translate } = useTranslate();
     const { showToast } = useToast();
 
     const copyToClipboard = useCallback(
-        async (value: string, toastMessage?: string) => {
+        async (
+            value: string,
+            toastMessage?: string,
+            { shouldShowToast = true }: CopyToClipboardOptions = {},
+        ) => {
             await Clipboard.setStringAsync(value);
 
-            showToast({
-                intent: 'neutral',
-                message: toastMessage ?? translate('moduleClipboard.copiedToClipboard'),
-                icon: 'copy',
-            });
+            if (shouldShowToast) {
+                showToast({
+                    intent: 'neutral',
+                    message: toastMessage ?? translate('moduleClipboard.copiedToClipboard'),
+                    icon: 'copy',
+                });
+            }
         },
         [showToast, translate],
     );

--- a/suite-native/clipboard/src/index.ts
+++ b/suite-native/clipboard/src/index.ts
@@ -1,1 +1,2 @@
+export * from './components/ClipboardCopyMenu';
 export * from './hooks/useCopyToClipboard';

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1009,6 +1009,16 @@ export const messages = {
         },
         addressActions: {
             verify: 'Verify',
+            copyAddress: 'Copy Address',
+            saveQRCodeImage: 'Save to photos',
+            shareQRCodeImage: 'Share',
+            qrCodeSavedToPhotos: 'QR code saved to photos.',
+            qrCodeCopiedToClipboard: 'QR code copied to clipboard.',
+            photoPermissionDenied: {
+                title: 'Photo access denied',
+                description: 'Enable photo access in your device settings to save QR codes.',
+                openSettings: 'Open settings',
+            },
         },
         addressCopiedBottomSheet: {
             title: 'Address copied.',

--- a/suite-native/module-receive/package.json
+++ b/suite-native/module-receive/package.json
@@ -49,10 +49,14 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/styles-native": "workspace:*",
+        "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/urls": "workspace:*",
+        "expo-clipboard": "~57.0.1",
+        "expo-media-library": "~57.0.3",
         "react": "19.2.3",
         "react-native": "0.86.0",
+        "react-native-view-shot": "5.1.0",
         "react-redux": "9.3.0"
     },
     "devDependencies": {

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
@@ -10,6 +10,7 @@ import { ReceiveAddressVerificationSource, ReceiveStackRoutes } from '@suite-nat
 import { renderWithBasicProvider, userEvent, waitFor } from '@suite-native/test-utils';
 
 import { ReceiveAddressActions } from './ReceiveAddressActions';
+import { ReceiveAddressInteractionsProvider } from './ReceiveAddressInteractionsProvider';
 
 const mockCopyToClipboard = jest.fn();
 const mockOpenCopiedAddressBottomSheet = jest.fn();
@@ -46,11 +47,13 @@ describe('ReceiveAddressActions', () => {
 
     const renderActions = () =>
         renderWithBasicProvider(
-            <ReceiveAddressActions
+            <ReceiveAddressInteractionsProvider
                 accountKey={accountKey}
                 address={address}
                 addressPath={addressPath}
-            />,
+            >
+                <ReceiveAddressActions address={address} />
+            </ReceiveAddressInteractionsProvider>,
             { services },
         );
 
@@ -78,10 +81,9 @@ describe('ReceiveAddressActions', () => {
         await userEvent.press(getByText(getTranslation('qrCode.copyButton')));
 
         await waitFor(() => {
-            expect(mockCopyToClipboard).toHaveBeenCalledWith(
-                address,
-                getTranslation('qrCode.addressCopied'),
-            );
+            expect(mockCopyToClipboard).toHaveBeenCalledWith(address, undefined, {
+                shouldShowToast: false,
+            });
             expect(mockOpenCopiedAddressBottomSheet).toHaveBeenCalledTimes(1);
             expect(mockOpenSharedAddressBottomSheet).not.toHaveBeenCalled();
             expect(mockAnalyticsReport).toHaveBeenCalledWith({

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
@@ -1,91 +1,23 @@
-import { Alert, Share } from 'react-native';
+import { Button, HStack, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
 
-import { useNavigation } from '@react-navigation/native';
-
-import { useServices } from '@suite-common/dependency-injection';
-import { type AccountKey } from '@suite-common/wallet-types';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Button, HStack, VStack, useBottomSheetModal } from '@suite-native/atoms';
-import { useCopyToClipboard } from '@suite-native/clipboard';
-import { Translation, useTranslate } from '@suite-native/intl';
-import {
-    ReceiveAddressVerificationSource,
-    type ReceiveStackParamList,
-    ReceiveStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
-
+import { useReceiveAddressInteractions } from './ReceiveAddressInteractionsProvider';
 import { ReceiveAddressVerificationBottomSheet } from './ReceiveAddressVerificationBottomSheet';
+import { useReceiveAddressSharing } from '../hooks/useReceiveAddressSharing';
 
 type ReceiveAddressActionsProps = {
-    accountKey: AccountKey;
     address: string;
-    addressPath: string;
 };
 
-type NavigationProp = StackNavigationProps<ReceiveStackParamList, ReceiveStackRoutes>;
-
-export const ReceiveAddressActions = ({
-    accountKey,
-    address,
-    addressPath,
-}: ReceiveAddressActionsProps) => {
-    const { analytics } = useServices(selectNativeAnalyticsDep);
-    const copyToClipboard = useCopyToClipboard();
-    const navigation = useNavigation<NavigationProp>();
-    const { translate } = useTranslate();
+export const ReceiveAddressActions = ({ address }: ReceiveAddressActionsProps) => {
+    const { handleCopyAddress, handleVerifyAddress } = useReceiveAddressInteractions();
     const {
-        bottomSheetRef: copiedAddressBottomSheetRef,
-        openModal: openCopiedAddressBottomSheet,
-        closeModal: closeCopiedAddressBottomSheet,
-    } = useBottomSheetModal();
-    const {
-        bottomSheetRef: sharedAddressBottomSheetRef,
-        openModal: openSharedAddressBottomSheet,
-        closeModal: closeSharedAddressBottomSheet,
-    } = useBottomSheetModal();
-
-    const handleCopyAddress = async () => {
-        await copyToClipboard(address, translate('qrCode.addressCopied'));
-        analytics.report({ type: events.receiveCopyAddressEvent.name });
-        openCopiedAddressBottomSheet();
-    };
-
-    const handleVerifyAddress = (source: ReceiveAddressVerificationSource) => {
-        analytics.report({ type: events.receiveStartVerificationEvent.name });
-        navigation.navigate(ReceiveStackRoutes.ReceiveAddressVerification, {
-            accountKey,
-            addressPath,
-            source,
-        });
-    };
-
-    const handleVerifyCopiedAddress = () => {
-        closeCopiedAddressBottomSheet();
-        handleVerifyAddress(ReceiveAddressVerificationSource.Pasted);
-    };
-
-    const handleVerifySharedAddress = () => {
-        closeSharedAddressBottomSheet();
-        handleVerifyAddress(ReceiveAddressVerificationSource.Shared);
-    };
-
-    const handleShareData = async () => {
-        try {
-            const { action } = await Share.share({
-                message: address,
-            });
-
-            if (action === Share.dismissedAction) {
-                return;
-            }
-
-            analytics.report({ type: events.receiveShareAddressEvent.name });
-            openSharedAddressBottomSheet();
-        } catch (error) {
-            Alert.alert('Something went wrong.', error.message);
-        }
-    };
+        sharedAddressBottomSheetRef,
+        closeSharedAddressBottomSheet,
+        handleShareAddress,
+        handleVerifySharedAddress,
+    } = useReceiveAddressSharing({ address, onVerifyAddress: handleVerifyAddress });
 
     return (
         <>
@@ -98,7 +30,7 @@ export const ReceiveAddressActions = ({
                         iconLeft="shareNetwork"
                         intent="neutral"
                         priority="secondary"
-                        onPress={handleShareData}
+                        onPress={handleShareAddress}
                         flex={1}
                     >
                         <Translation id="qrCode.shareButton" />
@@ -116,12 +48,6 @@ export const ReceiveAddressActions = ({
                     </Button>
                 </HStack>
             </VStack>
-            <ReceiveAddressVerificationBottomSheet
-                ref={copiedAddressBottomSheetRef}
-                source={ReceiveAddressVerificationSource.Pasted}
-                onVerifyAddress={handleVerifyCopiedAddress}
-                onSkipVerification={closeCopiedAddressBottomSheet}
-            />
             <ReceiveAddressVerificationBottomSheet
                 ref={sharedAddressBottomSheetRef}
                 source={ReceiveAddressVerificationSource.Shared}

--- a/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
@@ -12,6 +12,7 @@ import { type CloseActionType, Screen } from '@suite-native/navigation';
 
 import { ReceiveAddressActions } from './ReceiveAddressActions';
 import { ReceiveAddressCard } from './ReceiveAddressCard';
+import { ReceiveAddressInteractionsProvider } from './ReceiveAddressInteractionsProvider';
 import { ReceiveAddressLoader } from './ReceiveAddressLoader';
 import { ReceiveDestinationTagInfo } from './ReceiveDestinationTagInfo';
 import { ReceiveFreshAddressHeader } from './ReceiveFreshAddressHeader';
@@ -68,36 +69,41 @@ export const ReceiveAddressContent = ({
     }
 
     return (
-        <Screen
-            header={
-                <ReceiveFreshAddressHeader
-                    accountKey={accountKey}
-                    tokenContract={tokenContract}
-                    closeActionType={closeActionType}
-                />
-            }
-            footer={
-                <>
-                    <ScreenFooterGradient />
-                    <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
-                        <ReceiveAddressActions
-                            accountKey={accountKey}
-                            address={currentFreshAddress.address}
-                            addressPath={currentFreshAddress.path}
-                        />
-                    </VStack>
-                </>
-            }
-            noBottomPadding
+        <ReceiveAddressInteractionsProvider
+            accountKey={accountKey}
+            address={currentFreshAddress.address}
+            addressPath={currentFreshAddress.path}
         >
-            <VStack marginTop="sp8" spacing="sp16" flex={1}>
-                <ReceiveAddressCard
-                    accountKey={accountKey}
-                    address={currentFreshAddress.address}
-                    tokenContract={tokenContract}
-                />
-                <ReceiveDestinationTagInfo accountKey={accountKey} tokenContract={tokenContract} />
-            </VStack>
-        </Screen>
+            <Screen
+                header={
+                    <ReceiveFreshAddressHeader
+                        accountKey={accountKey}
+                        tokenContract={tokenContract}
+                        closeActionType={closeActionType}
+                    />
+                }
+                footer={
+                    <>
+                        <ScreenFooterGradient />
+                        <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
+                            <ReceiveAddressActions address={currentFreshAddress.address} />
+                        </VStack>
+                    </>
+                }
+                noBottomPadding
+            >
+                <VStack marginTop="sp8" spacing="sp16" flex={1}>
+                    <ReceiveAddressCard
+                        accountKey={accountKey}
+                        address={currentFreshAddress.address}
+                        tokenContract={tokenContract}
+                    />
+                    <ReceiveDestinationTagInfo
+                        accountKey={accountKey}
+                        tokenContract={tokenContract}
+                    />
+                </VStack>
+            </Screen>
+        </ReceiveAddressInteractionsProvider>
     );
 };

--- a/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressDetails.tsx
@@ -1,16 +1,17 @@
-import { Pressable, useWindowDimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 
 import type { NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountDescriptor, type TokenAddress } from '@suite-common/wallet-types';
 import { AddressLabelEditable } from '@suite-native/address';
-import { Card, VStack } from '@suite-native/atoms';
-import { useCopyToClipboard } from '@suite-native/clipboard';
+import { Box, VStack } from '@suite-native/atoms';
+import { ClipboardCopyMenu } from '@suite-native/clipboard';
 import { AddressFormatter } from '@suite-native/formatters';
-import { TokenIcon } from '@suite-native/icons';
-import { useTranslate } from '@suite-native/intl';
-import { QRCode } from '@suite-native/qr-code';
 import type { StaticSessionId } from '@trezor/connect';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+import { useReceiveAddressInteractions } from './ReceiveAddressInteractionsProvider';
+import { ReceiveQRCodeCard } from './ReceiveQRCodeCard';
+import { RECEIVE_QR_CODE_PADDING } from './ReceiveQRCodeCard.styles';
 
 type ReceiveAddressDetailsProps = {
     address: string;
@@ -26,11 +27,6 @@ const addressContainer = prepareNativeStyle(() => ({
     alignItems: 'center',
 }));
 
-const cardStyle = prepareNativeStyle(utils => ({
-    marginHorizontal: utils.spacings.sp8,
-    marginTop: utils.spacings.sp8,
-}));
-
 const MAX_RECEIVE_QR_CODE_SIZE = 310;
 
 export const ReceiveAddressDetails = ({
@@ -41,45 +37,30 @@ export const ReceiveAddressDetails = ({
     tokenContract,
     showLabelEdit = true,
 }: ReceiveAddressDetailsProps) => {
-    const copyToClipboard = useCopyToClipboard();
-    const { translate } = useTranslate();
     const {
         applyStyle,
         utils: { spacings },
     } = useNativeStyles();
     const { width: windowWidth } = useWindowDimensions();
+    const { handleCopyAddress } = useReceiveAddressInteractions();
 
     const screenHorizontalPadding = spacings.sp16 * 2;
     const cardHorizontalMargin = spacings.sp8 * 2;
-    const qrCodeHorizontalPadding = spacings.sp16 * 2;
-    const horizontalOffset =
-        screenHorizontalPadding + cardHorizontalMargin + qrCodeHorizontalPadding;
+    const qrCodePadding = spacings[RECEIVE_QR_CODE_PADDING] * 2;
+    const horizontalOffset = screenHorizontalPadding + cardHorizontalMargin + qrCodePadding;
     const qrCodeSize = Math.min(MAX_RECEIVE_QR_CODE_SIZE, windowWidth - horizontalOffset);
-
-    const handleCopyAddress = async () => {
-        await copyToClipboard(address, translate('qrCode.addressCopied'));
-    };
 
     return (
         <VStack spacing="sp24" flex={1}>
-            <Pressable onLongPress={handleCopyAddress}>
-                <Card noPadding style={applyStyle(cardStyle)}>
-                    <QRCode
-                        data={address}
-                        qrCodeSize={qrCodeSize}
-                        paddingHorizontal="sp16"
-                        paddingVertical="sp16"
-                        centerIcon={
-                            <TokenIcon
-                                symbol={networkSymbol}
-                                contractAddress={tokenContract}
-                                showNetworkIcon={tokenContract !== undefined}
-                                size="large"
-                            />
-                        }
-                    />
-                </Card>
-            </Pressable>
+            <Box marginHorizontal="sp8" marginTop="sp8">
+                <ReceiveQRCodeCard
+                    address={address}
+                    networkSymbol={networkSymbol}
+                    tokenContract={tokenContract}
+                    qrCodeSize={qrCodeSize}
+                    onCopyAddress={handleCopyAddress}
+                />
+            </Box>
             <VStack spacing="sp8" alignItems="center" justifyContent="center" flex={1}>
                 {showLabelEdit && (
                     <AddressLabelEditable
@@ -90,7 +71,7 @@ export const ReceiveAddressDetails = ({
                         testID="@receive/address-label"
                     />
                 )}
-                <Pressable onLongPress={handleCopyAddress} style={applyStyle(addressContainer)}>
+                <ClipboardCopyMenu onCopy={handleCopyAddress} style={applyStyle(addressContainer)}>
                     <AddressFormatter
                         value={address}
                         format="long"
@@ -98,7 +79,7 @@ export const ReceiveAddressDetails = ({
                         textAlign="center"
                         testID="@receive/confirmed-receive-address"
                     />
-                </Pressable>
+                </ClipboardCopyMenu>
             </VStack>
         </VStack>
     );

--- a/suite-native/module-receive/src/components/ReceiveAddressInteractionsProvider.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressInteractionsProvider.tsx
@@ -1,0 +1,87 @@
+import { type ReactNode, createContext, useContext } from 'react';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { useServices } from '@suite-common/dependency-injection';
+import type { AccountKey } from '@suite-common/wallet-types';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import {
+    ReceiveAddressVerificationSource,
+    type ReceiveStackParamList,
+    ReceiveStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+
+import { ReceiveAddressVerificationBottomSheet } from './ReceiveAddressVerificationBottomSheet';
+import { useReceiveAddressCopy } from '../hooks/useReceiveAddressCopy';
+
+type ReceiveAddressInteractionsContextValue = {
+    handleCopyAddress: () => Promise<void>;
+    handleVerifyAddress: (source: ReceiveAddressVerificationSource) => void;
+};
+
+const ReceiveAddressInteractionsContext = createContext<
+    ReceiveAddressInteractionsContextValue | undefined
+>(undefined);
+
+type ReceiveAddressInteractionsProviderProps = {
+    accountKey: AccountKey;
+    address: string;
+    addressPath: string;
+    children: ReactNode;
+};
+
+type NavigationProp = StackNavigationProps<ReceiveStackParamList, ReceiveStackRoutes>;
+
+export const ReceiveAddressInteractionsProvider = ({
+    accountKey,
+    address,
+    addressPath,
+    children,
+}: ReceiveAddressInteractionsProviderProps) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+
+    const navigation = useNavigation<NavigationProp>();
+
+    const handleVerifyAddress = (source: ReceiveAddressVerificationSource) => {
+        analytics.report({ type: events.receiveStartVerificationEvent.name });
+        navigation.navigate(ReceiveStackRoutes.ReceiveAddressVerification, {
+            accountKey,
+            addressPath,
+            source,
+        });
+    };
+
+    const {
+        copiedAddressBottomSheetRef,
+        closeCopiedAddressBottomSheet,
+        handleCopyAddress,
+        handleVerifyCopiedAddress,
+    } = useReceiveAddressCopy({ address, onVerifyAddress: handleVerifyAddress });
+
+    const contextValue = { handleCopyAddress, handleVerifyAddress };
+
+    return (
+        <ReceiveAddressInteractionsContext.Provider value={contextValue}>
+            {children}
+            <ReceiveAddressVerificationBottomSheet
+                ref={copiedAddressBottomSheetRef}
+                source={ReceiveAddressVerificationSource.Pasted}
+                onVerifyAddress={handleVerifyCopiedAddress}
+                onSkipVerification={closeCopiedAddressBottomSheet}
+            />
+        </ReceiveAddressInteractionsContext.Provider>
+    );
+};
+
+export const useReceiveAddressInteractions = () => {
+    const context = useContext(ReceiveAddressInteractionsContext);
+
+    if (context === undefined) {
+        throw new Error(
+            'useReceiveAddressInteractions must be used within ReceiveAddressInteractionsProvider',
+        );
+    }
+
+    return context;
+};

--- a/suite-native/module-receive/src/components/ReceiveQRCodeCard.ios.tsx
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeCard.ios.tsx
@@ -1,0 +1,71 @@
+// This is the iOS implementation selected by Metro through the `.ios` filename suffix.
+import ViewShot from 'react-native-view-shot';
+
+import { Card } from '@suite-native/atoms';
+import { ClipboardCopyMenu } from '@suite-native/clipboard';
+import { useTranslate } from '@suite-native/intl';
+import { useNativeStyles } from '@trezor/styles-native';
+
+import {
+    RECEIVE_QR_CODE_PADDING,
+    receiveQRCodeCardStyle,
+    receiveQRCodeContainerStyle,
+} from './ReceiveQRCodeCard.styles';
+import type { ReceiveQRCodeCardProps } from './ReceiveQRCodeCard.types';
+import { ReceiveQRCodeContent } from './ReceiveQRCodeContent';
+import { useReceiveQRCodeActions } from '../hooks/useReceiveQRCodeActions.ios';
+
+export const ReceiveQRCodeCard = ({
+    onCopyAddress,
+    ...qrCodeContentProps
+}: ReceiveQRCodeCardProps) => {
+    const {
+        applyStyle,
+        utils: { spacings },
+    } = useNativeStyles();
+    const { translate } = useTranslate();
+    const { qrCodeViewRef, handleCopyQRCode, handleSaveQRCode, handleShareQRCode } =
+        useReceiveQRCodeActions();
+    const qrCodePadding = spacings[RECEIVE_QR_CODE_PADDING] * 2;
+
+    return (
+        <ClipboardCopyMenu
+            menuActions={[
+                {
+                    label: translate('moduleReceive.addressActions.shareQRCodeImage'),
+                    systemImage: 'square.and.arrow.up',
+                    onPress: handleShareQRCode,
+                },
+                {
+                    label: translate('moduleReceive.addressActions.saveQRCodeImage'),
+                    systemImage: 'square.and.arrow.down',
+                    onPress: handleSaveQRCode,
+                },
+                {
+                    label: translate('generic.buttons.copy'),
+                    systemImage: 'qrcode',
+                    onPress: handleCopyQRCode,
+                },
+                {
+                    label: translate('moduleReceive.addressActions.copyAddress'),
+                    systemImage: 'doc.on.doc',
+                    onPress: onCopyAddress,
+                },
+            ]}
+        >
+            <Card noPadding noShadow style={applyStyle(receiveQRCodeCardStyle)}>
+                <ViewShot
+                    ref={qrCodeViewRef}
+                    options={{ fileName: 'trezor-receive-address-qr', format: 'png' }}
+                    style={applyStyle(receiveQRCodeContainerStyle, {
+                        qrCodeSize: qrCodeContentProps.qrCodeSize,
+                        paddingHorizontal: qrCodePadding,
+                        paddingVertical: qrCodePadding,
+                    })}
+                >
+                    <ReceiveQRCodeContent {...qrCodeContentProps} />
+                </ViewShot>
+            </Card>
+        </ClipboardCopyMenu>
+    );
+};

--- a/suite-native/module-receive/src/components/ReceiveQRCodeCard.styles.ts
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeCard.styles.ts
@@ -1,0 +1,18 @@
+import { prepareNativeStyle } from '@trezor/styles-native';
+import type { NativeSpacing } from '@trezor/theme';
+
+export const RECEIVE_QR_CODE_PADDING = 'sp16' satisfies NativeSpacing;
+
+export const receiveQRCodeCardStyle = prepareNativeStyle(() => ({
+    overflow: 'hidden',
+}));
+
+export const receiveQRCodeContainerStyle = prepareNativeStyle<{
+    qrCodeSize: number;
+    paddingHorizontal: number;
+    paddingVertical: number;
+}>((utils, { qrCodeSize, paddingHorizontal, paddingVertical }) => ({
+    width: qrCodeSize + paddingHorizontal,
+    height: qrCodeSize + paddingVertical,
+    backgroundColor: utils.colors.surfaceFillRaised,
+}));

--- a/suite-native/module-receive/src/components/ReceiveQRCodeCard.tsx
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeCard.tsx
@@ -1,0 +1,39 @@
+// This is the Android implementation selected by Metro as the unsuffixed fallback.
+import { Box, Card } from '@suite-native/atoms';
+import { ClipboardCopyMenu } from '@suite-native/clipboard';
+import { useNativeStyles } from '@trezor/styles-native';
+
+import {
+    RECEIVE_QR_CODE_PADDING,
+    receiveQRCodeCardStyle,
+    receiveQRCodeContainerStyle,
+} from './ReceiveQRCodeCard.styles';
+import type { ReceiveQRCodeCardProps } from './ReceiveQRCodeCard.types';
+import { ReceiveQRCodeContent } from './ReceiveQRCodeContent';
+
+export const ReceiveQRCodeCard = ({
+    onCopyAddress,
+    ...qrCodeContentProps
+}: ReceiveQRCodeCardProps) => {
+    const {
+        applyStyle,
+        utils: { spacings },
+    } = useNativeStyles();
+    const qrCodePadding = spacings[RECEIVE_QR_CODE_PADDING] * 2;
+
+    return (
+        <ClipboardCopyMenu onCopy={onCopyAddress}>
+            <Card noPadding noShadow style={applyStyle(receiveQRCodeCardStyle)}>
+                <Box
+                    style={applyStyle(receiveQRCodeContainerStyle, {
+                        qrCodeSize: qrCodeContentProps.qrCodeSize,
+                        paddingHorizontal: qrCodePadding,
+                        paddingVertical: qrCodePadding,
+                    })}
+                >
+                    <ReceiveQRCodeContent {...qrCodeContentProps} />
+                </Box>
+            </Card>
+        </ClipboardCopyMenu>
+    );
+};

--- a/suite-native/module-receive/src/components/ReceiveQRCodeCard.types.ts
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeCard.types.ts
@@ -1,0 +1,12 @@
+import type { NetworkSymbol } from '@suite-common/wallet-config';
+import type { TokenAddress } from '@suite-common/wallet-types';
+
+export type ReceiveQRCodeCardProps = {
+    address: string;
+    networkSymbol: NetworkSymbol;
+    tokenContract?: TokenAddress;
+    qrCodeSize: number;
+    onCopyAddress: () => Promise<void>;
+};
+
+export type ReceiveQRCodeContentProps = Omit<ReceiveQRCodeCardProps, 'onCopyAddress'>;

--- a/suite-native/module-receive/src/components/ReceiveQRCodeContent.tsx
+++ b/suite-native/module-receive/src/components/ReceiveQRCodeContent.tsx
@@ -1,0 +1,27 @@
+import { TokenIcon } from '@suite-native/icons';
+import { QRCode } from '@suite-native/qr-code';
+
+import { RECEIVE_QR_CODE_PADDING } from './ReceiveQRCodeCard.styles';
+import type { ReceiveQRCodeContentProps } from './ReceiveQRCodeCard.types';
+
+export const ReceiveQRCodeContent = ({
+    address,
+    networkSymbol,
+    tokenContract,
+    qrCodeSize,
+}: ReceiveQRCodeContentProps) => (
+    <QRCode
+        data={address}
+        qrCodeSize={qrCodeSize}
+        paddingHorizontal={RECEIVE_QR_CODE_PADDING}
+        paddingVertical={RECEIVE_QR_CODE_PADDING}
+        centerIcon={
+            <TokenIcon
+                symbol={networkSymbol}
+                contractAddress={tokenContract}
+                showNetworkIcon={tokenContract !== undefined}
+                size="large"
+            />
+        }
+    />
+);

--- a/suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useBottomSheetModal } from '@suite-native/atoms';
+import { useCopyToClipboard } from '@suite-native/clipboard';
+import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
+
+type UseReceiveAddressCopyParams = {
+    address: string;
+    onVerifyAddress: (source: ReceiveAddressVerificationSource) => void;
+};
+
+export const useReceiveAddressCopy = ({
+    address,
+    onVerifyAddress,
+}: UseReceiveAddressCopyParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const copyToClipboard = useCopyToClipboard();
+    const {
+        bottomSheetRef: copiedAddressBottomSheetRef,
+        openModal: openCopiedAddressBottomSheet,
+        closeModal: closeCopiedAddressBottomSheet,
+    } = useBottomSheetModal();
+
+    const handleCopyAddress = useCallback(async () => {
+        await copyToClipboard(address, undefined, { shouldShowToast: false });
+        analytics.report({ type: events.receiveCopyAddressEvent.name });
+        openCopiedAddressBottomSheet();
+    }, [address, analytics, copyToClipboard, openCopiedAddressBottomSheet]);
+
+    const handleVerifyCopiedAddress = useCallback(() => {
+        closeCopiedAddressBottomSheet();
+        onVerifyAddress(ReceiveAddressVerificationSource.Pasted);
+    }, [closeCopiedAddressBottomSheet, onVerifyAddress]);
+
+    return {
+        copiedAddressBottomSheetRef,
+        closeCopiedAddressBottomSheet,
+        handleCopyAddress,
+        handleVerifyCopiedAddress,
+    };
+};

--- a/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressSharing.test.ts
@@ -1,0 +1,101 @@
+import { Share } from 'react-native';
+
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
+import { act, renderHookWithBasicProvider, waitFor } from '@suite-native/test-utils';
+
+import { useReceiveAddressSharing } from './useReceiveAddressSharing';
+
+const mockOpenSharedAddressBottomSheet = jest.fn();
+const mockCloseSharedAddressBottomSheet = jest.fn();
+const mockVerifyAddress = jest.fn();
+const mockShare = jest.spyOn(Share, 'share');
+const mockUseBottomSheetModal = jest.fn();
+const mockAnalyticsReport = jest.fn();
+const mockShowAlert = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(mockAnalyticsReport),
+};
+
+jest.mock('@suite-native/atoms', () => ({
+    ...jest.requireActual('@suite-native/atoms'),
+    useBottomSheetModal: () => mockUseBottomSheetModal(),
+}));
+
+jest.mock('@suite-native/alerts', () => ({
+    useAlert: () => ({ showAlert: mockShowAlert }),
+}));
+
+describe('useReceiveAddressSharing', () => {
+    const address = 'bc1qreceiveaddress';
+
+    const renderUseReceiveAddressSharing = () =>
+        renderHookWithBasicProvider(
+            () =>
+                useReceiveAddressSharing({
+                    address,
+                    onVerifyAddress: mockVerifyAddress,
+                }),
+            { services },
+        );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockShare.mockResolvedValue({ action: Share.sharedAction });
+        mockUseBottomSheetModal.mockReturnValue({
+            bottomSheetRef: { current: null },
+            openModal: mockOpenSharedAddressBottomSheet,
+            closeModal: mockCloseSharedAddressBottomSheet,
+        });
+    });
+
+    it('opens shared address verification after sharing the address', async () => {
+        const { result } = renderUseReceiveAddressSharing();
+
+        await act(() => result.current.handleShareAddress());
+
+        expect(mockShare).toHaveBeenCalledWith({ message: address });
+        expect(mockOpenSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.receiveShareAddressEvent.name,
+        });
+    });
+
+    it('does not open shared address verification after cancelling sharing', async () => {
+        mockShare.mockResolvedValue({ action: Share.dismissedAction });
+        const { result } = renderUseReceiveAddressSharing();
+
+        await act(() => result.current.handleShareAddress());
+
+        expect(mockShare).toHaveBeenCalledWith({ message: address });
+        expect(mockOpenSharedAddressBottomSheet).not.toHaveBeenCalled();
+        expect(mockAnalyticsReport).not.toHaveBeenCalled();
+    });
+
+    it('starts shared address verification from the bottom sheet', () => {
+        const { result } = renderUseReceiveAddressSharing();
+
+        act(() => result.current.handleVerifySharedAddress());
+
+        expect(mockCloseSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
+        expect(mockVerifyAddress).toHaveBeenCalledWith(ReceiveAddressVerificationSource.Shared);
+    });
+
+    it('shows an error when sharing the address fails', async () => {
+        mockShare.mockRejectedValue(new Error('Sharing failed'));
+        const { result } = renderUseReceiveAddressSharing();
+
+        await act(() => result.current.handleShareAddress());
+
+        await waitFor(() => {
+            expect(mockShowAlert).toHaveBeenCalledWith({
+                title: 'Something went wrong',
+                pictogramVariant: 'critical',
+                primaryButtonTitle: 'Close',
+            });
+        });
+        expect(mockOpenSharedAddressBottomSheet).not.toHaveBeenCalled();
+        expect(mockAnalyticsReport).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-receive/src/hooks/useReceiveAddressSharing.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressSharing.ts
@@ -1,0 +1,59 @@
+import { useCallback } from 'react';
+import { Share } from 'react-native';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { useAlert } from '@suite-native/alerts';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useBottomSheetModal } from '@suite-native/atoms';
+import { useTranslate } from '@suite-native/intl';
+import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
+
+type UseReceiveAddressSharingParams = {
+    address: string;
+    onVerifyAddress: (source: ReceiveAddressVerificationSource) => void;
+};
+
+export const useReceiveAddressSharing = ({
+    address,
+    onVerifyAddress,
+}: UseReceiveAddressSharingParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const {
+        bottomSheetRef: sharedAddressBottomSheetRef,
+        openModal: openSharedAddressBottomSheet,
+        closeModal: closeSharedAddressBottomSheet,
+    } = useBottomSheetModal();
+    const { translate } = useTranslate();
+    const { showAlert } = useAlert();
+
+    const handleVerifySharedAddress = useCallback(() => {
+        closeSharedAddressBottomSheet();
+        onVerifyAddress(ReceiveAddressVerificationSource.Shared);
+    }, [closeSharedAddressBottomSheet, onVerifyAddress]);
+
+    const handleShareAddress = useCallback(async () => {
+        try {
+            const { action } = await Share.share({ message: address });
+
+            if (action === Share.dismissedAction) {
+                return;
+            }
+
+            analytics.report({ type: events.receiveShareAddressEvent.name });
+            openSharedAddressBottomSheet();
+        } catch {
+            showAlert({
+                title: translate('generic.unknownError'),
+                pictogramVariant: 'critical',
+                primaryButtonTitle: translate('generic.buttons.close'),
+            });
+        }
+    }, [address, analytics, openSharedAddressBottomSheet, showAlert, translate]);
+
+    return {
+        sharedAddressBottomSheetRef,
+        closeSharedAddressBottomSheet,
+        handleShareAddress,
+        handleVerifySharedAddress,
+    };
+};

--- a/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.test.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.test.ts
@@ -1,0 +1,177 @@
+// This is the iOS test selected through the `.ios` filename suffix.
+import { Linking, Share } from 'react-native';
+import { type ViewShotRef } from 'react-native-view-shot';
+
+import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { getTranslation } from '@suite-native/intl';
+import { act, renderHookWithBasicProvider, waitFor } from '@suite-native/test-utils';
+
+import { useReceiveQRCodeActions } from './useReceiveQRCodeActions.ios';
+
+const mockShare = jest.spyOn(Share, 'share');
+const mockOpenSettings = jest.spyOn(Linking, 'openSettings');
+const mockCaptureRef = jest.fn();
+const mockSetImageAsync = jest.fn();
+const mockRequestPermissionsAsync = jest.fn();
+const mockSaveToLibraryAsync = jest.fn();
+const mockAnalyticsReport = jest.fn();
+const mockShowToast = jest.fn();
+const mockShowAlert = jest.fn();
+const services: NativeAnalyticsDep = {
+    analytics: mockNativeAnalytics(mockAnalyticsReport),
+};
+
+jest.mock('react-native-view-shot', () => ({
+    captureRef: (...args: unknown[]) => mockCaptureRef(...args),
+}));
+
+jest.mock('expo-clipboard', () => ({
+    setImageAsync: (...args: unknown[]) => mockSetImageAsync(...args),
+}));
+
+jest.mock('expo-media-library/legacy', () => ({
+    requestPermissionsAsync: (...args: unknown[]) => mockRequestPermissionsAsync(...args),
+    saveToLibraryAsync: (...args: unknown[]) => mockSaveToLibraryAsync(...args),
+}));
+
+jest.mock('@suite-native/toasts', () => ({
+    useToast: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('@suite-native/alerts', () => ({
+    useAlert: () => ({ showAlert: mockShowAlert }),
+}));
+
+describe('useReceiveQRCodeActions', () => {
+    const qrCodeView = {} as ViewShotRef;
+
+    const renderUseReceiveQRCodeActions = () =>
+        renderHookWithBasicProvider(() => useReceiveQRCodeActions(), { services });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockShare.mockResolvedValue({ action: Share.sharedAction });
+        mockOpenSettings.mockResolvedValue();
+        mockCaptureRef.mockResolvedValue('/cache/trezor-receive-address-qr.png');
+        mockSetImageAsync.mockResolvedValue(undefined);
+        mockRequestPermissionsAsync.mockResolvedValue({ granted: true });
+        mockSaveToLibraryAsync.mockResolvedValue(undefined);
+    });
+
+    it('shares the QR code image', async () => {
+        const { result } = renderUseReceiveQRCodeActions();
+        result.current.qrCodeViewRef.current = qrCodeView;
+
+        await act(() => result.current.handleShareQRCode());
+
+        expect(mockCaptureRef).toHaveBeenCalledWith(qrCodeView, {
+            fileName: 'trezor-receive-address-qr',
+            format: 'png',
+            result: 'tmpfile',
+        });
+        expect(mockShare).toHaveBeenCalledWith({
+            url: 'file:///cache/trezor-receive-address-qr.png',
+            title: getTranslation('moduleReceive.addressActions.shareQRCodeImage'),
+        });
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.receiveQRCodeActionEvent.name,
+            payload: { action: 'share' },
+        });
+    });
+
+    it('copies the QR code image', async () => {
+        mockCaptureRef.mockResolvedValue('base64-image');
+        const { result } = renderUseReceiveQRCodeActions();
+        result.current.qrCodeViewRef.current = qrCodeView;
+
+        await act(() => result.current.handleCopyQRCode());
+
+        expect(mockCaptureRef).toHaveBeenCalledWith(qrCodeView, {
+            format: 'png',
+            result: 'base64',
+        });
+        expect(mockSetImageAsync).toHaveBeenCalledWith('base64-image');
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.receiveQRCodeActionEvent.name,
+            payload: { action: 'copy' },
+        });
+        expect(mockShowToast).toHaveBeenCalledWith({
+            icon: 'check',
+            intent: 'neutral',
+            message: getTranslation('moduleReceive.addressActions.qrCodeCopiedToClipboard'),
+        });
+    });
+
+    it('saves the QR code image', async () => {
+        const { result } = renderUseReceiveQRCodeActions();
+        result.current.qrCodeViewRef.current = qrCodeView;
+
+        await act(() => result.current.handleSaveQRCode());
+
+        expect(mockRequestPermissionsAsync).toHaveBeenCalledWith(true);
+        expect(mockCaptureRef).toHaveBeenCalledWith(qrCodeView, {
+            fileName: 'trezor-receive-address-qr',
+            format: 'png',
+            result: 'tmpfile',
+        });
+        expect(mockSaveToLibraryAsync).toHaveBeenCalledWith(
+            'file:///cache/trezor-receive-address-qr.png',
+        );
+        expect(mockAnalyticsReport).toHaveBeenCalledWith({
+            type: events.receiveQRCodeActionEvent.name,
+            payload: { action: 'save' },
+        });
+        expect(mockShowToast).toHaveBeenCalledWith({
+            icon: 'check',
+            intent: 'neutral',
+            message: getTranslation('moduleReceive.addressActions.qrCodeSavedToPhotos'),
+        });
+    });
+
+    it('does not save the QR code image when media library permission is denied', async () => {
+        mockRequestPermissionsAsync.mockResolvedValue({ granted: false });
+        const { result } = renderUseReceiveQRCodeActions();
+        result.current.qrCodeViewRef.current = qrCodeView;
+
+        await act(() => result.current.handleSaveQRCode());
+
+        expect(mockRequestPermissionsAsync).toHaveBeenCalledWith(true);
+        expect(mockCaptureRef).not.toHaveBeenCalled();
+        expect(mockSaveToLibraryAsync).not.toHaveBeenCalled();
+        expect(mockAnalyticsReport).not.toHaveBeenCalled();
+        expect(mockShowToast).not.toHaveBeenCalled();
+        expect(mockShowAlert).toHaveBeenCalledWith({
+            title: getTranslation('moduleReceive.addressActions.photoPermissionDenied.title'),
+            description: getTranslation(
+                'moduleReceive.addressActions.photoPermissionDenied.description',
+            ),
+            pictogramVariant: 'warning',
+            primaryButtonTitle: getTranslation(
+                'moduleReceive.addressActions.photoPermissionDenied.openSettings',
+            ),
+            onPressPrimaryButton: expect.any(Function),
+            secondaryButtonTitle: getTranslation('generic.buttons.cancel'),
+        });
+
+        const openSettingsAction = mockShowAlert.mock.calls[0]?.[0]?.onPressPrimaryButton;
+        openSettingsAction?.();
+
+        expect(mockOpenSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows an error when the QR code is not available', async () => {
+        const { result } = renderUseReceiveQRCodeActions();
+
+        await act(() => result.current.handleShareQRCode());
+
+        await waitFor(() => {
+            expect(mockShowAlert).toHaveBeenCalledWith({
+                title: 'Something went wrong',
+                pictogramVariant: 'critical',
+                primaryButtonTitle: 'Close',
+            });
+        });
+        expect(mockShare).not.toHaveBeenCalled();
+    });
+});

--- a/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.ts
+++ b/suite-native/module-receive/src/hooks/useReceiveQRCodeActions.ios.ts
@@ -1,0 +1,158 @@
+// This is the iOS implementation selected by Metro through the `.ios` filename suffix.
+import { useCallback, useRef } from 'react';
+import { Linking, Share } from 'react-native';
+import { type ViewShotRef, captureRef } from 'react-native-view-shot';
+
+import * as Clipboard from 'expo-clipboard';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { useAlert } from '@suite-native/alerts';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useTranslate } from '@suite-native/intl';
+import { useToast } from '@suite-native/toasts';
+import { exhaustive } from '@trezor/type-utils';
+
+import { saveQRCodeImageToPhotos } from '../utils/saveQRCodeImageToPhotos.ios';
+
+const getShareableFileURI = (uri: string): string =>
+    uri.startsWith('file://') ? uri : `file://${uri}`;
+
+const captureQRCodeImageURI = (qrCodeView: ViewShotRef): Promise<string> =>
+    captureRef(qrCodeView, {
+        fileName: 'trezor-receive-address-qr',
+        format: 'png',
+        result: 'tmpfile',
+    });
+
+const captureQRCodeImageBase64 = (qrCodeView: ViewShotRef): Promise<string> =>
+    captureRef(qrCodeView, {
+        format: 'png',
+        result: 'base64',
+    });
+
+export const useReceiveQRCodeActions = () => {
+    const qrCodeViewRef = useRef<ViewShotRef>(null);
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const { translate } = useTranslate();
+    const { showToast } = useToast();
+    const { showAlert } = useAlert();
+
+    const showGenericErrorAlert = useCallback(() => {
+        showAlert({
+            title: translate('generic.unknownError'),
+            pictogramVariant: 'critical',
+            primaryButtonTitle: translate('generic.buttons.close'),
+        });
+    }, [showAlert, translate]);
+
+    const handleShareQRCode = useCallback(async () => {
+        if (qrCodeViewRef.current === null) {
+            showGenericErrorAlert();
+
+            return;
+        }
+
+        try {
+            const qrCodeImageURI = await captureQRCodeImageURI(qrCodeViewRef.current);
+
+            const { action } = await Share.share({
+                url: getShareableFileURI(qrCodeImageURI),
+                title: translate('moduleReceive.addressActions.shareQRCodeImage'),
+            });
+
+            if (action === Share.dismissedAction) {
+                return;
+            }
+
+            analytics.report({
+                type: events.receiveQRCodeActionEvent.name,
+                payload: { action: 'share' },
+            });
+        } catch {
+            showGenericErrorAlert();
+        }
+    }, [analytics, showGenericErrorAlert, translate]);
+
+    const handleCopyQRCode = useCallback(async () => {
+        if (qrCodeViewRef.current === null) {
+            showGenericErrorAlert();
+
+            return;
+        }
+
+        try {
+            const qrCodeImageBase64 = await captureQRCodeImageBase64(qrCodeViewRef.current);
+            await Clipboard.setImageAsync(qrCodeImageBase64);
+            analytics.report({
+                type: events.receiveQRCodeActionEvent.name,
+                payload: { action: 'copy' },
+            });
+            showToast({
+                icon: 'check',
+                intent: 'neutral',
+                message: translate('moduleReceive.addressActions.qrCodeCopiedToClipboard'),
+            });
+        } catch {
+            showGenericErrorAlert();
+        }
+    }, [analytics, showGenericErrorAlert, showToast, translate]);
+
+    const handleSaveQRCode = useCallback(async () => {
+        const qrCodeView = qrCodeViewRef.current;
+
+        if (qrCodeView === null) {
+            showGenericErrorAlert();
+
+            return;
+        }
+
+        try {
+            const result = await saveQRCodeImageToPhotos(async () =>
+                getShareableFileURI(await captureQRCodeImageURI(qrCodeView)),
+            );
+
+            switch (result) {
+                case 'saved':
+                    analytics.report({
+                        type: events.receiveQRCodeActionEvent.name,
+                        payload: { action: 'save' },
+                    });
+                    showToast({
+                        icon: 'check',
+                        intent: 'neutral',
+                        message: translate('moduleReceive.addressActions.qrCodeSavedToPhotos'),
+                    });
+
+                    return;
+                case 'permissionDenied':
+                    showAlert({
+                        title: translate(
+                            'moduleReceive.addressActions.photoPermissionDenied.title',
+                        ),
+                        description: translate(
+                            'moduleReceive.addressActions.photoPermissionDenied.description',
+                        ),
+                        pictogramVariant: 'warning',
+                        primaryButtonTitle: translate(
+                            'moduleReceive.addressActions.photoPermissionDenied.openSettings',
+                        ),
+                        onPressPrimaryButton: () => void Linking.openSettings(),
+                        secondaryButtonTitle: translate('generic.buttons.cancel'),
+                    });
+
+                    return;
+                default:
+                    return exhaustive(result);
+            }
+        } catch {
+            showGenericErrorAlert();
+        }
+    }, [analytics, showAlert, showGenericErrorAlert, showToast, translate]);
+
+    return {
+        qrCodeViewRef,
+        handleCopyQRCode,
+        handleSaveQRCode,
+        handleShareQRCode,
+    };
+};

--- a/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
@@ -17,6 +17,7 @@ import { ReceiveBlockedDeviceCompromisedScreen } from './ReceiveBlockedDeviceCom
 import { ReceiveAddressActions } from '../components/ReceiveAddressActions';
 import { ReceiveAddressDetailHeader } from '../components/ReceiveAddressDetailHeader';
 import { ReceiveAddressDetails } from '../components/ReceiveAddressDetails';
+import { ReceiveAddressInteractionsProvider } from '../components/ReceiveAddressInteractionsProvider';
 import { ReceiveAddressReuseWarning } from '../components/ReceiveAddressReuseWarning';
 import { type ReceiveAddressRootState, selectReceiveAccountAddressByPath } from '../selectors';
 
@@ -32,6 +33,7 @@ export const ReceiveAddressDetailScreen = () => {
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
+
     if (hasFirmwareAuthenticityCheckHardFailed) {
         return <ReceiveBlockedDeviceCompromisedScreen />;
     }
@@ -54,31 +56,33 @@ export const ReceiveAddressDetailScreen = () => {
     const isUsed = address.transfers > 0;
 
     return (
-        <Screen
-            header={<ReceiveAddressDetailHeader address={address} symbol={networkSymbol} />}
-            footer={
-                <>
-                    <ScreenFooterGradient />
-                    <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
-                        <ReceiveAddressActions
-                            accountKey={accountKey}
-                            address={address.address}
-                            addressPath={addressPath}
-                        />
-                    </VStack>
-                </>
-            }
-            noBottomPadding
+        <ReceiveAddressInteractionsProvider
+            accountKey={accountKey}
+            address={address.address}
+            addressPath={addressPath}
         >
-            <VStack marginTop="sp8" spacing="sp16" flex={1}>
-                <ReceiveAddressDetails
-                    accountDescriptor={accountDescriptor}
-                    address={address.address}
-                    deviceStaticSessionId={deviceStaticSessionId}
-                    networkSymbol={networkSymbol}
-                />
-                {isUsed && <ReceiveAddressReuseWarning />}
-            </VStack>
-        </Screen>
+            <Screen
+                header={<ReceiveAddressDetailHeader address={address} symbol={networkSymbol} />}
+                footer={
+                    <>
+                        <ScreenFooterGradient />
+                        <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
+                            <ReceiveAddressActions address={address.address} />
+                        </VStack>
+                    </>
+                }
+                noBottomPadding
+            >
+                <VStack marginTop="sp8" spacing="sp16" flex={1}>
+                    <ReceiveAddressDetails
+                        accountDescriptor={accountDescriptor}
+                        address={address.address}
+                        deviceStaticSessionId={deviceStaticSessionId}
+                        networkSymbol={networkSymbol}
+                    />
+                    {isUsed && <ReceiveAddressReuseWarning />}
+                </VStack>
+            </Screen>
+        </ReceiveAddressInteractionsProvider>
     );
 };

--- a/suite-native/module-receive/src/utils/saveQRCodeImageToPhotos.ios.ts
+++ b/suite-native/module-receive/src/utils/saveQRCodeImageToPhotos.ios.ts
@@ -1,0 +1,20 @@
+// This is the iOS implementation selected by Metro through the `.ios` filename suffix.
+type SaveQRCodeImageToPhotosResult = 'saved' | 'permissionDenied';
+
+export const saveQRCodeImageToPhotos = async (
+    getQRCodeImageURI: () => Promise<string>,
+): Promise<SaveQRCodeImageToPhotosResult> => {
+    // The `legacy` entry point is used intentionally: `saveToLibraryAsync` only requires
+    // add-only ("write") photo permission, while the current `Asset.create` API needs full
+    // library access, which the app does not request.
+    const MediaLibrary = await import('expo-media-library/legacy');
+    const permission = await MediaLibrary.requestPermissionsAsync(true);
+
+    if (!permission.granted) {
+        return 'permissionDenied';
+    }
+
+    await MediaLibrary.saveToLibraryAsync(await getQRCodeImageURI());
+
+    return 'saved';
+};

--- a/suite-native/module-receive/tsconfig.json
+++ b/suite-native/module-receive/tsconfig.json
@@ -50,6 +50,7 @@
         {
             "path": "../../packages/styles-native"
         },
+        { "path": "../../packages/theme" },
         { "path": "../../packages/type-utils" },
         { "path": "../../packages/urls" },
         { "path": "../test-utils" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,6 +3841,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/ui@npm:56.0.24":
+  version: 56.0.24
+  resolution: "@expo/ui@npm:56.0.24"
+  dependencies:
+    sf-symbols-typescript: "npm:^2.1.0"
+    vaul: "npm:^1.1.2"
+  peerDependencies:
+    "@babel/core": "*"
+    expo: "*"
+    react: "*"
+    react-dom: "*"
+    react-native: "*"
+    react-native-worklets: "*"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    react-dom:
+      optional: true
+    react-native-worklets:
+      optional: true
+  checksum: 10/ca8cdc4825ab1a905291409794e027908167425bbe75395873bc1dd998387948f870ff2956bc47fed600a9b33089ebc65dcd303005dd7f9c23f07a73e8dab978
+  languageName: node
+  linkType: hard
+
 "@expo/ws-tunnel@npm:^2.0.0":
   version: 2.0.0
   resolution: "@expo/ws-tunnel@npm:2.0.0"
@@ -6711,6 +6735,275 @@ __metadata:
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
   checksum: 10/ddd16090cde777aaf102940f05d0274602079a95ad9805bd20bc55dcc7c3a2ba1b99dd5c73e5cc2753c3d31250ca52a67d58059459d7d27debb983a9f552936c
+  languageName: node
+  linkType: hard
+
+"@radix-ui/primitive@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/primitive@npm:1.1.7"
+  checksum: 10/04e646c2ec1ae21af6ba6f52a2527121347ccad83837483c4e54fba0d8c988369f4c0f158b9cdb762c2e4910defa15c3937bf484338308c86575b42eec26c5a7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/ffc1a289d944ba9db818bc645e44efb6ce122a1585b61fcd97737ba4d18b60ca585b3d46ff1836b6ad6c4a21c795c5082d540af58cb32daa1b692dffed3d2a15
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-context@npm:1.2.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/61facad40a83ba56ae02cfa5dc00b0343944b68626d5d9ee21bb3f306a62a050c2df47ea349dd28b52842ab9052944c76053d9f0b0dac21f44446b2a894ac915
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dialog@npm:^1.1.1":
+  version: 1.1.23
+  resolution: "@radix-ui/react-dialog@npm:1.1.23"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-context": "npm:1.2.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.19"
+    "@radix-ui/react-focus-guards": "npm:1.1.6"
+    "@radix-ui/react-focus-scope": "npm:1.1.16"
+    "@radix-ui/react-id": "npm:1.1.4"
+    "@radix-ui/react-portal": "npm:1.1.17"
+    "@radix-ui/react-presence": "npm:1.1.10"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-slot": "npm:1.3.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.6"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.7.2"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/41d1fe33099ec0b9a55cfd2a456b313bcd1a6fb8a806edd4ca4832475f894cc23ac1def0f3458939ae291ca3ca0eaf7968b93a266db99e3622df2762657ace41
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.1.19":
+  version: 1.1.19
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.19"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+    "@radix-ui/react-use-effect-event": "npm:0.0.5"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/f91426f0af90dcf3a3133f8ad9de4d5f9c76cfdb32761a2996d534dc112db36f907fdcdff069c3dbe54eb4415ae15f655ecd66ee69b29b0de55bd48c7e608e2e
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-guards@npm:1.1.6":
+  version: 1.1.6
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.6"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/bd25b5f7e896dcdf0e7c2a50d7b1d50fc33bb5b03e635855f4aba352cad4a22188727406c23b3b97326d8f1582e1f3ccecadbe30790de7dda72b22036a2ac809
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-scope@npm:1.1.16":
+  version: 1.1.16
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.16"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/da79c2b83c568b78a81cd8310f66860c4a4855e9c4670cedee884e60ede7467af8a759dc890d8367173154d9a3708325dea149baa9810728dc001a3028177d6a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-id@npm:1.1.4"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/3baf0bf45fdf8630e7db61be4d37c76f49a6a1ff0cb9ecabd6a707dbe06c2c894a0b105afa15c816df57169425a154348fdb9e567fc4202e319958cefd3f9af8
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.1.17":
+  version: 1.1.17
+  resolution: "@radix-ui/react-portal@npm:1.1.17"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.10"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/03f6b84a31b4316339053cec55a569db1b6c53998ac88e0ca3a75daa31e4536774690bfc7aec078547d662beb472d530d0e448c124f0882194a3ab2b9cb6d594
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.1.10":
+  version: 1.1.10
+  resolution: "@radix-ui/react-presence@npm:1.1.10"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/1d04c4c76f6e28dac602c4d7c3b44cd0ca24f29d31a701080fb8e374d2e6114a4b141f4a092e2fae33d2a986d8e3e6f2fae25196c638bc8ac7a0616efc895562
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.10":
+  version: 2.1.10
+  resolution: "@radix-ui/react-primitive@npm:2.1.10"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.3.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/fbb9c132001430998fbd33d3c1ca3eadd5a037656a2fbde630658b2fe2c3820bca8c27bfe9b144d8612359d2157beb9a8603f1a8de2dc5ad02d2dea1425cf72a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@radix-ui/react-slot@npm:1.3.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/97f305fb29c6284e1292cfee441cd807744f32322c0a1b541190a294f878edacce3bc37c174b4024724210243dad7b4feb762222e4c43668db2b65b9576d222a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/4bb27c92239d8ae06dd41606cdc54671a1d021528e804c75d838bb7432aa8d9a196d158b03955ebc0635ff92416e44130597337445320eab30d4b9ee6c2fcb5c
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.6"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.7"
+    "@radix-ui/react-use-effect-event": "npm:0.0.5"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b77985626e9782e399e04a4c136df7fa2905397f624f88ab0c1704e454f5ea4e53e3a21df68e61406ca7089cfdc95e5ae93c7872fb7bd333aedcb8cfde0a8439
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.5":
+  version: 0.0.5
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.5"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/9da3ef8ea100347eea03a3379d2eed547d763a76b1a652ca78a1d49432a084f124b85ba19b8f28befc226b32137a045d171bd40423b27fdb46db919f8df44c00
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.4"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/af034d75248004d59536c9f2c91ae6eb06889540720adc666fcb37095edcee51c08fca8ddafed56b46d8403332b3c8ff9d29316f53d0d5a3b384d39ae55ce983
   languageName: node
   linkType: hard
 
@@ -11884,10 +12177,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/clipboard@workspace:suite-native/clipboard"
   dependencies:
+    "@expo/ui": "npm:56.0.24"
     "@suite-native/intl": "workspace:*"
     "@suite-native/toasts": "workspace:*"
     expo-clipboard: "npm:~57.0.1"
+    expo-haptics: "npm:~57.0.1"
     react: "npm:19.2.3"
+    react-native: "npm:0.86.0"
   languageName: unknown
   linkType: soft
 
@@ -13268,10 +13564,14 @@ __metadata:
     "@trezor/device-utils": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     "@trezor/styles-native": "workspace:*"
+    "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/urls": "workspace:*"
+    expo-clipboard: "npm:~57.0.1"
+    expo-media-library: "npm:~57.0.3"
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
+    react-native-view-shot: "npm:5.1.0"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft
@@ -20898,6 +21198,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-hidden@npm:^1.2.4":
+  version: 1.2.6
+  resolution: "aria-hidden@npm:1.2.6"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10/1914e5a36225dccdb29f0b88cc891eeca736cdc5b0c905ab1437b90b28b5286263ed3a221c75b7dc788f25b942367be0044b2ac8ccf073a72e07a50b1d964202
+  languageName: node
+  linkType: hard
+
 "aria-query@npm:5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -21792,6 +22101,13 @@ __metadata:
   version: 0.1.0
   resolution: "base32.js@npm:0.1.0"
   checksum: 10/7d7401a8f5c4ec45336ff72c97ee554b9bc22c2153b301acf657e6f9e25928a6205b2cfc55731072ba5686515e4903e2d3e462bea49db5f1515bbd01da1276ad
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 10/15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -24096,6 +24412,15 @@ __metadata:
   dependencies:
     hyphenate-style-name: "npm:^1.0.3"
   checksum: 10/bd2f569f1870389004cfacfd7b798c0f40933d34af1f040c391a08322d097790b9a9524affb2ba4d26122e9cb8f4256afb59edb6077dbe607506944a9c673c67
+  languageName: node
+  linkType: hard
+
+"css-line-break@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "css-line-break@npm:2.1.0"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10/e75cae40de511026228d4fa69e8d464895714f8899880b8268a446b57f0faa84b490ba1bdda5ed9e7f38f99ab947c6bc941bb505d8119c49072db079c1cacea5
   languageName: node
   linkType: hard
 
@@ -27886,6 +28211,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-media-library@npm:~57.0.3":
+  version: 57.0.3
+  resolution: "expo-media-library@npm:57.0.3"
+  peerDependencies:
+    expo: "*"
+    react-native: "*"
+  checksum: 10/730cc8ec51544cbbf33b6c6662fca36125c489f1b93250112542979b69a7898145f87a481e1902557732a08cebe2cc49bcc3e4acb06f25c39a7ed54a80dcd2a3
+  languageName: node
+  linkType: hard
+
 "expo-modules-autolinking@npm:~57.0.9":
   version: 57.0.9
   resolution: "expo-modules-autolinking@npm:57.0.9"
@@ -29409,6 +29744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-nonce@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "get-nonce@npm:1.0.1"
+  checksum: 10/ad5104871d114a694ecc506a2d406e2331beccb961fe1e110dc25556b38bcdbf399a823a8a375976cd8889668156a9561e12ebe3fa6a4c6ba169c8466c2ff868
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
@@ -30674,6 +31016,16 @@ __metadata:
     webpack:
       optional: true
   checksum: 10/c5b484f7594c155ee2b47b28b291f69ab7948e25f989c8d7e2130bb58b6b5e6724ef4b309e8adcdcb50e4e072bf82bfbbaaa08a35161f2aaa81c01fc58280b68
+  languageName: node
+  linkType: hard
+
+"html2canvas@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "html2canvas@npm:1.4.1"
+  dependencies:
+    css-line-break: "npm:^2.1.0"
+    text-segmentation: "npm:^1.0.3"
+  checksum: 10/595790810557a1d4287f07b6ead49aed4f169f08eb00e20c1f030b93344003e84797d28cd8a220e8ec1b78641d460ca6add11b8531960725526f11a7b9fa9900
   languageName: node
   linkType: hard
 
@@ -40755,6 +41107,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-view-shot@npm:5.1.0":
+  version: 5.1.0
+  resolution: "react-native-view-shot@npm:5.1.0"
+  dependencies:
+    html2canvas: "npm:^1.4.1"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-native: ">=0.76.0"
+  checksum: 10/080b199b5476e2d2a7e450a475cbd70248ce5c0b59063b117eb351df2c8945016151d3bae505601bd46270b5b830d063b3fa5b6ba0db4837fd1d529a43a8578a
+  languageName: node
+  linkType: hard
+
 "react-native-web@npm:^0.21.0":
   version: 0.21.2
   resolution: "react-native-web@npm:0.21.2"
@@ -40906,6 +41270,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-remove-scroll-bar@npm:^2.3.7":
+  version: 2.3.8
+  resolution: "react-remove-scroll-bar@npm:2.3.8"
+  dependencies:
+    react-style-singleton: "npm:^2.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6c0f8cff98b9f49a4ee2263f1eedf12926dced5ce220fbe83bd93544460e2a7ec8ec39b35d1b2a75d2fced0b2d64afeb8e66f830431ca896e05a20585f9fc350
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll@npm:^2.7.2":
+  version: 2.7.2
+  resolution: "react-remove-scroll@npm:2.7.2"
+  dependencies:
+    react-remove-scroll-bar: "npm:^2.3.7"
+    react-style-singleton: "npm:^2.2.3"
+    tslib: "npm:^2.1.0"
+    use-callback-ref: "npm:^1.3.3"
+    use-sidecar: "npm:^1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6a7858f9a3eb57128abb64479ced78283b0cbee0b43c2b87e42711e75c564c27d1d3dd2b81f2ea95c80cb9e6b6965d1c9e2332f6a7e7b753cd8aeb02b9b97704
+  languageName: node
+  linkType: hard
+
 "react-select@npm:^5.10.2":
   version: 5.10.2
   resolution: "react-select@npm:5.10.2"
@@ -40937,6 +41336,22 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10/cc5593356d154253f61a2c0b7b2fa8a979527495e2fe47c4252628d86e93c72c75df988c5438867d373de4e5a47d871ab9262474c02e66c411f94f047ecb5b0f
+  languageName: node
+  linkType: hard
+
+"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "react-style-singleton@npm:2.2.3"
+  dependencies:
+    get-nonce: "npm:^1.0.0"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/62498094ff3877a37f351b29e6cad9e38b2eb1ac3c0cb27ebf80aee96554f80b35e17bdb552bcd7ac8b7cb9904fea93ea5668f2057c73d38f90b5d46bb9b27ab
   languageName: node
   linkType: hard
 
@@ -44684,6 +45099,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-segmentation@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "text-segmentation@npm:1.0.3"
+  dependencies:
+    utrie: "npm:^1.0.2"
+  checksum: 10/86191de83f09b96f356628c3dbaf6d281eda46a4dd4c94c3827495428871b9dd44ead4ef4cdf06a188b08a3b83e3943c5911841422b55286b121ba9e04c846dd
+  languageName: node
+  linkType: hard
+
 "thenby@npm:^1.3.4":
   version: 1.3.4
   resolution: "thenby@npm:1.3.4"
@@ -46515,6 +46939,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"utrie@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "utrie@npm:1.0.2"
+  dependencies:
+    base64-arraybuffer: "npm:^1.0.2"
+  checksum: 10/0c9458380bf3113f425a268e3d605aef163bfbaea62bf24de517b62b6e6744394d8ef1cdd9b07423359aec5ed402baab4bb2c5beec64f674ec635dc2f8dbd4bf
+  languageName: node
+  linkType: hard
+
 "uuid@npm:11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
@@ -46619,6 +47052,18 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
+  languageName: node
+  linkType: hard
+
+"vaul@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vaul@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-dialog": "npm:^1.1.1"
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10/9d34f7f9aae1994450233f7803fcd47dca7680bc621ee24717b8e78b72fda9c5156e1ff2c8af6c2705993224fd8d3725ed89d84ba5bd1d411124dd91cde2b2e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description
- add a shared native clipboard copy menu with iOS context menu support and Android long-press fallback
- wire receive QR/address long-press through the same copy handler as the Copy button
- suppress the receive copy toast because the copied-address modal is shown instead
- on copy the QR, open the bottom sheet same as if you press copy button at the bottom of the screen
- the native long press copy button is available on iOS only, android will fallback to copy the address directly (android doesn't have useful component for this in ExpoUI; it only has [this](https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/dropdownmenu/) which doesn't look good for this use case)

## Notes for QA
Test the things from description please.

## Screenshots

https://github.com/user-attachments/assets/3c02e007-7a6b-4875-a58b-31f106814336


https://github.com/user-attachments/assets/aa5dfd23-679d-4c76-98c6-05b0c499ba1c

Updated: with more actions: 

https://github.com/user-attachments/assets/a251220e-3a01-4879-b050-126967338406






<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all in suite-native (React Native mobile app), specifically the clipboard and receive-address modules. The available Playwright E2E candidate suite is for suite-web/suite-desktop only and does not exercise any suite-native code paths. Therefore none of the 127 candidate tests provide meaningful coverage for this change set. The risk is unmitigated by these E2E tests; mobile-native unit/component tests and manual verification would be required.

<details><summary><b>Changed files (14)</b></summary>

- `suite-native/app/package.json`
- `suite-native/clipboard/package.json`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.ios.tsx`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.tsx`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.types.ts`
- `suite-native/clipboard/src/hooks/useCopyToClipboard.ts`
- `suite-native/clipboard/src/index.ts`
- `suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressActions.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressCard.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`
- `suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts`
- `suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (14)**
- `suite-native/app/package.json`
- `suite-native/clipboard/package.json`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.ios.tsx`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.tsx`
- `suite-native/clipboard/src/components/ClipboardCopyMenu.types.ts`
- `suite-native/clipboard/src/hooks/useCopyToClipboard.ts`
- `suite-native/clipboard/src/index.ts`
- `suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressActions.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressCard.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressDetails.tsx`
- `suite-native/module-receive/src/hooks/useReceiveAddressCopy.ts`
- `suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx`

_Updated: 2026-08-05T09:38:44.237Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/qr-copy-tooltip/web/](https://dev.suite.sldev.cz/suite-web/juriczech/qr-copy-tooltip/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/qr-copy-tooltip&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/qr-copy-tooltip&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/qr-copy-tooltip&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T07:31:19.853Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T07:31:36.973Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->