### PR TITLE
test(suite): fix eslint

### DIFF
--- a/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts
@@ -96,7 +96,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
                 formattedSendAmount,
             );
             // The EVM max fee is live; we just crosscheck modal and device.
-            const reviewFee = (await devicePrompt.cryptoAmountOf('fee').textContent())?.trim();
+            const reviewFee = (await devicePrompt.cryptoAmountOf('fee').innerText())?.trim();
             if (!reviewFee) {
                 throw new Error('Review fee amount was not displayed on the confirmation modal');
             }

--- a/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
@@ -92,7 +92,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
             await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
                 formattedSendAmount,
             );
-            const reviewFee = (await devicePrompt.cryptoAmountOf('fee').textContent())?.trim();
+            const reviewFee = (await devicePrompt.cryptoAmountOf('fee').innerText())?.trim();
             if (!reviewFee) {
                 throw new Error('Review fee amount was not displayed on the confirmation modal');
             }


### PR DESCRIPTION
## Description

Fix eslint at two places probably forgotten in #30815
let's see if E2E passes :pray: 

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/eslint-in-e2e/web/](https://dev.suite.sldev.cz/suite-web/fix/eslint-in-e2e/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/eslint-in-e2e&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/eslint-in-e2e&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T17:35:56.795Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T17:35:51.566Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->