### PR TITLE
feat(suite): show rate change since tx date in transaction detail

### DIFF
--- a/packages/suite/src/components/suite/Ticker/TrendBadge.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendBadge.tsx
@@ -1,0 +1,59 @@
+import styled from 'styled-components';
+
+import { selectLanguage } from '@suite/settings';
+import { localizePercentage } from '@suite-common/wallet-utils';
+import { Icon, type IconComponent } from '@trezor/components';
+import { TrendDownIcon, TrendUpIcon } from '@trezor/icons';
+import { type Color, typography } from '@trezor/theme';
+
+import { useSelector } from 'src/hooks/suite';
+
+const PercentageWrapper = styled.div<{ $color: Color }>`
+    ${typography['body-sm-strong']}
+    gap: 4px;
+    display: flex;
+    align-items: center;
+    color: ${({ theme, $color }) => theme[$color]};
+`;
+
+type Trend = 'up' | 'down' | 'stable';
+
+const trendStyles: Record<Trend, { icon?: IconComponent; color: Color }> = {
+    up: { icon: TrendUpIcon, color: 'contentBrand' },
+    down: { icon: TrendDownIcon, color: 'contentCritical' },
+    stable: { color: 'contentSecondary' },
+};
+
+export const calculatePercentageDifference = (a: number, b: number) => (a - b) / b;
+
+// localizePercentage renders 1 decimal place, so a change below this rounds to ±0.0% and should
+// be shown as neutral rather than as a tiny up/down move.
+const NEUTRAL_TREND_THRESHOLD = 0.0005;
+
+const getTrend = (percentageChange: number): Trend => {
+    if (Math.abs(percentageChange) < NEUTRAL_TREND_THRESHOLD) return 'stable';
+    if (percentageChange > 0) return 'up';
+    if (percentageChange < 0) return 'down';
+
+    return 'stable';
+};
+
+type TrendBadgeProps = {
+    valueInFraction: number;
+};
+
+export const TrendBadge = ({ valueInFraction }: TrendBadgeProps) => {
+    const locale = useSelector(selectLanguage);
+    const trend = getTrend(valueInFraction);
+    const { icon, color } = trendStyles[trend];
+    // A change that rounds to ±0.0% is shown as a neutral "≈0%" instead of e.g. "-0.0%".
+    const formattedChange =
+        trend === 'stable' ? '≈0%' : localizePercentage({ valueInFraction, locale });
+
+    return (
+        <PercentageWrapper $color={color}>
+            {icon !== undefined && <Icon as={icon} color={color} size={16} />}
+            {formattedChange}
+        </PercentageWrapper>
+    );
+};

--- a/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
+++ b/packages/suite/src/components/suite/Ticker/TrendTicker.tsx
@@ -1,54 +1,23 @@
 import styled from 'styled-components';
 
-import { selectLanguage } from '@suite/settings';
 import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
-import { getFiatRateKey, localizePercentage } from '@suite-common/wallet-utils';
-import { Icon, type IconComponent, Skeleton } from '@trezor/components';
-import { TrendDownIcon, TrendUpIcon } from '@trezor/icons';
-import { type Color, typography } from '@trezor/theme';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { Skeleton } from '@trezor/components';
+import { typography } from '@trezor/theme';
 
 import { BaseCurrencyValue } from 'src/components/suite/BaseCurrencyValue';
 import { useSelector } from 'src/hooks/suite';
 
 import { NoRatesTooltip } from './NoRatesTooltip';
-
-const PercentageWrapper = styled.div<{ $color: Color }>`
-    ${typography['body-sm-strong']}
-    gap: 4px;
-    display: flex;
-    align-items: center;
-    color: ${({ theme, $color }) => theme[$color]};
-`;
+import { TrendBadge, calculatePercentageDifference } from './TrendBadge';
 
 const Empty = styled.div`
     ${typography['body-sm-strong']}
     color: ${({ theme }) => theme.contentSecondary};
 `;
