### PR TITLE
feat(suite-native): show Ethereum receive address info

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -971,6 +971,8 @@ export const messages = {
             alert: {
                 longCardanoAddress:
                     "This Cardano (ADA) address is too long to fit on your Trezor's screen. Scroll on both screens to view and confirm it.",
+                sharedAssetsAndTokens:
+                    'The receive address is the same for all assets and tokens within this account.',
                 token: 'Your receive address is your {networkName} address',
                 success: 'The receive address has been confirmed on your Trezor.',
             },

--- a/suite-native/module-receive/src/components/ReceiveAddressCard.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressCard.tsx
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountDescriptor,
@@ -8,10 +7,10 @@ import {
     selectAccountNetworkSymbol,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { Box, InlineAlertBox, type InlineAlertBoxProps, VStack } from '@suite-native/atoms';
-import { Translation } from '@suite-native/intl';
+import { VStack } from '@suite-native/atoms';
 
 import { ReceiveAddressDetails } from './ReceiveAddressDetails';
+import { ReceiveAddressInfo } from './ReceiveAddressInfo';
 
 type ReceiveAddressCardProps = {
     accountKey: AccountKey;
@@ -38,34 +37,7 @@ export const ReceiveAddressCard = ({
         return null;
     }
 
-    const { name: networkName } = getNetwork(symbol);
     const isTokenAddress = tokenContract !== undefined;
-
-    const getCardAlertProps = (): InlineAlertBoxProps | undefined => {
-        if (symbol === 'ada') {
-            return {
-                title: (
-                    <Translation id="moduleReceive.receiveAddressCard.alert.longCardanoAddress" />
-                ),
-                intent: 'info',
-            };
-        }
-        if (isTokenAddress) {
-            return {
-                title: (
-                    <Translation
-                        id="moduleReceive.receiveAddressCard.alert.token"
-                        values={{ networkName }}
-                    />
-                ),
-                intent: 'info',
-            };
-        }
-
-        return undefined;
-    };
-
-    const cardAlertProps = getCardAlertProps();
 
     return (
         <VStack spacing="sp16" flex={1}>
@@ -77,11 +49,7 @@ export const ReceiveAddressCard = ({
                 tokenContract={tokenContract}
                 showLabelEdit={!isTokenAddress}
             />
-            {cardAlertProps && (
-                <Box marginBottom="sp4">
-                    <InlineAlertBox {...cardAlertProps} />
-                </Box>
-            )}
+            <ReceiveAddressInfo networkSymbol={symbol} isTokenAddress={isTokenAddress} />
         </VStack>
     );
 };

--- a/suite-native/module-receive/src/components/ReceiveAddressInfo.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressInfo.test.tsx
@@ -1,0 +1,66 @@
+import { getTranslation } from '@suite-native/intl';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { ReceiveAddressInfo } from './ReceiveAddressInfo';
+
+describe('ReceiveAddressInfo', () => {
+    it('shows the shared assets and tokens information for an Ethereum account', () => {
+        const { getByText } = renderWithBasicProvider(
+            <ReceiveAddressInfo networkSymbol="eth" isTokenAddress={false} />,
+        );
+
+        expect(
+            getByText(
+                getTranslation('moduleReceive.receiveAddressCard.alert.sharedAssetsAndTokens'),
+            ),
+        ).toBeOnTheScreen();
+    });
+
+    it('shows the shared assets and tokens information for an Ethereum token', () => {
+        const { getByText } = renderWithBasicProvider(
+            <ReceiveAddressInfo networkSymbol="eth" isTokenAddress />,
+        );
+
+        expect(
+            getByText(
+                getTranslation('moduleReceive.receiveAddressCard.alert.sharedAssetsAndTokens'),
+            ),
+        ).toBeOnTheScreen();
+    });
+
+    it('does not show the shared assets and tokens information for a Bitcoin account', () => {
+        const { queryByText } = renderWithBasicProvider(
+            <ReceiveAddressInfo networkSymbol="btc" isTokenAddress={false} />,
+        );
+
+        expect(
+            queryByText(
+                getTranslation('moduleReceive.receiveAddressCard.alert.sharedAssetsAndTokens'),
+            ),
+        ).not.toBeOnTheScreen();
+    });
+
+    it('keeps the network-address information for tokens on other networks', () => {
+        const { getByText } = renderWithBasicProvider(
+            <ReceiveAddressInfo networkSymbol="sol" isTokenAddress />,
+        );
+
+        expect(
+            getByText(
+                getTranslation('moduleReceive.receiveAddressCard.alert.token', {
+                    networkName: 'Solana',
+                }),
+            ),
+        ).toBeOnTheScreen();
+    });
+
+    it('keeps the long-address information for Cardano', () => {
+        const { getByText } = renderWithBasicProvider(
+            <ReceiveAddressInfo networkSymbol="ada" isTokenAddress={false} />,
+        );
+
+        expect(
+            getByText(getTranslation('moduleReceive.receiveAddressCard.alert.longCardanoAddress')),
+        ).toBeOnTheScreen();
+    });
+});

--- a/suite-native/module-receive/src/components/ReceiveAddressInfo.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressInfo.tsx
@@ -1,0 +1,58 @@
+import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { Box, InlineAlertBox, type InlineAlertBoxProps } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+type ReceiveAddressInfoProps = {
+    networkSymbol: NetworkSymbol;
+    isTokenAddress: boolean;
+};
+
+export const ReceiveAddressInfo = ({ networkSymbol, isTokenAddress }: ReceiveAddressInfoProps) => {
+    const { name: networkName } = getNetwork(networkSymbol);
+
+    const getAlertProps = (): InlineAlertBoxProps | undefined => {
+        if (networkSymbol === 'ada') {
+            return {
+                title: (
+                    <Translation id="moduleReceive.receiveAddressCard.alert.longCardanoAddress" />
+                ),
+                intent: 'info',
+            };
+        }
+
+        if (networkSymbol === 'eth') {
+            return {
+                title: (
+                    <Translation id="moduleReceive.receiveAddressCard.alert.sharedAssetsAndTokens" />
+                ),
+                intent: 'info',
+            };
+        }
+
+        if (isTokenAddress) {
+            return {
+                title: (
+                    <Translation
+                        id="moduleReceive.receiveAddressCard.alert.token"
+                        values={{ networkName }}
+                    />
+                ),
+                intent: 'info',
+            };
+        }
+
+        return undefined;
+    };
+
+    const alertProps = getAlertProps();
+
+    if (!alertProps) {
+        return null;
+    }
+
+    return (
+        <Box marginBottom="sp4">
+            <InlineAlertBox {...alertProps} />
+        </Box>
+    );
+};


### PR DESCRIPTION
## Description

- Show the shared-address information banner below the QR code for Ethereum accounts and tokens.
- Preserve the existing Cardano long-address warning and non-Ethereum token address information.
- Add focused component coverage for all affected banner states.

## Notes for QA

1. Open Receive for an Ethereum account and confirm the information banner appears below the address.
2. Open Receive for an Ethereum token and confirm the same banner appears.
3. Confirm a Bitcoin receive screen does not show this banner.
4. Confirm existing Cardano and non-Ethereum token notices are unchanged.

## Related Issue
Resolves https://github.com/trezor/trezor-suite/issues/30636

## Screenshots:
<img width="418" height="879" alt="image" src="https://github.com/user-attachments/assets/bc766696-249e-4422-aef2-e648756b7ff7" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/audit-qr-code-banners&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->