### PR TITLE
fix(suite): remove doubled networks list in network reserve setting

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -1864,7 +1864,7 @@
   "TR_NETWORK_FEE": "Network fee",
   "TR_NETWORK_RESERVE": "Network reserve",
   "TR_NETWORK_RESERVE_BANNER": "We've reserved {amount} {displaySymbol} to cover any extra network fees.",
-  "TR_NETWORK_RESERVE_DESCRIPTION": "Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.",
+  "TR_NETWORK_RESERVE_DESCRIPTION": "Reserve a small amount of the native token to cover any extra network fees when you send, swap, or sell your assets.",
   "TR_NETWORK_RESERVE_MANAGE": "Manage",
   "TR_NETWORK_TESTNET": "This transaction is on a testnet network",
   "TR_NETWORK_TITLE": "Network",

--- a/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
@@ -44,12 +44,7 @@ export const NetworkReserve = () => {
                 >
                     <TextColumn
                         title={<Translation id="TR_NETWORK_RESERVE" />}
-                        description={
-                            <Translation
-                                id="TR_NETWORK_RESERVE_DESCRIPTION"
-                                values={{ supportedNetworks }}
-                            />
-                        }
+                        description={<Translation id="TR_NETWORK_RESERVE_DESCRIPTION" />}
                         bottomContent={
                             <Column gap={8} alignItems="flex-start">
                                 <SettingsRequirementBanner>

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1521,7 +1521,7 @@ export const messages = {
             networkReserve: {
                 title: 'Network reserve',
                 subtitle:
-                    'Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.',
+                    'Reserve a small amount of the native token to cover any extra network fees when you send, swap, or sell your assets.',
             },
             addressDisplay: {
                 title: 'Spaced address formatting',

--- a/suite-native/intl/translations/en-US.json
+++ b/suite-native/intl/translations/en-US.json
@@ -772,7 +772,7 @@
     "moduleSettings.advanced.authenticityChecks.device.subtitle": "Verify that your Trezor device is genuine. This helps ensure you never use a compromised or fake device. ",
     "moduleSettings.advanced.authenticityChecks.device.turnOffTitle": "Turn off device authenticity check?",
     "moduleSettings.advanced.networkReserve.title": "Network reserve",
-    "moduleSettings.advanced.networkReserve.subtitle": "Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.",
+    "moduleSettings.advanced.networkReserve.subtitle": "Reserve a small amount of the native token to cover any extra network fees when you send, swap, or sell your assets.",
     "moduleSettings.advanced.addressDisplay.title": "Spaced address formatting",
     "moduleSettings.advanced.addressDisplay.subtitle": "Add spaces to addresses for easier reading. When off, addresses are shown as a continuous string.",
     "moduleSettings.advanced.bitcoinBackends.title": "Bitcoin backend",

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2743,7 +2743,7 @@ export const messages = defineMessages({
     },
     TR_NETWORK_RESERVE_DESCRIPTION: {
         defaultMessage:
-            'Reserve a small amount of the native token on {supportedNetworks} to cover any extra network fees when you send, swap, or sell your assets.',
+            'Reserve a small amount of the native token to cover any extra network fees when you send, swap, or sell your assets.',
         id: 'TR_NETWORK_RESERVE_DESCRIPTION',
     },
     TR_SETTINGS_ADVANCED: {


### PR DESCRIPTION
## Description

Crowdin updated 

## Notes for QA

- Desktop/web: Settings → Advanced → Network reserve — the description no longer names networks; the "Available on Base, Optimism, Robinhood Chain, Solana." banner still does.
- Mobile: Settings → Advanced settings → Network reserve — subtitle shows the generic copy (previously it could show a raw `{supportedNetworks}` placeholder), the "Available on …" label still lists the networks.
- Non-English locales show the old description until Crowdin retranslates the updated source string.

## Related Issue

Resolve #30701

## Screenshots:

<img width="1160" height="359" alt="Screenshot 2026-08-04 at 20 51 17" src="https://github.com/user-attachments/assets/79bc0e86-028e-46f6-97b3-0574022316e4" />


Before:
<img width="1080" alt="before" src="https://github.com/user-attachments/assets/f2587464-fb4d-4b95-99dc-98ede9b1196b" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only functional code change is NetworkReserve.tsx, a general settings component whose primary observable behavior is the network reserve calculation in Solana sends. Translation/intl file changes have broad blast radius but no specific static E2E coverage. A targeted run of send-sol.test.ts provides the highest confidence, supplemented by send-base.test.ts to guard against regressions in shared send-form infrastructure.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite-data/files/translations/en-US.json`
- `packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx`
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-sol.test.ts` — This test directly exercises Solana send flows where the maximum sendable amount is computed from balance minus fees minus the network reserve, and its source hints reference getNetworkReserveAmount. A change to NetworkReserve.tsx or its translations would most likely surface here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — This test covers the EVM send form and device fee/amount confirmation flow. NetworkReserve lives under SettingsGeneral and could affect general send calculation or display behavior; running this confirms no regression in a parallel send path.

</details>

⚠️ **Changes with no test coverage (4)**
- `suite-native/intl/src/messages.ts`
- `suite-native/intl/translations/en-US.json`
- `packages/suite-data/files/translations/en-US.json`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-04T18:39:04.089Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/30701-network-reserve-doubled-networks/web/](https://dev.suite.sldev.cz/suite-web/fix/30701-network-reserve-doubled-networks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/30701-network-reserve-doubled-networks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/30701-network-reserve-doubled-networks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/30701-network-reserve-doubled-networks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T18:41:11.814Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T18:40:44.584Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->