-
-type Trend = 'up' | 'down' | 'stable';
-
-const trendStyles: Record<Trend, { icon?: IconComponent; color: Color }> = {
-    up: { icon: TrendUpIcon, color: 'contentBrand' },
-    down: { icon: TrendDownIcon, color: 'contentCritical' },
-    stable: { color: 'contentSecondary' },
-};
-
-const calculatePercentageDifference = (a: number, b: number) => (a - b) / b;
-
-// localizePercentage renders 1 decimal place, so a change below this rounds to ±0.0% and should
-// be shown as neutral rather than as a tiny up/down move.
-const NEUTRAL_TREND_THRESHOLD = 0.0005;
-
-const getTrend = (percentageChange: number): Trend => {
-    if (Math.abs(percentageChange) < NEUTRAL_TREND_THRESHOLD) return 'stable';
-    if (percentageChange > 0) return 'up';
-    if (percentageChange < 0) return 'down';
-
-    return 'stable';
-};
 
 interface TickerProps {
     symbol: NetworkSymbol;
@@ -64,7 +33,6 @@ export const TrendTicker = ({
     showLoadingSkeleton = true,
 }: TickerProps) => {
     const shouldAnimate = useSelector(selectShouldAnimateLoadingSkeleton);
-    const locale = useSelector(selectLanguage);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(symbol, baseCurrencyCode, contractAddress);
     const lastWeekRate = useSelector(state =>
@@ -92,13 +60,6 @@ export const TrendTicker = ({
     const percentageChange = isSuccessfullyFetched
         ? calculatePercentageDifference(currentRate.rate!, lastWeekRate.rate!)
         : 0;
-    const trend = getTrend(percentageChange);
-    const { icon, color } = trendStyles[trend];
-    // A change that rounds to ±0.0% is shown as a neutral "≈0%" instead of e.g. "-0.0%".
-    const formattedChange =
-        trend === 'stable'
-            ? '≈0%'
-            : localizePercentage({ valueInFraction: percentageChange, locale });
 
     const emptyStateComponent = noEmptyStateTooltip ? <Empty>—</Empty> : <NoRatesTooltip />;
 
@@ -106,10 +67,7 @@ export const TrendTicker = ({
         <BaseCurrencyValue amount="1" symbol={symbol} showLoadingSkeleton={false}>
             {({ rate, timestamp }) =>
                 rate && timestamp && isSuccessfullyFetched ? (
-                    <PercentageWrapper $color={color}>
-                        {icon !== undefined && <Icon as={icon} color={color} size={16} />}
-                        {formattedChange}
-                    </PercentageWrapper>
+                    <TrendBadge valueInFraction={percentageChange} />
                 ) : (
                     emptyStateComponent
                 )

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -27,6 +27,8 @@ import { AmountComponent } from 'src/components/wallet/AmountComponent';
 import { useSelector } from 'src/hooks/suite';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
+import { HistoricRateChange } from './HistoricRateChange';
+
 type AmountDetailsProps = {
     tx: WalletAccountTransaction;
     isTestnet: boolean;
@@ -66,6 +68,14 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
         return amount.isNegative() ? 'negative' : 'positive';
     };
 
+    const nativeRateChange = tx.blockTime ? (
+        <HistoricRateChange
+            symbol={tx.symbol}
+            historicRate={historicRate}
+            historicTimestamp={tx.blockTime as Timestamp}
+        />
+    ) : null;
+
     return (
         <Table hasBorders={false} isRowHighlightedOnHover={false} typographyStyle="body-sm">
             {!isTestnet && (
@@ -96,6 +106,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 }}
                             />
                         </Table.Cell>
+                        <Table.Cell />
                     </Table.Row>
                 </Table.Header>
             )}
@@ -138,6 +149,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                     />
                                 </Text>
                             </Table.Cell>
+                            <Table.Cell align="end">{nativeRateChange}</Table.Cell>
                         </Table.Row>
                     )}
                 {tx.internalTransfers.map((transfer, i) => (
@@ -176,6 +188,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 />
                             </Text>
                         </Table.Cell>
+                        <Table.Cell align="end">{nativeRateChange}</Table.Cell>
                     </Table.Row>
                 ))}
                 {tx.type !== 'self' &&
@@ -243,6 +256,17 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                         </Text>
                                     )}
                                 </Table.Cell>
+                                <Table.Cell align="end">
+                                    {tx.blockTime && (
+                                        <HistoricRateChange
+                                            symbol={tx.symbol}
+                                            historicRate={historicTokenRate}
+                                            historicTimestamp={tx.blockTime as Timestamp}
+                                            tokenAddress={transfer.contract as TokenAddress}
+                                            displaySymbol={transfer.symbol}
+                                        />
+                                    )}
+                                </Table.Cell>
                             </Table.Row>
                         );
                     })}
