### PR TITLE
refactor(suite): inject network configuration

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/storageActions.test.ts
@@ -299,8 +299,18 @@ describe('Storage actions', () => {
         );
 
         // add txs
-        store.dispatch(transactionsActions.addTransaction({ transactions: [tx1], account: acc1 }));
-        store.dispatch(transactionsActions.addTransaction({ transactions: [tx2], account: acc2 }));
+        store.dispatch(
+            transactionsActions.addTransaction(
+                { transactions: [tx1], account: acc1 },
+                extraDependencies.services.getNetworkConfig,
+            ),
+        );
+        store.dispatch(
+            transactionsActions.addTransaction(
+                { transactions: [tx2], account: acc2 },
+                extraDependencies.services.getNetworkConfig,
+            ),
+        );
 
         // remember devices
         await store.dispatch(storageActions.rememberDevice(dev1));
@@ -384,8 +394,18 @@ describe('Storage actions', () => {
         );
 
         // add txs
-        store.dispatch(transactionsActions.addTransaction({ transactions: [tx1], account: acc1 }));
-        store.dispatch(transactionsActions.addTransaction({ transactions: [tx2], account: acc2 }));
+        store.dispatch(
+            transactionsActions.addTransaction(
+                { transactions: [tx1], account: acc1 },
+                extraDependencies.services.getNetworkConfig,
+            ),
+        );
+        store.dispatch(
+            transactionsActions.addTransaction(
+                { transactions: [tx2], account: acc2 },
+                extraDependencies.services.getNetworkConfig,
+            ),
+        );
 
         // store in db
         await store.dispatch(storageActions.rememberDevice(dev1));

--- a/packages/suite/src/actions/wallet/exportTransactionsActions.ts
+++ b/packages/suite/src/actions/wallet/exportTransactionsActions.ts
@@ -71,7 +71,7 @@ export const exportTransactionsThunk = createThunk(
 
         const filteredTransaction =
             searchQuery.trim() !== ''
-                ? advancedSearchTransactions(transactions, searchLabels, searchQuery)
+                ? advancedSearchTransactions(services, transactions, searchLabels, searchQuery)
                 : transactions;
 
         // getAccountTransactions doesn't guarantee transactions will be sorted
@@ -79,6 +79,7 @@ export const exportTransactionsThunk = createThunk(
 
         // Prepare data in right format
         const data = await formatData(
+            services,
             {
                 symbol: account.symbol,
                 accountName,

--- a/packages/suite/src/actions/wallet/graphActions.ts
+++ b/packages/suite/src/actions/wallet/graphActions.ts
@@ -1,4 +1,4 @@
-import { createThunk } from '@suite-common/redux-utils';
+import { type ExtraDependencies, createThunk } from '@suite-common/redux-utils';
 import { resetTime } from '@suite-common/suite-utils';
 import { selectBaseCurrency, selectIsElectrumBackendSelected } from '@suite-common/wallet-core';
 import { type AccountKey, createAccountKey } from '@suite-common/wallet-types';
@@ -6,7 +6,7 @@ import { isTrezorConnectBackendType, tryGetAccountIdentity } from '@suite-common
 import TrezorConnect from '@trezor/connect';
 import { asCoinSymbol } from '@trezor/connect-common';
 
-import { type Dispatch, type GetState } from 'src/types/suite';
+import { type AppState, type Dispatch, type GetState } from 'src/types/suite';
 import { type Account } from 'src/types/wallet';
 import {
     type AccountHistoryWithBalance,
@@ -78,7 +78,7 @@ export const setSelectedRange = (range: GraphRange): GraphAction => ({
  */
 export const fetchAccountGraphData =
     (account: Account, options: { abortSignal?: AbortSignal }) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         dispatch({
             type: ACCOUNT_GRAPH_START,
             payload: {
@@ -113,6 +113,7 @@ export const fetchAccountGraphData =
 
         if (response?.success) {
             const responseWithRates = await ensureHistoryRates(
+                extra.services,
                 account.symbol,
                 response.payload,
                 baseCurrencyCode,
@@ -128,6 +129,7 @@ export const fetchAccountGraphData =
                     : undefined;
 
             const enhancedResponse = enhanceBlockchainAccountHistory(
+                extra.services,
                 responseWithRates,
                 account.symbol,
                 balanceBeforeFirstFreshPoint,
@@ -177,80 +179,68 @@ export const fetchAccountGraphData =
 export const updateGraphData = createThunk<
     void,
     { accounts: Account[]; abortSignal?: AbortSignal },
-    void
->(
-    'wallet/updateGraphData',
-    async (
-        { accounts, abortSignal },
-        {
-            dispatch,
-            getState,
-        }: {
-            dispatch: Dispatch;
-            getState: GetState;
-        },
-    ) => {
-        const { graph } = getState().wallet;
+    { state: AppState }
+>('wallet/updateGraphData', async ({ accounts, abortSignal }, { dispatch, getState, extra }) => {
+    const {graph} = getState().wallet;
 
-        const supportedAccounts = accounts.filter(
-            a =>
-                isTrezorConnectBackendType(a.backendType) &&
-                isNetworkWithGraphFeature(a.symbol, a.backendType),
-        );
+    const supportedAccounts = accounts.filter(
+        a =>
+            isTrezorConnectBackendType(a.backendType) &&
+            isNetworkWithGraphFeature(extra.services, a.symbol, a.backendType),
+    );
 
-        const graphDataPointsByAccount = new Map<AccountKey, AccountHistoryWithBalance[]>(
-            graph.data.map(({ account, data }) => [
-                createAccountKey({
-                    accountDescriptor: account.descriptor,
-                    networkSymbol: account.symbol,
-                    deviceStaticSessionId: account.deviceState,
-                }),
-                data,
-            ]),
-        );
-
-        const graphTxCountByAccount = new Map<AccountKey, number>(
-            Array.from(graphDataPointsByAccount.entries()).map(([key, data]) => {
-                const txCount = data.reduce((acc, point) => acc + point.txs, 0);
-
-                return [key, txCount];
+    const graphDataPointsByAccount = new Map<AccountKey, AccountHistoryWithBalance[]>(
+        graph.data.map(({ account, data }) => [
+            createAccountKey({
+                accountDescriptor: account.descriptor,
+                networkSymbol: account.symbol,
+                deviceStaticSessionId: account.deviceState,
             }),
-        );
+            data,
+        ]),
+    );
 
-        const accountsToFetch = supportedAccounts.filter(account => {
-            const txCount = graphTxCountByAccount.get(account.key) ?? 0;
+    const graphTxCountByAccount = new Map<AccountKey, number>(
+        Array.from(graphDataPointsByAccount.entries()).map(([key, data]) => {
+            const txCount = data.reduce((acc, point) => acc + point.txs, 0);
 
-            return txCount !== account.history.total;
+            return [key, txCount];
+        }),
+    );
+
+    const accountsToFetch = supportedAccounts.filter(account => {
+        const txCount = graphTxCountByAccount.get(account.key) ?? 0;
+
+        return txCount !== account.history.total;
+    });
+
+    if (accountsToFetch.length === 0) {
+        return;
+    }
+
+    try {
+        dispatch({
+            type: AGGREGATED_GRAPH_START,
         });
+        const promises = accountsToFetch.map(a =>
+            dispatch(
+                fetchAccountGraphData(a, {
+                    abortSignal,
+                }),
+            ),
+        );
+        await Promise.all(promises);
 
-        if (accountsToFetch.length === 0) {
-            return;
-        }
+        abortSignal?.throwIfAborted();
 
-        try {
-            dispatch({
-                type: AGGREGATED_GRAPH_START,
-            });
-            const promises = accountsToFetch.map(a =>
-                dispatch(
-                    fetchAccountGraphData(a, {
-                        abortSignal,
-                    }),
-                ),
-            );
-            await Promise.all(promises);
-
-            abortSignal?.throwIfAborted();
-
+        dispatch({
+            type: AGGREGATED_GRAPH_SUCCESS,
+        });
+    } catch (error) {
+        if (error.name === 'AbortError') {
             dispatch({
                 type: AGGREGATED_GRAPH_SUCCESS,
             });
-        } catch (error) {
-            if (error.name === 'AbortError') {
-                dispatch({
-                    type: AGGREGATED_GRAPH_SUCCESS,
-                });
-            }
         }
-    },
-);
+    }
+});

--- a/packages/suite/src/actions/wallet/selectedAccountActions.ts
+++ b/packages/suite/src/actions/wallet/selectedAccountActions.ts
@@ -6,7 +6,8 @@ import {
     selectRouterParams,
 } from '@suite/router';
 import { deviceActions, selectSelectedDevice } from '@suite-common/device';
-import { getNetwork } from '@suite-common/wallet-config';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
+import { toNetwork } from '@suite-common/wallet-config';
 import {
     accountsActions,
     blockchainActions,
@@ -24,7 +25,10 @@ import { type Action, type AppState, type Dispatch, type GetState } from 'src/ty
 import { getSelectedAccount } from 'src/utils/wallet/accountUtils';
 
 // move to selector!!!!
-export const getAccountState = (state: AppState): SelectedAccountStatus => {
+export const getAccountState = (
+    deps: GetNetworkConfigDep,
+    state: AppState,
+): SelectedAccountStatus => {
     const device = selectSelectedDevice(state);
 
     // waiting for device
@@ -65,7 +69,7 @@ export const getAccountState = (state: AppState): SelectedAccountStatus => {
               }
     ) as Pick<NonNullable<WalletParams>, 'symbol' | 'accountIndex' | 'accountType'>;
 
-    const network = getNetwork(params.symbol);
+    const network = toNetwork(params.symbol, deps.getNetworkConfig(params.symbol));
 
     // account cannot exists since requested network is not selected in settings/wallet
     if (!enabledNetworks.includes(network.symbol)) {
@@ -182,59 +186,61 @@ const actions = new Set<Action['type']>([
 /*
  * Called from WalletMiddleware
  */
-export const syncSelectedAccount = (action: Action) => (dispatch: Dispatch, getState: GetState) => {
-    // ignore not listed actions
-    if (!actions.has(action.type)) return;
-    const state = getState();
-    // ignore if not in wallet or in global trading routes (buy, sell, exchange, redirect)
-    if (selectRouterApp(state) !== 'wallet') {
-        return;
-    }
-
-    const routeName = selectRouteName(state);
-
-    if (
-        routeName?.startsWith('wallet-trading-buy') ||
-        routeName?.startsWith('wallet-trading-sell') ||
-        routeName?.startsWith('wallet-trading-exchange') ||
-        routeName === 'wallet-trading-redirect'
-    ) {
-        return;
-    }
-
-    // get new state
-    const newState = getAccountState(state);
-    if (!newState) return;
-
-    // find differences
-    const stateChanged = isChanged(state.wallet.selectedAccount, newState, {
-        account: [
-            'descriptor',
-            'availableBalance',
-            'misc',
-            'marker',
-            'tokens',
-            'metadata',
-            'addresses',
-            'visible',
-            'utxo',
-            'status',
-            'syncing',
-        ],
-    });
-
-    if (stateChanged) {
-        dispatch(accountsActions.updateSelectedAccount(newState));
-
-        // reset filter if user selects a different coin
-        const coinFilter = state.wallet.accountSearch?.coinFilter;
-        if (
-            coinFilter?.length !== 0 &&
-            newState.status !== 'none' &&
-            newState.network &&
-            !coinFilter.includes(newState.network.symbol)
-        ) {
-            dispatch(accountSearchActions.setCoinFilter([]));
+export const syncSelectedAccount =
+    (action: Action) =>
+    (dispatch: Dispatch, getState: GetState, extra: { services: GetNetworkConfigDep }) => {
+        // ignore not listed actions
+        if (!actions.has(action.type)) return;
+        const state = getState();
+        // ignore if not in wallet or in global trading routes (buy, sell, exchange, redirect)
+        if (selectRouterApp(state) !== 'wallet') {
+            return;
         }
-    }
-};
+
+        const routeName = selectRouteName(state);
+
+        if (
+            routeName?.startsWith('wallet-trading-buy') ||
+            routeName?.startsWith('wallet-trading-sell') ||
+            routeName?.startsWith('wallet-trading-exchange') ||
+            routeName === 'wallet-trading-redirect'
+        ) {
+            return;
+        }
+
+        // get new state
+        const newState = getAccountState(extra.services, state);
+        if (!newState) return;
+
+        // find differences
+        const stateChanged = isChanged(state.wallet.selectedAccount, newState, {
+            account: [
+                'descriptor',
+                'availableBalance',
+                'misc',
+                'marker',
+                'tokens',
+                'metadata',
+                'addresses',
+                'visible',
+                'utxo',
+                'status',
+                'syncing',
+            ],
+        });
+
+        if (stateChanged) {
+            dispatch(accountsActions.updateSelectedAccount(newState));
+
+            // reset filter if user selects a different coin
+            const coinFilter = state.wallet.accountSearch?.coinFilter;
+            if (
+                coinFilter?.length !== 0 &&
+                newState.status !== 'none' &&
+                newState.network &&
+                !coinFilter.includes(newState.network.symbol)
+            ) {
+                dispatch(accountSearchActions.setCoinFilter([]));
+            }
+        }
+    };

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -12,7 +12,7 @@ import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
+import { getEarnYieldClaimContractAddress } from '@suite-common/wallet-config';
 import {
     STABLECOIN_YIELD_PREFIX,
     type YieldEstimatedFeeLevel,
@@ -79,13 +79,13 @@ export const claimMerklRewardsThunk = createThunk(
             throw new Error('Yield claim currently supports only EVM accounts.');
         }
 
-        const network = getNetwork(account.symbol);
+        const network = extra.services.getNetworkConfig(account.symbol);
 
         if (!network.chainId) {
             throw new Error('Chain ID not found for network.');
         }
 
-        const merklXyzContractAddress = getEarnYieldClaimContractAddress(network.symbol);
+        const merklXyzContractAddress = getEarnYieldClaimContractAddress(account.symbol);
 
         if (!merklXyzContractAddress) {
             throw new Error('Merkl.xyz contract address not found for network.');
@@ -253,6 +253,7 @@ export const claimMerklRewardsThunk = createThunk(
 
                 const pushResponse = await TrezorConnect.pushTransaction({
                     tx: getMevProtectedTxData(
+                        extra.services,
                         account.symbol,
                         signingResponse.payload.serializedTx,
                         isMevProtectionEnabled && isMevProtectionFeatureEnabled,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -1,6 +1,6 @@
 import { asEvmAddress } from '@suite-common/calldata';
 import { getYieldVault } from '@suite-common/earn-stablecoin-api';
-import { getNetwork } from '@suite-common/wallet-config';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
 import {
     type YieldFeeEstimationError,
     type YieldFlowResolvedData,
@@ -17,7 +17,7 @@ import { type Result, err, ok } from '@trezor/type-utils';
 
 import type { AppState, Dispatch } from 'src/types/suite';
 
-export type ComposeYieldWithdrawTransactionParams = {
+export type ComposeYieldWithdrawTransactionParams = GetNetworkConfigDep & {
     account: Account & { networkType: 'ethereum' };
     flowData: YieldFlowResolvedData;
     amount: string;
@@ -33,6 +33,7 @@ export const composeYieldWithdrawTransaction = async ({
     flowType,
     dispatch,
     getState,
+    getNetworkConfig,
 }: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
     const { vault } = flowData;
 
@@ -42,7 +43,7 @@ export const composeYieldWithdrawTransaction = async ({
             vaultId: vault.id,
         },
     });
-    const network = getNetwork(account.symbol);
+    const network = getNetworkConfig(account.symbol);
 
     if (!network.chainId) {
         throw new Error(`Network ${account.symbol} is missing chainId.`);

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -2,6 +2,7 @@ import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowType,
@@ -49,7 +50,7 @@ export const getYieldSubmitErrorAnalyticsMessage = (error: unknown) =>
         ? 'push-failed'
         : 'submit-failed';
 
-export type SendYieldTransactionParams = {
+export type SendYieldTransactionParams = GetNetworkConfigDep & {
     account: Account;
     amount: string;
     token: YieldFlowDisplayToken;
@@ -71,6 +72,7 @@ export const sendYieldTransaction = async ({
     dispatch,
     getState,
     selectedFee,
+    getNetworkConfig,
 }: SendYieldTransactionParams) => {
     const device = selectSelectedDevice(getState());
     const addressDisplayType = selectAddressDisplayType(getState());
@@ -84,6 +86,7 @@ export const sendYieldTransaction = async ({
     }
 
     const transactionReview = buildStablecoinYieldTransactionReview({
+        getNetworkConfig,
         unsignedTransaction,
         selectedFee,
         amount,
@@ -154,6 +157,7 @@ export const sendYieldTransaction = async ({
 
         const pushResponse = await TrezorConnect.pushTransaction({
             tx: getMevProtectedTxData(
+                { getNetworkConfig },
                 account.symbol,
                 signingResponse.payload.serializedTx,
                 isMevProtectionEnabled && isMevProtectionFeatureEnabled,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -103,6 +103,7 @@ export const submitYieldDepositThunk = createThunk(
             const selectedFee = userAcceptedTxSimulation?.selectedFee ?? null;
 
             const sendResult = await sendYieldTransaction({
+                ...extra.services,
                 account: flowData.account,
                 amount,
                 token: flowData.token,

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -60,6 +60,7 @@ export const submitYieldWithdrawThunk = createThunk(
                 flowType,
                 dispatch,
                 getState,
+                getNetworkConfig: extra.services.getNetworkConfig,
             });
 
             if (!composeResult.success) {
@@ -107,6 +108,7 @@ export const submitYieldWithdrawThunk = createThunk(
             const reviewToken = flowType === 'redeem' ? flowData.receiptToken : flowData.token;
 
             const result = await sendYieldTransaction({
+                ...extra.services,
                 account,
                 amount,
                 token: reviewToken,

--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -5,6 +5,7 @@ import {
 } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type AdaPools } from '@suite-common/earn-staking-api';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
 import { type ExtraDependencies } from '@suite-common/redux-utils';
 import {
     calculate,
@@ -57,6 +58,7 @@ import { BigNumber } from '@trezor/utils';
 import { type Dispatch, type GetState } from 'src/types/suite';
 
 const calculateTransaction = (
+    deps: GetNetworkConfigDep,
     availableBalance: string,
     output: ExternalOutput,
     feeLevel: FeeLevel,
@@ -69,14 +71,17 @@ const calculateTransaction = (
     const stakingParams = {
         feeInBaseUnits,
         minBalanceForStakingInBaseUnits: networkAmountToSmallestUnit(
+            deps,
             MIN_CARDANO_BALANCE_FOR_STAKING.toString(),
             symbol,
         ),
         minAmountForStakingInBaseUnits: networkAmountToSmallestUnit(
+            deps,
             MIN_CARDANO_AMOUNT_FOR_STAKING.toString(),
             symbol,
         ),
         minAmountForWithdrawalInBaseUnits: networkAmountToSmallestUnit(
+            deps,
             MIN_CARDANO_FOR_WITHDRAWALS.toString(),
             symbol,
         ),
@@ -85,6 +90,7 @@ const calculateTransaction = (
     const estimatedFeeLevel = { ...feeLevel, ...estimatedFee?.payload };
 
     return calculate(
+        deps,
         availableBalance,
         output,
         estimatedFeeLevel,
@@ -96,6 +102,7 @@ const calculateTransaction = (
 };
 
 export const prepareTxPlan = async (
+    deps: GetNetworkConfigDep,
     account: Account,
     action: CardanoAction,
     cardanoPools: AdaPools['pools'],
@@ -178,7 +185,7 @@ export const prepareTxPlan = async (
         withdrawals,
         changeAddress,
         addressParameters,
-        testnet: isTestnet(account.symbol),
+        testnet: isTestnet(deps, account.symbol),
     });
 
     if (!response.success) throw new Error(response.error.message);
@@ -187,6 +194,7 @@ export const prepareTxPlan = async (
 };
 
 const getTransactionData = (
+    deps: GetNetworkConfigDep,
     formValues: StakeFormState,
     selectedAccount: SelectedAccountStatus,
     cardanoPools: AdaPools['pools'],
@@ -201,23 +209,24 @@ const getTransactionData = (
     const { account } = selectedAccount;
 
     if (stakeType === 'stake') {
-        return prepareTxPlan(account, 'delegate', cardanoPools, votingDelegation);
+        return prepareTxPlan(deps, account, 'delegate', cardanoPools, votingDelegation);
     }
 
     if (stakeType === 'unstake') {
-        return prepareTxPlan(account, 'deregister', cardanoPools, votingDelegation);
+        return prepareTxPlan(deps, account, 'deregister', cardanoPools, votingDelegation);
     }
 
     if (stakeType === 'claim') {
-        return prepareTxPlan(account, 'withdrawal', cardanoPools, votingDelegation);
+        return prepareTxPlan(deps, account, 'withdrawal', cardanoPools, votingDelegation);
     }
 
     if (stakeType === 'change-delegate') {
-        return prepareTxPlan(account, 'voteDelegate', cardanoPools, votingDelegation);
+        return prepareTxPlan(deps, account, 'voteDelegate', cardanoPools, votingDelegation);
     }
 };
 
 export const calculateOutputAmount = (
+    deps: GetNetworkConfigDep,
     account: Account,
     stakeType: StakeType,
     totalSpent?: string,
@@ -237,6 +246,7 @@ export const calculateOutputAmount = (
     }
 
     return subunitsToUnits({
+        ...deps,
         value: asAmountSubunit(amount),
         symbol: account.symbol,
     }).toString();
@@ -244,7 +254,7 @@ export const calculateOutputAmount = (
 
 export const composeTransaction =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
-    async (_: Dispatch, getState: GetState) => {
+    async (_: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { selectedAccount, stake } = getState().wallet;
         const cardanoPools = selectCardanoPoolsInfo(getState());
 
@@ -253,6 +263,7 @@ export const composeTransaction =
         if (selectedAccount.status !== 'loaded') return;
 
         const txData = await getTransactionData(
+            extra.services,
             formValues,
             selectedAccount,
             cardanoPools,
@@ -262,6 +273,7 @@ export const composeTransaction =
         if (txPlan?.type !== 'final') return;
 
         const amountAda = calculateOutputAmount(
+            extra.services,
             selectedAccount.account,
             formValues.stakeType,
             txPlan?.totalSpent,
@@ -300,6 +312,7 @@ export const composeTransaction =
         const predefinedLevels = levels.filter(l => l.label !== 'custom');
 
         return composeStakingTransaction(
+            extra.services,
             formValuesExtended,
             formState,
             predefinedLevels,
@@ -351,6 +364,7 @@ export const signTransaction =
         }
 
         const txData = await getTransactionData(
+            extra.services,
             formValues,
             selectedAccount,
             cardanoPools,
@@ -389,7 +403,7 @@ export const signTransaction =
             inputs: txPlan.inputs,
             outputs: txPlan.outputs,
             unsignedTx: txPlan.unsignedTx,
-            testnet: isTestnet(account.symbol),
+            testnet: isTestnet(extra.services, account.symbol),
             fee: txPlan.fee,
             protocolMagic: getProtocolMagic(account.symbol),
             networkId: getNetworkId(),

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,5 +1,6 @@
 import { asTypedDesktopAnalytics, events } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type ExtraDependencies } from '@suite-common/redux-utils';
 import {
     getStakeTxGasLimit,
@@ -40,6 +41,7 @@ import TrezorConnect, { type FeeLevel } from '@trezor/connect';
 import { type Dispatch, type GetState } from 'src/types/suite';
 
 const calculateStakingTransaction = (
+    deps: GetNetworkConfigDep,
     availableBalance: string,
     output: ExternalOutput,
     feeLevel: FeeLevel,
@@ -58,11 +60,20 @@ const calculateStakingTransaction = (
         minAmountForWithdrawalInBaseUnits: fromEther(MIN_ETH_FOR_WITHDRAWALS.toString()).toWei(),
     };
 
-    return calculate(availableBalance, output, feeLevel, compareWithAmount, symbol, stakingParams);
+    return calculate(
+        deps,
+        availableBalance,
+        output,
+        feeLevel,
+        compareWithAmount,
+        symbol,
+        stakingParams,
+    );
 };
 
 export const composeTransaction =
-    (formValues: StakeFormState, formState: ComposeActionContext) => async () => {
+    (formValues: StakeFormState, formState: ComposeActionContext) =>
+    async (_dispatch: Dispatch, _getState: GetState, extra: ExtraDependencies) => {
         const { account, feeInfo } = formState;
         if (!account || !feeInfo) return;
 
@@ -73,6 +84,7 @@ export const composeTransaction =
         // gasLimit calculation based on account.descriptor and amount
         const { stakeType } = formValues;
         const stakeTxGasLimit = await getStakeTxGasLimit({
+            ...extra.services,
             stakeType,
             from: account.descriptor,
             amount,
@@ -104,6 +116,7 @@ export const composeTransaction =
         }
 
         return composeStakingTransaction(
+            extra.services,
             formValues,
             formState,
             predefinedLevels,
@@ -147,6 +160,7 @@ export const signTransaction =
             const amount = formValues.outputs[0]?.amount ?? '0';
 
             txData = await prepareStakeEthTx({
+                ...extra.services,
                 symbol: account.symbol,
                 from: account.descriptor,
                 identity,
@@ -163,6 +177,7 @@ export const signTransaction =
             const amount = formValues.outputs[0]?.amount ?? '0';
 
             txData = await prepareUnstakeEthTx({
+                ...extra.services,
                 symbol: account.symbol,
                 from: account.descriptor,
                 identity,
@@ -178,6 +193,7 @@ export const signTransaction =
         }
         if (stakeType === 'claim') {
             txData = await prepareClaimEthTx({
+                ...extra.services,
                 symbol: account.symbol,
                 from: account.descriptor,
                 identity,

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -21,7 +21,7 @@ const getSolanaUserAgent = () => `Trezor Suite ${getSuiteVersion()}`;
 
 export const composeTransaction =
     (formValues: StakeFormState, formState: ComposeActionContext) =>
-    async (_: Dispatch, getState: GetState) => {
+    async (_: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const { selectedAccount, blockchain } = getState().wallet;
 
         if (selectedAccount.status !== 'loaded') return;
@@ -33,6 +33,7 @@ export const composeTransaction =
         if (!blockchainUrl) return;
 
         return await composeSolanaStakingTransaction({
+            ...extra.services,
             formValues,
             composeContext: formState,
             blockchainUrl,

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -105,6 +105,7 @@ const pushTransaction =
         if (!serializedTx || !precomposedTx || !account) return;
 
         const txData = getMevProtectedTxData(
+            extra.services,
             serializedTx.symbol,
             serializedTx.tx,
             isMevProtectionEnabled && isMevProtectionFeatureEnabled,
@@ -124,7 +125,13 @@ const pushTransaction =
             .toString();
 
         // get total amount without fee
-        const formattedAmount = formatNetworkAmount(spentWithoutFee, account.symbol, true, false);
+        const formattedAmount = formatNetworkAmount(
+            extra.services,
+            spentWithoutFee,
+            account.symbol,
+            true,
+            false,
+        );
 
         if (sentTx.success) {
             const { txid } = sentTx.payload;

--- a/packages/suite/src/actions/wallet/tokenActions.ts
+++ b/packages/suite/src/actions/wallet/tokenActions.ts
@@ -1,3 +1,4 @@
+import type { ExtraDependencies } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { accountsActions } from '@suite-common/wallet-core';
 import * as accountUtils from '@suite-common/wallet-utils';
@@ -8,12 +9,15 @@ import { type Account } from 'src/types/wallet';
 
 export const addToken =
     (account: Account, tokenInfo: TokenInfo[], options?: { showSuccessToast?: boolean }) =>
-    (dispatch: Dispatch) => {
+    (dispatch: Dispatch, _getState: unknown, extra: ExtraDependencies) => {
         dispatch(
-            accountsActions.updateAccount({
-                ...account,
-                tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
-            }),
+            accountsActions.updateAccount(
+                {
+                    ...account,
+                    tokens: (account.tokens || []).concat(accountUtils.enhanceTokens(tokenInfo)),
+                },
+                extra.services.getNetworkConfig,
+            ),
         );
 
         // Auto-tracking flows (e.g. wrapping a native token) add a token as a side effect and show

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -23,7 +23,7 @@ export const selectBuyQuoteThunk = createThunk(
         const buyInfo = selectTradingBuyInfo(getState());
         const quotesRequest = selectTradingBuyQuotesRequest(getState());
         const receiveAddress = selectTradingBuyReceiveAddress(getState());
-        const account = selectTradingFormAccount(getState(), 'buy');
+        const account = selectTradingFormAccount(getState(), 'buy', extra.services);
 
         const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
 
@@ -37,7 +37,10 @@ export const selectBuyQuoteThunk = createThunk(
         );
 
         const { symbol: cryptoNetworkSymbol, contractAddress: cryptoContractAddress } =
-            cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.receiveCurrency);
+            cryptoIdToNetworkSymbolAndContractAddress(
+                extra.services,
+                quotesRequest.receiveCurrency,
+            );
         const cryptoLabel = selectTradingCoinInfoByCryptoId(
             getState(),
             quotesRequest.receiveCurrency,

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -37,11 +37,11 @@ export const selectExchangeQuoteThunk = createThunk(
         }
 
         const { symbol: sendCryptoNetworkSymbol, contractAddress: sendCryptoContractAddress } =
-            cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.send);
+            cryptoIdToNetworkSymbolAndContractAddress(extra.services, quotesRequest.send);
         const {
             symbol: receiveCryptoNetworkSymbol,
             contractAddress: receiveCryptoContractAddress,
-        } = cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.receive);
+        } = cryptoIdToNetworkSymbolAndContractAddress(extra.services, quotesRequest.receive);
 
         asTypedDesktopAnalytics(extra.services.analytics).report({
             type: events.tradeExchangeEvent.name,

--- a/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
@@ -15,8 +15,8 @@ import { submitRequestForm } from '../tradingCommonActions';
 
 export const requestSellTradeThunk = createThunk(
     'trading/sell/requestTrade',
-    async ({ quote }: { quote: SellFiatTrade }, { dispatch, getState }) => {
-        const account = selectTradingSendAccount(getState(), 'sell');
+    async ({ quote }: { quote: SellFiatTrade }, { dispatch, getState, extra }) => {
+        const account = selectTradingSendAccount(getState(), 'sell', extra.services);
 
         if (!account) {
             return;

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -35,6 +35,7 @@ export const selectSellQuoteThunk = createThunk(
                 quotesRequest.cryptoCurrency,
             );
         const { symbol: cryptoNetworkSymbol } = cryptoIdToNetworkSymbolAndContractAddress(
+            extra.services,
             quotesRequest.cryptoCurrency,
         );
 

--- a/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
+++ b/packages/suite/src/actions/wallet/trading/tradingCommonActions.ts
@@ -1,3 +1,4 @@
+import type { ExtraDependencies } from '@suite-common/redux-utils';
 import { formDraftActions, selectDeepCopyOfFormDraft } from '@suite-common/wallet-core';
 import type { Output } from '@suite-common/wallet-types';
 import {
@@ -37,44 +38,50 @@ export const submitRequestForm =
         }
     };
 
-export const convertDrafts = () => (dispatch: Dispatch, getState: GetState) => {
-    const { accounts, formDrafts, settings } = getState().wallet;
-    const formDraftKeys = Object.keys(formDrafts);
+export const convertDrafts =
+    () => (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+        const { accounts, formDrafts, settings } = getState().wallet;
+        const formDraftKeys = Object.keys(formDrafts);
 
-    formDraftKeys.forEach(formDraftKey => {
-        const [_prefix, accountKey] = parseFormDraftKey(formDraftKey);
-        const relatedAccount = accounts.find(({ key }) => key === accountKey);
+        formDraftKeys.forEach(formDraftKey => {
+            const [_prefix, accountKey] = parseFormDraftKey(formDraftKey);
+            const relatedAccount = accounts.find(({ key }) => key === accountKey);
 
-        if (!relatedAccount || !hasNetworkFeatures(relatedAccount, 'amount-unit')) {
-            return;
-        }
-
-        const draft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as FormState | undefined;
-
-        if (draft) {
-            const areSatsSelected = settings.bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
-            const conversion = areSatsSelected
-                ? convertAmountUnitsToSubunits
-                : convertAmountSubunitsToUnits;
-            const decimals = getAccountDecimals(relatedAccount.symbol);
-
-            if (draft.cryptoInput) {
-                draft.cryptoInput = conversion(draft.cryptoInput, decimals);
-            }
-            if (draft.outputs) {
-                draft.outputs.forEach(output => {
-                    if (output.amount) {
-                        output.amount = conversion(output.amount, decimals);
-                    }
-                });
+            if (
+                !relatedAccount ||
+                !hasNetworkFeatures(extra.services, relatedAccount, 'amount-unit')
+            ) {
+                return;
             }
 
-            dispatch(
-                formDraftActions.storeDraft({
-                    key: formDraftKey,
-                    formDraft: draft,
-                }),
-            );
-        }
-    });
-};
+            const draft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as
+                | FormState
+                | undefined;
+
+            if (draft) {
+                const areSatsSelected = settings.bitcoinAmountUnit === PROTO.AmountUnit.SATOSHI;
+                const conversion = areSatsSelected
+                    ? convertAmountUnitsToSubunits
+                    : convertAmountSubunitsToUnits;
+                const decimals = getAccountDecimals(extra.services, relatedAccount.symbol);
+
+                if (draft.cryptoInput) {
+                    draft.cryptoInput = conversion(draft.cryptoInput, decimals);
+                }
+                if (draft.outputs) {
+                    draft.outputs.forEach(output => {
+                        if (output.amount) {
+                            output.amount = conversion(output.amount, decimals);
+                        }
+                    });
+                }
+
+                dispatch(
+                    formDraftActions.storeDraft({
+                        key: formDraftKey,
+                        formDraft: draft,
+                    }),
+                );
+            }
+        });
+    };

--- a/packages/suite/src/actions/wallet/transactionActions.test.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.test.ts
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { testMocks } from '@suite-common/test-utils';
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import {
     type TransactionsState,
     transactionsActions,
@@ -13,8 +13,6 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getAccountTransactions } from '@suite-common/wallet-utils';
 
 import { transactionsReducer } from 'src/reducers/wallet';
-
-const btcSymbol = asNetworkSymbol('btc');
 
 const { getWalletTransaction } = testMocks;
 
@@ -32,14 +30,17 @@ const initStore = (transactionsState?: TransactionsState) =>
 describe('Transaction Actions', () => {
     it('Add transaction for first page (used on account create)', () => {
         const store = initStore();
-        const account = mockWalletAccount({ symbol: btcSymbol });
+        const account = mockWalletAccount({ symbol: 'btc' });
         store.dispatch(
-            transactionsActions.addTransaction({
-                transactions: [getWalletTransaction()],
-                account,
-                page: 1,
-                perPage: getTxsPerPage(account.networkType),
-            }),
+            transactionsActions.addTransaction(
+                {
+                    transactions: [getWalletTransaction()],
+                    account,
+                    page: 1,
+                    perPage: getTxsPerPage(account.networkType),
+                },
+                mockNetworkConfigDeps.getNetworkConfig,
+            ),
         );
         expect(
             getAccountTransactions(account.key, store.getState().transactions.transactions).length,
@@ -48,11 +49,11 @@ describe('Transaction Actions', () => {
 
     it('Remove txs for a given account', () => {
         const account1 = mockWalletAccount({
-            symbol: btcSymbol,
+            symbol: 'btc',
             descriptor: asAccountDescriptor('xpub1'),
         });
         const account2 = mockWalletAccount({
-            symbol: btcSymbol,
+            symbol: 'btc',
             descriptor: asAccountDescriptor('xpub2'),
         });
         const store = initStore({

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -1,10 +1,9 @@
-import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
-import { asNetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
-import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
 import { submitUnwrapNativeTokenThunk } from './unwrapNativeTokenThunks';
 
@@ -24,29 +23,16 @@ jest.mock('@suite/modal', () => ({
 
 jest.mock('./stablecoin-yield/signingHelpers', () => ({
     sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
-    getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
-const ethSymbol = asNetworkSymbol('eth');
-const account = mockWalletAccount({ symbol: ethSymbol }) as Account;
+const account = mockWalletAccount({ symbol: 'eth' }) as Account;
 
 const token: YieldFlowDisplayToken & { contractAddress: string } = {
-    networkSymbol: ethSymbol,
+    networkSymbol: 'eth',
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 };
-
-const buildStore = (report: jest.Mock) =>
-    configureMockStore({
-        extra: { services: { analytics: mockAnalytics(report) } },
-        preloadedState: {},
-    });
-
-const dispatchUnwrap = (report: jest.Mock) =>
-    buildStore(report)
-        .dispatch(submitUnwrapNativeTokenThunk({ account, token, unwrapAmount: '1' }))
-        .unwrap();
 
 describe('submitUnwrapNativeTokenThunk', () => {
     beforeEach(() => {
@@ -59,11 +45,20 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
-        mockSendYieldTransaction.mockResolvedValue(undefined);
     });
 
     it('uses the shared unwrap composition from wallet-core', async () => {
-        await dispatchUnwrap(jest.fn());
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+        await store
+            .dispatch(
+                submitUnwrapNativeTokenThunk({
+                    account,
+                    token,
+                    unwrapAmount: '1',
+                }),
+            )
+            .unwrap();
 
         expect(mockComposeYieldUnwrapTransactionThunk).toHaveBeenCalledWith({
             account,
@@ -108,7 +103,7 @@ describe('submitUnwrapNativeTokenThunk', () => {
     });
 
     it('shows an unwrap toast displaying both the wrapped and native assets', async () => {
-        const store = buildStore(jest.fn());
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
@@ -132,118 +127,10 @@ describe('submitUnwrapNativeTokenThunk', () => {
                 },
                 receive: {
                     symbol: account.symbol,
-                    displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                    displaySymbol: getNetworkDisplaySymbol(mockNetworkConfigDeps, account.symbol),
                     amount: '1.5',
                 },
             },
         });
-    });
-
-    it('does not report standalone unwrap analytics for the in-flow withdraw step', async () => {
-        const report = jest.fn();
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
-        );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
-
-        await buildStore(report)
-            .dispatch(
-                submitUnwrapNativeTokenThunk({
-                    account,
-                    token,
-                    unwrapAmount: '1',
-                    yieldFlow: { flowKey: 'yield-flow', flowType: 'redeem' },
-                }),
-            )
-            .unwrap();
-
-        expect(report).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: events.yieldUnwrapEvent.name }),
-        );
-    });
-
-    it('reports the tx-simulation-modal cancel', async () => {
-        const report = jest.fn();
-
-        await dispatchUnwrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldUnwrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'tx-simulation-modal',
-                    action: 'cancel',
-                    networkSymbol: 'eth',
-                }),
-            }),
-        );
-    });
-
-    it('reports an error carrying the compose reason when composition fails', async () => {
-        const report = jest.fn();
-        mockComposeYieldUnwrapTransactionThunk.mockImplementation(() => () => ({
-            unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
-        }));
-
-        await dispatchUnwrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldUnwrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'error',
-                    errorMessage: 'fee-estimation-failed',
-                }),
-            }),
-        );
-    });
-
-    it('reports tx-simulation-modal continue and submit-failed when the tx is not broadcast', async () => {
-        const report = jest.fn();
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
-        );
-
-        await dispatchUnwrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldUnwrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'tx-simulation-modal',
-                    action: 'continue',
-                }),
-            }),
-        );
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldUnwrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'error',
-                    errorMessage: 'submit-failed',
-                }),
-            }),
-        );
-    });
-
-    it('reports the sent event when the transaction is broadcast', async () => {
-        const report = jest.fn();
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
-        );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
-
-        await dispatchUnwrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldUnwrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'sent',
-                    action: 'continue',
-                    networkSymbol: 'eth',
-                }),
-            }),
-        );
     });
 });

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -94,6 +94,7 @@ export const submitUnwrapNativeTokenThunk = createThunk(
             }
 
             const sendResult = await sendYieldTransaction({
+                ...extra.services,
                 account,
                 amount: unwrapAmount,
                 token,
@@ -141,7 +142,7 @@ export const submitUnwrapNativeTokenThunk = createThunk(
                         },
                         receive: {
                             symbol: account.symbol,
-                            displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            displaySymbol: getNetworkDisplaySymbol(extra.services, account.symbol),
                             amount: unwrapAmount,
                         },
                     },

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,19 +1,11 @@
-import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
-import { asNetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import {
-    type YieldFlowDisplayToken,
-    accountsActions,
-    stablecoinYieldActions,
-} from '@suite-common/wallet-core';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
+import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
-import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
-import { PUSH_TRANSACTION_FAILED_CAUSE } from './stablecoin-yield/signingHelpers';
 import { submitWrapNativeTokenThunk } from './wrapNativeTokenThunks';
-
-const ethSymbol = asNetworkSymbol('eth');
 
 const mockComposeYieldWrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
@@ -30,37 +22,19 @@ jest.mock('@suite/modal', () => ({
 }));
 
 jest.mock('./stablecoin-yield/signingHelpers', () => ({
-    ...jest.requireActual('./stablecoin-yield/signingHelpers'),
     sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
-    getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
-const account = mockWalletAccount({ symbol: ethSymbol }) as Account;
+const account = mockWalletAccount({ symbol: 'eth' }) as Account;
 
 const token: YieldFlowDisplayToken & { contractAddress: string } = {
-    networkSymbol: ethSymbol,
+    networkSymbol: 'eth',
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 };
 
-const buildStore = (report: jest.Mock) =>
-    configureMockStore({
-        extra: { services: { analytics: mockAnalytics(report) } },
-        preloadedState: {},
-    });
-
-const dispatchWrap = (report: jest.Mock) =>
-    buildStore(report)
-        .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
-        .unwrap();
-
 describe('submitWrapNativeTokenThunk', () => {
-    beforeAll(() => {
-        // The thunk logs every caught failure; the expected ones would clutter the test output.
-        jest.spyOn(console, 'error').mockImplementation();
-    });
-
     beforeEach(() => {
         jest.clearAllMocks();
         mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
@@ -71,11 +45,20 @@ describe('submitWrapNativeTokenThunk', () => {
                 }),
         }));
         mockOpenDeferredModal.mockImplementation(() => () => Promise.resolve({ value: false }));
-        mockSendYieldTransaction.mockResolvedValue(undefined);
     });
 
     it('uses the shared wrap composition from wallet-core', async () => {
-        await dispatchWrap(jest.fn());
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+        await store
+            .dispatch(
+                submitWrapNativeTokenThunk({
+                    account,
+                    token,
+                    wrapAmount: '1',
+                }),
+            )
+            .unwrap();
 
         expect(mockComposeYieldWrapTransactionThunk).toHaveBeenCalledWith({
             account,
@@ -119,27 +102,12 @@ describe('submitWrapNativeTokenThunk', () => {
         );
     });
 
-    const getTrackedTokenUpdates = (store: ReturnType<typeof configureMockStore>) =>
-        store
-            .getActions()
-            .filter(action => action.type === accountsActions.updateAccount.type)
-            .filter(action =>
-                action.payload.tokens?.some(
-                    (accountToken: { contract: string }) =>
-                        accountToken.contract.toLowerCase() === token.contractAddress.toLowerCase(),
-                ),
-            );
-
-    const acceptModalAndSucceed = () => {
+    it('shows a wrap toast displaying both the native and wrapped assets', async () => {
+        const store = configureMockStore({ extra: {}, preloadedState: {} });
         mockOpenDeferredModal.mockImplementation(
             () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
         );
         mockSendYieldTransaction.mockResolvedValue({ txid: '0xwrap' });
-    };
-
-    it('shows a wrap toast displaying both the native and wrapped assets', async () => {
-        acceptModalAndSucceed();
-        const store = buildStore(jest.fn());
 
         await store
             .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1.5' }))
@@ -153,7 +121,7 @@ describe('submitWrapNativeTokenThunk', () => {
             metadata: {
                 send: {
                     symbol: account.symbol,
-                    displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                    displaySymbol: getNetworkDisplaySymbol(mockNetworkConfigDeps, account.symbol),
                     amount: '1.5',
                 },
                 receive: {
@@ -164,258 +132,5 @@ describe('submitWrapNativeTokenThunk', () => {
                 },
             },
         });
-    });
-
-    it('starts tracking the wrapped native token after a successful wrap', async () => {
-        acceptModalAndSucceed();
-        const store = buildStore(jest.fn());
-
-        await store
-            .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
-            .unwrap();
-
-        const trackedTokenUpdates = getTrackedTokenUpdates(store);
-        expect(trackedTokenUpdates).toHaveLength(1);
-    });
-
-    it('does not track the wrapped native token when it is already tracked', async () => {
-        acceptModalAndSucceed();
-        const accountWithTrackedToken = mockWalletAccount({
-            symbol: ethSymbol,
-            tokens: [
-                {
-                    standard: 'ERC20',
-                    // stored in a different case to prove the dedupe is case-insensitive
-                    contract: token.contractAddress.toLowerCase(),
-                    symbol: 'WETH',
-                    decimals: 18,
-                },
-            ],
-        }) as Account;
-        const store = buildStore(jest.fn());
-
-        await store
-            .dispatch(
-                submitWrapNativeTokenThunk({
-                    account: accountWithTrackedToken,
-                    token,
-                    wrapAmount: '1',
-                }),
-            )
-            .unwrap();
-
-        expect(getTrackedTokenUpdates(store)).toHaveLength(0);
-    });
-
-    it('does not track the wrapped native token when the send fails', async () => {
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
-        );
-        mockSendYieldTransaction.mockResolvedValue(undefined);
-        const store = buildStore(jest.fn());
-
-        await store
-            .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
-            .unwrap();
-
-        expect(getTrackedTokenUpdates(store)).toHaveLength(0);
-    });
-
-    describe('failure reporting', () => {
-        const yieldFlow = { flowKey: 'yield-flow', flowType: 'deposit' } as const;
-
-        const acceptModalAndFailWith = (error: Error) => {
-            mockOpenDeferredModal.mockImplementation(
-                () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
-            );
-            mockSendYieldTransaction.mockRejectedValue(error);
-        };
-
-        const getFlowErrors = (store: ReturnType<typeof configureMockStore>) =>
-            store
-                .getActions()
-                .filter(action => action.type === stablecoinYieldActions.setError.type);
-
-        it('reports a push failure on the deposit step it was started from', async () => {
-            acceptModalAndFailWith(
-                new Error('push failed', { cause: PUSH_TRANSACTION_FAILED_CAUSE }),
-            );
-            const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-            await store
-                .dispatch(
-                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
-                )
-                .unwrap();
-
-            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
-                ...yieldFlow,
-                error: 'TR_EARN_YIELD_ERROR_PUSH_FAILED',
-            });
-        });
-
-        it('falls back to the generic error for an unrecognised failure', async () => {
-            acceptModalAndFailWith(new Error('boom'));
-            const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-            await store
-                .dispatch(
-                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
-                )
-                .unwrap();
-
-            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
-                error: 'TR_EARN_YIELD_ERROR_GENERIC',
-            });
-        });
-
-        it('still shows the signing toast, the only feedback a standalone wrap gets', async () => {
-            acceptModalAndFailWith(new Error('boom'));
-            const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-            await store
-                .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
-                .unwrap();
-
-            const signErrorToast = store
-                .getActions()
-                .find(action => action.payload?.type === 'sign-tx-error');
-
-            expect(signErrorToast?.payload).toMatchObject({ error: 'boom' });
-        });
-
-        it('does not report a flow error for a standalone wrap', async () => {
-            acceptModalAndFailWith(new Error('boom'));
-            const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-            await store
-                .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
-                .unwrap();
-
-            expect(getFlowErrors(store)).toHaveLength(0);
-        });
-
-        it('reports a compose failure on the deposit step it was started from', async () => {
-            mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
-                unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
-            }));
-            const store = configureMockStore({ extra: {}, preloadedState: {} });
-
-            await store
-                .dispatch(
-                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
-                )
-                .unwrap();
-
-            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
-                ...yieldFlow,
-                error: 'TR_EARN_YIELD_ERROR_GENERIC',
-            });
-        });
-    });
-
-    it('does not report standalone wrap analytics for the in-flow deposit step', async () => {
-        const report = jest.fn();
-        acceptModalAndSucceed();
-
-        await buildStore(report)
-            .dispatch(
-                submitWrapNativeTokenThunk({
-                    account,
-                    token,
-                    wrapAmount: '1',
-                    yieldFlow: { flowKey: 'yield-flow', flowType: 'deposit' },
-                }),
-            )
-            .unwrap();
-
-        expect(report).not.toHaveBeenCalledWith(
-            expect.objectContaining({ type: events.yieldWrapEvent.name }),
-        );
-    });
-
-    it('reports the tx-simulation-modal cancel', async () => {
-        const report = jest.fn();
-
-        await dispatchWrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldWrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'tx-simulation-modal',
-                    action: 'cancel',
-                    networkSymbol: 'eth',
-                }),
-            }),
-        );
-    });
-
-    it('reports an error carrying the compose reason when composition fails', async () => {
-        const report = jest.fn();
-        mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
-            unwrap: () => Promise.resolve({ type: 'error', reason: 'unsupported-network' }),
-        }));
-
-        await dispatchWrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldWrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'error',
-                    errorMessage: 'unsupported-network',
-                }),
-            }),
-        );
-    });
-
-    it('reports tx-simulation-modal continue and submit-failed when the tx is not broadcast', async () => {
-        const report = jest.fn();
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
-        );
-
-        await dispatchWrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldWrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'tx-simulation-modal',
-                    action: 'continue',
-                }),
-            }),
-        );
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldWrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'error',
-                    errorMessage: 'submit-failed',
-                }),
-            }),
-        );
-    });
-
-    it('reports the sent event when the transaction is broadcast', async () => {
-        const report = jest.fn();
-        mockOpenDeferredModal.mockImplementation(
-            () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
-        );
-        mockSendYieldTransaction.mockResolvedValue({ txid: '0xabc' });
-
-        await dispatchWrap(report);
-
-        expect(report).toHaveBeenCalledWith(
-            expect.objectContaining({
-                type: events.yieldWrapEvent.name,
-                payload: expect.objectContaining({
-                    type: 'sent',
-                    action: 'continue',
-                    networkSymbol: 'eth',
-                }),
-            }),
-        );
     });
 });

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -3,7 +3,7 @@ import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     composeYieldWrapTransactionThunk,
@@ -102,14 +102,15 @@ export const submitWrapNativeTokenThunk = createThunk(
                 return undefined;
             }
 
-            const network = getNetwork(account.symbol);
+            const network = extra.services.getNetworkConfig(account.symbol);
 
             const sendResult = await sendYieldTransaction({
+                ...extra.services,
                 account,
                 amount: wrapAmount,
                 token: {
                     networkSymbol: account.symbol,
-                    symbol: getNetworkDisplaySymbol(account.symbol),
+                    symbol: getNetworkDisplaySymbol(extra.services, account.symbol),
                     decimals: network.decimals,
                     contractAddress: null,
                 },
@@ -172,7 +173,7 @@ export const submitWrapNativeTokenThunk = createThunk(
                     metadata: {
                         send: {
                             symbol: account.symbol,
-                            displaySymbol: getNetworkDisplaySymbol(account.symbol),
+                            displaySymbol: getNetworkDisplaySymbol(extra.services, account.symbol),
                             amount: wrapAmount,
                         },
                         receive: {

--- a/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnAccountCellDetails.tsx
@@ -1,7 +1,9 @@
 import { type ReactNode } from 'react';
 
 import { AccountLabel } from '@suite/account';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Text } from '@trezor/components';
 
@@ -22,6 +24,7 @@ export const EarnAccountCellDetails = ({
     tokenBalance,
     subtitle,
 }: EarnAccountCellDetailsProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     if (!account) {
         return (
             <>
@@ -32,7 +35,7 @@ export const EarnAccountCellDetails = ({
                     ellipsisLineCount={1}
                     maxWidth="100%"
                 >
-                    {getNetwork(networkSymbol).name}
+                    {getNetworkConfig(networkSymbol).name}
                 </Text>
 
                 {subtitle && (

--- a/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnActivateButton.tsx
@@ -1,7 +1,9 @@
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     selectEnabledNetworks,
     selectHasRunningDiscovery,
@@ -16,13 +18,14 @@ type EarnActivateButtonProps = {
 };
 
 export const EarnActivateButton = ({ symbol }: EarnActivateButtonProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const isNetworkEnabled = enabledNetworks.includes(symbol);
     const isDiscoveringThisNetwork = isDiscoveryRunning && isNetworkEnabled;
-    const { name } = getNetwork(symbol);
+    const { name } = getNetworkConfig(symbol);
 
     const isDeviceDisconnected = !device?.connected;
     const isButtonDisabled = isDeviceDisconnected || isDiscoveryRunning;

--- a/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/common/EarnInactiveNetworkOpportunity.tsx
@@ -1,6 +1,8 @@
 import { type ReactNode } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Card, Column, Paragraph, Row, Table } from '@trezor/components';
 
 import { EarnAccountCell } from './EarnAccountCell';
@@ -20,7 +22,8 @@ export const EarnInactiveNetworkOpportunity = ({
     note,
     isCardLayout,
 }: EarnInactiveNetworkOpportunityProps) => {
-    const networkType = getNetworkType(symbol);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networkType = getNetworkType(networkConfigDeps, symbol);
 
     const noteParagraph = note && (
         <Paragraph typographyStyle="body-sm" intent="neutral">

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingAccountRow.tsx
@@ -7,7 +7,7 @@ import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAccountClaimTransactions,
     selectAccountIsStakingActive,
@@ -45,6 +45,7 @@ interface EarnStakingAccountRowProps {
 }
 
 export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAccountRowProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -57,9 +58,11 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         selectPoolStatsApy(state, { networkSymbol: account.symbol }),
     );
 
-    const displaySymbol = getDisplaySymbol(account.symbol);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, account.symbol);
     const isCardanoNetworkType = account.networkType === 'cardano';
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const isClaimPending = useSelector(state =>
         selectAccountClaimTransactions(state, account.key).some(tx => isPending(tx)),
     );
@@ -72,7 +75,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
         votingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
-    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+    const { canClaim = false } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
     const isClaimButtonDisabled = isClaimingDisabled || isClaimPending;
 
     const minStakingAmount = getStakingLimitsByNetworkSymbol(
@@ -80,7 +83,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
     )?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
 
     const accountBalance = account.formattedBalance;
-    const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
+    const stakingBalance = getAccountTotalStakingBalance(networkConfigDeps, account) ?? '0';
 
     const stakingStatus = useStakingAccountStatus(account);
 
@@ -89,7 +92,7 @@ export const EarnStakingAccountRow = ({ account, isCardLayout }: EarnStakingAcco
 
         dispatch(
             tradingActions.setTradingFromPrefilledAccount(
-                getTradingPrefilledFromAccountData(account),
+                getTradingPrefilledFromAccountData(networkConfigDeps, account),
             ),
         );
         dispatch(goto({ routeName: 'wallet-trading-buy' }));

--- a/packages/suite/src/components/earn/dashboard/staking/EarnStakingActivateRow.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/EarnStakingActivateRow.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 
 import { useStakingRate } from 'src/hooks/earn/useStakingRate';
@@ -13,13 +15,14 @@ interface EarnStakingActivateRowProps {
 }
 
 export const EarnStakingActivateRow = ({ symbol, isCardLayout }: EarnStakingActivateRowProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { rate } = useStakingRate({ symbol });
 
     const { isStakingDisabled } = useMessageSystemStaking(symbol);
 
     if (isStakingDisabled) return null;
 
-    const { displaySymbol } = getNetwork(symbol);
+    const { displaySymbol } = getNetworkConfig(symbol);
     const minStakingAmount =
         getStakingLimitsByNetworkSymbol(symbol)?.MIN_AMOUNT_FOR_STAKING_DASHBOARD;
 

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountStatus.ts
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountStatus.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive, selectCardanoPoolsInfo } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -23,14 +25,17 @@ export type StakingAccountStatus =
     | 'staking-remaining-votes';
 
 export const useStakingAccountStatus = (account: Account): StakingAccountStatus => {
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
     const isNewProviderBannerEnabled = useSelector(state =>
         selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
     );
 
     const accountBalance = account.formattedBalance;
-    const stakingBalance = getAccountTotalStakingBalance(account) ?? '0';
+    const stakingBalance = getAccountTotalStakingBalance(networkConfigDeps, account) ?? '0';
     const isCardanoNetworkType = account.networkType === 'cardano';
     const minStakingAmount = getStakingLimitsByNetworkSymbol(
         account.symbol,

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type StakingNetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     compareEarnByAmountDesc,
@@ -29,6 +31,7 @@ export const useStakingAccountsVisibility = ({
     adaNotActivated,
     trxNotActivated,
 }: UseAccountVisibilityProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isExpanded, setIsExpanded] = useState(false);
 
     const toggleExpanded = useCallback(() => {
@@ -38,7 +41,7 @@ export const useStakingAccountsVisibility = ({
     const getAccountStakedAmountInFiat = useCallback(
         (account: Account) =>
             toFiatCurrency({
-                amount: getAccountTotalStakingBalance(account) ?? '0',
+                amount: getAccountTotalStakingBalance(networkConfigDeps, account) ?? '0',
                 rate: isStakingSymbol(account.symbol) ? currentRates[account.symbol] : undefined,
             }) ?? '0',
         [currentRates],
@@ -56,7 +59,7 @@ export const useStakingAccountsVisibility = ({
     const [accountsStakingActive, accountsStakingNotActive] = arrayPartition(
         stakingAccounts,
         (account: Account) => {
-            const stakedAmount = getAccountTotalStakingBalance(account);
+            const stakedAmount = getAccountTotalStakingBalance(networkConfigDeps, account);
 
             return stakedAmount !== null && stakedAmount !== '0';
         },
@@ -97,7 +100,9 @@ export const useStakingAccountsVisibility = ({
         const hasAdaBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'ada');
         const hasTrxBaseAccount = alwaysVisibleAccounts.some(account => account.symbol === 'trx');
 
-        const sortedInsufficientFundsAccounts = sortByCoin([...accountsInsufficientFunds]);
+        const sortedInsufficientFundsAccounts = sortByCoin(networkConfigDeps, [
+            ...accountsInsufficientFunds,
+        ]);
 
         const additionalAccounts: Account[] = [];
 
@@ -133,7 +138,7 @@ export const useStakingAccountsVisibility = ({
             if (account) additionalAccounts.push(account);
         }
 
-        return sortByCoin([...additionalAccounts]);
+        return sortByCoin(networkConfigDeps, [...additionalAccounts]);
     }, [
         alwaysVisibleAccounts,
         accountsInsufficientFunds,
@@ -147,7 +152,7 @@ export const useStakingAccountsVisibility = ({
 
     const expandedAccounts = [
         ...alwaysVisibleAccounts,
-        ...sortByCoin([...accountsInsufficientFunds]),
+        ...sortByCoin(networkConfigDeps, [...accountsInsufficientFunds]),
     ];
 
     const displayedAccounts = isExpanded ? expandedAccounts : collapsedAccounts;

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingTableData.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type StakingNetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectDeviceSupportedNetworks,
     selectVisibleDeviceAccounts,
@@ -25,6 +27,7 @@ type UseStakingTableDataResult = {
 };
 
 export const useStakingTableData = (): UseStakingTableDataResult => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const ethCurrentRate = useCryptoCurrentRate('eth');
     const solCurrentRate = useCryptoCurrentRate('sol');
     const adaCurrentRate = useCryptoCurrentRate('ada');
@@ -52,7 +55,9 @@ export const useStakingTableData = (): UseStakingTableDataResult => {
             account.symbol === 'trx',
     );
 
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const deviceSupportedNetworkSymbols = useSelector(state =>
+        selectDeviceSupportedNetworks(state, networkConfigDeps),
+    );
 
     const ethNotActivated =
         deviceSupportedNetworkSymbols.includes('eth') &&

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldAccountOpportunity.tsx
@@ -13,6 +13,7 @@ import {
     toTokenCryptoId,
     tradingActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getYieldVaultContractAddress,
     isStablecoinYieldSupported,
@@ -46,6 +47,7 @@ export const EarnYieldAccountOpportunity = ({
     opportunity,
     isCardLayout,
 }: EarnYieldAccountOpportunityProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { CryptoAmountFormatter } = useFormatters();
@@ -113,14 +115,23 @@ export const EarnYieldAccountOpportunity = ({
         if (opportunity.account) {
             const tokenCryptoId = tokenAddress
                 ? toTokenCryptoId(
+                      networkConfigDeps,
                       networkSymbol,
-                      getContractAddressForNetworkSymbol(networkSymbol, tokenAddress),
+                      getContractAddressForNetworkSymbol(
+                          networkConfigDeps,
+                          networkSymbol,
+                          tokenAddress,
+                      ),
                   )
                 : undefined;
 
             dispatch(
                 tradingActions.setTradingFromPrefilledAccount(
-                    getTradingPrefilledFromAccountData(opportunity.account, tokenCryptoId),
+                    getTradingPrefilledFromAccountData(
+                        networkConfigDeps,
+                        opportunity.account,
+                        tokenCryptoId,
+                    ),
                 ),
             );
         }
@@ -230,6 +241,7 @@ export const EarnYieldAccountOpportunity = ({
             goto({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
+                    ...networkConfigDeps,
                     account: opportunity.account,
                     vaultAddress: vaultContractAddress,
                 }),
@@ -272,6 +284,7 @@ export const EarnYieldAccountOpportunity = ({
             goto({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
+                    ...networkConfigDeps,
                     account: opportunity.account,
                     vaultAddress: vaultContractAddress,
                 }),

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldApyBreakdown.tsx
@@ -1,10 +1,15 @@
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type RewardDtoV2,
     type TokenDtoV2,
     sortRewardsByUnderlyingToken,
 } from '@suite-common/earn-stablecoin-api';
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbol,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { getApyPercent } from '@suite-common/wallet-utils';
 import { Column, Icon, Row, Text } from '@trezor/components';
 import { ChartLineIcon } from '@trezor/icons';
@@ -61,6 +66,7 @@ export const EarnYieldApyBreakdown = ({
     networkSymbol,
     underlyingToken,
 }: EarnYieldApyBreakdownProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const sortedRewards = sortRewardsByUnderlyingToken(rewards, underlyingToken);
     // Only mention APR in the footer when a row actually shows an APR rate.
     const footerId = sortedRewards.some(isAprReward)
@@ -77,7 +83,7 @@ export const EarnYieldApyBreakdown = ({
                 // A wrapped-native reward (e.g. WETH in an ETH vault) is presented as its native
                 // asset (#29881), matching how the vault itself is labelled across the earn UI.
                 const displaySymbol = isWrappedNativeToken(networkSymbol, reward.token.address)
-                    ? getNetworkDisplaySymbol(networkSymbol)
+                    ? getNetworkDisplaySymbol(networkConfigDeps, networkSymbol)
                     : reward.token.symbol;
 
                 let rateNode;

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -7,6 +7,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
 import { useFormatters } from '@suite-common/formatters';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { compareAccountsByCoin } from '@suite-common/wallet-utils';
 import { CardList, Column, Modal, Row, Text, Tooltip } from '@trezor/components';
@@ -26,12 +27,13 @@ export const EarnYieldClaimSelectAccountModal = ({
     onClose,
 }: EarnYieldClaimSelectAccountModalProps) => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const isDebugModeActive = useSelector(selectIsDebugModeActive);
     const baseCurrency = useSelector(selectBaseCurrency);
 
     const sortedAccountsRewards = [...accountsRewards].sort((a, b) =>
-        compareAccountsByCoin(a.account, b.account),
+        compareAccountsByCoin(networkConfigDeps, a.account, b.account),
     );
 
     const handleOnSelect = (account: YieldAccountsRewards[number]) => {

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { sortByCoin } from '@suite-common/wallet-utils';
 import { isNotUndefined } from '@trezor/utils';
 
@@ -12,6 +14,7 @@ type UseYieldAccountsVisibilityProps = {
 export const useYieldAccountsVisibility = ({
     yieldAccountOpportunities,
 }: UseYieldAccountsVisibilityProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isExpanded, setIsExpanded] = useState(false);
 
     const { collapsedYieldAccountOpportunities, hiddenYieldAccountOpportunities } = useMemo(() => {
@@ -40,7 +43,7 @@ export const useYieldAccountsVisibility = ({
             const vaultAccounts = vaultOpportunities
                 .map(opportunity => opportunity.account)
                 .filter(isNotUndefined);
-            const [firstAccountByCoinOrder] = sortByCoin([...vaultAccounts]);
+            const [firstAccountByCoinOrder] = sortByCoin(networkConfigDeps, [...vaultAccounts]);
 
             const fallbackOpportunity = firstAccountByCoinOrder
                 ? vaultOpportunities.find(

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
@@ -1,16 +1,19 @@
 import { renderHook } from '@testing-library/react';
 
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getYieldOpportunityData, useYieldTableData } from './useYieldTableData';
 
-const ethSymbol = asNetworkSymbol('eth');
-
 jest.mock('src/hooks/suite', () => ({
     useSelector: () => [],
+}));
+
+jest.mock('@suite-common/dependency-injection', () => ({
+    useServices: () => mockNetworkConfigDeps,
 }));
 
 const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
@@ -67,7 +70,7 @@ describe(getYieldOpportunityData.name, () => {
     describe('wrapped-native (WETH) vault', () => {
         it('combines the token balance with the full native balance', () => {
             const account = mockWalletAccount({
-                symbol: ethSymbol,
+                symbol: 'eth',
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -80,8 +83,9 @@ describe(getYieldOpportunityData.name, () => {
             });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: wethVault,
             });
 
@@ -89,14 +93,12 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('counts a native-only account (no WETH token) as depositable', () => {
-            const account = mockWalletAccount({
-                symbol: ethSymbol,
-                formattedBalance: '1',
-            });
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: wethVault,
             });
 
@@ -106,14 +108,12 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {
-            const account = mockWalletAccount({
-                symbol: ethSymbol,
-                formattedBalance: '0.003',
-            });
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: wethVault,
             });
 
@@ -123,7 +123,7 @@ describe(getYieldOpportunityData.name, () => {
 
         it('denominates amounts in the native symbol without a token contract', () => {
             const account = mockWalletAccount({
-                symbol: ethSymbol,
+                symbol: 'eth',
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -136,8 +136,9 @@ describe(getYieldOpportunityData.name, () => {
             });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: wethVault,
             });
 
@@ -149,7 +150,7 @@ describe(getYieldOpportunityData.name, () => {
     describe('non-wrapped-native vault', () => {
         it('uses only the matched token balance and keeps the token denomination', () => {
             const account = mockWalletAccount({
-                symbol: ethSymbol,
+                symbol: 'eth',
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -162,8 +163,9 @@ describe(getYieldOpportunityData.name, () => {
             });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: usdcVault,
             });
 
@@ -173,14 +175,12 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('is not depositable without the matched token, regardless of native balance', () => {
-            const account = mockWalletAccount({
-                symbol: ethSymbol,
-                formattedBalance: '5',
-            });
+            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
 
             const data = getYieldOpportunityData({
+                ...mockNetworkConfigDeps,
                 account,
-                networkSymbol: ethSymbol,
+                networkSymbol: 'eth',
                 vault: usdcVault,
             });
 
@@ -193,12 +193,12 @@ describe(getYieldOpportunityData.name, () => {
 describe(useYieldTableData.name, () => {
     it('classifies a native-only account as depositable, ahead of empty accounts', () => {
         const emptyAccount = mockWalletAccount({
-            symbol: ethSymbol,
+            symbol: 'eth',
             descriptor: asAccountDescriptor('0xbe1030e5e50e5e0'),
             formattedBalance: '0',
         });
         const nativeOnlyAccount = mockWalletAccount({
-            symbol: ethSymbol,
+            symbol: 'eth',
             descriptor: asAccountDescriptor('0xde9051ab1e0e0e0'),
             formattedBalance: '1',
         });
@@ -207,7 +207,7 @@ describe(useYieldTableData.name, () => {
             useYieldTableData({
                 availableVaults: [wethVault],
                 visibleAccounts: [emptyAccount, nativeOnlyAccount],
-                visibleAccountSymbols: new Set<NetworkSymbol>([ethSymbol]),
+                visibleAccountSymbols: new Set<NetworkSymbol>(['eth']),
             }),
         );
 

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.ts
@@ -1,10 +1,14 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import {
     type NetworkSymbol,
-    getNetworkByYieldXyzId,
+    findNetworkByYieldXyzId,
     getNetworkDisplaySymbol,
+    getNetworks,
+    selectNetworkConfigDeps,
 } from '@suite-common/wallet-config';
 import {
     doTokensMatch,
@@ -30,16 +34,16 @@ import {
     type YieldInactiveVaultOpportunity,
     type YieldOpportunityData,
 } from '../types';
-
 const hasTokenSymbol = (
     accountToken: NonNullable<Account['tokens']>[number],
 ): accountToken is TokenInfoBranded => accountToken.symbol !== undefined;
 
 const getMatchedAccountToken = ({
+    getNetworkConfig,
     account,
     networkSymbol,
     token,
-}: {
+}: GetNetworkConfigDep & {
     account: Account;
     networkSymbol: NetworkSymbol;
     token?: Pick<TokenDtoV2, 'address' | 'symbol' | 'decimals'>;
@@ -52,6 +56,7 @@ const getMatchedAccountToken = ({
         (accountToken): accountToken is TokenInfoBranded =>
             hasTokenSymbol(accountToken) &&
             doTokensMatch({
+                getNetworkConfig,
                 networkSymbol,
                 firstToken: {
                     address: accountToken.contract,
@@ -64,26 +69,30 @@ const getMatchedAccountToken = ({
 };
 
 export const getYieldOpportunityData = ({
+    getNetworkConfig,
     account,
     networkSymbol,
     vault,
-}: {
+}: GetNetworkConfigDep & {
     account: Account;
     networkSymbol: NetworkSymbol;
     vault: YieldDtoV2;
 }): YieldOpportunityData => {
     const matchedInputToken = getMatchedAccountToken({
+        getNetworkConfig,
         account,
         networkSymbol,
         token: vault.token,
     });
     const matchedOutputToken = getMatchedAccountToken({
+        getNetworkConfig,
         account,
         networkSymbol,
         token: vault.outputToken,
     });
     const hasVaultPosition = new BigNumber(matchedOutputToken?.balance ?? '0').gt(0);
     const depositedAmount = getConvertedOutputTokenBalanceToInputTokenAmount({
+        getNetworkConfig,
         networkSymbol,
         token: vault.token,
         outputToken: vault.outputToken,
@@ -111,7 +120,7 @@ export const getYieldOpportunityData = ({
         depositedAmount,
         additionalDepositAmount,
         depositedSymbol: isWrappedNativeVault
-            ? toTokenSymbol(getNetworkDisplaySymbol(networkSymbol))
+            ? toTokenSymbol(getNetworkDisplaySymbol({ getNetworkConfig }, networkSymbol))
             : (matchedInputToken?.symbol ?? toTokenSymbol(vault.token.symbol)),
         depositedContractAddress: isWrappedNativeVault
             ? null
@@ -138,9 +147,11 @@ export const useYieldTableData = ({
     visibleAccounts,
     visibleAccountSymbols,
 }: UseYieldTableDataProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networks = getNetworks(networkConfigDeps);
     const yieldAccountOpportunities = useMemo<YieldAccountOpportunity[]>(() => {
         const allOpportunities = availableVaults.flatMap(vault => {
-            const network = getNetworkByYieldXyzId(vault.network);
+            const network = findNetworkByYieldXyzId(networks, vault.network);
 
             if (!network || !visibleAccountSymbols.has(network.symbol)) {
                 return [];
@@ -156,6 +167,7 @@ export const useYieldTableData = ({
                 networkSymbol: network.symbol,
                 vault,
                 ...getYieldOpportunityData({
+                    ...networkConfigDeps,
                     account,
                     networkSymbol: network.symbol,
                     vault,
@@ -189,22 +201,29 @@ export const useYieldTableData = ({
         return [
             ...activeOpportunities
                 .toSorted(compareEarnByAmountDesc(opportunity => opportunity.depositedAmount))
-                .toSorted(compareEarnByNetwork(opportunity => opportunity.account?.symbol)),
+                .toSorted(
+                    compareEarnByNetwork(
+                        networkConfigDeps,
+                        opportunity => opportunity.account?.symbol,
+                    ),
+                ),
             ...depositableOpportunities
                 .toSorted(
                     compareEarnByAmountDesc(opportunity => opportunity.additionalDepositAmount),
                 )
-                .toSorted(compareEarnByNetworkTokenOrder(toNetworkTokenSortKey)),
+                .toSorted(compareEarnByNetworkTokenOrder(networkConfigDeps, toNetworkTokenSortKey)),
             ...noBalanceOpportunities.toSorted(
-                compareEarnByNetworkTokenOrder(toNetworkTokenSortKey),
+                compareEarnByNetworkTokenOrder(networkConfigDeps, toNetworkTokenSortKey),
             ),
         ];
-    }, [availableVaults, visibleAccounts, visibleAccountSymbols]);
+    }, [availableVaults, networks, networkConfigDeps, visibleAccounts, visibleAccountSymbols]);
 
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const deviceSupportedNetworkSymbols = useSelector(state =>
+        selectDeviceSupportedNetworks(state, networkConfigDeps),
+    );
     const yieldInactiveVaultOpportunities = useMemo<YieldInactiveVaultOpportunity[]>(() => {
         const opportunities = availableVaults.flatMap(vault => {
-            const network = getNetworkByYieldXyzId(vault.network);
+            const network = findNetworkByYieldXyzId(networks, vault.network);
 
             if (!network) {
                 return [];
@@ -230,7 +249,7 @@ export const useYieldTableData = ({
         return opportunities.toSorted(
             compareEarnByApyDesc(opportunity => opportunity.apyPercentage),
         );
-    }, [availableVaults, deviceSupportedNetworkSymbols, visibleAccountSymbols]);
+    }, [availableVaults, deviceSupportedNetworkSymbols, networks, visibleAccountSymbols]);
 
     const isYieldActive = useMemo(
         () => yieldAccountOpportunities.some(opportunity => opportunity.hasVaultPosition),

--- a/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnClaimModal/EarnClaimModal.tsx
@@ -5,7 +5,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { setConnectionModal, setConnectionMode, useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
@@ -29,6 +29,7 @@ type EarnClaimModalProps = {
 };
 
 export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { device, isLocked } = useDevice();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -55,7 +56,8 @@ export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
     // used instead of formState.isValid, which is sometimes returning false even if there are no errors
     const formIsValid = Object.keys(errors).length === 0;
 
-    const { claimableAmount = '0', restakedReward = '0' } = getStakingDataForNetwork(account) ?? {};
+    const { claimableAmount = '0', restakedReward = '0' } =
+        getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const isFormInputsValid = !isCardanoNetworkType
         ? formIsValid && hasValues
@@ -133,14 +135,19 @@ export const EarnClaimModal = ({ onCancel, account }: EarnClaimModalProps) => {
             heading={
                 <Translation
                     id={isCardanoNetworkType ? 'TR_EARN_CLAIM_REWARDS' : 'TR_STAKE_CLAIM_TOKEN'}
-                    values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                    values={{ symbol: getNetworkDisplaySymbol(networkConfigDeps, account.symbol) }}
                 />
             }
             description={
                 !isCardanoNetworkType ? (
                     <Translation
                         id="TR_STAKE_CLAIMED_AMOUNT_TRANSFERRED"
-                        values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
+                        values={{
+                            networkDisplaySymbol: getNetworkDisplaySymbol(
+                                networkConfigDeps,
+                                account.symbol,
+                            ),
+                        }}
                     />
                 ) : undefined
             }

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/StakingEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/StakingEarnInANutshellModal.tsx
@@ -1,11 +1,12 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     EarnFlow,
     type EarnModalAction,
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { isStakingNetworkType } from '@suite-common/wallet-utils';
 import { Divider } from '@trezor/components';
@@ -36,6 +37,7 @@ export const StakingEarnInANutshellModal = ({
     actionType,
     yieldContext,
 }: StakingEarnInANutshellModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { handleAction, onCancelClick, unstakingPeriod } = useEarnInANutshell({
         flow: EarnFlow.Stake,
         provider,
@@ -49,7 +51,7 @@ export const StakingEarnInANutshellModal = ({
         return null;
     }
 
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     if (!displaySymbol) return null;
 

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/YieldEarnInANutshellModal.tsx
@@ -9,7 +9,7 @@ import {
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type YieldFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent, isStakingNetworkType } from '@suite-common/wallet-utils';
@@ -42,6 +42,7 @@ export const YieldEarnInANutshellModal = ({
     actionType,
     yieldContext,
 }: YieldEarnInANutshellModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const { handleAction, onCancelClick } = useEarnInANutshell({
@@ -68,7 +69,7 @@ export const YieldEarnInANutshellModal = ({
     // an intro highlight plus a wrap step on deposit and an unwrap step on withdrawal.
     const isWrappedNativeVault =
         vault !== undefined && isWrappedNativeToken(account.symbol, vault.token.address);
-    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeSymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const processes: EarnInANutshellProcess[] = [
         {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnStakingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnStakingInfo.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { CARDANO_ACTIVATION_PERIOD_DAYS, CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import { selectEthValidatorsQueue, selectPoolStatsApy } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -163,12 +164,13 @@ const CardanoStakingRows = ({ flow, apy }: EarnStakingRowsProps) => (
 );
 
 export const EarnStakingInfo = ({ account, flow }: EarnStakingInfoProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const validatorsQueue = useSelector(selectEthValidatorsQueue);
 
     const apy = useSelector(state => selectPoolStatsApy(state, { networkSymbol: account.symbol }));
 
     const daysToAddToPoolInitial = getDaysToAddToPoolInitial(validatorsQueue);
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const content = (() => {
         switch (account.networkType) {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnWithdrawingInfo.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/EarnWithdrawingInfo.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectEthValidatorsQueue } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
@@ -144,10 +145,11 @@ const CardanoWithdrawingRows = ({ flow, displaySymbol }: EarnWithdrawingRowsProp
 );
 
 export const EarnWithdrawingInfo = ({ account, flow }: EarnWithdrawingInfoProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const validatorsQueue = useSelector(selectEthValidatorsQueue);
     const daysToUnstake = getUnstakingPeriodInDays(account.networkType, validatorsQueue);
 
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const content = (() => {
         switch (account.networkType) {

--- a/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
+++ b/packages/suite/src/components/earn/modals/EarnInANutshell/components/UpdateEarnInANutshellHighlights.tsx
@@ -1,9 +1,11 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type NetworkSymbol,
     type StakingNetworkType,
     getNetworkDisplaySymbol,
 } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { HandCoinsIcon, PiggyBankIcon, WalletIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -25,7 +27,8 @@ export const UpdateEarnInANutshellHighlights = ({
     networkSymbol,
     apy,
 }: UpdateEarnInANutshellHighlightsProps) => {
-    const networkDisplaySymbol = getNetworkDisplaySymbol(networkSymbol);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, networkSymbol);
 
     const highlights: EarnInANutshellHighlight[] = [
         {

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/StakingEarnProviderConsentModal.tsx
@@ -1,10 +1,11 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     EarnFlow,
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { EarnProviderConsentModalLayout } from './components/EarnProviderConsentModalLayout';
@@ -26,6 +27,7 @@ export const StakingEarnProviderConsentModal = ({
     provider,
     yieldContext,
 }: StakingEarnProviderConsentModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { proceedToEarnFlow, onCancelClick } = useEarnProviderConsentActions({
         flow: EarnFlow.Stake,
         onCancel,
@@ -34,7 +36,7 @@ export const StakingEarnProviderConsentModal = ({
         yieldContext,
     });
 
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     const providerName = getEarnProviderName(provider);
 
     return (

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/UpdateEarnProviderConsentModal.tsx
@@ -1,10 +1,11 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     EarnFlow,
     type EarnProvider,
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { EarnProviderConsentModalLayout } from './components/EarnProviderConsentModalLayout';
@@ -26,6 +27,7 @@ export const UpdateEarnProviderConsentModal = ({
     provider,
     yieldContext,
 }: UpdateEarnProviderConsentModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { proceedToEarnFlow, onCancelClick } = useEarnProviderConsentActions({
         flow: EarnFlow.UpdateProvider,
         onCancel,
@@ -35,7 +37,7 @@ export const UpdateEarnProviderConsentModal = ({
         yieldContext,
     });
 
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     const providerName = getEarnProviderName(provider);
 
     return (

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -9,7 +9,7 @@ import {
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
 import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { isWrappedNativeToken } from '@trezor/network-ethereum-suite-common';
@@ -36,23 +36,31 @@ export const YieldEarnProviderConsentModal = ({
     provider,
     yieldContext,
 }: YieldEarnProviderConsentModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const tokenContractAddress = yieldContext?.tokenContractAddress;
     const normalizedTokenContractAddress = tokenContractAddress
-        ? getContractAddressForNetworkSymbol(account.symbol, tokenContractAddress)
+        ? getContractAddressForNetworkSymbol(
+              networkConfigDeps,
+              account.symbol,
+              tokenContractAddress,
+          )
         : undefined;
 
     const tokenSymbolFromAccount = account.tokens?.find(
         token =>
             normalizedTokenContractAddress !== undefined &&
             token.contract !== undefined &&
-            getContractAddressForNetworkSymbol(account.symbol, token.contract) ===
-                normalizedTokenContractAddress,
+            getContractAddressForNetworkSymbol(
+                networkConfigDeps,
+                account.symbol,
+                token.contract,
+            ) === normalizedTokenContractAddress,
     )?.symbol;
 
     const tokenCryptoId = normalizedTokenContractAddress
-        ? toTokenCryptoId(account.symbol, normalizedTokenContractAddress)
+        ? toTokenCryptoId(networkConfigDeps, account.symbol, normalizedTokenContractAddress)
         : undefined;
 
     const tokenSymbolFromTrading = useSelector(state =>
@@ -65,7 +73,7 @@ export const YieldEarnProviderConsentModal = ({
         networkSymbol: account.symbol,
         yieldContext,
     });
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     const depositSymbol = isWrappedNativeToken(account.symbol, normalizedTokenContractAddress)
         ? displaySymbol
         : (tokenSymbolFromAccount ?? tokenSymbolFromTrading ?? displaySymbol);

--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/hooks/useEarnProviderConsentActions.ts
@@ -8,6 +8,7 @@ import {
     type EarnYieldContext,
 } from '@suite-common/suite-types/src/staking';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     DEFAULT_VOTING_OPTION,
     selectVotingDelegationOption,
@@ -39,6 +40,7 @@ export const useEarnProviderConsentActions = ({
 }: UseEarnProviderConsentActionsProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
     const report = (action: EarnModalAction) => {
@@ -67,6 +69,7 @@ export const useEarnProviderConsentActions = ({
                         goto({
                             routeName: 'earn-yield-deposit',
                             params: getEarnRouteParams({
+                                ...networkConfigDeps,
                                 account,
                                 vaultAddress: yieldContext.vaultAddress,
                             }),

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/CardanoStakeWarningBanner.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/CardanoStakeWarningBanner.tsx
@@ -1,5 +1,6 @@
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Banner } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -13,6 +14,7 @@ export const CardanoStakeWarningBanner = ({
     account,
     isCardanoStakingDisabled,
 }: CardanoStakeWarningBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { symbol } = account;
 
     if (!isCardanoStakingDisabled) return;
@@ -25,7 +27,7 @@ export const CardanoStakeWarningBanner = ({
                 <Translation
                     id="TR_STAKE_NOT_ENOUGH_FUNDS_WARNING"
                     values={{
-                        networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
+                        networkDisplaySymbol: getNetworkDisplaySymbol(networkConfigDeps, symbol),
                     }}
                 />
             }

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/ConfirmStakeModal.tsx
@@ -7,6 +7,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { getDaysToAddToPoolInitial } from '@suite-common/staking';
 import { EarnFlow, type StakeModalFlow } from '@suite-common/suite-types/src/staking';
 import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectEthValidatorsQueue } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getStakingHelpCenterLink } from '@suite-common/wallet-utils';
@@ -38,6 +39,7 @@ export const ConfirmStakeModal = ({
     onCancel,
     flow,
 }: ConfirmStakeModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const [hasAgreed, setHasAgreed] = useState(false);
@@ -113,7 +115,10 @@ export const ConfirmStakeModal = ({
                         <Translation
                             id={getStakeEnteringMessage(account.networkType)}
                             values={{
-                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                networkDisplaySymbol: getNetworkDisplaySymbol(
+                                    networkConfigDeps,
+                                    account.symbol,
+                                ),
                                 count:
                                     account.networkType === 'ethereum'
                                         ? daysToAddToPool
@@ -133,7 +138,10 @@ export const ConfirmStakeModal = ({
                         <Translation
                             id="TR_STAKE_ETH_WILL_BE_BLOCKED"
                             values={{
-                                networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                networkDisplaySymbol: getNetworkDisplaySymbol(
+                                    networkConfigDeps,
+                                    account.symbol,
+                                ),
                             }}
                         />
                     }

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeInputs.tsx
@@ -4,7 +4,7 @@ import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type StakeFormState } from '@suite-common/wallet-types';
 import { getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
@@ -26,6 +26,7 @@ import {
 import { type FormPercentButtonValue } from 'src/views/wallet/trading/common/TradingForm/tradingFormInputsUtils';
 
 export const StakeInputs = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const locale = useSelector(selectLanguage);
@@ -86,9 +87,11 @@ export const StakeInputs = () => {
             }),
             decimals: validateDecimals(translationString, { decimals: network.decimals }),
             reserveOrBalance: validateReserveOrBalance(translationString, {
+                ...networkConfigDeps,
                 account,
             }),
             limits: validateCryptoLimits(translationString, {
+                ...networkConfigDeps,
                 amountLimits,
                 formatter: CryptoAmountFormatter,
             }),
@@ -98,7 +101,7 @@ export const StakeInputs = () => {
     const shouldShowAmountForWithdrawalWarning =
         isLessAmountForWithdrawalWarningShown || isAmountForWithdrawalWarningShown;
 
-    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const isFractionButtonDisabled = (divisor: number) => {
         if (!account.formattedBalance || !network.decimals) return false;

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeForm/StakeRegistrationDepositCard.tsx
@@ -1,5 +1,6 @@
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { CARDANO_STAKING_REGISTRATION_DEPOSIT } from '@suite-common/wallet-constants';
 import {
     selectAccountIsStakingActive,
@@ -17,11 +18,14 @@ type StakeRegistrationDepositCardProps = {
 };
 
 export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepositCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { symbol, key } = account;
 
     const selectedVotingDelegation = useSelector(selectVotingDelegationOption);
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, key ?? ''));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, key ?? '', networkConfigDeps),
+    );
     const isUpdateProviderFlow = isStakingActive && account.networkType === 'cardano';
 
     return (
@@ -52,7 +56,8 @@ export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepos
                             data-testid="@modal/staking/registration-deposit-amount-with-symbol"
                             typographyStyle="body-md-strong"
                         >
-                            {CARDANO_STAKING_REGISTRATION_DEPOSIT} {getNetworkDisplaySymbol(symbol)}
+                            {CARDANO_STAKING_REGISTRATION_DEPOSIT}{' '}
+                            {getNetworkDisplaySymbol(networkConfigDeps, symbol)}
                         </Paragraph>
                     </Row>
                     <Row gap={20} justifyContent="space-between">
@@ -95,7 +100,10 @@ export const StakeRegistrationDepositCard = ({ account }: StakeRegistrationDepos
                                 : 'TR_STAKE_FUNDS_WARNING'
                         }
                         values={{
-                            networkDisplaySymbol: getNetworkDisplaySymbol(symbol),
+                            networkDisplaySymbol: getNetworkDisplaySymbol(
+                                networkConfigDeps,
+                                symbol,
+                            ),
                         }}
                     />
                 }

--- a/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/StakeModal/StakeModal.tsx
@@ -2,7 +2,7 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { type StakeModalFlow } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Grid, Modal } from '@trezor/components';
@@ -22,11 +22,14 @@ type StakeModalProps = {
 };
 
 export const StakeModal = ({ onCancel, account, flow }: StakeModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const stakeContextValues = useStakeForm({ account });
     const { isBelowTablet } = useLayoutSize();
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const isUpdateProviderFlow = isStakingActive && account.networkType === 'cardano';
 
     const onCancelClick = () => {
@@ -55,7 +58,9 @@ export const StakeModal = ({ onCancel, account, flow }: StakeModalProps) => {
                         id={
                             isUpdateProviderFlow ? 'TR_EARN_UPDATE_PROVIDER' : 'TR_EARN_STAKE_TOKEN'
                         }
-                        values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                        values={{
+                            symbol: getNetworkDisplaySymbol(networkConfigDeps, account.symbol),
+                        }}
                     />
                 }
                 onCancel={onCancelClick}

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeForm.tsx
@@ -1,7 +1,8 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
-import { getDisplaySymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol, getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getSolanaUnstakeAmountBounds,
     getStakingDataForNetwork,
@@ -21,6 +22,7 @@ import { UnstakeInputs } from './UnstakeInputs';
 import { EarnAvailableBalance } from '../../StakeModal/StakeForm/EarnAvailableBalance';
 
 export const UnstakeForm = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account,
         formState: { errors },
@@ -43,14 +45,18 @@ export const UnstakeForm = () => {
         autocompoundBalance = '0',
         canClaim = false,
         claimableAmount = '0',
-    } = getStakingDataForNetwork(account) ?? {};
+    } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const inputError = errors[CRYPTO_INPUT] || errors[FIAT_INPUT] || errors?.outputs?.[0]?.amount;
     const showError = inputError && !['required', 'min'].includes(inputError.type);
 
     const unstakeAmountBounds =
         inputError?.type === 'solanaUnstakeAmount'
-            ? getSolanaUnstakeAmountBounds(account, getValues(OUTPUT_AMOUNT) ?? '')
+            ? getSolanaUnstakeAmountBounds(
+                  networkConfigDeps,
+                  account,
+                  getValues(OUTPUT_AMOUNT) ?? '',
+              )
             : null;
 
     const renderClickableUnstakeAmount = (amount: string) => (
@@ -77,7 +83,10 @@ export const UnstakeForm = () => {
                                         id="TR_STAKE_CAN_CLAIM_WARNING"
                                         values={{
                                             amount: claimableAmount,
-                                            symbol: getDisplaySymbol(account.symbol),
+                                            symbol: getDisplaySymbol(
+                                                networkConfigDeps,
+                                                account.symbol,
+                                            ),
                                             br: <br />,
                                         }}
                                     />
@@ -112,6 +121,7 @@ export const UnstakeForm = () => {
                                                     }
                                                     values={{
                                                         symbol: getNetworkDisplaySymbol(
+                                                            networkConfigDeps,
                                                             account.symbol,
                                                         ),
                                                         higher: renderClickableUnstakeAmount(
@@ -176,7 +186,10 @@ export const UnstakeForm = () => {
                                     <Translation
                                         id="TR_STAKE_UNSTAKING_APPROXIMATE"
                                         values={{
-                                            symbol: getDisplaySymbol(account.symbol),
+                                            symbol: getDisplaySymbol(
+                                                networkConfigDeps,
+                                                account.symbol,
+                                            ),
                                         }}
                                     />
                                 </Tooltip>

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeForm/UnstakeInputs.tsx
@@ -1,8 +1,9 @@
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getStakingDataForNetwork } from '@suite-common/wallet-utils';
 import { Column, type FractionButtonProps, Text } from '@trezor/components';
 import { InputWithOptions } from '@trezor/product-components';
@@ -23,6 +24,7 @@ import {
 } from 'src/utils/suite/validation';
 
 export const UnstakeInputs = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
 
@@ -47,13 +49,13 @@ export const UnstakeInputs = () => {
         autocompoundBalance = '0',
         depositedBalance = '0',
         restakedReward = '0',
-    } = getStakingDataForNetwork(account) ?? {};
+    } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const isRewardsVisible = restakedReward != '';
     const isRewardsDisabled = restakedReward === '0';
 
     const { symbol } = account;
-    const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, symbol);
 
     const { outputs } = getValues();
     const amount = outputs?.[0]?.amount;
@@ -74,6 +76,7 @@ export const UnstakeInputs = () => {
                 rate: currentRate?.rate,
             }),
             solanaUnstakeAmount: validateSolanaUnstakeFiatAmount(translationString, {
+                ...networkConfigDeps,
                 account,
                 decimals: network.decimals,
                 rate: currentRate?.rate,
@@ -87,10 +90,14 @@ export const UnstakeInputs = () => {
             min: validateMin(translationString),
             decimals: validateDecimals(translationString, { decimals: network.decimals }),
             limits: validateCryptoLimits(translationString, {
+                ...networkConfigDeps,
                 amountLimits,
                 formatter: CryptoAmountFormatter,
             }),
-            solanaUnstakeAmount: validateSolanaUnstakeAmount(translationString, { account }),
+            solanaUnstakeAmount: validateSolanaUnstakeAmount(translationString, {
+                ...networkConfigDeps,
+                account,
+            }),
         },
     };
 

--- a/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
+++ b/packages/suite/src/components/earn/modals/UnstakeModal/UnstakeModal.tsx
@@ -2,7 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { CollapsibleBox, Column, Grid, H3, Modal } from '@trezor/components';
 
@@ -19,6 +19,7 @@ type UnstakeModalProps = {
 };
 
 export const UnstakeModal = ({ onCancel, account }: UnstakeModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const withdrawalContextValues = useWithdrawalForm({ account });
     const { isBelowTablet } = useLayoutSize();
@@ -43,7 +44,9 @@ export const UnstakeModal = ({ onCancel, account }: UnstakeModalProps) => {
                 heading={
                     <Translation
                         id="TR_STAKE_UNSTAKE_TOKEN"
-                        values={{ symbol: getNetworkDisplaySymbol(account.symbol) }}
+                        values={{
+                            symbol: getNetworkDisplaySymbol(networkConfigDeps, account.symbol),
+                        }}
                     />
                 }
                 description={

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimAmount.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getTronStakingRewards } from '@suite-common/wallet-utils';
 import { Card, Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -10,9 +12,10 @@ import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeInfoRow } from '../TronStakeInfoRow';
 
 export const TronClaimAmount = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, form } = useTronStakeContext();
     const snapshotAmount = form.methods.watch('amount');
-    const reward = snapshotAmount || getTronStakingRewards(account);
+    const reward = snapshotAmount || getTronStakingRewards(networkConfigDeps, account);
 
     return (
         <Card paddingType="none">

--- a/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/claim/TronClaimSubmitButton.tsx
@@ -3,6 +3,7 @@ import { useDevice } from '@suite/device';
 import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronStakingRewards, isTronClaimSupported } from '@suite-common/wallet-utils';
 import { Button, Tooltip } from '@trezor/components';
@@ -15,6 +16,7 @@ import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronClaimSubmitButton = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { device, isLocked } = useDevice();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { translationString } = useTranslation();
@@ -26,7 +28,7 @@ export const TronClaimSubmitButton = () => {
 
     const { isClaimingDisabled, claimingMessageContent } = useMessageSystemStaking(account.symbol);
 
-    const hasReward = new BigNumber(getTronStakingRewards(account)).gt(0);
+    const hasReward = new BigNumber(getTronStakingRewards(networkConfigDeps, account)).gt(0);
     const isDeviceLocked = !!device?.connected && !!device?.available && isLocked();
     const isClaimFirmwareOutdated = !isTronClaimSupported(device);
 

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeAmount.tsx
@@ -3,8 +3,10 @@ import { useFormState } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { TRON_STAKING_RESERVE } from '@suite-common/wallet-constants';
 import { composeTronFreezeFeeLevelsThunk } from '@suite-common/wallet-core';
 import {
@@ -30,6 +32,8 @@ import { TronCurrencySwitchButton } from '../TronCurrencySwitchButton';
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronFreezeAmount = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
@@ -50,6 +54,7 @@ export const TronFreezeAmount = () => {
     } = amountInput;
 
     const availableBalance = subunitsToUnits({
+        ...networkConfigDeps,
         value: asAmountSubunit(new BigNumber(account.availableBalance)),
         symbol: account.symbol,
     }).toString();
@@ -57,13 +62,14 @@ export const TronFreezeAmount = () => {
     const stakingLimits = getStakingLimitsByNetworkSymbol(account.symbol);
     const minStakingAmount = stakingLimits?.MIN_AMOUNT_FOR_STAKING;
 
-    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const amount = form.methods.watch('amount');
     const resourceType = form.methods.watch('resourceType');
 
     const maxFreezeAmount = useMemo(async () => {
         const availableBalanceUnits = subunitsToUnits({
+            ...networkConfigDeps,
             value: asAmountSubunit(new BigNumber(account.availableBalance)),
             symbol: account.symbol,
         }).toString();
@@ -82,6 +88,7 @@ export const TronFreezeAmount = () => {
         const maxInSun = BigNumber.max(new BigNumber(account.availableBalance).minus(feeInSun), 0);
 
         return subunitsToUnits({
+            ...networkConfigDeps,
             value: asAmountSubunit(maxInSun),
             symbol: account.symbol,
         }).toString();
@@ -100,10 +107,11 @@ export const TronFreezeAmount = () => {
                 }
             },
             decimals: validateDecimals(translationString, {
-                decimals: getNetwork(account.symbol).decimals,
+                decimals: getNetworkConfig(account.symbol).decimals,
             }),
             reserveOrBalance: async (value: string) => {
                 const reserveOrBalanceResult = validateReserveOrBalance(translationString, {
+                    ...networkConfigDeps,
                     account,
                 })(value);
 

--- a/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeResourceSelect.tsx
+++ b/packages/suite/src/components/earn/staking/tron/freeze/TronFreezeResourceSelect.tsx
@@ -1,6 +1,8 @@
 import { useWatch } from 'react-hook-form';
 
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { TRON_RESOURCE_TYPES, type TronResourceType } from '@suite-common/wallet-types';
 import { asAmountSubunit, getResourceGain, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Icon, Row, SelectBar, Text, Tooltip } from '@trezor/components';
@@ -15,6 +17,7 @@ const RESOURCE_LABEL: Record<TronResourceType, TranslationKey> = {
 };
 
 export const TronFreezeResourceSelect = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, form, actions } = useTronStakeContext();
     const { control, setValue } = form.methods;
 
@@ -23,6 +26,7 @@ export const TronFreezeResourceSelect = () => {
     const tronResources = account.networkType === 'tron' ? account.misc.tronResources : undefined;
 
     const availableBalance = subunitsToUnits({
+        ...networkConfigDeps,
         value: asAmountSubunit(new BigNumber(account.availableBalance)),
         symbol: account.symbol,
     }).toString();

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronAmountInput.ts
@@ -1,7 +1,8 @@
 import { useCallback, useState } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { selectBaseCurrency, selectFiatRatesByFiatRateKey } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -21,6 +22,7 @@ type UseTronAmountInputProps = {
 };
 
 export const useTronAmountInput = ({ account, methods }: UseTronAmountInputProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [currency, setCurrency] = useState<'crypto' | 'fiat'>('crypto');
 
     const { setValue, clearErrors } = methods;
@@ -28,7 +30,7 @@ export const useTronAmountInput = ({ account, methods }: UseTronAmountInputProps
     const baseCurrencyCode = useSelector(selectBaseCurrency);
 
     const fiatRateKey = getFiatRateKey(account.symbol, baseCurrencyCode);
-    const { decimals } = getNetwork(account.symbol);
+    const { decimals } = getNetworkConfig(account.symbol);
 
     const currentRate = useSelector(state =>
         selectFiatRatesByFiatRateKey(state, fiatRateKey, 'current'),

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeActions.ts
@@ -3,6 +3,7 @@ import { setConnectionModal, setConnectionMode, useDevice } from '@suite/device'
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { useTronStakingStats } from '@suite-common/earn-staking-api';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { TRON_REPRESENTATIVE_TERMS_OF_SERVICE_URLS } from '@suite-common/wallet-constants';
 import {
     type TronFlow,
@@ -46,6 +47,7 @@ export const useTronStakeActions = ({
     form,
     flow,
 }: UseTronStakeActionsProps): TronStakeActions => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { device } = useDevice();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -185,7 +187,10 @@ export const useTronStakeActions = ({
             case 'withdraw':
                 if (isWithdrawingDisabled) break;
 
-                form.methods.setValue('amount', getTronWithdrawableBalance(account));
+                form.methods.setValue(
+                    'amount',
+                    getTronWithdrawableBalance(networkConfigDeps, account),
+                );
                 dispatch(
                     submitTronWithdrawThunk({
                         account,
@@ -202,7 +207,7 @@ export const useTronStakeActions = ({
             case 'claim':
                 if (isClaimingDisabled) break;
 
-                form.methods.setValue('amount', getTronStakingRewards(account));
+                form.methods.setValue('amount', getTronStakingRewards(networkConfigDeps, account));
                 dispatch(
                     submitTronClaimThunk({
                         account,

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakeForm.ts
@@ -3,6 +3,8 @@ import { useForm } from 'react-hook-form';
 import { useTranslation } from '@suite/intl';
 import { selectAddressValidatorDep } from '@suite-common/address';
 import { useServices } from '@suite-common/dependency-injection';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TronFlow } from '@suite-common/wallet-core';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import { type FeeLevel } from '@trezor/connect';
@@ -10,17 +12,17 @@ import { type FeeLevel } from '@trezor/connect';
 import { getStakedBalance } from '../unstake/unstakeUtils';
 import { CUSTOM_REPRESENTATIVE } from '../vote/constants';
 
-interface GetDefaultResourceTypeProps {
+interface GetDefaultResourceTypeProps extends GetNetworkConfigDep {
     account: Account;
     flow: TronFlow;
 }
 
-const getDefaultResourceType = ({ account, flow }: GetDefaultResourceTypeProps) => {
+const getDefaultResourceType = ({ account, flow, ...deps }: GetDefaultResourceTypeProps) => {
     if (flow !== 'unstake') {
         return 'bandwidth';
     }
 
-    const stakedBandwidthBalance = getStakedBalance(account, 'bandwidth');
+    const stakedBandwidthBalance = getStakedBalance(deps, account, 'bandwidth');
 
     return stakedBandwidthBalance === '0' ? 'energy' : 'bandwidth';
 };
@@ -42,13 +44,14 @@ interface UseTronStakeFormProps {
 export const useTronStakeForm = ({ account, flow }: UseTronStakeFormProps) => {
     const { translationString } = useTranslation();
     const { addressValidator } = useServices(selectAddressValidatorDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
 
     const methods = useForm<TronStakeFormValues>({
         mode: 'onChange',
         defaultValues: {
             amount: '',
             fiatAmount: '',
-            resourceType: getDefaultResourceType({ account, flow }),
+            resourceType: getDefaultResourceType({ ...networkConfigDeps, account, flow }),
             selectedFee: 'normal',
             representative: '',
             customRepresentativeAddress: '',

--- a/packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/staking/tron/hooks/useTronStakePendingTransactionTracking.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type TronFlow,
     fetchAndUpdateAccountThunk,
@@ -32,12 +34,15 @@ export const useTronStakePendingTransactionTracking = ({
     account,
     flow,
 }: UseTronStakePendingTransactionTrackingProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { pendingTxid } = useSelector(state => selectTronStakeSession(state, account.key, flow));
     const trackedTransaction = useSelector(state =>
         pendingTxid ? selectTransactionByAccountKeyAndTxid(state, account.key, pendingTxid) : null,
     );
-    const feeInfo = useSelector(state => selectConvertedNetworkFeeInfo(state, account.symbol));
+    const feeInfo = useSelector(state =>
+        selectConvertedNetworkFeeInfo(state, account.symbol, networkConfigDeps),
+    );
     const pollIntervalMs = getPollIntervalMs(feeInfo?.blockTime);
 
     const isCurrentlyPending =

--- a/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/unstake/TronUnstakeAmount.tsx
@@ -2,8 +2,10 @@ import { useFormState, useWatch } from 'react-hook-form';
 
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { toFiatCurrency } from '@suite-common/wallet-utils';
 import { Banner, Button, Column, Row, Text } from '@trezor/components';
 import { NumberInput } from '@trezor/product-components';
@@ -19,6 +21,8 @@ import { useTronStakeContext } from '../TronStakeContext';
 import { getStakedBalance } from './unstakeUtils';
 
 export const TronUnstakeAmount = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
     const { account, form, actions, amountInput } = useTronStakeContext();
@@ -36,16 +40,16 @@ export const TronUnstakeAmount = () => {
     } = amountInput;
 
     const resourceType = useWatch({ control, name: 'resourceType' });
-    const stakedBalance = getStakedBalance(account, resourceType);
+    const stakedBalance = getStakedBalance(networkConfigDeps, account, resourceType);
 
-    const networkDisplaySymbol = getNetworkDisplaySymbol(account.symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const cryptoInputRules = {
         required: translationString('AMOUNT_IS_NOT_SET'),
         validate: {
             min: validateMin(translationString),
             decimals: validateDecimals(translationString, {
-                decimals: getNetwork(account.symbol).decimals,
+                decimals: getNetworkConfig(account.symbol).decimals,
             }),
             staked: (value: string) =>
                 new BigNumber(value || 0).lte(stakedBalance) ||

--- a/packages/suite/src/components/earn/staking/tron/unstake/unstakeUtils.ts
+++ b/packages/suite/src/components/earn/staking/tron/unstake/unstakeUtils.ts
@@ -1,8 +1,13 @@
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-export const getStakedBalance = (account: Account, resourceType: TronResourceType): string => {
+export const getStakedBalance = (
+    deps: GetNetworkConfigDep,
+    account: Account,
+    resourceType: TronResourceType,
+): string => {
     const stakingInfo =
         account.networkType === 'tron' ? account.misc.tronResources?.stakingInfo : undefined;
 
@@ -19,6 +24,7 @@ export const getStakedBalance = (account: Account, resourceType: TronResourceTyp
     const unstakeable = BigNumber.max(new BigNumber(staked ?? 0).minus(delegated ?? 0), 0);
 
     return subunitsToUnits({
+        ...deps,
         value: asAmountSubunit(unstakeable),
         symbol: account.symbol,
     }).toString();

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteForm.tsx
@@ -1,7 +1,8 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Banner, Card, Column, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
 
@@ -16,6 +17,7 @@ import { TronVoteRepresentativeSelect } from './TronVoteRepresentativeSelect';
 import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteForm = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, form, actions, fees } = useTronStakeContext();
     const { error, pendingTxid } = actions;
 
@@ -57,7 +59,10 @@ export const TronVoteForm = () => {
                             <Translation
                                 id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
                                 values={{
-                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(
+                                        networkConfigDeps,
+                                        account.symbol,
+                                    ),
                                 }}
                             />
                         }

--- a/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
+++ b/packages/suite/src/components/earn/staking/tron/vote/TronVoteStep.tsx
@@ -1,7 +1,8 @@
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Banner, Column } from '@trezor/components';
 
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
@@ -14,6 +15,7 @@ import { TronVoteRepresentativeSelect } from './TronVoteRepresentativeSelect';
 import { TronVoteSubmitButton } from './TronVoteSubmitButton';
 
 export const TronVoteStep = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { form, actions, account, fees } = useTronStakeContext();
     const { error, pendingTxid } = actions;
 
@@ -39,7 +41,10 @@ export const TronVoteStep = () => {
                             <Translation
                                 id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
                                 values={{
-                                    networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol),
+                                    networkDisplaySymbol: getNetworkDisplaySymbol(
+                                        networkConfigDeps,
+                                        account.symbol,
+                                    ),
                                 }}
                             />
                         }

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawAmount.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawAmount.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { Card, Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -10,8 +12,9 @@ import { useTronStakeContext } from '../TronStakeContext';
 import { TronStakeInfoRow } from '../TronStakeInfoRow';
 
 export const TronWithdrawAmount = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = useTronStakeContext();
-    const amount = getTronWithdrawableBalance(account);
+    const amount = getTronWithdrawableBalance(networkConfigDeps, account);
 
     return (
         <Card paddingType="none">

--- a/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
+++ b/packages/suite/src/components/earn/staking/tron/withdraw/TronWithdrawSubmitButton.tsx
@@ -2,6 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { Button, Tooltip } from '@trezor/components';
@@ -13,6 +14,7 @@ import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking
 import { useTronStakeContext } from '../TronStakeContext';
 
 export const TronWithdrawSubmitButton = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { device, isLocked } = useDevice();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
@@ -23,7 +25,9 @@ export const TronWithdrawSubmitButton = () => {
         account.symbol,
     );
 
-    const hasWithdrawableAmount = new BigNumber(getTronWithdrawableBalance(account)).gt(0);
+    const hasWithdrawableAmount = new BigNumber(
+        getTronWithdrawableBalance(networkConfigDeps, account),
+    ).gt(0);
     const isDeviceUnavailable = !!device?.connected && !!device?.available && isLocked();
 
     const handleClick = () => {

--- a/packages/suite/src/components/earn/utils/getEarnRouteParams.ts
+++ b/packages/suite/src/components/earn/utils/getEarnRouteParams.ts
@@ -1,8 +1,9 @@
 import { type RouteParams } from '@suite/router';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type Account } from '@suite-common/wallet-types';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 
-type GetEarnRouteParamsProps = {
+type GetEarnRouteParamsProps = GetNetworkConfigDep & {
     account: Account;
     vaultAddress: string;
 };
@@ -12,6 +13,7 @@ type GetEarnRouteParamsProps = {
  * normalized so the same vault always yields the same URL, whatever casing the API reports.
  */
 export const getEarnRouteParams = ({
+    getNetworkConfig,
     account,
     vaultAddress,
 }: GetEarnRouteParamsProps): RouteParams => ({
@@ -19,6 +21,6 @@ export const getEarnRouteParams = ({
     accountIndex: account.index,
     accountType: account.accountType,
     vaultAddress: encodeURIComponent(
-        getContractAddressForNetworkSymbol(account.symbol, vaultAddress),
+        getContractAddressForNetworkSymbol({ getNetworkConfig }, account.symbol, vaultAddress),
     ),
 });

--- a/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldApproveModal.tsx
@@ -7,6 +7,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useYieldOpportunity } from '@suite-common/earn-stablecoin-api';
 import { parseCryptoId, toTokenCryptoId } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getAssetLogoUrl } from '@trezor/asset-utils';
 import { isWrappedNativeToken } from '@trezor/network-ethereum-suite-common';
@@ -40,6 +41,7 @@ export const YieldApproveModal = ({
     onCancel,
     onSuccess,
 }: YieldApproveModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
@@ -47,7 +49,7 @@ export const YieldApproveModal = ({
         tx: { approvalTxid, setApprovalTxid },
     } = useAllowanceContext();
     const handledTxidRef = useRef<string | null>(null);
-    const cryptoId = toTokenCryptoId(account.symbol, contractAddress);
+    const cryptoId = toTokenCryptoId(networkConfigDeps, account.symbol, contractAddress);
     const { networkId, contractAddress: parsedContract } = parseCryptoId(cryptoId);
     const { data: vaultName } = useYieldOpportunity(vaultId, {
         select: yieldOpportunity => yieldOpportunity.metadata.name,

--- a/packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.ts
+++ b/packages/suite/src/components/earn/yield/common/useWrappedNativePendingTx.ts
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
+import {
+    type WrappedNativeFlowType,
+    fetchAndUpdateAccountThunk,
+    selectAccountTransactions,
+    selectConvertedNetworkFeeInfo,
+} from '@suite-common/wallet-core';
+import { type Account, type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { getNativeWrapTxKind, isPending } from '@suite-common/wallet-utils';
+
+import { useDispatch, useSelector } from 'src/hooks/suite';
+
+const DEFAULT_POLL_INTERVAL_MS = 3_000;
+const MIN_POLL_INTERVAL_MS = 2_000;
+const BLOCK_TIME_TO_POLL_INTERVAL_RATIO = 2;
+
+export type WrappedNativePendingTxStatus = 'pending' | 'confirmed' | 'failed';
+
+type TrackedWrappedNativeTransaction = {
+    transaction: WalletAccountTransaction;
+    isReplacement: boolean;
+};
+
+export const findTrackedWrappedNativeTransaction = ({
+    transactions,
+    txid,
+    nonce,
+}: {
+    transactions: WalletAccountTransaction[];
+    txid: string;
+    nonce?: number;
+}): TrackedWrappedNativeTransaction | undefined => {
+    const originalTransaction = transactions.find(transaction => transaction.txid === txid);
+
+    if (originalTransaction) {
+        return { transaction: originalTransaction, isReplacement: false };
+    }
+
+    if (nonce === undefined) {
+        return undefined;
+    }
+
+    const replacementTransaction = transactions.find(
+        transaction => transaction.ethereumSpecific?.nonce === nonce,
+    );
+
+    return replacementTransaction
+        ? { transaction: replacementTransaction, isReplacement: true }
+        : undefined;
+};
+
+export const getWrappedNativePendingTxStatus = ({
+    txid,
+    trackedTransaction,
+    flowType,
+}: {
+    txid: string | null;
+    trackedTransaction?: TrackedWrappedNativeTransaction;
+    flowType: WrappedNativeFlowType;
+}): WrappedNativePendingTxStatus | null => {
+    if (!txid) {
+        return null;
+    }
+
+    if (!trackedTransaction || isPending(trackedTransaction.transaction)) {
+        return 'pending';
+    }
+
+    if (
+        trackedTransaction.transaction.type === 'failed' ||
+        (trackedTransaction.isReplacement &&
+            getNativeWrapTxKind(trackedTransaction.transaction) !== flowType)
+    ) {
+        return 'failed';
+    }
+
+    return 'confirmed';
+};
+
+export const useWrappedNativePendingTx = (
+    account: Account,
+    txid: string | null,
+    flowType: WrappedNativeFlowType,
+): WrappedNativePendingTxStatus | null => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const dispatch = useDispatch();
+    const transactions = useSelector(state => selectAccountTransactions(state, account.key));
+    const feeInfo = useSelector(state =>
+        selectConvertedNetworkFeeInfo(state, account.symbol, networkConfigDeps),
+    );
+    const [trackedNonce, setTrackedNonce] = useState<{ txid: string; nonce: number } | null>(null);
+    const trackedTransaction = txid
+        ? findTrackedWrappedNativeTransaction({
+              transactions,
+              txid,
+              nonce: trackedNonce?.txid === txid ? trackedNonce.nonce : undefined,
+          })
+        : undefined;
+    const originalNonce =
+        trackedTransaction && !trackedTransaction.isReplacement
+            ? trackedTransaction.transaction.ethereumSpecific?.nonce
+            : undefined;
+
+    useEffect(() => {
+        if (!txid || originalNonce === undefined) {
+            return;
+        }
+
+        setTrackedNonce(current =>
+            current?.txid === txid && current.nonce === originalNonce
+                ? current
+                : { txid, nonce: originalNonce },
+        );
+    }, [originalNonce, txid]);
+
+    const pollIntervalMs = feeInfo?.blockTime
+        ? Math.max(
+              (feeInfo.blockTime / BLOCK_TIME_TO_POLL_INTERVAL_RATIO) * 1000,
+              MIN_POLL_INTERVAL_MS,
+          )
+        : DEFAULT_POLL_INTERVAL_MS;
+
+    const status = getWrappedNativePendingTxStatus({ txid, trackedTransaction, flowType });
+
+    useEffect(() => {
+        if (status !== 'pending') {
+            return undefined;
+        }
+
+        const interval = setInterval(() => {
+            dispatch(fetchAndUpdateAccountThunk({ accountKey: account.key }));
+        }, pollIntervalMs);
+
+        return () => clearInterval(interval);
+    }, [status, account.key, dispatch, pollIntervalMs]);
+
+    return status;
+};

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -2,7 +2,7 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     getYieldFlowStepSequence,
@@ -27,6 +27,7 @@ import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldWrapStep } from '../common/YieldWrapStep';
 
 export const YieldDepositForm = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
@@ -82,7 +83,7 @@ export const YieldDepositForm = () => {
     const wrapPendingTransaction =
         pendingTransaction?.type === 'wrap' ? pendingTransaction : undefined;
 
-    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeSymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     // Approximate fiat value shown under the amount input, from the token's own rate.
     const approxFiat = {
         symbol: token.networkSymbol,

--- a/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useResolvedYieldFlowData.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TokenDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowToken,
@@ -22,9 +24,10 @@ const hasTokenSymbol = (
 ): accountToken is TokenInfoBranded => accountToken.symbol !== undefined;
 
 const getMatchedAccountToken = ({
+    getNetworkConfig,
     account,
     token,
-}: {
+}: Pick<NetworkConfigDeps, 'getNetworkConfig'> & {
     account: Account;
     token?: Pick<TokenDtoV2, 'address' | 'symbol' | 'decimals'>;
 }) => {
@@ -36,6 +39,7 @@ const getMatchedAccountToken = ({
         (accountToken): accountToken is TokenInfoBranded =>
             hasTokenSymbol(accountToken) &&
             doTokensMatch({
+                getNetworkConfig,
                 networkSymbol: account.symbol,
                 firstToken: {
                     address: accountToken.contract,
@@ -66,6 +70,7 @@ export const useResolvedYieldFlowData = ({
     account,
     vault,
 }: UseResolvedYieldFlowDataProps): UseResolvedYieldFlowDataResult => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const resolvedContractAddress = vault.token.address;
 
     const matchedToken = useMemo(() => {
@@ -73,8 +78,13 @@ export const useResolvedYieldFlowData = ({
             return account.tokens?.find((token): token is TokenInfo => {
                 const normalizedTokenAddress =
                     token.contract &&
-                    getContractAddressForNetworkSymbol(account.symbol, token.contract);
+                    getContractAddressForNetworkSymbol(
+                        networkConfigDeps,
+                        account.symbol,
+                        token.contract,
+                    );
                 const normalizedRouteAddress = getContractAddressForNetworkSymbol(
+                    networkConfigDeps,
                     account.symbol,
                     resolvedContractAddress,
                 );
@@ -84,18 +94,20 @@ export const useResolvedYieldFlowData = ({
         }
 
         return getMatchedAccountToken({
+            ...networkConfigDeps,
             account,
             token: vault.token,
         });
-    }, [account, resolvedContractAddress, vault.token]);
+    }, [account, networkConfigDeps, resolvedContractAddress, vault.token]);
 
     const matchedOutputToken = useMemo(
         () =>
             getMatchedAccountToken({
+                ...networkConfigDeps,
                 account,
                 token: vault.outputToken,
             }),
-        [account, vault],
+        [account, networkConfigDeps, vault],
     );
 
     const token = useMemo<YieldFlowToken | null>(
@@ -104,7 +116,7 @@ export const useResolvedYieldFlowData = ({
             symbol:
                 matchedToken?.symbol ??
                 vault.token.symbol ??
-                getNetworkDisplaySymbol(account.symbol),
+                getNetworkDisplaySymbol(networkConfigDeps, account.symbol),
             decimals: matchedToken?.decimals ?? vault.token.decimals,
             contractAddress: resolvedContractAddress ?? null,
             coingeckoId: vault.token.coinGeckoId,
@@ -128,6 +140,7 @@ export const useResolvedYieldFlowData = ({
     }, [account, token, vault]);
 
     const depositedAmount = getConvertedOutputTokenBalanceToInputTokenAmount({
+        ...networkConfigDeps,
         networkSymbol: account.symbol,
         token: vault.token,
         outputToken: vault.outputToken,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -8,7 +8,7 @@ import { openModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type YieldAllowanceStatus,
     type YieldApproveModalState,
@@ -138,6 +138,7 @@ export const useYieldFlow = ({
 }: UseYieldFlowProps): UseYieldFlowResult => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { device } = useDevice();
     const methods = useForm<YieldFlowFormValues>({
         mode: 'onChange',
@@ -179,6 +180,7 @@ export const useYieldFlow = ({
     // Fiat entry prices the amount by the token currently shown (native for wrap/unwrap, the vault
     // asset for deposit/withdraw, none while redeeming shares).
     const rateToken = getYieldFiatRateToken({
+        ...networkConfigDeps,
         step: session.step,
         flowType,
         accountSymbol: account.symbol,
@@ -188,7 +190,7 @@ export const useYieldFlow = ({
         methods,
         symbol: rateToken?.symbol,
         tokenAddress: rateToken?.tokenAddress,
-        decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
+        decimals: token?.decimals ?? networkConfigDeps.getNetworkConfig(account.symbol).decimals,
         vaultId: vault.id,
     });
 
@@ -392,6 +394,7 @@ export const useYieldFlow = ({
         }
 
         return getYieldUnwrapDefaultAmount({
+            ...networkConfigDeps,
             flowType,
             withdrawnAmount: session.result.completedAmount,
             token,
@@ -399,7 +402,14 @@ export const useYieldFlow = ({
             pricePerShareState,
             fallbackAmount: token.balance,
         });
-    }, [flowType, pricePerShareState, receiptToken, session.result.completedAmount, token]);
+    }, [
+        flowType,
+        networkConfigDeps,
+        pricePerShareState,
+        receiptToken,
+        session.result.completedAmount,
+        token,
+    ]);
 
     useEffect(() => {
         if (session.step !== 'unwrap') {

--- a/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldPendingTransactionTracking.ts
@@ -4,6 +4,7 @@ import { type AnalyticsDesktopEvents, selectDesktopAnalyticsDep } from '@suite/a
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type YieldFlowType,
     type YieldPendingTransactionState,
@@ -185,6 +186,7 @@ export const useYieldPendingTransactionTracking = ({
 }: UseYieldPendingTransactionTrackingProps) => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const pendingTransaction = useSelector(
         state => selectStablecoinYieldSession(state, flowType, flowKey).action.pendingTransaction,
     );
@@ -193,7 +195,9 @@ export const useYieldPendingTransactionTracking = ({
             ? selectTransactionByAccountKeyAndTxid(state, account.key, pendingTransaction.txid)
             : null,
     );
-    const feeInfo = useSelector(state => selectConvertedNetworkFeeInfo(state, account.symbol));
+    const feeInfo = useSelector(state =>
+        selectConvertedNetworkFeeInfo(state, account.symbol, networkConfigDeps),
+    );
     const pollIntervalMs = getPollIntervalMs(feeInfo?.blockTime);
 
     const isCurrentlyPending =

--- a/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/unwrap/UnwrapNativeToken.tsx
@@ -5,8 +5,9 @@ import { useMutation } from '@tanstack/react-query';
 
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowFormValues,
@@ -54,6 +55,7 @@ export const UnwrapNativeToken = ({
     tokenContractAddress,
     onFlowCompleteChange,
 }: UnwrapNativeTokenProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
     const {
@@ -76,7 +78,12 @@ export const UnwrapNativeToken = ({
         decimals: tokenDecimals,
     });
 
-    const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'unwrap');
+    const pendingTxStatus = useWrappedNativePendingTx(
+        networkConfigDeps,
+        account,
+        broadcast?.txid ?? null,
+        'unwrap',
+    );
     const isFlowComplete = !!broadcast && pendingTxStatus === 'confirmed';
 
     useEffect(() => {
@@ -95,7 +102,7 @@ export const UnwrapNativeToken = ({
     const isAmountTooHigh = amount.gt(tokenBalance);
     const isAmountValid = amount.gt(0) && !isAmountTooHigh && methods.formState.isValid;
 
-    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeSymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
     const baseCurrency = useSelector(selectBaseCurrency);
     // The wrapped-native token (WETH) is not held as a balance, so its fiat rate is not fetched by

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -4,7 +4,8 @@ import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getYieldFlowStepSequence, splitYieldPendingTransaction } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
@@ -20,7 +21,10 @@ import { YieldFlowCompleteWithdraw } from '../common/YieldFlowCompleteWithdraw';
 import { YieldFlowStepList } from '../common/YieldFlowStepList';
 import { YieldUnwrapStep } from '../common/YieldUnwrapStep';
 
+
 export const YieldWithdrawForm = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
     const {
@@ -67,7 +71,7 @@ export const YieldWithdrawForm = () => {
         pendingTransaction?.type === 'unwrap' ? pendingTransaction : undefined;
     const withdrawInputUnit = flowType === 'redeem' ? 'shares' : 'asset';
 
-    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeSymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     const withdrawActionToken = flowType === 'redeem' ? receiptToken : token;
     // Approximate fiat value shown under the amount input, from the token's own rate.
     const actionApproxFiat = {
@@ -279,7 +283,7 @@ export const YieldWithdrawForm = () => {
                                     id="TR_EARN_YIELD_UNWRAP_DESCRIPTION"
                                     values={{
                                         tokenSymbol: token.symbol,
-                                        networkName: getNetwork(account.symbol).name,
+                                        networkName: getNetworkConfig(account.symbol).name,
                                     }}
                                 />
                             ),

--- a/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
@@ -1,14 +1,12 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { mockGetNetworkConfig } from '@suite-common/networks/mocks';
 import { type YieldFlowDisplayToken, type YieldFlowToken } from '@suite-common/wallet-core';
 
 import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
 
 type Params = Parameters<typeof getYieldWithdrawCompletedValues>[0];
 
-const ethSymbol = asNetworkSymbol('eth');
-
 const token: YieldFlowToken = {
-    networkSymbol: ethSymbol,
+    networkSymbol: 'eth',
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -16,7 +14,7 @@ const token: YieldFlowToken = {
 };
 
 const receiptToken: YieldFlowDisplayToken = {
-    networkSymbol: ethSymbol,
+    networkSymbol: 'eth',
     symbol: 'trSHETHp',
     decimals: 18,
     contractAddress: '0x1111111111111111111111111111111111111111',
@@ -29,12 +27,13 @@ const pricePerShareState: Params['pricePerShareState'] = {
     quoteToken: { symbol: 'WETH', network: 'ethereum', name: 'Wrapped Ether', decimals: 18 },
 };
 
-const base = {
-    networkSymbol: ethSymbol,
+const base: Omit<Params, 'flowType' | 'completedAmount' | 'unwrappedAmount'> = {
+    getNetworkConfig: mockGetNetworkConfig,
+    networkSymbol: 'eth',
     token,
     receiptToken,
     pricePerShareState,
-} satisfies Omit<Params, 'flowType' | 'completedAmount' | 'unwrappedAmount'>;
+};
 
 describe('getYieldWithdrawCompletedValues', () => {
     it('redeem without unwrap: sends the trSHETHp shares entered, receives WETH', () => {

--- a/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.ts
@@ -1,9 +1,6 @@
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import {
-    type NetworkSymbol,
-    getNetwork,
-    getNetworkDisplaySymbol,
-} from '@suite-common/wallet-config';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowCompleteValue,
     type YieldFlowDisplayToken,
@@ -15,7 +12,7 @@ import {
 
 type PricePerShareState = NonNullable<YieldDtoV2['state']>['pricePerShareState'];
 
-type GetYieldWithdrawCompletedValuesParams = {
+type GetYieldWithdrawCompletedValuesParams = GetNetworkConfigDep & {
     networkSymbol: NetworkSymbol;
     flowType: YieldWithdrawFlowType;
     completedAmount: string;
@@ -50,12 +47,14 @@ export const getYieldWithdrawCompletedValues = ({
     token,
     receiptToken,
     pricePerShareState,
+    getNetworkConfig,
 }: GetYieldWithdrawCompletedValuesParams): YieldWithdrawCompletedValues => {
     const isSharesInput = flowType === 'redeem';
 
     const sentReceiptAmount = isSharesInput
         ? completedAmount
         : (getWithdrawRequestAmount({
+              getNetworkConfig,
               networkSymbol,
               amount: completedAmount,
               token,
@@ -74,8 +73,8 @@ export const getYieldWithdrawCompletedValues = ({
             output: {
                 token: {
                     networkSymbol,
-                    symbol: getNetworkDisplaySymbol(networkSymbol),
-                    decimals: getNetwork(networkSymbol).decimals,
+                    symbol: getNetworkDisplaySymbol({ getNetworkConfig }, networkSymbol),
+                    decimals: getNetworkConfig(networkSymbol).decimals,
                 },
                 amount: unwrappedAmount,
             },
@@ -89,6 +88,7 @@ export const getYieldWithdrawCompletedValues = ({
             amount:
                 isSharesInput && pricePerShareState
                     ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                          getNetworkConfig,
                           networkSymbol,
                           token,
                           outputToken: receiptToken,

--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type YieldFlowCompleteValue, type YieldWithdrawFlowType } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
@@ -25,6 +27,7 @@ export const useYieldWithdraw = ({
     account,
     vault,
 }: UseYieldWithdrawProps): YieldWithdrawContextValues | null => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [flowType, setFlowType] = useState<YieldWithdrawFlowType>('withdraw');
     const [isMaxWithdrawSelectionPending, setIsMaxWithdrawSelectionPending] = useState(false);
     const [maxWithdrawInfoAmount, setMaxWithdrawInfoAmount] = useState<string | null>(null);
@@ -88,6 +91,7 @@ export const useYieldWithdraw = ({
 
     const { completedAmount, unwrappedAmount } = flowResult;
     const { input: completedInput, output: completedOutput } = getYieldWithdrawCompletedValues({
+        getNetworkConfig,
         networkSymbol: account.symbol,
         flowType,
         completedAmount,

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -5,8 +5,9 @@ import { useMutation } from '@tanstack/react-query';
 
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     type YieldFlowDisplayToken,
@@ -45,6 +46,7 @@ type BroadcastWrap = {
 };
 
 export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNativeTokenProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const ensureDeviceReady = useWrappedNativeDeviceGuard();
     const {
@@ -61,7 +63,12 @@ export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNa
         },
     });
 
-    const pendingTxStatus = useWrappedNativePendingTx(account, broadcast?.txid ?? null, 'wrap');
+    const pendingTxStatus = useWrappedNativePendingTx(
+        networkConfigDeps,
+        account,
+        broadcast?.txid ?? null,
+        'wrap',
+    );
     const isFlowComplete = !!broadcast && pendingTxStatus === 'confirmed';
 
     useEffect(() => {
@@ -75,7 +82,7 @@ export const WrapNativeToken = ({ account, token, onFlowCompleteChange }: WrapNa
         networkSymbol: account.symbol,
     });
 
-    const nativeSymbol = getNetworkDisplaySymbol(account.symbol);
+    const nativeSymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
     const nativeToken: YieldFlowDisplayToken = {
         networkSymbol: account.symbol,
         symbol: nativeSymbol,

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -1,21 +1,7 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
 
-import {
-    getYieldCryptoInputValue,
-    getYieldFiatInputValue,
-    getYieldFiatRateToken,
-    getYieldFlowSteps,
-    getYieldMaxFiatInputValue,
-    getYieldUnwrapDefaultAmount,
-    shouldInitializeYieldAllowance,
-} from './yieldFlowUtils';
-
-// Checksummed WETH address; the helper lower-cases it for the (evm) rate key.
-const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-const WETH_LOWER = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const ethSymbol = asNetworkSymbol('eth');
-const ethToken = { networkSymbol: ethSymbol, contractAddress: WETH } as const;
+import { getYieldFlowSteps, getYieldUnwrapDefaultAmount } from './yieldFlowUtils';
 
 const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
 const depositWithWrapSequence = getYieldFlowStepSequence({
@@ -51,17 +37,18 @@ const pricePerShareState = {
 };
 
 const baseUnwrapParams: Parameters<typeof getYieldUnwrapDefaultAmount>[0] = {
+    ...mockNetworkConfigDeps,
     flowType: 'withdraw',
     withdrawnAmount: '0.5',
     token: {
-        networkSymbol: ethSymbol,
+        networkSymbol: 'eth',
         symbol: 'WETH',
         decimals: 18,
         contractAddress: WETH_ADDRESS,
         balance: '5',
     },
     receiptToken: {
-        networkSymbol: ethSymbol,
+        networkSymbol: 'eth',
         symbol: 'trSHETHp',
         decimals: 18,
         contractAddress: VAULT_ADDRESS,
@@ -200,189 +187,6 @@ describe('yieldFlowUtils', () => {
                     fallbackAmount: '5',
                 }),
             ).toBe('5');
-        });
-    });
-
-    describe('getYieldFiatRateToken', () => {
-        it('prices wrap/unwrap by the account native symbol (no token address)', () => {
-            expect(
-                getYieldFiatRateToken({
-                    step: 'wrap',
-                    flowType: 'deposit',
-                    accountSymbol: ethSymbol,
-                    token: ethToken,
-                }),
-            ).toEqual({ symbol: 'eth' });
-
-            expect(
-                getYieldFiatRateToken({
-                    step: 'unwrap',
-                    flowType: 'withdraw',
-                    accountSymbol: ethSymbol,
-                    token: ethToken,
-                }),
-            ).toEqual({ symbol: 'eth' });
-        });
-
-        it('prices deposit by the asset token contract address (lower-cased)', () => {
-            expect(
-                getYieldFiatRateToken({
-                    step: 'action',
-                    flowType: 'deposit',
-                    accountSymbol: ethSymbol,
-                    token: ethToken,
-                }),
-            ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
-        });
-
-        it('returns null when fiat entry is impossible (withdraw flow or no token address)', () => {
-            expect(
-                getYieldFiatRateToken({
-                    step: 'action',
-                    flowType: 'withdraw',
-                    accountSymbol: ethSymbol,
-                    token: ethToken,
-                }),
-            ).toBeNull();
-
-            expect(
-                getYieldFiatRateToken({
-                    step: 'action',
-                    flowType: 'redeem',
-                    accountSymbol: ethSymbol,
-                    token: ethToken,
-                }),
-            ).toBeNull();
-
-            expect(
-                getYieldFiatRateToken({
-                    step: 'action',
-                    flowType: 'deposit',
-                    accountSymbol: ethSymbol,
-                    token: null,
-                }),
-            ).toBeNull();
-
-            expect(
-                getYieldFiatRateToken({
-                    step: 'action',
-                    flowType: 'deposit',
-                    accountSymbol: ethSymbol,
-                    token: { networkSymbol: ethSymbol, contractAddress: null },
-                }),
-            ).toBeNull();
-        });
-    });
-
-    describe('getYieldFiatInputValue', () => {
-        it('converts crypto to fiat with two decimals', () => {
-            expect(getYieldFiatInputValue({ amount: '2', rate: 1500 })).toBe('3000.00');
-            expect(getYieldFiatInputValue({ amount: '0.001', rate: 1234.5 })).toBe('1.23');
-        });
-
-        it('returns an empty string for an empty amount or missing rate', () => {
-            expect(getYieldFiatInputValue({ amount: '', rate: 1500 })).toBe('');
-            expect(getYieldFiatInputValue({ amount: '2', rate: undefined })).toBe('');
-        });
-    });
-
-    describe('getYieldMaxFiatInputValue', () => {
-        it('rounds the max fiat down so it never converts back above the balance', () => {
-            // 0.1 * 3333.35 = 333.335 → down = 333.33 (half-up would overstate it as 333.34).
-            expect(getYieldMaxFiatInputValue({ amount: '0.1', rate: 3333.35 })).toBe('333.33');
-            expect(getYieldFiatInputValue({ amount: '0.1', rate: 3333.35 })).toBe('333.34');
-        });
-
-        it('returns an empty string for an empty amount or missing rate', () => {
-            expect(getYieldMaxFiatInputValue({ amount: '', rate: 1500 })).toBe('');
-            expect(getYieldMaxFiatInputValue({ amount: '1', rate: undefined })).toBe('');
-        });
-    });
-
-    describe('getYieldCryptoInputValue', () => {
-        it('converts fiat to crypto, trimming trailing zeros and capping at the token decimals', () => {
-            expect(getYieldCryptoInputValue({ fiat: '3000', rate: 1500, decimals: 18 })).toBe('2');
-            expect(getYieldCryptoInputValue({ fiat: '10', rate: 3, decimals: 6 })).toBe('3.333333');
-        });
-
-        it('returns an empty string for an empty fiat or missing rate', () => {
-            expect(getYieldCryptoInputValue({ fiat: '', rate: 1500, decimals: 18 })).toBe('');
-            expect(getYieldCryptoInputValue({ fiat: '100', rate: undefined, decimals: 6 })).toBe(
-                '',
-            );
-        });
-    });
-
-    describe('shouldInitializeYieldAllowance', () => {
-        const wrappedNativeParams = {
-            isWrappedNativeVault: true,
-            hasWrappedNativeSession: true,
-            step: 'approve',
-            allowanceStatus: 'idle',
-        } as const;
-
-        it('reads the allowance for a plain ERC-20 vault on any step', () => {
-            const erc20Params = {
-                isWrappedNativeVault: false,
-                hasWrappedNativeSession: false,
-                allowanceStatus: 'idle',
-            } as const;
-
-            expect(shouldInitializeYieldAllowance({ ...erc20Params, step: 'approve' })).toBe(true);
-            expect(shouldInitializeYieldAllowance({ ...erc20Params, step: 'action' })).toBe(true);
-        });
-
-        it('reads the allowance only when it is idle', () => {
-            expect(
-                shouldInitializeYieldAllowance({
-                    ...wrappedNativeParams,
-                    allowanceStatus: 'loading',
-                }),
-            ).toBe(false);
-            expect(
-                shouldInitializeYieldAllowance({
-                    ...wrappedNativeParams,
-                    allowanceStatus: 'loaded',
-                }),
-            ).toBe(false);
-            expect(
-                shouldInitializeYieldAllowance({
-                    ...wrappedNativeParams,
-                    allowanceStatus: 'error',
-                }),
-            ).toBe(false);
-        });
-
-        it('skips the read on the wrap step, before the amount to approve is known', () => {
-            expect(shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'wrap' })).toBe(
-                false,
-            );
-        });
-
-        it('reads the allowance on the approve step of a wrapped-native deposit', () => {
-            expect(shouldInitializeYieldAllowance(wrappedNativeParams)).toBe(true);
-        });
-
-        // Otherwise the status stays idle for the rest of the flow and the banner never returns.
-        it('re-reads the allowance on the action step of a wrapped-native deposit', () => {
-            expect(shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'action' })).toBe(
-                true,
-            );
-        });
-
-        it('skips the read until the session reports the wrapped-native shape', () => {
-            expect(
-                shouldInitializeYieldAllowance({
-                    ...wrappedNativeParams,
-                    hasWrappedNativeSession: false,
-                }),
-            ).toBe(false);
-        });
-
-        it('skips the read once the flow is complete', () => {
-            expect(
-                shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'complete' }),
-            ).toBe(false);
         });
     });
 });

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,3 +1,4 @@
+import type { GetNetworkConfigDep } from '@suite-common/networks';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type YieldAllowanceStatus,
@@ -48,7 +49,7 @@ export const getYieldModifyAmountInput = ({
         : nextAmount;
 };
 
-type YieldUnwrapDefaultAmountParams = {
+type YieldUnwrapDefaultAmountParams = GetNetworkConfigDep & {
     flowType: YieldWithdrawFlowType;
     /** Amount just withdrawn, in the flow's input unit — assets for `withdraw`, shares for `redeem`. */
     withdrawnAmount: string;
@@ -73,6 +74,7 @@ type YieldUnwrapDefaultAmountParams = {
  * price-per-share. Falls back to the full balance only when the asset amount can't be resolved.
  */
 export const getYieldUnwrapDefaultAmount = ({
+    getNetworkConfig,
     flowType,
     withdrawnAmount,
     token,
@@ -83,6 +85,7 @@ export const getYieldUnwrapDefaultAmount = ({
     const withdrawnAssetAmount =
         flowType === 'redeem'
             ? getConvertedOutputTokenBalanceToInputTokenAmount({
+                  getNetworkConfig,
                   networkSymbol: token.networkSymbol,
                   token,
                   outputToken: receiptToken,
@@ -138,7 +141,7 @@ export type YieldFiatRateToken = {
     tokenAddress?: TokenAddress;
 };
 
-type YieldFiatRateTokenParams = {
+type YieldFiatRateTokenParams = GetNetworkConfigDep & {
     step: YieldFlowStepId;
     flowType: YieldPositionFlowType;
     accountSymbol: NetworkSymbol;
@@ -154,6 +157,7 @@ type YieldFiatRateTokenParams = {
  * Returns `null` when fiat entry is not possible for the current step.
  */
 export const getYieldFiatRateToken = ({
+    getNetworkConfig,
     step,
     flowType,
     accountSymbol,
@@ -174,7 +178,11 @@ export const getYieldFiatRateToken = ({
     return {
         symbol: token.networkSymbol,
         tokenAddress: toTokenAddress(
-            getContractAddressForNetworkSymbol(token.networkSymbol, token.contractAddress),
+            getContractAddressForNetworkSymbol(
+                { getNetworkConfig },
+                token.networkSymbol,
+                token.contractAddress,
+            ),
         ),
     };
 };

--- a/packages/suite/src/components/suite/AppRouter.tsx
+++ b/packages/suite/src/components/suite/AppRouter.tsx
@@ -9,6 +9,7 @@ import {
     suiteRoutes,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -19,10 +20,17 @@ type AppRouterProps = {
 export const AppRouter = memo(({ components }: AppRouterProps) => {
     const routeName = useSelector(selectRouteName);
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
+    const { suiteRouterHistory, ...networkConfigDeps } = useServices(
+        selectSuiteRouterHistoryDep,
+        selectNetworkConfigDeps,
+    );
 
     const resolvedRouteName =
-        resolveEffectiveBackgroundRouteName(route, suiteRouterHistory.getLocation()) ?? routeName;
+        resolveEffectiveBackgroundRouteName(
+            networkConfigDeps,
+            route,
+            suiteRouterHistory.getLocation(),
+        ) ?? routeName;
 
     // Resolve component by route name, with nested routes falling back to parent component
     let componentName = resolvedRouteName;

--- a/packages/suite/src/components/suite/BaseCurrencyValue.tsx
+++ b/packages/suite/src/components/suite/BaseCurrencyValue.tsx
@@ -5,9 +5,11 @@ import styled from 'styled-components';
 
 import { HiddenPlaceholder, type HiddenPlaceholderProps } from '@suite/discreet-mode';
 import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
 import { CONTRACT_ADDRESS_FOR_NATIVE_TOKEN } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type RateTypeWithoutHistoric,
     type TokenAddress,
@@ -75,6 +77,7 @@ export const BaseCurrencyValue = ({
     isLoading,
     rateType,
 }: BaseCurrencyValueProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const shouldAnimate = useSelector(selectShouldAnimateLoadingSkeleton);
     const isNativeToken = !tokenAddress || tokenAddress === CONTRACT_ADDRESS_FOR_NATIVE_TOKEN;
     const { baseCurrencyCode, fiatAmount, rate, currentRate } = useFiatFromCryptoValue({
@@ -95,7 +98,12 @@ export const BaseCurrencyValue = ({
     const WrapperComponent = disableHiddenPlaceholder ? SameWidthNums : HiddenPlaceholder;
 
     const isTokenKnown = useSelector(state =>
-        selectIsSpecificCoinDefinitionKnown(state, symbol, tokenAddress || ('' as TokenAddress)),
+        selectIsSpecificCoinDefinitionKnown(
+            state,
+            symbol,
+            tokenAddress || ('' as TokenAddress),
+            networkConfigDeps,
+        ),
     );
 
     const isZeroAmount = new BigNumber(amount ?? 0).isZero();

--- a/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
+++ b/packages/suite/src/components/suite/FormattedCryptoAmount.tsx
@@ -2,13 +2,11 @@ import { useMemo } from 'react';
 
 import { HiddenPlaceholder, RedactNumericalValue } from '@suite/discreet-mode';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { isSignValuePositive } from '@suite-common/formatters';
 import { type SignValue } from '@suite-common/suite-types';
-import {
-    type NetworkSymbolExtended,
-    getDisplaySymbol,
-    getNetworkOptional,
-} from '@suite-common/wallet-config';
+import { type NetworkSymbolExtended, getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { LOW_BALANCE_THRESHOLD } from '@suite-common/wallet-constants';
 import {
     type AmountUnit,
@@ -56,6 +54,7 @@ export const FormattedCryptoAmount = ({
     className,
     'data-testid': dataTest,
 }: FormattedCryptoAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const locale = useSelector(selectLanguage);
 
     const { areSatsDisplayed } = useBitcoinAmountUnit();
@@ -72,22 +71,29 @@ export const FormattedCryptoAmount = ({
     }
 
     const lowerCaseSymbol = symbol?.toLowerCase();
-    const {
-        features: networkFeatures,
-        testnet: isTestnet,
-        symbol: networkSymbol,
-    } = getNetworkOptional(lowerCaseSymbol) ?? {};
+    const networkSymbol =
+        lowerCaseSymbol &&
+        networkConfigDeps.networkModuleRepository.isSupportedNetwork(lowerCaseSymbol)
+            ? lowerCaseSymbol
+            : undefined;
+    const network = networkSymbol ? networkConfigDeps.getNetworkConfig(networkSymbol) : undefined;
+    const networkFeatures = network?.features;
+    const isTestnet = network?.testnet;
 
     const areSatsSupported = !!networkFeatures?.includes('amount-unit');
 
     let formattedValue = value;
-    let formattedSymbol = symbol && getDisplaySymbol(symbol, contractAddress);
+    let formattedSymbol = symbol && getDisplaySymbol(networkConfigDeps, symbol, contractAddress);
 
     const isSatoshis = areSatsSupported && areSatsDisplayed;
 
     // convert to satoshis if needed
     if (isSatoshis && networkSymbol) {
-        formattedValue = networkAmountToSmallestUnit(String(value), networkSymbol);
+        formattedValue = networkAmountToSmallestUnit(
+            networkConfigDeps,
+            String(value),
+            networkSymbol,
+        );
 
         formattedSymbol = isTestnet ? `sat ${formattedSymbol}` : 'sat';
     }

--- a/packages/suite/src/components/suite/UnstakingTxAmount.tsx
+++ b/packages/suite/src/components/suite/UnstakingTxAmount.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
@@ -16,6 +18,7 @@ interface UnstakingTxAmountProps {
 }
 
 export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { ethereumSpecific, solanaSpecific, tronSpecific, symbol } = transaction;
 
     const unstakeAmount = useMemo(() => {
@@ -39,6 +42,7 @@ export const UnstakingTxAmount = ({ transaction }: UnstakingTxAmountProps) => {
             {' '}
             <FormattedCryptoAmount
                 value={subunitsToUnits({
+                    ...networkConfigDeps,
                     value: asAmountSubunit(new BigNumber(unstakeAmount)),
                     symbol,
                 })}

--- a/packages/suite/src/components/suite/WrapTxAmount.tsx
+++ b/packages/suite/src/components/suite/WrapTxAmount.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
@@ -19,6 +21,7 @@ interface WrapTxAmountProps {
 }
 
 export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { symbol } = transaction;
 
     const amount = useMemo(() => {
@@ -34,7 +37,11 @@ export const WrapTxAmount = ({ transaction, wrapped }: WrapTxAmountProps) => {
                 : getUnwrapAmountByEthereumDataHex(transaction.ethereumSpecific?.data);
 
         return subunits
-            ? subunitsToUnits({ value: asAmountSubunit(new BigNumber(subunits)), symbol })
+            ? subunitsToUnits({
+                  ...networkConfigDeps,
+                  value: asAmountSubunit(new BigNumber(subunits)),
+                  symbol,
+              })
             : undefined;
     }, [transaction, symbol]);
 

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetDetails.tsx
@@ -1,4 +1,6 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Badge, Column, Row, Text } from '@trezor/components';
 import { hasOwn } from '@trezor/utils';
 
@@ -15,8 +17,9 @@ type AssetDetailsProps = {
 );
 
 export function AssetDetails({ name, displaySymbol, ...props }: AssetDetailsProps) {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const badge = hasOwn(props, 'networkSymbol')
-        ? getNetwork(props.networkSymbol).name
+        ? getNetworkConfig(props.networkSymbol).name
         : props.networkName;
 
     return (

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AccountAmount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AccountAmount.tsx
@@ -1,3 +1,5 @@
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Text } from '@trezor/components';
@@ -11,7 +13,9 @@ interface AccountAmountProps {
 }
 
 export function AccountAmount({ account }: AccountAmountProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const accountBalance = subunitsToUnits({
+        ...networkConfigDeps,
         value: asAmountSubunit(new BigNumber(account.balance)),
         symbol: account.symbol,
     });

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowAccountWithBalance.tsx
@@ -1,4 +1,5 @@
-import { getDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol, getNetworkDisplaySymbolName , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -17,16 +18,18 @@ export function AssetRowAccountWithBalance({
     account,
     onClick,
 }: AssetRowAccountWithBalanceProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
     return (
         <ItemClickableContainer onClick={() => onClick(account)}>
             <Row data-testid={dataTestId} gap={12} alignItems="center" overflow="hidden">
                 <TokenIcon symbol={account.symbol} size={40} showNetworkIcon />
                 <Column overflow="hidden" alignItems="flex-start" justifyContent="flex-start">
                     <Text typographyStyle="body-md" ellipsisLineCount={1} maxWidth="100%">
-                        {getNetworkDisplaySymbolName(account.symbol)}
+                        {getNetworkDisplaySymbolName(networkConfigDeps, account.symbol)}
                     </Text>
                     <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
-                        {getDisplaySymbol(account.symbol)}
+                        {getDisplaySymbol(networkConfigDeps, account.symbol)}
                     </Text>
                 </Column>
             </Row>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowReceiveToAccount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAccount/AssetRowReceiveToAccount.tsx
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 
 import { AccountLabel } from '@suite/account';
 import { Translation } from '@suite/intl';
-import { getNetworkFeatures } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkFeatures , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -20,8 +21,9 @@ export function AssetRowReceiveToAccount({
     account,
     onClick,
 }: AssetRowReceiveToAccountProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const supportsTokens = useMemo(
-        () => getNetworkFeatures(account.symbol).includes('tokens'),
+        () => getNetworkFeatures(networkConfigDeps, account.symbol).includes('tokens'),
         [account.symbol],
     );
 

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowAsset/AssetRowAsset.tsx
@@ -1,4 +1,6 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { type TradingAssetOption } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Row } from '@trezor/components';
 import { TokenIcon, shouldShowNetworkIcon } from '@trezor/product-components';
 
@@ -12,6 +14,8 @@ export type AssetRowAssetProps = {
 };
 
 export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
     return (
         <ItemClickableContainer
             onClick={() => {
@@ -28,6 +32,7 @@ export function AssetRowAsset({ asset, dataTestId, onClick }: AssetRowAssetProps
                         contractAddress={asset.contractAddress}
                         placeholder={asset.displaySymbol}
                         showNetworkIcon={shouldShowNetworkIcon(
+                            networkConfigDeps,
                             asset.networkSymbol,
                             asset.contractAddress,
                         )}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -1,4 +1,5 @@
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Row } from '@trezor/components';
 import { TokenIcon, shouldShowNetworkIcon } from '@trezor/product-components';
@@ -24,6 +25,8 @@ export function AssetRowToken({
     onClick,
     isHiddenToken = false,
 }: AssetRowTokenProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
     return (
         <ItemClickableContainer
             onClick={() => {
@@ -37,8 +40,12 @@ export function AssetRowToken({
                     size={40}
                     symbol={account.symbol}
                     contractAddress={token.contract}
-                    placeholder={getDisplaySymbol(token.symbol!, token.contract)}
-                    showNetworkIcon={shouldShowNetworkIcon(account.symbol, token.contract)}
+                    placeholder={getDisplaySymbol(networkConfigDeps, token.symbol!, token.contract)}
+                    showNetworkIcon={shouldShowNetworkIcon(
+                        networkConfigDeps,
+                        account.symbol,
+                        token.contract,
+                    )}
                 />
                 <AssetDetails
                     name={token.name!}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetsListEmpty/AssetsListEmpty.tsx
@@ -5,7 +5,7 @@ import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectFindNetworkSymbolForProtocolDep } from '@suite-common/networks';
-import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Button, Column, Paragraph } from '@trezor/components';
 
@@ -27,6 +27,7 @@ export const AssetsListEmpty = ({
     children,
     height,
 }: AssetsListEmptyProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { findNetworkSymbolForProtocol } = useServices(selectFindNetworkSymbolForProtocolDep);
     const protocolScheme = useSelector(selectProtocolSendFormScheme);
@@ -34,7 +35,9 @@ export const AssetsListEmpty = ({
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
     const protocolSymbol = protocolScheme ? findNetworkSymbolForProtocol(protocolScheme) : null;
-    const network = protocolSymbol ? getNetworkDisplaySymbolName(protocolSymbol) : undefined;
+    const network = protocolSymbol
+        ? getNetworkDisplaySymbolName(networkConfigDeps, protocolSymbol)
+        : undefined;
 
     const openActivateNetworkModal = () => {
         if (!protocolSymbol || !device) return;

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
@@ -6,11 +6,8 @@ import {
     type TradingAssetOption,
     type TradingAssetOptionWithContractAddress,
 } from '@suite-common/trading';
-import {
-    type NetworkSymbol,
-    asNetworkSymbol,
-    toNetworkSymbolNonTestnet,
-} from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { BigNumber } from '@trezor/utils';
 
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
@@ -28,9 +25,6 @@ jest.mock('@suite-common/trading', () => ({
         buildAssetOptions: jest.fn(() => ({ assets: [] })),
     }),
 }));
-
-const ethSymbol = toNetworkSymbolNonTestnet('eth');
-const polSymbol = asNetworkSymbol('pol');
 
 const createAccount = (symbol: NetworkSymbol): AccountWithSuiteSyncLabel =>
     ({
@@ -62,14 +56,14 @@ const createAsset = (
         displaySymbol: 'ASSET',
         contractAddress: '0x1',
         networkName: 'Ethereum',
-        networkSymbol: ethSymbol,
+        networkSymbol: 'eth',
         ...assetOverrides,
     };
 };
 
 describe('useAccountsWithTokenDisplayNames', () => {
-    const ethereumAccount = createAccount(ethSymbol);
-    const polygonAccount = createAccount(polSymbol);
+    const ethereumAccount = createAccount('eth');
+    const polygonAccount = createAccount('pol');
 
     const accountOption: AccountWithTokensOption = {
         type: 'account',
@@ -114,6 +108,7 @@ describe('useAccountsWithTokenDisplayNames', () => {
 
     it('returns accounts with canonical token display names', () => {
         const accountsWithDisplayNames = getAccountsWithTokenDisplayNames(
+            mockNetworkConfigDeps,
             accountsWithTokens,
             new Map<CryptoId, string>([
                 ['ethereum--0x1' as CryptoId, 'Canonical One'],

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.ts
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TradingAssetOption } from '@suite-common/trading';
+import { type NetworkConfigDeps, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { exhaustive } from '@trezor/type-utils';
 
 import { type AccountWithTokensOption } from '../types';
@@ -34,6 +36,7 @@ export const getTokenDisplayNameSources = (accountsWithTokens: AccountWithTokens
 };
 
 export const getAccountsWithTokenDisplayNames = (
+    networkConfigDeps: NetworkConfigDeps,
     accountsWithTokens: AccountWithTokensOption[],
     tokenDisplaySymbolNames: Map<CryptoId, string>,
 ): AccountWithTokensOption[] =>
@@ -47,6 +50,7 @@ export const getAccountsWithTokenDisplayNames = (
                     token: {
                         ...item.token,
                         name: getTokenDisplaySymbolName({
+                            ...networkConfigDeps,
                             tokenDisplaySymbolNames,
                             account: item.account,
                             token: item.token,
@@ -60,6 +64,7 @@ export const getAccountsWithTokenDisplayNames = (
                     tokens: item.tokens.map(token => ({
                         ...token,
                         name: getTokenDisplaySymbolName({
+                            ...networkConfigDeps,
                             tokenDisplaySymbolNames,
                             account: item.account,
                             token,
@@ -75,6 +80,7 @@ export const useAccountsWithTokenDisplayNames = (
     accountsWithTokens: AccountWithTokensOption[],
     assets?: TradingAssetOption[],
 ): AccountWithTokensOption[] => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const tokens = useMemo(
         () => getTokenDisplayNameSources(accountsWithTokens),
         [accountsWithTokens],
@@ -82,7 +88,12 @@ export const useAccountsWithTokenDisplayNames = (
     const tokenDisplaySymbolNames = useTokenDisplaySymbolNames(tokens, assets);
 
     return useMemo(
-        () => getAccountsWithTokenDisplayNames(accountsWithTokens, tokenDisplaySymbolNames),
+        () =>
+            getAccountsWithTokenDisplayNames(
+                networkConfigDeps,
+                accountsWithTokens,
+                tokenDisplaySymbolNames,
+            ),
         [accountsWithTokens, tokenDisplaySymbolNames],
     );
 };

--- a/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useFilterAccountsWithTokens.ts
@@ -3,6 +3,8 @@ import { useMemo } from 'react';
 import { getDefaultAccountLabel } from '@suite/account';
 import { useTranslation } from '@suite/intl';
 import { selectAccountLabelsLegacy } from '@suite/metadata';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
@@ -16,6 +18,7 @@ export function useFilterAccountsWithTokens(
     search: string,
 ) {
     const { translationString } = useTranslation();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const accountLegacyLabels = useSelector(selectAccountLabelsLegacy);
 
     return useMemo(() => {
@@ -39,11 +42,16 @@ export function useFilterAccountsWithTokens(
                     const accountLabel =
                         item.account.label ??
                         accountLegacyLabels[key] ??
-                        getDefaultAccountLabel(translationString, item.account) ??
+                        getDefaultAccountLabel(
+                            networkConfigDeps,
+                            translationString,
+                            item.account,
+                        ) ??
                         '';
 
                     if (
                         accountSearchFn(item.account, search, {
+                            ...networkConfigDeps,
                             tokensMatch: false,
                             accountLabel,
                         })
@@ -109,5 +117,5 @@ export function useFilterAccountsWithTokens(
 
                 return item;
             });
-    }, [accountLegacyLabels, accountsWithTokens, search, translationString]);
+    }, [accountLegacyLabels, accountsWithTokens, networkConfigDeps, search, translationString]);
 }

--- a/packages/suite/src/components/suite/asset-picker/hooks/useTokenDisplaySymbolNames.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useTokenDisplaySymbolNames.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TradingAssetOption, useTradingAssets } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import {
     type TokenDisplayNameSource,
@@ -12,6 +14,7 @@ export const useTokenDisplaySymbolNames = (
     tokens: TokenDisplayNameSource[],
     assets?: TradingAssetOption[],
 ) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { buildAssetOptions } = useTradingAssets();
 
     const resolvedAssets = useMemo(() => {
@@ -19,7 +22,7 @@ export const useTokenDisplaySymbolNames = (
             return assets;
         }
 
-        const includedCryptoIds = getTokenCryptoIds(tokens);
+        const includedCryptoIds = getTokenCryptoIds(networkConfigDeps, tokens);
 
         if (includedCryptoIds.size === 0) {
             return [];
@@ -31,7 +34,7 @@ export const useTokenDisplaySymbolNames = (
     }, [assets, buildAssetOptions, tokens]);
 
     return useMemo(
-        () => getTokensDisplaySymbolNames({ assets: resolvedAssets, tokens }),
+        () => getTokensDisplaySymbolNames({ ...networkConfigDeps, assets: resolvedAssets, tokens }),
         [resolvedAssets, tokens],
     );
 };

--- a/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
@@ -4,15 +4,13 @@ import {
     type TradingAssetOption,
     type TradingAssetOptionWithContractAddress,
 } from '@suite-common/trading';
-import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import {
     type TokenDisplayNameSource,
     getTokenDisplaySymbolName,
     getTokensDisplaySymbolNames,
 } from './tokenDisplayNames';
-
-const ethSymbol = toNetworkSymbolNonTestnet('eth');
 
 const createAsset = (
     overrides: Partial<TradingAssetOptionWithContractAddress> &
@@ -29,7 +27,7 @@ const createAsset = (
         displaySymbol: 'ASSET',
         contractAddress: '0x1',
         networkName: 'Ethereum',
-        networkSymbol: ethSymbol,
+        networkSymbol: 'eth',
         ...assetOverrides,
     };
 };
@@ -37,12 +35,13 @@ const createAsset = (
 describe('tokenDisplayNames', () => {
     it('returns canonical displaySymbolName for matching token crypto id', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: ethSymbol },
+            account: { symbol: 'eth' },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];
 
         const tokenDisplaySymbolNames = getTokensDisplaySymbolNames({
+            ...mockNetworkConfigDeps,
             assets: [
                 createAsset({
                     id: 'ethereum--0x1' as CryptoId,
@@ -54,6 +53,7 @@ describe('tokenDisplayNames', () => {
 
         expect(
             getTokenDisplaySymbolName({
+                ...mockNetworkConfigDeps,
                 tokenDisplaySymbolNames,
                 account: tokenSource.account,
                 token: tokenSource.token,
@@ -63,12 +63,13 @@ describe('tokenDisplayNames', () => {
 
     it('falls back to asset name when displaySymbolName is missing', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: ethSymbol },
+            account: { symbol: 'eth' },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];
 
         const tokenDisplaySymbolNames = getTokensDisplaySymbolNames({
+            ...mockNetworkConfigDeps,
             assets: [
                 createAsset({
                     id: 'ethereum--0x1' as CryptoId,
@@ -80,6 +81,7 @@ describe('tokenDisplayNames', () => {
 
         expect(
             getTokenDisplaySymbolName({
+                ...mockNetworkConfigDeps,
                 tokenDisplaySymbolNames,
                 account: tokenSource.account,
                 token: tokenSource.token,
@@ -89,18 +91,20 @@ describe('tokenDisplayNames', () => {
 
     it('falls back to discovered token name for unmatched tokens', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: ethSymbol },
+            account: { symbol: 'eth' },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];
 
         const tokenDisplaySymbolNames = getTokensDisplaySymbolNames({
+            ...mockNetworkConfigDeps,
             assets: [createAsset({ id: 'ethereum--0x2' as CryptoId })],
             tokens,
         });
 
         expect(
             getTokenDisplaySymbolName({
+                ...mockNetworkConfigDeps,
                 tokenDisplaySymbolNames,
                 account: tokenSource.account,
                 token: tokenSource.token,
@@ -109,6 +113,8 @@ describe('tokenDisplayNames', () => {
     });
 
     it('handles empty assets and tokens', () => {
-        expect(getTokensDisplaySymbolNames({ assets: [], tokens: [] })).toEqual(new Map());
+        expect(
+            getTokensDisplaySymbolNames({ ...mockNetworkConfigDeps, assets: [], tokens: [] }),
+        ).toEqual(new Map());
     });
 });

--- a/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.ts
@@ -1,7 +1,7 @@
 import { type CryptoId } from 'invity-api';
 
 import { type TradingAssetOption, getCryptoId } from '@suite-common/trading';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenInfo } from '@trezor/connect';
 
 export type TokenDisplayNameSource = {
@@ -14,32 +14,34 @@ export type TokenDisplayNameSource = {
     };
 };
 
-type GetTokensDisplaySymbolNamesProps = {
+type GetTokensDisplaySymbolNamesProps = NetworkConfigDeps & {
     assets: TradingAssetOption[];
     tokens: TokenDisplayNameSource[];
 };
 
-type GetTokenDisplaySymbolNameProps = {
+type GetTokenDisplaySymbolNameProps = NetworkConfigDeps & {
     tokenDisplaySymbolNames: Map<CryptoId, string>;
     account: TokenDisplayNameSource['account'];
     token: TokenDisplayNameSource['token'];
 };
 
-export const getTokenCryptoIds = (tokens: TokenDisplayNameSource[]) => {
+export const getTokenCryptoIds = (deps: NetworkConfigDeps, tokens: TokenDisplayNameSource[]) => {
     const tokenCryptoIds = new Set<CryptoId>();
 
     for (const { account, token } of tokens) {
-        tokenCryptoIds.add(getCryptoId(account.symbol, token.contract));
+        tokenCryptoIds.add(getCryptoId(deps, account.symbol, token.contract));
     }
 
     return tokenCryptoIds;
 };
 
 export const getTokensDisplaySymbolNames = ({
+    getNetworkConfig,
+    networkModuleRepository,
     assets,
     tokens,
 }: GetTokensDisplaySymbolNamesProps) => {
-    const tokenCryptoIds = getTokenCryptoIds(tokens);
+    const tokenCryptoIds = getTokenCryptoIds({ getNetworkConfig, networkModuleRepository }, tokens);
     const displaySymbolNames = new Map<CryptoId, string>();
 
     if (tokenCryptoIds.size === 0) {
@@ -62,8 +64,12 @@ export const getTokensDisplaySymbolNames = ({
 };
 
 export const getTokenDisplaySymbolName = ({
+    getNetworkConfig,
+    networkModuleRepository,
     tokenDisplaySymbolNames,
     account,
     token,
 }: GetTokenDisplaySymbolNameProps) =>
-    tokenDisplaySymbolNames.get(getCryptoId(account.symbol, token.contract)) ?? token.name;
+    tokenDisplaySymbolNames.get(
+        getCryptoId({ getNetworkConfig, networkModuleRepository }, account.symbol, token.contract),
+    ) ?? token.name;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/components/GlobalReceiveAccountListItem.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/components/GlobalReceiveAccountListItem.tsx
@@ -1,6 +1,7 @@
 import { AccountLabel } from '@suite/account';
 import { Translation } from '@suite/intl';
-import { getNetworkFeatures } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkFeatures , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { CardList, Column, Row, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -16,7 +17,8 @@ export const GlobalReceiveAccountListItem = ({
     dataTestId,
     onClick,
 }: GlobalReceiveAccountListItemProps) => {
-    const supportsTokens = getNetworkFeatures(account.symbol).includes('tokens');
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const supportsTokens = getNetworkFeatures(networkConfigDeps, account.symbol).includes('tokens');
 
     return (
         <CardList.Item onClick={() => onClick(account)}>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useAccountsOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useAccountsOptions.ts
@@ -1,15 +1,18 @@
 import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 
 import { ASSET_ROW_HEIGHT } from 'src/components/suite/asset-picker/constants';
 import { useSelector } from 'src/hooks/suite';
 
 export function useAccountsOptions() {
-    const baseAccounts = useSelector(selectAllAccountsToList);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const baseAccounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const device = useSelector(selectSelectedDevice);
 
     const accounts = useSelector(state =>

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalReceiveModal/hooks/useFilterAccounts.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { accountSearchFn } from '@suite-common/wallet-utils';
 
 import { useSelector } from 'src/hooks/suite';
@@ -8,6 +10,7 @@ import { globalSendReceiveFiltersSelectors } from 'src/slices/wallet/globalSendR
 import { type AccountOption } from './useAccountsOptions';
 
 export function useFilterAccounts(accounts: AccountOption[]) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { search, networkSymbol } = useSelector(globalSendReceiveFiltersSelectors.selectFilters);
 
     return useMemo(
@@ -15,6 +18,7 @@ export function useFilterAccounts(accounts: AccountOption[]) {
             accounts.filter(account =>
                 search || networkSymbol
                     ? accountSearchFn(account.account, search, {
+                          ...networkConfigDeps,
                           coinsFilter: networkSymbol,
                           accountLabel: account.account.label ?? '',
                       })

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectCurrentFiatRates,
@@ -42,6 +44,7 @@ export function useAccountWithTokensOptions({
     expandedHiddenTokensGroups,
     staticSessionId,
 }: UseAccountWithTokensOptionsProps): AccountWithTokensOption[] {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseAccounts = useSelector(selectVisibleDeviceAccounts);
 
     const accounts = useSelector(state =>
@@ -70,6 +73,7 @@ export function useAccountWithTokensOptions({
 
         return networkAccounts.map(account => {
             const { shownWithBalance, hiddenWithBalance } = getTokens({
+                ...networkConfigDeps,
                 tokens: account.tokens ?? [],
                 symbol: account.symbol,
                 tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendReceive.tsx
@@ -1,6 +1,8 @@
 import { memo } from 'react';
 
 import { useDevice } from '@suite/device';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
@@ -18,11 +20,12 @@ import { useGlobalSendReceiveAnalytics } from './hooks/useGlobalSendReceiveAnaly
 import { useGlobalSendReceiveModal } from './hooks/useGlobalSendReceiveModal';
 
 export const GlobalSendReceive = memo(function GlobalSendReceiveInner() {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { device } = useDevice();
     const { activeModal, openModal, closeModal } = useGlobalSendReceiveModal();
     const { sendAnalytics, receiveAnalytics } = useGlobalSendReceiveAnalytics();
     const dispatch = useDispatch();
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
 
     const isDeviceConnected = !!device?.connected && !!device?.available;

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/HeaderDropdown.tsx
@@ -2,7 +2,9 @@ import { type JSX } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Dropdown, type DropdownMenuItemProps, type IconComponent } from '@trezor/components';
 import { PencilLineIcon, WalletConnectIcon } from '@trezor/icons';
@@ -26,6 +28,8 @@ type HeaderDropdownProps = {
     showSignAndVerify?: boolean;
 };
 export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdownProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const goToWithAnalytics = useGoToWithAnalytics();
     const account = useSelector(selectSelectedAccount);
 
@@ -42,7 +46,9 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
                       },
                       title: <Translation id="TR_NAV_SIGN_AND_VERIFY" />,
                       icon: PencilLineIcon,
-                      isHidden: account ? !hasNetworkFeatures(account, 'sign-verify') : false,
+                      isHidden: account
+                          ? !hasNetworkFeatures(networkConfigDeps, account, 'sign-verify')
+                          : false,
                   },
               ]
             : []),
@@ -57,7 +63,7 @@ export const HeaderDropdown = ({ isDisabled, showSignAndVerify }: HeaderDropdown
             title: <Translation id="TR_WALLETCONNECT" />,
             icon: WalletConnectIcon,
             // caipId marks networks with a WalletConnect adapter (see suite-common/walletconnect)
-            isHidden: account ? !getNetwork(account.symbol).caipId : true,
+            isHidden: account ? !getNetworkConfig(account.symbol).caipId : true,
         },
     ];
 

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageHeader.tsx
@@ -10,6 +10,7 @@ import {
     selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccounts } from '@suite-common/wallet-core';
 import { Row } from '@trezor/components';
 import { zIndices } from '@trezor/theme';
@@ -67,8 +68,12 @@ interface PageHeaderProps {
 export const PageHeader = ({ children, expandable }: PageHeaderProps) => {
     const selectedAccountKey = useSelector(selectSelectedAccountKey);
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
+    const { suiteRouterHistory, ...networkConfigDeps } = useServices(
+        selectSuiteRouterHistoryDep,
+        selectNetworkConfigDeps,
+    );
     const effectiveRouteName = resolveEffectiveBackgroundRouteName(
+        networkConfigDeps,
         route,
         suiteRouterHistory.getLocation(),
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/PageNames/PageName.tsx
@@ -7,6 +7,7 @@ import {
     selectSuiteRouterHistoryDep,
 } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useSelector } from 'src/hooks/suite';
 
@@ -17,8 +18,12 @@ import { SettingsName } from './SettingsName';
 
 export const PageName = () => {
     const route = useSelector(selectRoute);
-    const { suiteRouterHistory } = useServices(selectSuiteRouterHistoryDep);
+    const { suiteRouterHistory, ...networkConfigDeps } = useServices(
+        selectSuiteRouterHistoryDep,
+        selectNetworkConfigDeps,
+    );
     const currentRoute = resolveEffectiveBackgroundRouteName(
+        networkConfigDeps,
         route,
         suiteRouterHistory.getLocation(),
     );

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/TradeActions.tsx
@@ -3,6 +3,7 @@ import { Translation } from '@suite/intl';
 import { goto, selectIsAccountTabPage, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type SelectedAccountStatus } from '@suite-common/wallet-types';
 import { ButtonGroup, Row } from '@trezor/components';
 import { MinusIcon, PlusIcon } from '@trezor/icons';
@@ -16,6 +17,7 @@ interface TradeActionsProps {
 }
 
 export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const account = selectedAccount?.account;
@@ -46,7 +48,7 @@ export const TradeActions = ({ selectedAccount }: TradeActionsProps) => {
         if (account) {
             dispatch(
                 tradingActions.setTradingFromPrefilledAccount(
-                    getTradingPrefilledFromAccountData(account),
+                    getTradingPrefilledFromAccountData(networkConfigDeps, account),
                 ),
             );
         }

--- a/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
+++ b/packages/suite/src/components/suite/modals/ConfirmEvmExplanationModal.tsx
@@ -1,6 +1,7 @@
 import { Translation, type TranslationKey } from '@suite/intl';
 import { closeModal } from '@suite/modal';
-import { networks } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Column, H2, Modal, Paragraph } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -17,6 +18,7 @@ export const ConfirmEvmExplanationModal = ({
     account,
     route,
 }: ConfirmNetworkExplanationModalProps) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const close = () => {
         dispatch(closeModal());
@@ -37,7 +39,7 @@ export const ConfirmEvmExplanationModal = ({
         return null;
     }
 
-    const network = networks[account.symbol];
+    const network = getNetworkConfig(account.symbol);
     const isVisible =
         account.empty &&
         network.networkType === 'ethereum' &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/ConfirmValueModal/ConfirmValueModal.tsx
@@ -13,7 +13,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { getDeviceInternalModel } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     Banner,
@@ -73,6 +73,7 @@ export const ConfirmValueModal = ({
     isAddress = false,
     value,
 }: ConfirmValueModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isCopied, setIsCopied] = useState(false);
     const { device } = useDevice();
     const modalContext = useSelector(state => state.modal.context);
@@ -188,7 +189,10 @@ export const ConfirmValueModal = ({
                                         a: chunks => (
                                             <Link onClick={handleOpenGuide}>{chunks}</Link>
                                         ),
-                                        displaySymbol: getDisplaySymbol(account.symbol),
+                                        displaySymbol: getDisplaySymbol(
+                                            networkConfigDeps,
+                                            account.symbol,
+                                        ),
                                     }}
                                 />
                             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/SignMessageModal.tsx
@@ -2,12 +2,14 @@ import styled from 'styled-components';
 
 import { AccountLabel } from '@suite/account';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import {
     type NetworkSymbol,
-    getNetwork,
-    getNetworkByEvmChainId,
+    findNetworkByEvmChainId,
+    getNetworks,
+    selectNetworkConfigDeps,
 } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -50,6 +52,8 @@ export const SignMessageModal = ({
     coin,
     serializedPath,
 }: SignMessageModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networks = getNetworks(networkConfigDeps);
     const accounts = useSelector(selectDeviceAccounts);
     const deviceModelInternal = device.features?.internal_model;
 
@@ -70,15 +74,16 @@ export const SignMessageModal = ({
         eip712parsed()?.primaryType && eip712parsed()?.domain && eip712parsed()?.message;
     const eip712ChainId = eip712parsed()?.domain?.chainId;
     const network = eip712ChainId
-        ? getNetworkByEvmChainId(eip712ChainId)
-        : getNetwork(networkSymbol ?? 'eth');
+        ? findNetworkByEvmChainId(networks, eip712ChainId)
+        : networks.find(({ symbol }) => symbol === (networkSymbol ?? 'eth'));
+    const selectedNetwork = network ?? undefined;
 
     const address = useSelector((state: AccountsRootState & DeviceRootState) =>
-        selectAddressByNetworkAndPath(state, network, serializedPath),
+        selectAddressByNetworkAndPath(state, selectedNetwork, serializedPath),
     );
     const account =
-        network && address
-            ? findAccountsByAddress(network.symbol, address, accounts)[0]
+        selectedNetwork && address
+            ? findAccountsByAddress(selectedNetwork.symbol, address, accounts)[0]
             : undefined;
 
     return (
@@ -101,9 +106,9 @@ export const SignMessageModal = ({
                 }
                 description={
                     <Row columnGap={16} rowGap={4} flexWrap="wrap" margin={{ top: 8 }}>
-                        {network && (
+                        {selectedNetwork && (
                             <Row gap={4}>
-                                <TokenIcon size={16} symbol={network.symbol} />
+                                <TokenIcon size={16} symbol={selectedNetwork.symbol} />
                                 {account ? (
                                     <AccountLabel
                                         account={account}
@@ -111,7 +116,7 @@ export const SignMessageModal = ({
                                         accountTypeBadgeSize="small"
                                     />
                                 ) : (
-                                    network.name
+                                    selectedNetwork.name
                                 )}
                             </Row>
                         )}

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -6,6 +6,7 @@ import { closeModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
 import { selectTradingComposedTransactionInfo } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type SerializedTx,
     selectIsTxOutputInternal,
@@ -106,6 +107,7 @@ export const TransactionReviewModalBodyInner = ({
     setIsSending,
     hasTxReviewExpired,
 }: TransactionReviewModalBodyInnerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const [areDetailsVisible, setAreDetailsVisible] = useState(false);
@@ -133,13 +135,18 @@ export const TransactionReviewModalBodyInner = ({
             : undefined;
 
     const buttonRequestsCount = useSelector((state: DeviceRootState) =>
-        selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId),
+        selectSendFormReviewButtonRequestsCount(
+            state,
+            networkConfigDeps,
+            account?.symbol,
+            decreaseOutputId,
+        ),
     );
 
     const lastButtonRequestCount = useRef(buttonRequestsCount);
 
     const lastButtonRequestCode = useSelector((state: DeviceRootState) =>
-        selectSendFormReviewLastButtonCode(state, symbol),
+        selectSendFormReviewLastButtonCode(state, networkConfigDeps, symbol),
     );
 
     const [reviewStep, setReviewStep] = useState(0);
@@ -212,6 +219,7 @@ export const TransactionReviewModalBodyInner = ({
 
     const actionTranslation = (source: 'heading' | 'button') =>
         getTransactionReviewModalActionTranslation({
+            ...networkConfigDeps,
             symbol,
             stakeType,
             precomposedForm,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { selectTradingExchangeSelectedQuote } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type SerializedTx,
     selectSendFormReviewButtonRequestsCount,
@@ -55,6 +57,7 @@ export const TransactionReviewModalContent = ({
     isSending,
     isRbfConfirmedError,
 }: TransactionReviewModalContentProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { symbol, networkType } = account;
     const device = useSelector(selectSelectedDevice);
     const swapSlippage = useSelector(selectTradingExchangeSelectedQuote)?.swapSlippage;
@@ -75,7 +78,7 @@ export const TransactionReviewModalContent = ({
             : undefined;
 
     const buttonRequestsCount = useSelector((state: DeviceRootState) =>
-        selectSendFormReviewButtonRequestsCount(state, symbol, decreaseOutputId),
+        selectSendFormReviewButtonRequestsCount(state, networkConfigDeps, symbol, decreaseOutputId),
     );
 
     const outputs = useMemo(

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutput.tsx
@@ -7,9 +7,12 @@ import {
     useTranslation,
 } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type Locale, type TrezorDevice } from '@suite-common/suite-types';
 import { type NetworkType, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { BTC_LOCKTIME_VALUE } from '@suite-common/wallet-constants';
 import { selectAccounts } from '@suite-common/wallet-core';
 import {
@@ -288,7 +291,7 @@ const getOutputTitle = (
     }
 };
 
-interface GetOutputLinesParams {
+interface GetOutputLinesParams extends GetNetworkConfigDep {
     type: ReviewOutput['type'];
     account: Account;
     value: string;
@@ -305,6 +308,7 @@ interface GetOutputLinesParams {
 }
 
 const getOutputLines = ({
+    getNetworkConfig,
     type,
     account,
     value,
@@ -450,7 +454,7 @@ const getOutputLines = ({
                         id: 'data',
                         type: 'default',
                         value: translationString(translation, {
-                            symbol: getNetworkDisplaySymbol(symbol),
+                            symbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol),
                         }),
                     },
                 ];
@@ -489,7 +493,7 @@ const getOutputLines = ({
                     type: 'data',
                     value: isWrappedNativeAction(evmTxType)
                         ? translationString(wrappedNativeIntentStrings[evmTxType], {
-                              nativeSymbol: getNetworkDisplaySymbol(symbol),
+                              nativeSymbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol),
                               tokenSymbol: getWrappedNativeSymbol(symbol),
                           })
                         : '',
@@ -651,6 +655,7 @@ export type TransactionReviewOutputProps = {
 } & ReviewOutput;
 
 export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         type,
         state,
@@ -678,7 +683,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
     const { translationString } = useTranslation();
     const isFiatVisible =
         ['fee', 'amount', 'gas', 'fee-replace', 'reduce-output'].includes(type) &&
-        !isTestnet(symbol) &&
+        !isTestnet(networkConfigDeps, symbol) &&
         !nativeToken;
 
     const outputTitle = getOutputTitle(
@@ -694,6 +699,7 @@ export const TransactionReviewOutput = (props: TransactionReviewOutputProps) => 
     );
 
     const outputLines = getOutputLines({
+        ...networkConfigDeps,
         type,
         account,
         value: value ?? '',

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputAssets.tsx
@@ -4,8 +4,9 @@ import { type CryptoId } from 'invity-api';
 
 import { Address } from '@suite/address';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
-import { getCoingeckoId, getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type FormStateTradingCryptoCurrency,
     type FormStateTradingFiatCurrency,
@@ -40,14 +41,16 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
     cryptoCurrency,
     type,
 }: TransactionReviewOutputAssetsCryptoCurrencyProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = networkConfigDeps;
     const { symbol, contractAddress, amount } = cryptoCurrency;
-    const network = getNetwork(symbol);
+    const network = getNetworkConfig(symbol);
     const isTokenAmount = !!cryptoCurrency.contractAddress;
     const formattedAmount = localizeNumber(amount, 'en-US');
 
     const cryptoId = contractAddress
-        ? toTokenCryptoId(symbol, contractAddress)
-        : (getCoingeckoId(symbol) as CryptoId);
+        ? toTokenCryptoId(networkConfigDeps, symbol, contractAddress)
+        : (network.coingeckoId as CryptoId);
     const displaySymbol = useSelector(state =>
         contractAddress
             ? selectTradingCoinSymbolByCryptoId(state, cryptoId)
@@ -62,7 +65,11 @@ const TransactionReviewOutputAssetsCryptoCurrency = ({
                     symbol={symbol}
                     contractAddress={contractAddress}
                     placeholder={displaySymbol ?? ''}
-                    showNetworkIcon={shouldShowNetworkIcon(symbol, contractAddress)}
+                    showNetworkIcon={shouldShowNetworkIcon(
+                        networkConfigDeps,
+                        symbol,
+                        contractAddress,
+                    )}
                 />
             );
         }

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputElement.tsx
@@ -4,7 +4,9 @@ import styled, { css } from 'styled-components';
 
 import { Address } from '@suite/address';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountSubunitsToUnits, formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -105,6 +107,7 @@ type ValueProps = {
 };
 
 const Value = ({ value, type, symbol, token, isFiatVisible, state, isChunked }: ValueProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
     switch (type) {
@@ -125,7 +128,7 @@ const Value = ({ value, type, symbol, token, isFiatVisible, state, isChunked }: 
         case 'amount': {
             const formattedValue = token
                 ? convertAmountSubunitsToUnits(value, token.decimals)
-                : formatNetworkAmount(value, symbol);
+                : formatNetworkAmount(networkConfigDeps, value, symbol);
 
             return (
                 <Column alignItems="flex-end">

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -3,7 +3,9 @@ import { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectSendFormReviewLastButtonCode } from '@suite-common/wallet-core';
 import type {
     FormState,
@@ -76,6 +78,7 @@ export const TransactionReviewOutputList = ({
     onTryAgain,
     isSending,
 }: TransactionReviewOutputListProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const outputRefs = useRef<(HTMLDivElement | null)[]>([]);
     const totalOutputRef = useRef<HTMLDivElement | null>(null);
     const accounts = useSelector(state => state.wallet.accounts);
@@ -84,7 +87,7 @@ export const TransactionReviewOutputList = ({
     const isFirstOutputAddress = outputs[0]?.type === 'address';
 
     const lastButtonRequestCode = useSelector((state: DeviceRootState) =>
-        selectSendFormReviewLastButtonCode(state, symbol),
+        selectSendFormReviewLastButtonCode(state, networkConfigDeps, symbol),
     );
 
     const reviewState = getTransactionReviewState({

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewTotalOutput.tsx
@@ -1,6 +1,8 @@
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
 import { type NetworkType } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type Account,
     type FormState,
@@ -199,6 +201,7 @@ export const TransactionReviewTotalOutput = ({
     stakeType,
     isRbf,
 }: TransactionReviewTotalOutputProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const device = useSelector(selectSelectedDevice);
     const { translationString } = useTranslation();
 
@@ -220,8 +223,10 @@ export const TransactionReviewTotalOutput = ({
         account.accountType === 'placeholder' && 'nativeToken' in precomposedTx
             ? precomposedTx.nativeToken
             : undefined;
-    const isFiatVisible = !isTestnet(account.symbol) && account.accountType !== 'placeholder';
+    const isFiatVisible =
+        !isTestnet(networkConfigDeps, account.symbol) && account.accountType !== 'placeholder';
     const isClearSignedTradingSwap = isClearSignedEvmTradingSwapTransaction({
+        ...networkConfigDeps,
         account,
         device,
         precomposedTx,
@@ -229,6 +234,7 @@ export const TransactionReviewTotalOutput = ({
         trading: precomposedForm.trading,
     });
     const isClearSignedWrapUnwrap = isClearSignedWrappedNativeTransaction({
+        ...networkConfigDeps,
         account,
         device,
         precomposedTx,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewSummary.tsx
@@ -2,8 +2,9 @@ import { AccountLabel } from '@suite/account';
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import { useServices } from '@suite-common/dependency-injection';
 import { formatDurationStrict } from '@suite-common/suite-utils';
-import { type NetworkType, networks } from '@suite-common/wallet-config';
+import { type NetworkType, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import {
     type FeeInfo,
@@ -61,12 +62,13 @@ export const TransactionReviewSummary = ({
     stakeType,
     timer,
 }: TransactionReviewSummaryProps) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const drafts = useSelector(selectSendFormDrafts);
     const currentAccountKey = useSelector(selectCurrentAccountKey) as string;
     const rawFeeInfo = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const locale = useLocales();
     const { symbol, networkType } = account;
-    const network = networks[symbol];
+    const network = getNetworkConfig(symbol);
     const fee = getFee(account.networkType, tx);
     const estimateTime = getEstimatedTime(networkType, rawFeeInfo, tx);
     const connectPopupCall = useSelector(selectConnectPopupCall);

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewTronFeeNotes.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type GeneralPrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
@@ -21,11 +23,12 @@ export const TransactionReviewTronFeeNotes = ({
     tx,
     account,
 }: TransactionReviewTronFeeNotesProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
 
     const tronResources = account.networkType === 'tron' ? account.misc.tronResources : undefined;
     const { trxBurned, coveredEnergy, coveredBandwidth } =
-        calculateTronFeeBreakdown(tx, tronResources, account.symbol) ?? {};
+        calculateTronFeeBreakdown(networkConfigDeps, tx, tronResources, account.symbol) ?? {};
 
     const accountActivationFee = 'accountActivationFee' in tx ? tx.accountActivationFee : undefined;
 
@@ -34,6 +37,7 @@ export const TransactionReviewTronFeeNotes = ({
             ? trxBurned.plus(
                   new BigNumber(
                       subunitsToUnits({
+                          ...networkConfigDeps,
                           value: asAmountSubunit(new BigNumber(accountActivationFee)),
                           symbol: account.symbol,
                       }),

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AccountTypeSelect/AccountTypeDescription.tsx
@@ -1,10 +1,11 @@
 import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type AccountType,
     type NetworkSymbol,
     type NetworkType,
-    getNetwork,
 } from '@suite-common/wallet-config';
 import { getAccountTypeDesc, getAccountTypeUrl } from '@suite-common/wallet-utils';
 import { Column, Paragraph } from '@trezor/components';
@@ -23,13 +24,17 @@ export const AccountTypeDescription = ({
     symbol,
     networkType,
 }: AccountTypeDescriptionProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const accountTypeUrl = getAccountTypeUrl(bip43Path);
     const accountTypeDescId = getAccountTypeDesc({ path: bip43Path, accountType, networkType });
 
     return (
         <Column alignItems="flex-start" gap={12}>
             <Paragraph>
-                <Translation id={accountTypeDescId} values={{ value: getNetwork(symbol).name }} />
+                <Translation
+                    id={accountTypeDescId}
+                    values={{ value: getNetworkConfig(symbol).name }}
+                />
             </Paragraph>
             {accountTypeUrl && <LearnMoreButton url={accountTypeUrl} />}
         </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AddAccountModal/AddAccountModal.tsx
@@ -12,9 +12,9 @@ import {
     type Network,
     type NetworkAccount,
     type NetworkSymbol,
-    getNetwork,
-    networks,
+    toNetwork,
 } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     accountsActions,
     changeCoinVisibility,
@@ -42,6 +42,7 @@ import { SelectNetwork } from './SelectNetwork';
 import { verifyAvailability } from './verifyAvailability';
 import { AdvancedCoinSettingsModal } from '../AdvancedCoinSettingsModal/AdvancedCoinSettingsModal';
 
+
 type AddAccountProps = {
     device: TrezorDevice;
     onCancel: () => void;
@@ -63,6 +64,7 @@ export const AddAccountModal = ({
     isCoinjoinDisabled,
     isBackClickDisabled,
 }: AddAccountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const accounts = useSelector(selectAccounts);
     const app = useSelector(selectRouterApp);
     const isDebug = useSelector(selectIsDebugModeActive);
@@ -111,7 +113,7 @@ export const AddAccountModal = ({
     // or in case of only btc is enabled on bitcoin-only firmware
     const bitcoinOnlyDefaultNetworkSelection =
         isBitcoinOnlyFirmware && supportedMainnets.length === 1 && allTestnetNetworksDisabled
-            ? networks.btc
+            ? supportedMainnets.find(network => network.symbol === 'btc')
             : undefined;
 
     const isCoinjoinVisible = (isCoinjoinPublic || isDebug) && !isCoinjoinDisabled;
@@ -122,7 +124,7 @@ export const AddAccountModal = ({
                 return undefined;
             }
 
-            return getAvailableAccountTypes(network.symbol, {
+            return getAvailableAccountTypes(networkConfigDeps, network.symbol, {
                 isCoinjoinVisible,
                 isDebug,
             });
@@ -151,7 +153,7 @@ export const AddAccountModal = ({
     const availableNetworksSymbols = useAvailableNetworkSymbols();
 
     const enabledNetworks = availableNetworksSymbols.map(networkSymbol =>
-        getNetwork(networkSymbol),
+        toNetwork(networkSymbol, networkConfigDeps.getNetworkConfig(networkSymbol)),
     );
     const [enabledMainnetNetworks, enabledTestnetNetworks] = useMemo(
         () => arrayPartition(enabledNetworks, network => !network?.testnet),
@@ -358,6 +360,7 @@ export const AddAccountModal = ({
         }
 
         const newAccount = await prepareNewAccountPayload({
+            ...networkConfigDeps,
             accountType: account.accountType,
             networkSymbol: account.symbol,
             index: account.index + 1,
@@ -378,7 +381,10 @@ export const AddAccountModal = ({
             return;
         }
 
-        const createAccountAction = accountsActions.createAccount(newAccount);
+        const createAccountAction = accountsActions.createAccount(
+            newAccount,
+            networkConfigDeps.getNetworkConfig,
+        );
         dispatch(createAccountAction);
         finishEnableAccount(createAccountAction.payload);
     }
@@ -393,6 +399,7 @@ export const AddAccountModal = ({
         accountTypes: NetworkAccount[];
     }) {
         const newAccount = await prepareNewAccountPayload({
+            ...networkConfigDeps,
             accountType: account.accountType,
             networkSymbol: network.symbol,
             index: 0,
@@ -414,7 +421,7 @@ export const AddAccountModal = ({
         }
 
         onCancel();
-        dispatch(accountsActions.createAccount(newAccount));
+        dispatch(accountsActions.createAccount(newAccount, networkConfigDeps.getNetworkConfig));
         resetAccountSearch(newAccount.symbol);
         reportNewAccountAnalytics(newAccount);
         dispatch(reportWalletBalanceThunk());
@@ -428,7 +435,10 @@ export const AddAccountModal = ({
             return;
         }
 
-        const networkToSelect = networks[networkSymbol];
+        const networkToSelect = toNetwork(
+            networkSymbol,
+            networkConfigDeps.getNetworkConfig(networkSymbol),
+        );
 
         if (!networkToSelect) {
             return;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AdvancedCoinSettingsModal/AdvancedCoinSettingsModal.tsx
@@ -4,7 +4,9 @@ import { Translation } from '@suite/intl';
 import { selectModalType } from '@suite/modal';
 import { selectHasExperimentalFeature } from '@suite/settings';
 import { selectTorState } from '@suite/tor';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, toNetwork } from '@suite-common/wallet-config';
 import {
     Badge,
     Banner,
@@ -41,7 +43,8 @@ export const AdvancedCoinSettingsModal = ({
     onCancel,
     onBackClick,
 }: AdvancedCoinSettingsModalProps) => {
-    const network = getNetwork(symbol);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const network = toNetwork(symbol, getNetworkConfig(symbol));
     const { isTorEnabled } = useSelector(selectTorState);
     const modalType = useSelector(selectModalType);
     const dispatch = useDispatch();

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal.tsx
@@ -6,7 +6,8 @@ import { type CryptoId, type DexApprovalType } from 'invity-api';
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { isAllowanceUnlimited } from '@suite-common/wallet-utils';
 import {
@@ -49,6 +50,7 @@ interface ApproveModalProps {
 }
 
 export const ApproveModal = (props: ApproveModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, provider, spender, preapprovedAmount, showSpender, heading, description } =
         props;
     const { device } = useDevice();
@@ -75,7 +77,7 @@ export const ApproveModal = (props: ApproveModalProps) => {
 
     if (!token?.symbol) return null;
 
-    const displaySymbol = getDisplaySymbol(token.symbol, token.contract);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, token.symbol, token.contract);
     const hasPreapprovedAmount = !!preapprovedAmount && preapprovedAmount !== '0';
     const isPreapprovedAmountUnlimited =
         hasPreapprovedAmount &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModalTypeSelector.tsx
@@ -3,7 +3,9 @@ import { useRef } from 'react';
 import { type DexApprovalType } from 'invity-api';
 
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import {
@@ -60,9 +62,10 @@ export const ApproveModalTypeSelector = ({
     displayAmount,
     hasPreapprovedAmount,
 }: ApproveModalTypeSelectorProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const popoverRef = useRef<PopoverRef>(null);
     const displaySymbol = token.symbol
-        ? getDisplaySymbol(token.symbol, token.contract)
+        ? getDisplaySymbol(networkConfigDeps, token.symbol, token.contract)
         : token.name;
 
     const translationValues = {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal.tsx
@@ -6,7 +6,8 @@ import { type CryptoId } from 'invity-api';
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { isAllowanceUnlimited, shouldShowRevokeAllowanceBanner } from '@suite-common/wallet-utils';
 import {
@@ -49,6 +50,7 @@ interface RevokeModalProps {
 }
 
 export const RevokeModal = (props: RevokeModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account,
         provider,
@@ -86,7 +88,7 @@ export const RevokeModal = (props: RevokeModalProps) => {
 
     if (!token?.symbol) return null;
 
-    const displaySymbol = getDisplaySymbol(token.symbol, token.contract);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, token.symbol, token.contract);
     const hasPreapprovedAmount = !!preapprovedAmount && preapprovedAmount !== '0';
     const isPreapprovedAmountUnlimited =
         !!preapprovedAmount &&

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/SelectAccountRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ConnectSelectAccount/SelectAccountRow.tsx
@@ -2,6 +2,8 @@ import { type MouseEvent, type ReactNode } from 'react';
 
 import { Translation } from '@suite/intl';
 import { type SelectAccountCandidate } from '@suite-common/connect-popup';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config/src/utils';
 import {
     Badge,
@@ -57,6 +59,7 @@ export const SelectAccountRow = ({
     onVerify,
     onRetry,
 }: SelectAccountRowProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         accountIndex,
         address,
@@ -111,7 +114,7 @@ export const SelectAccountRow = ({
             return (
                 <Row alignItems="center" gap={8}>
                     <Text typographyStyle="body-sm">
-                        {balance ?? '0'} {getNetworkDisplaySymbol(symbol)}
+                        {balance ?? '0'} {getNetworkDisplaySymbol(networkConfigDeps, symbol)}
                     </Text>
                     <Icon as={CaretRightIcon} size={16} intent="neutral" />
                 </Row>
@@ -121,7 +124,7 @@ export const SelectAccountRow = ({
         return (
             <>
                 <Text typographyStyle="body-sm">
-                    {balance ?? '0'} {getNetworkDisplaySymbol(symbol)}
+                    {balance ?? '0'} {getNetworkDisplaySymbol(networkConfigDeps, symbol)}
                 </Text>
                 {displayValue && (
                     <Row alignItems="center" gap={8} onClick={stop}>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/DisableTorModal.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
 import { isOnionUrl } from '@suite/tor';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type UserContextPayload } from '@suite-common/suite-types';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { blockchainActions, selectCustomBackends } from '@suite-common/wallet-core';
 import { Banner, Button, Card, Column, H3, Modal, Paragraph, Row } from '@trezor/components';
 import { GearIcon, TorBrowserIcon } from '@trezor/icons';
@@ -18,6 +20,7 @@ type DisableTorModalProps = Omit<Extract<UserContextPayload, { type: 'disable-to
 };
 
 export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const [symbol, setSymbol] = useState<NetworkSymbol>();
     const customBackends = useSelector(selectCustomBackends);
@@ -87,7 +90,7 @@ export const DisableTorModal = ({ onCancel, decision }: DisableTorModalProps) =>
                                 <Row key={symbol} gap={16}>
                                     <TokenIcon symbol={symbol} />
                                     <Column>
-                                        <Paragraph>{getNetwork(symbol).name}</Paragraph>
+                                        <Paragraph>{getNetworkConfig(symbol).name}</Paragraph>
                                         <Paragraph
                                             intent="neutral"
                                             priority="secondary"

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/ImportTransactionModal.tsx
@@ -1,8 +1,9 @@
 import { type ReactNode, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type UserContextPayload } from '@suite-common/suite-types';
-import { networksCollection } from '@suite-common/wallet-config';
+import { getNetworks, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { parseCSV } from '@suite-common/wallet-utils';
 import { Card, CollapsibleBox, Column, Modal, Tabs, Text, Textarea } from '@trezor/components';
 import { FileCsvIcon } from '@trezor/icons';
@@ -17,6 +18,8 @@ type ImportTransactionModalProps = {
 };
 
 export const ImportTransactionModal = ({ onCancel, decision }: ImportTransactionModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networks = getNetworks(networkConfigDeps);
     const [mode, setMode] = useState<'upload' | 'manual'>('upload');
     const [delimiter, setDelimiter] = useState<string | undefined>(undefined);
     const [content, setContent] = useState<string>('');
@@ -26,9 +29,7 @@ export const ImportTransactionModal = ({ onCancel, decision }: ImportTransaction
         const parsed = parseCSV(input, ['address', 'amount', 'currency', 'label'], delimiter);
 
         parsed.forEach(item => {
-            const network = networksCollection.find(
-                network => network.displaySymbol === item.currency,
-            );
+            const network = networks.find(network => network.displaySymbol === item.currency);
 
             if (network) {
                 item.currency = network.symbol;

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/useExampleCSV.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/ImportTransactionModal/useExampleCSV.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from '@suite/intl';
 import { selectIsLabelingAvailable } from '@suite/metadata';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useSelector } from 'src/hooks/suite';
 
 export const useExampleCSV = (): string => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, network } = useSelector(state => state.wallet.selectedAccount);
     const isLabelingAvailable = useSelector(selectIsLabelingAvailable);
     const { translationString } = useTranslation();
@@ -22,7 +24,7 @@ export const useExampleCSV = (): string => {
     const headerLine = `address,amount,currency${isLabelingAvailable ? ',label' : ''}`;
 
     // Create example lines
-    const example1 = `${addresses[0]},0.31337,${getNetworkDisplaySymbol(account.symbol)}${
+    const example1 = `${addresses[0]},0.31337,${getNetworkDisplaySymbol(networkConfigDeps, account.symbol)}${
         isLabelingAvailable ? `,${translationString('TR_SENDFORM_LABELING_EXAMPLE_1')}` : ''
     }`;
     const lines = [headerLine, example1];

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/SolanaStakingLimitBanner.tsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { Translation } from '@suite/intl';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBlockchainState } from '@suite-common/wallet-core';
 import { type Account, type PrecomposedLevels } from '@suite-common/wallet-types';
 import {
@@ -29,6 +30,7 @@ export const SolanaStakingLimitBanner = ({
     composedLevels,
     type,
 }: SolanaStakingLimitBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const blockchain = useSelector(selectBlockchainState);
 
     const [limit, setLimit] = useState<SolanaStakingLimit>(NO_LIMIT);
@@ -83,8 +85,12 @@ export const SolanaStakingLimitBanner = ({
                     }
                     values={{
                         limit: MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT,
-                        amount: formatNetworkAmount(limit.estimatedAmount, account.symbol),
-                        symbol: getDisplaySymbol(account.symbol),
+                        amount: formatNetworkAmount(
+                            networkConfigDeps,
+                            limit.estimatedAmount,
+                            account.symbol,
+                        ),
+                        symbol: getDisplaySymbol(networkConfigDeps, account.symbol),
                     }}
                 />
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/StellarManageTokenModal.tsx
@@ -5,13 +5,15 @@ import { selectSelectedAccount } from '@suite/account';
 import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
     DefinitionType,
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     activateStellarTokenThunk,
     deactivateStellarTokenThunk,
@@ -29,6 +31,7 @@ import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useComposedLevelsPlaceholder } from 'src/hooks/wallet/form/useComposedLevelsPlaceholder';
 import { useFees } from 'src/hooks/wallet/form/useFees';
+
 
 type StellarManageTokenModalProps =
     | {
@@ -48,6 +51,8 @@ type StellarManageTokenModalProps =
       };
 
 export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { mode, symbol, contractAddress, onCancel } = props;
     const tokenBalance = mode === 'deactivate' ? props.tokenBalance : undefined;
@@ -58,7 +63,7 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
     const { translationString } = useTranslation();
     const [isProcessing, setIsProcessing] = useState(false);
 
-    const network = getNetwork(symbol);
+    const network = getNetworkConfig(symbol);
     const resolvedNetworkType = account?.networkType ?? network.networkType;
 
     const feeInfo = getConvertedOrDefaultFeeInfo({
@@ -106,8 +111,18 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
 
         if (availableBalance.lt(requiredAmount)) {
             return {
-                required: formatNetworkAmount(requiredAmount.toString(), symbol, true),
-                available: formatNetworkAmount(availableBalance.toString(), symbol, true),
+                required: formatNetworkAmount(
+                    networkConfigDeps,
+                    requiredAmount.toString(),
+                    symbol,
+                    true,
+                ),
+                available: formatNetworkAmount(
+                    networkConfigDeps,
+                    availableBalance.toString(),
+                    symbol,
+                    true,
+                ),
             };
         }
 
@@ -271,8 +286,9 @@ export const StellarManageTokenModal = (props: StellarManageTokenModalProps) => 
                                 id={descriptionId}
                                 values={{
                                     token: tokenCode,
-                                    network: getNetwork(symbol).name,
+                                    network: getNetworkConfig(symbol).name,
                                     reserve: formatNetworkAmount(
+                                        networkConfigDeps,
                                         account.misc.baseReserve ?? STELLAR_BASE_RESERVE,
                                         symbol,
                                         true,

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/AffectedTransactions/DecreasedOutputs.tsx
@@ -1,7 +1,9 @@
 import { Address } from '@suite/address';
 import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, type FormState } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import {
@@ -29,7 +31,10 @@ type AmountRowProps = {
 };
 
 const AmountItem = ({ labelTranslationKey, shouldSendInSats, amount, symbol }: AmountRowProps) => {
-    const value = shouldSendInSats ? formatNetworkAmount(amount, symbol) : amount;
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const value = shouldSendInSats
+        ? formatNetworkAmount(networkConfigDeps, amount, symbol)
+        : amount;
 
     return (
         <Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/useCancelTransactionData.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/CancelTransaction/useCancelTransactionData.ts
@@ -1,4 +1,6 @@
 import { type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -28,16 +30,17 @@ export const useCancelTransactionData = ({
     tx,
     account,
 }: UseCancelTransactionDataParams): UseCancelTransactionDataResult => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { networkType } = account;
     const { composedCancelTx } = useCancelTxContext();
 
     if (!composedCancelTx) return null;
 
     const feePerByte = new BigNumber(composedCancelTx.feePerByte);
-    const newFee = formatNetworkAmount(composedCancelTx.fee, tx.symbol) ?? '0';
+    const newFee = formatNetworkAmount(networkConfigDeps, composedCancelTx.fee, tx.symbol) ?? '0';
 
     if (networkType === 'ethereum') {
-        const originalFee = formatNetworkAmount(tx.fee, tx.symbol) ?? '0';
+        const originalFee = formatNetworkAmount(networkConfigDeps, tx.fee, tx.symbol) ?? '0';
 
         return {
             noticeId: 'TR_CANCEL_TX_NOTICE_EVM',
@@ -51,7 +54,8 @@ export const useCancelTransactionData = ({
     if (composedCancelTx.outputs.length !== 1) return null;
 
     const output = composedCancelTx.outputs[0];
-    const returnAmount = formatNetworkAmount(output?.amount.toString() ?? '', tx.symbol) ?? '0';
+    const returnAmount =
+        formatNetworkAmount(networkConfigDeps, output?.amount.toString() ?? '', tx.symbol) ?? '0';
 
     return {
         noticeId: 'TR_CANCEL_TX_NOTICE',

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/ChangeFee.tsx
@@ -2,7 +2,10 @@ import { type ReactNode } from 'react';
 import { FormProvider } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
-import { type NetworkType, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkType } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { formatNetworkAmount, isEip1559 } from '@suite-common/wallet-utils';
 import { Card, Divider, InfoItem, Row, Text } from '@trezor/components';
@@ -46,6 +49,8 @@ const getFeeRate = (tx: WalletAccountTransaction, networkType: NetworkType) => {
 };
 
 const ChangeFeeLoaded = (props: ChangeFeeProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { tx, showChained, children } = props;
     const {
         account: { networkType },
@@ -53,7 +58,7 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
         methods,
     } = useRbfContext();
 
-    const fee = formatNetworkAmount(tx.fee, tx.symbol);
+    const fee = formatNetworkAmount(networkConfigDeps, tx.fee, tx.symbol);
 
     return (
         <FormProvider {...methods}>
@@ -68,7 +73,7 @@ const ChangeFeeLoaded = (props: ChangeFeeProps) => {
                         <>
                             <Translation
                                 id={
-                                    getNetwork(tx.symbol).networkType === 'ethereum'
+                                    getNetworkConfig(tx.symbol).networkType === 'ethereum'
                                         ? 'TR_CURRENT_MAXIMUM_FEE_SPEED_UP'
                                         : 'TR_CURRENT_FEE_SPEED_UP'
                                 }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/RbfFees.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/ChangeFee/RbfFees.tsx
@@ -1,10 +1,12 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 
 import { Fees } from 'src/components/wallet/Fees/Fees';
 import { useRbfContext } from 'src/hooks/wallet/useRbfForm';
 
 // wrapper for shareable Fees component
 export const RbfFees = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { changeFeeLevel, account, feeInfo, composedLevels } = useRbfContext();
 
     return (
@@ -14,7 +16,7 @@ export const RbfFees = () => {
             composedLevels={composedLevels}
             changeFeeLevel={changeFeeLevel}
             label={
-                getNetwork(account.symbol).networkType === 'ethereum'
+                getNetworkConfig(account.symbol).networkType === 'ethereum'
                     ? 'TR_NEW_MAXIMUM_FEE'
                     : 'TR_NEW_FEE'
             }

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AdvancedTxDetails.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type AccountType, type Network } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type ChainedTransactions,
     type WalletAccountTransaction,
@@ -33,12 +35,18 @@ export const AdvancedTxDetails = ({
     chainedTxs,
     explorerUrl,
 }: AdvancedTxDetailsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [selectedTab, setSelectedTab] = useState<TabID>(defaultTab ?? 'amount');
 
     const getContent = () => {
         switch (selectedTab) {
             case 'amount':
-                return <AmountDetails tx={tx} isTestnet={isTestnet(network.symbol)} />;
+                return (
+                    <AmountDetails
+                        tx={tx}
+                        isTestnet={isTestnet(networkConfigDeps, network.symbol)}
+                    />
+                );
             case 'io':
                 return <IODetails tx={tx} />;
             case 'chained':

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectHistoricFiatRates,
@@ -36,6 +38,7 @@ type AmountDetailsProps = {
 
 // TODO: Do not show FEE for sent but not mine transactions
 export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(tx.symbol, baseCurrencyCode);
 
@@ -45,11 +48,11 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
 
     const historicFiatRates = useSelector(selectHistoricFiatRates);
 
-    const fee = formatNetworkAmount(tx.fee, tx.symbol);
-    const amount = new BigNumber(formatNetworkAmount(tx.amount, tx.symbol));
+    const fee = formatNetworkAmount(networkConfigDeps, tx.fee, tx.symbol);
+    const amount = new BigNumber(formatNetworkAmount(networkConfigDeps, tx.amount, tx.symbol));
     const displayAmount = tx.blockHash ? amount : amount.minus(fee);
-    const cardanoWithdrawal = formatCardanoWithdrawal(tx);
-    const cardanoDeposit = formatCardanoDeposit(tx);
+    const cardanoWithdrawal = formatCardanoWithdrawal(networkConfigDeps, tx);
+    const cardanoDeposit = formatCardanoDeposit(networkConfigDeps, tx);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     const txSignature = tx.ethereumSpecific?.parsedData?.methodId;
@@ -164,7 +167,11 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         <Table.Cell align="end">
                             <Text intent="neutral">
                                 <FormattedCryptoAmount
-                                    value={formatNetworkAmount(transfer.amount, tx.symbol)}
+                                    value={formatNetworkAmount(
+                                        networkConfigDeps,
+                                        transfer.amount,
+                                        tx.symbol,
+                                    )}
                                     symbol={tx.symbol}
                                     signValue={getTxOperation(transfer.type, true)}
                                 />
@@ -173,7 +180,11 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         <Table.Cell align="end">
                             <Text intent="neutral">
                                 <BaseCurrencyValue
-                                    amount={formatNetworkAmount(transfer.amount, tx.symbol)}
+                                    amount={formatNetworkAmount(
+                                        networkConfigDeps,
+                                        transfer.amount,
+                                        tx.symbol,
+                                    )}
                                     symbol={tx.symbol}
                                     historicRate={historicRate}
                                     useHistoricRate
@@ -183,7 +194,11 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                         <Table.Cell align="end">
                             <Text intent="neutral">
                                 <BaseCurrencyValue
-                                    amount={formatNetworkAmount(transfer.amount, tx.symbol)}
+                                    amount={formatNetworkAmount(
+                                        networkConfigDeps,
+                                        transfer.amount,
+                                        tx.symbol,
+                                    )}
                                     symbol={tx.symbol}
                                 />
                             </Text>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsPhishingTransaction } from '@suite-common/wallet-core';
 import { type WalletAccountTransaction, createAccountKey } from '@suite-common/wallet-types';
 import { Column, Divider } from '@trezor/components';
@@ -15,6 +17,7 @@ type IODetailsProps = {
 
 // Not ready for Cardano tokens because they are utxo based
 export const IODetails = ({ tx }: IODetailsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const network = useSelector(state => state.wallet.selectedAccount.network);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
@@ -22,7 +25,7 @@ export const IODetails = ({ tx }: IODetailsProps) => {
         deviceStaticSessionId: tx.deviceState,
     });
     const { isPhishing: isPhishingTransaction } = useSelector(state =>
-        selectIsPhishingTransaction(state, tx.txid, accountKey),
+        selectIsPhishingTransaction(state, tx.txid, accountKey, networkConfigDeps),
     );
 
     const getContent = () => {

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -3,7 +3,9 @@ import { type ReactNode } from 'react';
 import { selectFullSelectedAccount } from '@suite/account';
 import { Address } from '@suite/address';
 import { useExternalLink } from '@suite/external-links';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -33,6 +35,7 @@ export const IOItem = ({
     amount,
     isPhishingTransaction,
 }: IOItem) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { network } = useSelector(selectFullSelectedAccount);
     const explorer = useSelector(state => selectExplorer(state, network?.symbol));
     const explorerUrl = getExplorerUrl(explorer, 'address');
@@ -62,8 +65,12 @@ export const IOItem = ({
                                     <Text intent="neutral" priority="secondary" as="div">
                                         <FormattedCryptoAmount
                                             value={
-                                                isNetworkSymbol(symbol)
-                                                    ? formatNetworkAmount(amount, symbol)
+                                                isNetworkSymbol(networkConfigDeps, symbol)
+                                                    ? formatNetworkAmount(
+                                                          networkConfigDeps,
+                                                          amount,
+                                                          symbol,
+                                                      )
                                                     : amount
                                             }
                                             symbol={symbol}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/DetailModal.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
-import { type Explorer, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type Explorer, toNetwork } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectAccountByKey, selectExplorer } from '@suite-common/wallet-core';
 import {
@@ -42,13 +44,14 @@ export const DetailModal = ({
     nonceStatus,
     nextNonce,
 }: DetailModalProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
         networkSymbol: tx.symbol,
         deviceStaticSessionId: tx.deviceState,
     });
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
     const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
 
     return (

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useRef, useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getInstantStakeType } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     selectAccountByKey,
     selectAllPendingTransactions,
@@ -54,6 +55,7 @@ export const TxDetailModal = ({
     showCancelButton,
     onCancel,
 }: TxDetailModalProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [section, setSection] = useState<TxDetailModalProps['flow']>(flow);
     const [tab, setTab] = useState<TabID | undefined>(undefined);
 
@@ -141,7 +143,7 @@ export const TxDetailModal = ({
         );
     }
 
-    const network = getNetwork(account.symbol);
+    const network = getNetworkConfig(account.symbol);
     const networkFeatures = network.accountTypes[account.accountType]?.features ?? network.features;
 
     // A pending EVM tx whose own nonce is gapped or already superseded can't be bumped OR

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModalBase.tsx
@@ -2,9 +2,12 @@ import { type ReactNode } from 'react';
 
 import { TrezorLink } from '@suite/external-links';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectIsDeviceRemembered } from '@suite-common/device';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type PhishingDetectorId } from '@suite-common/token-definitions';
-import { type Explorer, getNetwork } from '@suite-common/wallet-config';
+import { type Explorer, toNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import {
     selectAccountByKey,
@@ -65,6 +68,8 @@ export const TxDetailModalBase = ({
     nonceStatus,
     nextNonce,
 }: TxDetailModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const accountKey = createAccountKey({
         accountDescriptor: tx.descriptor,
         networkSymbol: tx.symbol,
@@ -74,12 +79,12 @@ export const TxDetailModalBase = ({
         selectTransactionConfirmations(state, tx.txid, accountKey),
     );
     const account = useSelector(state => selectAccountByKey(state, accountKey)) as Account;
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
     const explorer = useSelector(state => selectExplorer(state, account.symbol)) as Explorer;
     const isDeviceRemembered = useSelector(selectIsDeviceRemembered);
 
     const { isPhishing: isPhishingTransaction, detectorId: phishingDetectorId } = useSelector(
-        state => selectIsPhishingTransaction(state, tx.txid, accountKey),
+        state => selectIsPhishingTransaction(state, tx.txid, accountKey, networkConfigDeps),
     );
     const isTxMarkedAsNotScam = useSelector(state =>
         selectTransactionIsMarkedAsNotScam(state, tx.txid, accountKey),

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/UnecoCoinjoinModal.tsx
@@ -3,6 +3,8 @@ import { UNECONOMICAL_COINJOIN_THRESHOLD } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { convertAmountSubunitsToUnits, getAccountDecimals } from '@suite-common/wallet-utils';
 import { Column, H3, Modal, Paragraph } from '@trezor/components';
 import { ArrowsInIcon } from '@trezor/icons';
@@ -12,6 +14,7 @@ import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 export const UnecoCoinjoinModal = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const account = useSelector(selectSelectedAccount);
     const dispatch = useDispatch();
 
@@ -20,7 +23,7 @@ export const UnecoCoinjoinModal = () => {
     }
 
     const { symbol } = account;
-    const decimals = getAccountDecimals(symbol) || 8;
+    const decimals = getAccountDecimals(networkConfigDeps, symbol) || 8;
 
     const handleContinue = () => {
         dispatch(closeModal());

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -7,7 +7,9 @@ import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
+import { useServices } from '@suite-common/dependency-injection';
 import { useDappScan } from '@suite-common/tx-simulation';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
@@ -48,12 +50,14 @@ interface WalletConnectProposalModalProps {
 }
 
 export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const pendingProposal = useSelector(selectPendingProposal);
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const selectableAccounts = useMemo<Account[]>(
         () =>
             sortByCoin(
+                networkConfigDeps,
                 pendingProposal?.networks
                     .filter(network => network.status === 'active')
                     .flatMap(network =>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -4,6 +4,8 @@ import { useDispatch } from 'react-redux';
 import { AccountLabel, AccountTypeBadge } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
@@ -26,22 +28,24 @@ export const WalletConnectSwitchAccountModal = ({
     sessionTopic,
 }: WalletConnectSwitchAccountModalProps) => {
     const dispatch = useDispatch();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const sessions = useSelector(selectSessions);
     const session = sessions.find(s => s.topic === sessionTopic);
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
 
     const selectableAccounts = useMemo<Account[]>(
         () =>
             session
                 ? sortByCoin(
-                      getSessionNetworks(session)
+                      networkConfigDeps,
+                      getSessionNetworks(networkConfigDeps, session)
                           .filter(network => network.status === 'active')
                           .flatMap(network =>
                               accounts.filter(account => account.symbol === network.symbol),
                           ),
                   )
                 : [],
-        [accounts, session],
+        [accounts, networkConfigDeps, session],
     );
     const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
         session?.lastAccount || selectableAccounts[0] || null,

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/CoinProtocolRenderer.tsx
@@ -12,6 +12,7 @@ import {
     getNetworkDisplaySymbol,
     getNetworkDisplaySymbolName,
 } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -34,14 +35,17 @@ export const CoinProtocolRenderer = ({
     render,
     notification,
 }: NotificationRendererProps<'coin-scheme-protocol'>) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { findNetworkSymbolForProtocol } = useServices(selectFindNetworkSymbolForProtocolDep);
     const selectedAccount = useSelector(selectSelectedAccount);
     const routeName = useSelector(selectRouteName);
 
     const networkSymbol = findNetworkSymbolForProtocol(notification.scheme);
-    const displaySymbol = networkSymbol && getNetworkDisplaySymbol(networkSymbol);
-    const networkName = networkSymbol && getNetworkDisplaySymbolName(networkSymbol);
+    const displaySymbol =
+        networkSymbol && getNetworkDisplaySymbol(networkConfigDeps, networkSymbol);
+    const networkName =
+        networkSymbol && getNetworkDisplaySymbolName(networkConfigDeps, networkSymbol);
     const networkAccounts = useSelector(state =>
         selectDeviceAccountsByNetworkSymbol(state, networkSymbol),
     ).filter(a => new BigNumber(a.balance).gt(0));

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.tsx
@@ -10,10 +10,11 @@ import {
     useTranslation,
 } from '@suite/intl';
 import { TRADING_ERROR_MESSAGE } from '@suite/trading';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
 import { AUTH_DEVICE, type NotificationEntry } from '@suite-common/toast-notifications';
 import { getTradingErrorDisplay } from '@suite-common/trading';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { DEVICE } from '@trezor/connect';
 import { ArrowDownIcon, ArrowUpIcon, CheckIcon, GearIcon, TorBrowserIcon } from '@trezor/icons';
 import { exhaustive } from '@trezor/type-utils';
@@ -72,6 +73,7 @@ export const NotificationRenderer = ({
     notification,
     render,
 }: NotificationRendererProps): JSX.Element => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
     const { translationString } = useTranslation();
 
@@ -681,7 +683,10 @@ export const NotificationRenderer = ({
                 message: 'TOAST_SUCCESSFUL_CLAIM',
                 icon: CheckIcon,
                 values: {
-                    networkDisplaySymbol: getNetworkDisplaySymbol(notification.symbol),
+                    networkDisplaySymbol: getNetworkDisplaySymbol(
+                        networkConfigDeps,
+                        notification.symbol,
+                    ),
                 },
             });
 

--- a/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
+++ b/packages/suite/src/components/tx-simulation/common/hooks/useEvmTxSimulationFeesForm.ts
@@ -1,12 +1,14 @@
 import { useCallback, useMemo } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TxSimulationEVMResult } from '@suite-common/tx-simulation';
 import {
     type NetworkSymbol,
     type NetworkType,
     getNetworkDisplaySymbol,
 } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type EvmSelectedFee } from '@suite-common/wallet-types';
@@ -41,6 +43,7 @@ export function useEvmTxSimulationFeesForm({
     defaultGasLimit = ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
     txValue = '0',
 }: UseTxFeesFormProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const form = useForm<FeesFormValues>({
         defaultValues: {
             feeLimit: defaultGasLimit,
@@ -91,7 +94,12 @@ export function useEvmTxSimulationFeesForm({
         if (new BigNumber(fee).gt(accountBalance)) {
             return {
                 id: 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE',
-                values: { networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol) },
+                values: {
+                    networkDisplaySymbol: getNetworkDisplaySymbol(
+                        networkConfigDeps,
+                        networkSymbol,
+                    ),
+                },
             } as const;
         }
 
@@ -100,7 +108,7 @@ export function useEvmTxSimulationFeesForm({
         }
 
         return undefined;
-    }, [accountBalance, composedLevels, networkSymbol, selectedFee, txValue]);
+    }, [accountBalance, composedLevels, networkConfigDeps, networkSymbol, selectedFee, txValue]);
 
     function handleTxSimulationResult({ simulation, gas_estimation }: TxSimulationEVMResult) {
         const newFeeLimit =

--- a/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
+++ b/packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModal.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
 import { type UserContextModalType } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { composeStablecoinYieldTxSimulationAction } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 
 import { useSelector } from 'src/hooks/suite';
@@ -20,9 +22,15 @@ export function EarnYieldTxSimulationModal({
     decision,
     closeModal,
 }: EarnYieldTxSimulationModalProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const parsedData = useMemo(
-        () => composeStablecoinYieldTxSimulationAction(data, globalThis.location.origin),
-        [data],
+        () =>
+            composeStablecoinYieldTxSimulationAction(
+                networkConfigDeps,
+                data,
+                globalThis.location.origin,
+            ),
+        [data, networkConfigDeps],
     );
     const account = useSelector(state =>
         parsedData ? selectAccountByKey(state, parsedData.accountKey) : null,

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/hooks/useNetworkFeeOptions.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/StandardFee/hooks/useNetworkFeeOptions.ts
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
-import { type NetworkSymbol, type NetworkType, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
 import { type PrecomposedLevels, type PrecomposedLevelsCardano } from '@suite-common/wallet-types';
 import { type AmountUnit, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { type FeeLevel } from '@trezor/connect';
@@ -31,6 +33,8 @@ export function useNetworkFeeOptions({
     levels,
     composedLevels,
 }: UseNetworkFeeOptionsProps): FeeOptionType[] {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+
     return useMemo(() => {
         const filteredLevels = levels.filter(level => level.label !== 'custom');
 
@@ -42,7 +46,7 @@ export function useNetworkFeeOptions({
                 ? subunitsToUnits({
                       value: asAmountSubunit(new BigNumber(transactionInfo.fee)),
                       symbol: networkSymbol,
-                      decimals: getNetwork(networkSymbol)?.decimals,
+                      decimals: getNetworkConfig(networkSymbol)?.decimals,
                   })
                 : null;
             // Needed only for Solana because of fee estimation on compose Tx

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/TronFee/TronFee.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/TronFee/TronFee.tsx
@@ -1,5 +1,7 @@
 import { useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 import { calculateTronFeeBreakdown } from '@suite-common/wallet-utils';
@@ -17,6 +19,7 @@ type TronFeeProps = {
 };
 
 export function TronFee({ typographyStyle }: TronFeeProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { networkSymbol, composedLevels, tronResources } = useFeesContext();
     const areFeesLoading = useSelector(state => selectAreFeesLoading(state, networkSymbol));
     const formFeeLimit = useWatch<FormState, 'feeLimit'>({ name: 'feeLimit' });
@@ -27,7 +30,13 @@ export function TronFee({ typographyStyle }: TronFeeProps) {
         formFeeLimit && estimatedFeeLimit && new BigNumber(formFeeLimit).gt(estimatedFeeLimit)
             ? formFeeLimit
             : estimatedFeeLimit;
-    const fees = calculateTronFeeBreakdown(tx, tronResources, networkSymbol, feeLimitSun);
+    const fees = calculateTronFeeBreakdown(
+        networkConfigDeps,
+        tx,
+        tronResources,
+        networkSymbol,
+        feeLimitSun,
+    );
 
     return (
         <LoadingContent

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/hooks/useTransactionMaxFee.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     asAmountSubunit,
     roundToNonZeroFractionDigits,
@@ -19,6 +20,7 @@ export function useTransactionMaxFee({
     composedLevels,
     selectedFeeLevel,
 }: TransactionMaxFeeProps) {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const transactionInfo = selectedFeeLevel ? composedLevels?.[selectedFeeLevel.label] : null;
     const txFee = transactionInfo?.type !== 'error' ? transactionInfo?.fee : null;
 
@@ -31,7 +33,7 @@ export function useTransactionMaxFee({
             subunitsToUnits({
                 value: asAmountSubunit(new BigNumber(txFee)),
                 symbol: networkSymbol,
-                decimals: getNetwork(networkSymbol)?.decimals,
+                decimals: getNetworkConfig(networkSymbol)?.decimals,
             }),
             4,
         ).toString();

--- a/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
+++ b/packages/suite/src/components/wallet/TokenIconSetWrapper.tsx
@@ -1,5 +1,7 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { TokenIconSet } from '@trezor/product-components';
@@ -19,6 +21,7 @@ type TokenIconSetWrapperProps = {
 };
 
 export const TokenIconSetWrapper = ({ accounts, symbol }: TokenIconSetWrapperProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRates = useSelector(selectCurrentFiatRates);
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
@@ -30,6 +33,7 @@ export const TokenIconSetWrapper = ({ accounts, symbol }: TokenIconSetWrapperPro
     if (!allTokensWithRates.length) return null;
 
     const tokens = getTokens<TokensWithRates>({
+        ...networkConfigDeps,
         tokens: allTokensWithRates,
         symbol,
         tokenDefinitions: coinDefinitions,

--- a/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/CoinjoinBatchItem.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { IconCircle, Link } from '@trezor/components';
 import { ShuffleIcon } from '@trezor/icons';
@@ -19,6 +21,7 @@ type CoinjoinBatchItemProps = {
 };
 
 export const CoinjoinBatchItem = ({ transactions, isPending }: CoinjoinBatchItemProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
 
     return (
@@ -72,6 +75,7 @@ export const CoinjoinBatchItem = ({ transactions, isPending }: CoinjoinBatchItem
                         amount={
                             <FormattedCryptoAmount
                                 value={formatNetworkAmount(
+                                    networkConfigDeps,
                                     transactionAmount.abs().toString(),
                                     transaction.symbol,
                                 )}

--- a/packages/suite/src/components/wallet/TransactionItem/InstantStakeBadge.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/InstantStakeBadge.tsx
@@ -3,8 +3,10 @@ import { useSelector } from 'react-redux';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { getInstantStakeType } from '@suite-common/staking';
 import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type StakeType } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Badge, Row } from '@trezor/components';
@@ -39,9 +41,11 @@ interface InstantStakeBadgeProps {
 }
 
 export const InstantStakeBadge = memo(({ transaction, symbol }: InstantStakeBadgeProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { descriptor: selectedAccountAddress } = useSelector(selectSelectedAccount) || {};
 
-    if (!selectedAccountAddress || !symbol || !isNetworkSymbol(symbol)) return null;
+    if (!selectedAccountAddress || !symbol || !isNetworkSymbol(networkConfigDeps, symbol))
+        return null;
 
     const internalTx = getInternalTransaction(transaction, selectedAccountAddress, symbol);
     if (!internalTx) return null;
@@ -52,7 +56,8 @@ export const InstantStakeBadge = memo(({ transaction, symbol }: InstantStakeBadg
     const translationId = getTranslationId(instantStakeType);
     if (!translationId) return null;
 
-    const amount = internalTx.amount && formatNetworkAmount(internalTx.amount, symbol);
+    const amount =
+        internalTx.amount && formatNetworkAmount(networkConfigDeps, internalTx.amount, symbol);
 
     return (
         <Badge size="small" iconLeft={LightningIcon}>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -1,6 +1,7 @@
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { redactNumericalSubstring, useDiscreetMode } from '@suite-common/discreet-mode';
-import { getNetworkDisplaySymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, isNetworkSymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TronTxContractType } from '@suite-common/wallet-constants';
 import { type StakeType } from '@suite-common/wallet-types';
 import {
@@ -123,6 +124,7 @@ const getTronTransactionMessageId = (transaction: WalletAccountTransaction) => {
 };
 
 export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { isDiscreetMode } = useDiscreetMode();
 
@@ -140,7 +142,7 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
             <Translation
                 id={wrapKind === 'wrap' ? 'TR_TX_WRAP' : 'TR_TX_UNWRAP'}
                 values={{
-                    nativeSymbol: getNetworkDisplaySymbol(transaction.symbol),
+                    nativeSymbol: getNetworkDisplaySymbol(networkConfigDeps, transaction.symbol),
                     wrappedAmount: <WrapTxAmount transaction={transaction} wrapped />,
                 }}
             />
@@ -237,11 +239,11 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
             ...transaction.tokens,
             ...transaction.internalTransfers.map(t => ({
                 type: t.type,
-                symbol: getNetworkDisplaySymbol(transaction.symbol),
+                symbol: getNetworkDisplaySymbol(networkConfigDeps, transaction.symbol),
             })),
             ...transaction.targets.map(_ => ({
                 type: 'sent',
-                symbol: getNetworkDisplaySymbol(transaction.symbol),
+                symbol: getNetworkDisplaySymbol(networkConfigDeps, transaction.symbol),
             })),
         ];
         const fromSymbol = combined.find(t => t.type === 'sent')?.symbol;
@@ -259,8 +261,8 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
     const isMultiTokenTransaction = transaction.tokens.length > 1;
     const transactionSymbol = getTxHeaderSymbol(transaction);
     const symbol =
-        transactionSymbol && isNetworkSymbol(transactionSymbol)
-            ? getNetworkDisplaySymbol(transactionSymbol)
+        transactionSymbol && isNetworkSymbol(networkConfigDeps, transactionSymbol)
+            ? getNetworkDisplaySymbol(networkConfigDeps, transactionSymbol)
             : transactionSymbol?.toUpperCase();
 
     return (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -6,7 +6,9 @@ import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { AccountTransactionBaseAnchor, useAnchor } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { type AccountType, type Network } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     createTargets,
     selectAccountByKey,
@@ -70,6 +72,7 @@ export const TransactionItem = memo(
         disableBumpFee,
         index,
     }: TransactionItemProps) => {
+        const networkConfigDeps = useServices(selectNetworkConfigDeps);
         const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(transaction.symbol);
 
         const account = useSelector(selectSelectedAccount) || null;
@@ -85,7 +88,7 @@ export const TransactionItem = memo(
 
         const allOutputs = account !== null ? createTargets({ transaction, account }) : [];
 
-        const fee = formatNetworkAmount(transaction.fee, transaction.symbol);
+        const fee = formatNetworkAmount(networkConfigDeps, transaction.fee, transaction.symbol);
         const showFeeRow = isTxFeePaid(transaction);
 
         const isTxCancellable = isTransactionCancellable(transaction, isPending, networkFeatures);
@@ -154,7 +157,8 @@ export const TransactionItem = memo(
             );
         };
         const { isPhishing: isPhishingTransaction, detectorId: phishingDetectorId } = useSelector(
-            state => selectIsPhishingTransaction(state, transaction.txid, accountKey),
+            state =>
+                selectIsPhishingTransaction(state, transaction.txid, accountKey, networkConfigDeps),
         );
 
         const dataTestBase = `@transaction-item/${index}${

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionRow.tsx
@@ -1,5 +1,7 @@
 import { type ExtendedMessageDescriptor, Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type SignOperator } from '@suite-common/suite-types';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectHistoricFiatRatesByTimestamp } from '@suite-common/wallet-core';
 import { type Timestamp } from '@suite-common/wallet-types';
 import {
@@ -92,16 +94,20 @@ export const WithdrawalRow = ({
 }: {
     transaction: WalletAccountTransaction;
     useFiatValues?: boolean;
-}) => (
-    <CustomRow
-        {...baseLayoutProps}
-        title="TR_TX_WITHDRAWAL"
-        sign="positive"
-        amount={formatCardanoWithdrawal(transaction) ?? '0'}
-        transaction={transaction}
-        useFiatValues={useFiatValues}
-    />
-);
+}) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
+    return (
+        <CustomRow
+            {...baseLayoutProps}
+            title="TR_TX_WITHDRAWAL"
+            sign="positive"
+            amount={formatCardanoWithdrawal(networkConfigDeps, transaction) ?? '0'}
+            transaction={transaction}
+            useFiatValues={useFiatValues}
+        />
+    );
+};
 
 export const DepositRow = ({
     transaction,
@@ -110,16 +116,20 @@ export const DepositRow = ({
 }: {
     transaction: WalletAccountTransaction;
     useFiatValues?: boolean;
-}) => (
-    <CustomRow
-        {...baseLayoutProps}
-        title="TR_TX_DEPOSIT"
-        sign={getCardanoStakingSignValue(transaction)}
-        amount={formatCardanoDeposit(transaction) ?? '0'}
-        transaction={transaction}
-        useFiatValues={useFiatValues}
-    />
-);
+}) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
+    return (
+        <CustomRow
+            {...baseLayoutProps}
+            title="TR_TX_DEPOSIT"
+            sign={getCardanoStakingSignValue(transaction)}
+            amount={formatCardanoDeposit(networkConfigDeps, transaction) ?? '0'}
+            transaction={transaction}
+            useFiatValues={useFiatValues}
+        />
+    );
+};
 
 type CoinjoinRowProps = {
     transaction: WalletAccountTransaction;
@@ -127,6 +137,7 @@ type CoinjoinRowProps = {
 };
 
 export const CoinjoinRow = ({ transaction, useFiatValues }: CoinjoinRowProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(transaction.symbol, baseCurrencyCode);
     const historicRate = useSelector(state =>
@@ -139,6 +150,7 @@ export const CoinjoinRow = ({ transaction, useFiatValues }: CoinjoinRowProps) =>
                 useFiatValues ? (
                     <BaseCurrencyValue
                         amount={formatNetworkAmount(
+                            networkConfigDeps,
                             new BigNumber(transaction.amount).abs().toString(),
                             transaction.symbol,
                         )}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -7,9 +7,11 @@ import {
     selectLabelingDataForAccount,
     selectLabelingValueBeingEdited,
 } from '@suite/metadata';
+import { useServices } from '@suite-common/dependency-injection';
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncOutputLabels } from '@suite-common/suite-sync';
 import { type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type Target,
     selectBaseCurrency,
@@ -56,6 +58,7 @@ export const TransactionTarget = ({
     targetId,
     ...baseLayoutProps
 }: TransactionTargetProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
 
     const accountMetadata = useSelector(state => selectLabelingDataForAccount(state, accountKey));
@@ -90,9 +93,12 @@ export const TransactionTarget = ({
 
         switch (type) {
             case 'target':
-                return getTargetAmount(payload, transaction);
+                return getTargetAmount(networkConfigDeps, payload, transaction);
             case 'internal':
-                return payload.amount && formatNetworkAmount(payload.amount, transaction.symbol);
+                return (
+                    payload.amount &&
+                    formatNetworkAmount(networkConfigDeps, payload.amount, transaction.symbol)
+                );
             case 'token':
                 return convertAmountSubunitsToUnits(payload.amount, payload.decimals);
             default:

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EarnEthBanner.tsx
@@ -5,6 +5,7 @@ import { goto } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Banner } from '@trezor/components';
 import { PiggyBankIcon, XIcon } from '@trezor/icons';
 
@@ -17,11 +18,12 @@ type EarnEthBannerProps = {
 };
 
 export const EarnEthBanner = ({ networkSymbol, apy }: EarnEthBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { earnEthBannerClosed } = useSelector(selectFlags);
 
-    const displaySymbol = getDisplaySymbol(networkSymbol);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, networkSymbol);
 
     const closeBanner = () => {
         dispatch(setFlag({ key: 'earnEthBannerClosed', value: true }));

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/EvmExplanationBanner.tsx
@@ -1,6 +1,7 @@
 import { Translation } from '@suite/intl';
 import { selectRouteName } from '@suite/router';
-import { networks } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { SUITE } from 'src/actions/suite/constants';
 import { useDispatch } from 'src/hooks/suite/useDispatch';
@@ -15,6 +16,7 @@ interface EvmExplanationBannerProps {
 }
 
 export const EvmExplanationBanner = ({ account }: EvmExplanationBannerProps) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const { explanationBannerClosed } = useSelector(state => state.suite.evmSettings);
     const routeName = useSelector(selectRouteName);
     const dispatch = useDispatch();
@@ -25,14 +27,14 @@ export const EvmExplanationBanner = ({ account }: EvmExplanationBannerProps) => 
         account &&
         !explanationBannerClosed[account.symbol] &&
         account.symbol !== 'eth' &&
-        networks[account.symbol].networkType === 'ethereum' &&
+        getNetworkConfig(account.symbol).networkType === 'ethereum' &&
         !isReceiveRoute;
 
     if (!isVisible) {
         return null;
     }
 
-    const network = networks[account.symbol];
+    const network = getNetworkConfig(account.symbol);
 
     const close = () =>
         dispatch({

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/ReserveBanner.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
-import { getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
 import { HELP_CENTER_XLM_URL, HELP_CENTER_XRP_URL } from '@trezor/urls';
@@ -12,6 +14,8 @@ interface ReserveBannerProps {
 }
 
 export const ReserveBanner = ({ account }: ReserveBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     let learnMoreUrl: string;
 
     switch (account?.networkType) {
@@ -40,9 +44,13 @@ export const ReserveBanner = ({ account }: ReserveBannerProps) => {
                 <Translation
                     id="TR_RESERVE_INFO"
                     values={{
-                        minBalance: formatNetworkAmount(account.misc.reserve, account.symbol),
-                        networkName: getNetwork(account.symbol).name,
-                        displaySymbol: getDisplaySymbol(account.symbol),
+                        minBalance: formatNetworkAmount(
+                            networkConfigDeps,
+                            account.misc.reserve,
+                            account.symbol,
+                        ),
+                        networkName: getNetworkConfig(account.symbol).name,
+                        displaySymbol: getDisplaySymbol(networkConfigDeps, account.symbol),
                     }}
                 />
             }

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/StakingBanner.tsx
@@ -8,6 +8,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
 import { type NetworkType, getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -33,6 +34,7 @@ type StakingBannerProps = {
 };
 
 export const StakingBanner = ({ account }: StakingBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const { CryptoAmountFormatter } = useFormatters();
@@ -44,11 +46,13 @@ export const StakingBanner = ({ account }: StakingBannerProps) => {
     } = useSelector(selectFlags);
     const { route } = useSelector(selectRouter);
     const { rate } = useStakingRate({ symbol: account.symbol, accountKey: account.key });
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const earnEthBanner = useEarnEthBanner(account);
 
-    const displaySymbol = getDisplaySymbol(account.symbol);
-    const stakingData = getStakingDataForNetwork(account);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, account.symbol);
+    const stakingData = getStakingDataForNetwork(networkConfigDeps, account);
 
     const accountBalance = account.formattedBalance;
     const stakingBalance = stakingData?.depositedBalance ?? '0';

--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/hooks/useEarnEthBanner.ts
@@ -1,12 +1,17 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import {
     Feature,
     type MessageSystemRootState,
     selectIsYieldFeatureDisabled,
 } from '@suite-common/message-system';
-import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
+import {
+    findNetworkByYieldXyzId,
+    getNetworks,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent, isApyAvailable } from '@suite-common/wallet-utils';
@@ -28,6 +33,8 @@ const isVaultDepositEnabled = (state: MessageSystemRootState, vault: YieldDtoV2)
     );
 
 export const useEarnEthBanner = (account: Account) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networks = getNetworks(networkConfigDeps);
     const { rate: stakingRate } = useStakingRate({
         symbol: account.symbol,
         accountKey: account.key,
@@ -50,11 +57,12 @@ export const useEarnEthBanner = (account: Account) => {
                       vault =>
                           !vault.metadata.underMaintenance &&
                           !vault.metadata.deprecated &&
-                          getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                          findNetworkByYieldXyzId(networks, vault.network)?.symbol ===
+                              account.symbol &&
                           isWrappedNativeToken(account.symbol, vault.token.address),
                   )
                 : emptyVaults,
-        [isYieldOptionRelevant, availableVaults, account.symbol],
+        [isYieldOptionRelevant, availableVaults, account.symbol, networks],
     );
 
     const hasYieldOption = useSelector(state =>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountNavigation.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountNavigation.tsx
@@ -4,7 +4,7 @@ import { Translation } from '@suite/intl';
 import { selectRouterParams } from '@suite/router';
 import { selectIsNftSectionEnabled } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworkOptional } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 
 import { type NavigationItem, SubpageNavigation } from 'src/components/suite/layouts/SuiteLayout';
@@ -13,11 +13,16 @@ import { useSelector } from 'src/hooks/suite';
 import { type WalletParams } from 'src/types/wallet';
 
 export const AccountNavigation = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const account = useSelector(selectSelectedAccount);
     const routerParams = useSelector(selectRouterParams) as WalletParams;
     const enabledNftSection = useSelector(selectIsNftSectionEnabled);
-    const network = getNetworkOptional(routerParams?.symbol);
+    const networkSymbol =
+        routerParams?.symbol &&
+        networkConfigDeps.networkModuleRepository.isSupportedNetwork(routerParams.symbol)
+            ? routerParams.symbol
+            : undefined;
     const goToWithAnalytics = useGoToWithAnalytics(account);
 
     const accountTabs: NavigationItem[] = [
@@ -36,7 +41,7 @@ export const AccountNavigation = () => {
                 goToWithAnalytics({ routeName: 'wallet-tokens', preserveParams: true });
             },
             title: <Translation id="TR_NAV_TOKENS" />,
-            isHidden: !hasNetworkFeatures(account, 'tokens'),
+            isHidden: !hasNetworkFeatures(networkConfigDeps, account, 'tokens'),
             activeRoutes: [
                 'wallet-tokens',
                 'wallet-tokens-hidden',
@@ -51,7 +56,7 @@ export const AccountNavigation = () => {
                 goToWithAnalytics({ routeName: 'wallet-nfts', preserveParams: true });
             },
             title: <Translation id="TR_NAV_NFTS" />,
-            isHidden: !hasNetworkFeatures(account, 'nfts') || !enabledNftSection,
+            isHidden: !hasNetworkFeatures(networkConfigDeps, account, 'nfts') || !enabledNftSection,
             activeRoutes: ['wallet-nfts', 'wallet-nfts-hidden'],
             'data-testid': '@wallet/menu/wallet-nfts',
         },
@@ -65,12 +70,12 @@ export const AccountNavigation = () => {
                     payload: {
                         action: 'navigate',
                         from: 'account/navigation',
-                        networkSymbol: network?.symbol,
+                        networkSymbol,
                     },
                 });
             },
             title: <Translation id="TR_NAV_STAKING" />,
-            isHidden: !hasNetworkFeatures(account, 'staking'),
+            isHidden: !hasNetworkFeatures(networkConfigDeps, account, 'staking'),
             'data-testid': '@wallet/menu/staking',
         },
         {

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/BalancePlaceholder.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItem/AccountRow/AccountItemContent/BalancePlaceholder.tsx
@@ -1,5 +1,7 @@
 import { selectShouldAnimateLoadingSkeleton } from '@suite/ui-animations';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { Column, Skeleton } from '@trezor/components';
 
@@ -10,13 +12,14 @@ type BalancePlaceholderProps = {
 };
 
 export function BalancePlaceholder({ networkSymbol }: BalancePlaceholderProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const shouldAnimate = useSelector(selectShouldAnimateLoadingSkeleton);
 
     return (
         <Column gap={8}>
             <Skeleton width={100} height={16} animate={shouldAnimate} />
 
-            {!isTestnet(networkSymbol) && (
+            {!isTestnet(networkConfigDeps, networkSymbol) && (
                 <Skeleton width={100} height={16} animate={shouldAnimate} />
             )}
         </Column>

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountItemsGroup.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 import { selectRouteName } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import {
     BASE_CURRENCY_ZERO,
@@ -58,8 +60,9 @@ export const AccountItemsGroup = ({
     dataTestKey,
     onItemClick,
 }: AccountItemsGroupProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { isSidebarCollapsed } = useResponsiveContext();
-    const stakingBalance = getAccountTotalStakingBalance(account);
+    const stakingBalance = getAccountTotalStakingBalance(networkConfigDeps, account);
 
     const routeName = useSelector(selectRouteName);
     const baseCurrencyCode = useSelector(selectBaseCurrency);

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountSection.tsx
@@ -1,4 +1,6 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
@@ -25,6 +27,7 @@ export const AccountSection = ({
     selected,
     onItemClick,
 }: AccountSectionProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         symbol,
         accountType,
@@ -36,14 +39,15 @@ export const AccountSection = ({
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
 
-    const showGroup = hasNetworkFeatures(account, 'tokens');
+    const showGroup = hasNetworkFeatures(networkConfigDeps, account, 'tokens');
 
     const isStakeShownStored = useSelector(state =>
-        selectAccountIsStakingActive(state, account.key),
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
     );
     const isStakeShown = !hideStaking && isStakeShownStored;
 
     const tokens = getTokens({
+        ...networkConfigDeps,
         tokens: accountTokens,
         symbol: account.symbol,
         tokenDefinitions: coinDefinitions,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsList.tsx
@@ -3,9 +3,11 @@ import { selectCoinjoinIsPreloading } from '@suite/coinjoin';
 import { Translation, useTranslation } from '@suite/intl';
 import { selectAccountLabelsLegacy } from '@suite/metadata';
 import { type RouteParams, selectRouterParams } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { getTokens, selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn, getAccountTypeName } from '@suite-common/wallet-utils';
@@ -66,7 +68,7 @@ export const AccountsList = ({
     onItemClick,
 }: AccountListProps) => {
     const device = useSelector(selectSelectedDevice);
-    const baseAccounts = useSelector(selectAllAccountsToList);
+    const baseAccounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
 
     const coinjoinIsPreloading = useSelector(selectCoinjoinIsPreloading);
     const accountLegacyLabels = useSelector(selectAccountLabelsLegacy);
@@ -80,6 +82,7 @@ export const AccountsList = ({
     );
 
     const { translationString } = useTranslation();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { isSidebarCollapsed } = useResponsiveContext();
     const { coinFilter, searchString } = useAccountSearch();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
@@ -99,10 +102,15 @@ export const AccountsList = ({
                       account.label ??
                       (Object.prototype.hasOwnProperty.call(accountLegacyLabels, key)
                           ? accountLegacyLabels[key]
-                          : getDefaultAccountLabel(translationString, account)) ??
+                          : getDefaultAccountLabel(
+                                networkConfigDeps,
+                                translationString,
+                                account,
+                            )) ??
                       '';
 
                   const { shownWithBalance } = getTokens({
+                      ...networkConfigDeps,
                       tokens: account.tokens ?? [],
                       symbol: account.symbol,
                       tokenDefinitions: tokenDefinitions[account.symbol]?.coin,
@@ -119,6 +127,7 @@ export const AccountsList = ({
                             });
 
                   return accountSearchFn(account, searchString, {
+                      ...networkConfigDeps,
                       coinsFilter: coinFilter,
                       accountLabel,
                       searchableTokens: shownWithBalance,

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/AccountsMenuHeader.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { selectIsCoinsFilterVisible, suiteSettingsActions } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Box, Column, Divider, Icon, Row, Skeleton, Tooltip } from '@trezor/components';
 import { FunnelSimpleIcon } from '@trezor/icons';
@@ -32,10 +34,11 @@ const RelativeWrapper = styled.div`
 `;
 
 export const AccountsMenuHeader = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { coinFilter } = useAccountSearch();
 
     const device = useSelector(selectSelectedDevice);
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
 
     const isEmpty = accounts.length === 0;
 

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/CoinsFilter.tsx
@@ -1,7 +1,8 @@
 import { AnimatePresence, type MotionProps, motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { TOOLTIP_DELAY_NORMAL, Tooltip, motionEasing } from '@trezor/components';
 import { NetworkIcon } from '@trezor/product-components';
 
@@ -42,6 +43,7 @@ const Container = styled.div`
 `;
 
 export const CoinsFilter = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { coinFilter, setCoinFilter, toggleCoinFilter } = useAccountSearch();
     const availableNetworksSymbols = useAvailableNetworkSymbols();
 
@@ -79,7 +81,7 @@ export const CoinsFilter = () => {
                     return (
                         <Tooltip
                             key={networkSymbol}
-                            content={getNetwork(networkSymbol).name}
+                            content={getNetworkConfig(networkSymbol).name}
                             cursor="pointer"
                             delayShow={TOOLTIP_DELAY_NORMAL}
                         >

--- a/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountsMenu/useAvailableNetworkSymbols.ts
@@ -1,10 +1,12 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectEnabledNetworks } from '@suite-common/wallet-core';
 
 import { useNetworkSupport } from 'src/hooks/settings/useNetworkSupport';
 import { useSelector } from 'src/hooks/suite';
 
 export const useAvailableNetworkSymbols = () => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const enabledNetworks = useSelector(selectEnabledNetworks);
     const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
@@ -14,7 +16,7 @@ export const useAvailableNetworkSymbols = () => {
 
     const availableNetworksSymbols = enabledNetworks.filter(networkSymbol => {
         // if the testnet is enabled, show it even though testnets are disabled in experimental features
-        const isTestnet = getNetwork(networkSymbol).testnet;
+        const isTestnet = getNetworkConfig(networkSymbol).testnet;
 
         return isTestnet || supportedNetworkSymbols.includes(networkSymbol);
     });

--- a/packages/suite/src/constants/suite/experimental.ts
+++ b/packages/suite/src/constants/suite/experimental.ts
@@ -1,7 +1,7 @@
 import type { ExperimentalFeature } from '@suite/experimental';
 import { type ExtendedMessageDescriptor } from '@suite/intl';
 import { type Route } from '@suite/router';
-import { networksCollection } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, getNetworks } from '@suite-common/wallet-config';
 import { blockchainActions } from '@suite-common/wallet-core';
 import { isDesktop } from '@trezor/env-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
@@ -14,11 +14,6 @@ import {
 
 import { type SuiteServices } from '../../support/extraDependencies';
 import { type Dispatch } from '../../types/suite';
-
-const experimentalNetworks = networksCollection.filter(
-    network => network.isExperimentalOnlyNetwork,
-);
-const experimentalNetworkNames = experimentalNetworks.map(network => network.name);
 
 export type ExperimentalFeatureConfig = {
     title: ExtendedMessageDescriptor;
@@ -37,73 +32,84 @@ export type ExperimentalFeatureConfig = {
     }) => void;
 };
 
-export const EXPERIMENTAL_FEATURES: Record<ExperimentalFeature, ExperimentalFeatureConfig> = {
-    'password-manager': {
-        title: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER' },
-        description: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION' },
-        knowledgeBaseUrl: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
-        routeName: 'password-manager-index',
-    },
-    'tor-external': {
-        title: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL' },
-        description: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL_DESCRIPTION' },
-        knowledgeBaseUrl: HELP_CENTER_TOR_URL,
-        isDisabled: () => !isDesktop(),
-        onToggle: async ({ newValue }) => {
-            const result = await desktopApi.getTorSettings();
-            if (result.success && result.payload.useExternalTor !== newValue) {
-                await desktopApi.changeTorSettings({
-                    ...result.payload,
-                    useExternalTor: newValue,
-                });
-            }
+export const createExperimentalFeatures = (
+    networkConfigDeps: NetworkConfigDeps,
+): Record<ExperimentalFeature, ExperimentalFeatureConfig> => {
+    const networks = getNetworks(networkConfigDeps);
+    const experimentalNetworks = networks.filter(network => network.isExperimentalOnlyNetwork);
+    const experimentalNetworkNames = experimentalNetworks.map(network => network.name);
+
+    return {
+        'password-manager': {
+            title: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER' },
+            description: { id: 'TR_EXPERIMENTAL_PASSWORD_MANAGER_DESCRIPTION' },
+            knowledgeBaseUrl: EXPERIMENTAL_PASSWORD_MANAGER_KB_URL,
+            routeName: 'password-manager-index',
         },
-    },
-    slip24: {
-        title: { id: 'TR_EXPERIMENTAL_SLIP24' },
-        description: { id: 'TR_EXPERIMENTAL_SLIP24_DESCRIPTION' },
-        isDisabled: ({ isDebug }) => !isDebug,
-    },
-    'experimental-networks': {
-        title: {
-            id: 'TR_EXPERIMENTAL_NETWORKS',
-            values: {
-                networkNames: experimentalNetworkNames.join(', '),
-                count: experimentalNetworks.length,
+        'tor-external': {
+            title: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL' },
+            description: { id: 'TR_EXPERIMENTAL_TOR_EXTERNAL_DESCRIPTION' },
+            knowledgeBaseUrl: HELP_CENTER_TOR_URL,
+            isDisabled: () => !isDesktop(),
+            onToggle: async ({ newValue }) => {
+                const result = await desktopApi.getTorSettings();
+                if (result.success && result.payload.useExternalTor !== newValue) {
+                    await desktopApi.changeTorSettings({
+                        ...result.payload,
+                        useExternalTor: newValue,
+                    });
+                }
             },
         },
-        description: {
-            id: 'TR_EXPERIMENTAL_NETWORKS_DESCRIPTION',
-            values: {
-                networkNames: experimentalNetworkNames.join(', '),
-                count: experimentalNetworks.length,
+        slip24: {
+            title: { id: 'TR_EXPERIMENTAL_SLIP24' },
+            description: { id: 'TR_EXPERIMENTAL_SLIP24_DESCRIPTION' },
+            isDisabled: ({ isDebug }) => !isDebug,
+        },
+        'experimental-networks': {
+            title: {
+                id: 'TR_EXPERIMENTAL_NETWORKS',
+                values: {
+                    networkNames: experimentalNetworkNames.join(', '),
+                    count: experimentalNetworks.length,
+                },
+            },
+            description: {
+                id: 'TR_EXPERIMENTAL_NETWORKS_DESCRIPTION',
+                values: {
+                    networkNames: experimentalNetworkNames.join(', '),
+                    count: experimentalNetworks.length,
+                },
+            },
+            isDisabled: () => experimentalNetworks.length === 0,
+        },
+        'mcp-server': {
+            title: { id: 'TR_EXPERIMENTAL_MCP_SERVER' },
+            description: { id: 'TR_EXPERIMENTAL_MCP_SERVER_DESCRIPTION' },
+            knowledgeBaseUrl: GITHUB_MCP_DOCS_URL,
+            isDisabled: () => !isDesktop(),
+            onToggle: async ({ newValue }) => {
+                await desktopApi.mcpSetEnabled(newValue);
             },
         },
-        isDisabled: () => experimentalNetworks.length === 0,
-    },
-    'mcp-server': {
-        title: { id: 'TR_EXPERIMENTAL_MCP_SERVER' },
-        description: { id: 'TR_EXPERIMENTAL_MCP_SERVER_DESCRIPTION' },
-        knowledgeBaseUrl: GITHUB_MCP_DOCS_URL,
-        isDisabled: () => !isDesktop(),
-        onToggle: async ({ newValue }) => {
-            await desktopApi.mcpSetEnabled(newValue);
+        'gap-limit': {
+            title: { id: 'TR_EXPERIMENTAL_GAP_LIMIT' },
+            description: { id: 'TR_EXPERIMENTAL_GAP_LIMIT_DESCRIPTION' },
+            // TODO: let's add some knowledgeBaseUrl post if we move this forward.
+            onToggle: ({ newValue, dispatch }) => {
+                if (!newValue) {
+                    networks
+                        .filter(network => network.networkType === 'bitcoin')
+                        .forEach(({ symbol }) =>
+                            dispatch(
+                                blockchainActions.setBackendGapLimit({
+                                    symbol,
+                                    gapLimit: undefined,
+                                }),
+                            ),
+                        );
+                }
+            },
         },
-    },
-    'gap-limit': {
-        title: { id: 'TR_EXPERIMENTAL_GAP_LIMIT' },
-        description: { id: 'TR_EXPERIMENTAL_GAP_LIMIT_DESCRIPTION' },
-        // TODO: let's add some knowledgeBaseUrl post if we move this forward.
-        onToggle: ({ newValue, dispatch }) => {
-            if (!newValue) {
-                networksCollection
-                    .filter(network => network.networkType === 'bitcoin')
-                    .forEach(({ symbol }) =>
-                        dispatch(
-                            blockchainActions.setBackendGapLimit({ symbol, gapLimit: undefined }),
-                        ),
-                    );
-            }
-        },
-    },
+    };
 };

--- a/packages/suite/src/hooks/earn/useCardanoStaking.ts
+++ b/packages/suite/src/hooks/earn/useCardanoStaking.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasPendingStakeTypeTransaction, selectCardanoPoolsInfo } from '@suite-common/wallet-core';
 import {
     type ActionAvailability,
@@ -20,6 +22,7 @@ import trezorConnect, { type CardanoCertificate } from '@trezor/connect';
 import { useSelector } from 'src/hooks/suite';
 
 export const useCardanoStaking = (): CardanoStaking => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const account = useSelector(state => state.wallet.selectedAccount.account);
 
     const isCardano = account?.networkType === 'cardano';
@@ -110,7 +113,7 @@ export const useCardanoStaking = (): CardanoStaking => {
                 withdrawals,
                 changeAddress,
                 addressParameters,
-                testnet: isTestnet(account.symbol),
+                testnet: isTestnet(networkConfigDeps, account.symbol),
             });
 
             if (!response.success) throw new Error(response.error.message);

--- a/packages/suite/src/hooks/earn/useClaimForm.ts
+++ b/packages/suite/src/hooks/earn/useClaimForm.ts
@@ -1,8 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
+import { toNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
@@ -25,11 +27,12 @@ type UseClaimFormsProps = {
 };
 
 export const useClaimForm = ({ account }: UseClaimFormsProps): ClaimContextValues => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
 
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
 
     const defaultValues = useMemo(() => {

--- a/packages/suite/src/hooks/earn/useNativeYieldVault.ts
+++ b/packages/suite/src/hooks/earn/useNativeYieldVault.ts
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
-import { getNetworkByYieldXyzId } from '@suite-common/wallet-config';
+import {
+    findNetworkByYieldXyzId,
+    getNetworks,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { isYieldVaultOperational } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent } from '@suite-common/wallet-utils';
@@ -21,6 +26,8 @@ const emptyVaults: YieldDtoV2[] = [];
  * wrapped-native token (the native balance can be wrapped on the way into the vault).
  */
 export const useNativeYieldVault = (account: Account) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networks = getNetworks(networkConfigDeps);
     const yieldDepositMessageSystem = useMessageSystemYield('deposit');
     const isYieldOptionRelevant =
         account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
@@ -35,11 +42,12 @@ export const useNativeYieldVault = (account: Account) => {
                       vault =>
                           isYieldVaultOperational(vault) &&
                           vault.status.enter &&
-                          getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                          findNetworkByYieldXyzId(networks, vault.network)?.symbol ===
+                              account.symbol &&
                           isWrappedNativeToken(account.symbol, vault.token.address),
                   )
                 : emptyVaults,
-        [isYieldOptionRelevant, availableVaults, account.symbol],
+        [isYieldOptionRelevant, availableVaults, account.symbol, networks],
     );
 
     const hasYieldOption = useSelector(state =>

--- a/packages/suite/src/hooks/earn/useStakeForm.ts
+++ b/packages/suite/src/hooks/earn/useStakeForm.ts
@@ -3,8 +3,10 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import useDebounce from 'react-use/lib/useDebounce';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getStakeFormsDefaultValues, getStakingContractAddress } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
+import { toNetwork } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectFiatRatesByFiatRateKey,
@@ -42,8 +44,9 @@ type UseStakeFormProps = {
 };
 
 export const useStakeForm = ({ account }: UseStakeFormProps): StakeContextValues => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));

--- a/packages/suite/src/hooks/earn/useWithdrawalForm.ts
+++ b/packages/suite/src/hooks/earn/useWithdrawalForm.ts
@@ -3,12 +3,14 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import useDebounce from 'react-use/lib/useDebounce';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     getStakeFormsDefaultValues,
     getStakingContractAddress,
     simulateUnstake,
 } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps, toNetwork } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectFiatRatesByFiatRateKey,
@@ -53,12 +55,14 @@ type UseWithdrawalFormProps = {
 };
 
 export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): WithdrawalContextValues => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const [approximatedInstantEthAmount, setApproximatedInstantEthAmount] = useState<string | null>(
         null,
     );
 
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
     const { symbol } = account;
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
@@ -74,7 +78,8 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
         selectFiatRatesByFiatRateKey(state, getFiatRateKey(symbol, baseCurrencyCode), 'current'),
     );
 
-    const { autocompoundBalance = '0' } = getStakingDataForNetwork(account) ?? {};
+    const { autocompoundBalance = '0' } =
+        getStakingDataForNetwork(networkConfigDeps, account) ?? {};
     const amountLimits: AmountLimitProps = {
         currency: symbol,
         maxCrypto: autocompoundBalance,
@@ -135,6 +140,7 @@ export const useWithdrawalForm = ({ account }: UseWithdrawalFormProps): Withdraw
 
         const simulateUnstakeAmount = async () => {
             const approximatedEthAmount = await simulateUnstake({
+                getNetworkConfig,
                 amount: cryptoInput,
                 from: account.descriptor,
                 symbol: account.symbol,

--- a/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
+++ b/packages/suite/src/hooks/settings/backends/useBackendsForm.ts
@@ -5,10 +5,10 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useTranslation } from '@suite/intl';
 import { isOnionUrl } from '@suite/tor';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type NetworkSymbol,
     type ServerType,
-    getNetwork,
     getServerAddressExample,
     validateServerAddress,
 } from '@suite-common/wallet-config';
@@ -17,6 +17,7 @@ import { type BackendSettings } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
 
 type BackendsFormData = {
     type: ServerType;
@@ -71,6 +72,7 @@ const getStoredState = (
 });
 
 export const useBackendsForm = (symbol: NetworkSymbol) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const backends = useSelector(state => state.wallet.blockchain[symbol].backends);
     const dispatch = useDispatch();
@@ -126,7 +128,7 @@ export const useBackendsForm = (symbol: NetworkSymbol) => {
         setIsValidating(true);
         setValidationError(null);
 
-        const network = getNetwork(symbol);
+        const network = getNetworkConfig(symbol);
         const expectedChainId = network.chainId;
 
         if (!expectedChainId) {

--- a/packages/suite/src/hooks/settings/useNetworkSupport.ts
+++ b/packages/suite/src/hooks/settings/useNetworkSupport.ts
@@ -1,7 +1,9 @@
 import { selectIsDebugModeActive } from '@suite/debug';
 import { selectHasExperimentalFeature, selectIsTestnetNetworksEnabled } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type Network, getMainnets, getTestnets } from '@suite-common/wallet-config';
+import { type Network, getMainnets, getNetworks, getTestnets } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectDeviceSupportedNetworks } from '@suite-common/wallet-core';
 import { DeviceModelInternal, hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { arrayPartition } from '@trezor/utils';
@@ -9,19 +11,29 @@ import { arrayPartition } from '@trezor/utils';
 import { useSelector } from 'src/hooks/suite';
 
 export const useNetworkSupport = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const device = useSelector(selectSelectedDevice);
     const isDebug = useSelector(selectIsDebugModeActive);
     const useExperimentalNetworks = useSelector(
         selectHasExperimentalFeature('experimental-networks'),
     );
     const useTestnetNetworks = useSelector(selectIsTestnetNetworksEnabled);
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const deviceSupportedNetworkSymbols = useSelector(state =>
+        selectDeviceSupportedNetworks(state, networkConfigDeps),
+    );
 
+    const allNetworks = getNetworks(networkConfigDeps);
     const mainnets = getMainnets({
         debug: isDebug,
         useExperimentalNetworks,
+        allNetworks,
     });
-    const testnets = getTestnets({ debug: isDebug, useExperimentalNetworks, useTestnetNetworks });
+    const testnets = getTestnets({
+        debug: isDebug,
+        useExperimentalNetworks,
+        useTestnetNetworks,
+        allNetworks,
+    });
 
     const isNetworkSupported = (network: Network) =>
         deviceSupportedNetworkSymbols.includes(network.symbol);

--- a/packages/suite/src/hooks/suite/useAppShortcuts.tsx
+++ b/packages/suite/src/hooks/suite/useAppShortcuts.tsx
@@ -5,8 +5,10 @@ import { useToggleDebugMode } from '@suite/debug';
 import { openModal } from '@suite/modal';
 import { SettingsAnchor, closeModalApp, goto } from '@suite/router';
 import { selectAutodetectTheme, selectTheme, suiteSettingsActions } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { useDiscreetMode } from '@suite-common/discreet-mode';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList, startDiscoveryThunk } from '@suite-common/wallet-core';
 import { KEYBOARD_CODE } from '@trezor/components';
 import { isDesktop } from '@trezor/env-utils';
@@ -31,13 +33,14 @@ const isTypingTarget = (target: EventTarget | null): boolean => {
 };
 
 export const useAppShortcuts = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const selectedDevice = useSelector(selectSelectedDevice);
     const dispatch = useDispatch();
 
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const discoveryInProgress = discoveryStatus?.status === 'loading';
 
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const selectedAccount = useSelector(selectSelectedAccount);
     const currentTheme = useSelector(selectTheme);
     const autodetectTheme = useSelector(selectAutodetectTheme);

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -8,7 +8,8 @@ import { type SuiteSyncDataState, type SuiteSyncState } from '@suite-common/suit
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { testMocks } from '@suite-common/test-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { type Network, getNetwork } from '@suite-common/wallet-config';
+import { type Network } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import {
     accountsActions,
@@ -332,10 +333,10 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
             ),
             explorer: createReducer(
                 {
-                    btc: { default: getNetwork('btc').explorer.base },
-                    eth: { default: getNetwork('eth').explorer.base },
-                    xrp: { default: getNetwork('xrp').explorer.base },
-                    sol: { default: getNetwork('sol').explorer.base },
+                    btc: { default: mockNetworkConfigDeps.getNetworkConfig('btc').explorer.base },
+                    eth: { default: mockNetworkConfigDeps.getNetworkConfig('eth').explorer.base },
+                    xrp: { default: mockNetworkConfigDeps.getNetworkConfig('xrp').explorer.base },
+                    sol: { default: mockNetworkConfigDeps.getNetworkConfig('sol').explorer.base },
                 },
                 () => ({}),
             ),

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
@@ -11,12 +11,11 @@ import {
     buyInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import { useBuyQuotes } from './useBuyQuotes';
 import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
-
-const btcSymbol = asNetworkSymbol('btc');
 
 const QUOTES: BuyTrade[] = [
     {
@@ -61,7 +60,7 @@ const VALID_DEFAULTS: TradingBuyFormProps = {
     fiatInput: '100',
     cryptoInput: '',
     currencySelect: { value: 'eur', label: 'EUR' },
-    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: btcSymbol } as TradingAssetOption,
+    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: 'btc' } as TradingAssetOption,
     countrySelect: { value: 'DE', label: 'Germany' } as TradingCountryOption,
     countrySubdivisionSelect: undefined,
     paymentMethod: undefined,
@@ -103,7 +102,11 @@ const renderBuyQuotes = (
                 defaultValues,
                 resolver,
             });
-            useBuyQuotes({ methods, network: getNetwork(btcSymbol), shouldSendInSats: false });
+            useBuyQuotes({
+                methods,
+                network: toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc')),
+                shouldSendInSats: false,
+            });
 
             return methods;
         },

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useTradingBuyForm.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
@@ -18,7 +19,7 @@ import {
     selectTradingBuySelectedQuote,
     tradingBuyActions,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps, toNetwork } from '@suite-common/wallet-config';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingCurrencySwitcher } from 'src/hooks/wallet/trading/form/common/useTradingCurrencySwitcher';
@@ -36,6 +37,7 @@ import { useTradingFormAccount } from '../useTradingFormAccount';
 import { useTradingReceiveAddress } from '../useTradingReceiveAddress';
 
 export const useTradingBuyForm = (): TradingBuyFormContextProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const type = 'buy';
     const dispatch = useDispatch();
 
@@ -100,7 +102,8 @@ export const useTradingBuyForm = (): TradingBuyFormContextProps => {
     const isFormInvalid = !(formIsValid && hasValues) || !isReceiveAddressFormValid;
 
     // based on selected cryptoSymbol, because of using for validation cryptoInput
-    const network = getNetwork(cryptoSelect?.networkSymbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY);
+    const networkSymbol = cryptoSelect?.networkSymbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY;
+    const network = toNetwork(networkSymbol, networkConfigDeps.getNetworkConfig(networkSymbol));
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(
         cryptoSelect?.networkSymbol,
     );

--- a/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
@@ -1,25 +1,23 @@
 import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
-import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { useSelectedTradingAsset } from './useSelectedTradingAsset';
 
-const ethSymbol = asNetworkSymbol('eth');
-
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ELIGIBLE_ACCOUNT: Account = mockWalletAccount({
-    symbol: ethSymbol,
+    symbol: 'eth',
     descriptor: asAccountDescriptor('0xEligible'),
     balance: '1000000000000000000',
     formattedBalance: '1',
 });
 const INELIGIBLE_ACCOUNT: Account = mockWalletAccount({
-    symbol: ethSymbol,
+    symbol: 'eth',
     descriptor: asAccountDescriptor('0xIneligible'),
     balance: '0',
     tokens: [],
@@ -67,11 +65,11 @@ describe('useSelectedTradingAsset', () => {
 
         expect(result.current).toEqual({
             symbol: 'eth',
-            decimals: getNetwork(ethSymbol).decimals,
+            decimals: mockNetworkConfigDeps.getNetworkConfig('eth').decimals,
             balance: ELIGIBLE_ACCOUNT.balance,
             formattedBalance: ELIGIBLE_ACCOUNT.formattedBalance,
             tokens: ELIGIBLE_ACCOUNT.tokens,
-            cryptoId: getNetwork(ethSymbol).tradeCryptoId,
+            cryptoId: mockNetworkConfigDeps.getNetworkConfig('eth').tradeCryptoId,
             isToken: false,
         });
     });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.ts
@@ -1,6 +1,11 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { type TradingType, selectSelectedTradingAsset } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useSelector } from 'src/hooks/suite';
 
-export const useSelectedTradingAsset = (tradingType: TradingType) =>
-    useSelector(state => selectSelectedTradingAsset(state, tradingType));
+export const useSelectedTradingAsset = (tradingType: TradingType) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
+    return useSelector(state => selectSelectedTradingAsset(state, tradingType, networkConfigDeps));
+};

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingAssetDecimals.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingAssetDecimals.ts
@@ -2,8 +2,9 @@ import { useCallback } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { cryptoIdToNetwork } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 
 import { useTradingFindAccountOrToken } from './useTradingFindAccountOrToken';
@@ -11,18 +12,21 @@ import { useTradingFindAccountOrToken } from './useTradingFindAccountOrToken';
 /**
  * Get decimals for the given asset
  */
-export function useTradingAssetDecimals(defaultDecimals = getNetwork('btc').decimals) {
+export function useTradingAssetDecimals(defaultDecimals?: number) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = networkConfigDeps;
+    const resolvedDefaultDecimals = defaultDecimals ?? getNetworkConfig('btc').decimals;
     const findAccountOrToken = useTradingFindAccountOrToken();
 
     const getAssetDecimals = useCallback(
         ({ accountKey, cryptoId }: { accountKey?: AccountKey; cryptoId?: CryptoId }) => {
             if (!accountKey || !cryptoId) {
-                return defaultDecimals;
+                return resolvedDefaultDecimals;
             }
 
             const accountOrToken = findAccountOrToken.current({ accountKey, cryptoId });
-            const network = cryptoIdToNetwork(cryptoId);
-            const fallbackDecimals = network?.decimals ?? defaultDecimals;
+            const network = cryptoIdToNetwork(networkConfigDeps, cryptoId);
+            const fallbackDecimals = network?.decimals ?? resolvedDefaultDecimals;
 
             if (!accountOrToken) {
                 return fallbackDecimals;
@@ -34,9 +38,9 @@ export function useTradingAssetDecimals(defaultDecimals = getNetwork('btc').deci
                 return token.decimals ?? fallbackDecimals;
             }
 
-            return getNetwork(account.symbol).decimals ?? fallbackDecimals;
+            return getNetworkConfig(account.symbol).decimals ?? fallbackDecimals;
         },
-        [defaultDecimals, findAccountOrToken],
+        [findAccountOrToken, getNetworkConfig, networkConfigDeps, resolvedDefaultDecimals],
     );
 
     return { getAssetDecimals };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
@@ -4,7 +4,8 @@ import { act, waitFor } from '@testing-library/react';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingSellFormProps } from '@suite-common/trading';
-import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -101,7 +102,10 @@ const renderComposeTransaction = () => {
             const compose = useTradingComposeTransaction({
                 type: 'sell',
                 account,
-                network: getNetwork(account.symbol),
+                network: toNetwork(
+                    account.symbol,
+                    mockNetworkConfigDeps.getNetworkConfig(account.symbol),
+                ),
                 methods,
                 setShowReserveBanner: jest.fn(),
             });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingDefaultSellAsset.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingDefaultSellAsset.ts
@@ -2,12 +2,14 @@ import { useMemo } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetSellOption,
     createAssetNativeTokenOption,
     useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 
 import { useTradingFindAccountOrToken } from './useTradingFindAccountOrToken';
@@ -24,6 +26,7 @@ export function useTradingDefaultSellAsset({
     accountKey,
     cryptoId,
 }: UseTradingDefaultSellAssetProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const findAccountOrToken = useTradingFindAccountOrToken();
     const { resolveAssetTokenOption } = useTradingAssets();
     const accountOrToken = useMemo(() => {
@@ -50,7 +53,10 @@ export function useTradingDefaultSellAsset({
         }
 
         return {
-            ...createAssetNativeTokenOption(selectedAccount.symbol as NetworkSymbol),
+            ...createAssetNativeTokenOption(
+                networkConfigDeps,
+                selectedAccount.symbol as NetworkSymbol,
+            ),
             accountKey: selectedAccount.key,
         } satisfies TradingAssetSellOption;
     }, [accountOrToken, resolveAssetTokenOption]);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.ts
@@ -3,6 +3,7 @@ import { type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { type FiatCurrencyCode } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_CURRENCY,
@@ -11,6 +12,7 @@ import {
     type TradingFiatRatesReturn,
     mapFiatCurrencyCodeToBaseCurrencyCode,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     asAmountSubunit,
     getDecimalsForBaseCurrency,
@@ -39,6 +41,7 @@ export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProp
     networkDecimals,
     shouldSendInSats,
 }: UseTradingFiatCryptoAmountProps<T>) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { getValues, setValue, control } =
         methods as unknown as UseFormReturn<TradingSellExchangeFormProps>;
 
@@ -81,6 +84,7 @@ export const useTradingFiatCryptoAmount = <T extends TradingSellExchangeFormProp
         ) {
             const fiatValueBigNumber = formattedAmount.multipliedBy(rate.rate);
             const fiatDecimals = getDecimalsForBaseCurrency({
+                ...networkConfigDeps,
                 code: mappedBaseCurrencyCode,
                 isInSats: false,
             });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatValues.ts
@@ -1,3 +1,4 @@
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_DEFAULT_CRYPTO_CURRENCY,
     type TradingFiatRatesProps,
@@ -5,6 +6,7 @@ import {
     cryptoIdToNetworkAndContractAddress,
     useTradingFiatValues as useCommonTradingFiatValues,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useBitcoinAmountUnit } from 'src/hooks/wallet/useBitcoinAmountUnit';
 
@@ -14,7 +16,8 @@ export const useTradingFiatValues = ({
     cryptoId,
     ...rest
 }: SuiteTradingFiatRatesProps): TradingFiatRatesReturn | null => {
-    const { network } = cryptoIdToNetworkAndContractAddress(cryptoId);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { network } = cryptoIdToNetworkAndContractAddress(networkConfigDeps, cryptoId);
     const symbol = network?.symbol ?? TRADING_DEFAULT_CRYPTO_CURRENCY;
 
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFindAccountOrToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFindAccountOrToken.ts
@@ -2,7 +2,9 @@ import { useCallback } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { getCryptoId, parseCryptoId } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
 import { useCurrentRef } from '@trezor/react-utils';
@@ -18,6 +20,7 @@ export interface UseTradingFindAccountOrTokenProps {
  * Based on `accountKey` and `cryptoId` find corresponding account or its token
  */
 export function useTradingFindAccountOrToken() {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const accounts = useSelector(selectVisibleDeviceAccounts);
     const findAccountOrToken = useCallback(
         ({ accountKey, cryptoId }: UseTradingFindAccountOrTokenProps) => {
@@ -29,19 +32,23 @@ export function useTradingFindAccountOrToken() {
 
             const { contractAddress } = parseCryptoId(cryptoId);
 
-            if (getCryptoId(account.symbol) === cryptoId || !contractAddress) {
+            if (getCryptoId(networkConfigDeps, account.symbol) === cryptoId || !contractAddress) {
                 return { account, token: null };
             }
 
             const contractAddressForNetworkSymbol = getContractAddressForNetworkSymbol(
+                networkConfigDeps,
                 account.symbol,
                 contractAddress,
             );
             const token =
                 account.tokens?.find(
                     token =>
-                        getContractAddressForNetworkSymbol(account.symbol, token.contract) ===
-                        contractAddressForNetworkSymbol,
+                        getContractAddressForNetworkSymbol(
+                            networkConfigDeps,
+                            account.symbol,
+                            token.contract,
+                        ) === contractAddressForNetworkSymbol,
                 ) ?? null;
 
             return { account, token };

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.ts
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetSellOption,
     type TradingComposedTransactionInfo,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -41,6 +43,7 @@ export const useTradingSendAssetBalance = ({
     composedLevels,
     composedTransactionInfo,
 }: UseTradingSendAssetBalanceProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const sendCryptoAccount = useSelector(state =>
         selectAccountByKey(state, sendCryptoSelect?.accountKey),
     );
@@ -70,6 +73,7 @@ export const useTradingSendAssetBalance = ({
 
     const feeInUnits = account
         ? getFeeInUnits({
+              ...networkConfigDeps,
               symbol: account.symbol,
               composedLevels,
               selectedFee: composedTransactionInfo?.selectedFee,

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.ts
@@ -3,6 +3,7 @@ import { type UseFormReturn, useWatch } from 'react-hook-form';
 
 import { type ExchangeTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_EXCHANGE_FORM_DEX,
     TRADING_FORM_OUTPUT_ADDRESS,
@@ -13,7 +14,7 @@ import {
     getDexEstimationData,
     isSendingEvmNativeToken,
 } from '@suite-common/trading';
-import { isAccountBasedNetwork } from '@suite-common/wallet-config';
+import { isAccountBasedNetwork , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { ETHEREUM_ADJUST_GAS_LIMIT, updateFeeInfoThunk } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getEvmTransactionTextSignature } from '@suite-common/wallet-utils';
@@ -51,6 +52,7 @@ export const useExchangeDexQuote = ({
     dexQuotes,
     composeRequest,
 }: UseExchangeDexQuoteProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { setValue, control } = methods;
 
@@ -82,7 +84,9 @@ export const useExchangeDexQuote = ({
             return;
         }
 
-        const fromAddress = isAccountBasedNetwork(account.symbol) ? account.descriptor : undefined;
+        const fromAddress = isAccountBasedNetwork(networkConfigDeps, account.symbol)
+            ? account.descriptor
+            : undefined;
 
         setValue('fromAddress', fromAddress);
     }, [account, setValue]);
@@ -99,8 +103,8 @@ export const useExchangeDexQuote = ({
             return;
         }
 
-        const sendNetwork = cryptoIdToNetwork(sendCryptoSelect.id);
-        const isEvmNativeToken = isSendingEvmNativeToken(sendCryptoSelect.id);
+        const sendNetwork = cryptoIdToNetwork(networkConfigDeps, sendCryptoSelect.id);
+        const isEvmNativeToken = isSendingEvmNativeToken(networkConfigDeps, sendCryptoSelect.id);
         const requiresApproval = sendNetwork?.networkType === 'ethereum' && !isEvmNativeToken;
 
         const quote = requiresApproval ? selectedQuote : dexQuotes[0];
@@ -114,7 +118,7 @@ export const useExchangeDexQuote = ({
 
         const { dexTx } = quote;
 
-        setValue('transactionData', getDexEstimationData(quote) ?? '');
+        setValue('transactionData', getDexEstimationData(networkConfigDeps, quote) ?? '');
         setValue(TRADING_FORM_OUTPUT_ADDRESS, dexTx.to);
         setValue('ethereumAdjustGasLimit', ETHEREUM_ADJUST_GAS_LIMIT);
     }, [

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.ts
@@ -1,5 +1,6 @@
 import { useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_CRYPTO_TOKEN,
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -10,6 +11,7 @@ import {
     type TradingExchangeFormProps,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectIsNetworkReserveEnabled,
     selectVisibleDeviceAccounts,
@@ -43,6 +45,7 @@ export const useExchangeFormInputs = ({
     setShowReserveBanner,
     setAccountOnChange,
 }: UseExchangeFormInputsProps): TradingUseFormActionsReturnProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account?.symbol);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
@@ -95,6 +98,7 @@ export const useExchangeFormInputs = ({
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
 
         const { cryptoInputValue, cryptoAmountWithReserve } = calcRatioAmount({
+            ...networkConfigDeps,
             divisor,
             balance: tokenData ? tokenData.balance || '0' : account.formattedBalance,
             decimals: tokenData ? tokenData.decimals : networkDecimals,

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.test.tsx
@@ -11,18 +11,11 @@ import {
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
 } from '@suite-common/trading';
-import {
-    type Network,
-    type NetworkSymbol,
-    getNetwork,
-    toNetworkSymbolNonTestnet,
-} from '@suite-common/wallet-config';
+import { type Network, type NetworkSymbol, toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeQuotes } from './useExchangeQuotes';
-
-const btcSymbol = toNetworkSymbolNonTestnet('btc');
-const ethSymbol = toNetworkSymbolNonTestnet('eth');
 
 const QUOTES: ExchangeTrade[] = [
     { exchange: 'provider-1', send: 'bitcoin' as CryptoId, receive: 'ethereum' as CryptoId },
@@ -79,11 +72,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: btcSymbol,
+    symbol: 'btc',
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: btcSymbol,
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
+    networkSymbol: 'btc',
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
 };
 
 const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
@@ -92,10 +85,10 @@ const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
     name: 'Ethereum',
     coingeckoId: 'ethereum',
     contractAddress: null,
-    symbol: ethSymbol,
+    symbol: 'eth',
     displaySymbol: 'ETH',
     networkName: 'Ethereum',
-    networkSymbol: ethSymbol,
+    networkSymbol: 'eth',
 };
 
 const VALID_DEFAULTS: TradingExchangeFormProps = {
@@ -151,7 +144,10 @@ const renderExchangeQuotes = (
     } = {},
 ) => {
     const { receiveAddress, receiveAccountKey, receiveAccountSymbol, resolver } = options;
-    const network = 'network' in options ? options.network : getNetwork(btcSymbol);
+    const network =
+        'network' in options
+            ? options.network
+            : toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc'));
 
     const store = configureMockStore({
         preloadedState: {
@@ -253,8 +249,8 @@ describe('useExchangeQuotes', () => {
     it('does not dispatch a quotes request while the receive identity is incoherent (#28143/#30213)', async () => {
         const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
-            receiveAccountSymbol: ethSymbol,
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
         });
 
         await act(async () => {
@@ -290,8 +286,8 @@ describe('useExchangeQuotes', () => {
 
         const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
-            receiveAccountSymbol: ethSymbol,
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
         });
 
         await act(async () => {
@@ -316,8 +312,8 @@ describe('useExchangeQuotes', () => {
     it('clears the selected quote and refetches when only the receive account changes', async () => {
         const { result, rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
-            receiveAccountSymbol: ethSymbol,
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
+            receiveAccountSymbol: 'eth',
         });
 
         await act(async () => {
@@ -329,10 +325,10 @@ describe('useExchangeQuotes', () => {
         mockSaveSelectedQuote.mockClear();
 
         rerender({
-            currentNetwork: getNetwork(btcSymbol),
+            currentNetwork: toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc')),
             currentReceiveAccountKey: mockAccountKey({
                 descriptor: 'receiveaccount2',
-                symbol: ethSymbol,
+                symbol: 'eth',
             }),
         });
 
@@ -355,7 +351,7 @@ describe('useExchangeQuotes', () => {
         expect(mockHandleRequest).not.toHaveBeenCalled();
 
         rerender({
-            currentNetwork: getNetwork(btcSymbol),
+            currentNetwork: toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc')),
             currentReceiveAccountKey: undefined,
         });
 

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.ts
@@ -20,6 +20,7 @@ import {
     tradingExchangeActions,
 } from '@suite-common/trading';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -50,6 +51,7 @@ export const useExchangeQuotes = ({
     receiveAccountSymbol,
     composeRequestCallback,
 }: UseExchangeQuotesProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { addressValidator, analytics } = useServices(
         selectAddressValidatorDep,
@@ -108,6 +110,7 @@ export const useExchangeQuotes = ({
 
         if (
             !isReceiveAddressCoherent({
+                ...networkConfigDeps,
                 addressValidator,
                 receiveAddress,
                 receiveCryptoId: receiveCryptoSelect?.id,

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useTradingExchangeForm.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_EXCHANGE_FORM,
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -24,7 +25,7 @@ import {
     selectTradingVerifiedAddress,
     tradingExchangeActions,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps, toNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
@@ -48,6 +49,7 @@ import { useTradingFormAccount } from '../useTradingFormAccount';
 import { useTradingReceiveAddress } from '../useTradingReceiveAddress';
 
 export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const type = 'exchange';
     const dispatch = useDispatch();
     const quotesRequest = useSelector(selectTradingExchangeQuotesRequest);
@@ -62,7 +64,7 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
     const { tradingAccountKey: accountKey, cryptoId } = useTradingFormAccount(type);
 
     const trade = useSelector(selectTradingExchangeActiveTrade);
-    const account = useSelector(state => selectTradingSendAccount(state, type));
+    const account = useSelector(state => selectTradingSendAccount(state, type, networkConfigDeps));
 
     const [showReserveBanner, setShowReserveBanner] = useState<boolean>(false);
     const [isApproval, setIsApproval] = useState<boolean>(false);
@@ -73,7 +75,9 @@ export const useTradingExchangeForm = (): TradingExchangeFormContextProps => {
 
     const symbol = account?.symbol;
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
-    const network = symbol ? getNetwork(symbol) : undefined;
+    const network = symbol
+        ? toNetwork(symbol, networkConfigDeps.getNetworkConfig(symbol))
+        : undefined;
 
     const { defaultValues } = useTradingExchangeFormDefaultValues(accountKey, cryptoId);
 

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.ts
@@ -1,5 +1,6 @@
 import { useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_CRYPTO_TOKEN,
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -9,6 +10,7 @@ import {
     TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT,
     type TradingSellFormProps,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectIsNetworkReserveEnabled,
     selectVisibleDeviceAccounts,
@@ -42,6 +44,7 @@ export const useSellFormInputs = ({
     setShowReserveBanner,
     setAccountOnChange,
 }: UseSellFormInputsProps): TradingUseFormActionsReturnProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
     const accounts = useSelector(selectVisibleDeviceAccounts);
 
@@ -96,6 +99,7 @@ export const useSellFormInputs = ({
         clearErrors([TRADING_FORM_OUTPUT_FIAT, TRADING_FORM_OUTPUT_AMOUNT]);
 
         const { cryptoInputValue, cryptoAmountWithReserve } = calcRatioAmount({
+            ...networkConfigDeps,
             divisor,
             balance: tokenData ? tokenData.balance || '0' : account.formattedBalance,
             decimals: tokenData ? tokenData.decimals : networkDecimals,

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
@@ -10,13 +10,12 @@ import {
     sellInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { type Network, getNetwork, toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
+import { type Network, toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useSellQuotes } from './useSellQuotes';
 import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
-
-const btcSymbol = toNetworkSymbolNonTestnet('btc');
 
 const QUOTES: SellFiatTrade[] = [
     {
@@ -72,11 +71,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: btcSymbol,
+    symbol: 'btc',
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: btcSymbol,
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
+    networkSymbol: 'btc',
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
 };
 
 const VALID_DEFAULTS: TradingSellFormProps = {
@@ -133,7 +132,7 @@ const renderSellQuotes = (
 ) => {
     const { resolver } = options;
     const initialProps: { currentNetwork: Network | undefined } = {
-        currentNetwork: getNetwork(btcSymbol),
+        currentNetwork: toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc')),
     };
 
     const store = configureMockStore({

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellForm.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
     TRADING_FORM_OUTPUT_FIAT,
@@ -17,7 +18,7 @@ import {
     selectTradingSendAccount,
     tradingSellActions,
 } from '@suite-common/trading';
-import { networks } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps, toNetwork } from '@suite-common/wallet-config';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useSolanaSubscribeBlocks } from 'src/hooks/wallet/form/useSolanaSubscribeBlocks';
@@ -36,6 +37,7 @@ import { useTradingFormReset } from '../common/useTradingFormReset';
 import { useTradingFormAccount } from '../useTradingFormAccount';
 
 export const useTradingSellForm = (): TradingSellFormContextProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const type = 'sell';
     const dispatch = useDispatch();
     const isLoading = useSelector(selectTradingSellIsLoading);
@@ -50,13 +52,15 @@ export const useTradingSellForm = (): TradingSellFormContextProps => {
     const { tradingAccountKey: accountKey, cryptoId } = useTradingFormAccount(type);
 
     const trade = useSelector(selectTradingSellActiveTrade);
-    const account = useSelector(state => selectTradingSendAccount(state, type));
+    const account = useSelector(state => selectTradingSendAccount(state, type, networkConfigDeps));
 
     useServerEnvironment();
 
     const composedTransactionInfo = useSelector(selectTradingComposedTransactionInfo);
 
-    const network = account ? networks[account.symbol] : undefined;
+    const network = account
+        ? toNetwork(account.symbol, networkConfigDeps.getNetworkConfig(account.symbol))
+        : undefined;
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(account?.symbol);
 
     const { defaultValues } = useTradingSellFormDefaultValues(

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellFormRedirectValues.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useTradingSellFormRedirectValues.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 
 import { type SellFiatTradeQuoteRequest } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetOption,
     type TradingAssetSellOption,
@@ -13,6 +14,7 @@ import {
     selectTradingComposedTransactionInfo,
     useTradingAssets,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
@@ -25,6 +27,7 @@ export const useTradingSellFormRedirectValues = (
     isFromRedirect: boolean,
     quotesRequest: SellFiatTradeQuoteRequest | undefined,
 ): TradingSellFormProps | null => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { composed, selectedFee } = useSelector(selectTradingComposedTransactionInfo);
     const { createAssetOptionFromCryptoId } = useTradingAssets();
     const accounts = useSelector(selectVisibleDeviceAccounts);
@@ -40,8 +43,13 @@ export const useTradingSellFormRedirectValues = (
                     assetOption.contractAddress &&
                     !!account.tokens?.find(
                         token =>
-                            getContractAddressForNetworkSymbol(account.symbol, token.contract) ===
                             getContractAddressForNetworkSymbol(
+                                networkConfigDeps,
+                                account.symbol,
+                                token.contract,
+                            ) ===
+                            getContractAddressForNetworkSymbol(
+                                networkConfigDeps,
                                 assetOption.networkSymbol,
                                 assetOption.contractAddress,
                             ),

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingType,
     selectTradingAccountKeyByTradeType,
@@ -11,14 +12,20 @@ import {
     tradingExchangeActions,
     tradingSellActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useTradingFormAccount = (tradingType: TradingType) => {
     const dispatch = useDispatch();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
 
-    const account = useSelector(state => selectTradingFormAccount(state, tradingType));
-    const cryptoId = useSelector(state => selectTradingFormCryptoId(state, tradingType));
+    const account = useSelector(state =>
+        selectTradingFormAccount(state, tradingType, networkConfigDeps),
+    );
+    const cryptoId = useSelector(state =>
+        selectTradingFormCryptoId(state, tradingType, networkConfigDeps),
+    );
     const accountKey = useSelector(state => selectTradingAccountKeyByTradeType(state, tradingType));
     const prefilled = useSelector(selectTradingPrefilledFromAccount);
 

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingReceiveAddress.ts
@@ -9,7 +9,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import {
     type TradingType,
-    cryptoIdToNetworkSymbol,
+    cryptoIdToSymbol,
     getUnusedAddressFromAccount,
     selectTradingBuyReceiveAccountKey,
     selectTradingBuyReceiveAddress,
@@ -19,6 +19,7 @@ import {
     tradingBuyActions,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { filterReceiveAccounts } from '@suite-common/wallet-utils';
@@ -59,6 +60,7 @@ export const useTradingReceiveAddress = ({
     cryptoId,
     nonSuiteAccount,
 }: UseTradingReceiveAddressProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { addressValidator } = useServices(selectAddressValidatorDep);
     const accounts = useSelector(state => state.wallet.accounts);
@@ -79,7 +81,7 @@ export const useTradingReceiveAddress = ({
 
     const isDebug = useSelector(selectIsDebugModeActive);
 
-    const symbol = cryptoId && cryptoIdToNetworkSymbol(cryptoId);
+    const symbol = cryptoId && cryptoIdToSymbol(networkConfigDeps, cryptoId);
     const { supportedMainnets, supportedTestnets } = useNetworkSupport();
 
     const methods = useForm<TradingVerifyFormProps>({
@@ -101,6 +103,7 @@ export const useTradingReceiveAddress = ({
     const suiteReceiveAccounts = useMemo(
         () =>
             filterReceiveAccounts({
+                ...networkConfigDeps,
                 accounts,
                 deviceState: device?.state?.staticSessionId,
                 symbol,

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingVerifyAccount.ts
@@ -3,9 +3,10 @@ import { useForm } from 'react-hook-form';
 
 import { selectIsDebugModeActive } from '@suite/debug';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import {
-    cryptoIdToNetworkSymbol,
+    cryptoIdToSymbol,
     getUnusedAddressFromAccount,
     parseCryptoId,
     selectTradingAccountKeyByTradeType,
@@ -13,6 +14,7 @@ import {
     selectTradingBuyReceiveAccountKey,
     selectTradingExchangeAccountKey,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { filterReceiveAccounts } from '@suite-common/wallet-utils';
 
@@ -46,6 +48,7 @@ const useTradingVerifyAccount = ({
     cryptoId,
     nonSuiteAccount,
 }: TradingVerifyAccountProps): TradingVerifyAccountReturnProps => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const activeSection = useSelector(selectTradingActiveSection);
     const formAccountKey = useSelector(state =>
         selectTradingAccountKeyByTradeType(state, activeSection),
@@ -72,7 +75,7 @@ const useTradingVerifyAccount = ({
     const [hasSelectionInitialized, setHasSelectionInitialized] = useState(false);
 
     const networkId = cryptoId && parseCryptoId(cryptoId).networkId;
-    const symbol = cryptoId && cryptoIdToNetworkSymbol(cryptoId);
+    const symbol = cryptoId && cryptoIdToSymbol(networkConfigDeps, cryptoId);
 
     const isSupportedNetwork = [...supportedMainnets, ...supportedTestnets].some(
         network => network.symbol === symbol,
@@ -84,6 +87,7 @@ const useTradingVerifyAccount = ({
         }
 
         return filterReceiveAccounts({
+            ...networkConfigDeps,
             accounts,
             deviceState: device?.state?.staticSessionId,
             symbol,

--- a/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingStellarActivateToken.ts
@@ -2,8 +2,10 @@ import { useState } from 'react';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { desktopQueryKeys, useQuery } from '@suite-common/react-query';
 import { cryptoIdToNetworkAndContractAddress } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getStellarInactiveTokens } from '@suite-common/wallet-utils';
 
@@ -16,6 +18,7 @@ export const useTradingStellarActivateToken = ({
     account,
     receiveCryptoId,
 }: UseTradingStellarActivateTokenProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- cache identity is account.symbol + account.key; the queryFn passes the full account to getStellarInactiveTokens, but the extra fields aren't part of the key
@@ -27,7 +30,7 @@ export const useTradingStellarActivateToken = ({
     });
 
     const { network: selectedAssetNetwork, contractAddress: selectedAssetContractAddress } =
-        cryptoIdToNetworkAndContractAddress(receiveCryptoId);
+        cryptoIdToNetworkAndContractAddress(networkConfigDeps, receiveCryptoId);
 
     const inactiveToken =
         selectedAssetNetwork?.networkType === 'stellar'

--- a/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
+++ b/packages/suite/src/hooks/wallet/useBitcoinAmountUnit.ts
@@ -1,11 +1,13 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { selectDeviceUnavailableCapabilities } from '@suite-common/device';
-import { type NetworkSymbol, getNetworkOptional } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { setBitcoinAmountUnits, toggleBitcoinAmountUnits } from '@suite-common/wallet-core';
 import { PROTO } from '@trezor/connect';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const bitcoinAmountUnit = useSelector(state => state.wallet.settings.bitcoinAmountUnit);
     const unavailableCapabilities = useSelector(selectDeviceUnavailableCapabilities);
     const dispatch = useDispatch();
@@ -23,7 +25,9 @@ export const useBitcoinAmountUnit = (symbol?: NetworkSymbol) => {
 
     const areUnitsSupportedByDevice = !unavailableCapabilities?.amountUnit;
 
-    const areUnitsSupportedByNetwork = getNetworkOptional(symbol)?.features.includes('amount-unit');
+    const areUnitsSupportedByNetwork = symbol
+        ? getNetworkConfig(symbol).features.includes('amount-unit')
+        : false;
 
     return {
         bitcoinAmountUnit,

--- a/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts
+++ b/packages/suite/src/hooks/wallet/useEthereumCancelTxCompose.ts
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 
 import { useMutation } from '@tanstack/react-query';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { toNetwork } from '@suite-common/wallet-config';
 import {
     type ComposeFeeLevelsError,
     composeSendFormTransactionFeeLevelsThunk,
@@ -44,8 +46,11 @@ const parseError = (mutationError: unknown): string | null => {
 };
 
 export const useEthereumCancelTxCompose = ({ account, tx }: UseEthereumCancelTxComposeParams) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
-    const feeInfo = useSelector(state => selectConvertedNetworkFeeInfo(state, account.symbol));
+    const feeInfo = useSelector(state =>
+        selectConvertedNetworkFeeInfo(state, account.symbol, { getNetworkConfig }),
+    );
 
     const {
         mutate,
@@ -62,7 +67,7 @@ export const useEthereumCancelTxCompose = ({ account, tx }: UseEthereumCancelTxC
             }
 
             const { rbfParams } = tx;
-            const network = getNetwork(account.symbol);
+            const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
 
             const formState: FormState = {
                 outputs: [

--- a/packages/suite/src/hooks/wallet/useRbfForm.ts
+++ b/packages/suite/src/hooks/wallet/useRbfForm.ts
@@ -2,7 +2,9 @@ import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { type UseFormReturn, useForm } from 'react-hook-form';
 
 import { selectCurrentTargetAnonymity } from '@suite/coinjoin';
-import { type Network, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type Network, toNetwork } from '@suite-common/wallet-config';
 import {
     DEFAULT_OPRETURN,
     DEFAULT_PAYMENT,
@@ -173,12 +175,13 @@ const getRbfFeeInfo = (info: FeeInfo, rbfParams: RbfTransactionParams) => {
 };
 
 const useRbfState = ({ account, rbfParams, chainedTxs }: UseRbfProps): RbfState => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const networkFees = useSelector(state => selectRawNetworkFeeInfo(state, account.symbol));
     const targetAnonymity = useSelector(selectCurrentTargetAnonymity);
     const coinjoinRegisteredUtxos = useCoinjoinRegisteredUtxos({ account });
 
     const { shouldSendInSats } = useBitcoinAmountUnit(account.symbol);
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
 
     return useMemo(() => {
         const rbfFeeInfo = networkFees ? getRbfFeeInfo(networkFees, rbfParams) : DEFAULT_FEE_INFO;

--- a/packages/suite/src/hooks/wallet/useSendFormFields.ts
+++ b/packages/suite/src/hooks/wallet/useSendFormFields.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react';
 import { type FieldPath, type UseFormReturn } from 'react-hook-form';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectCurrentFiatRates } from '@suite-common/wallet-core';
 import {
     type FormOptions,
@@ -40,6 +42,7 @@ export const useSendFormFields = ({
     network,
     formState: { errors },
 }: UseSendFormFieldsParams) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { shouldSendInSats, areSatsDisplayed } = useBitcoinAmountUnit(network.symbol);
     const currentRates = useSelector(selectCurrentFiatRates);
 
@@ -116,6 +119,7 @@ export const useSendFormFields = ({
                 }
 
                 return parseCryptoToFormattedBaseCurrency({
+                    ...networkConfigDeps,
                     baseCurrencyCode,
                     rate: fiatRate,
                     value: new BigNumber(amount),
@@ -156,6 +160,7 @@ export const useSendFormFields = ({
                 }
 
                 return parseBaseCurrencyToFormattedCrypto({
+                    ...networkConfigDeps,
                     cryptoDecimals,
                     rate: fiatRate,
                     isCryptoInSats: shouldSendInSats === true,

--- a/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
+++ b/packages/suite/src/hooks/wallet/useTotalFiatBalance.ts
@@ -1,3 +1,5 @@
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, type RatesByKey } from '@suite-common/wallet-types';
 import { getTotalFiatBalance } from '@suite-common/wallet-utils/src/accountUtils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -10,10 +12,12 @@ export const useTotalFiatBalance = (
     baseCurrencyCode: BaseCurrencyCode,
     rates?: RatesByKey,
 ) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const tokenDefinitions = useSelector(state => state.tokenDefinitions);
     const deviceAccounts: Account[] = accounts.map(account => {
         const coinDefinitions = tokenDefinitions?.[account.symbol]?.coin;
         const tokens = getTokens({
+            ...networkConfigDeps,
             tokens: account.tokens ?? [],
             symbol: account.symbol,
             tokenDefinitions: coinDefinitions,
@@ -23,6 +27,7 @@ export const useTotalFiatBalance = (
     });
 
     const totalBaseCurrencyBalance = getTotalFiatBalance({
+        ...networkConfigDeps,
         deviceAccounts,
         baseCurrencyCode,
         rates,

--- a/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
+++ b/packages/suite/src/middlewares/suite/analyticsMiddleware.ts
@@ -168,8 +168,11 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     .filter(
                         account =>
                             new BigNumber(account.balance).gt(0) ||
-                            new BigNumber(getAccountTotalStakingBalance(account) || 0).gt(0) ||
+                            new BigNumber(
+                                getAccountTotalStakingBalance(extra.services, account) || 0,
+                            ).gt(0) ||
                             hasVisibleTokens(
+                                extra.services,
                                 account.symbol,
                                 account.tokens ?? [],
                                 state.tokenDefinitions,
@@ -182,7 +185,12 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
                     .reduce<Record<string, number>>((acc, { symbol, tokens }) => {
                         if (
                             tokens?.length &&
-                            !hasVisibleTokens(symbol, tokens, state.tokenDefinitions)
+                            !hasVisibleTokens(
+                                extra.services,
+                                symbol,
+                                tokens,
+                                state.tokenDefinitions,
+                            )
                         ) {
                             return acc;
                         }
@@ -193,7 +201,9 @@ const analyticsMiddleware = createMiddlewareWithExtraDeps(
 
                 const accountsWithStaking = state.wallet.accounts
                     .filter(account =>
-                        new BigNumber(getAccountTotalStakingBalance(account) || 0).gt(0),
+                        new BigNumber(
+                            getAccountTotalStakingBalance(extra.services, account) || 0,
+                        ).gt(0),
                     )
                     .reduce(accumulateAccountCountBySymbolAndType, {});
 

--- a/packages/suite/src/middlewares/wallet/index.ts
+++ b/packages/suite/src/middlewares/wallet/index.ts
@@ -18,14 +18,14 @@ import graphMiddleware from './graphMiddleware';
 import { replaceByFeeErrorMiddleware } from './replaceByFeeErrorMiddleware';
 import { storageMiddleware } from './storageMiddleware';
 import { tradingMiddleware } from './tradingMiddleware';
-import walletMiddleware from './walletMiddleware';
+import { prepareWalletMiddleware } from './walletMiddleware';
 
 export const getWalletMiddlewares = (
     getExtra: () => ExtraDependencies | null,
 ): ((api: MiddlewareAPI) => any)[] => [
     prepareBlockchainMiddleware(getExtra),
     prepareAccountsMiddleware(getExtra),
-    walletMiddleware,
+    prepareWalletMiddleware(getExtra),
     prepareDiscoveryMiddleware(getExtra),
     prepareFiatRatesMiddleware(getExtra),
     prepareTokenDefinitionsMiddleware(getExtra),

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.test.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@suite-common/wallet-core';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
-import walletMiddleware from 'src/middlewares/wallet/walletMiddleware';
+import { prepareWalletMiddleware } from 'src/middlewares/wallet/walletMiddleware';
 import { accountsReducer, blockchainReducer, walletSettingsReducer } from 'src/reducers/wallet';
 import { extraDependencies } from 'src/support/extraDependencies';
 
@@ -68,7 +68,7 @@ type State = ReturnType<typeof getInitialState>;
 const mockStore = (preloadedState: State) =>
     configureMockStore({
         middleware: [
-            walletMiddleware,
+            prepareWalletMiddleware(() => extraDependenciesCommonMock),
             prepareBlockchainMiddleware(() => extraDependenciesCommonMock),
         ],
         reducer: (state = preloadedState, action) => ({

--- a/packages/suite/src/middlewares/wallet/walletMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/walletMiddleware.ts
@@ -1,9 +1,9 @@
 import { isAnyOf } from '@reduxjs/toolkit';
-import type { MiddlewareAPI } from 'redux';
 
 import { selectSelectedAccountKey } from '@suite/account';
 import { routerLocationChange, selectRouteName } from '@suite/router';
 import { deviceActions } from '@suite-common/device';
+import { createMiddlewareWithExtraDeps } from '@suite-common/redux-utils';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { tradingActions } from '@suite-common/trading';
 import {
@@ -18,95 +18,94 @@ import {
     transactionsActions,
     unsubscribeBlockchainThunk,
 } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
 
 import * as selectedAccountActions from 'src/actions/wallet/selectedAccountActions';
 import * as tradingCommonActions from 'src/actions/wallet/trading/tradingCommonActions';
-import type { Action, AppState, Dispatch } from 'src/types/suite';
+import type { Action } from 'src/types/suite';
 
-const walletMiddleware =
-    (api: MiddlewareAPI<Dispatch, AppState>) =>
-    (next: Dispatch) =>
-    (action: Action): Action => {
-        const prevState = api.getState();
+export const prepareWalletMiddleware = createMiddlewareWithExtraDeps<Action>((action, api) => {
+    const prevState = api.getState();
 
-        if (deviceActions.forgetDevice.match(action)) {
-            const deviceState = action.payload.device.state?.staticSessionId;
-            const accountsToRemove = api
-                .getState()
-                .wallet.accounts.filter(a => a.deviceState === deviceState);
-            api.dispatch(accountsActions.removeAccount(accountsToRemove));
-        }
+    if (deviceActions.forgetDevice.match(action)) {
+        const deviceState = action.payload.device.state?.staticSessionId;
+        const accountsToRemove = api
+            .getState()
+            .wallet.accounts.filter((a: Account) => a.deviceState === deviceState);
+        api.dispatch(accountsActions.removeAccount(accountsToRemove));
+    }
 
-        // propagate action to reducers, this needs to happen before addTransaction is dispatched because it needs to have account in redux already
-        next(action);
+    // propagate action to reducers, this needs to happen before addTransaction is dispatched because it needs to have account in redux already
+    api.next(action);
 
-        if (accountsActions.createAccount.match(action)) {
-            // gather transactions from account.create action
-            const account = action.payload;
-            api.dispatch(
-                transactionsActions.addTransaction({
+    if (accountsActions.createAccount.match(action)) {
+        // gather transactions from account.create action
+        const account = action.payload;
+        api.dispatch(
+            transactionsActions.addTransaction(
+                {
                     transactions: account.history.transactions || [],
                     account,
                     page: 1,
                     perPage: getTxsPerPage(account.networkType),
-                }),
-            );
-        }
+                },
+                api.extra.services.getNetworkConfig,
+            ),
+        );
+    }
 
-        if (isAnyOf(accountsActions.createAccount, accountsActions.updateAccount)(action)) {
-            api.dispatch(subscribeBlockchainThunk({ symbol: action.payload.symbol }));
-        }
+    if (isAnyOf(accountsActions.createAccount, accountsActions.updateAccount)(action)) {
+        api.dispatch(subscribeBlockchainThunk({ symbol: action.payload.symbol }));
+    }
 
-        if (accountsActions.removeAccount.match(action)) {
-            api.dispatch(unsubscribeBlockchainThunk(action.payload));
-        }
+    if (accountsActions.removeAccount.match(action)) {
+        api.dispatch(unsubscribeBlockchainThunk(action.payload));
+    }
 
-        // Update custom backends
-        if (blockchainActions.setBackend.match(action)) {
-            api.dispatch(setCustomBackendThunk(action.payload.symbol));
-        }
+    // Update custom backends
+    if (blockchainActions.setBackend.match(action)) {
+        api.dispatch(setCustomBackendThunk(action.payload.symbol));
+    }
 
-        const prevRouter = prevState.router;
-        const nextRouter = api.getState().router;
-        let resetReducers = action.type === deviceActions.selectDevice.type;
+    const prevRouter = prevState.router;
+    const nextRouter = api.getState().router;
+    let resetReducers = action.type === deviceActions.selectDevice.type;
 
-        if (
-            deviceActions.forgetDevice.match(action) &&
-            prevState.wallet.selectedAccount.account?.deviceState ===
-                action.payload.device.state?.staticSessionId
-        ) {
-            // if currently selected account is related to forgotten device
-            resetReducers = true;
-        }
+    if (
+        deviceActions.forgetDevice.match(action) &&
+        prevState.wallet.selectedAccount.account?.deviceState ===
+            action.payload.device.state?.staticSessionId
+    ) {
+        // if currently selected account is related to forgotten device
+        resetReducers = true;
+    }
 
-        if (prevRouter.app === 'wallet' && action.type === routerLocationChange.type) {
-            // leaving wallet app or switching between accounts
-            resetReducers =
-                (nextRouter.app !== 'wallet' && !nextRouter.route?.isForegroundApp) ||
-                (nextRouter.app === 'wallet' && nextRouter.hash !== prevRouter.hash);
-        }
-        if (resetReducers) {
-            api.dispatch(accountsActions.disposeAccount());
-            api.dispatch(sendFormActions.dispose());
-            api.dispatch(tradingActions.setVerifiedAddress(undefined));
-            api.dispatch(stakeActions.dispose());
-        }
+    if (prevRouter.app === 'wallet' && action.type === routerLocationChange.type) {
+        // leaving wallet app or switching between accounts
+        resetReducers =
+            (nextRouter.app !== 'wallet' && !nextRouter.route?.isForegroundApp) ||
+            (nextRouter.app === 'wallet' && nextRouter.hash !== prevRouter.hash);
+    }
+    if (resetReducers) {
+        api.dispatch(accountsActions.disposeAccount());
+        api.dispatch(sendFormActions.dispose());
+        api.dispatch(tradingActions.setVerifiedAddress(undefined));
+        api.dispatch(stakeActions.dispose());
+    }
 
-        if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {
-            const nextSelectedAccountKey = selectSelectedAccountKey(api.getState());
-            const suiteRouteName = selectRouteName(api.getState());
-            api.dispatch(
-                convertSendFormDraftsBtcAmountUnitsThunk({
-                    selectedAccountKey: nextSelectedAccountKey,
-                    isOnSendPage: suiteRouteName === 'wallet-send',
-                }),
-            );
-            api.dispatch(tradingCommonActions.convertDrafts());
-        }
+    if (action.type === WALLET_SETTINGS.SET_BITCOIN_AMOUNT_UNITS) {
+        const nextSelectedAccountKey = selectSelectedAccountKey(api.getState());
+        const suiteRouteName = selectRouteName(api.getState());
+        api.dispatch(
+            convertSendFormDraftsBtcAmountUnitsThunk({
+                selectedAccountKey: nextSelectedAccountKey,
+                isOnSendPage: suiteRouteName === 'wallet-send',
+            }),
+        );
+        api.dispatch(tradingCommonActions.convertDrafts());
+    }
 
-        api.dispatch(selectedAccountActions.syncSelectedAccount(action));
+    api.dispatch(selectedAccountActions.syncSelectedAccount(action));
 
-        return action;
-    };
-
-export default walletMiddleware;
+    return action;
+});

--- a/packages/suite/src/storage/index.ts
+++ b/packages/suite/src/storage/index.ts
@@ -4,8 +4,10 @@ import { idbVersionToString } from '@suite/idb-migration-utils';
 import { desktopApi } from '@trezor/suite-desktop-api';
 import SuiteDB, { type OnUpgradeFunc } from '@trezor/suite-storage';
 
+import { suiteNetworkConfigDeps } from 'src/support/extraDependencies';
+
 import type { SuiteDBSchema } from './definitions';
-import { runLegacyMigrations } from './migrations';
+import { createRunLegacyMigrations } from './migrations';
 import * as migrations from './migrations/versions';
 
 const LAST_LEGACY_VERSION = 57;
@@ -17,6 +19,9 @@ const LAST_LEGACY_VERSION = 57;
 const normalizeVersion = (version: number) => (version < 0x01000000 ? version << 8 : version);
 
 const MIGRATIONS = Object.values(migrations)
+    .map(migration =>
+        typeof migration === 'function' ? migration(suiteNetworkConfigDeps) : migration,
+    )
     .map(m => ({ ...m, threshold: normalizeVersion(m.threshold) }))
     .sort((a, b) => a.threshold - b.threshold);
 
@@ -61,7 +66,12 @@ const onUpgrade: OnUpgradeFunc<SuiteDBSchema> = async (db, oldVersion, newVersio
     }
 
     if (oldVersion < LAST_LEGACY_VERSION) {
-        await runLegacyMigrations(db, oldVersion, newVersion, transaction);
+        await createRunLegacyMigrations(suiteNetworkConfigDeps)(
+            db,
+            oldVersion,
+            newVersion,
+            transaction,
+        );
     }
 
     await runMigrations(db, oldVersion, transaction);

--- a/packages/suite/src/storage/migrations/index.ts
+++ b/packages/suite/src/storage/migrations/index.ts
@@ -1,8 +1,7 @@
 import {
+    type NetworkConfigDeps,
     type NetworkSymbol,
-    getNetwork,
     isNetworkSymbol,
-    networkSymbolCollection,
 } from '@suite-common/wallet-config';
 import {
     type AccountKey,
@@ -40,1160 +39,1187 @@ export type DBWalletAccountTransactionCompatible = {
     tx: DBWalletAccountTransaction['tx'] & { totalSpent: string };
 };
 
-export const runLegacyMigrations: OnUpgradeFunc<SuiteDBSchema> = async (
-    db,
-    oldVersion,
-    newVersion,
-    transaction,
-) => {
-    console.log(`Migrating database from version ${oldVersion} to ${newVersion}`);
+export const createRunLegacyMigrations =
+    (networkConfigDeps: NetworkConfigDeps): OnUpgradeFunc<SuiteDBSchema> =>
+    async (db, oldVersion, newVersion, transaction) => {
+        console.log(`Migrating database from version ${oldVersion} to ${newVersion}`);
 
-    // TODO: make separate file for each iterative migration
+        // TODO: make separate file for each iterative migration
 
-    // migrations from version older than 13 (internal releases) are not implemented
-    if (oldVersion < 13) {
-        // object store for wallet transactions
-        const txsStore = db.createObjectStore('txs', {
-            keyPath: ['tx.deviceState', 'tx.descriptor', 'tx.txid', 'tx.type'],
-        });
-        txsStore.createIndex('txid', 'tx.txid', { unique: false });
-        txsStore.createIndex('order', 'order', { unique: false });
-        txsStore.createIndex('blockTime', 'tx.blockTime', { unique: false });
-        txsStore.createIndex('deviceState', 'tx.deviceState', { unique: false });
-        txsStore.createIndex('accountKey', ['tx.descriptor', 'tx.symbol', 'tx.deviceState'], {
-            unique: false,
-        });
-
-        // object store for settings
-        db.createObjectStore('suiteSettings');
-        db.createObjectStore('walletSettings');
-
-        // object store for devices
-        db.createObjectStore('devices');
-
-        // object store for accounts
-        const accountsStore = db.createObjectStore('accounts', {
-            keyPath: ['descriptor', 'symbol', 'deviceState'],
-        });
-        accountsStore.createIndex('deviceState', 'deviceState', { unique: false });
-
-        db.createObjectStore('analytics');
-    }
-
-    if (oldVersion < 14) {
-        // added graph object store
-        const graphStore = db.createObjectStore('graph', {
-            keyPath: ['account.descriptor', 'account.symbol', 'account.deviceState'],
-        });
-        graphStore.createIndex('accountKey', [
-            'account.descriptor',
-            'account.symbol',
-            'account.deviceState',
-        ]);
-        graphStore.createIndex('deviceState', 'account.deviceState');
-    }
-
-    if (oldVersion < 15) {
-        db.createObjectStore('metadata');
-
-        await updateAll(transaction, 'accounts', account => {
-            account.metadata = {
-                key: '',
-                // @ts-expect-error
-                fileName: '',
-                aesKey: '',
-                outputLabels: {},
-                addressLabels: {},
-            };
-            account.key = createAccountKey({
-                accountDescriptor: account.descriptor,
-                networkSymbol: account.symbol,
-                deviceStaticSessionId: account.deviceState,
+        // migrations from version older than 13 (internal releases) are not implemented
+        if (oldVersion < 13) {
+            // object store for wallet transactions
+            const txsStore = db.createObjectStore('txs', {
+                keyPath: ['tx.deviceState', 'tx.descriptor', 'tx.txid', 'tx.type'],
+            });
+            txsStore.createIndex('txid', 'tx.txid', { unique: false });
+            txsStore.createIndex('order', 'order', { unique: false });
+            txsStore.createIndex('blockTime', 'tx.blockTime', { unique: false });
+            txsStore.createIndex('deviceState', 'tx.deviceState', { unique: false });
+            txsStore.createIndex('accountKey', ['tx.descriptor', 'tx.symbol', 'tx.deviceState'], {
+                unique: false,
             });
 
-            return account;
-        });
+            // object store for settings
+            db.createObjectStore('suiteSettings');
+            db.createObjectStore('walletSettings');
 
-        await updateAll(transaction, 'devices', device => {
-            device.metadata = {
-                // @ts-expect-error
-                status: 'disabled',
-            };
+            // object store for devices
+            db.createObjectStore('devices');
 
-            return device;
-        });
-    }
+            // object store for accounts
+            const accountsStore = db.createObjectStore('accounts', {
+                keyPath: ['descriptor', 'symbol', 'deviceState'],
+            });
+            accountsStore.createIndex('deviceState', 'deviceState', { unique: false });
 
-    if (oldVersion < 16) {
-        // @ts-expect-error sendForm doesn't exists anymore
-        if (db.objectStoreNames.contains('sendForm')) {
-            // @ts-expect-error sendForm doesn't exists anymore
-            db.deleteObjectStore('sendForm');
+            db.createObjectStore('analytics');
         }
-        // object store for send form
-        db.createObjectStore('sendFormDrafts');
-    }
 
-    if (oldVersion < 17) {
-        // @ts-expect-error coinmarketTrades doesn't exists anymore
-        db.createObjectStore('coinmarketTrades', { keyPath: 'key' });
-    }
+        if (oldVersion < 14) {
+            // added graph object store
+            const graphStore = db.createObjectStore('graph', {
+                keyPath: ['account.descriptor', 'account.symbol', 'account.deviceState'],
+            });
+            graphStore.createIndex('accountKey', [
+                'account.descriptor',
+                'account.symbol',
+                'account.deviceState',
+            ]);
+            graphStore.createIndex('deviceState', 'account.deviceState');
+        }
 
-    if (oldVersion < 18) {
-        await updateAll(transaction, 'devices', device => {
-            device.walletNumber = device.instance;
+        if (oldVersion < 15) {
+            db.createObjectStore('metadata');
 
-            return device;
-        });
-    }
-
-    if (oldVersion < 19) {
-        // no-op - this migration code became obsolete
-    }
-
-    if (oldVersion < 20) {
-        // enhance tx.details
-        await updateAll(transaction, 'txs', tx => {
-            if (tx.tx.details) {
-                tx.tx.details = {
-                    ...tx.tx.details,
-                    vin: tx.tx.details.vin.map(v => ({
-                        ...v,
-                        value: v.value ? formatNetworkAmount(v.value, tx.tx.symbol) : v.value,
-                    })),
-                    vout: tx.tx.details.vout.map(v => ({
-                        ...v,
-                        value: v.value ? formatNetworkAmount(v.value, tx.tx.symbol) : v.value,
-                    })),
-                    totalInput: formatNetworkAmount(tx.tx.details.totalInput, tx.tx.symbol),
-                    totalOutput: formatNetworkAmount(tx.tx.details.totalOutput, tx.tx.symbol),
+            await updateAll(transaction, 'accounts', account => {
+                account.metadata = {
+                    key: '',
+                    // @ts-expect-error
+                    fileName: '',
+                    aesKey: '',
+                    outputLabels: {},
+                    addressLabels: {},
                 };
+                account.key = createAccountKey({
+                    accountDescriptor: account.descriptor,
+                    networkSymbol: account.symbol,
+                    deviceStaticSessionId: account.deviceState,
+                });
+
+                return account;
+            });
+
+            await updateAll(transaction, 'devices', device => {
+                device.metadata = {
+                    // @ts-expect-error
+                    status: 'disabled',
+                };
+
+                return device;
+            });
+        }
+
+        if (oldVersion < 16) {
+            // @ts-expect-error sendForm doesn't exists anymore
+            if (db.objectStoreNames.contains('sendForm')) {
+                // @ts-expect-error sendForm doesn't exists anymore
+                db.deleteObjectStore('sendForm');
             }
+            // object store for send form
+            db.createObjectStore('sendFormDrafts');
+        }
 
-            return tx;
-        });
-    }
+        if (oldVersion < 17) {
+            // @ts-expect-error coinmarketTrades doesn't exists anymore
+            db.createObjectStore('coinmarketTrades', { keyPath: 'key' });
+        }
 
-    if (oldVersion < 21) {
-        // do the same thing as in blockchain-link's transformTransaction
-        const symbolsToExclude = ['eth', 'etc', 'xrp', 'trop', 'txrp'];
-        await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
-            if (!tx.tx.totalSpent) {
-                if (!symbolsToExclude.includes(tx.tx.symbol)) {
-                    // btc-like txs
-                    if (tx.tx.type === 'sent') {
-                        // fix tx.amount = tx.amount - tx.fee for btc-like sent txs
-                        tx.tx.totalSpent = tx.tx.amount;
-                        tx.tx.amount = new BigNumber(tx.tx.amount).minus(tx.tx.fee).toString();
-                    } else {
-                        tx.tx.totalSpent = tx.tx.amount;
-                    }
-                } else if (tx.tx.type === 'sent') {
-                    // eth, xrp like sent txs
-                    if (tx.tx.ethereumSpecific) {
-                        if (tx.tx.tokens.length > 0 || tx.tx.ethereumSpecific.status === 0) {
-                            // eth with tokens (amount === fee == totalSpent)
+        if (oldVersion < 18) {
+            await updateAll(transaction, 'devices', device => {
+                device.walletNumber = device.instance;
+
+                return device;
+            });
+        }
+
+        if (oldVersion < 19) {
+            // no-op - this migration code became obsolete
+        }
+
+        if (oldVersion < 20) {
+            // enhance tx.details
+            await updateAll(transaction, 'txs', tx => {
+                if (tx.tx.details) {
+                    tx.tx.details = {
+                        ...tx.tx.details,
+                        vin: tx.tx.details.vin.map(v => ({
+                            ...v,
+                            value: v.value
+                                ? formatNetworkAmount(networkConfigDeps, v.value, tx.tx.symbol)
+                                : v.value,
+                        })),
+                        vout: tx.tx.details.vout.map(v => ({
+                            ...v,
+                            value: v.value
+                                ? formatNetworkAmount(networkConfigDeps, v.value, tx.tx.symbol)
+                                : v.value,
+                        })),
+                        totalInput: formatNetworkAmount(
+                            networkConfigDeps,
+                            tx.tx.details.totalInput,
+                            tx.tx.symbol,
+                        ),
+                        totalOutput: formatNetworkAmount(
+                            networkConfigDeps,
+                            tx.tx.details.totalOutput,
+                            tx.tx.symbol,
+                        ),
+                    };
+                }
+
+                return tx;
+            });
+        }
+
+        if (oldVersion < 21) {
+            // do the same thing as in blockchain-link's transformTransaction
+            const symbolsToExclude = ['eth', 'etc', 'xrp', 'trop', 'txrp'];
+            await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
+                if (!tx.tx.totalSpent) {
+                    if (!symbolsToExclude.includes(tx.tx.symbol)) {
+                        // btc-like txs
+                        if (tx.tx.type === 'sent') {
+                            // fix tx.amount = tx.amount - tx.fee for btc-like sent txs
                             tx.tx.totalSpent = tx.tx.amount;
+                            tx.tx.amount = new BigNumber(tx.tx.amount).minus(tx.tx.fee).toString();
+                        } else {
+                            tx.tx.totalSpent = tx.tx.amount;
+                        }
+                    } else if (tx.tx.type === 'sent') {
+                        // eth, xrp like sent txs
+                        if (tx.tx.ethereumSpecific) {
+                            if (tx.tx.tokens.length > 0 || tx.tx.ethereumSpecific.status === 0) {
+                                // eth with tokens (amount === fee == totalSpent)
+                                tx.tx.totalSpent = tx.tx.amount;
+                            } else {
+                                tx.tx.totalSpent = new BigNumber(tx.tx.amount)
+                                    .plus(tx.tx.fee)
+                                    .toString();
+                            }
                         } else {
                             tx.tx.totalSpent = new BigNumber(tx.tx.amount)
                                 .plus(tx.tx.fee)
                                 .toString();
                         }
                     } else {
-                        tx.tx.totalSpent = new BigNumber(tx.tx.amount).plus(tx.tx.fee).toString();
+                        // self, recv txs
+                        tx.tx.totalSpent = tx.tx.amount;
                     }
-                } else {
-                    // self, recv txs
-                    tx.tx.totalSpent = tx.tx.amount;
+
+                    return tx;
+                }
+            });
+        }
+
+        if (oldVersion < 22) {
+            await updateAll(transaction, 'accounts', account => {
+                if (account.symbol === 'ltc' && account.accountType === 'normal') {
+                    // change account type from normal to segwit
+                    account.accountType = 'segwit';
+
+                    return account;
+                }
+            });
+        }
+
+        if (oldVersion < 23) {
+            db.createObjectStore('messageSystem');
+        }
+
+        if (oldVersion < 24) {
+            db.createObjectStore('formDrafts');
+        }
+
+        if (oldVersion < 25) {
+            await updateAll<
+                'walletSettings',
+                WalletSettings & {
+                    blockbookUrls?: BlockbookUrl[];
+                } & WalletWithBackends
+            >(transaction, 'walletSettings', settings => {
+                if (!settings.backends && settings.blockbookUrls) {
+                    settings.backends = settings.blockbookUrls.reduce<{ [key: string]: any }>(
+                        (backends, { coin, url, tor }) =>
+                            tor // automatically torified backends should be omitted
+                                ? backends
+                                : {
+                                      ...backends,
+                                      [coin]: {
+                                          type: 'blockbook',
+                                          urls: [...(backends[coin]?.urls || []), url],
+                                      },
+                                  },
+                        {},
+                    );
+                    delete settings.blockbookUrls;
+
+                    return settings;
+                }
+            });
+        }
+
+        if (oldVersion < 26) {
+            await updateAll(transaction, 'accounts', account => {
+                // @ts-expect-error
+                if (account.symbol === 'vtc' && account.accountType === 'normal') {
+                    // change account type from normal to segwit
+                    account.accountType = 'segwit';
+
+                    return account;
+                }
+            });
+        }
+
+        if (oldVersion < 27) {
+            const backendSettings = db.createObjectStore('backendSettings');
+
+            await updateAll<'walletSettings', WalletSettings & WalletWithBackends>(
+                transaction,
+                'walletSettings',
+                settings => {
+                    const { backends = {}, ...rest } = settings;
+                    Object.entries(backends).forEach(([symbol, { type, urls }]) => {
+                        const settings: BackendSettings = {
+                            selected: type,
+                            urls: {
+                                [type]: urls,
+                            },
+                        };
+
+                        if (isNetworkSymbol(networkConfigDeps, symbol)) {
+                            backendSettings.add(settings, symbol);
+                        }
+                    });
+
+                    return rest;
+                },
+            );
+        }
+
+        if (oldVersion < 28) {
+            await updateAll(transaction, 'devices', device => {
+                if ((device.state as string)?.includes('undefined')) {
+                    // @ts-expect-error
+                    device.state = device.state.replace('undefined', '0');
+
+                    return device;
+                }
+            });
+
+            // accounts
+            const accountsStoreOld = transaction.objectStore('accounts');
+            const accounts = await accountsStoreOld.getAll();
+            db.deleteObjectStore('accounts');
+
+            const accountsStoreNew = db.createObjectStore('accounts', {
+                keyPath: ['descriptor', 'symbol', 'deviceState'],
+            });
+            accountsStoreNew.createIndex('deviceState', 'deviceState', { unique: false });
+
+            accounts.forEach(account => {
+                // @ts-expect-error
+                account.deviceState = account.deviceState.replace('undefined', '0');
+                account.key = account.key.replace('undefined', '0') as AccountKey;
+                accountsStoreNew.add(account);
+            });
+
+            // transactions
+            const txsStoreOld = transaction.objectStore('txs');
+            const txs = await txsStoreOld.getAll();
+            db.deleteObjectStore('txs');
+
+            const txsStoreNew = db.createObjectStore('txs', {
+                keyPath: ['tx.deviceState', 'tx.descriptor', 'tx.txid', 'tx.type'],
+            });
+            txsStoreNew.createIndex('txid', 'tx.txid', { unique: false });
+            txsStoreNew.createIndex('order', 'order', { unique: false });
+            txsStoreNew.createIndex('blockTime', 'tx.blockTime', { unique: false });
+            txsStoreNew.createIndex('deviceState', 'tx.deviceState', { unique: false });
+            txsStoreNew.createIndex(
+                'accountKey',
+                ['tx.descriptor', 'tx.symbol', 'tx.deviceState'],
+                {
+                    unique: false,
+                },
+            );
+
+            txs.forEach(tx => {
+                // @ts-expect-error
+                tx.tx.deviceState = tx.tx.deviceState.replace('undefined', '0');
+                txsStoreNew.add(tx);
+            });
+
+            // graph
+            const graphStoreOld = transaction.objectStore('graph');
+            const graphs = await graphStoreOld.getAll();
+            db.deleteObjectStore('graph');
+
+            const graphStoreNew = db.createObjectStore('graph', {
+                keyPath: ['account.descriptor', 'account.symbol', 'account.deviceState'],
+            });
+            graphStoreNew.createIndex('accountKey', [
+                'account.descriptor',
+                'account.symbol',
+                'account.deviceState',
+            ]);
+            graphStoreNew.createIndex('deviceState', 'account.deviceState');
+
+            graphs.forEach(graph => {
+                // @ts-expect-error
+                graph.account.deviceState = graph.account.deviceState.replace('undefined', '0');
+                graphStoreNew.add(graph);
+            });
+        }
+
+        if (oldVersion < 29) {
+            db.createObjectStore('firmware');
+
+            await updateAll(transaction, 'metadata', state => {
+                // @ts-expect-error (token property removed)
+                if (state.provider?.token) {
+                    if (isDesktop()) {
+                        // @ts-expect-error (provider removed in later version)
+                        state.provider.tokens = {
+                            accessToken: '',
+                            // @ts-expect-error
+                            refreshToken: state.provider.token,
+                        };
+                    }
+                    // @ts-expect-error
+                    delete state.provider.token;
+
+                    return state;
+                }
+            });
+        }
+
+        if (oldVersion < 30) {
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                if (walletSettings.bitcoinAmountUnit || !walletSettings) {
+                    return;
                 }
 
-                return tx;
-            }
-        });
-    }
+                walletSettings.bitcoinAmountUnit = 0;
 
-    if (oldVersion < 22) {
-        await updateAll(transaction, 'accounts', account => {
-            if (account.symbol === 'ltc' && account.accountType === 'normal') {
-                // change account type from normal to segwit
-                account.accountType = 'segwit';
+                return walletSettings;
+            });
+        }
 
-                return account;
-            }
-        });
-    }
+        if (oldVersion < 31) {
+            await updateAll<'txs', DBWalletAccountTransactionCompatible>(
+                transaction,
+                'txs',
+                ({ order, tx: origTx }) => {
+                    const unformat = (amount: string) =>
+                        networkAmountToSmallestUnit(networkConfigDeps, amount, origTx.symbol);
+                    const unformatIfDefined = (amount: string | undefined) =>
+                        amount ? unformat(amount) : amount;
 
-    if (oldVersion < 23) {
-        db.createObjectStore('messageSystem');
-    }
-
-    if (oldVersion < 24) {
-        db.createObjectStore('formDrafts');
-    }
-
-    if (oldVersion < 25) {
-        await updateAll<
-            'walletSettings',
-            WalletSettings & {
-                blockbookUrls?: BlockbookUrl[];
-            } & WalletWithBackends
-        >(transaction, 'walletSettings', settings => {
-            if (!settings.backends && settings.blockbookUrls) {
-                settings.backends = settings.blockbookUrls.reduce<{ [key: string]: any }>(
-                    (backends, { coin, url, tor }) =>
-                        tor // automatically torified backends should be omitted
-                            ? backends
-                            : {
-                                  ...backends,
-                                  [coin]: {
-                                      type: 'blockbook',
-                                      urls: [...(backends[coin]?.urls || []), url],
-                                  },
-                              },
-                    {},
-                );
-                delete settings.blockbookUrls;
-
-                return settings;
-            }
-        });
-    }
-
-    if (oldVersion < 26) {
-        await updateAll(transaction, 'accounts', account => {
-            // @ts-expect-error
-            if (account.symbol === 'vtc' && account.accountType === 'normal') {
-                // change account type from normal to segwit
-                account.accountType = 'segwit';
-
-                return account;
-            }
-        });
-    }
-
-    if (oldVersion < 27) {
-        const backendSettings = db.createObjectStore('backendSettings');
-
-        await updateAll<'walletSettings', WalletSettings & WalletWithBackends>(
-            transaction,
-            'walletSettings',
-            settings => {
-                const { backends = {}, ...rest } = settings;
-                Object.entries(backends).forEach(([symbol, { type, urls }]) => {
-                    const settings: BackendSettings = {
-                        selected: type,
-                        urls: {
-                            [type]: urls,
+                    const unenhancedTx = {
+                        ...origTx,
+                        amount: unformat(origTx.amount),
+                        fee: unformat(origTx.fee),
+                        totalSpent: unformat(origTx.totalSpent),
+                        tokens: origTx.tokens.map(tok => ({
+                            ...tok,
+                            amount: convertAmountUnitsToSubunits(tok.amount, tok.decimals),
+                        })),
+                        targets: origTx.targets.map(target => ({
+                            ...target,
+                            amount: unformatIfDefined(target.amount),
+                        })),
+                        ethereumSpecific: origTx.ethereumSpecific
+                            ? {
+                                  ...origTx.ethereumSpecific,
+                                  gasPrice: fromGwei(
+                                      origTx.ethereumSpecific?.gasPrice ?? '0',
+                                  ).toWei(),
+                              }
+                            : undefined,
+                        cardanoSpecific: origTx.cardanoSpecific
+                            ? {
+                                  ...origTx.cardanoSpecific,
+                                  withdrawal: unformatIfDefined(origTx.cardanoSpecific.withdrawal),
+                                  deposit: unformatIfDefined(origTx.cardanoSpecific.deposit),
+                              }
+                            : undefined,
+                        details: origTx.details && {
+                            ...origTx.details,
+                            vin: origTx.details.vin.map(v => ({
+                                ...v,
+                                value: unformatIfDefined(v.value),
+                            })),
+                            vout: origTx.details.vout.map(v => ({
+                                ...v,
+                                value: unformatIfDefined(v.value),
+                            })),
+                            totalInput: unformat(origTx.details.totalInput),
+                            totalOutput: unformat(origTx.details.totalOutput),
                         },
                     };
 
-                    if (isNetworkSymbol(symbol)) {
-                        backendSettings.add(settings, symbol);
+                    return { order, tx: unenhancedTx };
+                },
+            );
+
+            await updateAll(transaction, 'devices', device => {
+                const { features } = device;
+
+                device.firmwareType =
+                    features?.capabilities &&
+                    !features.capabilities.includes('Capability_Bitcoin_like')
+                        ? FirmwareType.BitcoinOnly
+                        : FirmwareType.Universal;
+
+                return device;
+            });
+        }
+
+        if (oldVersion < 32) {
+            db.createObjectStore('coinjoinAccounts');
+        }
+
+        if (oldVersion < 33) {
+            await updateAll(transaction, 'messageSystem', messageSystem => {
+                Object.values(messageSystem.dismissedMessages).forEach(dismissedMessage => {
+                    if (typeof dismissedMessage.feature === 'undefined') {
+                        dismissedMessage.feature = false;
                     }
                 });
 
-                return rest;
-            },
-        );
-    }
+                return messageSystem;
+            });
+        }
 
-    if (oldVersion < 28) {
-        await updateAll(transaction, 'devices', device => {
-            if ((device.state as string)?.includes('undefined')) {
+        if (oldVersion < 34) {
+            db.createObjectStore('coinjoinDebugSettings');
+        }
+
+        if (oldVersion < 35) {
+            const accountsToUpdate = ['eth', 'etc', 'trop', 'tgor'];
+
+            // remove ethereum network transactions
+            await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
+                if (accountsToUpdate.includes(tx.tx.symbol)) {
+                    return null;
+                }
+                tx.tx.internalTransfers = [];
+
+                return tx;
+            });
+
+            // force to fetch ethereum network transactions again
+            await updateAll(transaction, 'accounts', account => {
+                if (accountsToUpdate.includes(account.symbol)) {
+                    account.history = { total: 0, unconfirmed: 0, tokens: 0 };
+
+                    return account;
+                }
+            });
+        }
+
+        if (oldVersion < 36) {
+            // remove trop network transactions, change token address to contract
+            await updateAll(transaction, 'txs', tx => {
                 // @ts-expect-error
-                device.state = device.state.replace('undefined', '0');
+                if (tx.tx.symbol === 'trop') {
+                    return null;
+                }
+                tx.tx.tokens.forEach(token => {
+                    // @ts-expect-error
+                    token.contract = token.address;
+                    // @ts-expect-error
+                    delete token.address;
+                });
+
+                return tx;
+            });
+
+            // remove trop network accounts, change token address to contract
+            await updateAll(transaction, 'accounts', account => {
+                // @ts-expect-error
+                if (account.symbol === 'trop') {
+                    return null;
+                }
+                account.tokens?.forEach(token => {
+                    // @ts-expect-error
+                    token.contract = token.address;
+                    // @ts-expect-error
+                    delete token.address;
+                });
+
+                return account;
+            });
+
+            // remove trop from coin settings
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
+                    // @ts-expect-error
+                    network => network !== 'trop',
+                );
+
+                return walletSettings;
+            });
+
+            // remove trop from backend settings
+            const backendSettings = transaction.objectStore('backendSettings');
+            // @ts-expect-error
+            await backendSettings.delete('trop');
+        }
+
+        if (oldVersion < 37) {
+            await updateAll(transaction, 'coinjoinAccounts', account => {
+                delete account.session;
+                // @ts-expect-error previousSessions field is removed
+                delete account.previousSessions;
+
+                return account;
+            });
+        }
+
+        if (oldVersion < 38) {
+            await updateAll(transaction, 'devices', device => {
+                const { features } = device;
+                if (!features.internal_model) {
+                    let deviceInternalModel;
+                    switch (features.model.toUpperCase()) {
+                        case 'T':
+                            deviceInternalModel = DeviceModelInternal.T2T1;
+                            break;
+                        case '1':
+                        default:
+                            deviceInternalModel = DeviceModelInternal.T1B1;
+                            break;
+                    }
+                    device.features.internal_model = deviceInternalModel;
+                }
 
                 return device;
-            }
-        });
-
-        // accounts
-        const accountsStoreOld = transaction.objectStore('accounts');
-        const accounts = await accountsStoreOld.getAll();
-        db.deleteObjectStore('accounts');
-
-        const accountsStoreNew = db.createObjectStore('accounts', {
-            keyPath: ['descriptor', 'symbol', 'deviceState'],
-        });
-        accountsStoreNew.createIndex('deviceState', 'deviceState', { unique: false });
-
-        accounts.forEach(account => {
-            // @ts-expect-error
-            account.deviceState = account.deviceState.replace('undefined', '0');
-            account.key = account.key.replace('undefined', '0') as AccountKey;
-            accountsStoreNew.add(account);
-        });
-
-        // transactions
-        const txsStoreOld = transaction.objectStore('txs');
-        const txs = await txsStoreOld.getAll();
-        db.deleteObjectStore('txs');
-
-        const txsStoreNew = db.createObjectStore('txs', {
-            keyPath: ['tx.deviceState', 'tx.descriptor', 'tx.txid', 'tx.type'],
-        });
-        txsStoreNew.createIndex('txid', 'tx.txid', { unique: false });
-        txsStoreNew.createIndex('order', 'order', { unique: false });
-        txsStoreNew.createIndex('blockTime', 'tx.blockTime', { unique: false });
-        txsStoreNew.createIndex('deviceState', 'tx.deviceState', { unique: false });
-        txsStoreNew.createIndex('accountKey', ['tx.descriptor', 'tx.symbol', 'tx.deviceState'], {
-            unique: false,
-        });
-
-        txs.forEach(tx => {
-            // @ts-expect-error
-            tx.tx.deviceState = tx.tx.deviceState.replace('undefined', '0');
-            txsStoreNew.add(tx);
-        });
-
-        // graph
-        const graphStoreOld = transaction.objectStore('graph');
-        const graphs = await graphStoreOld.getAll();
-        db.deleteObjectStore('graph');
-
-        const graphStoreNew = db.createObjectStore('graph', {
-            keyPath: ['account.descriptor', 'account.symbol', 'account.deviceState'],
-        });
-        graphStoreNew.createIndex('accountKey', [
-            'account.descriptor',
-            'account.symbol',
-            'account.deviceState',
-        ]);
-        graphStoreNew.createIndex('deviceState', 'account.deviceState');
-
-        graphs.forEach(graph => {
-            // @ts-expect-error
-            graph.account.deviceState = graph.account.deviceState.replace('undefined', '0');
-            graphStoreNew.add(graph);
-        });
-    }
-
-    if (oldVersion < 29) {
-        db.createObjectStore('firmware');
-
-        await updateAll(transaction, 'metadata', state => {
-            // @ts-expect-error (token property removed)
-            if (state.provider?.token) {
-                if (isDesktop()) {
-                    // @ts-expect-error (provider removed in later version)
-                    state.provider.tokens = {
-                        accessToken: '',
-                        // @ts-expect-error
-                        refreshToken: state.provider.token,
-                    };
-                }
-                // @ts-expect-error
-                delete state.provider.token;
-
-                return state;
-            }
-        });
-    }
-
-    if (oldVersion < 30) {
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            if (walletSettings.bitcoinAmountUnit || !walletSettings) {
-                return;
-            }
-
-            walletSettings.bitcoinAmountUnit = 0;
-
-            return walletSettings;
-        });
-    }
-
-    if (oldVersion < 31) {
-        await updateAll<'txs', DBWalletAccountTransactionCompatible>(
-            transaction,
-            'txs',
-            ({ order, tx: origTx }) => {
-                const unformat = (amount: string) =>
-                    networkAmountToSmallestUnit(amount, origTx.symbol);
-                const unformatIfDefined = (amount: string | undefined) =>
-                    amount ? unformat(amount) : amount;
-
-                const unenhancedTx = {
-                    ...origTx,
-                    amount: unformat(origTx.amount),
-                    fee: unformat(origTx.fee),
-                    totalSpent: unformat(origTx.totalSpent),
-                    tokens: origTx.tokens.map(tok => ({
-                        ...tok,
-                        amount: convertAmountUnitsToSubunits(tok.amount, tok.decimals),
-                    })),
-                    targets: origTx.targets.map(target => ({
-                        ...target,
-                        amount: unformatIfDefined(target.amount),
-                    })),
-                    ethereumSpecific: origTx.ethereumSpecific
-                        ? {
-                              ...origTx.ethereumSpecific,
-                              gasPrice: fromGwei(origTx.ethereumSpecific?.gasPrice ?? '0').toWei(),
-                          }
-                        : undefined,
-                    cardanoSpecific: origTx.cardanoSpecific
-                        ? {
-                              ...origTx.cardanoSpecific,
-                              withdrawal: unformatIfDefined(origTx.cardanoSpecific.withdrawal),
-                              deposit: unformatIfDefined(origTx.cardanoSpecific.deposit),
-                          }
-                        : undefined,
-                    details: origTx.details && {
-                        ...origTx.details,
-                        vin: origTx.details.vin.map(v => ({
-                            ...v,
-                            value: unformatIfDefined(v.value),
-                        })),
-                        vout: origTx.details.vout.map(v => ({
-                            ...v,
-                            value: unformatIfDefined(v.value),
-                        })),
-                        totalInput: unformat(origTx.details.totalInput),
-                        totalOutput: unformat(origTx.details.totalOutput),
-                    },
-                };
-
-                return { order, tx: unenhancedTx };
-            },
-        );
-
-        await updateAll(transaction, 'devices', device => {
-            const { features } = device;
-
-            device.firmwareType =
-                features?.capabilities && !features.capabilities.includes('Capability_Bitcoin_like')
-                    ? FirmwareType.BitcoinOnly
-                    : FirmwareType.Universal;
-
-            return device;
-        });
-    }
-
-    if (oldVersion < 32) {
-        db.createObjectStore('coinjoinAccounts');
-    }
-
-    if (oldVersion < 33) {
-        await updateAll(transaction, 'messageSystem', messageSystem => {
-            Object.values(messageSystem.dismissedMessages).forEach(dismissedMessage => {
-                if (typeof dismissedMessage.feature === 'undefined') {
-                    dismissedMessage.feature = false;
-                }
             });
-
-            return messageSystem;
-        });
-    }
-
-    if (oldVersion < 34) {
-        db.createObjectStore('coinjoinDebugSettings');
-    }
-
-    if (oldVersion < 35) {
-        const accountsToUpdate = ['eth', 'etc', 'trop', 'tgor'];
-
-        // remove ethereum network transactions
-        await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
-            if (accountsToUpdate.includes(tx.tx.symbol)) {
-                return null;
-            }
-            tx.tx.internalTransfers = [];
-
-            return tx;
-        });
-
-        // force to fetch ethereum network transactions again
-        await updateAll(transaction, 'accounts', account => {
-            if (accountsToUpdate.includes(account.symbol)) {
-                account.history = { total: 0, unconfirmed: 0, tokens: 0 };
-
-                return account;
-            }
-        });
-    }
-
-    if (oldVersion < 36) {
-        // remove trop network transactions, change token address to contract
-        await updateAll(transaction, 'txs', tx => {
-            // @ts-expect-error
-            if (tx.tx.symbol === 'trop') {
-                return null;
-            }
-            tx.tx.tokens.forEach(token => {
+        }
+        if (oldVersion < 39) {
+            await updateAll(transaction, 'accounts', account => {
                 // @ts-expect-error
-                token.contract = token.address;
-                // @ts-expect-error
-                delete token.address;
-            });
-
-            return tx;
-        });
-
-        // remove trop network accounts, change token address to contract
-        await updateAll(transaction, 'accounts', account => {
-            // @ts-expect-error
-            if (account.symbol === 'trop') {
-                return null;
-            }
-            account.tokens?.forEach(token => {
-                // @ts-expect-error
-                token.contract = token.address;
-                // @ts-expect-error
-                delete token.address;
-            });
-
-            return account;
-        });
-
-        // remove trop from coin settings
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
-                // @ts-expect-error
-                network => network !== 'trop',
-            );
-
-            return walletSettings;
-        });
-
-        // remove trop from backend settings
-        const backendSettings = transaction.objectStore('backendSettings');
-        // @ts-expect-error
-        await backendSettings.delete('trop');
-    }
-
-    if (oldVersion < 37) {
-        await updateAll(transaction, 'coinjoinAccounts', account => {
-            delete account.session;
-            // @ts-expect-error previousSessions field is removed
-            delete account.previousSessions;
-
-            return account;
-        });
-    }
-
-    if (oldVersion < 38) {
-        await updateAll(transaction, 'devices', device => {
-            const { features } = device;
-            if (!features.internal_model) {
-                let deviceInternalModel;
-                switch (features.model.toUpperCase()) {
-                    case 'T':
-                        deviceInternalModel = DeviceModelInternal.T2T1;
-                        break;
-                    case '1':
-                    default:
-                        deviceInternalModel = DeviceModelInternal.T1B1;
-                        break;
+                if (!account.metadata?.fileName || !account.metadata?.aesKey) {
+                    return;
                 }
-                device.features.internal_model = deviceInternalModel;
-            }
-
-            return device;
-        });
-    }
-    if (oldVersion < 39) {
-        await updateAll(transaction, 'accounts', account => {
-            // @ts-expect-error
-            if (!account.metadata?.fileName || !account.metadata?.aesKey) {
-                return;
-            }
-            account.metadata = {
-                key: account.metadata.key,
-                1: {
-                    // @ts-expect-error
-                    fileName: `${account.metadata.fileName}.mtdt`,
-                    // @ts-expect-error
-                    aesKey: account.metadata.aesKey,
-                },
-            };
-
-            return account;
-        });
-
-        await updateAll(transaction, 'devices', device => {
-            if (
-                // @ts-expect-error
-                device.metadata.status === 'enabled' &&
-                // @ts-expect-error
-                device.metadata.fileName &&
-                // @ts-expect-error
-                device.metadata.aesKey
-            ) {
-                device.metadata = {
-                    // @ts-expect-error
-                    status: device.metadata.status,
+                account.metadata = {
+                    key: account.metadata.key,
                     1: {
                         // @ts-expect-error
-                        key: device.metadata.key,
+                        fileName: `${account.metadata.fileName}.mtdt`,
                         // @ts-expect-error
-                        fileName: `${device.metadata.fileName}.mtdt`,
-                        // @ts-expect-error
-                        aesKey: device.metadata.aesKey,
+                        aesKey: account.metadata.aesKey,
                     },
                 };
-            }
 
-            return device;
-        });
+                return account;
+            });
 
-        // @ts-expect-error
-        await updateAll(transaction, 'metadata', metadata => {
-            const updatedMetadata = {
-                selectedProvider: { labels: '' },
-                providers: [],
-                enabled: metadata.enabled,
-            };
-            // @ts-expect-error
-            if (metadata.provider) {
-                let clientId: string;
-
-                // @ts-expect-error
-                switch (metadata.provider.type) {
-                    case 'dropbox':
-                        clientId = 'wg0yz2pbgjyhoda';
-                        break;
-                    case 'google':
-                        // select clientId supporting refresh tokens if refresh token was avaialble
-                        clientId =
-                            // @ts-expect-error
-                            metadata.provider.tokens?.refreshToken
-                                ? '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com'
-                                : '705190185912-nejegm4dbdecdaiumncbaa4ulrfnpk82.apps.googleusercontent.com';
-                        break;
-                    case 'fileSystem':
-                        clientId = 'fileSystem';
-                        break;
-                    default:
-                }
-                // @ts-expect-error
-                updatedMetadata.providers[0] = { ...metadata.provider, clientId, data: {} };
-                updatedMetadata.selectedProvider = {
+            await updateAll(transaction, 'devices', device => {
+                if (
                     // @ts-expect-error
-                    labels: clientId,
+                    device.metadata.status === 'enabled' &&
+                    // @ts-expect-error
+                    device.metadata.fileName &&
+                    // @ts-expect-error
+                    device.metadata.aesKey
+                ) {
+                    device.metadata = {
+                        // @ts-expect-error
+                        status: device.metadata.status,
+                        1: {
+                            // @ts-expect-error
+                            key: device.metadata.key,
+                            // @ts-expect-error
+                            fileName: `${device.metadata.fileName}.mtdt`,
+                            // @ts-expect-error
+                            aesKey: device.metadata.aesKey,
+                        },
+                    };
+                }
+
+                return device;
+            });
+
+            // @ts-expect-error
+            await updateAll(transaction, 'metadata', metadata => {
+                const updatedMetadata = {
+                    selectedProvider: { labels: '' },
+                    providers: [],
+                    enabled: metadata.enabled,
                 };
-            }
-
-            return updatedMetadata;
-        });
-    }
-
-    if (oldVersion < 40) {
-        // device.metadata.status does not exist anymore. this information is derivable from
-        // device.metadata[key]
-        // and
-        // metadata.error[deviceState]
-        await updateAll(transaction, 'devices', device => {
-            if (
                 // @ts-expect-error
-                device.metadata.status
-            ) {
-                // @ts-expect-error
-                delete device.metadata.status;
-            }
+                if (metadata.provider) {
+                    let clientId: string;
 
-            return device;
-        });
-    }
+                    // @ts-expect-error
+                    switch (metadata.provider.type) {
+                        case 'dropbox':
+                            clientId = 'wg0yz2pbgjyhoda';
+                            break;
+                        case 'google':
+                            // select clientId supporting refresh tokens if refresh token was avaialble
+                            clientId =
+                                // @ts-expect-error
+                                metadata.provider.tokens?.refreshToken
+                                    ? '705190185912-m4mrh55knjbg6gqhi72fr906a6n0b0u1.apps.googleusercontent.com'
+                                    : '705190185912-nejegm4dbdecdaiumncbaa4ulrfnpk82.apps.googleusercontent.com';
+                            break;
+                        case 'fileSystem':
+                            clientId = 'fileSystem';
+                            break;
+                        default:
+                    }
+                    // @ts-expect-error
+                    updatedMetadata.providers[0] = { ...metadata.provider, clientId, data: {} };
+                    updatedMetadata.selectedProvider = {
+                        // @ts-expect-error
+                        labels: clientId,
+                    };
+                }
 
-    if (oldVersion < 41) {
-        await updateAll(transaction, 'metadata', metadata => {
-            if (!metadata.selectedProvider) {
-                metadata.selectedProvider = { labels: '', passwords: '' };
-            }
-            metadata.selectedProvider.passwords = '';
-
-            return metadata;
-        });
-    }
-
-    if (oldVersion < 42) {
-        // @ts-expect-error fiatRates doesn't exists anymore
-        if (db.objectStoreNames.contains('fiatRates')) {
-            // @ts-expect-error fiatRates doesn't exists anymore
-            db.deleteObjectStore('fiatRates');
+                return updatedMetadata;
+            });
         }
-    }
 
-    if (oldVersion < 43) {
-        await updateAll(transaction, 'metadata', metadata => {
-            // although selectedProvider is added in version 39 I saw a report by QA that
-            // migration was trying to set 'passwords' of undefined in migration 41.
-            if (!metadata.selectedProvider) {
-                metadata.selectedProvider = { labels: '', passwords: '' };
-            }
-            if (!metadata.selectedProvider.passwords) {
+        if (oldVersion < 40) {
+            // device.metadata.status does not exist anymore. this information is derivable from
+            // device.metadata[key]
+            // and
+            // metadata.error[deviceState]
+            await updateAll(transaction, 'devices', device => {
+                if (
+                    // @ts-expect-error
+                    device.metadata.status
+                ) {
+                    // @ts-expect-error
+                    delete device.metadata.status;
+                }
+
+                return device;
+            });
+        }
+
+        if (oldVersion < 41) {
+            await updateAll(transaction, 'metadata', metadata => {
+                if (!metadata.selectedProvider) {
+                    metadata.selectedProvider = { labels: '', passwords: '' };
+                }
                 metadata.selectedProvider.passwords = '';
+
+                return metadata;
+            });
+        }
+
+        if (oldVersion < 42) {
+            // @ts-expect-error fiatRates doesn't exists anymore
+            if (db.objectStoreNames.contains('fiatRates')) {
+                // @ts-expect-error fiatRates doesn't exists anymore
+                db.deleteObjectStore('fiatRates');
             }
+        }
 
-            return metadata;
-        });
-    }
+        if (oldVersion < 43) {
+            await updateAll(transaction, 'metadata', metadata => {
+                // although selectedProvider is added in version 39 I saw a report by QA that
+                // migration was trying to set 'passwords' of undefined in migration 41.
+                if (!metadata.selectedProvider) {
+                    metadata.selectedProvider = { labels: '', passwords: '' };
+                }
+                if (!metadata.selectedProvider.passwords) {
+                    metadata.selectedProvider.passwords = '';
+                }
 
-    if (oldVersion < 44) {
-        // remove tgor network transactions
-        await updateAll(transaction, 'txs', tx => {
-            // @ts-expect-error
-            if (tx.tx.symbol === 'tgor') {
-                return null;
-            }
+                return metadata;
+            });
+        }
 
-            return tx;
-        });
-
-        // remove tgor network accounts
-        await updateAll(transaction, 'accounts', account => {
-            // @ts-expect-error
-            if (account.symbol === 'tgor') {
-                return null;
-            }
-
-            return account;
-        });
-
-        // remove tgor from coin settings
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
+        if (oldVersion < 44) {
+            // remove tgor network transactions
+            await updateAll(transaction, 'txs', tx => {
                 // @ts-expect-error
-                network => network !== 'tgor',
+                if (tx.tx.symbol === 'tgor') {
+                    return null;
+                }
+
+                return tx;
+            });
+
+            // remove tgor network accounts
+            await updateAll(transaction, 'accounts', account => {
+                // @ts-expect-error
+                if (account.symbol === 'tgor') {
+                    return null;
+                }
+
+                return account;
+            });
+
+            // remove tgor from coin settings
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
+                    // @ts-expect-error
+                    network => network !== 'tgor',
+                );
+
+                return walletSettings;
+            });
+
+            // remove tgor from backend settings
+            const backendSettings = transaction.objectStore('backendSettings');
+            // @ts-expect-error
+            backendSettings.delete('tgor');
+        }
+
+        if (oldVersion < 45) {
+            db.createObjectStore('historicRates');
+
+            await updateAll(transaction, 'txs', tx => {
+                // @ts-expect-error
+                delete tx.tx.rates;
+
+                return tx;
+            });
+
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                // @ts-expect-error
+                Object.keys(walletSettings.lastUsedFeeLevel).forEach(coin => {
+                    // @ts-expect-error
+                    if (walletSettings.lastUsedFeeLevel[coin].label === 'low') {
+                        // @ts-expect-error
+                        delete walletSettings.lastUsedFeeLevel[coin];
+                    }
+                });
+
+                return walletSettings;
+            });
+
+            await updateAll(transaction, 'suiteSettings', suiteSettings => {
+                // @ts-expect-error
+                delete suiteSettings.flags.showDashboardT2B1PromoBanner;
+
+                return suiteSettings;
+            });
+        }
+
+        if (oldVersion < 46) {
+            db.createObjectStore('tokenManagement');
+
+            await updateAll(transaction, 'devices', device => {
+                device.passwords = {};
+
+                return device;
+            });
+
+            await updateAll(transaction, 'accounts', account => {
+                if (account.networkType === 'cardano') {
+                    account.tokens = account.tokens?.map(token => {
+                        const { policyId } = parseAsset(token.contract);
+
+                        return {
+                            balance: token.balance,
+                            contract: token.contract,
+                            name: token.symbol,
+                            symbol: token.symbol,
+                            decimals: token.decimals,
+                            fingerprint: token.name,
+                            policyId,
+                            standard: token.standard,
+                        };
+                    });
+                }
+
+                return account;
+            });
+
+            await updateAll(transaction, 'txs', tx => {
+                if (tx.tx.symbol === 'ada') {
+                    tx.tx.tokens = tx.tx.tokens?.map(token => {
+                        const { policyId } = parseAsset(token.contract);
+
+                        return {
+                            amount: token.amount,
+                            contract: token.contract,
+                            decimals: token.decimals,
+                            from: token.from,
+                            name: token.symbol || '',
+                            symbol: token.symbol,
+                            fingerprint: token.name,
+                            to: token.to,
+                            type: token.type,
+                            policyId,
+                        };
+                    });
+                }
+
+                return tx;
+            });
+
+            await updateAll(transaction, 'suiteSettings', suiteSettings => suiteSettings);
+        }
+
+        if (oldVersion < 47) {
+            //  migrate matic to pol
+
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                // @ts-expect-error
+                const indexOfMatic = walletSettings.enabledNetworks.indexOf('matic');
+                if (indexOfMatic !== -1) {
+                    walletSettings.enabledNetworks[indexOfMatic] = 'pol';
+                }
+
+                return walletSettings;
+            });
+
+            await updateAll(transaction, 'suiteSettings', suiteSettings => {
+                if (
+                    // @ts-expect-error
+                    typeof suiteSettings.evmSettings?.confirmExplanationModalClosed?.matic ==
+                    'boolean'
+                ) {
+                    suiteSettings.evmSettings.confirmExplanationModalClosed.pol =
+                        // @ts-expect-error
+                        suiteSettings.evmSettings.confirmExplanationModalClosed.matic;
+                    // @ts-expect-error
+                    delete suiteSettings.evmSettings.confirmExplanationModalClosed.matic;
+                }
+
+                if (
+                    // @ts-expect-error
+                    typeof suiteSettings.evmSettings?.explanationBannerClosed?.matic == 'boolean'
+                ) {
+                    suiteSettings.evmSettings.explanationBannerClosed.pol =
+                        // @ts-expect-error
+                        suiteSettings.evmSettings.explanationBannerClosed.matic;
+                    // @ts-expect-error
+                    delete suiteSettings.evmSettings.explanationBannerClosed.matic;
+                }
+
+                return suiteSettings;
+            });
+
+            const backendSettings = transaction.objectStore('backendSettings');
+            // @ts-expect-error
+            const maticBackendSettings = await backendSettings.get('matic');
+            if (maticBackendSettings) {
+                backendSettings.add(maticBackendSettings, 'pol');
+                // @ts-expect-error
+                backendSettings.delete('matic');
+            }
+
+            const tokenManagement = transaction.objectStore('tokenManagement');
+            const maticTokenManagementShow = await tokenManagement.get('matic-coin-show');
+            if (maticTokenManagementShow) {
+                tokenManagement.add(maticTokenManagementShow, 'pol-coin-show');
+                tokenManagement.delete('matic-coin-show');
+            }
+
+            const maticTokenManagementHide = await tokenManagement.get('matic-coin-hide');
+            if (maticTokenManagementHide) {
+                tokenManagement.add(maticTokenManagementHide, 'pol-coin-hide');
+                tokenManagement.delete('matic-coin-hide');
+            }
+
+            const accounts = transaction.objectStore('accounts');
+            let accountsCursor = await accounts.openCursor();
+            while (accountsCursor) {
+                const account = accountsCursor.value;
+                // @ts-expect-error
+                if (account.symbol === 'matic') {
+                    const newAccount = {
+                        ...account,
+                        symbol: 'pol' as const,
+                        key: account.key.replace('matic', 'pol') as AccountKey,
+                    };
+                    await accountsCursor.delete();
+                    await accounts.add(newAccount);
+                }
+
+                accountsCursor = await accountsCursor.continue();
+            }
+
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                // @ts-expect-error
+                if (walletSettings.lastUsedFeeLevel['matic']) {
+                    // @ts-expect-error
+                    walletSettings.lastUsedFeeLevel = {
+                        // @ts-expect-error
+                        ...walletSettings.lastUsedFeeLevel,
+                        // @ts-expect-error
+                        pol: { ...walletSettings.lastUsedFeeLevel['matic'] },
+                    };
+
+                    // @ts-expect-error
+                    delete walletSettings.lastUsedFeeLevel['matic'];
+                }
+
+                return walletSettings;
+            });
+
+            await updateAll(transaction, 'txs', tx => {
+                // @ts-expect-error
+                if (tx.tx.symbol === 'matic') {
+                    tx.tx = { ...tx.tx, symbol: 'pol' };
+                }
+
+                return tx;
+            });
+
+            const graphs = transaction.objectStore('graph');
+            let graphCursor = await graphs.openCursor();
+            while (graphCursor) {
+                const graph = graphCursor.value;
+                //@ts-expect-error
+                if (graph.account.symbol === 'matic') {
+                    const newGraph = {
+                        ...graph,
+                        account: { ...graph.account, symbol: 'pol' as const },
+                    };
+                    await graphCursor.delete();
+                    await graphs.add(newGraph);
+                }
+
+                graphCursor = await graphCursor.continue();
+            }
+
+            await updateAll(transaction, 'historicRates', rates => {
+                const rate = Object.keys(rates).reduce((newRates, key) => {
+                    const newKey = key.replace('matic', 'pol');
+                    // @ts-expect-error
+                    newRates[newKey] = rates[key];
+
+                    return newRates;
+                }, {});
+
+                return rate;
+            });
+
+            const historicRates = transaction.objectStore('historicRates');
+            const historicRatesKeys = await historicRates.getAllKeys();
+            const historicRatesKeysWithMatic = historicRatesKeys.filter(key =>
+                key.includes('matic'),
             );
 
-            return walletSettings;
-        });
+            historicRatesKeysWithMatic.forEach(async key => {
+                const rate = await historicRates.get(key);
+                if (rate) {
+                    historicRates.add(rate, key.replace('matic', 'pol'));
+                }
+                historicRates.delete(key);
+            });
 
-        // remove tgor from backend settings
-        const backendSettings = transaction.objectStore('backendSettings');
-        // @ts-expect-error
-        backendSettings.delete('tgor');
-    }
+            const sendFormDrafts = transaction.objectStore('sendFormDrafts');
+            const sendFormDraftsKeys = await sendFormDrafts.getAllKeys();
+            const sendFormDraftsKeysWithMatic = sendFormDraftsKeys.filter(key =>
+                key.includes('matic'),
+            );
 
-    if (oldVersion < 45) {
-        db.createObjectStore('historicRates');
+            sendFormDraftsKeysWithMatic.forEach(async key => {
+                const draft = await sendFormDrafts.get(key);
+                if (draft) {
+                    sendFormDrafts.add(draft, key.replace('matic', 'pol') as AccountKey);
+                }
+                sendFormDrafts.delete(key);
+            });
 
-        await updateAll(transaction, 'txs', tx => {
-            // @ts-expect-error
-            delete tx.tx.rates;
+            const formDrafts = transaction.objectStore('formDrafts');
+            const formDraftsKeys = await formDrafts.getAllKeys();
+            const formDraftsKeysWithMatic = formDraftsKeys.filter(key => key.includes('matic'));
 
-            return tx;
-        });
+            formDraftsKeysWithMatic.forEach(async key => {
+                const draft = await formDrafts.get(key);
+                if (draft) {
+                    formDrafts.add(draft, key.replace('matic', 'pol'));
+                }
+                formDrafts.delete(key);
+            });
 
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            // @ts-expect-error
-            Object.keys(walletSettings.lastUsedFeeLevel).forEach(coin => {
-                // @ts-expect-error
-                if (walletSettings.lastUsedFeeLevel[coin].label === 'low') {
-                    // @ts-expect-error
-                    delete walletSettings.lastUsedFeeLevel[coin];
+            await updateAll(transaction, 'formDrafts', draft => {
+                if (draft.cryptoSelect?.label === 'MATIC') {
+                    draft.cryptoSelect = {
+                        ...draft.cryptoSelect,
+                        label: 'POL',
+                        value: 'polygon-ecosystem-token',
+                    };
+                }
+
+                if (draft.receiveCryptoSelect?.label === 'MATIC') {
+                    draft.receiveCryptoSelect = {
+                        ...draft.receiveCryptoSelect,
+                        label: 'POL',
+                        value: 'polygon-ecosystem-token',
+                    };
+                }
+
+                if (draft.sendCryptoSelect?.label === 'MATIC') {
+                    draft.sendCryptoSelect = {
+                        ...draft.sendCryptoSelect,
+                        label: 'POL',
+                        value: 'polygon-ecosystem-token',
+                    };
+                }
+
+                return draft;
+            });
+        }
+
+        if (oldVersion < 48) {
+            // Migrate device state to new object format
+            await updateAll(transaction, 'devices', device => {
+                if (typeof device.state === 'string') {
+                    const legacyDevice = device as typeof device & { _state?: DeviceState };
+                    if (typeof legacyDevice?._state?.staticSessionId === 'string') {
+                        // Has _state property, migrate to that
+                        device.state = legacyDevice._state;
+                    } else {
+                        // No _state property, create new object
+                        device.state = {
+                            staticSessionId: device.state,
+                        };
+                    }
+                }
+
+                return device;
+            });
+        }
+
+        if (oldVersion < 49) {
+            const supportedNetworkSymbols =
+                networkConfigDeps.networkModuleRepository.getSupportedNetworks();
+
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                walletSettings.enabledNetworks.sort(
+                    (a, b) =>
+                        supportedNetworkSymbols.indexOf(a) - supportedNetworkSymbols.indexOf(b),
+                );
+
+                return walletSettings;
+            });
+
+            await updateAll(transaction, 'txs', tx => {
+                if (['sol', 'dsol'].includes(tx.tx.symbol)) {
+                    tx.tx.amount = new BigNumber(tx.tx.amount).abs().toString();
+                }
+
+                return tx;
+            });
+        }
+
+        if (oldVersion < 50) {
+            await migrationOfBnbNetwork(db, oldVersion, newVersion, transaction);
+        }
+
+        if (oldVersion < 51) {
+            await updateAll(transaction, 'accounts', account => {
+                if (account.networkType === 'cardano') {
+                    account.misc.staking.drep = null;
+
+                    return account;
                 }
             });
 
-            return walletSettings;
-        });
+            await updateAll(transaction, 'accounts', account => {
+                if (account.networkType === 'ethereum' && account.symbol !== 'eth') {
+                    const { chainId } = networkConfigDeps.getNetworkConfig(account.symbol);
+                    account.metadata.key = `${account.descriptor}-${chainId}`;
 
-        await updateAll(transaction, 'suiteSettings', suiteSettings => {
-            // @ts-expect-error
-            delete suiteSettings.flags.showDashboardT2B1PromoBanner;
-
-            return suiteSettings;
-        });
-    }
-
-    if (oldVersion < 46) {
-        db.createObjectStore('tokenManagement');
-
-        await updateAll(transaction, 'devices', device => {
-            device.passwords = {};
-
-            return device;
-        });
-
-        await updateAll(transaction, 'accounts', account => {
-            if (account.networkType === 'cardano') {
-                account.tokens = account.tokens?.map(token => {
-                    const { policyId } = parseAsset(token.contract);
-
-                    return {
-                        balance: token.balance,
-                        contract: token.contract,
-                        name: token.symbol,
-                        symbol: token.symbol,
-                        decimals: token.decimals,
-                        fingerprint: token.name,
-                        policyId,
-                        standard: token.standard,
-                    };
-                });
-            }
-
-            return account;
-        });
-
-        await updateAll(transaction, 'txs', tx => {
-            if (tx.tx.symbol === 'ada') {
-                tx.tx.tokens = tx.tx.tokens?.map(token => {
-                    const { policyId } = parseAsset(token.contract);
-
-                    return {
-                        amount: token.amount,
-                        contract: token.contract,
-                        decimals: token.decimals,
-                        from: token.from,
-                        name: token.symbol || '',
-                        symbol: token.symbol,
-                        fingerprint: token.name,
-                        to: token.to,
-                        type: token.type,
-                        policyId,
-                    };
-                });
-            }
-
-            return tx;
-        });
-
-        await updateAll(transaction, 'suiteSettings', suiteSettings => suiteSettings);
-    }
-
-    if (oldVersion < 47) {
-        //  migrate matic to pol
-
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            // @ts-expect-error
-            const indexOfMatic = walletSettings.enabledNetworks.indexOf('matic');
-            if (indexOfMatic !== -1) {
-                walletSettings.enabledNetworks[indexOfMatic] = 'pol';
-            }
-
-            return walletSettings;
-        });
-
-        await updateAll(transaction, 'suiteSettings', suiteSettings => {
-            if (
-                // @ts-expect-error
-                typeof suiteSettings.evmSettings?.confirmExplanationModalClosed?.matic == 'boolean'
-            ) {
-                suiteSettings.evmSettings.confirmExplanationModalClosed.pol =
-                    // @ts-expect-error
-                    suiteSettings.evmSettings.confirmExplanationModalClosed.matic;
-                // @ts-expect-error
-                delete suiteSettings.evmSettings.confirmExplanationModalClosed.matic;
-            }
-
-            if (
-                // @ts-expect-error
-                typeof suiteSettings.evmSettings?.explanationBannerClosed?.matic == 'boolean'
-            ) {
-                suiteSettings.evmSettings.explanationBannerClosed.pol =
-                    // @ts-expect-error
-                    suiteSettings.evmSettings.explanationBannerClosed.matic;
-                // @ts-expect-error
-                delete suiteSettings.evmSettings.explanationBannerClosed.matic;
-            }
-
-            return suiteSettings;
-        });
-
-        const backendSettings = transaction.objectStore('backendSettings');
-        // @ts-expect-error
-        const maticBackendSettings = await backendSettings.get('matic');
-        if (maticBackendSettings) {
-            backendSettings.add(maticBackendSettings, 'pol');
-            // @ts-expect-error
-            backendSettings.delete('matic');
-        }
-
-        const tokenManagement = transaction.objectStore('tokenManagement');
-        const maticTokenManagementShow = await tokenManagement.get('matic-coin-show');
-        if (maticTokenManagementShow) {
-            tokenManagement.add(maticTokenManagementShow, 'pol-coin-show');
-            tokenManagement.delete('matic-coin-show');
-        }
-
-        const maticTokenManagementHide = await tokenManagement.get('matic-coin-hide');
-        if (maticTokenManagementHide) {
-            tokenManagement.add(maticTokenManagementHide, 'pol-coin-hide');
-            tokenManagement.delete('matic-coin-hide');
-        }
-
-        const accounts = transaction.objectStore('accounts');
-        let accountsCursor = await accounts.openCursor();
-        while (accountsCursor) {
-            const account = accountsCursor.value;
-            // @ts-expect-error
-            if (account.symbol === 'matic') {
-                const newAccount = {
-                    ...account,
-                    symbol: 'pol' as const,
-                    key: account.key.replace('matic', 'pol') as AccountKey,
-                };
-                await accountsCursor.delete();
-                await accounts.add(newAccount);
-            }
-
-            accountsCursor = await accountsCursor.continue();
-        }
-
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            // @ts-expect-error
-            if (walletSettings.lastUsedFeeLevel['matic']) {
-                // @ts-expect-error
-                walletSettings.lastUsedFeeLevel = {
-                    // @ts-expect-error
-                    ...walletSettings.lastUsedFeeLevel,
-                    // @ts-expect-error
-                    pol: { ...walletSettings.lastUsedFeeLevel['matic'] },
-                };
-
-                // @ts-expect-error
-                delete walletSettings.lastUsedFeeLevel['matic'];
-            }
-
-            return walletSettings;
-        });
-
-        await updateAll(transaction, 'txs', tx => {
-            // @ts-expect-error
-            if (tx.tx.symbol === 'matic') {
-                tx.tx = { ...tx.tx, symbol: 'pol' };
-            }
-
-            return tx;
-        });
-
-        const graphs = transaction.objectStore('graph');
-        let graphCursor = await graphs.openCursor();
-        while (graphCursor) {
-            const graph = graphCursor.value;
-            //@ts-expect-error
-            if (graph.account.symbol === 'matic') {
-                const newGraph = {
-                    ...graph,
-                    account: { ...graph.account, symbol: 'pol' as const },
-                };
-                await graphCursor.delete();
-                await graphs.add(newGraph);
-            }
-
-            graphCursor = await graphCursor.continue();
-        }
-
-        await updateAll(transaction, 'historicRates', rates => {
-            const rate = Object.keys(rates).reduce((newRates, key) => {
-                const newKey = key.replace('matic', 'pol');
-                // @ts-expect-error
-                newRates[newKey] = rates[key];
-
-                return newRates;
-            }, {});
-
-            return rate;
-        });
-
-        const historicRates = transaction.objectStore('historicRates');
-        const historicRatesKeys = await historicRates.getAllKeys();
-        const historicRatesKeysWithMatic = historicRatesKeys.filter(key => key.includes('matic'));
-
-        historicRatesKeysWithMatic.forEach(async key => {
-            const rate = await historicRates.get(key);
-            if (rate) {
-                historicRates.add(rate, key.replace('matic', 'pol'));
-            }
-            historicRates.delete(key);
-        });
-
-        const sendFormDrafts = transaction.objectStore('sendFormDrafts');
-        const sendFormDraftsKeys = await sendFormDrafts.getAllKeys();
-        const sendFormDraftsKeysWithMatic = sendFormDraftsKeys.filter(key => key.includes('matic'));
-
-        sendFormDraftsKeysWithMatic.forEach(async key => {
-            const draft = await sendFormDrafts.get(key);
-            if (draft) {
-                sendFormDrafts.add(draft, key.replace('matic', 'pol') as AccountKey);
-            }
-            sendFormDrafts.delete(key);
-        });
-
-        const formDrafts = transaction.objectStore('formDrafts');
-        const formDraftsKeys = await formDrafts.getAllKeys();
-        const formDraftsKeysWithMatic = formDraftsKeys.filter(key => key.includes('matic'));
-
-        formDraftsKeysWithMatic.forEach(async key => {
-            const draft = await formDrafts.get(key);
-            if (draft) {
-                formDrafts.add(draft, key.replace('matic', 'pol'));
-            }
-            formDrafts.delete(key);
-        });
-
-        await updateAll(transaction, 'formDrafts', draft => {
-            if (draft.cryptoSelect?.label === 'MATIC') {
-                draft.cryptoSelect = {
-                    ...draft.cryptoSelect,
-                    label: 'POL',
-                    value: 'polygon-ecosystem-token',
-                };
-            }
-
-            if (draft.receiveCryptoSelect?.label === 'MATIC') {
-                draft.receiveCryptoSelect = {
-                    ...draft.receiveCryptoSelect,
-                    label: 'POL',
-                    value: 'polygon-ecosystem-token',
-                };
-            }
-
-            if (draft.sendCryptoSelect?.label === 'MATIC') {
-                draft.sendCryptoSelect = {
-                    ...draft.sendCryptoSelect,
-                    label: 'POL',
-                    value: 'polygon-ecosystem-token',
-                };
-            }
-
-            return draft;
-        });
-    }
-
-    if (oldVersion < 48) {
-        // Migrate device state to new object format
-        await updateAll(transaction, 'devices', device => {
-            if (typeof device.state === 'string') {
-                const legacyDevice = device as typeof device & { _state?: DeviceState };
-                if (typeof legacyDevice?._state?.staticSessionId === 'string') {
-                    // Has _state property, migrate to that
-                    device.state = legacyDevice._state;
-                } else {
-                    // No _state property, create new object
-                    device.state = {
-                        staticSessionId: device.state,
-                    };
+                    return account;
                 }
-            }
-
-            return device;
-        });
-    }
-
-    if (oldVersion < 49) {
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            walletSettings.enabledNetworks.sort(
-                (a, b) => networkSymbolCollection.indexOf(a) - networkSymbolCollection.indexOf(b),
-            );
-
-            return walletSettings;
-        });
-
-        await updateAll(transaction, 'txs', tx => {
-            if (['sol', 'dsol'].includes(tx.tx.symbol)) {
-                tx.tx.amount = new BigNumber(tx.tx.amount).abs().toString();
-            }
-
-            return tx;
-        });
-    }
-
-    if (oldVersion < 50) {
-        await migrationOfBnbNetwork(db, oldVersion, newVersion, transaction);
-    }
-
-    if (oldVersion < 51) {
-        await updateAll(transaction, 'accounts', account => {
-            if (account.networkType === 'cardano') {
-                account.misc.staking.drep = null;
 
                 return account;
-            }
-        });
-
-        await updateAll(transaction, 'accounts', account => {
-            if (account.networkType === 'ethereum' && account.symbol !== 'eth') {
-                const { chainId } = getNetwork(account.symbol);
-                account.metadata.key = `${account.descriptor}-${chainId}`;
-
-                return account;
-            }
-
-            return account;
-        });
-    }
-
-    if (oldVersion < 52) {
-        // Deprecate Vertcoin (VTC) and other networks
-        const deprecatedNetworks = ['vtc', 'btg', 'nmc', 'dgb', 'dash'];
-
-        // Remove transactions related to deprecated networks
-        await updateAll(transaction, 'txs', tx => {
-            if (deprecatedNetworks.includes(tx.tx.symbol)) {
-                return null; // Delete transaction
-            }
-
-            return tx;
-        });
-
-        // Remove accounts related to deprecated networks
-        await updateAll(transaction, 'accounts', account => {
-            if (deprecatedNetworks.includes(account.symbol)) {
-                return null; // Delete account
-            }
-
-            return account;
-        });
-
-        // Remove deprecated networks from enabled networks in wallet settings
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
-                network => !deprecatedNetworks.includes(network), // Exclude deprecated networks from enabled networks
-            );
-
-            return walletSettings;
-        });
-
-        // Remove deprecated networks from backend settings
-        const backendSettings = transaction.objectStore('backendSettings');
-        for (const network of deprecatedNetworks) {
-            await backendSettings.delete(network as NetworkSymbol); // Delete backend settings for each deprecated network
+            });
         }
 
-        // remove ripple network transactions
-        const accountsToUpdate = ['xrp', 'txrp'];
+        if (oldVersion < 52) {
+            // Deprecate Vertcoin (VTC) and other networks
+            const deprecatedNetworks = ['vtc', 'btg', 'nmc', 'dgb', 'dash'];
 
-        await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
-            if (accountsToUpdate.includes(tx.tx.symbol)) {
-                return null;
-            }
+            // Remove transactions related to deprecated networks
+            await updateAll(transaction, 'txs', tx => {
+                if (deprecatedNetworks.includes(tx.tx.symbol)) {
+                    return null; // Delete transaction
+                }
 
-            return tx;
-        });
+                return tx;
+            });
 
-        // force to fetch ripple network transactions again
-        await updateAll(transaction, 'accounts', account => {
-            if (accountsToUpdate.includes(account.symbol)) {
-                account.history = { total: 0, unconfirmed: 0, tokens: 0 };
+            // Remove accounts related to deprecated networks
+            await updateAll(transaction, 'accounts', account => {
+                if (deprecatedNetworks.includes(account.symbol)) {
+                    return null; // Delete account
+                }
 
                 return account;
+            });
+
+            // Remove deprecated networks from enabled networks in wallet settings
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                walletSettings.enabledNetworks = walletSettings.enabledNetworks.filter(
+                    network => !deprecatedNetworks.includes(network), // Exclude deprecated networks from enabled networks
+                );
+
+                return walletSettings;
+            });
+
+            // Remove deprecated networks from backend settings
+            const backendSettings = transaction.objectStore('backendSettings');
+            for (const network of deprecatedNetworks) {
+                await backendSettings.delete(network as NetworkSymbol); // Delete backend settings for each deprecated network
             }
-        });
 
-        // @ts-expect-error security no longer exists
-        db.createObjectStore('security');
-    }
+            // remove ripple network transactions
+            const accountsToUpdate = ['xrp', 'txrp'];
 
-    if (oldVersion < 53) {
-        await updateAll(transaction, 'walletSettings', walletSettings => {
-            // @ts-expect-error
-            delete walletSettings.lastUsedFeeLevel;
+            await updateAll<'txs', DBWalletAccountTransactionCompatible>(transaction, 'txs', tx => {
+                if (accountsToUpdate.includes(tx.tx.symbol)) {
+                    return null;
+                }
 
-            return walletSettings;
-        });
-    }
+                return tx;
+            });
 
-    if (oldVersion < 54) {
-        db.createObjectStore('connect');
-    }
+            // force to fetch ripple network transactions again
+            await updateAll(transaction, 'accounts', account => {
+                if (accountsToUpdate.includes(account.symbol)) {
+                    account.history = { total: 0, unconfirmed: 0, tokens: 0 };
 
-    if (oldVersion < 56) {
-        await migrateToV56(db, oldVersion, newVersion, transaction);
-    }
+                    return account;
+                }
+            });
 
-    // !!! DO NOT ADD ANY MORE MIGRATION CODE BELOW !!!
-    // These are legacy migrations, instead follow the instructions in /suite/idb-migration-utils/MIGRATION.md
-};
+            // @ts-expect-error security no longer exists
+            db.createObjectStore('security');
+        }
+
+        if (oldVersion < 53) {
+            await updateAll(transaction, 'walletSettings', walletSettings => {
+                // @ts-expect-error
+                delete walletSettings.lastUsedFeeLevel;
+
+                return walletSettings;
+            });
+        }
+
+        if (oldVersion < 54) {
+            db.createObjectStore('connect');
+        }
+
+        if (oldVersion < 56) {
+            await migrateToV56(networkConfigDeps, db, oldVersion, newVersion, transaction);
+        }
+
+        // !!! DO NOT ADD ANY MORE MIGRATION CODE BELOW !!!
+        // These are legacy migrations, instead follow the instructions in /suite/idb-migration-utils/MIGRATION.md
+    };

--- a/packages/suite/src/storage/migrations/legacyVersions/migrateToV56.ts
+++ b/packages/suite/src/storage/migrations/legacyVersions/migrateToV56.ts
@@ -1,7 +1,7 @@
 import { type CryptoId } from 'invity-api';
 
 import { type TradingTransaction, cryptoIdToNetwork, toTokenCryptoId } from '@suite-common/trading';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 import {
     findAccountsByAddress,
@@ -34,6 +34,7 @@ const findAccountForBuyTrade = (
 };
 
 const findAccountForTrade = (
+    networkConfigDeps: NetworkConfigDeps,
     accounts: Account[],
     address: string | undefined,
     cryptoId: CryptoId | undefined,
@@ -42,7 +43,7 @@ const findAccountForTrade = (
         return undefined;
     }
 
-    const network = cryptoIdToNetwork(cryptoId);
+    const network = cryptoIdToNetwork(networkConfigDeps, cryptoId);
     if (!network) {
         return undefined;
     }
@@ -57,22 +58,25 @@ const findAccountForTrade = (
         const cryptoIds = [
             ...(account.tokens?.flatMap(token =>
                 toTokenCryptoId(
+                    networkConfigDeps,
                     account.symbol,
-                    getContractAddressForNetworkSymbol(account.symbol, token.contract),
+                    getContractAddressForNetworkSymbol(
+                        networkConfigDeps,
+                        account.symbol,
+                        token.contract,
+                    ),
                 ),
             ) ?? []),
-            getNetwork(account.symbol).tradeCryptoId,
+            networkConfigDeps.getNetworkConfig(account.symbol).tradeCryptoId,
         ].filter(Boolean) as CryptoId[];
 
         return account.descriptor === address && cryptoIds.includes(cryptoId);
     });
 };
 
-export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
-    db,
-    oldVersion,
-    _newVersion,
-    transaction,
+export const migrateToV56 = async (
+    networkConfigDeps: NetworkConfigDeps,
+    ...[db, oldVersion, _newVersion, transaction]: Parameters<OnUpgradeFunc<SuiteDBSchema>>
 ) => {
     const oldStoreName = 'coinmarketTrades';
     const newStoreName = 'tradingTrades';
@@ -107,6 +111,7 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
         if (trade.tradeType === 'buy') {
             if (trade.receiveAccountKey === undefined) {
                 trade.receiveAccountKey = findAccountForTrade(
+                    networkConfigDeps,
                     accounts,
                     trade.data.receiveAddress,
                     trade.data.receiveCurrency,
@@ -128,6 +133,7 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
 
         if (trade.tradeType === 'sell' && trade.sendAccountKey === undefined) {
             trade.sendAccountKey = findAccountForTrade(
+                networkConfigDeps,
                 accounts,
                 // account may be incorrect because it may not be current, but the default
                 // @ts-expect-error - account deprecated property
@@ -141,6 +147,7 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
         if (trade.tradeType === 'exchange') {
             if (trade.sendAccountKey === undefined) {
                 trade.sendAccountKey = findAccountForTrade(
+                    networkConfigDeps,
                     accounts,
                     // @ts-expect-error - account deprecated property
                     trade.account.descriptor,
@@ -150,6 +157,7 @@ export const migrateToV56: OnUpgradeFunc<SuiteDBSchema> = async (
 
             if (trade.receiveAccountKey === undefined) {
                 trade.receiveAccountKey = findAccountForTrade(
+                    networkConfigDeps,
                     accounts,
                     trade.data.receiveAddress,
                     trade.data.receive,

--- a/packages/suite/src/storage/migrations/versions/26.2.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.2.0.ts
@@ -1,24 +1,25 @@
 import { createMigration } from '@suite/idb-migration-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
 import { updateAll } from '../utils';
 
-export default createMigration<SuiteDBSchema>('26.2.0', async (_, tx) => {
-    await updateAll(tx, 'txs', transaction => {
-        if (getNetwork(transaction.tx.symbol).features.includes('tokens')) {
-            return null;
-        }
+export default ({ getNetworkConfig }: GetNetworkConfigDep) =>
+    createMigration<SuiteDBSchema>('26.2.0', async (_, tx) => {
+        await updateAll(tx, 'txs', transaction => {
+            if (getNetworkConfig(transaction.tx.symbol).features.includes('tokens')) {
+                return null;
+            }
 
-        return transaction;
+            return transaction;
+        });
+
+        await updateAll(tx, 'accounts', account => {
+            if (getNetworkConfig(account.symbol).features.includes('tokens')) {
+                account.history = { total: 0, unconfirmed: 0, tokens: 0 };
+            }
+
+            return account;
+        });
     });
-
-    await updateAll(tx, 'accounts', account => {
-        if (getNetwork(account.symbol).features.includes('tokens')) {
-            account.history = { total: 0, unconfirmed: 0, tokens: 0 };
-        }
-
-        return account;
-    });
-});

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -62,7 +62,7 @@ import {
     buildTokenDefinitionsFromStorage,
 } from '@suite-common/token-definitions';
 import { selectTradedAccountKeys } from '@suite-common/trading';
-import { isNetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, isNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type BlockchainState,
     type ExplorerConfig,
@@ -123,6 +123,15 @@ export type SuiteExtra = ExtraDependenciesStatic & { services: SuiteServices };
 
 export const selectSuiteServices = (services: any): SuiteServices => services;
 
+const networkModules = createNetworksCompositionRoot();
+const networkModuleRepository = createNetworkModuleRepository({ networkModules });
+const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
+
+export const suiteNetworkConfigDeps: NetworkConfigDeps = {
+    networkModuleRepository,
+    getNetworkConfig,
+};
+
 export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteServices => {
     const { ensureDelegatedIdentityKey } = delegatedIdentityKeyCompositionRoot({
         dispatch: deps.dispatch,
@@ -174,9 +183,6 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         dispatch: deps.dispatch,
         getState: deps.getState,
     });
-    const networkModules = createNetworksCompositionRoot();
-    const networkModuleRepository = createNetworkModuleRepository({ networkModules });
-    const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
     const findNetworkSymbolForProtocol = createFindNetworkSymbolForProtocol({
         getNetworkConfig,
         networkModuleRepository,
@@ -263,7 +269,8 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
     };
 };
 
-export const extraDependencies: ExtraDependenciesStatic = {
+export const extraDependencies: ExtraDependenciesStatic & { services: NetworkConfigDeps } = {
+    services: suiteNetworkConfigDeps,
     thunks: {
         initMetadata: metadataLabelingActions.init,
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
@@ -341,7 +348,7 @@ export const extraDependencies: ExtraDependenciesStatic = {
             if (payload.tokenManagement) {
                 const tokenDefinitions = buildTokenDefinitionsFromStorage(payload.tokenManagement);
                 Object.keys(tokenDefinitions).forEach(symbol => {
-                    if (isNetworkSymbol(symbol)) {
+                    if (isNetworkSymbol(suiteNetworkConfigDeps, symbol)) {
                         state[symbol] = tokenDefinitions[symbol];
                     }
                 });
@@ -350,6 +357,7 @@ export const extraDependencies: ExtraDependenciesStatic = {
         storageLoadAccounts: (_, { payload }: StorageLoadAction) =>
             // Storage returns accounts in IndexedDB key order, sort them like the reducer does.
             sortByCoin(
+                suiteNetworkConfigDeps,
                 payload.accounts.map(acc =>
                     acc.backendType === 'coinjoin' ? fixLoadedCoinjoinAccount(acc) : acc,
                 ),

--- a/packages/suite/src/utils/suite/transactionReview.ts
+++ b/packages/suite/src/utils/suite/transactionReview.ts
@@ -1,11 +1,12 @@
 import { type ExtendedMessageDescriptor } from '@suite/intl';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type FormState, type StakeFormState } from '@suite-common/wallet-types';
 import { getEvmTransactionPurpose } from '@suite-common/wallet-utils';
 import { type TokenInfo } from '@trezor/blockchain-link-types';
 import { getWrappedNativeSymbol } from '@trezor/network-ethereum-suite-common';
 
-interface GetTransactionReviewModalActionTranslationParams {
+interface GetTransactionReviewModalActionTranslationParams extends GetNetworkConfigDep {
     symbol: NetworkSymbol;
     stakeType: StakeFormState['stakeType'] | null;
     precomposedForm: FormState | StakeFormState;
@@ -18,6 +19,7 @@ interface GetTransactionReviewModalActionTranslationParams {
 }
 
 export const getTransactionReviewModalActionTranslation = ({
+    getNetworkConfig,
     symbol,
     stakeType,
     precomposedForm,
@@ -38,17 +40,17 @@ export const getTransactionReviewModalActionTranslation = ({
         case 'stake':
             return {
                 id: source === 'heading' ? 'TR_EARN_STAKE_TOKEN' : 'TR_STAKE_STAKE',
-                values: { symbol: getNetworkDisplaySymbol(symbol) },
+                values: { symbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol) },
             };
         case 'unstake':
             return {
                 id: source === 'heading' ? 'TR_STAKE_UNSTAKE_TOKEN' : 'TR_STAKE_UNSTAKE',
-                values: { symbol: getNetworkDisplaySymbol(symbol) },
+                values: { symbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol) },
             };
         case 'claim':
             return {
                 id: source === 'heading' ? 'TR_STAKE_CLAIM_TOKEN' : 'TR_STAKE_CLAIM',
-                values: { symbol: getNetworkDisplaySymbol(symbol) },
+                values: { symbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol) },
             };
         // no default
     }
@@ -105,7 +107,7 @@ export const getTransactionReviewModalActionTranslation = ({
                         ? 'TR_EARN_YIELD_WRAP_TITLE'
                         : 'TR_EARN_YIELD_UNWRAP_TITLE',
                 values: {
-                    nativeSymbol: getNetworkDisplaySymbol(symbol),
+                    nativeSymbol: getNetworkDisplaySymbol({ getNetworkConfig }, symbol),
                     tokenSymbol: getWrappedNativeSymbol(symbol),
                 },
             };

--- a/packages/suite/src/utils/suite/validation.ts
+++ b/packages/suite/src/utils/suite/validation.ts
@@ -1,6 +1,7 @@
 import { type TranslationFunction } from '@suite/intl';
 import { type Formatter, type Formatters } from '@suite-common/formatters';
 import {
+    type NetworkConfigDeps,
     getDisplaySymbol,
     getNetworkDisplaySymbol,
     isNetworkSymbol,
@@ -59,7 +60,7 @@ export type AmountLimitProps = {
 
 export type CryptoAmountLimitProps = Pick<AmountLimitProps, 'currency' | 'minCrypto' | 'maxCrypto'>;
 
-interface ValidateCryptoLimitsOptions {
+interface ValidateCryptoLimitsOptions extends NetworkConfigDeps {
     amountLimits?: AmountLimitProps;
     areSatsUsed?: boolean;
     formatter: Formatter<string, string>;
@@ -68,7 +69,7 @@ interface ValidateCryptoLimitsOptions {
 export const validateCryptoLimits =
     (
         translationString: TranslationFunction,
-        { amountLimits, areSatsUsed, formatter }: ValidateCryptoLimitsOptions,
+        { amountLimits, areSatsUsed, formatter, ...networkConfigDeps }: ValidateCryptoLimitsOptions,
     ) =>
     (value: string) => {
         if (value && amountLimits) {
@@ -78,9 +79,13 @@ export const validateCryptoLimits =
 
             if (amountLimits.minCrypto) {
                 minCrypto =
-                    areSatsUsed && isNetworkSymbol(currency)
+                    areSatsUsed && isNetworkSymbol(networkConfigDeps, currency)
                         ? new BigNumber(
-                              networkAmountToSmallestUnit(amountLimits.minCrypto, currency),
+                              networkAmountToSmallestUnit(
+                                  networkConfigDeps,
+                                  amountLimits.minCrypto,
+                                  currency,
+                              ),
                           )
                         : new BigNumber(amountLimits.minCrypto);
             }
@@ -99,9 +104,13 @@ export const validateCryptoLimits =
 
             if (amountLimits.maxCrypto) {
                 maxCrypto =
-                    areSatsUsed && isNetworkSymbol(currency)
+                    areSatsUsed && isNetworkSymbol(networkConfigDeps, currency)
                         ? new BigNumber(
-                              networkAmountToSmallestUnit(amountLimits.maxCrypto, currency),
+                              networkAmountToSmallestUnit(
+                                  networkConfigDeps,
+                                  amountLimits.maxCrypto,
+                                  currency,
+                              ),
                           )
                         : new BigNumber(amountLimits.maxCrypto);
             }
@@ -135,19 +144,22 @@ export const validateCryptoLimits =
         }
     };
 
-interface ValidateSolanaUnstakeAmountOptions {
+interface ValidateSolanaUnstakeAmountOptions extends NetworkConfigDeps {
     account: Account;
 }
 
 export const validateSolanaUnstakeAmount =
-    (translationString: TranslationFunction, { account }: ValidateSolanaUnstakeAmountOptions) =>
+    (
+        translationString: TranslationFunction,
+        { account, ...networkConfigDeps }: ValidateSolanaUnstakeAmountOptions,
+    ) =>
     (value: string) => {
         if (!value) return;
 
-        const bounds = getSolanaUnstakeAmountBounds(account, value);
+        const bounds = getSolanaUnstakeAmountBounds(networkConfigDeps, account, value);
         if (!bounds) return;
 
-        const symbol = getNetworkDisplaySymbol(account.symbol);
+        const symbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
 
         // the fiat approximations are only rendered in the rich <Translation> banner
         return bounds.closestLower
@@ -165,7 +177,7 @@ export const validateSolanaUnstakeAmount =
               });
     };
 
-interface ValidateSolanaUnstakeFiatAmountOptions {
+interface ValidateSolanaUnstakeFiatAmountOptions extends NetworkConfigDeps {
     account: Account;
     decimals: number;
     rate?: number;
@@ -174,7 +186,7 @@ interface ValidateSolanaUnstakeFiatAmountOptions {
 export const validateSolanaUnstakeFiatAmount =
     (
         translationString: TranslationFunction,
-        { account, decimals, rate }: ValidateSolanaUnstakeFiatAmountOptions,
+        { account, decimals, rate, ...networkConfigDeps }: ValidateSolanaUnstakeFiatAmountOptions,
     ) =>
     (value: string, formValues?: { outputs?: { amount?: string }[] }) => {
         if (!value) return;
@@ -190,7 +202,7 @@ export const validateSolanaUnstakeFiatAmount =
             toFiatCurrency({ amount: outputAmount, rate })?.toFixed(2, BigNumber.ROUND_FLOOR) ===
                 value;
 
-        return validateSolanaUnstakeAmount(translationString, { account })(
+        return validateSolanaUnstakeAmount(translationString, { ...networkConfigDeps, account })(
             isFiatOfOutputAmount ? outputAmount : cryptoAmount,
         );
     };
@@ -296,7 +308,7 @@ export const validateMin =
         }
     };
 
-interface ValidateReserveOrBalanceOptions {
+interface ValidateReserveOrBalanceOptions extends NetworkConfigDeps {
     account: Account;
     areSatsUsed?: boolean;
     contractAddress?: string | null;
@@ -305,10 +317,16 @@ interface ValidateReserveOrBalanceOptions {
 export const validateReserveOrBalance =
     (
         translationString: TranslationFunction,
-        { account, areSatsUsed, contractAddress }: ValidateReserveOrBalanceOptions,
+        {
+            account,
+            areSatsUsed,
+            contractAddress,
+            ...networkConfigDeps
+        }: ValidateReserveOrBalanceOptions,
     ) =>
     (value: string) => {
         const result = getAmountValidationResult({
+            ...networkConfigDeps,
             amount: value,
             account,
             areSatsUsed,
@@ -318,7 +336,7 @@ export const validateReserveOrBalance =
         if (result.type === 'reserve') {
             return translationString('AMOUNT_IS_MORE_THAN_RESERVE', {
                 reserve: result.reserve,
-                displaySymbol: getDisplaySymbol(account.symbol),
+                displaySymbol: getDisplaySymbol(networkConfigDeps, account.symbol),
             });
         }
 

--- a/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
+++ b/packages/suite/src/utils/wallet/exportTransactionsUtils.ts
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 import type PdfMake from 'pdfmake/build/pdfmake';
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
 
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { trezorLogo } from '@suite-common/suite-constants';
 import { type TokenDefinitions, isPhishingTransaction } from '@suite-common/token-definitions';
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
@@ -75,11 +76,14 @@ const timeFormat = {
     timeZoneName: 'shortOffset',
 } as const;
 
-const formatIfDefined = (amount: string | undefined, symbol: NetworkSymbol) =>
-    amount ? formatNetworkAmount(amount, symbol) : undefined;
+const formatIfDefined = (
+    deps: GetNetworkConfigDep,
+    amount: string | undefined,
+    symbol: NetworkSymbol,
+) => (amount ? formatNetworkAmount(deps, amount, symbol) : undefined);
 
 const formatAmounts =
-    (symbol: NetworkSymbol) =>
+    (deps: GetNetworkConfigDep, symbol: NetworkSymbol) =>
     (tx: AccountTransactionForExports): AccountTransactionForExports => ({
         ...tx,
         tokens: tx.tokens.map(token => ({
@@ -90,26 +94,26 @@ const formatAmounts =
         })),
         internalTransfers: tx.internalTransfers.map(internal => ({
             ...internal,
-            amount: formatNetworkAmount(internal.amount, symbol),
+            amount: formatNetworkAmount(deps, internal.amount, symbol),
         })),
-        amount: formatNetworkAmount(tx.amount, symbol),
-        fee: formatNetworkAmount(tx.fee, symbol),
+        amount: formatNetworkAmount(deps, tx.amount, symbol),
+        fee: formatNetworkAmount(deps, tx.fee, symbol),
         targets: tx.targets.map(tr => ({
             ...tr,
-            amount: formatIfDefined(tr.amount, symbol),
+            amount: formatIfDefined(deps, tr.amount, symbol),
         })),
         details: {
             ...tx.details,
             vin: tx.details.vin.map(v => ({
                 ...v,
-                value: formatIfDefined(v.value, symbol),
+                value: formatIfDefined(deps, v.value, symbol),
             })),
             vout: tx.details.vout.map(v => ({
                 ...v,
-                value: formatIfDefined(v.value, symbol),
+                value: formatIfDefined(deps, v.value, symbol),
             })),
-            totalInput: formatNetworkAmount(tx.details.totalInput, symbol),
-            totalOutput: formatNetworkAmount(tx.details.totalOutput, symbol),
+            totalInput: formatNetworkAmount(deps, tx.details.totalInput, symbol),
+            totalOutput: formatNetworkAmount(deps, tx.details.totalOutput, symbol),
         },
         ethereumSpecific: tx.ethereumSpecific
             ? {
@@ -120,8 +124,8 @@ const formatAmounts =
         cardanoSpecific: tx.cardanoSpecific
             ? {
                   ...tx.cardanoSpecific,
-                  withdrawal: formatIfDefined(tx.cardanoSpecific.withdrawal, symbol),
-                  deposit: formatIfDefined(tx.cardanoSpecific.deposit, symbol),
+                  withdrawal: formatIfDefined(deps, tx.cardanoSpecific.withdrawal, symbol),
+                  deposit: formatIfDefined(deps, tx.cardanoSpecific.deposit, symbol),
               }
             : undefined,
     });
@@ -142,6 +146,7 @@ const makePdf = (definitions: TDocumentDefinitions, pdfMake: typeof PdfMake): Pr
     pdfMake.createPdf(definitions).getBlob();
 
 const prepareContent = (
+    deps: GetNetworkConfigDep,
     data: Data,
     tokenDefinitions: TokenDefinitions,
     txsMarkedAsNotScam: string[],
@@ -153,13 +158,14 @@ const prepareContent = (
         .filter(
             t =>
                 !isPhishingTransaction({
+                    ...deps,
                     transaction: t,
                     tokenDefinitions,
                     historicRates: historicFiatRates,
                     txsMarkedAsNotScam,
                 }).isPhishing,
         )
-        .map(formatAmounts(symbol))
+        .map(formatAmounts(deps, symbol))
         .flatMap(t => {
             const sharedData = {
                 date: new Intl.DateTimeFormat('default', dateFormat).format(
@@ -172,7 +178,7 @@ const prepareContent = (
                 type: t.type.toUpperCase(),
                 txid: t.txid,
             };
-            const symbol = getNetworkDisplaySymbol(data.symbol);
+            const symbol = getNetworkDisplaySymbol(deps, data.symbol);
             const fiatRateKey = getFiatRateKey(t.symbol, baseCurrencyCode);
             const roundedTimestamp = roundTimestampToNearestPastHour(t.blockTime as Timestamp);
             const historicRate = historicFiatRates?.[fiatRateKey]?.[roundedTimestamp];
@@ -329,6 +335,7 @@ export const sanitizeCsvValue = (value: string): string => {
 };
 
 const prepareCsv = (
+    deps: GetNetworkConfigDep,
     data: Data,
     tokenDefinitions: TokenDefinitions,
     txsMarkedAsNotScam: string[],
@@ -350,7 +357,13 @@ const prepareCsv = (
         other: 'Other',
     };
 
-    const content = prepareContent(data, tokenDefinitions, txsMarkedAsNotScam, historicFiatRates);
+    const content = prepareContent(
+        deps,
+        data,
+        tokenDefinitions,
+        txsMarkedAsNotScam,
+        historicFiatRates,
+    );
 
     const lines: string[] = [];
 
@@ -380,6 +393,7 @@ const prepareCsv = (
 };
 
 const preparePdf = (
+    deps: GetNetworkConfigDep,
     data: Data,
     tokenDefinitions: TokenDefinitions,
     txsMarkedAsNotScam: string[],
@@ -397,7 +411,13 @@ const preparePdf = (
     const fieldKeys = Object.keys(pdfFields);
     const fieldValues = Object.values(pdfFields);
 
-    const content = prepareContent(data, tokenDefinitions, txsMarkedAsNotScam, historicFiatRates);
+    const content = prepareContent(
+        deps,
+        data,
+        tokenDefinitions,
+        txsMarkedAsNotScam,
+        historicFiatRates,
+    );
 
     const lines: any[] = [];
     content.forEach(item => {
@@ -476,6 +496,7 @@ const preparePdf = (
 };
 
 export const formatData = async (
+    deps: GetNetworkConfigDep,
     data: Data,
     tokenDefinitions: TokenDefinitions,
     txsMarkedAsNotScam: string[],
@@ -485,12 +506,19 @@ export const formatData = async (
 
     switch (type) {
         case 'csv': {
-            const csv = prepareCsv(data, tokenDefinitions, txsMarkedAsNotScam, historicFiatRates);
+            const csv = prepareCsv(
+                deps,
+                data,
+                tokenDefinitions,
+                txsMarkedAsNotScam,
+                historicFiatRates,
+            );
 
             return new Blob([csv], { type: 'text/csv;charset=utf-8' });
         }
         case 'pdf': {
             const pdfLayout = preparePdf(
+                deps,
                 data,
                 tokenDefinitions,
                 txsMarkedAsNotScam,
@@ -505,7 +533,7 @@ export const formatData = async (
             const json = JSON.stringify(
                 {
                     coin: symbol,
-                    transactions: transactions.map(formatAmounts(symbol)),
+                    transactions: transactions.map(formatAmounts(deps, symbol)),
                 },
                 null,
                 2,

--- a/packages/suite/src/utils/wallet/graph/utils.ts
+++ b/packages/suite/src/utils/wallet/graph/utils.ts
@@ -1,11 +1,11 @@
 import { differenceInMonths, fromUnixTime, getUnixTime, isWithinInterval } from 'date-fns';
 
 import { getFiatRatesForTimestamps } from '@suite-common/fiat-services';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { resetTime } from '@suite-common/suite-utils';
 import {
     type BackendType,
     type NetworkSymbol,
-    getNetwork,
     getNetworkFeatures,
 } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
@@ -33,18 +33,20 @@ export const deviceGraphDataFilterFn = (d: GraphData, deviceState: StaticSession
 };
 
 export const ensureHistoryRates = async (
+    deps: GetNetworkConfigDep,
     symbol: NetworkSymbol,
     data: BlockchainAccountBalanceHistory[],
     baseCurrencyCode: BaseCurrencyCode,
     isElectrumBackend: boolean,
 ): Promise<BlockchainAccountBalanceHistory[]> => {
-    if (!getNetwork(symbol).coingeckoId) return data;
+    if (!deps.getNetworkConfig(symbol).coingeckoId) return data;
 
     const missingRates = data
         .filter(({ rates }) => !Object.keys(rates || {}).length)
         .map(({ time }) => time);
 
     const rateDictionary = await getFiatRatesForTimestamps(
+        deps,
         { symbol },
         missingRates,
         baseCurrencyCode,
@@ -75,8 +77,12 @@ export function getPristineAccounts(graph: AppState['wallet']['graph'], accounts
 /**
  * Does given network has backend type with support for retrieving transactions history, e.g. for showing graph?
  */
-export function isNetworkWithGraphFeature(symbol: NetworkSymbol, backendType?: BackendType) {
-    const hasGraphFeature = getNetworkFeatures(symbol).includes('graph');
+export function isNetworkWithGraphFeature(
+    deps: GetNetworkConfigDep,
+    symbol: NetworkSymbol,
+    backendType?: BackendType,
+) {
+    const hasGraphFeature = getNetworkFeatures(deps, symbol).includes('graph');
     if (!hasGraphFeature) {
         return false;
     }
@@ -85,6 +91,7 @@ export function isNetworkWithGraphFeature(symbol: NetworkSymbol, backendType?: B
 }
 
 export const enhanceBlockchainAccountHistory = (
+    deps: GetNetworkConfigDep,
     data: BlockchainAccountBalanceHistory[],
     symbol: NetworkSymbol,
     balanceBefore = '0',
@@ -99,8 +106,8 @@ export const enhanceBlockchainAccountHistory = (
             ? new BigNumber(dataPoint.sent).minus(dataPoint.sentToSelf || 0).toFixed()
             : dataPoint.sent;
 
-        const formattedReceived = formatNetworkAmount(normalizedReceived, symbol);
-        const formattedSent = formatNetworkAmount(normalizedSent, symbol);
+        const formattedReceived = formatNetworkAmount(deps, normalizedReceived, symbol);
+        const formattedSent = formatNetworkAmount(deps, normalizedSent, symbol);
         balance = new BigNumber(balance).plus(formattedReceived).minus(formattedSent).toFixed();
 
         return {

--- a/packages/suite/src/utils/wallet/tokenUtils.test.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.test.ts
@@ -1,4 +1,4 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import { getTokensFixtures, hasVisibleTokensFixtures } from './__fixtures__/tokenUtils';
 import { getTokens, hasVisibleTokens } from './tokenUtils';
@@ -7,12 +7,11 @@ describe('getTokens', () => {
     getTokensFixtures.forEach(
         ({ testName, tokens, symbol, coinDefinitions, searchQuery, result }) => {
             test(testName, () => {
-                const networkSymbol = asNetworkSymbol(symbol);
-
                 expect(
                     getTokens({
+                        ...mockNetworkConfigDeps,
                         tokens,
-                        symbol: networkSymbol,
+                        symbol,
                         tokenDefinitions: coinDefinitions,
                         searchQuery,
                     }),
@@ -25,9 +24,9 @@ describe('getTokens', () => {
 describe('hasVisibleTokens', () => {
     hasVisibleTokensFixtures.forEach(({ testName, tokens, symbol, tokenDefinitions, result }) => {
         test(testName, () => {
-            const networkSymbol = asNetworkSymbol(symbol);
-
-            expect(hasVisibleTokens(networkSymbol, tokens, tokenDefinitions)).toStrictEqual(result);
+            expect(
+                hasVisibleTokens(mockNetworkConfigDeps, symbol, tokens, tokenDefinitions),
+            ).toStrictEqual(result);
         });
     });
 });

--- a/packages/suite/src/utils/wallet/tokenUtils.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.ts
@@ -1,6 +1,10 @@
 import { type TranslationId } from '@suite/intl';
 import { type TokenDefinitionsState } from '@suite-common/token-definitions';
-import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
+import {
+    type NetworkConfigDeps,
+    type NetworkSymbol,
+    type NetworkType,
+} from '@suite-common/wallet-config';
 import { type GetTokensOutputType, getTokens } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -66,6 +70,7 @@ export const enhanceTokensWithRates = (
 export type EnahncedTokenInfoWithFiat = ReturnType<typeof enhanceTokensWithRates>[number];
 
 export const hasVisibleTokens = (
+    networkConfigDeps: NetworkConfigDeps,
     symbol: NetworkSymbol,
     tokens: TokenInfo[] | undefined,
     tokenDefinitions: Partial<TokenDefinitionsState>,
@@ -77,6 +82,7 @@ export const hasVisibleTokens = (
     if (!coinDefinitions) return false;
 
     const currentTokens = getTokens({
+        ...networkConfigDeps,
         tokens,
         symbol,
         tokenDefinitions: coinDefinitions,
@@ -101,10 +107,11 @@ export const getTokenAddressTranslationId = (networkType: NetworkType): Translat
 };
 
 export function getAccountsWithPositiveBalanceOrVisibleTokens(
+    networkConfigDeps: NetworkConfigDeps,
     accounts: Account[],
     tokenDefinitions: TokenDefinitionsState,
 ): Account[] {
     return accounts.filter(account =>
-        hasVisibleTokens(account.symbol, account.tokens, tokenDefinitions),
+        hasVisibleTokens(networkConfigDeps, account.symbol, account.tokens, tokenDefinitions),
     );
 }

--- a/packages/suite/src/utils/wallet/trading/__fixtures__/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/__fixtures__/tradingUtils.ts
@@ -15,6 +15,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'btc',
+                networkType: 'bitcoin',
                 descriptor: asAccountDescriptor('bbb'),
             },
             tokenContractAddress: undefined,
@@ -28,6 +29,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'eth',
+                networkType: 'ethereum',
                 descriptor: asAccountDescriptor('eee'),
             },
             tokenContractAddress: undefined,
@@ -41,6 +43,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'eth',
+                networkType: 'ethereum',
                 descriptor: asAccountDescriptor('aaa'),
             },
             tokenContractAddress: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
@@ -54,6 +57,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'sol',
+                networkType: 'solana',
                 descriptor: asAccountDescriptor('sss'),
             },
             tokenContractAddress: undefined,
@@ -67,6 +71,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'sol',
+                networkType: 'solana',
                 descriptor: asAccountDescriptor('ddd'),
             },
             tokenContractAddress: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
@@ -80,6 +85,7 @@ export const FIXTURE_ACCOUNT_OPTIONS: Array<{
         option: {
             account: {
                 symbol: 'ada',
+                networkType: 'cardano',
                 descriptor: asAccountDescriptor('ccc'),
             },
             tokenContractAddress: undefined,

--- a/packages/suite/src/utils/wallet/trading/sellExchangeAmountUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/sellExchangeAmountUtils.test.ts
@@ -1,4 +1,5 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import { calcCryptoFromFiat, calcMaxTokenAmount, calcRatioAmount } from './sellExchangeAmountUtils';
 
@@ -39,6 +40,7 @@ describe('calcCryptoFromFiat', () => {
 
 describe('calcRatioAmount', () => {
     const defaultParams = {
+        ...mockNetworkConfigDeps,
         balance: '2',
         decimals: 8,
         networkDecimals: 8,

--- a/packages/suite/src/utils/wallet/trading/sellExchangeAmountUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/sellExchangeAmountUtils.ts
@@ -1,3 +1,4 @@
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     asAmountUnit,
@@ -35,7 +36,7 @@ export const calcCryptoFromFiat = ({
         : cryptoAmount;
 };
 
-type CalcRatioAmountParams = {
+type CalcRatioAmountParams = GetNetworkConfigDep & {
     divisor: number;
     balance: string;
     decimals: number;
@@ -59,6 +60,7 @@ export const calcRatioAmount = ({
     contractAddress,
     formattedBalance,
     fee,
+    getNetworkConfig,
 }: CalcRatioAmountParams): { cryptoInputValue: string; cryptoAmountWithReserve: string } => {
     const amount = new BigNumber(balance || '0').dividedBy(divisor).decimalPlaces(decimals);
 
@@ -68,6 +70,7 @@ export const calcRatioAmount = ({
 
     const cryptoAmountWithReserve = isNetworkReserveEnabled
         ? getCryptoAmountWithReserve({
+              getNetworkConfig,
               symbol,
               contractAddress,
               balance: formattedBalance,

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.test.ts
@@ -1,4 +1,5 @@
-import { type Network, asNetworkSymbol, networks } from '@suite-common/wallet-config';
+import { type Network, toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -90,7 +91,7 @@ describe('trading utils', () => {
                     },
                 } as unknown as Account;
 
-                const network = networks.btc;
+                const network = toNetwork('btc', mockNetworkConfigDeps.getNetworkConfig('btc'));
 
                 const result = await getComposeAddressPlaceholder(account, network);
 
@@ -143,7 +144,7 @@ describe('trading utils', () => {
 
         it('returns empty string for tron (fee uses compose context recipient)', async () => {
             const account = mockWalletAccount({
-                symbol: asNetworkSymbol('trx'),
+                symbol: 'trx',
                 descriptor: asAccountDescriptor('TTronAddress123'),
             });
 

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.ts
@@ -1,6 +1,7 @@
 import { type ExtendedMessageDescriptor } from '@suite/intl';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import type { TradingType } from '@suite-common/trading';
-import { type Network, type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Output,
     type PrecomposedLevels,
@@ -165,14 +166,16 @@ interface ResolveAddressAndTokenProps {
     token: string | null;
 }
 
-export const resolveAddressAndToken = <A extends Pick<Account, 'symbol' | 'descriptor'>>(
+export const resolveAddressAndToken = <
+    A extends Pick<Account, 'symbol' | 'descriptor' | 'networkType'>,
+>(
     account: A | undefined | null,
     tokenContractAddress: TokenInfo['contract'] | undefined | null,
 ): ResolveAddressAndTokenProps => {
     if (!account) {
         return { address: '', token: null };
     }
-    const networkType = getNetworkType(account.symbol);
+    const { networkType } = account;
 
     // set token address for ERC20 transaction to estimate the fees more precisely
     if (networkType === 'ethereum') {
@@ -189,7 +192,7 @@ export const resolveAddressAndToken = <A extends Pick<Account, 'symbol' | 'descr
     return { address: '', token: tokenContractAddress ?? null };
 };
 
-interface GetFeeInUnitsProps {
+interface GetFeeInUnitsProps extends GetNetworkConfigDep {
     symbol: NetworkSymbol;
     composedLevels?: PrecomposedLevels | PrecomposedLevelsCardano;
     selectedFee?: FeeLevel['label'];
@@ -199,6 +202,7 @@ export const getFeeInUnits = ({
     symbol,
     composedLevels,
     selectedFee = 'normal',
+    getNetworkConfig,
 }: GetFeeInUnitsProps): string => {
     const selectedFeeLevel = composedLevels?.[selectedFee];
     if (!selectedFeeLevel) return '0';
@@ -210,6 +214,7 @@ export const getFeeInUnits = ({
     const { fee } = selectedFeeLevel;
 
     const feeInUnits = subunitsToUnits({
+        getNetworkConfig,
         value: asAmountSubunit(new BigNumber(fee)),
         symbol,
     }).toString();

--- a/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetActionButton.tsx
@@ -1,8 +1,10 @@
 import { type MouseEvent, type ReactNode } from 'react';
 
 import { type Route, goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectVisibleDeviceAccounts } from '@suite-common/wallet-core';
 import { Button } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
@@ -26,6 +28,7 @@ export const AssetActionButton = ({
     routeName,
     'data-testid': dataTest,
 }: AssetActionButtonProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { toggleCoinFilter, setSearchString } = useAccountSearch();
     const accounts = useSelector(selectVisibleDeviceAccounts);
@@ -54,7 +57,7 @@ export const AssetActionButton = ({
                 if (account) {
                     dispatch(
                         tradingActions.setTradingFromPrefilledAccount(
-                            getTradingPrefilledFromAccountData(account),
+                            getTradingPrefilledFromAccountData(networkConfigDeps, account),
                         ),
                     );
                 }

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCard/AssetCard.tsx
@@ -8,6 +8,7 @@ import { type AssetFiatBalance } from '@suite-common/assets';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAnyAccountIsStakingActive, useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { type Account, type RatesByKey } from '@suite-common/wallet-types';
 import { type AmountUnit } from '@suite-common/wallet-utils';
@@ -88,6 +89,7 @@ export const AssetCard = ({
     accounts,
     isStakeNetwork,
 }: AssetCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { symbol } = network;
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -110,11 +112,12 @@ export const AssetCard = ({
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
 
     const isStakingActive = useSelector(state =>
-        selectAnyAccountIsStakingActive(state, stakingAccountsForAsset),
+        selectAnyAccountIsStakingActive(state, stakingAccountsForAsset, networkConfigDeps),
     );
 
     const { tokensFiatBalance, assetStakingBalance, shouldRenderStakingRow, shouldRenderTokenRow } =
         handleTokensAndStakingData(
+            networkConfigDeps,
             assetTokens,
             stakingAccountsForAsset,
             isStakingActive,

--- a/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetCoinLogo.tsx
@@ -20,8 +20,8 @@ type AssetCoinLogoProps = {
 };
 
 export const AssetCoinLogo = ({ symbol, assetsFiatBalances, index }: AssetCoinLogoProps) => {
-    const locale = useSelector(selectLanguage);
     const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const locale = useSelector(selectLanguage);
 
     const assetPercentage = assetsFiatBalances
         ? calculateAssetsPercentage(assetsFiatBalances).find(

--- a/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetTable/AssetRow.tsx
@@ -7,6 +7,7 @@ import { type AssetFiatBalance } from '@suite-common/assets';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectCoinDefinitions } from '@suite-common/token-definitions';
 import { type Network } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAnyAccountIsStakingActive, useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { type Account, type RatesByKey } from '@suite-common/wallet-types';
 import { type AmountUnit, isTestnet } from '@suite-common/wallet-utils';
@@ -58,6 +59,7 @@ export const AssetRow = memo(
         accounts,
         isStakeNetwork,
     }: AssetTableRowProps) => {
+        const networkConfigDeps = useServices(selectNetworkConfigDeps);
         const { symbol } = network;
         const dispatch = useDispatch();
         const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -81,7 +83,7 @@ export const AssetRow = memo(
         );
 
         const isStakingActive = useSelector(state =>
-            selectAnyAccountIsStakingActive(state, stakingAccountsForAsset),
+            selectAnyAccountIsStakingActive(state, stakingAccountsForAsset, networkConfigDeps),
         );
 
         const {
@@ -90,6 +92,7 @@ export const AssetRow = memo(
             shouldRenderStakingRow,
             shouldRenderTokenRow,
         } = handleTokensAndStakingData(
+            networkConfigDeps,
             assetTokens,
             stakingAccountsForAsset,
             isStakingActive,
@@ -198,7 +201,7 @@ export const AssetRow = memo(
                                 </AssetActionButton>
                             )}
 
-                            {!isTestnet(symbol) && (
+                            {!isTestnet(networkConfigDeps, symbol) && (
                                 <AssetActionButton
                                     symbol={symbol}
                                     routeName="wallet-trading-buy"

--- a/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
+++ b/packages/suite/src/views/dashboard/AssetsView/AssetsView.tsx
@@ -6,12 +6,14 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { type AssetFiatBalance } from '@suite-common/assets';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type NetworkSymbol,
-    getNetwork,
     getNetworkFeatures,
     isNetworkSymbol,
+    toNetwork,
 } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
     selectBaseCurrency,
@@ -55,6 +57,7 @@ import { AssetCard, AssetCardSkeleton } from './AssetCard/AssetCard';
 import { type AssetData } from './AssetData';
 import { AssetTable } from './AssetTable/AssetTable';
 
+
 const InfoMessage = styled.div`
     padding: 16px 24px;
     align-items: center;
@@ -90,6 +93,8 @@ const useAssetsFiatBalances = (
     }, []);
 
 export const AssetsView = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { dashboardAssetsGridMode } = useSelector(selectFlags);
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
@@ -97,7 +102,7 @@ export const AssetsView = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const { supportedMainnets } = useNetworkSupport();
     const { isBelowTablet } = useLayoutSize();
 
@@ -121,10 +126,12 @@ export const AssetsView = () => {
         assets[account.symbol] = symbolAssets;
     });
 
-    const assetSymbols = typedObjectKeys(assets).filter(symbol => isNetworkSymbol(symbol));
+    const assetSymbols = typedObjectKeys(assets).filter(symbol =>
+        isNetworkSymbol(networkConfigDeps, symbol),
+    );
 
     const assetsData: AssetData[] = assetSymbols.map((symbol): AssetData => {
-        const network = getNetwork(symbol);
+        const network = toNetwork(symbol, getNetworkConfig(symbol));
 
         const assetNativeCryptoBalance =
             assets[symbol] !== undefined
@@ -160,7 +167,7 @@ export const AssetsView = () => {
                     isSupportedTronStakingNetworkSymbol(account.symbol),
             ),
             accounts,
-            isStakeNetwork: getNetworkFeatures(symbol).includes('staking'),
+            isStakeNetwork: getNetworkFeatures(networkConfigDeps, symbol).includes('staking'),
         };
     });
 

--- a/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
+++ b/packages/suite/src/views/dashboard/AssetsView/assetsViewUtils.ts
@@ -1,5 +1,5 @@
 import { type TokenDefinition } from '@suite-common/token-definitions';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type RatesByKey } from '@suite-common/wallet-types';
 import { getAccountTotalStakingBalance } from '@suite-common/wallet-utils';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -13,6 +13,7 @@ import {
 } from 'src/utils/wallet/tokenUtils';
 
 export const handleTokensAndStakingData = (
+    networkConfigDeps: NetworkConfigDeps,
     assetTokens: TokenInfo[],
     accountsThatStaked: Account[],
     isStakingActive: boolean,
@@ -22,10 +23,12 @@ export const handleTokensAndStakingData = (
     currentFiatRates?: RatesByKey,
 ) => {
     const assetStakingBalance = accountsThatStaked.reduce(
-        (total, account) => total.plus(getAccountTotalStakingBalance(account) ?? '0'),
+        (total, account) =>
+            total.plus(getAccountTotalStakingBalance(networkConfigDeps, account) ?? '0'),
         new BigNumber(0),
     );
     const tokens = getTokens({
+        ...networkConfigDeps,
         tokens: assetTokens ?? [],
         symbol,
         tokenDefinitions: coinDefinitions,

--- a/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
+++ b/packages/suite/src/views/dashboard/DashboardPromoBanner/DashboardPromoBanner.tsx
@@ -6,6 +6,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { Feature, selectFeaturesConfig } from '@suite-common/message-system';
 import { type Feature as MessageFeature } from '@suite-common/suite-types';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOverallStatus';
@@ -22,11 +23,14 @@ const isCarouselBannerKey = (key: string): key is DashboardBannerType => isDashb
 export const DashboardPromoBanner = () => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const isDiscoveryEmpty = discoveryStatus?.type === 'discovery-empty';
     const flags = useSelector(selectFlags);
     const selectedDevice = useSelector(selectSelectedDevice);
-    const isOnboardingFeedbackBannerShown = useSelector(selectShouldShowOnboardingFeedbackBanner);
+    const isOnboardingFeedbackBannerShown = useSelector(state =>
+        selectShouldShowOnboardingFeedbackBanner(state, networkConfigDeps),
+    );
 
     const allPromoBanners = useSelector(state =>
         selectFeaturesConfig(state, Feature.banners.dashboard.promo),

--- a/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx
+++ b/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/OnboardingFeedbackBanner.tsx
@@ -9,6 +9,7 @@ import { setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     Box,
     Button,
@@ -94,10 +95,13 @@ const CTAButton = ({ onClick }: { onClick: () => void }) => {
 export const OnboardingFeedbackBanner = () => {
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { isBelowLaptop, isBelowDesktop } = useLayoutSize();
     const isVerticalLayout = useIsContentBelowBreakpoint();
 
-    const isEligible = useSelector(selectShouldShowOnboardingFeedbackBanner);
+    const isEligible = useSelector(state =>
+        selectShouldShowOnboardingFeedbackBanner(state, networkConfigDeps),
+    );
 
     const clearBanner = () => {
         dispatch(setFlag({ key: 'showOnboardingFeedbackBanner', value: false }));

--- a/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts
+++ b/packages/suite/src/views/dashboard/OnboardingFeedbackBanner/onboardingFeedbackBannerSelectors.ts
@@ -1,4 +1,5 @@
 import { selectIsOnboardingFeedbackBannerShown } from '@suite/flags';
+import { type NetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 
 import { type AppState } from 'src/types/suite';
@@ -7,9 +8,12 @@ import { selectDiscoveryOverallStatus } from 'src/utils/wallet/selectDiscoveryOv
 // The onboarding feedback banner is shown after onboarding is completed, as long as the device
 // has no funds yet. It takes precedence over the dashboard promo banner, so the promo banner is
 // hidden while this one is eligible.
-export const selectShouldShowOnboardingFeedbackBanner = (state: AppState) => {
+export const selectShouldShowOnboardingFeedbackBanner = (
+    state: AppState,
+    networkConfigDeps: NetworkConfigDeps,
+) => {
     const isBannerShown = selectIsOnboardingFeedbackBannerShown(state);
-    const accounts = selectAllAccountsToList(state);
+    const accounts = selectAllAccountsToList(state, networkConfigDeps);
     const discoveryStatus = selectDiscoveryOverallStatus(state);
 
     const isDeviceEmpty = accounts.every(account => account.empty);

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCard.tsx
@@ -3,7 +3,8 @@ import { memo, useMemo } from 'react';
 import { useDevice } from '@suite/device';
 import { selectFlags, setFlag } from '@suite/flags';
 import { Translation } from '@suite/intl';
-import { networksCollection } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworks , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
     selectBaseCurrency,
@@ -42,13 +43,14 @@ import { PortfolioCardHeader } from './PortfolioCardHeader';
 import { UnsupportedAssetsMessage, useUnsupportedNetworkMessage } from './UnsupportedAssetsMessage';
 
 export const PortfolioCard = memo(() => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const currentFiatRates = useSelector(selectCurrentFiatRates);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const { discovery, isDiscoveryRunning } = useDiscovery();
     const discoveryStatus = useSelector(selectDiscoveryOverallStatus);
     const enabledNetworks = useSelector(selectEnabledNetworks);
 
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const { dashboardGraphHidden } = useSelector(selectFlags);
     const dispatch = useDispatch();
     const { device } = useDevice();
@@ -65,9 +67,10 @@ export const PortfolioCard = memo(() => {
     const passphraseEntryCanceled =
         accounts.length === 0 && discoveryStatus === undefined && discovery?.status === 'cancelled';
 
-    const hasNetworkWithEnabledGraph = networksCollection.some(
+    const hasNetworkWithEnabledGraph = getNetworks(networkConfigDeps).some(
         network =>
-            isNetworkWithGraphFeature(network.symbol) && enabledNetworks.includes(network.symbol),
+            isNetworkWithGraphFeature(networkConfigDeps, network.symbol) &&
+            enabledNetworks.includes(network.symbol),
     );
 
     // TODO: DashboardGraph will get mounted twice (thus triggering data processing twice)

--- a/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/PortfolioCardException.tsx
@@ -5,7 +5,8 @@ import { useDevice } from '@suite/device';
 import { Translation, type TranslationKey } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
-import { type NetworkType, getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkType } from '@suite-common/wallet-config';
 import { startOrRestartDiscoveryThunk } from '@suite-common/wallet-core';
 import { type DiscoveryStatus, type FailedAccount } from '@suite-common/wallet-types';
 import {
@@ -23,6 +24,7 @@ import { PlusIcon, RepeatIcon, WarningIcon } from '@trezor/icons';
 import { applySettings } from 'src/actions/settings/deviceSettingsActions';
 import { useDispatch } from 'src/hooks/suite';
 import { type DiscoveryStatusType } from 'src/types/wallet';
+
 
 interface CTA {
     label?: TranslationKey;
@@ -103,6 +105,7 @@ const discoveryFailedMessage = (
     discovery: DiscoveryStatus | undefined,
     failed: FailedAccount[],
 ) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     if (discovery?.status !== 'failed') return '';
     if (discovery.error) return <div>{discovery.error}</div>;
 
@@ -110,7 +113,7 @@ const discoveryFailedMessage = (
     const networkError: string[] = [];
 
     const details = failed.reduce((value, account) => {
-        const network = getNetwork(account.symbol);
+        const network = getNetworkConfig(account.symbol);
         if (networkError.includes(account.symbol)) return value;
         networkError.push(account.symbol);
 

--- a/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
+++ b/packages/suite/src/views/dashboard/PortfolioCard/UnsupportedAssetsMessage.tsx
@@ -1,14 +1,23 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { type NetworkSymbol, getNetwork, getNetworkFeatures } from '@suite-common/wallet-config';
+import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
 import { unique } from '@trezor/utils';
 
 import { isNetworkWithGraphFeature } from 'src/utils/wallet/graph';
 
-const hasAnyAccountWithTokens = (accounts: Account[]): boolean =>
-    accounts.some(account => getNetworkFeatures(account.symbol).includes('tokens'));
+
+const hasAnyAccountWithTokens = (
+    getNetworkConfig: GetNetworkConfigDep['getNetworkConfig'],
+    accounts: Account[],
+): boolean =>
+    accounts.some(account =>
+        getNetworkFeatures({ getNetworkConfig }, account.symbol).includes('tokens'),
+    );
 
 export const useUnsupportedNetworkMessage = ({
     showGraphControls,
@@ -19,19 +28,24 @@ export const useUnsupportedNetworkMessage = ({
     device?: TrezorDevice;
     accounts: Account[];
 }) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const affectedAccounts =
         showGraphControls && !hasBitcoinOnlyFirmware(device)
             ? accounts
                   .filter(
                       account =>
                           account.history &&
-                          !isNetworkWithGraphFeature(account.symbol, account.backendType),
+                          !isNetworkWithGraphFeature(
+                              { getNetworkConfig },
+                              account.symbol,
+                              account.backendType,
+                          ),
                   )
                   .map(({ symbol }) => symbol)
             : [];
 
     const affectedNetworks = unique(affectedAccounts);
-    const hasTokens = hasAnyAccountWithTokens(accounts);
+    const hasTokens = hasAnyAccountWithTokens(getNetworkConfig, accounts);
     const showMissingDataTooltip = showGraphControls && (affectedNetworks.length > 0 || hasTokens);
 
     return { affectedNetworks, showMissingDataTooltip, hasTokens };
@@ -43,8 +57,11 @@ type MessageProps = {
 };
 
 const Message = ({ affectedNetworks, hasTokens }: MessageProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const hasNetworks = affectedNetworks.length > 0;
-    const networksString = affectedNetworks.map(network => getNetwork(network).name).join(', ');
+    const networksString = affectedNetworks
+        .map(network => getNetworkConfig(network).name)
+        .join(', ');
 
     if (hasNetworks && hasTokens) {
         return (

--- a/packages/suite/src/views/earn/yield/useEarnLayout.tsx
+++ b/packages/suite/src/views/earn/yield/useEarnLayout.tsx
@@ -2,11 +2,18 @@ import { useEffect } from 'react';
 
 import { type TranslationKey } from '@suite/intl';
 import { type EarnParams, goto } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type YieldDtoV2, useGetVaultByAddress } from '@suite-common/earn-stablecoin-api';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { type EarnAnalyticsStep } from '@suite-common/suite-types/src/staking';
-import { getNetworkByYieldXyzId, getNetworkOptional } from '@suite-common/wallet-config';
+import {
+    type NetworkConfigDeps,
+    findNetworkByYieldXyzId,
+    getNetworks,
+    selectNetworkConfigDeps,
+    toNetwork,
+} from '@suite-common/wallet-config';
 import {
     type YieldPositionFlowType,
     getYieldVaultContractAddress,
@@ -27,7 +34,7 @@ type UseEarnLayoutParams = {
     fallbackTitleId: TranslationKey;
 };
 
-type GetEarnLayoutResultParams = {
+type GetEarnLayoutResultParams = NetworkConfigDeps & {
     account?: Account;
     device?: TrezorDevice;
     routeParams?: EarnParams;
@@ -38,7 +45,7 @@ type GetEarnLayoutResultParams = {
     isYieldOpportunitiesError: boolean;
 };
 
-type VaultValidationParams = {
+type VaultValidationParams = NetworkConfigDeps & {
     account: Account;
     vault?: YieldDtoV2;
 };
@@ -57,12 +64,16 @@ const getAnalyticsStep = (type: YieldPositionFlowType): EarnYieldAnalyticsStep =
     }
 };
 
-const isVaultNetworkMismatch = ({ account, vault }: VaultValidationParams): boolean => {
+const isVaultNetworkMismatch = ({
+    account,
+    vault,
+    ...networkConfigDeps
+}: VaultValidationParams): boolean => {
     if (!vault) {
         return false;
     }
 
-    const vaultNetwork = getNetworkByYieldXyzId(vault.network);
+    const vaultNetwork = findNetworkByYieldXyzId(getNetworks(networkConfigDeps), vault.network);
 
     return vaultNetwork?.symbol !== account.symbol;
 };
@@ -70,6 +81,7 @@ const isVaultNetworkMismatch = ({ account, vault }: VaultValidationParams): bool
 // The vault is looked up by the address in the route, so this only guards against a backend
 // returning something other than what was asked for.
 const isVaultAddressMismatch = ({
+    getNetworkConfig,
     account,
     routeParams,
     vault,
@@ -85,12 +97,18 @@ const isVaultAddressMismatch = ({
     }
 
     return (
-        getContractAddressForNetworkSymbol(account.symbol, vaultAddress) !==
-        getContractAddressForNetworkSymbol(account.symbol, routeParams.vaultAddress)
+        getContractAddressForNetworkSymbol({ getNetworkConfig }, account.symbol, vaultAddress) !==
+        getContractAddressForNetworkSymbol(
+            { getNetworkConfig },
+            account.symbol,
+            routeParams.vaultAddress,
+        )
     );
 };
 
 const getEarnLayoutResult = ({
+    getNetworkConfig,
+    networkModuleRepository,
     account,
     device,
     routeParams,
@@ -100,6 +118,7 @@ const getEarnLayoutResult = ({
     isYieldOpportunitiesSuccess,
     isYieldOpportunitiesError,
 }: GetEarnLayoutResultParams): EarnLayoutState => {
+    const networkConfigDeps = { getNetworkConfig, networkModuleRepository };
     if (!routeParams) {
         return { status: 'invalid', reason: 'missing-route-params' };
     }
@@ -124,11 +143,11 @@ const getEarnLayoutResult = ({
         return { status: 'invalid', reason: 'missing-vault' };
     }
 
-    if (isVaultNetworkMismatch({ account, vault })) {
+    if (isVaultNetworkMismatch({ ...networkConfigDeps, account, vault })) {
         return { status: 'invalid', reason: 'network-mismatch' };
     }
 
-    if (isVaultAddressMismatch({ account, routeParams, vault })) {
+    if (isVaultAddressMismatch({ ...networkConfigDeps, account, routeParams, vault })) {
         return { status: 'invalid', reason: 'missing-vault' };
     }
 
@@ -146,13 +165,18 @@ const getEarnLayoutResult = ({
 };
 
 export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): EarnLayoutState => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const analyticsStep = getAnalyticsStep(type);
     const dispatch = useDispatch();
     const { account, routeParams } = useEarnRouteAccount();
     const selectedDevice = useSelector(selectSelectedDevice);
     // Normalized so a hand-written URL resolves the same vault as one the app produced.
     const vaultAddress = routeParams?.vaultAddress
-        ? getContractAddressForNetworkSymbol(routeParams.symbol, routeParams.vaultAddress)
+        ? getContractAddressForNetworkSymbol(
+              networkConfigDeps,
+              routeParams.symbol,
+              routeParams.vaultAddress,
+          )
         : undefined;
     const {
         data: vault,
@@ -162,7 +186,10 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
     } = useGetVaultByAddress({
         enabled: true,
         outputToken: vaultAddress,
-        network: getNetworkOptional(routeParams?.symbol)?.yieldXyzId ?? undefined,
+        network: routeParams
+            ? (toNetwork(routeParams.symbol, networkConfigDeps.getNetworkConfig(routeParams.symbol))
+                  .yieldXyzId ?? undefined)
+            : undefined,
     });
 
     useEffect(() => {
@@ -172,6 +199,7 @@ export const useEarnLayout = ({ type, fallbackTitleId }: UseEarnLayoutParams): E
     }, [dispatch, routeParams]);
 
     const layoutState = getEarnLayoutResult({
+        ...networkConfigDeps,
         account,
         device: selectedDevice,
         routeParams,

--- a/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
+++ b/packages/suite/src/views/settings/SettingsCoins/SettingsCoins.tsx
@@ -13,6 +13,7 @@ import { selectIsTestnetNetworksEnabled } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
 import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     changeCoinVisibility,
     selectDeviceSupportedNetworks,
@@ -49,6 +50,7 @@ const discoveryButtonAnimationConfig: MotionProps = {
 };
 
 export const SettingsCoins = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const hasContentBelowTabletWidth = useIsContentBelowBreakpoint(breakpoints.tablet);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
@@ -61,11 +63,13 @@ export const SettingsCoins = () => {
         supportedTestnets,
         unsupportedTestnets,
     } = useNetworkSupport();
-    const deviceSupportedNetworkSymbols = useSelector(selectDeviceSupportedNetworks);
+    const deviceSupportedNetworkSymbols = useSelector(state =>
+        selectDeviceSupportedNetworks(state, networkConfigDeps),
+    );
     const { device, isLocked } = useDevice();
     const isDeviceLocked = !!device && isLocked();
     const isDiscoveryButtonVisible = useSelector(state =>
-        selectShowRediscoverButton(state, device),
+        selectShowRediscoverButton(state, networkConfigDeps, device),
     );
     const useTestnetNetworks = useSelector(selectIsTestnetNetworksEnabled);
 

--- a/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/ConnectPermissions.tsx
@@ -12,6 +12,8 @@ import {
     permissionIcons,
     selectConnectAppPermissions,
 } from '@suite-common/connect-popup';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     Box,
     Card,
@@ -180,6 +182,7 @@ const PermissionGroup = ({
     onRemovePermission,
 }: PermissionGroupProps) => {
     const { translationString } = useTranslation();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isOpen, setIsOpen] = useState(defaultIsOpen);
 
     return (
@@ -190,7 +193,11 @@ const PermissionGroup = ({
                         <Row gap={12}>
                             <GroupBadge coin={coin} />
                             <Text typographyStyle="body-md-strong">
-                                {coin ? getCoinLabel(coin) : <Translation id="TR_DEVICE" />}
+                                {coin ? (
+                                    getCoinLabel(networkConfigDeps, coin)
+                                ) : (
+                                    <Translation id="TR_DEVICE" />
+                                )}
                             </Text>
                         </Row>
                         {!isOpen && <PermissionPreview permissions={permissions} />}

--- a/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
+++ b/packages/suite/src/views/settings/SettingsConnectedApps/WalletConnectList.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getSessionNetworks,
     selectSessions,
@@ -18,6 +20,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const WalletConnectList = () => {
     const dispatch = useDispatch();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const sessions = useSelector(selectSessions);
 
     if (sessions.length === 0) {
@@ -71,7 +74,7 @@ export const WalletConnectList = () => {
                             </Row>
 
                             <Text intent="neutral" priority="secondary">
-                                {getSessionNetworks(session)
+                                {getSessionNetworks(networkConfigDeps, session)
                                     .map(network => network.name)
                                     .join(', ')}
                             </Text>

--- a/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Backends.tsx
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectEnabledNetworks, selectNetworkBlockchainInfo } from '@suite-common/wallet-core';
 import { type ConnectionStatus } from '@suite-common/wallet-types';
 import { Button } from '@trezor/components';
@@ -119,6 +121,7 @@ const BackendItem = ({
 };
 
 const CoinItem = ({ symbol }: CoinItemProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { url, error, connected, reconnectionTime, identityConnections } = useSelector(state =>
         selectNetworkBlockchainInfo(state, symbol),
     );
@@ -140,7 +143,7 @@ const CoinItem = ({ symbol }: CoinItemProps) => {
                 <div>
                     <CoinCell>
                         <TokenIcon symbol={symbol} />
-                        <Title>{getNetwork(symbol).name}</Title>
+                        <Title>{getNetworkConfig(symbol).name}</Title>
                     </CoinCell>
                     <Button size="small" intent="neutral" priority="secondary" onClick={onSettings}>
                         <Translation id="TR_SETTINGS" />

--- a/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/CoinjoinApi.tsx
@@ -8,14 +8,16 @@ import {
     type CoinjoinSymbol,
 } from '@suite/coinjoin';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { BITCOIN_ONLY_SYMBOLS } from '@suite-common/suite-constants';
 import { selectReloadAppDep } from '@suite-common/suite-types';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Button } from '@trezor/components';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 import { typedObjectKeys } from '@trezor/utils';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
 
 const CoordinatorVersionContainer = styled.div`
     display: flex;
@@ -58,13 +60,14 @@ const CoordinatorServer = ({
     value,
     onChange,
 }: CoordinatorServerProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const options = environments.map(environment => ({
         label: environment,
         value: environment,
     }));
 
     const selectedOption = (value && options.find(option => option.value === value)) ?? options[0];
-    const networkName = getNetwork(symbol).name;
+    const networkName = getNetworkConfig(symbol).name;
 
     if (!isCoinjoinSupportedSymbol(symbol)) return null;
 

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -16,7 +16,7 @@ import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-component
 import { EXPERIMENTAL_FEATURES_KB_URL } from '@trezor/urls';
 import { typedObjectKeys } from '@trezor/utils';
 
-import { EXPERIMENTAL_FEATURES } from 'src/constants/suite/experimental';
+import { createExperimentalFeatures } from 'src/constants/suite/experimental';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { selectSuiteServices } from 'src/support/extraDependencies';
 
@@ -28,9 +28,10 @@ type FeatureLineProps = {
 const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const dispatch = useDispatch();
     const services = useImperativeServices(selectSuiteServices);
+    const experimentalFeaturesConfig = createExperimentalFeatures(services);
     const checked = enabledFeatures.includes(feature);
 
-    const config = EXPERIMENTAL_FEATURES[feature];
+    const config = experimentalFeaturesConfig[feature];
     const { title, description } = config;
     const url = config.knowledgeBaseUrl;
 
@@ -122,10 +123,14 @@ export const Experimental = () => {
 
     const dispatch = useDispatch();
     const services = useImperativeServices(selectSuiteServices);
+    const experimentalFeaturesConfig = useMemo(
+        () => createExperimentalFeatures(services),
+        [services],
+    );
 
     const onSwitchExperimental = () => {
         enabledFeatures?.forEach(feature =>
-            EXPERIMENTAL_FEATURES[feature]?.onToggle?.({
+            experimentalFeaturesConfig[feature]?.onToggle?.({
                 services,
                 newValue: !isExperimentalEnabled,
                 dispatch,
@@ -141,13 +146,13 @@ export const Experimental = () => {
 
     const experimentalFeatures = useMemo(
         () =>
-            typedObjectKeys(EXPERIMENTAL_FEATURES).filter(
+            typedObjectKeys(experimentalFeaturesConfig).filter(
                 feature =>
-                    !EXPERIMENTAL_FEATURES[feature]?.isDisabled?.({
+                    !experimentalFeaturesConfig[feature]?.isDisabled?.({
                         isDebug,
                     }),
             ),
-        [isDebug],
+        [experimentalFeaturesConfig, isDebug],
     );
 
     return (

--- a/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/MevProtection.tsx
@@ -2,7 +2,11 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworksWithMevProtection } from '@suite-common/wallet-config';
+import {
+    getNetworks,
+    getNetworksWithFeature,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { selectIsMevProtectionEnabled, setMevProtection } from '@suite-common/wallet-core';
 import { Column, Switch } from '@trezor/components';
 import {
@@ -16,10 +20,14 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const MevProtection = () => {
     const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
 
-    const supportedNetworks = getNetworksWithMevProtection();
+    const supportedNetworks = getNetworksWithFeature(
+        getNetworks(networkConfigDeps),
+        'mev-protection',
+    );
 
     const handleSwitchChange = () => {
         const nextIsMevProtectionEnabled = !isMevProtectionEnabled;

--- a/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/NetworkReserve.tsx
@@ -3,7 +3,7 @@ import { LearnMoreButton } from '@suite/external-links';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworksWithNativeTokenReserve } from '@suite-common/wallet-config';
+import { getNetworks, getNetworksWithNativeTokenReserve , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled, setNetworkReserve } from '@suite-common/wallet-core';
 import { Column, Switch } from '@trezor/components';
 import {
@@ -17,11 +17,12 @@ import { NETWORK_RESERVE_URL } from '@trezor/urls';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
 export const NetworkReserve = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const dispatch = useDispatch();
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
-    const supportedNetworks = getNetworksWithNativeTokenReserve();
+    const supportedNetworks = getNetworksWithNativeTokenReserve(getNetworks(networkConfigDeps));
 
     const handleSwitchChange = () => {
         const nextIsNetworkReserveEnabled = !isNetworkReserveEnabled;

--- a/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/SettingsGeneral.tsx
@@ -5,9 +5,10 @@ import { ContextMessage } from '@suite/message-system';
 import { selectIsLegacyLabelingVisible, selectSelectedProviderForLabels } from '@suite/metadata';
 import { selectHasExperimentalFeature } from '@suite/settings';
 import { TorStatus, selectTorState } from '@suite/tor';
+import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
 import { selectIsMevProtectionSettingsVisible } from '@suite-common/mev';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     selectEnabledNetworks,
     selectIsNetworkReserveSettingsVisible,
@@ -61,6 +62,7 @@ import { TorOnionLinks } from './TorOnionLinks';
 import { VersionWithUpdate } from './VersionWithUpdate';
 
 export const SettingsGeneral = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const shouldShowSettingsDesktopAppPromoBanner = useSelector(
         selectIsSettingsDesktopAppPromoBannerShown,
     );
@@ -74,7 +76,7 @@ export const SettingsGeneral = () => {
     const hasContentBelowMobileWidth = useIsContentBelowBreakpoint(breakpoints.mobile);
 
     const hasBitcoinNetworks = enabledNetworks.some(symbol => {
-        const networkFeatures = getNetwork(symbol).features;
+        const networkFeatures = getNetworkConfig(symbol).features;
 
         return networkFeatures.includes('amount-unit');
     });

--- a/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
+++ b/packages/suite/src/views/suite/SwitchDevice/DeviceItem/WalletInstance.tsx
@@ -5,6 +5,8 @@ import { Labeling } from '@suite/labeling';
 import { selectIsLegacyLabelingVisible } from '@suite/metadata';
 import { SuiteSyncWalletDebug } from '@suite/suite-sync';
 import { useWalletLabel } from '@suite/wallet';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getAccountsByDeviceState,
     selectAllAccountsToList,
@@ -52,6 +54,7 @@ export const WalletInstance = ({
     onCancel,
     ...rest
 }: WalletInstanceProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isEjecting, setIsEjecting] = useState(false);
     const accounts = useSelector(state => state.wallet.accounts);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
@@ -86,7 +89,10 @@ export const WalletInstance = ({
 
             // NOTE: to determine which account is the first one, we need to filter out empty accounts
             // that are currently displayed in the UI
-            const unfilteredUIAccountGroups = selectAllAccountsToList(store.getState());
+            const unfilteredUIAccountGroups = selectAllAccountsToList(
+                store.getState(),
+                networkConfigDeps,
+            );
             const currentFirstAccount = unfilteredUIAccountGroups[0];
             // NOTE: attempt to determine, if the currently selected account
             // has a corresponding account in the next wallet accounts

--- a/packages/suite/src/views/wallet/nfts/NftsTable/NftsTable.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTable/NftsTable.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { toNetwork } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Card, Column, Table } from '@trezor/components';
 
@@ -9,6 +11,7 @@ import { type GetTokensOutputType } from 'src/utils/wallet/tokenUtils';
 
 import NftsRow from './NftsRow';
 import { DropdownRow } from '../../tokens/DropdownRow';
+
 
 type NftsTableProps = {
     selectedAccount: SelectedAccountLoaded;
@@ -18,8 +21,9 @@ type NftsTableProps = {
 };
 
 const NftsTable = ({ selectedAccount, isShown, verified, nfts }: NftsTableProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { account } = selectedAccount;
-    const network = getNetwork(account.symbol);
+    const network = toNetwork(account.symbol, getNetworkConfig(account.symbol));
     const [isEmptyCollectionsOpen, setIsEmptyCollectionsOpen] = useState(false);
 
     const getNftsToShow = () => {

--- a/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
+++ b/packages/suite/src/views/wallet/nfts/NftsTablesSection.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectNftDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Banner, Column, H3 } from '@trezor/components';
 
@@ -21,10 +23,12 @@ export const NftsTablesSection = ({
     searchQuery,
     isShown = true,
 }: EvmNftsTablesProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const nftDefinitions = useSelector(state =>
         selectNftDefinitions(state, selectedAccount.account.symbol),
     );
     const nfts = getTokens({
+        ...networkConfigDeps,
         tokens: selectedAccount.account.tokens || [],
         symbol: selectedAccount.account.symbol,
         tokenDefinitions: nftDefinitions,

--- a/packages/suite/src/views/wallet/receive/components/Header.tsx
+++ b/packages/suite/src/views/wallet/receive/components/Header.tsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { H2, Paragraph } from '@trezor/components';
 
 import { type Account } from 'src/types/wallet';
@@ -15,10 +16,13 @@ interface HeaderProps {
 }
 
 export const Header = ({ account }: HeaderProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const title = (
         <Translation
             id="RECEIVE_TITLE"
-            values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
+            values={{
+                networkDisplaySymbol: getNetworkDisplaySymbol(networkConfigDeps, account.symbol),
+            }}
         />
     );
     if (account.networkType === 'bitcoin') {

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/CoinControl.tsx
@@ -4,8 +4,10 @@ import styled from 'styled-components';
 
 import { selectCurrentTargetAnonymity } from '@suite/coinjoin';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { filterAndCategorizeUtxos } from '@suite-common/transaction-search';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { COMPOSE_ERROR_TYPES } from '@suite-common/wallet-constants';
 import { fetchUtxoTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits, formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -45,6 +47,7 @@ type CoinControlProps = {
 };
 
 export const CoinControl = ({ close }: CoinControlProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [currentPage, setSelectedPage] = useState(1);
     const [searchQuery, setSearchQuery] = useState('');
     const {
@@ -75,7 +78,7 @@ export const CoinControl = ({ close }: CoinControlProps) => {
     const getTotal = (amounts: number[]) =>
         amounts.reduce((previous, current) => previous + current, 0);
     const getFormattedAmount = (amount: number) =>
-        formatNetworkAmount(amount.toString(), account.symbol);
+        formatNetworkAmount(networkConfigDeps, amount.toString(), account.symbol);
 
     // calculate and format amounts
     const inputs = isCoinControlEnabled ? selectedUtxos : composedInputs;

--- a/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
+++ b/packages/suite/src/views/wallet/send/Options/BitcoinOptions/CoinControl/UtxoSelectionList/UtxoSelection/UtxoSelection.tsx
@@ -8,9 +8,11 @@ import {
     selectLabelingDataForSelectedAccount,
 } from '@suite/metadata';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { selectIsSuiteSyncEnabled, selectSuiteSyncOutputLabels } from '@suite-common/suite-sync';
 import { type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { formatNetworkAmount, isSameUtxo } from '@suite-common/wallet-utils';
 import {
@@ -71,6 +73,7 @@ type UtxoSelectionProps = {
 };
 
 export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account,
         network,
@@ -214,7 +217,11 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                             </Labeling>
                         </Text>
                         <FormattedCryptoAmount
-                            value={formatNetworkAmount(utxo.amount, account.symbol)}
+                            value={formatNetworkAmount(
+                                networkConfigDeps,
+                                utxo.amount,
+                                account.symbol,
+                            )}
                             symbol={account.symbol}
                         />
                     </Row>
@@ -281,7 +288,12 @@ export const UtxoSelection = ({ transaction, utxo }: UtxoSelectionProps) => {
                                 as="div"
                             >
                                 <BaseCurrencyValue
-                                    amount={formatNetworkAmount(utxo.amount, account.symbol, false)}
+                                    amount={formatNetworkAmount(
+                                        networkConfigDeps,
+                                        utxo.amount,
+                                        account.symbol,
+                                        false,
+                                    )}
                                     symbol={network.symbol}
                                 />
                             </Text>

--- a/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
+++ b/packages/suite/src/views/wallet/send/Options/MiscNetworkOptions/DestinationTag.tsx
@@ -1,6 +1,8 @@
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { U_INT_32 } from '@suite-common/wallet-constants';
 import { isInteger } from '@suite-common/wallet-utils';
 import { Banner, Button, Card, Column, Input, Note, Row, Switch } from '@trezor/components';
@@ -18,6 +20,7 @@ interface DestinationTagProps {
 }
 
 export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const {
         register,
         getDefaultValue,
@@ -30,7 +33,7 @@ export const DestinationTag = ({ networkSymbol }: DestinationTagProps) => {
     const { translationString } = useTranslation();
     const { openNodeById } = useGuideOpenNode();
 
-    const { networkType, name } = getNetwork(networkSymbol);
+    const { networkType, name } = getNetworkConfig(networkSymbol);
 
     if (networkType !== 'ripple' && networkType !== 'stellar') {
         return null;

--- a/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
+++ b/packages/suite/src/views/wallet/send/Options/TronOptions/TronNote.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     Card,
     Column,
@@ -25,6 +26,7 @@ type TronNoteProps = {
 };
 
 export const TronNote = ({ close }: TronNoteProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account: { symbol },
         register,
@@ -35,7 +37,7 @@ export const TronNote = ({ close }: TronNoteProps) => {
 
     const { translationString } = useTranslation();
 
-    const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, symbol);
 
     const value = watch(inputName);
     const byteSize = Buffer.from(value || '', 'utf8').length;

--- a/packages/suite/src/views/wallet/send/Outputs/Address.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Address.tsx
@@ -22,6 +22,7 @@ import { selectFindNetworkSymbolForProtocolDep } from '@suite-common/networks';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isAmountPresent, parseTransferUri } from '@suite-common/transfer-uri';
 import { formInputsMaxLength } from '@suite-common/validators';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import type { Output } from '@suite-common/wallet-types';
 import {
     checkIsAddressNotUsedNotChecksummed,
@@ -85,10 +86,17 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
         clearErrors,
     } = useSendFormContext();
     const { translationString } = useTranslation();
-    const { analytics, addressValidator, findNetworkSymbolForProtocol } = useServices(
+    const {
+        analytics,
+        addressValidator,
+        findNetworkSymbolForProtocol,
+        getNetworkConfig,
+        networkModuleRepository,
+    } = useServices(
         selectDesktopAnalyticsDep,
         selectAddressValidatorDep,
         selectFindNetworkSymbolForProtocolDep,
+        selectNetworkConfigDeps,
     );
     const { descriptor, networkType, symbol } = account;
     const inputName = `outputs.${outputId}.address` as const;
@@ -138,7 +146,10 @@ export const Address = ({ output, outputId, outputsCount }: AddressProps) => {
             return;
         }
 
-        const result = parseTransferUri(uri, findNetworkSymbolForProtocol);
+        const result = parseTransferUri(
+            { findNetworkSymbolForProtocol, getNetworkConfig, networkModuleRepository },
+            uri,
+        );
 
         let parsedScheme: string | undefined;
         if (result.success) {

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/Amount.tsx
@@ -5,7 +5,7 @@ import { Translation, useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
 import { useServices } from '@suite-common/dependency-injection';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { type Output, type TokenAddress } from '@suite-common/wallet-types';
 import {
@@ -45,6 +45,7 @@ interface AmountProps {
 }
 
 export const Amount = ({ output, outputId }: AmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const {
@@ -106,8 +107,10 @@ export const Amount = ({ output, outputId }: AmountProps) => {
         decimals = network.decimals;
     }
 
-    const withTokens = hasNetworkFeatures(account, 'tokens');
-    const displayTicker = shouldSendInSats ? 'sat' : getNetworkDisplaySymbol(symbol);
+    const withTokens = hasNetworkFeatures(networkConfigDeps, account, 'tokens');
+    const displayTicker = shouldSendInSats
+        ? 'sat'
+        : getNetworkDisplaySymbol(networkConfigDeps, symbol);
     const isLowAnonymity = isLowAnonymityWarning(outputError);
     const hasError = !!error;
     const bottomText = isLowAnonymity ? undefined : error?.message;
@@ -115,6 +118,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
     const handleInputChange = (value: string) => handleAmountChange({ outputId, value });
 
     const feeInUnits = getFeeInUnits({
+        ...networkConfigDeps,
         symbol: account.symbol,
         composedLevels,
         selectedFee: getValues().selectedFee,
@@ -140,7 +144,10 @@ export const Amount = ({ output, outputId }: AmountProps) => {
 
                 // amounts below dust are not allowed
                 let dust =
-                    rawDust && (shouldSendInSats ? rawDust : formatNetworkAmount(rawDust, symbol));
+                    rawDust &&
+                    (shouldSendInSats
+                        ? rawDust
+                        : formatNetworkAmount(networkConfigDeps, rawDust, symbol));
 
                 if (dust && amountBig.lt(dust)) {
                     if (shouldSendInSats) {
@@ -148,11 +155,12 @@ export const Amount = ({ output, outputId }: AmountProps) => {
                     }
 
                     return translationString('AMOUNT_IS_BELOW_DUST', {
-                        dust: `${dust} ${shouldSendInSats ? 'sat' : getNetworkDisplaySymbol(symbol)}`,
+                        dust: `${dust} ${shouldSendInSats ? 'sat' : getNetworkDisplaySymbol(networkConfigDeps, symbol)}`,
                     });
                 }
             },
             reserveOrBalance: validateReserveOrBalance(translationString, {
+                ...networkConfigDeps,
                 account,
                 areSatsUsed: !!shouldSendInSats,
                 contractAddress: tokenValue,
@@ -160,6 +168,7 @@ export const Amount = ({ output, outputId }: AmountProps) => {
             networkReserve: isNetworkReserveEnabled
                 ? validateNetworkReserve(translationString, {
                       reserve: getNetworkReserve({
+                          ...networkConfigDeps,
                           symbol: account.symbol,
                           contractAddress: tokenValue,
                           isEnabled: isNetworkReserveEnabled,

--- a/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Amount/BaseCurrencyInput.tsx
@@ -4,7 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { formInputsMaxLength } from '@suite-common/validators';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { updateFiatRatesThunk } from '@suite-common/wallet-core';
 import {
     type BaseCurrencyOption,
@@ -52,6 +54,7 @@ export const BaseCurrencyInput = ({
     labelHoverRight,
     labelRight,
 }: FiatInputProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account,
         network,
@@ -87,6 +90,7 @@ export const BaseCurrencyInput = ({
     const baseCurrencyCode = currencyValue.value;
 
     const baseCurrencyDecimals = getDecimalsForBaseCurrency({
+        ...networkConfigDeps,
         code: baseCurrencyCode,
         isInSats: areSatsDisplayed,
     });
@@ -105,6 +109,7 @@ export const BaseCurrencyInput = ({
 
             if (isSendMaxActive) {
                 const formattedAmount = parseCryptoToFormattedBaseCurrency({
+                    ...networkConfigDeps,
                     ...baseFormatOptions,
                     value: cryptoValue,
                     baseCurrencyCode,
@@ -115,6 +120,7 @@ export const BaseCurrencyInput = ({
                 });
             } else {
                 const formattedAmount = parseBaseCurrencyToFormattedCrypto({
+                    ...networkConfigDeps,
                     ...baseFormatOptions,
                     value: fiatValue,
                     isCryptoInSats: shouldSendInSats === true,

--- a/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/CardanoMinAmountInfo.tsx
@@ -1,5 +1,6 @@
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { MIN_CARDANO_AMOUNT_FOR_SEND } from '@suite-common/wallet-constants';
 import {
     asAmountSubunit,
@@ -14,6 +15,7 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 export const CardanoMinAmountInfo = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account: { symbol, networkType, balance },
         composedLevels,
@@ -41,11 +43,17 @@ export const CardanoMinAmountInfo = () => {
             ? transactionInfo.totalSpent
             : new BigNumber(MIN_CARDANO_AMOUNT_FOR_SEND)
                   .times(formOutputs.length)
-                  .plus(unitsToSubunits({ symbol, value: asAmountUnit(totalAdaAmount) })),
+                  .plus(
+                      unitsToSubunits({
+                          ...networkConfigDeps,
+                          symbol,
+                          value: asAmountUnit(totalAdaAmount),
+                      }),
+                  ),
     );
 
     const hasEnoughADA = new BigNumber(balance).minus(minAdaAmount).gte(0);
-    const networkDisplaySymbol = getNetworkDisplaySymbol(symbol);
+    const networkDisplaySymbol = getNetworkDisplaySymbol(networkConfigDeps, symbol);
 
     return (
         <>
@@ -73,6 +81,7 @@ export const CardanoMinAmountInfo = () => {
                     <FormattedCryptoAmount
                         disableHiddenPlaceholder
                         value={subunitsToUnits({
+                            ...networkConfigDeps,
                             symbol,
                             value: asAmountSubunit(minAdaAmount),
                         })}

--- a/packages/suite/src/views/wallet/send/Outputs/Outputs.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/Outputs.tsx
@@ -3,7 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
-import { getNetworkFeatures } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkFeatures , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Card, Column, motionEasing } from '@trezor/components';
 import { motionEasingStrings } from '@trezor/components/src/config/motion';
 
@@ -27,6 +28,7 @@ interface OutputsProps {
 }
 
 export const Outputs = ({ disableAnim }: OutputsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [height, setHeight] = useState(0);
     const [hasRenderedOutputs, setHasRenderedOutputs] = useState(false);
 
@@ -63,7 +65,7 @@ export const Outputs = ({ disableAnim }: OutputsProps) => {
         }
     }, [outputs]);
 
-    const areTokensSupported = getNetworkFeatures(symbol).includes('tokens');
+    const areTokensSupported = getNetworkFeatures(networkConfigDeps, symbol).includes('tokens');
 
     return (
         <Container $height={height || 0}>

--- a/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/UtxoReceiveAddressOption.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/UtxoReceiveAddressOption.tsx
@@ -1,6 +1,7 @@
 import { Address } from '@suite/address';
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { BASE_CURRENCY_ZERO, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
@@ -24,7 +25,8 @@ export const UtxoReceiveAddressOption = ({
     address,
     onAddressSelect,
 }: UtxoReceiveAddressOptionProps) => {
-    const network = getNetwork(account.symbol);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const network = getNetworkConfig(account.symbol);
 
     const baseCurrency = useSelector(selectBaseCurrency);
     const { BaseCurrencyAmountFormatter } = useFormatters();

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildTokenOptions.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/SelectTokenAssetModal/hooks/useBuildTokenOptions.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type TokenDefinitions, selectCoinDefinitions } from '@suite-common/token-definitions';
+import { type NetworkConfigDeps, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 
@@ -20,12 +22,14 @@ import {
 } from 'src/utils/wallet/tokenUtils';
 
 const buildTokenOptions = (
+    networkConfigDeps: NetworkConfigDeps,
     account: Account,
     accountTokens: EnahncedTokenInfoWithFiat[],
     coinDefinitions: TokenDefinitions['coin'],
     expandedHiddenTokensGroups: AccountKey[],
 ): AccountWithTokensOption[] => {
     const tokens = getTokens<EnahncedTokenInfoWithFiat>({
+        ...networkConfigDeps,
         tokens: accountTokens,
         symbol: account.symbol,
         tokenDefinitions: coinDefinitions,
@@ -61,6 +65,7 @@ export function useBuildTokenOptions({
     account,
     expandedHiddenTokensGroups,
 }: UseBuildTokenOptionsParams): AccountWithTokensOption[] {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRates = useSelector(selectCurrentFiatRates);
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
@@ -76,10 +81,18 @@ export function useBuildTokenOptions({
         const sortedTokensWithRates = tokensWithRates.sort(sortTokensWithRates);
 
         return buildTokenOptions(
+            networkConfigDeps,
             account,
             sortedTokensWithRates,
             coinDefinitions,
             expandedHiddenTokensGroups,
         );
-    }, [account, baseCurrencyCode, fiatRates, coinDefinitions, expandedHiddenTokensGroups]);
+    }, [
+        account,
+        baseCurrencyCode,
+        fiatRates,
+        coinDefinitions,
+        expandedHiddenTokensGroups,
+        networkConfigDeps,
+    ]);
 }

--- a/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TokenSelect/TokenSelect.tsx
@@ -3,12 +3,11 @@ import { useEffect, useMemo, useState } from 'react';
 import { Address, copyAddressToClipboard, showCopyAddressModal } from '@suite/address';
 import { selectIsCopyAddressModalShown } from '@suite/flags';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { selectIsSpecificCoinDefinitionKnown } from '@suite-common/token-definitions';
-import {
-    type Explorer,
-    getNetwork,
-    getNetworkDisplaySymbolName,
-} from '@suite-common/wallet-config';
+import { type Explorer, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import {
@@ -35,6 +34,8 @@ type TokenSelectProps = {
 };
 
 export const TokenSelect = ({ outputId }: TokenSelectProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { account, setAmount, getValues, getDefaultValue, watch, setValue, setDraftSaveRequest } =
         useSendFormContext();
 
@@ -56,6 +57,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
             state,
             account.symbol,
             (tokenContractAddress || '') as TokenAddress,
+            networkConfigDeps,
         ),
     );
 
@@ -68,7 +70,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
     const tokenWatch = watch(tokenInputName, null);
 
     useEffect(() => {
-        if (hasNetworkFeatures(account, 'tokens') && !isSetMaxActive) {
+        if (hasNetworkFeatures(networkConfigDeps, account, 'tokens') && !isSetMaxActive) {
             const amountValue = getValues(`outputs.${outputId}.amount`);
             if (amountValue) setAmount(outputId, amountValue);
         }
@@ -95,7 +97,12 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
     const onOpenTokensModal = !hasNoStandardTokens ? () => setIsTokensModalActive(true) : undefined;
 
     const networkTokenContractAddress =
-        selectedToken && getContractAddressForNetworkSymbol(account.symbol, selectedToken.contract);
+        selectedToken &&
+        getContractAddressForNetworkSymbol(
+            networkConfigDeps,
+            account.symbol,
+            selectedToken.contract,
+        );
 
     const isDeFiToken = !!selectedToken && isErc4626(selectedToken);
 
@@ -128,7 +135,10 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                             <Row justifyContent="flex-start">
                                 <Text intent="neutral" typographyStyle="body-md">
                                     {selectedToken?.name ||
-                                        getNetworkDisplaySymbolName(account.symbol)}
+                                        getNetworkDisplaySymbolName(
+                                            networkConfigDeps,
+                                            account.symbol,
+                                        )}
                                 </Text>
                             </Row>
                             <Row>
@@ -171,7 +181,7 @@ export const TokenSelect = ({ outputId }: TokenSelectProps) => {
                                             <Link
                                                 href={getTokenExplorerUrl(
                                                     explorer,
-                                                    getNetwork(account.symbol).networkType,
+                                                    getNetworkConfig(account.symbol).networkType,
                                                     selectedToken,
                                                 )}
                                                 onClick={ev => ev.stopPropagation()}

--- a/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/TronNewAccountInfo.tsx
@@ -1,5 +1,6 @@
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { InfoItem, Tooltip } from '@trezor/components';
 
@@ -7,6 +8,7 @@ import { FormattedCryptoAmount } from 'src/components/suite';
 import { useSendFormContext } from 'src/hooks/wallet';
 
 export const TronNewAccountInfo = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account: { symbol, networkType },
         composedLevels,
@@ -40,7 +42,12 @@ export const TronNewAccountInfo = () => {
                     content={
                         <Translation
                             id="TR_TRON_ACCOUNT_ACTIVATION_FEE_TOOLTIP"
-                            values={{ networkDisplaySymbol: getNetworkDisplaySymbol(symbol) }}
+                            values={{
+                                networkDisplaySymbol: getNetworkDisplaySymbol(
+                                    networkConfigDeps,
+                                    symbol,
+                                ),
+                            }}
                         />
                     }
                 >
@@ -50,7 +57,7 @@ export const TronNewAccountInfo = () => {
         >
             <FormattedCryptoAmount
                 disableHiddenPlaceholder
-                value={formatNetworkAmount(accountActivationFee, symbol)}
+                value={formatNetworkAmount(networkConfigDeps, accountActivationFee, symbol)}
                 symbol={symbol}
             />
         </InfoItem>

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSent.tsx
@@ -3,6 +3,8 @@ import { type PropsWithChildren, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAreFeesLoading } from '@suite-common/wallet-core';
 import {
     calculateTronFeeBreakdown,
@@ -30,6 +32,7 @@ const Container = styled.div`
 `;
 
 export const TotalSent = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         account: { symbol, networkType, misc },
         composedLevels,
@@ -48,7 +51,7 @@ export const TotalSent = () => {
     const tronResources = misc && 'tronResources' in misc ? misc.tronResources : undefined;
     const tronFees =
         networkType === 'tron'
-            ? calculateTronFeeBreakdown(transactionInfo, tronResources, symbol)
+            ? calculateTronFeeBreakdown(networkConfigDeps, transactionInfo, tronResources, symbol)
             : null;
 
     const feeLabelId = useMemo(() => {
@@ -89,6 +92,7 @@ export const TotalSent = () => {
                                                           tokenInfo.decimals,
                                                       )
                                                     : formatNetworkAmount(
+                                                          networkConfigDeps,
                                                           transactionInfo.totalSpent,
                                                           symbol,
                                                       )

--- a/packages/suite/src/views/wallet/send/TotalSent/TotalSentFeeContent.tsx
+++ b/packages/suite/src/views/wallet/send/TotalSent/TotalSentFeeContent.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol, type NetworkType } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type TronFeeBreakdown, formatNetworkAmount } from '@suite-common/wallet-utils';
@@ -23,6 +25,7 @@ export function TotalSentFeeContent({
     tokenInfo,
     tronFees,
 }: TotalSentFeeContentProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(networkSymbol);
 
@@ -60,7 +63,7 @@ export function TotalSentFeeContent({
         return (
             <FormattedCryptoAmount
                 disableHiddenPlaceholder
-                value={formatNetworkAmount(transactionInfo.fee, networkSymbol)}
+                value={formatNetworkAmount(networkConfigDeps, transactionInfo.fee, networkSymbol)}
                 symbol={networkSymbol}
             />
         );
@@ -70,7 +73,11 @@ export function TotalSentFeeContent({
         return (
             <BaseCurrencyValue
                 disableHiddenPlaceholder
-                amount={formatNetworkAmount(transactionInfo.totalSpent, networkSymbol)}
+                amount={formatNetworkAmount(
+                    networkConfigDeps,
+                    transactionInfo.totalSpent,
+                    networkSymbol,
+                )}
                 symbol={networkSymbol}
             />
         );

--- a/packages/suite/src/views/wallet/staking/WalletStaking.tsx
+++ b/packages/suite/src/views/wallet/staking/WalletStaking.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { WarningIcon } from '@trezor/icons';
 
@@ -11,13 +13,14 @@ import { SolStakingDashboard } from './components/SolStakingDashboard/SolStaking
 import { TronStakingDashboard } from './components/TronStakingDashboard/TronStakingDashboard';
 
 export const WalletStaking = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
 
     if (selectedAccount.status !== 'loaded') {
         return <WalletLayout title="TR_NAV_STAKING" account={selectedAccount} />;
     }
 
-    if (hasNetworkFeatures(selectedAccount.account, 'staking')) {
+    if (hasNetworkFeatures(networkConfigDeps, selectedAccount.account, 'staking')) {
         switch (selectedAccount.account.networkType) {
             case 'cardano':
                 return <AdaStakingDashboard selectedAccount={selectedAccount} />;

--- a/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/AdaStakingDashboard.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { CARDANO_EPOCH_DAYS } from '@suite-common/wallet-constants';
 import {
     fetchAllTransactionsForAccountThunk,
@@ -32,6 +34,7 @@ interface AdaStakingDashboardProps {
 }
 
 export const AdaStakingDashboard = ({ selectedAccount }: AdaStakingDashboardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = selectedAccount;
     const accountKey = account?.key ?? '';
 
@@ -51,11 +54,13 @@ export const AdaStakingDashboard = ({ selectedAccount }: AdaStakingDashboardProp
         }
     }, [accountKey, dispatch]);
 
-    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+    const { canClaim = false } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const hasPendingTx = useSelector(state => hasPendingStakeTypeTransaction(state, account.key));
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
     const isStakedWithEverstake =

--- a/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/CardanoNewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/AdaStakingDashboard/CardanoNewProviderCard.tsx
@@ -1,5 +1,7 @@
 import { selectRouteName } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     hasPendingStakeTypeTransaction,
     selectAccountIsStakingActive,
@@ -20,6 +22,7 @@ interface CardanoNewProviderCardProps {
 }
 
 export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const routeName = useSelector(selectRouteName);
 
     const hasPendingTx = useSelector(state => hasPendingStakeTypeTransaction(state, account.key));
@@ -31,7 +34,9 @@ export function CardanoNewProviderCard({ account }: CardanoNewProviderCardProps)
     const isNewProviderBannerEnabled = useSelector(state =>
         selectIsFeatureEnabled(state, Feature.banners.staking.ada.newProvider, true),
     );
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
     const isCardanoNetworkType = account?.networkType === 'cardano';
 
     if (

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/EthStakingDashboard.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useEthereumValidatorsQueue } from '@suite-common/earn-staking-api/src/staking';
 import { getDaysToAddToPool, getDaysToUnstake } from '@suite-common/staking';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     fetchAllTransactionsForAccountThunk,
     selectAccountIsStakingActive,
@@ -36,6 +38,7 @@ interface EthStakingDashboardProps {
 }
 
 export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = selectedAccount;
 
     const accountKey = account.key;
@@ -72,9 +75,11 @@ export const EthStakingDashboard = ({ selectedAccount }: EthStakingDashboardProp
     const daysToAddToPool = getDaysToAddToPool(stakeTxs, validatorQueueData);
     const daysToUnstake = getDaysToUnstake(unstakeTxs, validatorQueueData);
 
-    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+    const { canClaim = false } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
 
     return (
         <StakingDashboard

--- a/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/EthStakingDashboard/InstantStakeBanner.tsx
@@ -2,8 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { getChangedInternalTx, getInstantStakeType } from '@suite-common/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type StakeType, type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { fromWei } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
@@ -35,6 +36,7 @@ export const InstantStakeBanner = ({
     daysToAddToPool,
     daysToUnstake,
 }: InstantStakeBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { descriptor: address, symbol } = useSelector(selectSelectedAccount) || {};
 
     const [instantStakeTransfer, setInstantStakeTransfer] = useState<InternalTransfer | null>(null);
@@ -65,7 +67,7 @@ export const InstantStakeBanner = ({
 
     if (!stakeType || stakeType === 'claim') return null; // claim is not supported
 
-    const displaySymbol = getNetworkDisplaySymbol(symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, symbol);
     const remainingDays = stakeType === 'stake' ? daysToAddToPool : daysToUnstake;
 
     return (

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/Rewards/RewardsList.tsx
@@ -1,7 +1,9 @@
 import React, { useRef } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type SolanaRewardsHistory } from '@suite-common/earn-staking-api/src/staking';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { formatNetworkAmount, isTestnet } from '@suite-common/wallet-utils';
 import { Card, Column, Grid, IconCircle, Row, Text } from '@trezor/components';
 import { PiggyBankIcon } from '@trezor/icons';
@@ -26,9 +28,10 @@ interface RewardsListProps {
 }
 
 export const RewardsList = ({ account, rewardsQueryResult, pagination }: RewardsListProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const sectionRef = useRef<HTMLDivElement>(null);
     const { isBelowTablet } = useLayoutSize();
-    const isSolanaMainnet = !isTestnet(account.symbol);
+    const isSolanaMainnet = !isTestnet(networkConfigDeps, account.symbol);
 
     const onPageSelected = (page: number) => {
         pagination.changePage(page);
@@ -114,6 +117,7 @@ export const RewardsList = ({ account, rewardsQueryResult, pagination }: Rewards
                                                         reward?.amount && (
                                                             <FormattedCryptoAmount
                                                                 value={formatNetworkAmount(
+                                                                    networkConfigDeps,
                                                                     reward?.amount,
                                                                     account.symbol,
                                                                 )}
@@ -126,6 +130,7 @@ export const RewardsList = ({ account, rewardsQueryResult, pagination }: Rewards
                                                         reward?.amount && (
                                                             <BaseCurrencyValue
                                                                 amount={formatNetworkAmount(
+                                                                    networkConfigDeps,
                                                                     reward?.amount,
                                                                     account.symbol,
                                                                 )}

--- a/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/SolStakingDashboard/SolStakingDashboard.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     useSolStakingRewardsWarning,
     useSolanaRewardsHistory,
 } from '@suite-common/earn-staking-api/src/staking';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAccountIsStakingActive,
     selectHasRunningDiscovery,
@@ -36,16 +38,19 @@ interface SolStakingDashboardProps {
 }
 
 export const SolStakingDashboard = ({ selectedAccount }: SolStakingDashboardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = selectedAccount;
 
     const { isBelowLaptop } = useLayoutSize();
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
 
-    const { canClaim = false } = getStakingDataForNetwork(account) ?? {};
+    const { canClaim = false } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const apy = useSelector(state => selectPoolStatsApy(state, { account }));
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
 
     const initialPage = 1;
     const pagination = usePagination({ pageSize: 10, initialPage });

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/StakingDashboard.tsx
@@ -1,4 +1,5 @@
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import { WalletLayout } from 'src/components/wallet';
@@ -11,12 +12,15 @@ interface StakingDashboardProps {
 }
 
 export const StakingDashboard = ({ selectedAccount, dashboard }: StakingDashboardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     if (selectedAccount.status !== 'loaded') return null;
 
     return (
         <WalletLayout
             title="TR_EARN_STAKE_TOKEN"
-            titleValues={{ symbol: getNetworkDisplaySymbol(selectedAccount.account.symbol) }}
+            titleValues={{
+                symbol: getNetworkDisplaySymbol(networkConfigDeps, selectedAccount.account.symbol),
+            }}
             account={selectedAccount}
         >
             {dashboard}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ClaimCard.tsx
@@ -6,6 +6,7 @@ import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountClaimTransactions } from '@suite-common/wallet-core';
 import { getStakingDataForNetwork, isPending } from '@suite-common/wallet-utils';
 import { Button, Card, Column, InfoItem, Paragraph, Tooltip } from '@trezor/components';
@@ -16,6 +17,7 @@ import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useMessageSystemStaking } from 'src/hooks/suite/useMessageSystemStaking';
 
 export const ClaimCard = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const selectedAccount = useSelector(selectSelectedAccount);
     const claimTxs = useSelector(state =>
@@ -28,7 +30,7 @@ export const ClaimCard = () => {
     const isClaimPending = useMemo(() => claimTxs.some(tx => isPending(tx)), [claimTxs]);
 
     const { canClaim = false, claimableAmount = '0' } =
-        getStakingDataForNetwork(selectedAccount) ?? {};
+        getStakingDataForNetwork(networkConfigDeps, selectedAccount) ?? {};
     const isClaimButtonDisabled = isClaimingDisabled || !selectedAccount;
 
     // Show success message when claim tx confirmation is complete.

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardData.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/EmptyStakingCard/useEmptyStakingCardData.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { getNetworkAdjustedStakingBalance } from '@suite-common/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     calculateRewards,
@@ -31,12 +32,13 @@ interface UseEmptyStakingCardDataProps {
 export const useEmptyStakingCardData = ({
     account,
 }: UseEmptyStakingCardDataProps): EmptyStakingCardData => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { CryptoAmountFormatter } = useFormatters();
     const { rate } = useStakingRate({ symbol: account?.symbol, accountKey: account?.key });
     const { isStakingDisabled } = useMessageSystemStaking(account?.symbol);
     const isStartStakingDisabled = isStakingDisabled || !account;
 
-    const stakingData = getStakingDataForNetwork(account);
+    const stakingData = getStakingDataForNetwork(networkConfigDeps, account);
 
     const accountBalance = account?.formattedBalance ?? '0';
     const stakingBalance = stakingData?.depositedBalance ?? '0';
@@ -64,7 +66,9 @@ export const useEmptyStakingCardData = ({
 
     const hasPotentialRewards = new BigNumber(potentialRewards).gt(0);
 
-    const displaySymbol = account?.symbol ? getNetworkDisplaySymbol(account.symbol) : '';
+    const displaySymbol = account?.symbol
+        ? getNetworkDisplaySymbol(networkConfigDeps, account.symbol)
+        : '';
 
     return {
         rate,

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/ExternalStakingProviderCard.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol, getDisplaySymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
 import { PuzzlePieceIcon } from '@trezor/icons';
@@ -17,8 +19,10 @@ export const ExternalStakingProviderCard = ({
     symbol,
     totalStaked,
 }: ExternalStakingProviderCardProps) => {
-    const displaySymbol = getDisplaySymbol(symbol);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const displaySymbol = getDisplaySymbol(networkConfigDeps, symbol);
     const totalStakedInUnits = subunitsToUnits({
+        ...networkConfigDeps,
         value: asAmountSubunit(new BigNumber(totalStaked || '0')),
         symbol,
     }).toString();

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/NewProviderCard.tsx
@@ -1,7 +1,8 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { EarnFlow, EarnProvider } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectPoolStatsApy } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { isCardanoStakedWithFiveBinaries } from '@suite-common/wallet-utils';
@@ -17,6 +18,7 @@ interface NewProviderCardProps {
 }
 
 export const NewProviderCard = ({ account }: NewProviderCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
 
     const { isStakingDisabled, stakingMessageContent } = useMessageSystemStaking(account?.symbol);
@@ -25,7 +27,9 @@ export const NewProviderCard = ({ account }: NewProviderCardProps) => {
 
     const isStakedWithFiveBinaries = isCardanoStakedWithFiveBinaries(account);
 
-    const displaySymbol = account?.symbol ? getNetworkDisplaySymbol(account.symbol) : '';
+    const displaySymbol = account?.symbol
+        ? getNetworkDisplaySymbol(networkConfigDeps, account.symbol)
+        : '';
 
     const openStakeInANutshellModal = () => {
         if (!isStakingDisabled) {

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/PayoutCardNextRewards.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 
 import { selectSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { BACKUP_REWARD_PAYOUT_DAYS } from '@suite-common/wallet-constants';
 import { getStakingDataForNetwork, secondsToDays } from '@suite-common/wallet-utils';
 import { Paragraph } from '@trezor/components';
@@ -22,9 +24,11 @@ export const PayoutCardNextRewards = ({
     daysToAddToPool,
     validatorWithdrawTime,
 }: PayoutCardNextRewardsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const selectedAccount = useSelector(selectSelectedAccount);
 
-    const { autocompoundBalance = '0' } = getStakingDataForNetwork(selectedAccount) ?? {};
+    const { autocompoundBalance = '0' } =
+        getStakingDataForNetwork(networkConfigDeps, selectedAccount) ?? {};
 
     const payout = useMemo(() => {
         if (!nextRewardPayout || !daysToAddToPool) return undefined;

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/StakingCard.tsx
@@ -4,7 +4,7 @@ import { openModal } from '@suite/modal';
 import { useServices } from '@suite-common/dependency-injection';
 import { useSolanaRewardsTotal } from '@suite-common/earn-staking-api/src/staking';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAccountIsStakingActive,
     selectAccountStakeTypeTransactions,
@@ -95,14 +95,18 @@ export const StakingCard = ({
     daysToUnstake,
     account,
 }: StakingCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { isBelowLaptop } = useLayoutSize();
 
     const cardanoStakingPools = useSelector(selectCardanoPoolsInfo);
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
 
     const solanaRewardsTotalQuery = useSolanaRewardsTotal(account);
     const { totalRewards, isTotalRewardsLoading } = getStakingTotalRewards(
+        networkConfigDeps,
         account,
         solanaRewardsTotalQuery,
     );
@@ -125,7 +129,7 @@ export const StakingCard = ({
         withdrawTotalAmount = '0',
         claimableAmount = '0',
         restakedReward = '0',
-    } = getStakingDataForNetwork(account) ?? {};
+    } = getStakingDataForNetwork(networkConfigDeps, account) ?? {};
 
     const isUnstakePending = new BigNumber(withdrawTotalAmount).gt(0);
 
@@ -271,6 +275,7 @@ export const StakingCard = ({
                                     id="TR_STAKE_FUNDS_FULLY_ACCESSIBLE"
                                     values={{
                                         networkDisplaySymbol: getNetworkDisplaySymbol(
+                                            networkConfigDeps,
                                             account.symbol,
                                         ),
                                     }}
@@ -310,6 +315,7 @@ export const StakingCard = ({
                                             id="TR_STAKE_ETH_REWARDS_EARN_APY"
                                             values={{
                                                 networkDisplaySymbol: getNetworkDisplaySymbol(
+                                                    networkConfigDeps,
                                                     account.symbol,
                                                 ),
                                             }}

--- a/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/utils/stakingTotalRewards.ts
+++ b/packages/suite/src/views/wallet/staking/components/StakingDashboard/components/utils/stakingTotalRewards.ts
@@ -1,4 +1,5 @@
 import { type SolanaRewardsTotalQueryResult } from '@suite-common/earn-staking-api/src/staking';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type Account } from '@suite-common/wallet-types';
 import {
     asAmountSubunit,
@@ -8,10 +9,11 @@ import {
 import { BigNumber } from '@trezor/utils';
 
 export const getStakingTotalRewards = (
+    deps: GetNetworkConfigDep,
     account: Account,
     solanaRewardsTotalQuery: SolanaRewardsTotalQueryResult,
 ) => {
-    const { restakedReward = '0' } = getStakingDataForNetwork(account) ?? {};
+    const { restakedReward = '0' } = getStakingDataForNetwork(deps, account) ?? {};
 
     switch (account.networkType) {
         case 'ethereum':
@@ -21,6 +23,7 @@ export const getStakingTotalRewards = (
             };
         case 'solana': {
             const formattedTotal = subunitsToUnits({
+                ...deps,
                 value: asAmountSubunit(new BigNumber(solanaRewardsTotalQuery.data ?? '0')),
                 symbol: account.symbol,
             });

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronResourceModal.tsx
@@ -2,6 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, type TronResourceType } from '@suite-common/wallet-types';
 import {
     getResourceGain,
@@ -27,6 +28,7 @@ interface TronResourceModalProps {
 }
 
 export const TronResourceModal = ({ account, resourceType, onClose }: TronResourceModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const resources = getTronResources(account);
@@ -46,7 +48,7 @@ export const TronResourceModal = ({ account, resourceType, onClose }: TronResour
     const delegatedSun = isEnergy
         ? (stakingInfo?.delegatedBalanceEnergy ?? '0')
         : (stakingInfo?.delegatedBalanceBandwidth ?? '0');
-    const delegatedTrx = sunToTrx(delegatedSun, account.symbol);
+    const delegatedTrx = sunToTrx(networkConfigDeps, delegatedSun, account.symbol);
     const delegatedToOthers = Math.round(
         getResourceGain(delegatedTrx, resourceType, resources) ?? 0,
     );

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakedCard.tsx
@@ -5,6 +5,7 @@ import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTronVotedApr, useTronStakingStats } from '@suite-common/earn-staking-api';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     getTronAccountTotalStakingBalance,
@@ -37,6 +38,7 @@ interface TronStakedCardProps {
 }
 
 export const TronStakedCard = ({ account }: TronStakedCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const [isVoteAllocationOpen, setIsVoteAllocationOpen] = useState(false);
@@ -51,7 +53,7 @@ export const TronStakedCard = ({ account }: TronStakedCardProps) => {
         votingMessageContent,
     } = useMessageSystemStaking(account.symbol);
 
-    const stakedBalance = getTronAccountTotalStakingBalance(account) ?? '0';
+    const stakedBalance = getTronAccountTotalStakingBalance(networkConfigDeps, account) ?? '0';
     const hasStake = new BigNumber(stakedBalance).gt(0);
     const votedAddresses = getTronVotes(account).map(vote => vote.address);
     const apr = votedAddresses.length > 0 ? getTronVotedApr(stats.data, votedAddresses) : maxApr;

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronStakingDashboard.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { Column, Row, TextButton } from '@trezor/components';
@@ -22,10 +24,13 @@ interface TronStakingDashboardProps {
 }
 
 export const TronStakingDashboard = ({ selectedAccount }: TronStakingDashboardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = selectedAccount;
     const { openNodeById } = useGuideOpenNode();
 
-    const isStakingActive = useSelector(state => selectAccountIsStakingActive(state, account.key));
+    const isStakingActive = useSelector(state =>
+        selectAccountIsStakingActive(state, account.key, networkConfigDeps),
+    );
 
     return (
         <WalletLayout title="TR_NAV_STAKING" account={selectedAccount}>

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronUnstakingCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronUnstakingCard.tsx
@@ -1,4 +1,6 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getTronPendingUnstakeBalance, getUnstakingPeriodInDays } from '@suite-common/wallet-utils';
 import { Box, Card, Column, Row, Text } from '@trezor/components';
@@ -11,7 +13,8 @@ interface TronUnstakingCardProps {
 }
 
 export const TronUnstakingCard = ({ account }: TronUnstakingCardProps) => {
-    const pendingAmount = getTronPendingUnstakeBalance(account);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const pendingAmount = getTronPendingUnstakeBalance(networkConfigDeps, account);
 
     if (new BigNumber(pendingAmount).lte(0)) {
         return null;

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronVotingRewardsCard.tsx
@@ -4,6 +4,7 @@ import { FirmwareUpgradeNeededModal } from '@suite/firmware-upgrade';
 import { Translation, useTranslation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     getTronRewardClaimCooldownEndsAt,
@@ -33,6 +34,7 @@ interface TronVotingRewardsCardProps {
 }
 
 export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const { device } = useDevice();
@@ -40,7 +42,7 @@ export const TronVotingRewardsCard = ({ account }: TronVotingRewardsCardProps) =
     const { isFirmwareModalOpen, openFirmwareModal, closeFirmwareModal, updateFirmware } =
         useFirmwareUpgradeModal();
 
-    const rewards = getTronStakingRewards(account);
+    const rewards = getTronStakingRewards(networkConfigDeps, account);
     const isClaimOnCooldown = isTronRewardClaimOnCooldown(account);
     const claimCooldownEndsAt = getTronRewardClaimCooldownEndsAt(account);
     const isClaimFirmwareOutdated = !isTronClaimSupported(device);

--- a/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
+++ b/packages/suite/src/views/wallet/staking/components/TronStakingDashboard/TronWithdrawReadyBanner.tsx
@@ -2,6 +2,7 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { getTronWithdrawableBalance } from '@suite-common/wallet-utils';
 import { Banner, Tooltip } from '@trezor/components';
@@ -16,9 +17,10 @@ interface TronWithdrawReadyBannerProps {
 }
 
 export const TronWithdrawReadyBanner = ({ account }: TronWithdrawReadyBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
-    const withdrawableAmount = getTronWithdrawableBalance(account);
+    const withdrawableAmount = getTronWithdrawableBalance(networkConfigDeps, account);
 
     const { isWithdrawingDisabled, withdrawingMessageContent } = useMessageSystemStaking(
         account.symbol,

--- a/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
+++ b/packages/suite/src/views/wallet/tokens/TokensNavigation.tsx
@@ -8,6 +8,7 @@ import { type Route, goto, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectCoinDefinitions, selectNftDefinitions } from '@suite-common/token-definitions';
 import { type NetworkType } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isErc4626 } from '@suite-common/wallet-utils';
 import {
@@ -111,6 +112,7 @@ export const TokensNavigation = ({
     onManualActivation,
     showManualActivation = false,
 }: TokensNavigationProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account } = selectedAccount;
     const routeName = useSelector(selectRouteName);
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -124,6 +126,7 @@ export const TokensNavigation = ({
     const { translationString } = useTranslation();
 
     const tokens = getTokens({
+        ...networkConfigDeps,
         tokens: selectedAccount.account.tokens || [],
         symbol: selectedAccount.account.symbol,
         tokenDefinitions,

--- a/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/coins/CoinsTable.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isErc4626, isTestnet, sortTokensByName } from '@suite-common/wallet-utils';
@@ -24,6 +26,7 @@ interface CoinsTableProps {
 }
 
 export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const fiatRates = useSelector(selectCurrentFiatRates);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
 
@@ -55,6 +58,7 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
 
     const tokens = useMemo(() => {
         const groupedTokens = getTokens({
+            ...networkConfigDeps,
             tokens: enhancedTokens,
             symbol: account.symbol,
             tokenDefinitions: coinDefinitions,
@@ -76,7 +80,7 @@ export const CoinsTable = ({ selectedAccount, searchQuery }: CoinsTableProps) =>
         searchQuery ? (
         <TokensTable
             account={account}
-            hideRates={isTestnet(account.symbol)}
+            hideRates={isTestnet(networkConfigDeps, account.symbol)}
             tokenStatusType={TokenManagementAction.HIDE}
             tokensWithBalance={tokens.shownWithBalance}
             tokensWithoutBalance={tokens.shownWithoutBalance}

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import {
@@ -9,6 +10,7 @@ import {
 } from '@suite-common/token-definitions';
 import { getUnusedAddressFromAccount } from '@suite-common/trading';
 import { type Network } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { Column, Row, Table, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -51,9 +53,15 @@ export const TokenRow = ({
     isCollapsed,
     yieldOpportunities,
 }: TokenRowProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const device = useSelector(selectSelectedDevice);
     const isTokenKnown = useSelector(state =>
-        selectIsSpecificCoinDefinitionKnown(state, account.symbol, token.contract as TokenAddress),
+        selectIsSpecificCoinDefinitionKnown(
+            state,
+            account.symbol,
+            token.contract as TokenAddress,
+            networkConfigDeps,
+        ),
     );
     const yieldBadge = useTokenYieldBadge({
         networkSymbol: account.symbol,

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/TokenRowActions.tsx
@@ -29,6 +29,7 @@ import {
     tradingActions,
 } from '@suite-common/trading';
 import { type Explorer, type Network } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getYieldVaultContractAddress,
     getYieldVaultForOutputToken,
@@ -100,6 +101,7 @@ const TokenRowBasicActions = ({
     yieldOpportunities,
     setShowDeactivateModal,
 }: TokenRowBasicActionsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const device = useSelector(selectSelectedDevice);
@@ -118,8 +120,12 @@ const TokenRowBasicActions = ({
     const explorer = useSelector(state => selectExplorer(state, network.symbol)) as Explorer;
     const explorerUrl = useExternalLink(getTokenExplorerUrl(explorer, network.networkType, token));
 
-    const contractAddress = getContractAddressForNetworkSymbol(account.symbol, token.contract);
-    const tokenCryptoId = toTokenCryptoId(account.symbol, contractAddress);
+    const contractAddress = getContractAddressForNetworkSymbol(
+        networkConfigDeps,
+        account.symbol,
+        token.contract,
+    );
+    const tokenCryptoId = toTokenCryptoId(networkConfigDeps, account.symbol, contractAddress);
     const tokenTradingOptions = coins?.[tokenCryptoId]?.services;
 
     const canBuyToken = !!tokenTradingOptions && tokenTradingOptions.buy;
@@ -131,6 +137,7 @@ const TokenRowBasicActions = ({
     const availableVault = useMemo(
         () =>
             getYieldVaultForOutputToken({
+                ...networkConfigDeps,
                 vaults: yieldOpportunities,
                 networkSymbol: account.symbol,
                 token: {
@@ -139,7 +146,14 @@ const TokenRowBasicActions = ({
                     decimals: token.decimals,
                 },
             }),
-        [yieldOpportunities, account.symbol, token.contract, token.symbol, token.decimals],
+        [
+            yieldOpportunities,
+            account.symbol,
+            token.contract,
+            token.symbol,
+            token.decimals,
+            networkConfigDeps,
+        ],
     );
     const availableVaultAddress = availableVault
         ? getYieldVaultContractAddress(availableVault)
@@ -189,6 +203,7 @@ const TokenRowBasicActions = ({
             goto({
                 routeName: 'earn-yield-deposit',
                 params: getEarnRouteParams({
+                    ...networkConfigDeps,
                     account,
                     vaultAddress: availableVaultAddress,
                 }),
@@ -214,6 +229,7 @@ const TokenRowBasicActions = ({
             goto({
                 routeName: 'earn-yield-withdraw',
                 params: getEarnRouteParams({
+                    ...networkConfigDeps,
                     account,
                     vaultAddress: availableVaultAddress,
                 }),
@@ -224,7 +240,7 @@ const TokenRowBasicActions = ({
     const onTradeButtonClick = (type: TradingType, ...[payload]: Parameters<typeof goto>) => {
         dispatch(
             tradingActions.setTradingFromPrefilledAccount(
-                getTradingPrefilledFromAccountData(account, tokenCryptoId),
+                getTradingPrefilledFromAccountData(networkConfigDeps, account, tokenCryptoId),
             ),
         );
 

--- a/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
+++ b/packages/suite/src/views/wallet/tokens/common/TokensTable/hooks/useTokenYieldBadge.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
 import { type EnhancedTokenInfo } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     getYieldVaultForOutputToken,
     getYieldVaultsForInputToken,
@@ -39,6 +41,7 @@ export const useTokenYieldBadge = ({
     type,
     yieldOpportunities,
 }: UseTokenYieldBadgeParams): TokenYieldBadgeData | null => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const matchedVaults = useMemo(() => {
         const heldToken = {
             address: token.contract,
@@ -52,6 +55,7 @@ export const useTokenYieldBadge = ({
         switch (type) {
             case 'defi': {
                 const vault = getYieldVaultForOutputToken({
+                    ...networkConfigDeps,
                     vaults: yieldOpportunities,
                     networkSymbol,
                     token: heldToken,
@@ -61,6 +65,7 @@ export const useTokenYieldBadge = ({
             }
             case 'default':
                 return getYieldVaultsForInputToken({
+                    ...networkConfigDeps,
                     vaults: yieldOpportunities,
                     networkSymbol,
                     token: heldToken,
@@ -70,14 +75,27 @@ export const useTokenYieldBadge = ({
             default:
                 return exhaustive(type);
         }
-    }, [yieldOpportunities, networkSymbol, token.contract, token.symbol, token.decimals, type]);
+    }, [
+        yieldOpportunities,
+        networkSymbol,
+        token.contract,
+        token.symbol,
+        token.decimals,
+        type,
+        networkConfigDeps,
+    ]);
 
     const vaultsWithPosition = useMemo(
         () =>
             matchedVaults.filter(vault =>
-                hasYieldVaultPosition({ networkSymbol, vault, accountTokens }),
+                hasYieldVaultPosition({
+                    ...networkConfigDeps,
+                    networkSymbol,
+                    vault,
+                    accountTokens,
+                }),
             ),
-        [matchedVaults, networkSymbol, accountTokens],
+        [matchedVaults, networkSymbol, accountTokens, networkConfigDeps],
     );
 
     // A vault the user already deposited into states the rate they actually earn, so it

--- a/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/defi/DefiTokensTable.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectCurrentFiatRates } from '@suite-common/wallet-core';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isErc4626, sortTokensByName } from '@suite-common/wallet-utils';
@@ -24,6 +26,7 @@ interface DefiTokensTableProps {
 }
 
 export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTableProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, network } = selectedAccount;
 
     const fiatRates = useSelector(selectCurrentFiatRates);
@@ -47,6 +50,7 @@ export const DefiTokensTable = ({ selectedAccount, searchQuery }: DefiTokensTabl
 
     const tokens = useMemo(() => {
         const groupedTokens = getTokens({
+            ...networkConfigDeps,
             tokens: enhancedTokens,
             symbol: account.symbol,
             tokenDefinitions: coinDefinitions,

--- a/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
+++ b/packages/suite/src/views/wallet/tokens/hidden-tokens/HiddenTokensTable.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { TokenManagementAction, selectCoinDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type SelectedAccountLoaded } from '@suite-common/wallet-types';
 import { isTestnet, sortTokensByName } from '@suite-common/wallet-utils';
 import { Banner, Column, H3 } from '@trezor/components';
@@ -16,6 +18,7 @@ interface HiddenTokensTableProps {
 }
 
 export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokensTableProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { account, network } = selectedAccount;
 
     const coinDefinitions = useSelector(state => selectCoinDefinitions(state, account.symbol));
@@ -23,12 +26,14 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
     const sortedTokens = account.tokens?.toSorted(sortTokensByName) ?? [];
 
     const filteredTokens = getTokens({
+        ...networkConfigDeps,
         tokens: sortedTokens,
         symbol: account.symbol,
         tokenDefinitions: coinDefinitions,
         searchQuery,
     });
     const tokens = getTokens({
+        ...networkConfigDeps,
         tokens: sortedTokens,
         symbol: account.symbol,
         tokenDefinitions: coinDefinitions,
@@ -51,7 +56,7 @@ export const HiddenTokensTable = ({ selectedAccount, searchQuery }: HiddenTokens
             )}
             {hiddenTokensCount > 0 && (
                 <TokensTable
-                    hideRates={isTestnet(account.symbol)}
+                    hideRates={isTestnet(networkConfigDeps, account.symbol)}
                     account={account}
                     tokenStatusType={TokenManagementAction.SHOW}
                     tokensWithBalance={filteredTokens.hiddenWithBalance}

--- a/packages/suite/src/views/wallet/tokens/index.tsx
+++ b/packages/suite/src/views/wallet/tokens/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import { goto, selectRouteName } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasNetworkFeatures } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 
@@ -17,6 +19,7 @@ import { HiddenTokensTable } from './hidden-tokens/HiddenTokensTable';
 import { InactiveTokensTable } from './inactive-tokens/InactiveTokensTable';
 
 export const Tokens = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [searchQuery, setSearchQuery] = useState('');
     const [showManualInput, setShowManualInput] = useState(false);
     const [manualTokenContract, setManualTokenContract] = useState<string | null>(null);
@@ -28,7 +31,7 @@ export const Tokens = () => {
     useEffect(() => {
         if (
             selectedAccount.status === 'loaded' &&
-            !hasNetworkFeatures(selectedAccount.account, 'tokens') &&
+            !hasNetworkFeatures(networkConfigDeps, selectedAccount.account, 'tokens') &&
             routeName !== 'wallet-index'
         ) {
             dispatch(goto({ routeName: 'wallet-index', preserveParams: true }));

--- a/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingBalance.tsx
@@ -1,6 +1,7 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { getNetworkDecimalsWithFallback } from '@suite-common/trading';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { Text } from '@trezor/components';
@@ -27,8 +28,10 @@ export const TradingBalance = ({
     tokenAddress,
     showOnlyAmount,
     amountInCrypto,
-    decimals: networkDecimals = getNetworkDecimalsWithFallback(symbol),
+    decimals,
 }: TradingBalanceProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networkDecimals = decimals ?? getNetworkDecimalsWithFallback(networkConfigDeps, symbol);
     const { isBtcSatsAmountUnit: shouldSendInSats } = useBitcoinAmountUnit(symbol);
     const balanceCurrency = tradingGetAccountLabel(displaySymbol ?? '', shouldSendInSats);
     const stringBalance = !isNaN(Number(balance)) ? balance : '0';

--- a/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCoinLogo.tsx
@@ -1,7 +1,12 @@
 import styled from 'styled-components';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { parseCryptoId } from '@suite-common/trading';
-import { getNetworkByCoingeckoId } from '@suite-common/wallet-config';
+import {
+    findNetworkByCoingeckoId,
+    getNetworks,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { TokenIcon } from '@trezor/product-components';
 
 import { type TradingCoinLogoProps } from 'src/types/trading/trading';
@@ -15,8 +20,12 @@ export const TradingCoinLogo = ({
     className,
     showNetworkIcon,
 }: TradingCoinLogoProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
-    const networkSymbol = getNetworkByCoingeckoId(networkId)?.symbol;
+    const networkSymbol = findNetworkByCoingeckoId(
+        getNetworks(networkConfigDeps),
+        networkId,
+    )?.symbol;
 
     if (!networkSymbol) return null;
 

--- a/packages/suite/src/views/wallet/trading/common/TradingCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingCryptoAmount.tsx
@@ -1,8 +1,9 @@
 import { type CryptoId } from 'invity-api';
 import styled from 'styled-components';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useTradingUtils } from '@suite-common/trading';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Row } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite';
@@ -25,6 +26,7 @@ export const TradingCryptoAmount = ({
     displayLogo,
     testId,
 }: TradingCryptoAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoId);
 
@@ -36,7 +38,7 @@ export const TradingCryptoAmount = ({
                         <TradingCoinLogo cryptoId={cryptoId} margin={{ right: 8 }} />
                     </LogoWrapper>
                 )}
-                {coinSymbol ? getDisplaySymbol(coinSymbol, contractAddress) : ''}
+                {coinSymbol ? getDisplaySymbol(networkConfigDeps, coinSymbol, contractAddress) : ''}
             </Row>
         );
     }

--- a/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingFiatAmount.tsx
@@ -1,4 +1,6 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
 import { isFiatBaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -16,6 +18,7 @@ export const TradingFiatAmount = ({
     currency,
     disableHiddenPlaceholder,
 }: TradingFiatAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { BaseCurrencyAmountFormatter } = useFormatters();
 
     const formatterOptions =
@@ -23,6 +26,7 @@ export const TradingFiatAmount = ({
             ? {
                   minimumFractionDigits: 0,
                   maximumFractionDigits: getDecimalsForBaseCurrency({
+                      ...networkConfigDeps,
                       code: currency,
                       isInSats: false,
                   }),

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingApproveModal.tsx
@@ -10,6 +10,7 @@ import {
     selectTradingSendAccount,
     tradeApi,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { ApproveModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/ApproveModal';
 import { useSelector } from 'src/hooks/suite';
@@ -28,9 +29,12 @@ interface TradingApproveModalProps {
 }
 
 export const TradingApproveModal = ({ amount, cryptoId }: TradingApproveModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { state } = useAllowanceContext();
     const context = useTradingFormContext();
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, context.type));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, context.type, networkConfigDeps),
+    );
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
     const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -14,6 +14,7 @@ import {
     selectTradingBuySupportedCryptoIds,
     tradingActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Column, Row } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils/src/firmwareUtils';
@@ -37,6 +38,7 @@ import { TradingFormInputCountrySubdivision } from './TradingFormInput/TradingFo
 import { TradingReceiveAddress } from '../TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 
 export const TradingBuyFormInputs = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext<TradingBuyType>();
     const quotes = useSelector(selectTradingBuyQuotes);
     const { networkModuleRepository } = useServices(selectNetworkModuleRepositoryDep);
@@ -70,7 +72,7 @@ export const TradingBuyFormInputs = () => {
 
     const supportedNetworks = networkModuleRepository.getSupportedNetworks();
     const buySupportedCryptoIds = useSelector(state =>
-        selectTradingBuySupportedCryptoIds(state, supportedNetworks),
+        selectTradingBuySupportedCryptoIds(state, supportedNetworks, networkConfigDeps),
     );
 
     const countryRequiresSubdivision = isCountrySubdivisionRequired(countrySelect?.value);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -20,6 +20,7 @@ import {
     selectTradingSendAccount,
     tradingActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Row } from '@trezor/components';
@@ -51,6 +52,7 @@ import { TradingFractionButtons } from './TradingFractionButtons';
 import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
 
 export const TradingExchangeFormInputs = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext<TradingExchangeType>();
     const { networkModuleRepository } = useServices(selectNetworkModuleRepositoryDep);
 
@@ -69,7 +71,7 @@ export const TradingExchangeFormInputs = () => {
         setAmountLimits,
     } = context;
     const asset = useSelectedTradingAsset(type);
-    const account = useSelector(state => selectTradingSendAccount(state, type));
+    const account = useSelector(state => selectTradingSendAccount(state, type, networkConfigDeps));
 
     const displayComposedLevels = useMemo(
         () => getDisplayComposedLevels(selectedQuote, composedLevels),
@@ -133,10 +135,10 @@ export const TradingExchangeFormInputs = () => {
 
     const supportedNetworks = networkModuleRepository.getSupportedNetworks();
     const exchangeBuySupportedCryptoIds = useSelector(state =>
-        selectTradingExchangeBuyCryptoIds(state, supportedNetworks),
+        selectTradingExchangeBuyCryptoIds(state, supportedNetworks, networkConfigDeps),
     );
     const exchangeSellSupportedCryptoIds = useSelector(state =>
-        selectTradingExchangeSellCryptoIds(state, supportedNetworks),
+        selectTradingExchangeSellCryptoIds(state, supportedNetworks, networkConfigDeps),
     );
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormApproval.tsx
@@ -14,6 +14,7 @@ import {
     useApprovalStep,
     useTradingUtils,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { Banner, Button, Column } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
@@ -38,6 +39,7 @@ const TextButton = styled.div<{ $disabled: boolean }>`
 `;
 
 export const TradingFormApproval = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext<TradingExchangeType>();
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -58,7 +60,9 @@ export const TradingFormApproval = () => {
         },
     } = context;
     const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, 'exchange'));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, 'exchange', networkConfigDeps),
+    );
 
     const { exchangeType, rateType } = watch();
 
@@ -85,7 +89,7 @@ export const TradingFormApproval = () => {
     });
 
     const onApproveTransactionClick = async () => {
-        if (!selectedQuote || !requiresTokenApproval(selectedQuote)) {
+        if (!selectedQuote || !requiresTokenApproval(networkConfigDeps, selectedQuote)) {
             return;
         }
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useBuildTradingAssetOptions.ts
@@ -3,13 +3,15 @@ import { useMemo } from 'react';
 import { type CryptoId } from 'invity-api';
 
 import { type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetOption,
     createAssetNativeTokenOption,
     createAssetTokenOption,
     getCryptoId,
 } from '@suite-common/trading';
-import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { accountSearchFn, isTokenMatchesSearch } from '@suite-common/wallet-utils';
 
@@ -49,14 +51,14 @@ function assetSearchFilter(asset: TradingAssetOption, search: string) {
     );
 }
 
-function excludeCryptoIds(excludedCryptoIds: Set<CryptoId>) {
+function excludeCryptoIds(deps: NetworkConfigDeps, excludedCryptoIds: Set<CryptoId>) {
     return function excludeCryptoIdsFilter(accountOrToken: AggregatedAccountWithTokens) {
         switch (accountOrToken.type) {
             case 'account':
-                return !excludedCryptoIds.has(getCryptoId(accountOrToken.account.symbol));
+                return !excludedCryptoIds.has(getCryptoId(deps, accountOrToken.account.symbol));
             case 'token':
                 return !excludedCryptoIds.has(
-                    getCryptoId(accountOrToken.account.symbol, accountOrToken.token.contract),
+                    getCryptoId(deps, accountOrToken.account.symbol, accountOrToken.token.contract),
                 );
             default:
                 return false;
@@ -67,23 +69,23 @@ function excludeCryptoIds(excludedCryptoIds: Set<CryptoId>) {
 /**
  * Note this is going to be replaced soon with more sophisticated top assets logic.
  */
-function createTopFiveAssets(excludedCryptoIds: Set<CryptoId>) {
+function createTopFiveAssets(deps: NetworkConfigDeps, excludedCryptoIds: Set<CryptoId>) {
     return (
         (
             [
-                createAssetNativeTokenOption('btc'),
-                createAssetNativeTokenOption('eth'),
-                createAssetTokenOption('eth', {
+                createAssetNativeTokenOption(deps, 'btc'),
+                createAssetNativeTokenOption(deps, 'eth'),
+                createAssetTokenOption(deps, 'eth', {
                     contract: '0xdac17f958d2ee523a2206206994597c13d831ec7',
                     symbol: 'USDT',
                     name: 'Tether',
                 }),
-                createAssetTokenOption('eth', {
+                createAssetTokenOption(deps, 'eth', {
                     contract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
                     symbol: 'USDC',
                     name: 'USDC',
                 }),
-                createAssetNativeTokenOption('sol'),
+                createAssetNativeTokenOption(deps, 'sol'),
             ] satisfies TradingAssetOption[]
         )
             // E.g. filter out "from" field value
@@ -92,19 +94,27 @@ function createTopFiveAssets(excludedCryptoIds: Set<CryptoId>) {
 }
 
 type GetOrderNetworksProps = {
+    networkConfigDeps: NetworkConfigDeps;
     topFiveAssets: TradingAssetOption[];
     assets: TradingAssetOption[];
     accountsWithTokens: AggregatedAccountWithTokens[];
 };
 
-function getOrderNetworks({ topFiveAssets, assets, accountsWithTokens }: GetOrderNetworksProps) {
+function getOrderNetworks({
+    networkConfigDeps,
+    topFiveAssets,
+    assets,
+    accountsWithTokens,
+}: GetOrderNetworksProps) {
     const networks: Set<NetworkSymbol> = new Set();
 
     topFiveAssets.forEach(asset => networks.add(asset.networkSymbol));
     assets.forEach(asset => networks.add(asset.networkSymbol));
     accountsWithTokens.forEach(item => networks.add(item.account.symbol));
 
-    return networkSymbolCollection.filter(networkSymbol => networks.has(networkSymbol));
+    return networkConfigDeps.networkModuleRepository
+        .getSupportedNetworks()
+        .filter(networkSymbol => networks.has(networkSymbol));
 }
 
 export type TradingAssetListItem =
@@ -148,6 +158,7 @@ export function useBuildTradingAssetOptions({
     search,
     networkSymbol,
 }: UseBuildTradingAssetOptionsProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { assets, includedCryptoIds, excludedCryptoIds } = useAssetsContext();
     const accountsWithTokens = useAgregatedAccountsWithTokens();
 
@@ -167,7 +178,9 @@ export function useBuildTradingAssetOptions({
         const listItems: TradingAssetListItem[] = [];
 
         const topFiveAssets =
-            search.length === 0 && !networkSymbol ? createTopFiveAssets(excludedCryptoIds) : [];
+            search.length === 0 && !networkSymbol
+                ? createTopFiveAssets(networkConfigDeps, excludedCryptoIds)
+                : [];
         const topFiveAssetIds = new Set(topFiveAssets.map(asset => asset.id));
 
         if (topFiveAssets.length > 0) {
@@ -185,14 +198,17 @@ export function useBuildTradingAssetOptions({
         }
 
         const allAccountsWithTokens = accountsWithTokens
-            .filter(excludeCryptoIds(excludedCryptoIds))
+            .filter(excludeCryptoIds(networkConfigDeps, excludedCryptoIds))
             .filter(accountOrToken => {
                 switch (accountOrToken.type) {
                     case 'account':
-                        return includedCryptoIds.has(getCryptoId(accountOrToken.account.symbol));
+                        return includedCryptoIds.has(
+                            getCryptoId(networkConfigDeps, accountOrToken.account.symbol),
+                        );
                     case 'token':
                         return includedCryptoIds.has(
                             getCryptoId(
+                                networkConfigDeps,
                                 accountOrToken.account.symbol,
                                 accountOrToken.token.contract,
                             ),
@@ -220,11 +236,13 @@ export function useBuildTradingAssetOptions({
                 switch (accountOrToken.type) {
                     case 'account':
                         return accountSearchFn(accountOrToken.account, search, {
+                            ...networkConfigDeps,
                             tokensMatch: false,
                             accountLabel: '', // Todo: select label from SuiteSync
                         });
                     case 'token': {
                         const displaySymbolName = getTokenDisplaySymbolName({
+                            ...networkConfigDeps,
                             tokenDisplaySymbolNames,
                             account: accountOrToken.account,
                             token: accountOrToken.token,
@@ -260,6 +278,7 @@ export function useBuildTradingAssetOptions({
 
                 case 'token': {
                     const tokenDisplaySymbolName = getTokenDisplaySymbolName({
+                        ...networkConfigDeps,
                         tokenDisplaySymbolNames,
                         account: accountOrToken.account,
                         token: accountOrToken.token,
@@ -309,6 +328,7 @@ export function useBuildTradingAssetOptions({
         }
 
         const orderedNetworks = getOrderNetworks({
+            networkConfigDeps,
             topFiveAssets,
             assets: allAssets,
             accountsWithTokens: allAccountsWithTokens,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -1,11 +1,13 @@
 import { useCallback } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetOption,
     createAssetNativeTokenOption,
     useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { type TradingAssetListItem } from './useBuildTradingAssetOptions';
 
@@ -15,6 +17,7 @@ export interface UseUpdateFormInputProps {
 }
 
 export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormInputProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { resolveAssetTokenOption } = useTradingAssets();
 
     const handleAssetClick = useCallback(
@@ -22,7 +25,10 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
             switch (asset.type) {
                 case 'account': {
                     onAssetSelect(
-                        createAssetNativeTokenOption(asset.account.symbol as NetworkSymbol),
+                        createAssetNativeTokenOption(
+                            networkConfigDeps,
+                            asset.account.symbol as NetworkSymbol,
+                        ),
                     );
                     break;
                 }

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputBuyAsset/hooks/useAgregatedAccountsWithTokens.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { useThrottle } from 'react-use';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectTokenDefinitions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAllAccountsToList,
     selectBaseCurrency,
@@ -46,8 +48,9 @@ type AccountTokenId = `${Account['symbol']}--${TokenInfo['contract']}`;
  * Aggregate all accounts and tokens per network, sum up its balances per network, sort by fiat balance in descending order
  */
 export function useAgregatedAccountsWithTokens() {
-    const accounts = useSelector(
-        selectAllAccountsToList,
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const accounts = useSelector<Account[]>(
+        state => selectAllAccountsToList(state, networkConfigDeps),
         // Prevent re-redering the `useAgregatedAccountsWithTokens` hook and thus its children when the accounts change (accounts are being constantly updated in Redux)
         areAccountsEqual,
     );
@@ -66,6 +69,7 @@ export function useAgregatedAccountsWithTokens() {
         }
 
         const accountsWithPositiveBalanceOrTokens = getAccountsWithPositiveBalanceOrVisibleTokens(
+            networkConfigDeps,
             throttledAccounts,
             tokenDefinitions,
         );
@@ -90,6 +94,7 @@ export function useAgregatedAccountsWithTokens() {
             }
 
             const { shownWithBalance } = getTokens({
+                ...networkConfigDeps,
                 tokens: account.tokens ?? [],
                 symbol: account.symbol,
                 tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
@@ -149,6 +154,7 @@ export function useAgregatedAccountsWithTokens() {
             type: 'account' as const,
             account,
             fiatAmount: getAccountFiatBalance({
+                ...networkConfigDeps,
                 account,
                 baseCurrencyCode,
                 rates: fiatRates,
@@ -177,7 +183,7 @@ export function useAgregatedAccountsWithTokens() {
         });
 
         return sortedAgregatedAccountsAndTokens;
-    }, [throttledAccounts, baseCurrencyCode, fiatRatesRef, tokenDefinitions]);
+    }, [throttledAccounts, baseCurrencyCode, fiatRatesRef, tokenDefinitions, networkConfigDeps]);
 }
 
 export type AggregatedAccountWithTokens = ReturnType<typeof useAgregatedAccountsWithTokens>[number];

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputCryptoAmount.tsx
@@ -3,6 +3,7 @@ import { type FieldErrors, type UseFormReturn, useWatch } from 'react-hook-form'
 
 import { useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
@@ -14,7 +15,7 @@ import {
     useTradingUtils,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountByKey, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { NumberInput } from '@trezor/product-components';
@@ -50,6 +51,7 @@ const TradingFormInputCryptoAmountContent = ({
     labelLeft,
     labelRight,
 }: TradingFormInputCryptoAmountContentProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { CryptoAmountFormatter } = useFormatters();
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
@@ -81,17 +83,18 @@ const TradingFormInputCryptoAmountContent = ({
     const outputToken = getValues('outputs')?.[0]?.token;
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoSelect?.id);
     const displaySymbol = tradingGetAccountLabel(
-        getDisplaySymbol(coinSymbol ?? '', contractAddress),
+        getDisplaySymbol(networkConfigDeps, coinSymbol ?? '', contractAddress),
         shouldSendInSats,
     );
     const decimals = isBuyContext
-        ? getNetworkDecimalsWithFallback(network?.symbol)
+        ? getNetworkDecimalsWithFallback(networkConfigDeps, network?.symbol)
         : getAssetDecimals({
               accountKey: getValues(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT)?.accountKey,
               cryptoId: cryptoSelect?.id,
           });
     const feeInUnits = isExchangeOrSellContext
         ? getFeeInUnits({
+              ...networkConfigDeps,
               symbol: validationAccount.symbol,
               composedLevels: context.composedLevels,
               selectedFee: context.composedTransactionInfo?.selectedFee,
@@ -107,6 +110,7 @@ const TradingFormInputCryptoAmountContent = ({
     const cryptoInputRules = useMemo(
         () =>
             getCryptoInputRules({
+                ...networkConfigDeps,
                 isBuyContext,
                 translationString,
                 shouldSendInSats,
@@ -175,6 +179,7 @@ const TradingFormInputCryptoAmountContent = ({
 };
 
 export const TradingFormInputCryptoAmount = (props: TradingFormInputFiatCryptoProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext();
     const { control } = context as UseFormReturn<TradingAllFormProps>;
 
@@ -185,7 +190,9 @@ export const TradingFormInputCryptoAmount = (props: TradingFormInputFiatCryptoPr
     const selectedSendAccount = useSelector(state =>
         selectAccountByKey(state, sendCryptoSelect?.accountKey),
     );
-    const sendAccount = useSelector(state => selectTradingSendAccount(state, context.type));
+    const sendAccount = useSelector(state =>
+        selectTradingSendAccount(state, context.type, networkConfigDeps),
+    );
     const validationAccount = selectedSendAccount ?? sendAccount;
 
     if (!validationAccount) {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -3,6 +3,7 @@ import { type FieldErrors, useFormContext, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { selectLanguage } from '@suite/settings';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type SelectedTradingAsset,
     TRADING_FORM_FIAT_CURRENCY_SELECT,
@@ -14,6 +15,7 @@ import {
     getNetworkDecimalsWithFallback,
 } from '@suite-common/trading';
 import { formInputsMaxLength } from '@suite-common/validators';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectCurrentFiatRates, selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import {
@@ -57,6 +59,7 @@ const TradingFormInputFiatContent = ({
     labelLeft,
     labelRight,
 }: TradingFormInputFiatContentProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const locale = useSelector(selectLanguage);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
@@ -95,12 +98,14 @@ const TradingFormInputFiatContent = ({
         ? findToken(asset.tokens, tokenAddress)?.balance
         : asset.formattedBalance;
     const networkReserve = getNetworkReserve({
+        ...networkConfigDeps,
         symbol: asset.symbol,
         contractAddress: tokenAddress,
         isEnabled: isNetworkReserveEnabled,
     });
     const feeInUnits = isExchangeOrSellContext
         ? getFeeInUnits({
+              ...networkConfigDeps,
               symbol: asset.symbol,
               composedLevels: context.composedLevels,
               selectedFee: context.composedTransactionInfo?.selectedFee,
@@ -130,7 +135,7 @@ const TradingFormInputFiatContent = ({
         asset.symbol === 'btc' && areSatsDisplayed && cryptoAmount
             ? convertAmountSubunitsToUnits(
                   cryptoAmount,
-                  getNetworkDecimalsWithFallback(asset.symbol),
+                  getNetworkDecimalsWithFallback(networkConfigDeps, asset.symbol),
               )
             : cryptoAmount;
 
@@ -155,6 +160,7 @@ const TradingFormInputFiatContent = ({
     const fiatInputRules = useMemo(
         () =>
             getFiatInputRules({
+                ...networkConfigDeps,
                 isExchangeContext,
                 isSellContext,
                 translationString,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiatCrypto.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiatCrypto.tsx
@@ -2,8 +2,9 @@ import { memo } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { TRADING_FORM_AMOUNT_IN_CRYPTO, useTradingUtils } from '@suite-common/trading';
-import { getDisplaySymbol } from '@suite-common/wallet-config';
+import { getDisplaySymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Text } from '@trezor/components';
 
 import { useTradingFormContext } from 'src/hooks/wallet/trading/form/useTradingCommonForm';
@@ -25,6 +26,7 @@ export const TradingFormInputFiatCrypto = memo(function TradingFormInputFiatCryp
     cryptoSelectName,
     fiatInputName,
 }: TradingFormInputFiatCryptoWrapProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const {
         type,
         form: {
@@ -38,7 +40,8 @@ export const TradingFormInputFiatCrypto = memo(function TradingFormInputFiatCryp
     const amountInCrypto = getValues(TRADING_FORM_AMOUNT_IN_CRYPTO);
     const amountLabels = tradingGetAmountLabels({ type, amountInCrypto });
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoCurrencyLabel);
-    const displaySymbol = coinSymbol && getDisplaySymbol(coinSymbol, contractAddress);
+    const displaySymbol =
+        coinSymbol && getDisplaySymbol(networkConfigDeps, coinSymbol, contractAddress);
 
     const inputProps = {
         cryptoInputName,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.test.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.test.ts
@@ -1,5 +1,6 @@
 import { type TranslationFunction } from '@suite/intl';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { type RatesByKey, asCryptoBaseCurrencyCode } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { BigNumber } from '@trezor/utils';
@@ -19,6 +20,7 @@ type ValidateMap = Record<
 >;
 
 const baseProps: Props = {
+    ...mockNetworkConfigDeps,
     isExchangeContext: false,
     isSellContext: false,
     translationString: t,

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/tradingFormInputFiatCryptoRules.ts
@@ -2,7 +2,7 @@ import { type UseControllerProps } from 'react-hook-form';
 
 import { type TranslationFunction } from '@suite/intl';
 import { type Formatter } from '@suite-common/formatters';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type RatesByKey, type TokenAddress } from '@suite-common/wallet-types';
 import {
     buildCurrencyShortOption,
@@ -24,7 +24,7 @@ import {
     validateReserveOrBalance,
 } from 'src/utils/suite/validation';
 
-type FiatInputRulesProps = {
+type FiatInputRulesProps = NetworkConfigDeps & {
     isExchangeContext: boolean;
     isSellContext: boolean;
     translationString: TranslationFunction;
@@ -41,6 +41,8 @@ type FiatInputRulesProps = {
 };
 
 export const getFiatInputRules = ({
+    getNetworkConfig,
+    networkModuleRepository,
     isExchangeContext,
     isSellContext,
     translationString,
@@ -56,6 +58,8 @@ export const getFiatInputRules = ({
     rates,
 }: FiatInputRulesProps): UseControllerProps['rules'] => {
     const fiatInputDecimals = getDecimalsForBaseCurrency({
+        getNetworkConfig,
+        networkModuleRepository,
         code: selectedCurrencyCode,
         isInSats: false,
     });
@@ -154,7 +158,7 @@ export const getFiatInputRules = ({
     };
 };
 
-type CryptoInputRulesProps = {
+type CryptoInputRulesProps = NetworkConfigDeps & {
     isBuyContext: boolean;
     translationString: TranslationFunction;
     shouldSendInSats: boolean | undefined;
@@ -169,6 +173,8 @@ type CryptoInputRulesProps = {
 };
 
 export const getCryptoInputRules = ({
+    getNetworkConfig,
+    networkModuleRepository,
     isBuyContext,
     translationString,
     shouldSendInSats,
@@ -180,35 +186,42 @@ export const getCryptoInputRules = ({
     isNetworkReserveEnabled,
     contractAddress,
     feeInUnits,
-}: CryptoInputRulesProps): UseControllerProps['rules'] => ({
-    validate: {
-        min: validateMin(translationString),
-        integer: validateInteger(translationString, { except: !shouldSendInSats }),
-        decimals: validateDecimals(translationString, { decimals }),
-        limits: validateCryptoLimits(translationString, {
-            amountLimits,
-            areSatsUsed: !!shouldSendInSats,
-            formatter,
-        }),
-        ...(!isBuyContext
-            ? {
-                  reserveOrBalance: validateReserveOrBalance(translationString, {
-                      account: validationAccount,
-                      areSatsUsed: !!shouldSendInSats,
-                      contractAddress: outputToken ?? undefined,
-                  }),
-                  networkReserve: isNetworkReserveEnabled
-                      ? validateNetworkReserve(translationString, {
-                            reserve: getNetworkReserve({
-                                symbol: validationAccount.symbol,
-                                contractAddress,
-                                isEnabled: isNetworkReserveEnabled,
-                            }),
-                            balance: validationAccount.formattedBalance,
-                            fee: feeInUnits,
-                        })
-                      : () => undefined,
-              }
-            : {}),
-    },
-});
+}: CryptoInputRulesProps): UseControllerProps['rules'] => {
+    const networkConfigDeps = { getNetworkConfig, networkModuleRepository };
+
+    return {
+        validate: {
+            min: validateMin(translationString),
+            integer: validateInteger(translationString, { except: !shouldSendInSats }),
+            decimals: validateDecimals(translationString, { decimals }),
+            limits: validateCryptoLimits(translationString, {
+                ...networkConfigDeps,
+                amountLimits,
+                areSatsUsed: !!shouldSendInSats,
+                formatter,
+            }),
+            ...(!isBuyContext
+                ? {
+                      reserveOrBalance: validateReserveOrBalance(translationString, {
+                          ...networkConfigDeps,
+                          account: validationAccount,
+                          areSatsUsed: !!shouldSendInSats,
+                          contractAddress: outputToken ?? undefined,
+                      }),
+                      networkReserve: isNetworkReserveEnabled
+                          ? validateNetworkReserve(translationString, {
+                                reserve: getNetworkReserve({
+                                    ...networkConfigDeps,
+                                    symbol: validationAccount.symbol,
+                                    contractAddress,
+                                    isEnabled: isNetworkReserveEnabled,
+                                }),
+                                balance: validationAccount.formattedBalance,
+                                fee: feeInUnits,
+                            })
+                          : () => undefined,
+                  }
+                : {}),
+        },
+    };
+};

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
@@ -3,11 +3,13 @@ import { useThrottle } from 'react-use';
 
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectAccountsWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { type EnhancedTokenInfo, selectTokenDefinitions } from '@suite-common/token-definitions';
 import { getCryptoId } from '@suite-common/trading';
-import { type NetworkSymbol, networkSymbolCollection } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectBaseCurrency,
     selectCurrentFiatRates,
@@ -32,23 +34,40 @@ import {
     sortTokensWithRates,
 } from 'src/utils/wallet/tokenUtils';
 
-interface GetSupportedTokensProps<T extends TokenInfo | EnhancedTokenInfo> {
+interface GetSupportedTokensProps<
+    T extends TokenInfo | EnhancedTokenInfo,
+> extends NetworkConfigDeps {
     networkSymbol: NetworkSymbol;
     tokens: T[] | undefined;
     supportedCryptoIds: Set<CryptoId>;
 }
 
 function getSupportedAndUnsupportedTokens<T extends TokenInfo | EnhancedTokenInfo>({
+    getNetworkConfig,
+    networkModuleRepository,
     networkSymbol,
     tokens = [],
     supportedCryptoIds,
 }: GetSupportedTokensProps<T>) {
     const supportedTokens = tokens.filter(token =>
-        supportedCryptoIds.has(getCryptoId(networkSymbol, token.contract)),
+        supportedCryptoIds.has(
+            getCryptoId(
+                { getNetworkConfig, networkModuleRepository },
+                networkSymbol,
+                token.contract,
+            ),
+        ),
     );
 
     const unsupportedTokens = tokens.filter(
-        token => !supportedCryptoIds.has(getCryptoId(networkSymbol, token.contract)),
+        token =>
+            !supportedCryptoIds.has(
+                getCryptoId(
+                    { getNetworkConfig, networkModuleRepository },
+                    networkSymbol,
+                    token.contract,
+                ),
+            ),
     );
 
     return { supportedTokens, unsupportedTokens };
@@ -70,6 +89,7 @@ export function useAccountWithTokensOptions({
     accountsWithTokens: AccountWithTokensOption[];
     networks: NetworkSymbol[];
 } {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const device = useSelector(selectSelectedDevice);
     const baseAccounts = useSelector(selectVisibleDeviceAccounts);
 
@@ -101,7 +121,10 @@ export function useAccountWithTokensOptions({
         }
 
         const validAccounts = throttledAccounts.filter(account => {
-            if (isTestnet(account.symbol) || account.accountType === 'coinjoin') {
+            if (
+                isTestnet(networkConfigDeps, account.symbol) ||
+                account.accountType === 'coinjoin'
+            ) {
                 return false;
             }
 
@@ -110,6 +133,7 @@ export function useAccountWithTokensOptions({
             }
 
             const { shownWithBalance, hiddenWithBalance } = getTokens({
+                ...networkConfigDeps,
                 tokens: account.tokens ?? [],
                 symbol: account.symbol,
                 tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
@@ -119,11 +143,13 @@ export function useAccountWithTokensOptions({
         });
 
         const networks = new Set(validAccounts.map(account => account.symbol));
-        const orderedNetworks = networkSymbolCollection.filter(network => networks.has(network));
+        const orderedNetworks = networkConfigDeps.networkModuleRepository
+            .getSupportedNetworks()
+            .filter(network => networks.has(network));
 
         const networkAccounts = filterAccountsByNetworkSymbol(validAccounts, networkSymbolFilter);
         const supportedNetworkAccounts = networkAccounts.filter(account =>
-            includedCryptoIds.has(getCryptoId(account.symbol)),
+            includedCryptoIds.has(getCryptoId(networkConfigDeps, account.symbol)),
         );
         const supportedCryptoIds = new Set(
             Array.from(includedCryptoIds).filter(cryptoId => !excludedCryptoIds.has(cryptoId)),
@@ -131,12 +157,14 @@ export function useAccountWithTokensOptions({
 
         const accountsAndTokensSortedByCoin = supportedNetworkAccounts.map(account => {
             const { shownWithBalance, hiddenWithBalance } = getTokens({
+                ...networkConfigDeps,
                 tokens: account.tokens ?? [],
                 symbol: account.symbol,
                 tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
             });
 
             const { supportedTokens, unsupportedTokens } = getSupportedAndUnsupportedTokens({
+                ...networkConfigDeps,
                 networkSymbol: account.symbol,
                 tokens: shownWithBalance.concat(hiddenWithBalance),
                 supportedCryptoIds,
@@ -183,7 +211,7 @@ export function useAccountWithTokensOptions({
 
         for (const { account, tokens, nonTradableTokens } of accountsWithTokens) {
             if (
-                supportedCryptoIds.has(getCryptoId(account.symbol)) &&
+                supportedCryptoIds.has(getCryptoId(networkConfigDeps, account.symbol)) &&
                 new BigNumber(account.balance).gt(0)
             ) {
                 accountsWithTokensOptions.push(createAccountOption(account));

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useUpdateFormInput.ts
@@ -1,11 +1,13 @@
 import { useCallback } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingAssetSellOption,
     createAssetNativeTokenOption,
     useTradingAssets,
 } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { type AssetPickerListItem } from 'src/components/suite/asset-picker/hooks';
 
@@ -15,6 +17,7 @@ export interface UseUpdateFormInputProps {
 }
 
 export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormInputProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { resolveAssetTokenOption } = useTradingAssets();
 
     const handleAssetClick = useCallback(
@@ -22,7 +25,10 @@ export function useUpdateFormInput({ closeModal, onAssetSelect }: UseUpdateFormI
             switch (asset.type) {
                 case 'account': {
                     onAssetSelect({
-                        ...createAssetNativeTokenOption(asset.account.symbol as NetworkSymbol),
+                        ...createAssetNativeTokenOption(
+                            networkConfigDeps,
+                            asset.account.symbol as NetworkSymbol,
+                        ),
                         accountKey: asset.account.key,
                     });
                     break;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferAmount/TradingFormOfferCryptoAmount.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferAmount/TradingFormOfferCryptoAmount.tsx
@@ -1,6 +1,8 @@
 import { type CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { cryptoIdToNetwork, useTradingUtils } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Column, Row, Text } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -14,6 +16,7 @@ interface TradingCryptoAmountProps {
 }
 
 export const TradingFormOfferCryptoAmount = ({ amount, cryptoId }: TradingCryptoAmountProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const { coinSymbol, contractAddress } = cryptoIdToSymbolAndContractAddress(cryptoId);
 
@@ -21,7 +24,7 @@ export const TradingFormOfferCryptoAmount = ({ amount, cryptoId }: TradingCrypto
         return null;
     }
 
-    const network = cryptoId && cryptoIdToNetwork(cryptoId);
+    const network = cryptoId && cryptoIdToNetwork(networkConfigDeps, cryptoId);
     const hasAmount = new BigNumber(amount).gt(0);
 
     return (

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/components/TradingFormOfferOTC.tsx
@@ -11,6 +11,7 @@ import {
     getOtcProvidersByCountry,
     useFetchOtc,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
@@ -24,6 +25,7 @@ import {
 } from 'src/utils/wallet/trading/tradingTypingUtils';
 
 export const TradingFormOfferOTC = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const otcQuery = useFetchOtc();
@@ -61,7 +63,7 @@ export const TradingFormOfferOTC = () => {
     }
 
     const { network, contractAddress } = cryptoCurrency
-        ? cryptoIdToNetworkAndContractAddress(cryptoCurrency)
+        ? cryptoIdToNetworkAndContractAddress(networkConfigDeps, cryptoCurrency)
         : { network: undefined, contractAddress: undefined };
 
     const countrySelect = context.getValues().countrySelect.value;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormOffer/hooks/useTradingFormOfferCommon.ts
@@ -1,10 +1,12 @@
 import { type TranslationKey } from '@suite/intl';
 import { selectTorState } from '@suite/tor';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type TradingType,
     selectTradingProviderCompanyName,
     selectTradingSendAccount,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAreFeesLoading, selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { type IconComponent } from '@trezor/components';
 import { ArrowSquareOutIcon } from '@trezor/icons';
@@ -23,6 +25,7 @@ import {
 import { useTradingSelectedQuote } from 'src/views/wallet/trading/common/hooks/useTradingSelectedQuote';
 
 export const useTradingFormOfferCommon = <T extends TradingType>() => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext();
     const {
         isAmountEmpty,
@@ -30,7 +33,9 @@ export const useTradingFormOfferCommon = <T extends TradingType>() => {
         form: { state },
         type,
     } = context;
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, type));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, type, networkConfigDeps),
+    );
 
     const { amountInCrypto } = watch();
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingNetworkReserveBanner.tsx
@@ -1,6 +1,8 @@
 import { Translation } from '@suite/intl';
 import { SettingsAnchor, goto } from '@suite/router';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { getNetworkReserve } from '@suite-common/wallet-utils';
 import { Banner } from '@trezor/components';
@@ -16,6 +18,7 @@ export const TradingNetworkReserveBanner = ({
     symbol,
     contractAddress,
 }: TradingNetworkReserveBannerProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
@@ -32,13 +35,14 @@ export const TradingNetworkReserveBanner = ({
     if (!isNetworkReserveEnabled) return null;
 
     const networkReserve = getNetworkReserve({
+        ...networkConfigDeps,
         symbol,
         contractAddress,
         isEnabled: isNetworkReserveEnabled,
     });
     if (!networkReserve) return null;
 
-    const network = getNetwork(symbol);
+    const network = networkConfigDeps.getNetworkConfig(symbol);
 
     return (
         <Banner

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingRevokeModal.tsx
@@ -10,6 +10,7 @@ import {
     selectTradingSendAccount,
     tradeApi,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { RevokeModal } from 'src/components/suite/modals/ReduxModal/UserContextModal/AllowanceModals/RevokeModal';
 import { useSelector } from 'src/hooks/suite';
@@ -27,9 +28,12 @@ interface TradingRevokeModalProps {
 }
 
 export const TradingRevokeModal = ({ cryptoId }: TradingRevokeModalProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { state } = useAllowanceContext();
     const context = useTradingFormContext();
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, context.type));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, context.type, networkConfigDeps),
+    );
     const { analytics } = useServices(selectDesktopAnalyticsDep);
     const getCryptoInfo = useTradingExchangeCryptoAndProviderInfo();
     const selectedQuote = useSelector(selectTradingExchangeSelectedQuote);

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingSellFormInputs.tsx
@@ -14,6 +14,7 @@ import {
     selectTradingSellSupportedCryptoIds,
     selectTradingSendAccount,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { Column, Row } from '@trezor/components';
@@ -43,6 +44,7 @@ import { TradingFormSection } from './TradingFormSection';
 import { TradingNetworkReserveBanner } from './TradingNetworkReserveBanner';
 
 export const TradingSellFormInputs = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const context = useTradingFormContext<TradingSellType>();
     const quotes = useSelector(selectTradingSellQuotes);
     const { networkModuleRepository } = useServices(selectNetworkModuleRepositoryDep);
@@ -57,7 +59,7 @@ export const TradingSellFormInputs = () => {
         showReserveBanner,
     } = context;
     const asset = useSelectedTradingAsset(type);
-    const account = useSelector(state => selectTradingSendAccount(state, type));
+    const account = useSelector(state => selectTradingSendAccount(state, type, networkConfigDeps));
 
     const { control } = useFormContext<TradingSellFormProps>();
 
@@ -97,7 +99,7 @@ export const TradingSellFormInputs = () => {
 
     const supportedNetworks = networkModuleRepository.getSupportedNetworks();
     const sellSupportedCryptoIds = useSelector(state =>
-        selectTradingSellSupportedCryptoIds(state, supportedNetworks),
+        selectTradingSellSupportedCryptoIds(state, supportedNetworks, networkConfigDeps),
     );
 
     const countryRequiresSubdivision = isCountrySubdivisionRequired(countrySelect?.value);

--- a/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingOffers/useTradingOfferRate.ts
@@ -1,5 +1,6 @@
 import type { CryptoId } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import {
     type TradingTradeType,
@@ -8,12 +9,14 @@ import {
     useTradingUtils,
 } from '@suite-common/trading';
 import { type NetworkSymbol, getNetworkDecimals } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type BaseCurrencyAmount, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
 const DEFAULT_TOKEN_DECIMALS_LENGTH = 18;
 
 export const useTradingOfferRate = (trade: TradingTradeType | undefined): string | undefined => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { CryptoAmountFormatter, BaseCurrencyAmountFormatter } = useFormatters();
     const { cryptoIdToCoinSymbol } = useTradingUtils();
 
@@ -27,7 +30,9 @@ export const useTradingOfferRate = (trade: TradingTradeType | undefined): string
     ) => {
         if (value === undefined || cryptoId === undefined) return undefined;
         const coinSymbol = cryptoIdToCoinSymbol(cryptoId);
-        const networkDecimals = coinSymbol ? getNetworkDecimals(coinSymbol) : undefined;
+        const networkDecimals = coinSymbol
+            ? getNetworkDecimals(networkConfigDeps, coinSymbol)
+            : undefined;
 
         return CryptoAmountFormatter.format(value, {
             maxDisplayedDecimals: networkDecimals ?? DEFAULT_TOKEN_DECIMALS_LENGTH,

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingInfo/TradingInfoItem.tsx
@@ -3,8 +3,9 @@ import { type CryptoId } from 'invity-api';
 import { AccountLabel } from '@suite/account';
 import { Address } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { cryptoIdToNetworkSymbolAndContractAddress, useTradingAssets } from '@suite-common/trading';
-import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { Card, Column, Row, Skeleton, Text } from '@trezor/components';
 import { TokenIcon } from '@trezor/product-components';
@@ -34,9 +35,11 @@ export const TradingInfoItem = ({
     cryptoAmountTestId,
     accountInfoTestId,
 }: TradingInfoItemProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translationString } = useTranslation();
     const { createAssetOptionFromCryptoId } = useTradingAssets();
-    const currencyInfo = currency && cryptoIdToNetworkSymbolAndContractAddress(currency);
+    const currencyInfo =
+        currency && cryptoIdToNetworkSymbolAndContractAddress(networkConfigDeps, currency);
     const accountLabelPrefix = translationString(isReceive ? 'TR_TO' : 'TR_FROM').toLowerCase();
 
     const showAccountLabel = !!account;
@@ -54,7 +57,9 @@ export const TradingInfoItem = ({
         symbol,
     } = createAssetOptionFromCryptoId(currency);
 
-    const displayName = isNativeToken ? getNetworkDisplaySymbolName(networkSymbol) : name;
+    const displayName = isNativeToken
+        ? getNetworkDisplaySymbolName(networkConfigDeps, networkSymbol)
+        : name;
 
     const showNetwork = networkSymbol !== displaySymbol.toLowerCase();
 

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchangeDetails.tsx
@@ -1,6 +1,7 @@
 import { type ExchangeTrade } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { ExperimentId, ExperimentWrapper } from '@suite-common/message-system';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import {
@@ -11,7 +12,7 @@ import {
     selectTradingExchangeReceiveAccountKey,
     useTradingUtils,
 } from '@suite-common/trading';
-import { networksCollection } from '@suite-common/wallet-config';
+import { getNetworks , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsMevProtectionEnabled } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
@@ -46,6 +47,7 @@ export const TradingOfferExchangeDetails = ({
     exchange,
     providers,
 }: TradingOfferExchangeDetailsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const formStep = useSelector(selectTradingExchangeFormStep);
     const exchangeInfo = useSelector(selectTradingExchangeInfo);
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
@@ -55,6 +57,7 @@ export const TradingOfferExchangeDetails = ({
 
     const { symbol } = account;
     const formattedNetworkFee = subunitsToUnits({
+        ...networkConfigDeps,
         value: asAmountSubunit(new BigNumber(networkFee || '0')),
         symbol,
     }).toString();
@@ -66,10 +69,12 @@ export const TradingOfferExchangeDetails = ({
         cryptoId: exchangeQuote.receive,
     });
 
-    const supportedMevProtectionNetworks = networksCollection
+    const supportedMevProtectionNetworks = getNetworks(networkConfigDeps)
         .filter(network => network.features.includes('mev-protection'))
         .map(network => network.name);
-    const sendNetwork = exchangeQuote.send ? cryptoIdToNetwork(exchangeQuote.send) : undefined;
+    const sendNetwork = exchangeQuote.send
+        ? cryptoIdToNetwork(networkConfigDeps, exchangeQuote.send)
+        : undefined;
     const isMevProtectionSupported = sendNetwork?.features.includes('mev-protection') ?? false;
 
     const { coinSymbol: receiveCoinSymbol, contractAddress: receiveContractAddress } =

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAccountModal/TradingReceiveAccountAddSuiteOption.tsx
@@ -1,7 +1,9 @@
 import { Translation } from '@suite/intl';
 import { openModal } from '@suite/modal';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { cryptoIdToNetworkSymbol, parseCryptoId, useTradingUtils } from '@suite-common/trading';
+import { cryptoIdToSymbol, parseCryptoId, useTradingUtils } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectHasRunningDiscovery } from '@suite-common/wallet-core';
 import { IconCircle, Row } from '@trezor/components';
 import { PlusIcon } from '@trezor/icons';
@@ -13,6 +15,7 @@ import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/
 import { useTradingReceiveAddressValues } from '../useTradingReceiveAddressValues';
 
 export const TradingReceiveAccountAddSuiteOption = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { cryptoId } = useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
 
@@ -21,7 +24,7 @@ export const TradingReceiveAccountAddSuiteOption = () => {
     const isDiscoveryRunning = useSelector(selectHasRunningDiscovery);
     const { cryptoIdToPlatformName, cryptoIdToCoinName } = useTradingUtils();
 
-    const symbol = cryptoIdToNetworkSymbol(cryptoId);
+    const symbol = cryptoIdToSymbol(networkConfigDeps, cryptoId);
 
     const { networkId, contractAddress } = parseCryptoId(cryptoId);
     const networkName = contractAddress

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddressModal.tsx
@@ -4,7 +4,7 @@ import { Translation, useTranslation } from '@suite/intl';
 import { selectAddressValidatorDep } from '@suite-common/address';
 import { useServices } from '@suite-common/dependency-injection';
 import { cryptoIdToNetwork, parseCryptoId, useTradingUtils } from '@suite-common/trading';
-import { isNetworkSymbol } from '@suite-common/wallet-config';
+import { isNetworkSymbol , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { isHexValid, isInteger } from '@suite-common/wallet-utils';
 import { Column, Input, Modal, Text } from '@trezor/components';
 
@@ -15,6 +15,7 @@ import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/
 import { useTradingReceiveAddressValues } from './useTradingReceiveAddressValues';
 
 export const TradingReceiveAddressModal = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { tradingReceiveAddress, cryptoId, extraFieldDescription } =
         useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
@@ -42,12 +43,13 @@ export const TradingReceiveAddressModal = () => {
         validate: value => {
             if (cryptoId) {
                 const symbol =
-                    cryptoIdToNetwork(cryptoId)?.symbol ?? cryptoIdToNativeCoinSymbol(cryptoId);
+                    cryptoIdToNetwork(networkConfigDeps, cryptoId)?.symbol ??
+                    cryptoIdToNativeCoinSymbol(cryptoId);
                 let isValid = true;
 
                 try {
                     isValid =
-                        value && symbol !== undefined && isNetworkSymbol(symbol)
+                        value && symbol !== undefined && isNetworkSymbol(networkConfigDeps, symbol)
                             ? addressValidator.isAddressValid(value, symbol)
                             : true;
                 } catch {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
@@ -1,6 +1,7 @@
 import { Address } from '@suite/address';
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { BASE_CURRENCY_ZERO, asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
@@ -28,10 +29,11 @@ export const TradingUtxoReceiveAddressOption = ({
     address,
     label,
 }: TradingUtxoReceiveAddressOptionProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { tradingReceiveAddress } = useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
 
-    const network = getNetwork(account.symbol);
+    const network = getNetworkConfig(account.symbol);
 
     const baseCurrency = useSelector(selectBaseCurrency);
     const { BaseCurrencyAmountFormatter } = useFormatters();

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailPaymentSending.tsx
@@ -1,9 +1,10 @@
 import { type ExchangeTrade } from 'invity-api';
 
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { type TradingComposedTransactionInfo } from '@suite-common/trading';
-import { networks } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { Card, Column, InfoItem, type StepListItemState } from '@trezor/components';
 
@@ -44,13 +45,14 @@ export const TradingExchangeDetailPaymentSending = ({
     account,
     composedTransaction,
 }: TradingExchangeDetailPaymentSendingProps) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const locale = useLocales();
     const rawFeeInfo = useSelector(state =>
         account ? selectRawNetworkFeeInfo(state, account.symbol) : undefined,
     );
 
     const state = getState(trade);
-    const networkType = account ? networks[account.symbol]?.networkType : undefined;
+    const networkType = account ? getNetworkConfig(account.symbol).networkType : undefined;
     const estimatedTimeSeconds = getTxEstimatedTimeSeconds(
         networkType,
         rawFeeInfo,

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailSidebar.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeDetail/TradingExchangeDetailSidebar.tsx
@@ -1,8 +1,9 @@
 import type { ExchangeTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { cryptoIdToNetwork, useTradingUtils } from '@suite-common/trading';
-import { networksCollection } from '@suite-common/wallet-config';
+import { getNetworks , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsMevProtectionEnabled } from '@suite-common/wallet-core';
 import { Card, Column } from '@trezor/components';
 
@@ -31,13 +32,14 @@ export const TradingExchangeDetailSidebar = ({
     sendAccount,
     trade,
 }: TradingExchangeDetailSidebarProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const isMevProtectionEnabled = useSelector(selectIsMevProtectionEnabled);
     const isMevProtectionFeatureEnabled = useSelector(selectIsMevProtectionFeatureEnabled);
     const { cryptoIdToSymbolAndContractAddress } = useTradingUtils();
     const { getAssetDecimals } = useTradingAssetDecimals();
-    const sendNetwork = cryptoIdToNetwork(trade.send);
+    const sendNetwork = cryptoIdToNetwork(networkConfigDeps, trade.send);
     const isMevProtectionSupported = sendNetwork?.features.includes('mev-protection') ?? false;
-    const supportedMevProtectionNetworks = networksCollection
+    const supportedMevProtectionNetworks = getNetworks(networkConfigDeps)
         .filter(network => network.features.includes('mev-protection'))
         .map(network => network.name);
 

--- a/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingExchangeForm.tsx
@@ -2,8 +2,10 @@ import { FormProvider } from 'react-hook-form';
 
 import { selectIsDeviceCompromised } from '@suite/authenticity-checks';
 import { ContextMessage } from '@suite/message-system';
+import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
 import { type TradingType, selectTradingSendAccount } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 
 import { useSelector } from 'src/hooks/suite';
 import { useMessageSystemTrading } from 'src/hooks/suite/useMessageSystemTrading';
@@ -18,8 +20,11 @@ import { TradingDisabled } from '../common/TradingDisabled';
 import { TradingExchangeFormInputs } from '../common/TradingForm/TradingExchangeFormInputs';
 
 const TradingExchangeFormWrapper = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const tradingExchangeContextValue = useTradingExchangeForm();
-    const account = useSelector(state => selectTradingSendAccount(state, 'exchange'));
+    const account = useSelector(state =>
+        selectTradingSendAccount(state, 'exchange', networkConfigDeps),
+    );
     const allowanceContextValue = useAllowance({ account });
 
     return (

--- a/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
+++ b/packages/suite/src/views/wallet/trading/exchange/TradingFormOfferExchangeActions.tsx
@@ -3,12 +3,14 @@ import { useEffect } from 'react';
 import type { CryptoId } from 'invity-api';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import {
     requiresTokenApproval,
     selectIsTradingNetworkFeeMissing,
     selectTradingSendAccount,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 import { Button } from '@trezor/components';
 
@@ -25,6 +27,7 @@ import { TradingRevokeModal } from 'src/views/wallet/trading/common/TradingForm/
 import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 
 export const TradingFormOfferExchangeActions = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const context = useTradingFormContext<'exchange'>();
     const {
@@ -37,7 +40,9 @@ export const TradingFormOfferExchangeActions = () => {
         isComposing,
         form: { state, helpers },
     } = context;
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, 'exchange'));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, 'exchange', networkConfigDeps),
+    );
 
     const modalControls = useReceiveAddressModalControls();
 
@@ -64,11 +69,13 @@ export const TradingFormOfferExchangeActions = () => {
     });
 
     const isReceiveAddressSelected = !!tradingReceiveAddress.receiveAddress;
-    const shouldShowApprovalStep = quote !== undefined && requiresTokenApproval(quote);
+    const shouldShowApprovalStep =
+        quote !== undefined && requiresTokenApproval(networkConfigDeps, quote);
     const isQuoteOutdated = quote?.send !== sendCryptoSelect?.id;
     const isQuoteForSelectedReceive = quote?.receive === receiveCryptoSelect?.id;
     const amountTooHigh = account
         ? isAmountTooHigh({
+              ...networkConfigDeps,
               amount,
               contractAddress: tokenAddress,
               account,

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.tsx
@@ -1,8 +1,10 @@
+import { useServices } from '@suite-common/dependency-injection';
 import {
     selectIsTradingNetworkFeeMissing,
     selectTradingSendAccount,
     tradingSellActions,
 } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { isAmountTooHigh } from '@suite-common/wallet-utils';
 
 import { selectSellQuoteThunk } from 'src/actions/wallet/trading/sell/selectSellQuoteThunk';
@@ -15,6 +17,7 @@ import { useTradingFormOfferCommon } from 'src/views/wallet/trading/common/Tradi
 import { TradingKYCWarning } from 'src/views/wallet/trading/common/TradingKYCWarning';
 
 export const TradingFormOfferSellActions = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const context = useTradingFormContext<'sell'>();
     const {
@@ -23,7 +26,9 @@ export const TradingFormOfferSellActions = () => {
         sellInfo,
         form: { state, helpers },
     } = context;
-    const account = useSelector(reduxState => selectTradingSendAccount(reduxState, 'sell'));
+    const account = useSelector(reduxState =>
+        selectTradingSendAccount(reduxState, 'sell', networkConfigDeps),
+    );
 
     const isNetworkFeeMissing = useSelector(selectIsTradingNetworkFeeMissing);
 
@@ -33,6 +38,7 @@ export const TradingFormOfferSellActions = () => {
 
     const amountTooHigh = account
         ? isAmountTooHigh({
+              ...networkConfigDeps,
               amount,
               contractAddress: tokenAddress,
               account,

--- a/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailPaymentSending.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingSellDetail/TradingSellDetailPaymentSending.tsx
@@ -1,9 +1,10 @@
 import { type SellFiatTrade } from 'invity-api';
 
 import { Translation, type TranslationKey } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { formatDurationStrict } from '@suite-common/suite-utils';
 import { type TradingComposedTransactionInfo } from '@suite-common/trading';
-import { networks } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectRawNetworkFeeInfo } from '@suite-common/wallet-core';
 import { Card, Column, InfoItem, type StepListItemState } from '@trezor/components';
 
@@ -37,13 +38,14 @@ export const TradingSellDetailPaymentSending = ({
     account,
     composedTransaction,
 }: TradingSellDetailPaymentSendingProps) => {
+    const { getNetworkConfig } = useServices(selectNetworkConfigDeps);
     const locale = useLocales();
     const rawFeeInfo = useSelector(state =>
         account ? selectRawNetworkFeeInfo(state, account.symbol) : undefined,
     );
 
     const state = getState(trade);
-    const networkType = account ? networks[account.symbol]?.networkType : undefined;
+    const networkType = account ? getNetworkConfig(account.symbol).networkType : undefined;
     const estimatedTimeSeconds = getTxEstimatedTimeSeconds(
         networkType,
         rawFeeInfo,

--- a/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
+++ b/packages/suite/src/views/wallet/transactions/CoinjoinSummary/BalancePrivacyBreakdown/CryptoAmountWithHeader.tsx
@@ -2,7 +2,8 @@ import { type ReactNode } from 'react';
 
 import styled from 'styled-components';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { typography } from '@trezor/theme';
 
@@ -50,17 +51,18 @@ export const CryptoAmountWithHeader = ({
     symbol,
     color,
     className,
-}: CryptoAmountWithHeaderProps) => (
-    <Container className={className}>
-        <Header>
-            {headerIcon && headerIcon} {header}
-        </Header>
+}: CryptoAmountWithHeaderProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const formattedValue = formatNetworkAmount(networkConfigDeps, value, symbol);
 
-        <CryptoAmount value={formatNetworkAmount(value, symbol)} symbol={symbol} $color={color} />
-        <BaseCurrencyValue
-            amount={formatNetworkAmount(value, symbol)}
-            symbol={symbol}
-            showApproximationIndicator
-        />
-    </Container>
-);
+    return (
+        <Container className={className}>
+            <Header>
+                {headerIcon && headerIcon} {header}
+            </Header>
+
+            <CryptoAmount value={formattedValue} symbol={symbol} $color={color} />
+            <BaseCurrencyValue amount={formattedValue} symbol={symbol} showApproximationIndicator />
+        </Container>
+    );
+};

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBox.tsx
@@ -1,6 +1,7 @@
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
-import { getNetworkDisplaySymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol, getNetworkDisplaySymbolName , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import { Card, Flex, InfoItem, Row, Text } from '@trezor/components';
 import { hasBitcoinOnlyFirmware } from '@trezor/device-utils';
@@ -21,6 +22,7 @@ type TradeBoxProps = {
 };
 
 export const TradeBox = ({ account }: TradeBoxProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { isBelowTablet, isBelowMobile } = useLayoutSize();
     const { device } = useDevice();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account.symbol);
@@ -42,7 +44,10 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                         <Row gap={12}>
                             <TokenIcon size={40} symbol={account.symbol} showNetworkIcon />
                             <InfoItem
-                                label={getNetworkDisplaySymbolName(account.symbol)}
+                                label={getNetworkDisplaySymbolName(
+                                    networkConfigDeps,
+                                    account.symbol,
+                                )}
                                 typographyStyle="body-md-strong"
                                 intent="neutral"
                                 priority="primary"
@@ -54,7 +59,7 @@ export const TradeBox = ({ account }: TradeBoxProps) => {
                                     priority="secondary"
                                     typographyStyle="body-sm"
                                 >
-                                    {getNetworkDisplaySymbol(account.symbol)}
+                                    {getNetworkDisplaySymbol(networkConfigDeps, account.symbol)}
                                 </Text>
                             </InfoItem>
                         </Row>

--- a/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/TradeBoxActionButton.tsx
@@ -5,6 +5,7 @@ import { type Route, goto } from '@suite/router';
 import { events as sharedEvents } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { Button } from '@trezor/components';
 import { exhaustive } from '@trezor/type-utils';
 
@@ -30,6 +31,7 @@ export const TradeBoxActionButton = ({
     children,
     isDisabled = false,
 }: TradeBoxActionButtonProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
@@ -45,7 +47,7 @@ export const TradeBoxActionButton = ({
 
                 dispatch(
                     tradingActions.setTradingFromPrefilledAccount(
-                        getTradingPrefilledFromAccountData(account),
+                        getTradingPrefilledFromAccountData(networkConfigDeps, account),
                     ),
                 );
 

--- a/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/WrapNativeTokenButton.tsx
@@ -8,7 +8,7 @@ import { goto } from '@suite/router';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
-import { getNetworkType } from '@suite-common/wallet-config';
+import { getNetworkType, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { isWrappedNativeFlowSupported } from '@suite-common/wallet-core';
 import { Button, Tooltip } from '@trezor/components';
 import {
@@ -31,6 +31,7 @@ type WrapNativeTokenButtonProps = {
  * without a wrapped-native contract configured.
  */
 export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const dispatch = useDispatch();
     const { translationString } = useTranslation();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -48,7 +49,7 @@ export const WrapNativeTokenButton = ({ account }: WrapNativeTokenButtonProps) =
 
     if (
         !isDebugModeActive ||
-        getNetworkType(symbol) !== 'ethereum' ||
+        getNetworkType(networkConfigDeps, symbol) !== 'ethereum' ||
         !wrappedAddress ||
         !wrappedSymbol
     ) {

--- a/packages/suite/src/views/wallet/transactions/TradeBox/hooks/useTradeBoxEarnOptions.ts
+++ b/packages/suite/src/views/wallet/transactions/TradeBox/hooks/useTradeBoxEarnOptions.ts
@@ -1,3 +1,5 @@
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { hasNetworkFeatures, isApyAvailable } from '@suite-common/wallet-utils';
 
 import { useNativeYieldVault } from 'src/hooks/earn/useNativeYieldVault';
@@ -15,6 +17,7 @@ type TradeBoxEarnOptions = {
 };
 
 export const useTradeBoxEarnOptions = (account: Account): TradeBoxEarnOptions => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { hasYieldOption, bestVault } = useNativeYieldVault(account);
     const { rate: stakingRate } = useStakingRate({
         symbol: account.symbol,
@@ -34,7 +37,7 @@ export const useTradeBoxEarnOptions = (account: Account): TradeBoxEarnOptions =>
         : null;
 
     return {
-        hasEarnOption: hasNetworkFeatures(account, 'staking') || hasYieldOption,
+        hasEarnOption: hasNetworkFeatures(networkConfigDeps, account, 'staking') || hasYieldOption,
         yieldBadge,
     };
 };

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionGroupedList.tsx
@@ -1,4 +1,6 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { toNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import {
     type GroupedTransactionsByDate,
@@ -13,6 +15,7 @@ import { type Account, type WalletAccountTransaction } from 'src/types/wallet';
 
 import { TransactionsGroup } from './TransactionsGroup/TransactionsGroup';
 
+
 interface TransactionGroupedListProps {
     transactionGroups: GroupedTransactionsByDate;
     symbol: WalletAccountTransaction['symbol'];
@@ -26,8 +29,9 @@ export const TransactionGroupedList = ({
     account,
     isPending,
 }: TransactionGroupedListProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
-    const network = getNetwork(symbol);
+    const network = toNetwork(symbol, getNetworkConfig(symbol));
 
     const transactionWithLowestNonce: WalletAccountTransaction | null =
         getTransactionWithLowestNonce(transactionGroups);

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionList.tsx
@@ -4,8 +4,10 @@ import useDebounce from 'react-use/lib/useDebounce';
 
 import { Translation } from '@suite/intl';
 import { findAnchorTransactionPage, selectRouterAnchor } from '@suite/router';
+import { useServices } from '@suite-common/dependency-injection';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { advancedSearchTransactions } from '@suite-common/transaction-search';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { groupTransactionsByDate, isPending } from '@suite-common/wallet-utils';
 import { Column } from '@trezor/components';
 
@@ -53,6 +55,7 @@ export const TransactionList = ({
 }: TransactionListProps) => {
     const anchor = useSelector(selectRouterAnchor);
     const dispatch = useDispatch();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const searchLabels = useSelector(state => selectAccountLabelsForSearch(state, account));
 
     const { fetchPage, fetchedAll, fetchAll } = useFetchTransactions(account, allTransactions);
@@ -65,11 +68,16 @@ export const TransactionList = ({
 
     useDebounce(
         () => {
-            const results = advancedSearchTransactions(transactions, searchLabels, searchQuery);
+            const results = advancedSearchTransactions(
+                networkConfigDeps,
+                transactions,
+                searchLabels,
+                searchQuery,
+            );
             setSearchedTransactions(results);
         },
         200,
-        [transactions, searchQuery, searchLabels],
+        [networkConfigDeps, searchLabels, searchQuery, transactions],
     );
 
     useEffect(() => {

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/ExportAction.tsx
@@ -4,8 +4,8 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation, useTranslation } from '@suite/intl';
 import { selectLabelingDataForSelectedAccount } from '@suite/metadata';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { notificationsActions } from '@suite-common/toast-notifications';
-import { getNetwork } from '@suite-common/wallet-config';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { type ExportFileType } from '@suite-common/wallet-types';
 import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
@@ -17,12 +17,14 @@ import { useDispatch } from 'src/hooks/suite';
 import { useSelector } from 'src/hooks/suite/useSelector';
 import { type Account } from 'src/types/wallet';
 
+
 export interface ExportActionProps {
     account: Account;
     searchQuery: string;
 }
 
 export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [isExportRunning, setIsExportRunning] = useState(false);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
@@ -34,7 +36,7 @@ export const ExportAction = ({ account, searchQuery }: ExportActionProps) => {
         }
 
         return translationString('LABELING_ACCOUNT', {
-            networkName: getNetwork(account.symbol).name,
+            networkName: getNetworkConfig(account.symbol).name,
             index: account.index + 1,
         });
     }, [account, translationString]);

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/TransactionListActions.tsx
@@ -1,8 +1,10 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from 'react';
 
 import { useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { fetchAllTransactionsForAccountThunk } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { Icon, Input } from '@trezor/components';
@@ -32,6 +34,7 @@ export const TransactionListActions = ({
     isExportable = true,
     isTxFilteringEnabled = true,
 }: TransactionListActionsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [hasFetchedAll, setHasFetchedAll] = useState(false);
 
     const transactionHistoryPrefill = useSelector(
@@ -103,9 +106,10 @@ export const TransactionListActions = ({
                     />
                 }
             />
-            {isTxFilteringEnabled && hasNetworkPotentialFraudTransactions(account.symbol) && (
-                <FilterAction symbol={account.symbol} />
-            )}
+            {isTxFilteringEnabled &&
+                hasNetworkPotentialFraudTransactions(networkConfigDeps, account.symbol) && (
+                    <FilterAction symbol={account.symbol} />
+                )}
             {isExportable && <ExportAction account={account} searchQuery={searchQuery} />}
         </Row>
     );

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionsGroup/TransactionsGroup.tsx
@@ -1,7 +1,9 @@
 import { type ReactNode } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { isTokenDefinitionKnown, selectCoinDefinitions } from '@suite-common/token-definitions';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectHistoricFiatRates } from '@suite-common/wallet-core';
 import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
 import {
@@ -41,10 +43,12 @@ export const TransactionsGroup = ({
     children,
     index,
 }: TransactionsGroupProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const historicFiatRates = useSelector(selectHistoricFiatRates);
     const tokenDefinitions = useSelector(state => selectCoinDefinitions(state, symbol));
-    const totalAmountPerDay = sumTransactions(transactions);
+    const totalAmountPerDay = sumTransactions(networkConfigDeps, transactions);
     const totalFiatAmountPerDay = sumTransactionsFiat(
+        networkConfigDeps,
         transactions,
         baseCurrencyCode,
         historicFiatRates,
@@ -63,6 +67,7 @@ export const TransactionsGroup = ({
             )
             .some(token => {
                 const isTokenKnown = isTokenDefinitionKnown(
+                    networkConfigDeps,
                     tokenDefinitions?.data,
                     symbol,
                     token.contract,

--- a/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/WalletTransactionList.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { hasNetworkPotentialFraudTransactions } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAreAllTransactionsLoaded,
     selectIsHideSuspiciousTransactions,
@@ -37,12 +39,14 @@ export const WalletTransactionList = ({
     customTotalItems,
     isExportable = true,
 }: TransactionListProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     // NOTE: The number of the displayed pages may be different from the number of the pages for all transactions
     const suspiciousTransactionsHidden = useSelector(state =>
         selectIsHideSuspiciousTransactions(state, symbol),
     );
     const fraudTransactionPossible =
-        suspiciousTransactionsHidden && hasNetworkPotentialFraudTransactions(symbol);
+        suspiciousTransactionsHidden &&
+        hasNetworkPotentialFraudTransactions(networkConfigDeps, symbol);
     const [visiblePages, setVisiblePages] = useState(1);
     const areAllTransactionsLoaded = useSelector(state =>
         Boolean(selectAreAllTransactionsLoaded(state, account.key)),

--- a/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/useFetchTransactions.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { isPhishingTransaction } from '@suite-common/token-definitions';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     fetchAllTransactionsForAccountThunk,
     fetchTransactionsPageThunk,
@@ -155,6 +157,7 @@ export const useVisibleTransactions = ({
     numberOfPagesRequested: number;
     enableFiltering?: boolean;
 }) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const allTransactions = useSelector(state =>
         selectAccountTransactionsWithNulls(state, account.key),
     );
@@ -183,6 +186,7 @@ export const useVisibleTransactions = ({
                 ? allTransactions.filter(
                       transaction =>
                           !isPhishingTransaction({
+                              ...networkConfigDeps,
                               transaction,
                               tokenDefinitions,
                               txsMarkedAsNotScam,
@@ -198,6 +202,7 @@ export const useVisibleTransactions = ({
             txsMarkedAsNotScam,
             historicRates,
             dustThreshold,
+            networkConfigDeps,
         ],
     );
 

--- a/packages/suite/src/views/wallet/transactions/Transactions.tsx
+++ b/packages/suite/src/views/wallet/transactions/Transactions.tsx
@@ -1,5 +1,7 @@
 import { type ReactNode } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     selectAccountTransactionsWithNulls,
     selectIsLoadingAccountTransactions,
@@ -35,6 +37,7 @@ const Layout = ({ selectedAccount, children }: LayoutProps) => (
 );
 
 export const Transactions = () => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
     const transactionsIsLoading = useSelector(state =>
         selectIsLoadingAccountTransactions(state, selectedAccount.account?.key || null),
@@ -49,7 +52,11 @@ export const Transactions = () => {
 
     const { account } = selectedAccount;
 
-    const isGraphSupported = isNetworkWithGraphFeature(account.symbol, account.backendType);
+    const isGraphSupported = isNetworkWithGraphFeature(
+        networkConfigDeps,
+        account.symbol,
+        account.backendType,
+    );
 
     if (account.backendType === 'coinjoin') {
         const isLoading = account.status === 'out-of-sync' && !!account.syncing;

--- a/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountEmpty.tsx
@@ -2,29 +2,31 @@ import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getTradingPrefilledFromAccountData, tradingActions } from '@suite-common/trading';
-import {
-    getNetwork,
-    getNetworkDisplaySymbol,
-    getNetworkFeatures,
-} from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbol, getNetworkFeatures , selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { ArrowDownIcon, ArrowsLeftRightIcon, CurrencyCircleDollarIcon } from '@trezor/icons';
 
 import { AccountExceptionLayout } from 'src/components/wallet';
 import { useDispatch } from 'src/hooks/suite';
 import { type Account } from 'src/types/wallet';
+
 interface AccountEmptyProps {
     account: Account;
 }
 
 export const AccountEmpty = ({ account }: AccountEmptyProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectDesktopAnalyticsDep);
 
-    const isTokensNetwork = getNetworkFeatures(account.symbol).includes('tokens');
+    const isTokensNetwork = getNetworkFeatures(networkConfigDeps, account.symbol).includes(
+        'tokens',
+    );
 
-    const displaySymbol = getNetworkDisplaySymbol(account.symbol);
-    const networkName = getNetwork(account.symbol).name;
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, account.symbol);
+    const networkName = getNetworkConfig(account.symbol).name;
 
     const handleNavigateToReceivePage = () => {
         dispatch(goto({ routeName: 'wallet-receive', preserveParams: true }));
@@ -38,7 +40,7 @@ export const AccountEmpty = ({ account }: AccountEmptyProps) => {
     const handleNavigateToBuyPage = () => {
         dispatch(
             tradingActions.setTradingFromPrefilledAccount(
-                getTradingPrefilledFromAccountData(account),
+                getTradingPrefilledFromAccountData(networkConfigDeps, account),
             ),
         );
         dispatch(goto({ routeName: 'wallet-trading-buy' }));

--- a/packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx
+++ b/packages/suite/src/views/wallet/transactions/components/AccountOverviewBalance.tsx
@@ -1,5 +1,7 @@
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAccountIsStakingActive, selectBaseCurrency } from '@suite-common/wallet-core';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { Column, Icon, Paragraph, Row, Skeleton, Text } from '@trezor/components';
@@ -47,10 +49,11 @@ type AccountOverviewBalanceProps = {
 };
 
 export const AccountOverviewBalance = ({ selectedAccount }: AccountOverviewBalanceProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const baseCurrency = useSelector(selectBaseCurrency);
     const hasStaking = useSelector(state =>
         selectedAccount.account
-            ? selectAccountIsStakingActive(state, selectedAccount.account.key)
+            ? selectAccountIsStakingActive(state, selectedAccount.account.key, networkConfigDeps)
             : false,
     );
     const { balanceSectionRef } = useAccountHeaderContext();
@@ -72,7 +75,7 @@ export const AccountOverviewBalance = ({ selectedAccount }: AccountOverviewBalan
 
     const { symbol, formattedBalance } = account;
     const shouldDisplayBaseCurrency = baseCurrency !== symbol;
-    const isMainnet = !isTestnet(symbol);
+    const isMainnet = !isTestnet(networkConfigDeps, symbol);
     const hasTokens = !!account.tokens?.length;
     const hasStakingExcludedFromBalance = hasStaking && account.networkType !== 'cardano';
     const balanceExcludesTranslationId = getBalanceExcludesTranslationId(

--- a/suite/account/src/labels/getDefaultAccountLabel.ts
+++ b/suite/account/src/labels/getDefaultAccountLabel.ts
@@ -1,11 +1,12 @@
 import { type TranslationFunction } from '@suite/intl';
-import { getNetwork } from '@suite-common/wallet-config';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
 import { type Account } from '@suite-common/wallet-types';
 import { getTitleForCoinjoinAccount } from '@suite-common/wallet-utils';
 
 type GetDefaultAccountLabelParams = Pick<Account, 'accountType' | 'symbol' | 'index'>;
 
 export const getDefaultAccountLabel = (
+    deps: GetNetworkConfigDep,
     translationString: TranslationFunction,
     { accountType, symbol, index = 0 }: GetDefaultAccountLabelParams,
 ) => {
@@ -14,7 +15,7 @@ export const getDefaultAccountLabel = (
     }
 
     return translationString('LABELING_ACCOUNT', {
-        networkName: getNetwork(symbol).name,
+        networkName: deps.getNetworkConfig(symbol).name,
         index: index + 1,
     });
 };

--- a/suite/account/src/labels/useAccountLabel.ts
+++ b/suite/account/src/labels/useAccountLabel.ts
@@ -1,6 +1,8 @@
 import { useSelector } from 'react-redux';
 
 import { useTranslation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { getDefaultAccountLabel } from './getDefaultAccountLabel';
@@ -17,6 +19,7 @@ type UseAccountLabelParams = {
 
 export const useAccountLabel = ({ account }: UseAccountLabelParams): AccountLabelResult => {
     const { translationString } = useTranslation();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
 
     const accountLabel = useSelector((state: SelectAccountLabelState) =>
         selectAccountLabel(state, {
@@ -27,7 +30,7 @@ export const useAccountLabel = ({ account }: UseAccountLabelParams): AccountLabe
         }),
     );
 
-    const defaultLabel = getDefaultAccountLabel(translationString, account);
+    const defaultLabel = getDefaultAccountLabel(networkConfigDeps, translationString, account);
 
     return {
         label: accountLabel || defaultLabel,

--- a/suite/coinjoin/src/coinjoinAccountActions.ts
+++ b/suite/coinjoin/src/coinjoinAccountActions.ts
@@ -4,6 +4,7 @@ import { selectIsDeviceLocked } from '@suite/locks';
 import { openModal } from '@suite/modal';
 import { goto, selectRouteName } from '@suite/router';
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
+import type { ExtraDependencies } from '@suite-common/redux-utils';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import type { Network, NetworkAccount, NetworkSymbol } from '@suite-common/wallet-config';
@@ -330,9 +331,10 @@ const coinjoinAccountCheckReorg =
     };
 
 const coinjoinAccountAddTransactions =
-    (props: Parameters<typeof transactionsActions.addTransaction>[0]) => (dispatch: Dispatch) => {
+    (props: Parameters<typeof transactionsActions.addTransaction>[0]) =>
+    (dispatch: Dispatch, _getState: unknown, extra: ExtraDependencies) => {
         if (props.transactions.length > 0) {
-            dispatch(transactionsActions.addTransaction(props));
+            dispatch(transactionsActions.addTransaction(props, extra.services.getNetworkConfig));
         }
     };
 
@@ -349,7 +351,8 @@ const coinjoinAccountAddTransactions =
  In case of adding a coinjoin transaction, log anonymity gain.
  */
 export const updatePendingAccountInfo =
-    (accountKey: AccountKey) => async (dispatch: Dispatch, getState: GetState) => {
+    (accountKey: AccountKey) =>
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         const coinjoinAccount = selectCoinjoinAccountByKey(state, accountKey);
@@ -376,7 +379,9 @@ export const updatePendingAccountInfo =
         );
         accountInfo.addresses.anonymitySet = anonymityScores;
 
-        dispatch(accountsActions.updateAccount(account, accountInfo));
+        dispatch(
+            accountsActions.updateAccount(account, extra.services.getNetworkConfig, accountInfo),
+        );
 
         // Log anonymity gain if the newly added transaction is a coinjoin transaction.
         if (accountInfo.history.transactions[0]?.type === 'joint') {
@@ -445,7 +450,7 @@ const cleanPendingTransactions =
 
 export const fetchAndUpdateAccount =
     ({ key: accountKey, symbol }: Account) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const state = getState();
         // do not sync if any account CoinjoinSession is in critical phase
         if (selectIsAnySessionInCriticalPhase(state)) return;
@@ -529,6 +534,7 @@ export const fetchAndUpdateAccount =
                 dispatch(
                     accountsActions.updateAccount(
                         { ...account, status: 'ready' as const },
+                        extra.services.getNetworkConfig,
                         accountInfo,
                     ),
                 );
@@ -564,7 +570,7 @@ const handleError = (error: string) => (dispatch: Dispatch) => {
 
 export const createCoinjoinAccount =
     (network: Network, account: NetworkAccount) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         if (account.accountType !== 'coinjoin') {
             throw new Error('createCoinjoinAccount: invalid account type');
         }
@@ -611,22 +617,25 @@ export const createCoinjoinAccount =
 
         // create empty account
         const coinjoinAccount = dispatch(
-            accountsActions.createAccount({
-                deviceState: device!.state!.staticSessionId!,
-                index: 0,
-                path,
-                unlockPath: unlockPath.payload,
-                accountType: account.accountType,
-                backendType: 'coinjoin',
-                status: 'initial',
-                symbol: network.symbol,
-                accountInfo: {
-                    ...EMPTY_ACCOUNT_INFO,
-                    descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,
-                    legacyXpub: publicKey.payload.xpub,
+            accountsActions.createAccount(
+                {
+                    deviceState: device!.state!.staticSessionId!,
+                    index: 0,
+                    path,
+                    unlockPath: unlockPath.payload,
+                    accountType: account.accountType,
+                    backendType: 'coinjoin',
+                    status: 'initial',
+                    symbol: network.symbol,
+                    accountInfo: {
+                        ...EMPTY_ACCOUNT_INFO,
+                        descriptor: publicKey.payload.xpubSegwit || publicKey.payload.xpub,
+                        legacyXpub: publicKey.payload.xpub,
+                    },
+                    visible: true,
                 },
-                visible: true,
-            }),
+                extra.services.getNetworkConfig,
+            ),
         );
 
         log(`CoinjoinAccount created: ${getAccountProgressHandle(coinjoinAccount.payload)}`);
@@ -657,7 +666,7 @@ export const createCoinjoinAccount =
 
 export const rescanCoinjoinAccount =
     (accountKey: AccountKey, fullRescan = false) =>
-    async (dispatch: Dispatch, getState: GetState) => {
+    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
         const state = getState();
         const account = selectAccountByKey(state, accountKey);
         if (account?.backendType !== 'coinjoin' || account.syncing) return;
@@ -681,6 +690,7 @@ export const rescanCoinjoinAccount =
         const { payload } = dispatch(
             accountsActions.updateAccount(
                 { ...account, status: 'initial' as const },
+                extra.services.getNetworkConfig,
                 { ...EMPTY_ACCOUNT_INFO, descriptor: account.descriptor },
             ),
         );

--- a/suite/discovery/src/discoveryMiddleware.ts
+++ b/suite/discovery/src/discoveryMiddleware.ts
@@ -18,7 +18,7 @@ import {
 } from './conditions';
 
 export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
-    async (action, { dispatch, next, getState }): Promise<AnyAction> => {
+    async (action, { dispatch, next, getState, extra }): Promise<AnyAction> => {
         // Pass action to next middleware, meaning that the code below runs *only after* the action has been completely processed in Redux.
         // Note: TS says next(action) generally isn't async, but the action may return anything; sometimes it's a Promise → needs to be awaited
         await next(action);
@@ -71,7 +71,7 @@ export const prepareDiscoveryMiddleware = createMiddlewareWithExtraDeps(
         ) {
             // 5. Nothing to discover (discovery would be no-op). It's intentionally inside the action matcher condition
             // so it won't be called on every action, because the selector is expensive and not viable for memoization.
-            const shouldRediscover = selectShouldRediscover(getState(), device);
+            const shouldRediscover = selectShouldRediscover(getState(), extra.services, device);
             if (!shouldRediscover) return action;
             dispatch(startOrRestartDiscoveryThunk());
         }

--- a/suite/e2e/tests/trading/swap-history.test.ts
+++ b/suite/e2e/tests/trading/swap-history.test.ts
@@ -1,6 +1,6 @@
 import { messages } from '@suite/intl';
-import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { cryptoIdToSymbol } from '@suite-common/trading';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { tradeEndpoint } from '../../fixtures/trading';
@@ -70,8 +70,8 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
                 type StatusKey = keyof typeof statusTranslationKeys;
                 const row = tradingPage.transactions.swapTransactionRow(trade.orderId);
                 const receiveSymbol = (
-                    cryptoIdToNetworkSymbol(
-                        trade.data.receive as Parameters<typeof cryptoIdToNetworkSymbol>[0],
+                    cryptoIdToSymbol(
+                        trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0],
                     ) ?? trade.data.receive
                 ).toUpperCase();
 
@@ -117,9 +117,8 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
 
         for (const trade of SEEDED_TRADES) {
             const receiveSymbol = (
-                cryptoIdToNetworkSymbol(
-                    trade.data.receive as Parameters<typeof cryptoIdToNetworkSymbol>[0],
-                ) ?? trade.data.receive
+                cryptoIdToSymbol(trade.data.receive as Parameters<typeof cryptoIdToSymbol>[0]) ??
+                trade.data.receive
             ).toUpperCase();
 
             await test.step(`Open detail for trade ${trade.orderId}`, async () => {
@@ -161,7 +160,7 @@ test.describe('Trading - Swap history', { tag: ['@webOnly', '@T3T1', '@T3W1'] },
                     .toHaveText(trade.orderId);
 
                 await expect(tradingPage.transactionDetailSidebar.sendAccount).toContainText(
-                    getNetwork(trade.sendSymbol as NetworkSymbol).name,
+                    getNetworkConfig(trade.sendSymbol as NetworkSymbol).name,
                 );
                 await expect(tradingPage.transactionDetailSidebar.receiveAccount).toBeVisible();
             });

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -1,4 +1,3 @@
-import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 import { Model } from '@trezor/trezor-user-env-link';
@@ -12,7 +11,7 @@ import { transformAddress } from '../../support/testExtends/customMatchers';
 const RECIPIENT_ADDRESS = 'ENk2eeP4umP6cjAGRsVG4NEVKEVQmRn6JEpN8hubv2Hf';
 const FORMATTED_ADDRESS = formatAddressWithNewlines(RECIPIENT_ADDRESS);
 const TRANSFORMED_ADDRESS = transformAddress(RECIPIENT_ADDRESS, 'fourTetragrams');
-const SOL_DECIMALS = getNetwork(asNetworkSymbol('sol')).decimals;
+const SOL_DECIMALS = getNetworkConfig('sol').decimals;
 
 test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
     test.use({
@@ -56,10 +55,9 @@ test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
                 await tradingPage.setMax.click();
 
                 await expect(tradingPage.fees.maxFee).not.toBeEmpty();
-                await expect(tradingPage.sendBalance).toHaveText(/\d/);
 
-                const balance = Number(await tradingPage.sendBalance.innerText());
-                maxFee = Number(await tradingPage.fees.maxFee.innerText());
+                const balance = Number(await tradingPage.sendBalance.textContent());
+                maxFee = Number(await tradingPage.fees.maxFee.textContent());
                 const reservedAmount = await tradingPage.fees.getNetworkReserveAmount();
                 sendMaxAmountWithReserve = localizeNumber(
                     new BigNumber(balance - maxFee - reservedAmount),

--- a/suite/receive/package.json
+++ b/suite/receive/package.json
@@ -15,6 +15,7 @@
         "@suite-common/address": "workspace:*",
         "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
+        "@suite-common/networks": "workspace:*",
         "@suite-common/receive": "workspace:*",
         "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-config": "workspace:*",

--- a/suite/receive/src/AddressHistory.tsx
+++ b/suite/receive/src/AddressHistory.tsx
@@ -6,6 +6,8 @@ import {
     selectAddressLabelsForAccount,
 } from '@suite/address';
 import { Translation } from '@suite/intl';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type ReceiveRootState,
     selectCurrentFreshAddress,
@@ -46,6 +48,7 @@ export const AddressHistory = ({
     onCopied,
     onVerify,
 }: AddressHistoryProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const account = useSelector((state: AddressHistoryRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -82,6 +85,7 @@ export const AddressHistory = ({
         () =>
             account
                 ? buildReceiveAddressItems({
+                      getNetworkConfig,
                       account,
                       touchedAddresses,
                       pendingAddresses,
@@ -89,7 +93,14 @@ export const AddressHistory = ({
                       currentFreshAddress,
                   })
                 : [],
-        [account, touchedAddresses, pendingAddresses, addressLabels, currentFreshAddress],
+        [
+            account,
+            touchedAddresses,
+            pendingAddresses,
+            addressLabels,
+            currentFreshAddress,
+            getNetworkConfig,
+        ],
     );
 
     // With no fresh address left, the newest card shows the most recent used address, so drop it here

--- a/suite/receive/src/NewestAddressCard.tsx
+++ b/suite/receive/src/NewestAddressCard.tsx
@@ -11,6 +11,8 @@ import {
 } from '@suite/address';
 import { Translation } from '@suite/intl';
 import { getReceiveAddressForFlowEntry, getReceiveAddressToAdd } from '@suite-common/address';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type ReceiveRootState,
     receiveActions,
@@ -59,6 +61,7 @@ export const NewestAddressCard = ({
     onVerify,
 }: NewestAddressCardProps) => {
     const dispatch = useDispatch();
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
 
     const account = useSelector((state: NewestAddressCardRootState) =>
         selectAccountByKey(state, accountKey),
@@ -128,6 +131,7 @@ export const NewestAddressCard = ({
         () =>
             account
                 ? buildReceiveAddressItems({
+                      getNetworkConfig,
                       account,
                       touchedAddresses,
                       pendingAddresses,
@@ -135,7 +139,14 @@ export const NewestAddressCard = ({
                       currentFreshAddress,
                   })
                 : [],
-        [account, touchedAddresses, pendingAddresses, addressLabels, currentFreshAddress],
+        [
+            account,
+            touchedAddresses,
+            pendingAddresses,
+            addressLabels,
+            currentFreshAddress,
+            getNetworkConfig,
+        ],
     );
 
     const addressToAdd = useMemo(

--- a/suite/receive/src/ReceiveContent.tsx
+++ b/suite/receive/src/ReceiveContent.tsx
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { Translation } from '@suite/intl';
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type Account } from '@suite-common/wallet-types';
 import { Banner, Column, H2 } from '@trezor/components';
 
@@ -21,6 +22,7 @@ export type ReceiveContentProps = {
 
 export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveContentProps) => {
     const dispatch = useDispatch();
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { isReceiveDisabled } = useReceiveDisabled();
 
     // Copying an address is the entry point to verification, so the cards report the copied path
@@ -58,13 +60,13 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
                     title={
                         <Translation
                             id="TR_EVM_EXPLANATION_TITLE"
-                            values={{ network: getNetwork(account.symbol).name }}
+                            values={{ network: getNetworkConfig(account.symbol).name }}
                         />
                     }
                     description={
                         <Translation
                             id="TR_EVM_EXPLANATION_RECEIVE_DESCRIPTION"
-                            values={{ network: getNetwork(account.symbol).name }}
+                            values={{ network: getNetworkConfig(account.symbol).name }}
                         />
                     }
                 />
@@ -73,7 +75,9 @@ export const ReceiveContent = ({ account, locked, AmountComponent }: ReceiveCont
             <H2>
                 <Translation
                     id="RECEIVE_TITLE"
-                    values={{ networkDisplaySymbol: getNetworkDisplaySymbol(account.symbol) }}
+                    values={{
+                        networkDisplaySymbol: getNetworkConfig(account.symbol).displaySymbol,
+                    }}
                 />
             </H2>
 

--- a/suite/receive/src/address/buildReceiveAddressItems.ts
+++ b/suite/receive/src/address/buildReceiveAddressItems.ts
@@ -1,4 +1,5 @@
 import { getReceiveAddressHistoryList } from '@suite-common/address';
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { type Account, type ReceiveInfo } from '@suite-common/wallet-types';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { getAddressPathIndex } from '@trezor/crypto-utils';
@@ -12,7 +13,7 @@ export type ReceiveAddressItem = {
     isFresh: boolean;
 };
 
-type BuildReceiveAddressItemsParams = {
+type BuildReceiveAddressItemsParams = GetNetworkConfigDep & {
     account: Account;
     touchedAddresses: ReceiveInfo[];
     pendingAddresses: string[];
@@ -21,6 +22,7 @@ type BuildReceiveAddressItemsParams = {
 };
 
 export const buildReceiveAddressItems = ({
+    getNetworkConfig,
     account,
     touchedAddresses,
     pendingAddresses,
@@ -39,7 +41,7 @@ export const buildReceiveAddressItems = ({
         address: address.address,
         pathIndex: getAddressPathIndex(address.path),
         received: address.transfers
-            ? formatNetworkAmount(address.received || '0', account.symbol)
+            ? formatNetworkAmount({ getNetworkConfig }, address.received || '0', account.symbol)
             : undefined,
         label: addressLabels[address.address] ?? undefined,
         isFresh: !address.transfers,

--- a/suite/receive/tsconfig.json
+++ b/suite/receive/tsconfig.json
@@ -7,6 +7,7 @@
             "path": "../../suite-common/dependency-injection"
         },
         { "path": "../../suite-common/device" },
+        { "path": "../../suite-common/networks" },
         { "path": "../../suite-common/receive" },
         {
             "path": "../../suite-common/toast-notifications"

--- a/suite/router/src/router.test.ts
+++ b/suite/router/src/router.test.ts
@@ -133,10 +133,18 @@ describe('router', () => {
                 },
                 route: getRoute('wallet-index'),
             };
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/0/normal' })).toEqual(
-                resp,
-            );
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/1/segwit' })).toEqual({
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc/0/normal',
+                }),
+            ).toEqual(resp);
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc/1/segwit',
+                }),
+            ).toEqual({
                 ...resp,
                 params: {
                     symbol: 'btc',
@@ -144,7 +152,12 @@ describe('router', () => {
                     accountType: 'segwit',
                 },
             });
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/1/legacy' })).toEqual({
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc/1/legacy',
+                }),
+            ).toEqual({
                 ...resp,
                 params: {
                     symbol: 'btc',
@@ -152,25 +165,42 @@ describe('router', () => {
                     accountType: 'legacy',
                 },
             });
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc/NaN' })).toEqual({
-                ...resp,
-                params: undefined,
-            });
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc-invalid/0' })).toEqual({
-                ...resp,
-                params: undefined,
-            });
             expect(
-                getAppWithParams({ pathname: '/accounts', hash: '#/btc/0/unknown-type' }),
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc/NaN',
+                }),
             ).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams({ pathname: '/accounts', hash: '#/btc' })).toEqual({
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc-invalid/0',
+                }),
+            ).toEqual({
                 ...resp,
                 params: undefined,
             });
-            expect(getAppWithParams({ pathname: '/accounts', hash: '' })).toEqual({
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, {
+                    pathname: '/accounts',
+                    hash: '#/btc/0/unknown-type',
+                }),
+            ).toEqual({
+                ...resp,
+                params: undefined,
+            });
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, { pathname: '/accounts', hash: '#/btc' }),
+            ).toEqual({
+                ...resp,
+                params: undefined,
+            });
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, { pathname: '/accounts', hash: '' }),
+            ).toEqual({
                 ...resp,
                 params: undefined,
                 route: getRoute('wallet-index'),
@@ -178,26 +208,28 @@ describe('router', () => {
         });
 
         it('other params validation', () => {
-            expect(getAppWithParams({ pathname: '/' })).toEqual({
+            expect(getAppWithParams(mockNetworkConfigDeps, { pathname: '/' })).toEqual({
                 app: 'dashboard',
                 params: undefined,
                 route: getRoute('suite-index'),
             });
 
-            expect(getAppWithParams({ pathname: '/onboarding/' })).toEqual({
+            expect(getAppWithParams(mockNetworkConfigDeps, { pathname: '/onboarding/' })).toEqual({
                 app: 'onboarding',
                 params: undefined,
                 route: getRoute('onboarding-index'),
             });
 
-            expect(getAppWithParams({ pathname: '/unknown-route/' })).toEqual({
+            expect(
+                getAppWithParams(mockNetworkConfigDeps, { pathname: '/unknown-route/' }),
+            ).toEqual({
                 app: 'unknown',
                 params: undefined,
                 route: undefined,
             });
 
             expect(
-                getAppWithParams({
+                getAppWithParams(mockNetworkConfigDeps, {
                     pathname: '/earn/yield/deposit',
                     hash: '#/eth/0/normal/0xvault',
                 }),
@@ -213,7 +245,7 @@ describe('router', () => {
             });
 
             expect(
-                getAppWithParams({
+                getAppWithParams(mockNetworkConfigDeps, {
                     pathname: '/earn/yield/withdraw',
                     hash: '#/eth/0/normal/0xvault',
                 }),
@@ -229,7 +261,7 @@ describe('router', () => {
             });
 
             expect(
-                getAppWithParams({
+                getAppWithParams(mockNetworkConfigDeps, {
                     pathname: '/earn/yield/deposit',
                     hash: '#/eth/0/normal',
                 }),
@@ -240,7 +272,7 @@ describe('router', () => {
             });
 
             expect(
-                getAppWithParams({
+                getAppWithParams(mockNetworkConfigDeps, {
                     pathname: '/earn/yield/claim',
                     hash: '#/eth/0/normal',
                 }),
@@ -255,7 +287,7 @@ describe('router', () => {
             });
 
             expect(
-                getAppWithParams({
+                getAppWithParams(mockNetworkConfigDeps, {
                     pathname: '/earn/tron/stake',
                     hash: '#/trx/0/normal',
                 }),
@@ -271,3 +303,4 @@ describe('router', () => {
         });
     });
 });
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';

--- a/suite/router/src/router.ts
+++ b/suite/router/src/router.ts
@@ -1,3 +1,4 @@
+import type { NetworkConfigDeps } from '@suite-common/wallet-config';
 import { type WalletParams as CommonWalletParams } from '@suite-common/wallet-types';
 
 import { type Route } from './route';
@@ -88,10 +89,10 @@ export const findRoute = (pathname: PathString): Route | undefined => {
 
 const parseHash = (hash: HashString) => hash.replace(/^#/, '').split('/').filter(Boolean);
 
-const validateWalletParams = (hash: HashString): CommonWalletParams => {
+const validateWalletParams = (deps: NetworkConfigDeps, hash: HashString): CommonWalletParams => {
     const [symbol, index, rawAccountType] = parseHash(hash);
 
-    return validateAccountRouteParams({
+    return validateAccountRouteParams(deps, {
         symbol,
         index,
         rawAccountType,
@@ -104,10 +105,10 @@ const accountScopedEarnYieldRoutes: Route['name'][] = [
     'earn-yield-wrap',
 ];
 
-const validateEarnYieldParams = (route: Route, hash: HashString) => {
+const validateEarnYieldParams = (deps: NetworkConfigDeps, route: Route, hash: HashString) => {
     const [symbol, index, rawAccountType, rawVaultAddress] = parseHash(hash);
 
-    const accountRouteParams = validateAccountRouteParams({
+    const accountRouteParams = validateAccountRouteParams(deps, {
         symbol,
         index,
         rawAccountType,
@@ -133,10 +134,10 @@ const validateEarnYieldParams = (route: Route, hash: HashString) => {
     });
 };
 
-const validateEarnStakingParams = (hash: HashString) => {
+const validateEarnStakingParams = (deps: NetworkConfigDeps, hash: HashString) => {
     const [symbol, index, rawAccountType] = parseHash(hash);
 
-    return validateAccountRouteParams({
+    return validateAccountRouteParams(deps, {
         symbol,
         index,
         rawAccountType,
@@ -191,37 +192,41 @@ const validateDashboardParams = (hash: HashString): DashboardParams | undefined 
     return params;
 };
 
-const getAppParams = (route: Route, hash: HashString = '') => {
+const getAppParams = (deps: NetworkConfigDeps, route: Route, hash: HashString = '') => {
     switch (route.app) {
         case 'dashboard':
             return validateDashboardParams(hash);
         case 'earn':
             return undefined;
         case 'earn-yield':
-            return validateEarnYieldParams(route, hash);
+            return validateEarnYieldParams(deps, route, hash);
         case 'earn-staking':
-            return validateEarnStakingParams(hash);
+            return validateEarnStakingParams(deps, hash);
         case 'wallet':
-            return validateWalletParams(hash);
+            return validateWalletParams(deps, hash);
         default:
             return route.params ? validateModalAppParams(hash, route.params) : undefined;
     }
 };
 
-export const getAppWithParams = (path: { pathname: PathString; hash?: HashString }) => {
+export const getAppWithParams = (
+    deps: NetworkConfigDeps,
+    path: { pathname: PathString; hash?: HashString },
+) => {
     const route = findRoute(path.pathname);
     const app = route?.app ?? 'unknown';
-    const params = route && getAppParams(route, path.hash);
+    const params = route && getAppParams(deps, route, path.hash);
 
     return { app, params, route } as RouterAppWithParams;
 };
 
 export const resolveEffectiveBackgroundRouteName = (
+    deps: NetworkConfigDeps,
     route: Route | undefined,
     location: { pathname: PathString; hash?: HashString },
 ) => {
     if (route?.isForegroundApp) {
-        return getAppWithParams(location).route?.name ?? route?.name;
+        return getAppWithParams(deps, location).route?.name ?? route?.name;
     }
 
     return route?.name;

--- a/suite/router/src/routerParams.ts
+++ b/suite/router/src/routerParams.ts
@@ -1,9 +1,10 @@
 import { yup } from '@suite-common/validators';
 import {
     type AccountType,
+    type NetworkConfigDeps,
     type NetworkSymbol,
-    getNetworkOptional,
     isAccountOfNetwork,
+    toNetwork,
 } from '@suite-common/wallet-config';
 import {
     type WalletParams as CommonWalletParams,
@@ -65,19 +66,25 @@ export const decodeEarnVaultAddress = (rawVaultAddress?: string): string | undef
     }
 };
 
-export const validateAccountRouteParams = ({
-    symbol,
-    index,
-    rawAccountType,
-}: {
-    symbol?: string;
-    index?: string;
-    rawAccountType?: string;
-}): CommonWalletParams => {
+export const validateAccountRouteParams = (
+    deps: NetworkConfigDeps,
+    {
+        symbol,
+        index,
+        rawAccountType,
+    }: {
+        symbol?: string;
+        index?: string;
+        rawAccountType?: string;
+    },
+): CommonWalletParams => {
     if (!index) return;
 
-    const network = getNetworkOptional(symbol);
-    if (!network) return;
+    const networkSymbol = deps.networkModuleRepository
+        .getSupportedNetworks()
+        .find(supportedNetwork => supportedNetwork === symbol);
+    if (!networkSymbol) return;
+    const network = toNetwork(networkSymbol, deps.getNetworkConfig(networkSymbol));
 
     const accountType = rawAccountType || 'normal';
     if (!isAccountOfNetwork(network, accountType)) return;

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -28,7 +28,7 @@ import { asSuiteRouterHistoryService } from './suiteRouterHistory';
  */
 export const onLocationChange = createThunk(
     '@router/onLocationChange',
-    (location: RouterPathOptional & { anchor?: AnchorType }, { dispatch, getState }) => {
+    (location: RouterPathOptional & { anchor?: AnchorType }, { dispatch, getState, extra }) => {
         const unlocked = selectCanNavigate(getState());
         const router = selectRouter(getState());
         if (!unlocked && router.loaded) return;
@@ -38,7 +38,7 @@ export const onLocationChange = createThunk(
         }
 
         // TODO: check if the view is not locked by the device request
-        const appWithParams = getAppWithParams(location);
+        const appWithParams = getAppWithParams(extra.services, location);
 
         return dispatch(routerLocationChange({ ...location, ...appWithParams }));
     },

--- a/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
@@ -1,6 +1,6 @@
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { type FindNetworkSymbolForProtocol } from '@suite-common/networks';
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import {
     type CoinProtocol,
@@ -9,8 +9,8 @@ import {
 } from './handleCoinProtocolUri';
 
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol => {
-    if (protocol === 'bitcoin') return asNetworkSymbol('btc');
-    if (protocol === 'ethereum') return asNetworkSymbol('eth');
+    if (protocol === 'bitcoin') return 'btc';
+    if (protocol === 'ethereum') return 'eth';
 
     return null;
 };
@@ -25,6 +25,7 @@ const setup = () => {
 
     const extra: HandleCoinProtocolUriDeps = {
         services: {
+            ...mockNetworkConfigDeps,
             analytics: mockDesktopAnalytics(report),
             findNetworkSymbolForProtocol,
         },

--- a/suite/transfer-uri/src/handleCoinProtocolUri.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.ts
@@ -4,6 +4,7 @@ import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import type { FindNetworkSymbolForProtocolDep } from '@suite-common/networks';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { isAmountPresent, parseTransferUri } from '@suite-common/transfer-uri';
+import type { NetworkConfigDeps } from '@suite-common/wallet-config';
 import type { Protocol } from '@trezor/network-module-suite-common-types';
 
 /** Flat transfer fields, matching the send-form state the protocol reducer persists. */
@@ -18,7 +19,7 @@ export type CoinProtocol = {
 type SaveCoinProtocol = (coinProtocol: CoinProtocol) => UnknownAction;
 
 export type HandleCoinProtocolUriDeps = {
-    services: FindNetworkSymbolForProtocolDep & DesktopAnalyticsDep;
+    services: FindNetworkSymbolForProtocolDep & DesktopAnalyticsDep & NetworkConfigDeps;
 };
 
 /**
@@ -38,7 +39,7 @@ export const handleCoinProtocolUri =
                 payload: { scheme, isAmountPresent: amountPresent },
             });
 
-        const result = parseTransferUri(uri, extra.services.findNetworkSymbolForProtocol);
+        const result = parseTransferUri(extra.services, uri);
 
         if (!result.success) {
             if (result.error.type === 'UNKNOWN_SCHEME') reportScheme(result.error.scheme, false);

--- a/suite/tx-simulation/src/evm/components/EvmInsufficientGasWarning.tsx
+++ b/suite/tx-simulation/src/evm/components/EvmInsufficientGasWarning.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 
 import { Translation } from '@suite/intl';
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbol,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type PrecomposedTransaction } from '@suite-common/wallet-types';
 import { Banner } from '@trezor/components';
 import { BigNumber } from '@trezor/utils';
@@ -17,6 +22,7 @@ export function EvmInsufficientGasWarning({
     accountBalance,
     networkSymbol,
 }: EvmInsufficientGasWarningProps) {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const fee = composedLevel?.type === 'final' ? composedLevel.fee : undefined;
     const hasSufficientFunds = useMemo(
         () => !fee || new BigNumber(fee).lte(accountBalance),
@@ -34,7 +40,10 @@ export function EvmInsufficientGasWarning({
                 <Translation
                     id="AMOUNT_NOT_ENOUGH_CURRENCY_FEE"
                     values={{
-                        networkDisplaySymbol: getNetworkDisplaySymbol(networkSymbol),
+                        networkDisplaySymbol: getNetworkDisplaySymbol(
+                            networkConfigDeps,
+                            networkSymbol,
+                        ),
                     }}
                 />
             }


### PR DESCRIPTION
## Description

Migrates the Desktop and Web Suite composition roots, actions, hooks, components, and tests to pass network configuration dependencies explicitly. This removes Desktop/Web reliance on the wallet-config package constructing its own network repository while preserving the existing runtime network data.\n\nThis platform layer changes 370 files with 4,086 additions and 2,274 deletions, isolated from the shared and Native migrations.