### PR TITLE
feat(suite-native): guard receive address verification

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1030,6 +1030,7 @@ export const messages = {
         addressVerificationScreen: {
             pastedTitle: 'Compare the pasted address against your Trezor',
             sharedTitle: 'Compare the shared address against your Trezor',
+            verifiedTitle: 'Check the address on your Trezor',
         },
         bottomSheets: {
             addressMismatch: {

--- a/suite-native/module-receive/package.json
+++ b/suite-native/module-receive/package.json
@@ -33,6 +33,7 @@
         "@suite-native/atoms": "workspace:*",
         "@suite-native/clipboard": "workspace:*",
         "@suite-native/device": "workspace:*",
+        "@suite-native/device-authorization": "workspace:*",
         "@suite-native/device-mutex": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/icons": "workspace:*",

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx
@@ -2,6 +2,7 @@ import { Share } from 'react-native';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type NativeAnalyticsDep, events } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { getTranslation } from '@suite-native/intl';
@@ -15,7 +16,6 @@ const mockOpenCopiedAddressBottomSheet = jest.fn();
 const mockCloseCopiedAddressBottomSheet = jest.fn();
 const mockOpenSharedAddressBottomSheet = jest.fn();
 const mockCloseSharedAddressBottomSheet = jest.fn();
-const mockVerifyAddress = jest.fn();
 const mockShare = jest.spyOn(Share, 'share');
 const mockUseBottomSheetModal = jest.fn();
 const mockNavigate = jest.fn();
@@ -39,19 +39,24 @@ jest.mock('@suite-native/atoms', () => ({
 }));
 
 describe('ReceiveAddressActions', () => {
+    const accountKey = mockAccountKey();
     const address = 'bc1qreceiveaddress';
+    const addressPath = "m/84'/0'/0'/0/0";
     const mockUseNavigation = jest.mocked(useNavigation);
 
     const renderActions = () =>
         renderWithBasicProvider(
-            <ReceiveAddressActions address={address} onVerifyAddress={mockVerifyAddress} />,
+            <ReceiveAddressActions
+                accountKey={accountKey}
+                address={address}
+                addressPath={addressPath}
+            />,
             { services },
         );
 
     beforeEach(() => {
         jest.clearAllMocks();
         mockCopyToClipboard.mockResolvedValue(undefined);
-        mockVerifyAddress.mockResolvedValue(undefined);
         mockShare.mockResolvedValue({ action: Share.sharedAction });
         mockUseNavigation.mockReturnValue({ navigate: mockNavigate } as never);
         mockUseBottomSheetModal
@@ -85,22 +90,23 @@ describe('ReceiveAddressActions', () => {
         });
     });
 
-    it('closes the sheet and starts address verification', async () => {
+    it('closes the sheet and opens address verification', async () => {
         const { getByTestId } = renderActions();
 
         await userEvent.press(getByTestId('@receive/address-verification/pasted/verify-button'));
 
         expect(mockCloseCopiedAddressBottomSheet).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith(ReceiveStackRoutes.ReceiveAddressVerification, {
+            accountKey,
+            addressPath,
             source: ReceiveAddressVerificationSource.Pasted,
         });
-        expect(mockVerifyAddress).toHaveBeenCalledWith();
         expect(mockAnalyticsReport).toHaveBeenCalledWith({
             type: events.receiveStartVerificationEvent.name,
         });
     });
 
-    it('starts address verification directly', async () => {
+    it('opens address verification directly', async () => {
         const { getByText } = renderActions();
 
         await userEvent.press(getByText(getTranslation('moduleReceive.addressActions.verify')));
@@ -108,9 +114,10 @@ describe('ReceiveAddressActions', () => {
         expect(mockCloseCopiedAddressBottomSheet).not.toHaveBeenCalled();
         expect(mockCloseSharedAddressBottomSheet).not.toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith(ReceiveStackRoutes.ReceiveAddressVerification, {
-            source: ReceiveAddressVerificationSource.Pasted,
+            accountKey,
+            addressPath,
+            source: ReceiveAddressVerificationSource.Verified,
         });
-        expect(mockVerifyAddress).toHaveBeenCalledWith();
         expect(mockAnalyticsReport).toHaveBeenCalledWith({
             type: events.receiveStartVerificationEvent.name,
         });
@@ -126,9 +133,10 @@ describe('ReceiveAddressActions', () => {
         expect(mockOpenSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
         expect(mockCloseSharedAddressBottomSheet).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith(ReceiveStackRoutes.ReceiveAddressVerification, {
+            accountKey,
+            addressPath,
             source: ReceiveAddressVerificationSource.Shared,
         });
-        expect(mockVerifyAddress).toHaveBeenCalledWith();
         expect(mockAnalyticsReport).toHaveBeenCalledWith({
             type: events.receiveShareAddressEvent.name,
         });

--- a/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressActions.tsx
@@ -3,6 +3,7 @@ import { Alert, Share } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
+import { type AccountKey } from '@suite-common/wallet-types';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, HStack, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
@@ -17,13 +18,18 @@ import {
 import { ReceiveAddressVerificationBottomSheet } from './ReceiveAddressVerificationBottomSheet';
 
 type ReceiveAddressActionsProps = {
+    accountKey: AccountKey;
     address: string;
-    onVerifyAddress: () => Promise<void>;
+    addressPath: string;
 };
 
 type NavigationProp = StackNavigationProps<ReceiveStackParamList, ReceiveStackRoutes>;
 
-export const ReceiveAddressActions = ({ address, onVerifyAddress }: ReceiveAddressActionsProps) => {
+export const ReceiveAddressActions = ({
+    accountKey,
+    address,
+    addressPath,
+}: ReceiveAddressActionsProps) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const copyToClipboard = useCopyToClipboard();
     const navigation = useNavigation<NavigationProp>();
@@ -47,8 +53,11 @@ export const ReceiveAddressActions = ({ address, onVerifyAddress }: ReceiveAddre
 
     const handleVerifyAddress = (source: ReceiveAddressVerificationSource) => {
         analytics.report({ type: events.receiveStartVerificationEvent.name });
-        navigation.navigate(ReceiveStackRoutes.ReceiveAddressVerification, { source });
-        void onVerifyAddress();
+        navigation.navigate(ReceiveStackRoutes.ReceiveAddressVerification, {
+            accountKey,
+            addressPath,
+            source,
+        });
     };
 
     const handleVerifyCopiedAddress = () => {
@@ -98,7 +107,9 @@ export const ReceiveAddressActions = ({ address, onVerifyAddress }: ReceiveAddre
                         iconLeft="trezorDevices"
                         intent="neutral"
                         priority="secondary"
-                        onPress={() => handleVerifyAddress(ReceiveAddressVerificationSource.Pasted)}
+                        onPress={() =>
+                            handleVerifyAddress(ReceiveAddressVerificationSource.Verified)
+                        }
                         flex={1}
                     >
                         <Translation id="moduleReceive.addressActions.verify" />

--- a/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
+++ b/suite-native/module-receive/src/components/ReceiveAddressContent.tsx
@@ -15,7 +15,6 @@ import { ReceiveAddressCard } from './ReceiveAddressCard';
 import { ReceiveAddressLoader } from './ReceiveAddressLoader';
 import { ReceiveDestinationTagInfo } from './ReceiveDestinationTagInfo';
 import { ReceiveFreshAddressHeader } from './ReceiveFreshAddressHeader';
-import { useReceiveAddressVerification } from '../hooks/useReceiveAddressVerification';
 import { setCurrentFreshAddressForFlowEntryThunk } from '../receiveThunks';
 import { ReceiveBlockedDeviceCompromisedScreen } from '../screens/ReceiveBlockedDeviceCompromisedScreen';
 import { type ReceiveAddressListRootState } from '../selectors';
@@ -47,11 +46,6 @@ export const ReceiveAddressContent = ({
             dispatch(setCurrentFreshAddressForFlowEntryThunk({ accountKey }));
             setInitializedAccountKey(accountKey);
         }, [accountKey, dispatch, initializedAccountKey]),
-    );
-
-    const { verifyAddressOnDevice } = useReceiveAddressVerification(
-        accountKey,
-        currentFreshAddress?.path,
     );
 
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
@@ -87,8 +81,9 @@ export const ReceiveAddressContent = ({
                     <ScreenFooterGradient />
                     <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
                         <ReceiveAddressActions
+                            accountKey={accountKey}
                             address={currentFreshAddress.address}
-                            onVerifyAddress={verifyAddressOnDevice}
+                            addressPath={currentFreshAddress.path}
                         />
                     </VStack>
                 </>

--- a/suite-native/module-receive/src/hooks/useReceiveAddressVerification.tsx
+++ b/suite-native/module-receive/src/hooks/useReceiveAddressVerification.tsx
@@ -10,8 +10,8 @@ import { useAlert } from '@suite-native/alerts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation } from '@suite-native/intl';
 import type {
-    ReceiveStackParamList,
-    ReceiveStackRoutes,
+    ReceiveAddressVerificationStackParamList,
+    ReceiveAddressVerificationStackRoutes,
     StackNavigationProps,
 } from '@suite-native/navigation';
 import { useToast } from '@suite-native/toasts';
@@ -20,7 +20,10 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { AddressVerificationResultType, verifyReceiveAddress } from '../addressVerification';
 
-type NavigationProp = StackNavigationProps<ReceiveStackParamList, ReceiveStackRoutes>;
+type NavigationProp = StackNavigationProps<
+    ReceiveAddressVerificationStackParamList,
+    ReceiveAddressVerificationStackRoutes.ContinueOnTrezor
+>;
 
 export const useReceiveAddressVerification = (
     accountKey: AccountKey,

--- a/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx
+++ b/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx
@@ -1,0 +1,64 @@
+import { Text } from 'react-native';
+
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
+import { ReceiveAddressVerificationSource, ReceiveStackRoutes } from '@suite-native/navigation';
+import { renderWithBasicProvider } from '@suite-native/test-utils';
+
+import { ReceiveAddressVerificationStackNavigator } from './ReceiveAddressVerificationStackNavigator';
+
+const mockIsDeviceConnectionGuardVisible = jest.fn().mockReturnValue(false);
+
+jest.mock('@suite-native/device-authorization', () => ({
+    DeviceConnectionGuardScreen: () => <Text>Connect device</Text>,
+    useDeviceConnectionGuard: () => ({
+        isDeviceConnectionGuardVisible: mockIsDeviceConnectionGuardVisible(),
+    }),
+}));
+
+jest.mock('../screens/ReceiveAddressVerificationScreen', () => ({
+    ReceiveAddressVerificationScreen: () => <Text>Continue on Trezor</Text>,
+}));
+
+describe('ReceiveAddressVerificationStackNavigator', () => {
+    const accountKey = mockAccountKey();
+    const addressPath = "m/84'/0'/0'/0/0";
+    const route = {
+        key: 'receive-address-verification',
+        name: ReceiveStackRoutes.ReceiveAddressVerification,
+        params: {
+            accountKey,
+            addressPath,
+            source: ReceiveAddressVerificationSource.Pasted,
+        },
+    } as const;
+
+    const renderNavigator = () =>
+        renderWithBasicProvider(
+            <ReceiveAddressVerificationStackNavigator navigation={{} as never} route={route} />,
+        );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsDeviceConnectionGuardVisible.mockReturnValue(false);
+    });
+
+    it('shows the continuation screen immediately when the device is ready', async () => {
+        const { findByText } = renderNavigator();
+
+        expect(await findByText('Continue on Trezor')).toBeTruthy();
+    });
+
+    it('shows the connection guard until the device is ready', async () => {
+        mockIsDeviceConnectionGuardVisible.mockReturnValue(true);
+        const { findByText, rerender } = renderNavigator();
+
+        expect(await findByText('Connect device')).toBeTruthy();
+
+        mockIsDeviceConnectionGuardVisible.mockReturnValue(false);
+        rerender(
+            <ReceiveAddressVerificationStackNavigator navigation={{} as never} route={route} />,
+        );
+
+        expect(await findByText('Continue on Trezor')).toBeTruthy();
+    });
+});

--- a/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.tsx
+++ b/suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.tsx
@@ -1,0 +1,48 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import {
+    DeviceConnectionGuardScreen,
+    useDeviceConnectionGuard,
+} from '@suite-native/device-authorization';
+import {
+    type ReceiveAddressVerificationStackParamList,
+    ReceiveAddressVerificationStackRoutes,
+    type ReceiveStackParamList,
+    type ReceiveStackRoutes,
+    type StackProps,
+    stackNavigationOptionsConfig,
+} from '@suite-native/navigation';
+
+import { ReceiveAddressVerificationScreen } from '../screens/ReceiveAddressVerificationScreen';
+
+const ReceiveAddressVerificationStack =
+    createNativeStackNavigator<ReceiveAddressVerificationStackParamList>();
+
+export const ReceiveAddressVerificationStackNavigator = ({
+    route: {
+        params: { accountKey, addressPath, source },
+    },
+}: StackProps<ReceiveStackParamList, ReceiveStackRoutes.ReceiveAddressVerification>) => {
+    const { isDeviceConnectionGuardVisible } = useDeviceConnectionGuard();
+
+    if (isDeviceConnectionGuardVisible) {
+        return (
+            <ReceiveAddressVerificationStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+                <ReceiveAddressVerificationStack.Screen
+                    name={ReceiveAddressVerificationStackRoutes.DeviceConnectionGuard}
+                    component={DeviceConnectionGuardScreen}
+                />
+            </ReceiveAddressVerificationStack.Navigator>
+        );
+    }
+
+    return (
+        <ReceiveAddressVerificationStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+            <ReceiveAddressVerificationStack.Screen
+                name={ReceiveAddressVerificationStackRoutes.ContinueOnTrezor}
+                component={ReceiveAddressVerificationScreen}
+                initialParams={{ accountKey, addressPath, source }}
+            />
+        </ReceiveAddressVerificationStack.Navigator>
+    );
+};

--- a/suite-native/module-receive/src/navigation/ReceiveStackNavigator.tsx
+++ b/suite-native/module-receive/src/navigation/ReceiveStackNavigator.tsx
@@ -6,10 +6,10 @@ import {
     stackNavigationOptionsConfig,
 } from '@suite-native/navigation';
 
+import { ReceiveAddressVerificationStackNavigator } from './ReceiveAddressVerificationStackNavigator';
 import { ReceiveAccountsScreen } from '../screens/ReceiveAccountsScreen';
 import { ReceiveAddressDetailScreen } from '../screens/ReceiveAddressDetailScreen';
 import { ReceiveAddressListScreen } from '../screens/ReceiveAddressListScreen';
-import { ReceiveAddressVerificationScreen } from '../screens/ReceiveAddressVerificationScreen';
 import { ReceiveFreshAddressScreen } from '../screens/ReceiveFreshAddressScreen';
 
 const ReceiveStack = createNativeStackNavigator<ReceiveStackParamList>();
@@ -29,7 +29,7 @@ export const ReceiveStackNavigator = () => (
         />
         <ReceiveStack.Screen
             name={ReceiveStackRoutes.ReceiveAddressVerification}
-            component={ReceiveAddressVerificationScreen}
+            component={ReceiveAddressVerificationStackNavigator}
         />
         <ReceiveStack.Screen
             name={ReceiveStackRoutes.ReceiveAddressList}

--- a/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx
@@ -18,7 +18,6 @@ import { ReceiveAddressActions } from '../components/ReceiveAddressActions';
 import { ReceiveAddressDetailHeader } from '../components/ReceiveAddressDetailHeader';
 import { ReceiveAddressDetails } from '../components/ReceiveAddressDetails';
 import { ReceiveAddressReuseWarning } from '../components/ReceiveAddressReuseWarning';
-import { useReceiveAddressVerification } from '../hooks/useReceiveAddressVerification';
 import { type ReceiveAddressRootState, selectReceiveAccountAddressByPath } from '../selectors';
 
 export const ReceiveAddressDetailScreen = () => {
@@ -33,8 +32,6 @@ export const ReceiveAddressDetailScreen = () => {
     const hasFirmwareAuthenticityCheckHardFailed = useSelector(
         selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
     );
-    const { verifyAddressOnDevice } = useReceiveAddressVerification(accountKey, addressPath);
-
     if (hasFirmwareAuthenticityCheckHardFailed) {
         return <ReceiveBlockedDeviceCompromisedScreen />;
     }
@@ -64,8 +61,9 @@ export const ReceiveAddressDetailScreen = () => {
                     <ScreenFooterGradient />
                     <VStack paddingHorizontal="sp16" paddingTop="sp8" paddingBottom="sp16">
                         <ReceiveAddressActions
+                            accountKey={accountKey}
                             address={address.address}
-                            onVerifyAddress={verifyAddressOnDevice}
+                            addressPath={addressPath}
                         />
                     </VStack>
                 </>

--- a/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx
@@ -3,13 +3,25 @@ import { Text } from 'react-native';
 
 import { useRoute } from '@react-navigation/native';
 
+import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { ReceiveAddressVerificationSource } from '@suite-native/navigation';
-import { renderWithBasicProvider } from '@suite-native/test-utils';
+import { act, renderWithBasicProvider } from '@suite-native/test-utils';
 
 import { ReceiveAddressVerificationScreen } from './ReceiveAddressVerificationScreen';
 
+const mockVerifyAddressOnDevice = jest.fn();
+const mockUseFocusEffect = jest.fn();
+let handleScreenFocus = () => {};
+
+jest.mock('../hooks/useReceiveAddressVerification', () => ({
+    useReceiveAddressVerification: () => ({
+        verifyAddressOnDevice: mockVerifyAddressOnDevice,
+    }),
+}));
+
 jest.mock('@react-navigation/native', () => ({
     ...jest.requireActual('@react-navigation/native'),
+    useFocusEffect: (callback: () => void) => mockUseFocusEffect(callback),
     useRoute: jest.fn(),
 }));
 
@@ -27,12 +39,22 @@ jest.mock('@suite-native/navigation', () => ({
 }));
 
 describe('ReceiveAddressVerificationScreen', () => {
+    const accountKey = mockAccountKey();
+    const addressPath = "m/84'/0'/0'/0/0";
     const mockUseRoute = jest.mocked(useRoute);
 
     beforeEach(() => {
         jest.clearAllMocks();
+        mockUseFocusEffect.mockImplementation(callback => {
+            handleScreenFocus = callback;
+        });
+        mockVerifyAddressOnDevice.mockResolvedValue(undefined);
         mockUseRoute.mockReturnValue({
-            params: { source: ReceiveAddressVerificationSource.Pasted },
+            params: {
+                accountKey,
+                addressPath,
+                source: ReceiveAddressVerificationSource.Pasted,
+            },
         } as never);
     });
 
@@ -42,9 +64,22 @@ describe('ReceiveAddressVerificationScreen', () => {
         expect(getByText('moduleReceive.addressVerificationScreen.pastedTitle')).toBeTruthy();
     });
 
+    it('starts address verification only once when focused repeatedly', () => {
+        renderWithBasicProvider(<ReceiveAddressVerificationScreen />);
+
+        act(handleScreenFocus);
+        act(handleScreenFocus);
+
+        expect(mockVerifyAddressOnDevice).toHaveBeenCalledTimes(1);
+    });
+
     it('displays shared address verification instructions', () => {
         mockUseRoute.mockReturnValue({
-            params: { source: ReceiveAddressVerificationSource.Shared },
+            params: {
+                accountKey,
+                addressPath,
+                source: ReceiveAddressVerificationSource.Shared,
+            },
         } as never);
 
         const { getByText } = renderWithBasicProvider(<ReceiveAddressVerificationScreen />);

--- a/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx
+++ b/suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx
@@ -1,6 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
-import { type RouteProp, useRoute } from '@react-navigation/native';
+import { type RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
 
 import {
     ContinueOnTrezorScreenContent,
@@ -8,16 +8,53 @@ import {
 } from '@suite-native/device';
 import {
     ReceiveAddressVerificationSource,
-    type ReceiveStackParamList,
-    type ReceiveStackRoutes,
+    type ReceiveAddressVerificationStackParamList,
+    type ReceiveAddressVerificationStackRoutes,
     useInterceptNativeNavigation,
 } from '@suite-native/navigation';
 import TrezorConnect from '@trezor/connect';
+import { exhaustive } from '@trezor/type-utils';
+
+import { useReceiveAddressVerification } from '../hooks/useReceiveAddressVerification';
+
+const getTitleTxKey = (source: ReceiveAddressVerificationSource) => {
+    switch (source) {
+        case ReceiveAddressVerificationSource.Pasted:
+            return 'moduleReceive.addressVerificationScreen.pastedTitle';
+        case ReceiveAddressVerificationSource.Shared:
+            return 'moduleReceive.addressVerificationScreen.sharedTitle';
+        case ReceiveAddressVerificationSource.Verified:
+            return 'moduleReceive.addressVerificationScreen.verifiedTitle';
+        default:
+            return exhaustive(source);
+    }
+};
 
 export const ReceiveAddressVerificationScreen = () => {
     const {
-        params: { source },
-    } = useRoute<RouteProp<ReceiveStackParamList, ReceiveStackRoutes.ReceiveAddressVerification>>();
+        params: { accountKey, addressPath, source },
+    } =
+        useRoute<
+            RouteProp<
+                ReceiveAddressVerificationStackParamList,
+                ReceiveAddressVerificationStackRoutes.ContinueOnTrezor
+            >
+        >();
+    const { verifyAddressOnDevice } = useReceiveAddressVerification(accountKey, addressPath);
+    const hasStartedVerificationRef = useRef(false);
+
+    // This screen becomes focused only after the connection guard is cleared. Start verification
+    // here and guard against focus returning after device authorization.
+    useFocusEffect(
+        useCallback(() => {
+            if (hasStartedVerificationRef.current) {
+                return;
+            }
+
+            hasStartedVerificationRef.current = true;
+            void verifyAddressOnDevice();
+        }, [verifyAddressOnDevice]),
+    );
 
     const handleCancel = useCallback(() => {
         TrezorConnect.cancel();
@@ -25,14 +62,9 @@ export const ReceiveAddressVerificationScreen = () => {
 
     useInterceptNativeNavigation({ onPress: handleCancel });
 
-    const titleTxKey =
-        source === ReceiveAddressVerificationSource.Shared
-            ? 'moduleReceive.addressVerificationScreen.sharedTitle'
-            : 'moduleReceive.addressVerificationScreen.pastedTitle';
-
     return (
         <DeviceInteractionScreenWrapper>
-            <ContinueOnTrezorScreenContent titleTxKey={titleTxKey} />
+            <ContinueOnTrezorScreenContent titleTxKey={getTitleTxKey(source)} />
         </DeviceInteractionScreenWrapper>
     );
 };

--- a/suite-native/module-receive/tsconfig.json
+++ b/suite-native/module-receive/tsconfig.json
@@ -33,6 +33,7 @@
         { "path": "../atoms" },
         { "path": "../clipboard" },
         { "path": "../device" },
+        { "path": "../device-authorization" },
         { "path": "../device-mutex" },
         { "path": "../formatters" },
         { "path": "../icons" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -39,6 +39,7 @@ import {
     type OnboardingStackRoutes,
     type PassphraseStackRoutes,
     type ReceiveAddressVerificationSource,
+    type ReceiveAddressVerificationStackRoutes,
     type ReceiveStackRoutes,
     type RootStackRoutes,
     type SendStackRoutes,
@@ -175,6 +176,8 @@ export type ReceiveStackParamList = {
     [ReceiveStackRoutes.ReceiveAccounts]: undefined;
     [ReceiveStackRoutes.ReceiveAddress]: AccountDetailParams;
     [ReceiveStackRoutes.ReceiveAddressVerification]: {
+        accountKey: AccountKey;
+        addressPath: string;
         source: ReceiveAddressVerificationSource;
     };
     [ReceiveStackRoutes.ReceiveAddressList]: {
@@ -183,6 +186,15 @@ export type ReceiveStackParamList = {
     [ReceiveStackRoutes.ReceiveAddressDetail]: {
         accountKey: AccountKey;
         addressPath: string;
+    };
+};
+
+export type ReceiveAddressVerificationStackParamList = {
+    [ReceiveAddressVerificationStackRoutes.DeviceConnectionGuard]: undefined;
+    [ReceiveAddressVerificationStackRoutes.ContinueOnTrezor]: {
+        accountKey: AccountKey;
+        addressPath: string;
+        source: ReceiveAddressVerificationSource;
     };
 };
 

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -274,6 +274,12 @@ export enum ReceiveStackRoutes {
 export enum ReceiveAddressVerificationSource {
     Pasted = 'pasted',
     Shared = 'shared',
+    Verified = 'verified',
+}
+
+export enum ReceiveAddressVerificationStackRoutes {
+    DeviceConnectionGuard = 'DeviceConnectionGuard',
+    ContinueOnTrezor = 'ContinueOnTrezor',
 }
 
 export enum SendStackRoutes {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13247,6 +13247,7 @@ __metadata:
     "@suite-native/atoms": "workspace:*"
     "@suite-native/clipboard": "workspace:*"
     "@suite-native/device": "workspace:*"
+    "@suite-native/device-authorization": "workspace:*"
     "@suite-native/device-mutex": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/icons": "workspace:*"


### PR DESCRIPTION
## Summary

- add a dedicated receive-address verification stack with the standard device connection guard
- start verification when the receive-specific Continue on Trezor screen gains focus
- pass the account, address path, and verification source through typed navigation params for direct, copy, and share flows

## Notes for QA
Please verify that receive flow works as expected without connected device. Try also with passphrase and pin combinations, cancelling screens should take you where you'd expect.

## Screenshots

https://github.com/user-attachments/assets/dbb2bf62-6cfe-4e62-9ea2-1eb1217f2ec2



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/mobile-receive-redirect/web/](https://dev.suite.sldev.cz/suite-web/juriczech/mobile-receive-redirect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T10:04:33.498Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T10:04:51.551Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/mobile-receive-redirect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/mobile-receive-redirect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/mobile-receive-redirect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all in suite-native (the mobile React Native app), specifically the module-receive feature and navigation/intl configuration. All 134 candidate tests are Playwright E2E tests for suite-web (browser/desktop Suite) and do not exercise the native mobile receive flow. There is no functional overlap, so no E2E tests are recommended. The risk is localized to the native receive address verification flow and should be covered by native/mobile unit/integration tests instead.

<details><summary><b>Changed files (15)</b></summary>

- `suite-native/intl/src/messages.ts`
- `suite-native/module-receive/package.json`
- `suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressActions.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/hooks/useReceiveAddressVerification.tsx`
- `suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx`
- `suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.tsx`
- `suite-native/module-receive/src/navigation/ReceiveStackNavigator.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx`
- `suite-native/module-receive/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (15)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-receive/package.json`
- `suite-native/module-receive/src/components/ReceiveAddressActions.test.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressActions.tsx`
- `suite-native/module-receive/src/components/ReceiveAddressContent.tsx`
- `suite-native/module-receive/src/hooks/useReceiveAddressVerification.tsx`
- `suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.test.tsx`
- `suite-native/module-receive/src/navigation/ReceiveAddressVerificationStackNavigator.tsx`
- `suite-native/module-receive/src/navigation/ReceiveStackNavigator.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressDetailScreen.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.test.tsx`
- `suite-native/module-receive/src/screens/ReceiveAddressVerificationScreen.tsx`
- `suite-native/module-receive/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`

_Updated: 2026-08-06T10:02:14.120Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->