@@ -277,6 +301,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <BaseCurrencyValue amount={cardanoWithdrawal} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
+                        <Table.Cell align="end">{nativeRateChange}</Table.Cell>
                     </Table.Row>
                 )}
                 {cardanoDeposit && (
@@ -310,6 +335,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <BaseCurrencyValue amount={cardanoDeposit} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
+                        <Table.Cell align="end">{nativeRateChange}</Table.Cell>
                     </Table.Row>
                 )}
                 {/* TX FEE */}
@@ -344,6 +370,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                                 <BaseCurrencyValue amount={fee} symbol={tx.symbol} />
                             </Text>
                         </Table.Cell>
+                        <Table.Cell align="end">{nativeRateChange}</Table.Cell>
                     </Table.Row>
                 )}
             </Table.Body>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/HistoricRateChange.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/HistoricRateChange.tsx
@@ -1,0 +1,112 @@
+import { HiddenPlaceholder } from '@suite/discreet-mode';
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { type NetworkSymbol, type NetworkSymbolExtended } from '@suite-common/wallet-config';
+import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
+import {
+    type Timestamp,
+    type TokenAddress,
+    asBaseCurrencyAmount,
+} from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
+import { Column, Row, Text, Tooltip } from '@trezor/components';
+import { BigNumber } from '@trezor/utils';
+
+import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { FormattedDate } from 'src/components/suite/FormattedDate';
+import { TrendBadge, calculatePercentageDifference } from 'src/components/suite/Ticker/TrendBadge';
+import { useSelector } from 'src/hooks/suite';
+
+// Unit prices are rendered with the same precision as PriceTicker so that
+// low-value assets do not round to zero.
+const UNIT_PRICE_FORMATTER_OPTIONS = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 4,
+};
+
+type HistoricRateChangeProps = {
+    symbol: NetworkSymbol;
+    historicRate: number | undefined;
+    historicTimestamp: Timestamp;
+    tokenAddress?: TokenAddress;
+    // Symbol shown in the tooltip heading; the rate lookup always uses `symbol` + `tokenAddress`.
+    displaySymbol?: NetworkSymbolExtended;
+};
+
+const isValidRate = (rate: number | undefined): rate is number =>
+    rate !== undefined && Number.isFinite(rate) && rate > 0;
+
+export const HistoricRateChange = ({
+    symbol,
+    historicRate,
+    historicTimestamp,
+    tokenAddress,
+    displaySymbol,
+}: HistoricRateChangeProps) => {
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const fiatRateKey = getFiatRateKey(symbol, baseCurrencyCode, tokenAddress);
+    const currentRate = useSelector(state => selectFiatRatesByFiatRateKey(state, fiatRateKey));
+
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+
+    const currentRateValue = currentRate?.rate;
+    const currentRateTimestamp = currentRate?.lastTickerTimestamp;
+
+    if (
+        currentRate?.error ||
+        !isValidRate(historicRate) ||
+        !isValidRate(currentRateValue) ||
+        !currentRateTimestamp
+    ) {
+        return null;
+    }
+
+    const renderUnitPrice = (rate: number) => (
+        <HiddenPlaceholder>
+            <BaseCurrencyAmountFormatter
+                currency={baseCurrencyCode}
+                value={asBaseCurrencyAmount(new BigNumber(rate))}
+                {...UNIT_PRICE_FORMATTER_OPTIONS}
+            />
+        </HiddenPlaceholder>
+    );
+
+    return (
+        <Tooltip
+            content={
+                <Column gap={4} alignItems="stretch">
+                    <Text typographyStyle="body-sm-strong">
+                        <FormattedCryptoAmount
+                            value="1"
+                            symbol={displaySymbol ?? symbol}
+                            contractAddress={tokenAddress}
+                        />
+                    </Text>
+                    <Row gap={16} justifyContent="space-between">
+                        <FormattedDate value={new Date(historicTimestamp * 1000)} date />
+                        {renderUnitPrice(historicRate)}
+                    </Row>
+                    <Row gap={16} justifyContent="space-between">
+                        <Translation
+                            id="TR_TODAY_DATE"
+                            values={{
+                                date: (
+                                    <FormattedDate
+                                        value={currentRateTimestamp}
+                                        date
+                                        year={undefined}
+                                    />
+                                ),
+                            }}
+                        />
+                        {renderUnitPrice(currentRateValue)}
+                    </Row>
+                </Column>
+            }
+        >
+            <TrendBadge
+                valueInFraction={calculatePercentageDifference(currentRateValue, historicRate)}
+            />
+        </Tooltip>
+    );
+};


### PR DESCRIPTION
## Description

The Amount tab in the transaction detail modal shows the fiat value at the transaction date and today, but not how much the price actually moved. This adds a fifth column with a per-row percentage-change badge (fiat rate at tx date vs. today, for that row's asset), styled identically to the 7-day trend ticker in the tokens table. Hovering a badge opens a tooltip with the price per 1 unit on both dates:

```
1 UNI
November 9, 2025      $6.5492
Today, August 4       $3.9160
```

Token rows resolve their own current and historic rates via the contract address, so a swap correctly shows e.g. USDC ≈0%, UNI −40.2%, fee (ETH) −47.6% instead of one misleading number.

## Notes for QA

- Open any confirmed transaction detail → Amount tab: each row (amount, token transfers, fee, cardano withdrawal/deposit) has a change badge in the last column; the percentage matches (today fiat − then fiat) / then fiat of that row.
- Multi-asset txs (e.g. a token swap): each row shows its own asset's change — USDC-like rows ≈0%, the token and the ETH fee differ.
- Hover a badge: tooltip shows that asset's price per 1 unit at the tx date and today.
- Testnet accounts, pending txs, and coins/tokens without fiat rates: empty cell, layout otherwise unchanged.
- Discreet mode: tooltip prices are blurred like other fiat values.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30826

## Screenshots:

<img width="857" height="679" alt="Screenshot 2026-08-04 at 22 14 54" src="https://github.com/user-attachments/assets/547f8dca-3be7-4568-86fe-ad0f29734d00" />
<img width="995" height="569" alt="Screenshot 2026-08-04 at 22 14 30" src="https://github.com/user-attachments/assets/7d1420c6-e38d-43c4-9982-78010293927a" />
<img width="904" height="554" alt="Screenshot 2026-08-04 at 22 13 07" src="https://github.com/user-attachments/assets/1212afab-a824-4e78-811c-126891e79f86" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/tx-detail-fiat-rate-change/web/](https://dev.suite.sldev.cz/suite-web/feat/tx-detail-fiat-rate-change/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/tx-detail-fiat-rate-change&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/tx-detail-fiat-rate-change&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T20:06:48.353Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T20:07:07.096Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch price-trend UI components and advanced transaction-detail amount/rate panels. Because the affected files are widely imported, only tests that actually render these views are selected: one high-priority test for the transaction detail modal and a few medium-priority tests for dashboard balance surfaces and post-send transaction details.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/Ticker/TrendBadge.tsx`
- `packages/suite/src/components/suite/Ticker/TrendTicker.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/HistoricRateChange.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test explicitly opens the transaction detail modal to retrieve the txid, which renders the AdvancedTxDetails subtree including AmountDetails and HistoricRateChange. A regression in amount formatting or historic rate display would be directly visible here.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — The test asserts on portfolio, asset card, asset row, and wallet fiat amounts — the exact surfaces where TrendTicker and TrendBadge likely render alongside balances. A layout or text regression in the trend components could break these assertions.
- `suite/e2e/tests/wallet/send-base.test.ts` — Navigates to transaction details after broadcasting a Base send, which exercises the TxDetailModal advanced details path. Inferred coverage for AmountDetails/HistoricRateChange via the parent modal.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Navigates to transaction details after sending a regtest transaction with locktime and OP_RETURN outputs, exercising the advanced transaction detail view. Inferred coverage for AmountDetails/HistoricRateChange via the parent modal.

</details>

_Updated: 2026-08-04T20:05:10.237Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

