### PR TITLE
refactor(suite-native): inject network configuration

### DIFF
--- a/suite-native/accounts/src/components/NetworkFilterBottomSheet.tsx
+++ b/suite-native/accounts/src/components/NetworkFilterBottomSheet.tsx
@@ -3,7 +3,9 @@ import { useSelector } from 'react-redux';
 
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     BottomSheetModal,
     Button,
@@ -31,6 +33,7 @@ export const NetworkFilterBottomSheet = forwardRef(
         { selectedNetworks, onApply, onClear, isSendFlow }: NetworkFilterBottomSheetProps,
         ref: Ref<BottomSheetModalMethods>,
     ) => {
+        const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
         const { translate } = useTranslate();
         const [pendingSelection, setPendingSelection] = useState<NetworkSymbol[]>(selectedNetworks);
         const selectedNetworksRef = useRef(selectedNetworks);
@@ -95,7 +98,7 @@ export const NetworkFilterBottomSheet = forwardRef(
                                     <TokenIcon symbol={symbol} />
                                     <VStack flex={1} spacing={0}>
                                         <Text variant="body-md-strong">
-                                            {getNetwork(symbol).name}
+                                            {getNetworkConfig(symbol).name}
                                         </Text>
                                         <Text variant="body-sm" color="contentSecondary">
                                             <Translation

--- a/suite-native/accounts/src/components/SelectableNetworkItem.tsx
+++ b/suite-native/accounts/src/components/SelectableNetworkItem.tsx
@@ -1,5 +1,7 @@
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Badge, Box, HStack, PressableOpacity, RoundedIcon, Text } from '@suite-native/atoms';
 import { Icon, type IconName } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -25,6 +27,7 @@ const tokensBadgeStyle = prepareNativeStyle(utils => ({
 }));
 
 export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: SelectableAssetItemProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { applyStyle } = useNativeStyles();
     const { DisplaySymbolFormatter } = useFormatters();
 
@@ -33,7 +36,7 @@ export const SelectableNetworkItem = ({ symbol, onPress, rightIcon }: Selectable
         onPress(symbol);
     };
 
-    const networkName = getNetwork(symbol).name;
+    const networkName = getNetworkConfig(symbol).name;
 
     const isNetworkSupportingTokens = isNetworkWithTokens(symbol);
 

--- a/suite-native/accounts/src/utils.ts
+++ b/suite-native/accounts/src/utils.ts
@@ -4,7 +4,6 @@ import { type AccountWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import {
     type AccountType,
     type NetworkSymbol,
-    getNetwork,
     networkSymbolCollection,
     networks,
 } from '@suite-common/wallet-config';
@@ -33,7 +32,7 @@ export const isFilterValueMatchingAccount = (
 
     if (isMatchingLabel) return true;
 
-    const accountNetwork = getNetwork(account.symbol);
+    const accountNetwork = getNetworkConfig(account.symbol);
     const isMatchingNetworkName = accountNetwork.name.toLowerCase().includes(lowerCaseFilterValue);
 
     if (isMatchingNetworkName) return true;

--- a/suite-native/assets/src/components/PercentageIcon.tsx
+++ b/suite-native/assets/src/components/PercentageIcon.tsx
@@ -12,10 +12,10 @@ import { type AssetsRootState } from '../types';
 type PercentageIconProps = { symbol: NetworkSymbol };
 
 export const PercentageIcon = memo(({ symbol }: PercentageIconProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const assetPercentages = useSelector((state: AssetsRootState) =>
         selectAssetFiatValuePercentage(state, symbol),
     );
-    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
 
     const { color: percentageColor } = getNetworkConfig(symbol);
 

--- a/suite-native/atoms/src/Badge.tsx
+++ b/suite-native/atoms/src/Badge.tsx
@@ -1,6 +1,11 @@
 import { type ReactNode } from 'react';
 
-import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    isNetworkSymbol,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { Icon, type IconName, type IconSize, TokenIcon, icons } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { type Color } from '@trezor/theme';
@@ -73,6 +78,7 @@ export const Badge = ({
     style,
     ...boxProps
 }: BadgeProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { applyStyle, utils } = useNativeStyles();
     const { backgroundColor, textColor } = badgeIntentToStylePropsMap[intent];
 
@@ -80,7 +86,7 @@ export const Badge = ({
     const iconSize: IconSize = size === 'small' ? 'medium' : 'mediumLarge';
 
     const getCryptoIcon = (iconInput: IconType) =>
-        isNetworkSymbol(iconInput) ? (
+        isNetworkSymbol(networkConfigDeps, iconInput) ? (
             <TokenIcon symbol={iconInput} size={size === 'small' ? 'extraSmall' : 'small'} />
         ) : null;
 

--- a/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
+++ b/suite-native/coin-enabling/src/components/CryptoIconSet.tsx
@@ -1,8 +1,6 @@
-import {
-    type NetworkSymbol,
-    getNetwork,
-    getRepresentativeAssets,
-} from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, getRepresentativeAssets } from '@suite-common/wallet-config';
 import { Box, Text } from '@suite-native/atoms';
 import { TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -41,6 +39,7 @@ const countStyle = prepareNativeStyle(utils => ({
 }));
 
 export const CryptoIconSet = ({ symbol }: CryptoIconSetProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { applyStyle } = useNativeStyles();
 
     const assets = getRepresentativeAssets(symbol);
@@ -53,7 +52,7 @@ export const CryptoIconSet = ({ symbol }: CryptoIconSetProps) => {
 
     // Native coins have no contract – render their icon via the settlement layer symbol
     // (e.g. Base/Arbitrum... → ETH), falling back to the network symbol itself.
-    const nativeCoinSymbol = getNetwork(symbol).settlementLayer ?? symbol;
+    const nativeCoinSymbol = getNetworkConfig(symbol).settlementLayer ?? symbol;
 
     return (
         <Box flexDirection="row" alignItems="center">

--- a/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
+++ b/suite-native/coin-enabling/src/components/DiscoveryCoinsFilter.tsx
@@ -1,8 +1,10 @@
 import { memo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectIsDeviceConnected } from '@suite-common/device';
-import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type Network, type NetworkSymbol } from '@suite-common/wallet-config';
 import { Text, VStack } from '@suite-native/atoms';
 import { type DiscoveryRootState, selectDiscoveryNetworkGroups } from '@suite-native/discovery';
 import { useFormContext } from '@suite-native/forms';
@@ -55,6 +57,7 @@ export const DiscoveryCoinsFilter = ({
     searchQuery,
     onDisablingLastCoin,
 }: DiscoveryCoinsFilterProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
         useSelector((state: DiscoveryRootState) =>
             selectDiscoveryNetworkGroups(state, searchQuery),
@@ -96,7 +99,7 @@ export const DiscoveryCoinsFilter = ({
             }
 
             if (!isDeviceConnected && nextIsEnabled) {
-                const { name } = getNetwork(symbol);
+                const { name } = getNetworkConfig(symbol);
                 showToast({
                     intent: 'neutral',
                     message: (

--- a/suite-native/coin-enabling/src/components/NetworkListItem.tsx
+++ b/suite-native/coin-enabling/src/components/NetworkListItem.tsx
@@ -1,7 +1,9 @@
 import { type ReactNode } from 'react';
 import { type AccessibilityRole } from 'react-native';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Box, Card, PressableOpacity } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -33,9 +35,10 @@ export const NetworkListItem = ({
     accessibilityRole,
     testID,
 }: NetworkListItemProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { applyStyle } = useNativeStyles();
 
-    const network = getNetwork(symbol);
+    const network = getNetworkConfig(symbol);
     const { testnet: isTestnet } = network;
 
     return (

--- a/suite-native/config/src/supportedNetworks.ts
+++ b/suite-native/config/src/supportedNetworks.ts
@@ -3,9 +3,10 @@ import { A } from '@mobily/ts-belt';
 import {
     type AccountType,
     type Network,
+    type NetworkConfigDeps,
     type NetworkSymbol,
     type NetworkType,
-    networkSymbolCollection,
+    getNetworks,
 } from '@suite-common/wallet-config';
 import { isTestnet } from '@suite-common/wallet-utils';
 
@@ -19,19 +20,23 @@ export const orderedAccountTypes: AccountType[] = [
 
 export const sendDisabledNetworkTypes: NetworkType[] = ['cardano'];
 
-export const sortNetworks = (networksToSort: Network[]) =>
-    A.sort(networksToSort, (a, b) => {
-        const aOrder = networkSymbolCollection.indexOf(a.symbol);
-        const bOrder = networkSymbolCollection.indexOf(b.symbol);
+export const sortNetworks = (deps: NetworkConfigDeps, networksToSort: Network[]) => {
+    const networkSymbols = getNetworks(deps).map(network => network.symbol);
+
+    return A.sort(networksToSort, (a, b) => {
+        const aOrder = networkSymbols.indexOf(a.symbol);
+        const bOrder = networkSymbols.indexOf(b.symbol);
 
         return aOrder - bOrder;
     });
+};
 
 export const filterTestnetNetworks = (
+    deps: NetworkConfigDeps,
     networkSymbols: NetworkSymbol[],
     isTestnetEnabled: boolean,
 ) => {
     if (isTestnetEnabled) return networkSymbols;
 
-    return networkSymbols.filter(networkSymbol => !isTestnet(networkSymbol));
+    return networkSymbols.filter(networkSymbol => !isTestnet(deps, networkSymbol));
 };

--- a/suite-native/discovery/src/discoverySelectors.test.ts
+++ b/suite-native/discovery/src/discoverySelectors.test.ts
@@ -2,7 +2,8 @@ import { type StateFromReducersMapObject } from '@reduxjs/toolkit';
 
 import { deviceInitialState } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { networks } from '@suite-common/wallet-config';
+import { toNetwork } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { accountsInitialState, initialWalletSettingsState } from '@suite-common/wallet-core';
 import { featureFlagsInitialState } from '@suite-native/feature-flags';
 import { appSettingsInitialState } from '@suite-native/settings';
@@ -23,14 +24,8 @@ jest.mock('@suite-native/config', () => ({
     isDetoxTestBuild: jest.fn(() => false),
 }));
 
-jest.mock('@suite-common/wallet-config', () => ({
-    ...jest.requireActual('@suite-common/wallet-config'),
-    getNetwork: jest.fn((symbol: string) => ({
-        symbol,
-        isDebugOnlyNetwork: symbol === 'xlm',
-        isHidden: false,
-    })),
-}));
+const getNetwork = (symbol: Parameters<typeof mockNetworkConfigDeps.getNetworkConfig>[0]) =>
+    toNetwork(symbol, mockNetworkConfigDeps.getNetworkConfig(symbol));
 
 const reducer = {
     appSettings: createStaticReducer(appSettingsInitialState),
@@ -78,8 +73,11 @@ describe('selectDiscoverySupportedNetworks', () => {
     it('should be stable (return same reference for same inputs)', () => {
         const store = createTestStore();
 
-        const firstCall = selectDiscoverySupportedNetworks(store.getState());
-        const secondCall = selectDiscoverySupportedNetworks(store.getState());
+        const firstCall = selectDiscoverySupportedNetworks(store.getState(), mockNetworkConfigDeps);
+        const secondCall = selectDiscoverySupportedNetworks(
+            store.getState(),
+            mockNetworkConfigDeps,
+        );
 
         expect(firstCall).toBe(secondCall);
     });
@@ -89,7 +87,7 @@ describe('selectDiscoverySupportedNetworks', () => {
             appSettings: { areTestnetsEnabled: false },
         });
 
-        const result = selectDiscoverySupportedNetworks(store.getState());
+        const result = selectDiscoverySupportedNetworks(store.getState(), mockNetworkConfigDeps);
         const networkSymbols = result.map(n => n.symbol);
 
         // Test networks should be filtered out
@@ -109,7 +107,7 @@ describe('selectDiscoverySupportedNetworks', () => {
             appSettings: { areTestnetsEnabled: true },
         });
 
-        const result = selectDiscoverySupportedNetworks(store.getState());
+        const result = selectDiscoverySupportedNetworks(store.getState(), mockNetworkConfigDeps);
         const networkSymbols = result.map(n => n.symbol);
 
         // Test networks should be included
@@ -129,7 +127,7 @@ describe('selectDiscoverySupportedNetworks', () => {
             featureFlags: { areDebugOnlyNetworksEnabled: false },
         });
 
-        const result = selectDiscoverySupportedNetworks(store.getState());
+        const result = selectDiscoverySupportedNetworks(store.getState(), mockNetworkConfigDeps);
         const networkSymbols = result.map(n => n.symbol);
 
         // XLM is marked as debug-only in our mock, so it should be filtered out
@@ -144,7 +142,7 @@ describe('selectDiscoverySupportedNetworks', () => {
             featureFlags: { areDebugOnlyNetworksEnabled: true },
         });
 
-        const result = selectDiscoverySupportedNetworks(store.getState());
+        const result = selectDiscoverySupportedNetworks(store.getState(), mockNetworkConfigDeps);
         const networkSymbols = result.map(n => n.symbol);
 
         // XLM should be included when debug networks are enabled
@@ -159,9 +157,9 @@ describe(selectDiscoveryNetworkGroups.name, () => {
         const store = createTestStore();
 
         const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
-            selectDiscoveryNetworkGroups(store.getState());
+            selectDiscoveryNetworkGroups(store.getState(), '', mockNetworkConfigDeps);
 
-        expect(supportedMainnets).toContain(networks.btc);
+        expect(supportedMainnets).toContain(getNetwork('btc'));
         expect(supportedTestnets).toEqual([]);
         expect(unsupportedMainnets).toEqual([]);
         expect(unsupportedTestnets).toEqual([]);
@@ -173,11 +171,11 @@ describe(selectDiscoveryNetworkGroups.name, () => {
         });
 
         const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
-            selectDiscoveryNetworkGroups(store.getState());
+            selectDiscoveryNetworkGroups(store.getState(), '', mockNetworkConfigDeps);
 
-        expect(supportedMainnets).toContain(networks.btc);
-        expect(supportedTestnets).toContain(networks.test);
-        expect(supportedTestnets).not.toContain(networks.regtest);
+        expect(supportedMainnets).toContain(getNetwork('btc'));
+        expect(supportedTestnets).toContain(getNetwork('test'));
+        expect(supportedTestnets).not.toContain(getNetwork('regtest'));
         expect(unsupportedMainnets).toEqual([]);
         expect(unsupportedTestnets).toEqual([]);
     });
@@ -189,11 +187,11 @@ describe(selectDiscoveryNetworkGroups.name, () => {
         });
 
         const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
-            selectDiscoveryNetworkGroups(store.getState());
+            selectDiscoveryNetworkGroups(store.getState(), '', mockNetworkConfigDeps);
 
-        expect(supportedMainnets).toContain(networks.btc);
-        expect(supportedTestnets).toContain(networks.test);
-        expect(supportedTestnets).toContain(networks.regtest);
+        expect(supportedMainnets).toContain(getNetwork('btc'));
+        expect(supportedTestnets).toContain(getNetwork('test'));
+        expect(supportedTestnets).toContain(getNetwork('regtest'));
         expect(unsupportedMainnets).toEqual([]);
         expect(unsupportedTestnets).toEqual([]);
     });
@@ -210,12 +208,12 @@ describe(selectDiscoveryNetworkGroups.name, () => {
         });
 
         const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
-            selectDiscoveryNetworkGroups(store.getState());
+            selectDiscoveryNetworkGroups(store.getState(), '', mockNetworkConfigDeps);
 
-        expect(supportedMainnets).toContain(networks.btc);
-        expect(supportedTestnets).toContain(networks.test);
-        expect(unsupportedMainnets).toContain(networks.eth);
-        expect(unsupportedTestnets).toContain(networks.tsep);
+        expect(supportedMainnets).toContain(getNetwork('btc'));
+        expect(supportedTestnets).toContain(getNetwork('test'));
+        expect(unsupportedMainnets).toContain(getNetwork('eth'));
+        expect(unsupportedTestnets).toContain(getNetwork('tsep'));
     });
 
     it('returns both supported and unsupported networks filtered by searchQuery', () => {
@@ -230,11 +228,11 @@ describe(selectDiscoveryNetworkGroups.name, () => {
         });
 
         const { supportedMainnets, supportedTestnets, unsupportedMainnets, unsupportedTestnets } =
-            selectDiscoveryNetworkGroups(store.getState(), 'bitcoin');
+            selectDiscoveryNetworkGroups(store.getState(), 'bitcoin', mockNetworkConfigDeps);
 
-        expect(supportedMainnets).toContain(networks.btc);
-        expect(supportedTestnets).toContain(networks.test);
-        expect(supportedTestnets).toContain(networks.regtest);
+        expect(supportedMainnets).toContain(getNetwork('btc'));
+        expect(supportedTestnets).toContain(getNetwork('test'));
+        expect(supportedTestnets).toContain(getNetwork('regtest'));
         expect(unsupportedMainnets).toEqual([]);
         expect(unsupportedTestnets).toEqual([]);
     });

--- a/suite-native/discovery/src/discoverySelectors.ts
+++ b/suite-native/discovery/src/discoverySelectors.ts
@@ -5,12 +5,12 @@ import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/r
 import { type TrezorDevice } from '@suite-common/suite-types';
 import {
     type Network,
+    type NetworkConfigDeps,
     type NetworkSymbol,
     filterNetworksByName,
     getMainnets,
-    getNetwork,
+    getNetworks,
     getTestnets,
-    networksCollection,
 } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -44,10 +44,11 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<DiscoveryRootStat
  * Filter collection of activated networks to only include those supported by device & suite
  */
 const filterUnavailableNetworks = (
+    deps: NetworkConfigDeps,
     enabledNetworks: NetworkSymbol[],
     device?: TrezorDevice,
 ): Network[] =>
-    networksCollection.filter(n => {
+    getNetworks(deps).filter(n => {
         const firmwareVersion = getFirmwareVersion(device);
         const internalModel = device?.features?.internal_model;
 
@@ -71,19 +72,21 @@ export const selectDiscoverySupportedNetworks = createMemoizedSelector(
         selectAreTestnetsEnabled,
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreDebugOnlyNetworksEnabled),
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
+        (_state, deps: NetworkConfigDeps) => deps,
     ],
     (
         deviceNetworks,
         areTestnetsEnabled,
         areDebugOnlyNetworksEnabled,
         areExperimentalOnlyNetworksEnabled,
+        deps,
     ) =>
         pipe(
             deviceNetworks,
-            networkSymbols => filterTestnetNetworks(networkSymbols, areTestnetsEnabled),
+            networkSymbols => filterTestnetNetworks(deps, networkSymbols, areTestnetsEnabled),
             networkSymbols =>
                 networkSymbols.filter(symbol => {
-                    const network = getNetwork(symbol);
+                    const network = deps.getNetworkConfig(symbol);
 
                     if (network.isDebugOnlyNetwork) {
                         return areDebugOnlyNetworksEnabled;
@@ -95,14 +98,18 @@ export const selectDiscoverySupportedNetworks = createMemoizedSelector(
 
                     return true;
                 }),
-            filterUnavailableNetworks,
-            sortNetworks,
+            networkSymbols => filterUnavailableNetworks(deps, networkSymbols),
+            networks => sortNetworks(deps, networks),
             returnStableArrayIfEmpty,
         ),
 );
 
 export const selectDiscoveryNetworkSymbols = createMemoizedSelector(
-    [selectDiscoverySupportedNetworks, (_state, searchQuery: string = '') => searchQuery],
+    [
+        (state, searchQuery: string = '', deps: NetworkConfigDeps) =>
+            selectDiscoverySupportedNetworks(state, deps),
+        (_state, searchQuery: string = '') => searchQuery,
+    ],
     (supportedNetworks, searchQuery) =>
         returnStableArrayIfEmpty(
             filterNetworksByName(supportedNetworks, searchQuery).map(n => n.symbol),
@@ -117,12 +124,16 @@ export const selectDeviceEnabledDiscoveryNetworkSymbols = createMemoizedSelector
 );
 
 export const selectTokenDefinitionsEnabledNetworks = createMemoizedSelector(
-    [selectEnabledNetworks, selectNetworkSymbolsOfAccountsWithTokensAllowed],
-    (enabledNetworkSymbols, accountNetworkSymbols) =>
+    [
+        selectEnabledNetworks,
+        selectNetworkSymbolsOfAccountsWithTokensAllowed,
+        (_state, deps: NetworkConfigDeps) => deps,
+    ],
+    (enabledNetworkSymbols, accountNetworkSymbols, deps) =>
         returnStableArrayIfEmpty(
             pipe(
                 [...enabledNetworkSymbols, ...accountNetworkSymbols],
-                A.filter(s => isNetworkWithTokens(s)),
+                A.filter(s => isNetworkWithTokens(deps, s)),
                 A.uniq,
             ),
         ),
@@ -135,6 +146,7 @@ export const selectDiscoveryNetworkGroups = createMemoizedSelector(
         state => selectIsFeatureFlagEnabled(state, FeatureFlag.AreExperimentalOnlyNetworksEnabled),
         selectAreTestnetsEnabled,
         (_state, searchQuery: string = '') => searchQuery,
+        (_state, _searchQuery, deps: NetworkConfigDeps) => deps,
     ],
     (
         deviceSupportedNetworks,
@@ -142,12 +154,15 @@ export const selectDiscoveryNetworkGroups = createMemoizedSelector(
         areExperimentalOnlyNetworksEnabled,
         areTestnetsEnabled,
         searchQuery,
+        deps,
     ) => {
         const mainnets = getMainnets({
+            allNetworks: getNetworks(deps),
             debug: areDebugOnlyNetworksEnabled,
             useExperimentalNetworks: areExperimentalOnlyNetworksEnabled,
         });
         const testnets = getTestnets({
+            allNetworks: getNetworks(deps),
             debug: areDebugOnlyNetworksEnabled,
             useExperimentalNetworks: areExperimentalOnlyNetworksEnabled,
             useTestnetNetworks: areTestnetsEnabled,

--- a/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/BaseCurrencyAmountFormatter.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { isTestnet } from '@suite-common/wallet-utils';
 import { type TextProps } from '@suite-native/atoms';
@@ -31,9 +32,10 @@ export const BaseCurrencyAmountFormatter = React.memo(
         maximumFractionDigits,
         ...otherProps
     }: FiatAmountFormatterProps) => {
+        const networkConfigDeps = useServices(selectNetworkConfigDeps);
         const { BaseCurrencyAmountFormatter: formatter } = useFormatters();
 
-        if (!!symbol && isTestnet(symbol)) {
+        if (!!symbol && isTestnet(networkConfigDeps, symbol)) {
             return <EmptyAmountText variant={variant} />;
         }
         if (isLoading || (value === null && !isForcedDiscreetMode)) {

--- a/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
+++ b/suite-native/formatters/src/components/CryptoAmountFormatter.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 import { G } from '@mobily/ts-belt';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
-import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    isNetworkSymbol,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type TokenSymbol } from '@suite-common/wallet-types';
 import { getAccountDecimals } from '@suite-common/wallet-utils';
 import { type TextProps } from '@suite-native/atoms';
@@ -36,6 +41,7 @@ export const CryptoAmountFormatter = React.memo(
         decimals,
         ...otherProps
     }: CryptoToFiatAmountFormatterProps) => {
+        const networkConfigDeps = useServices(selectNetworkConfigDeps);
         const { CryptoAmountFormatter: formatter } = useFormatters();
 
         if (value === null || isLoading) {
@@ -43,7 +49,10 @@ export const CryptoAmountFormatter = React.memo(
         }
 
         const maxDisplayedDecimals =
-            decimals ?? (isNetworkSymbol(symbol) ? getAccountDecimals(symbol) : undefined);
+            decimals ??
+            (isNetworkSymbol(networkConfigDeps, symbol)
+                ? getAccountDecimals(networkConfigDeps, symbol)
+                : undefined);
 
         const stringValue = G.isNumber(value) ? value.toString() : value;
 

--- a/suite-native/formatters/src/components/FeeFormatter.tsx
+++ b/suite-native/formatters/src/components/FeeFormatter.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import { networks } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { fromWei, getEffectiveGasPrice, getFeeRate, getFeeUnits } from '@suite-common/wallet-utils';
 import { Text } from '@suite-native/atoms';
@@ -10,7 +11,8 @@ type FeeFormatterProps = {
 };
 
 export const FeeFormatter = ({ transaction }: FeeFormatterProps) => {
-    const { networkType } = networks[transaction.symbol];
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const { networkType } = getNetworkConfig(transaction.symbol);
 
     const formattedValue = useMemo(
         () =>

--- a/suite-native/formatters/src/components/NetworkDisplaySymbolNameFormatter.tsx
+++ b/suite-native/formatters/src/components/NetworkDisplaySymbolNameFormatter.tsx
@@ -1,4 +1,9 @@
-import { type NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbolName,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type TextProps } from '@suite-native/atoms';
 
 import { type FormatterProps } from '../types';
@@ -7,4 +12,8 @@ type NetworkDisplaySymbolNameFormatterProps = FormatterProps<NetworkSymbol> & Te
 
 export const NetworkDisplaySymbolNameFormatter = ({
     value,
-}: NetworkDisplaySymbolNameFormatterProps) => getNetworkDisplaySymbolName(value);
+}: NetworkDisplaySymbolNameFormatterProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
+    return getNetworkDisplaySymbolName(networkConfigDeps, value);
+};

--- a/suite-native/formatters/src/hooks/useCryptoFiatConverters.ts
+++ b/suite-native/formatters/src/hooks/useCryptoFiatConverters.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type FiatRatesRootState,
     type WalletSettingsRootState,
@@ -41,9 +42,10 @@ export const useCryptoFiatConverters = ({
     historicRate,
     useHistoricRate,
 }: UseConvertFiatToCryptoParams) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const symbolHelper = symbol ?? 'btc'; // handles passing the value to selectors
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
-        selectIsAmountInSats(state, symbolHelper),
+        selectIsAmountInSats(state, symbolHelper, networkConfigDeps),
     );
 
     const baseCurrencyCode = useSelector(selectBaseCurrency);
@@ -54,7 +56,7 @@ export const useCryptoFiatConverters = ({
     );
 
     const rate = useHistoricRate ? historicRate : currentRate?.rate;
-    const isTestnetCoin = isTestnet(symbolHelper);
+    const isTestnetCoin = isTestnet(networkConfigDeps, symbolHelper);
 
     if (!rate || currentRate?.error || isTestnetCoin || !symbol) return null;
 
@@ -66,6 +68,7 @@ export const useCryptoFiatConverters = ({
             const baseCurrencyUnitAmount = isBaseCurrencyInSats
                 ? asBaseCurrencyAmount(
                       subunitsToUnits({
+                          ...networkConfigDeps,
                           value: asAmountSubunit(baseCurrencyAmount),
                           symbol: 'btc',
                       }),
@@ -83,13 +86,13 @@ export const useCryptoFiatConverters = ({
 
             // 2. If the Crypto Amount is in Sats, we now need to convert it back
             return isAmountInSats
-                ? unitsToSubunits({ value: cryptoUnitAmount, symbol })
+                ? unitsToSubunits({ ...networkConfigDeps, value: cryptoUnitAmount, symbol })
                 : cryptoUnitAmount;
         },
         convertCryptoToFiat: (amount: BigNumber) => {
             // 1. Crypto Amount may be in Sats or not
             const amountUnit = isAmountInSats
-                ? subunitsToUnits({ value: asAmountSubunit(amount), symbol })
+                ? subunitsToUnits({ ...networkConfigDeps, value: asAmountSubunit(amount), symbol })
                 : asAmountUnit(amount);
 
             const baseCurrency = toFiatCurrency({ amount: amountUnit, rate });
@@ -101,7 +104,11 @@ export const useCryptoFiatConverters = ({
             // 2. If BaseUnits are Sats (BTC only), we have to convert it to sats
             return isBaseCurrencyInSats
                 ? asBaseCurrencyAmount(
-                      unitsToSubunits({ value: asAmountUnit(baseCurrency), symbol: 'btc' }),
+                      unitsToSubunits({
+                          ...networkConfigDeps,
+                          value: asAmountUnit(baseCurrency),
+                          symbol: 'btc',
+                      }),
                   )
                 : baseCurrency;
         },

--- a/suite-native/formatters/src/hooks/useFiatFromCryptoValue.ts
+++ b/suite-native/formatters/src/hooks/useFiatFromCryptoValue.ts
@@ -1,7 +1,8 @@
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { convertCryptoToFiatAmount } from '@suite-common/formatters';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type FiatRatesRootState,
     selectBaseCurrency,
@@ -31,6 +32,7 @@ export const useFiatFromCryptoValue = ({
     isBalance = false,
     tokenDecimals = 0,
 }: useFiatFromCryptoValueParams) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const fiatCurrencyCode = useSelector(selectBaseCurrency);
     const fiatRateKey = getFiatRateKey(symbol, fiatCurrencyCode, tokenAddress);
     const currentRate = useSelector((state: FiatRatesRootState) =>
@@ -39,7 +41,7 @@ export const useFiatFromCryptoValue = ({
 
     const rate = useHistoricRate ? historicRate : currentRate?.rate;
 
-    const isTestnetCoin = isTestnet(symbol);
+    const isTestnetCoin = isTestnet(networkConfigDeps, symbol);
 
     if (!cryptoValue || isTestnetCoin) return null;
 
@@ -56,6 +58,7 @@ export const useFiatFromCryptoValue = ({
     if (!rate || currentRate?.error) return null;
 
     return convertCryptoToFiatAmount({
+        ...networkConfigDeps,
         amount: cryptoValue,
         symbol,
         isAmountInSats: !isBalance,

--- a/suite-native/helpers/src/hooks/useAmountInputTransformers.ts
+++ b/suite-native/helpers/src/hooks/useAmountInputTransformers.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type WalletSettingsRootState,
     selectIsAmountInSats,
@@ -11,8 +12,9 @@ import { decimalTransformer, integerTransformer } from '@trezor/utils';
 export { decimalTransformer, integerTransformer } from '@trezor/utils';
 
 export const useAmountInputTransformers = (symbol: NetworkSymbol | undefined) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const isAmountInSats = useSelector((state: WalletSettingsRootState) =>
-        selectIsAmountInSats(state, symbol),
+        selectIsAmountInSats(state, symbol, networkConfigDeps),
     );
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
 

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { asNetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
+import { getCoingeckoId } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { act, fireEvent, renderWithBasicProvider, waitFor } from '@suite-native/test-utils';
@@ -19,13 +20,10 @@ const networkIconHint = 'Network Icon';
 
 const contractA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const contractB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-const btcSymbol = asNetworkSymbol('btc');
-const ethSymbol = asNetworkSymbol('eth');
-const opSymbol = asNetworkSymbol('op');
 
 const getTokenIconUrl = (contractAddress: string, size = 32) =>
     getAssetLogoUrl({
-        coingeckoId: getCoingeckoId(ethSymbol)!,
+        coingeckoId: getCoingeckoId(mockNetworkConfigDeps, 'eth')!,
         contractAddress,
         density: 2,
         size,
@@ -36,18 +34,16 @@ describe('TokenIcon', () => {
         renderWithBasicProvider(<TokenIcon {...props} />);
 
     it('shows a placeholder immediately and the correct icon after resolving when a recycled instance receives new props', async () => {
-        const fresh = renderTokenIcon({ symbol: ethSymbol });
+        const fresh = renderTokenIcon({ symbol: 'eth' });
         await act(async () => {});
         const ethSource = fresh.getByHintText(tokenIconHint).props.source;
         fresh.unmount();
 
-        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
-            symbol: btcSymbol,
-        });
+        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({ symbol: 'btc' });
         await act(async () => {});
 
         // simulates FlashList cell recycling: same mounted instance, new asset props
-        rerender(<TokenIcon symbol={ethSymbol} />);
+        rerender(<TokenIcon symbol="eth" />);
 
         expect(queryByHintText(tokenIconHint)).toBeNull();
 
@@ -63,11 +59,11 @@ describe('TokenIcon', () => {
         );
 
         const { getByHintText, rerender } = renderTokenIcon({
-            symbol: ethSymbol,
+            symbol: 'eth',
             contractAddress: contractA,
         });
 
-        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractB} />);
+        rerender(<TokenIcon symbol="eth" contractAddress={contractB} />);
 
         await waitFor(() => {
             expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -86,10 +82,7 @@ describe('TokenIcon', () => {
     it('shows a text placeholder when the url resolution rejects', async () => {
         (getAssetLogoContractAddresses as jest.Mock).mockRejectedValue(new Error('failed'));
 
-        const { queryByHintText } = renderTokenIcon({
-            symbol: ethSymbol,
-            contractAddress: contractA,
-        });
+        const { queryByHintText } = renderTokenIcon({ symbol: 'eth', contractAddress: contractA });
 
         await act(async () => {});
 
@@ -102,7 +95,7 @@ describe('TokenIcon', () => {
         );
 
         const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
-            symbol: ethSymbol,
+            symbol: 'eth',
             contractAddress: contractA,
             size: 32,
         });
@@ -112,7 +105,7 @@ describe('TokenIcon', () => {
         fireEvent(getByHintText(tokenIconHint), 'error', { nativeEvent: {} });
         expect(queryByHintText(tokenIconHint)).toBeNull();
 
-        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractA} size={64} />);
+        rerender(<TokenIcon symbol="eth" contractAddress={contractA} size={64} />);
         await act(async () => {});
 
         expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -122,7 +115,7 @@ describe('TokenIcon', () => {
 
     it('should render without network icon for networks that are not l2 networks = op, arb, base', async () => {
         const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
-            symbol: btcSymbol,
+            symbol: 'btc',
             showNetworkIcon: true,
         });
 
@@ -137,7 +130,7 @@ describe('TokenIcon', () => {
 
     it('should render network with network icon for l2 networks = op, arb, base and ETH as icon', async () => {
         const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
-            symbol: opSymbol,
+            symbol: 'op',
             showNetworkIcon: true,
         });
 
@@ -152,7 +145,7 @@ describe('TokenIcon', () => {
     it('should render with network icon for contracts', async () => {
         const contract = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo' as TokenAddress;
         const { getByHintText, getByLabelText } = renderTokenIcon({
-            symbol: opSymbol,
+            symbol: 'op',
             contractAddress: contract,
             showNetworkIcon: true,
         });
@@ -162,61 +155,6 @@ describe('TokenIcon', () => {
             expect(getByHintText(tokenIconHint)).toBeTruthy();
             expect(getByLabelText(`op:${contract}`)).toBeTruthy();
             expect(getByHintText(networkIconHint)).toBeTruthy();
-        });
-    });
-
-    describe('wrappedTokenIcon', () => {
-        const wethContract = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as TokenAddress;
-
-        it('renders the native icon with a network badge for a wrapped-native token when set to network', async () => {
-            const { getByHintText, getByLabelText } = renderTokenIcon({
-                symbol: ethSymbol,
-                contractAddress: wethContract,
-                showNetworkIcon: true,
-                wrappedTokenIcon: 'network',
-            });
-
-            expect(getByHintText(networkIconHint)).toBeTruthy();
-            await waitFor(() => {
-                expect(getByHintText(tokenIconHint)).toBeTruthy();
-                expect(getByLabelText('ETH')).toBeTruthy();
-            });
-        });
-
-        it('keeps the wrapped-native token icon by default', async () => {
-            (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
-                (_symbol: string, contract: string) => Promise.resolve([contract]),
-            );
-
-            const { getByHintText, getByLabelText } = renderTokenIcon({
-                symbol: ethSymbol,
-                contractAddress: wethContract,
-                showNetworkIcon: true,
-            });
-
-            await waitFor(() => {
-                expect(getByLabelText(`eth:${wethContract}`)).toBeTruthy();
-                expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
-                    getTokenIconUrl(wethContract),
-                );
-            });
-        });
-
-        it('keeps the token icon for a non-wrapped token even when set to network', async () => {
-            (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
-                (_symbol: string, contract: string) => Promise.resolve([contract]),
-            );
-
-            const { getByLabelText } = renderTokenIcon({
-                symbol: ethSymbol,
-                contractAddress: contractA,
-                showNetworkIcon: true,
-                wrappedTokenIcon: 'network',
-            });
-
-            await waitFor(() => {
-                expect(getByLabelText(`eth:${contractA}`)).toBeTruthy();
-            });
         });
     });
 });

--- a/suite-native/icons/src/TokenIcon.tsx
+++ b/suite-native/icons/src/TokenIcon.tsx
@@ -3,6 +3,7 @@ import { Text, View } from 'react-native';
 
 import { Image } from 'expo-image';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type CryptoIconName, cryptoIcons, genericTokenIcon } from '@suite-common/icons';
 import {
     type NetworkDisplaySymbol,
@@ -10,6 +11,7 @@ import {
     getCoingeckoId,
     getNetworkDisplaySymbol,
     isNetworkSymbol,
+    selectNetworkConfigDeps,
 } from '@suite-common/wallet-config';
 import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { useTranslate } from '@suite-native/intl';
@@ -105,6 +107,7 @@ interface TokenIconProps {
 }
 
 const TokenIconComponent = ({ symbol, contractAddress, size = 'small' }: TokenIconProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
 
@@ -127,10 +130,14 @@ const TokenIconComponent = ({ symbol, contractAddress, size = 'small' }: TokenIc
     } | null>(null);
 
     const resolvedUrls = useAsyncMemo(async (): Promise<(string | number)[]> => {
-        if (isNetworkSymbol(symbol)) {
-            const coingeckoId = getCoingeckoId(symbol);
+        if (isNetworkSymbol(networkConfigDeps, symbol)) {
+            const coingeckoId = getCoingeckoId(networkConfigDeps, symbol);
             if (coingeckoId && contractAddress) {
-                const logoAddresses = await getAssetLogoContractAddresses(symbol, contractAddress);
+                const logoAddresses = await getAssetLogoContractAddresses(
+                    networkConfigDeps,
+                    symbol,
+                    contractAddress,
+                );
                 if (logoAddresses?.length) {
                     return logoAddresses.map(address =>
                         getAssetLogoUrl({
@@ -145,7 +152,7 @@ const TokenIconComponent = ({ symbol, contractAddress, size = 'small' }: TokenIc
         }
 
         return [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
-    }, [contractAddress, sizeNumber, symbol]);
+    }, [contractAddress, networkConfigDeps, sizeNumber, symbol]);
 
     const sourceUrls = resolvedUrls ?? [];
     const sourceKey = resolvedUrls ? `${asyncKey}#resolved` : `${asyncKey}#fallback`;
@@ -201,21 +208,22 @@ export const TokenIcon = ({
     size = 'small',
     wrappedTokenIcon = 'token',
 }: TokenIconProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { applyStyle } = useNativeStyles();
 
     if (
         wrappedTokenIcon === 'network' &&
-        isNetworkSymbol(symbol) &&
+        isNetworkSymbol(networkConfigDeps, symbol) &&
         isWrappedNativeToken(symbol, contractAddress)
     ) {
         contractAddress = undefined;
     }
 
-    if (!showNetworkIcon || !isNetworkSymbol(symbol)) {
+    if (!showNetworkIcon || !isNetworkSymbol(networkConfigDeps, symbol)) {
         return <TokenIconComponent symbol={symbol} contractAddress={contractAddress} size={size} />;
     }
 
-    const displaySymbol = getNetworkDisplaySymbol(symbol);
+    const displaySymbol = getNetworkDisplaySymbol(networkConfigDeps, symbol);
     const showForNativeToken = displaySymbol === 'ETH' && symbol !== 'eth';
     const shouldShowNetwork =
         showForNativeToken || contractAddress || wrappedTokenIcon === 'network';

--- a/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportConfirmFormScreen.tsx
@@ -6,11 +6,12 @@ import { FlashList } from '@shopify/flash-list';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type TokenDefinitionsRootState,
     selectFilterKnownTokens,
 } from '@suite-common/token-definitions';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountsByNetworkAndDeviceState,
@@ -36,6 +37,7 @@ import { AccountImportOverview } from './AccountImportOverview';
 import { AccountImportSummaryScreen } from './AccountImportSummaryScreen';
 import { TokenInfoCard } from './TokenInfoCard';
 
+
 type AccountImportConfirmFormScreenProps = {
     symbol: NetworkSymbol;
     accountInfo: AccountInfo;
@@ -51,6 +53,7 @@ export const AccountImportConfirmFormScreen = ({
     symbol,
     accountInfo,
 }: AccountImportConfirmFormScreenProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const navigation = useNavigation<NavigationProp>();
@@ -66,7 +69,7 @@ export const AccountImportConfirmFormScreen = ({
     );
 
     const nonEmptyTokens = knownTokens.filter(info => parseFloat(info.balance ?? '0') > 0);
-    const defaultAccountLabel = `${getNetwork(symbol).name} #${deviceNetworkAccounts.length + 1}`;
+    const defaultAccountLabel = `${getNetworkConfig(symbol).name} #${deviceNetworkAccounts.length + 1}`;
 
     const form = useAccountLabelForm(defaultAccountLabel);
     const {

--- a/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
+++ b/suite-native/module-accounts-import/src/components/AccountImportOverview.tsx
@@ -1,6 +1,8 @@
 import { type Control } from 'react-hook-form';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { useDisplayBaseCurrency } from '@suite-common/wallet-core';
 import {
     type AccountFormValues,
@@ -25,6 +27,7 @@ type AssetsOverviewProps = {
 };
 
 export const AccountImportOverview = ({ balance, symbol, formControl }: AssetsOverviewProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { translate } = useTranslate();
     const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(symbol);
 
@@ -39,7 +42,7 @@ export const AccountImportOverview = ({ balance, symbol, formControl }: AssetsOv
     return (
         <AccountImportOverviewCard
             icon={<RoundedIcon symbol={symbol} />}
-            coinName={getNetwork(symbol).name}
+            coinName={getNetworkConfig(symbol).name}
             cryptoAmount={
                 <CryptoAmountFormatter
                     value={balance}

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -5,19 +5,16 @@ import { useDispatch, useSelector } from 'react-redux';
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { useNavigation } from '@react-navigation/native';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { selectSelectedDevice } from '@suite-common/device';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     DefinitionType,
     type TokenDefinitionsRootState,
     TokenManagementAction,
     tokenDefinitionsActions,
 } from '@suite-common/token-definitions';
-import {
-    getDisplaySymbol,
-    getNetwork,
-    getWrappedNativeAddress,
-    isWrappedNativeToken,
-} from '@suite-common/wallet-config';
+import { getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TokensRootState,
@@ -59,6 +56,10 @@ import {
     selectAccountTokenInfo,
 } from '@suite-native/tokens';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+import {
+    getWrappedNativeAddress,
+    isWrappedNativeToken,
+} from '@trezor/network-ethereum-suite-common';
 
 import { selectIsUnrecognizedToken } from '../selectors';
 
@@ -104,6 +105,7 @@ export const TokenSettingsBottomSheet = forwardRef(
         { accountKey, tokenContract, onNavigateAway }: TokenSettingsBottomSheetProps,
         ref: Ref<BottomSheetModalMethods>,
     ) => {
+        const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
         const { applyStyle } = useNativeStyles();
         const dispatch = useDispatch();
         const navigation =
@@ -131,10 +133,10 @@ export const TokenSettingsBottomSheet = forwardRef(
 
         if (!account || !symbol) return null;
 
-        const displaySymbol = getDisplaySymbol(account.symbol);
+        const displaySymbol = getDisplaySymbol({ getNetworkConfig }, account.symbol);
 
         const balance = token?.balance ?? account.balance;
-        const networkName = getNetwork(symbol).name;
+        const networkName = getNetworkConfig(symbol).name;
 
         const isHidden = hiddenTokens.some(
             t => t.contract.toLowerCase() === tokenContract?.toLowerCase(),

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryFinishedScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryFinishedScreen.tsx
@@ -1,7 +1,8 @@
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type AccountsRootState,
     selectDeviceAccountsByNetworkSymbol,
@@ -28,6 +29,7 @@ export const AddCoinDiscoveryFinishedScreen = ({
     AddCoinAccountStackParamList,
     AddCoinAccountStackRoutes.AddCoinDiscoveryFinished
 >) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { networkSymbol, flowType } = route.params;
 
     const { applyStyle } = useNativeStyles();
@@ -71,7 +73,7 @@ export const AddCoinDiscoveryFinishedScreen = ({
                         id={titleKey}
                         values={{
                             count: accounts.length.toString(),
-                            coin: getNetwork(networkSymbol).name,
+                            coin: getNetworkConfig(networkSymbol).name,
                         }}
                     />
                 </Text>

--- a/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
+++ b/suite-native/module-add-accounts/src/screens/AddCoinDiscoveryRunningScreen.tsx
@@ -3,8 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type AccountsRootState,
     changeCoinVisibility,
@@ -31,6 +32,7 @@ import { isPassphraseDiscoveryFailure } from '@suite-native/passphrase';
 export const AddCoinDiscoveryRunningScreen = ({
     route,
 }: StackProps<AddCoinAccountStackParamList, AddCoinAccountStackRoutes.AddCoinDiscoveryRunning>) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { networkSymbol, flowType } = route.params;
     const dispatch = useDispatch();
     const navigation = useNavigation<AddCoinAccountNavigationProps>();
@@ -134,7 +136,7 @@ export const AddCoinDiscoveryRunningScreen = ({
                     <Text variant="headline-sm" textAlign="center">
                         <Translation
                             id="moduleAddAccounts.coinDiscoveryRunningScreen.title"
-                            values={{ coin: getNetwork(networkSymbol).name }}
+                            values={{ coin: getNetworkConfig(networkSymbol).name }}
                         />
                     </Text>
                     <Text variant="body-md" textAlign="center" color="contentSecondary">

--- a/suite-native/module-connect-popup/src/components/GroupedPermissionsList.tsx
+++ b/suite-native/module-connect-popup/src/components/GroupedPermissionsList.tsx
@@ -8,8 +8,9 @@ import {
     groupPermissionsByCoin,
     permissionIcons,
 } from '@suite-common/connect-popup';
+import { useServices } from '@suite-common/dependency-injection';
 import { isNetworkIconSymbol } from '@suite-common/icons';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { AccordionContent, AnimatedBox, Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { Icon, NetworkIcon } from '@suite-native/icons';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
@@ -88,6 +89,7 @@ type PermissionGroupProps = {
 };
 
 const PermissionGroup = ({ coin, permissions, defaultIsOpen }: PermissionGroupProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const [isOpen, setIsOpen] = useState(defaultIsOpen);
     const isOpenedShared = useSharedValue(defaultIsOpen);
 
@@ -122,7 +124,7 @@ const PermissionGroup = ({ coin, permissions, defaultIsOpen }: PermissionGroupPr
                             {coin ? (
                                 <Translation
                                     id="moduleConnectPopup.permissions.coinHeading"
-                                    values={{ coin: getCoinLabel(coin) }}
+                                    values={{ coin: getCoinLabel(networkConfigDeps, coin) }}
                                 />
                             ) : (
                                 <Translation id="moduleConnectPopup.permissions.deviceHeading" />

--- a/suite-native/module-connect-popup/src/screens/WalletConnectSwitchAccountScreen.tsx
+++ b/suite-native/module-connect-popup/src/screens/WalletConnectSwitchAccountScreen.tsx
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import {
@@ -27,21 +29,22 @@ type NavigationProps = StackProps<RootStackParamList, RootStackRoutes.WalletConn
 export const WalletConnectSwitchAccountScreen = ({ route }: NavigationProps) => {
     const navigation = useNavigation();
     const dispatch = useDispatch();
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
 
     const { sessionTopic } = route.params;
     const sessions = useSelector(selectSessions);
     const session = sessions.find(s => s.topic === sessionTopic);
-    const accounts = useSelector(selectAllAccountsToList);
+    const accounts = useSelector(state => selectAllAccountsToList(state, networkConfigDeps));
     const selectableAccounts = useMemo<Account[]>(
         () =>
             session
-                ? getSessionNetworks(session)
+                ? getSessionNetworks(networkConfigDeps, session)
                       .filter(network => network.status === 'active')
                       .flatMap(network =>
                           accounts.filter(account => account.symbol === network.symbol),
                       )
                 : [],
-        [accounts, session],
+        [accounts, networkConfigDeps, session],
     );
 
     const handleSave = (account: Account) => {

--- a/suite-native/module-earn/src/components/EarnFiatAmountInput.tsx
+++ b/suite-native/module-earn/src/components/EarnFiatAmountInput.tsx
@@ -2,7 +2,9 @@ import { type RefObject } from 'react';
 import { type TextInputProps } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Input, type InputType, Text } from '@suite-native/atoms';
@@ -26,9 +28,10 @@ export const EarnFiatAmountInput = ({
     isDisabled = false,
     onPress,
 }: EarnFiatAmountInputProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { setValue } = useFormContext<EarnFormValues>();
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
-    const { decimals } = getNetwork(symbol);
+    const { decimals } = getNetworkConfig(symbol);
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
     const converters = useCryptoFiatConverters({ symbol });

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
@@ -1,6 +1,8 @@
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { formatNetworkAmount, getStakingLimitsByNetworkSymbol } from '@suite-common/wallet-utils';
@@ -15,6 +17,7 @@ type EarnWithdrawalFeesBannerProps = {
 };
 
 export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalFeesBannerProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -24,7 +27,7 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
 
     if (!limits || !account) return null;
 
-    const { displaySymbol } = getNetwork(symbol);
+    const { displaySymbol } = getNetworkConfig(symbol);
     const formattedBalance = formatNetworkAmount(account.availableBalance, symbol);
 
     const isVisible =

--- a/suite-native/module-earn/src/components/EnableNetworkForEarnBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/EnableNetworkForEarnBottomSheet.tsx
@@ -1,6 +1,6 @@
 import { useServices } from '@suite-common/dependency-injection';
 import { selectGetNetworkConfigDep } from '@suite-common/networks';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -48,10 +48,10 @@ export const EnableNetworkForEarnBottomSheet = ({
     onEnablePress,
     onDismiss,
 }: EnableNetworkForEarnBottomSheetProps) => {
-    const { applyStyle } = useNativeStyles();
     const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
+    const { applyStyle } = useNativeStyles();
 
-    const networkName = symbol ? getNetwork(symbol).name : '';
+    const networkName = symbol ? getNetworkConfig(symbol).name : '';
     const networkColor = symbol ? getNetworkConfig(symbol).color : undefined;
     const translationIds = translationIdByEarnType[type];
 

--- a/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowScreenHeader.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { formatCoinBalance } from '@suite-common/wallet-utils';
 import { Box, DiscreetText, HStack, IconButton, Text, VStack } from '@suite-native/atoms';
@@ -23,11 +24,13 @@ export const YieldDepositFlowScreenHeader = ({
     tokenContract,
     vaultName,
 }: YieldDepositFlowScreenHeaderProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const locale = useSelector(selectSupportedLanguageLocale);
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const network = getNetworkConfig(account.symbol);
+    const accountLabel = account.accountLabel ?? network.name;
     // Same format as the desktop yield page header: `formatCoinBalance` keeps the leading
     // significant digits and appends an ellipsis (…) once the fractional part gets too long.
-    const formattedBalance = `${formatCoinBalance(account.formattedBalance, locale)} ${getNetworkDisplaySymbol(account.symbol)}`;
+    const formattedBalance = `${formatCoinBalance(account.formattedBalance, locale)} ${network.displaySymbol}`;
 
     return (
         <ScreenHeader

--- a/suite-native/module-earn/src/components/YieldTxSimulationBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldTxSimulationBottomSheet.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     type StablecoinYieldTxSimulationParams,
     composeStablecoinYieldTxSimulationAction,
 } from '@suite-common/earn-stablecoin/src/tx-simulation';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import {
     BottomSheetModal,
@@ -43,9 +45,11 @@ export const YieldTxSimulationBottomSheet = ({
     ref,
     unsignedTx,
 }: YieldTxSimulationBottomSheetProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const parsedData = useMemo(
         () =>
             composeStablecoinYieldTxSimulationAction(
+                networkConfigDeps,
                 {
                     flow,
                     account,
@@ -53,7 +57,7 @@ export const YieldTxSimulationBottomSheet = ({
                 },
                 STABLECOIN_YIELD_NATIVE_SOURCE_ORIGIN,
             ),
-        [account, flow, unsignedTx],
+        [account, flow, networkConfigDeps, unsignedTx],
     );
 
     return (

--- a/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
+++ b/suite-native/module-earn/src/hooks/useComposeEarnFees.ts
@@ -4,8 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useIsFocused } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -82,6 +83,7 @@ export const useComposeEarnFees = ({
     formState,
     formDraftPrefix,
 }: UseComposeEarnFeesParams) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const isFocused = useIsFocused();
@@ -162,7 +164,7 @@ export const useComposeEarnFees = ({
                                   composeContext: {
                                       account,
                                       feeInfo,
-                                      network: getNetwork(account.symbol),
+                                      network: getNetworkConfig(account.symbol),
                                   },
                               }),
                           );

--- a/suite-native/module-earn/src/hooks/useEarnForm.ts
+++ b/suite-native/module-earn/src/hooks/useEarnForm.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { buildStakeData, getEthereumStakingAddressByType } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
 import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -15,12 +16,13 @@ import { buildEarnComposeFormState } from '../utils';
 import { useComposeEarnFees } from './useComposeEarnFees';
 
 export const useEarnForm = (accountKey: AccountKey) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { translate } = useTranslate();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
 
-    const network = account ? getNetwork(account.symbol) : null;
+    const network = account ? getNetworkConfig(account.symbol) : null;
 
     const form = useForm<EarnFormValues>({
         validation: earnFormValidationSchema,

--- a/suite-native/module-earn/src/hooks/useUnstakeForm.ts
+++ b/suite-native/module-earn/src/hooks/useUnstakeForm.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { buildUnstakeData, getEthereumStakingAddressByType } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
 import { UNSTAKE_INTERCHANGES, WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
@@ -29,6 +30,7 @@ import { useApproximateInstantUnstakeAmount } from './useApproximateInstantUnsta
 import { useComposeEarnFees } from './useComposeEarnFees';
 
 export const useUnstakeForm = (accountKey: AccountKey) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { translate } = useTranslate();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -44,7 +46,7 @@ export const useUnstakeForm = (accountKey: AccountKey) => {
             selectClaimableAmountByAccountKey(state, accountKey),
         ) ?? '0';
 
-    const network = account ? getNetwork(account.symbol) : null;
+    const network = account ? getNetworkConfig(account.symbol) : null;
 
     const form = useForm<EarnFormValues>({
         validation: unstakeFormValidationSchema,

--- a/suite-native/module-earn/src/hooks/useYieldClaimFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldClaimFees.ts
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import {
     buildClaimCalldata,
     buildUnsignedClaimTransaction,
 } from '@suite-common/earn-stablecoin/src/signing';
 import type { UnsignedClaimTransaction } from '@suite-common/earn-stablecoin/src/signing';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type EvmHexString } from '@suite-common/schemas/src/evm';
-import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
+import { getEarnYieldClaimContractAddress } from '@suite-common/wallet-config';
 import {
     type FeesRootState,
     type FormDraftRootState,
@@ -84,6 +86,7 @@ const getClaimFormDraft = ({
 });
 
 export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFeesParams) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const requestIdRef = useRef(0);
@@ -133,7 +136,7 @@ export const useYieldClaimFees = ({ accountRewards, isEnabled }: UseYieldClaimFe
             return null;
         }
 
-        const network = getNetwork(accountRewards.account.symbol);
+        const network = getNetworkConfig(accountRewards.account.symbol);
         const contractAddress = getEarnYieldClaimContractAddress(accountRewards.account.symbol);
 
         if (

--- a/suite-native/module-earn/src/hooks/useYieldDepositRevokeScreen.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositRevokeScreen.ts
@@ -4,7 +4,8 @@ import { useDispatch } from 'react-redux';
 import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-navigation/native';
 import { isFulfilled } from '@reduxjs/toolkit';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     REVOKE_ALLOWANCE_AMOUNT,
     stablecoinYieldActions,
@@ -36,6 +37,7 @@ type NavigationProps = StackNavigationProps<
 >;
 
 export const useYieldDepositRevokeScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const dispatch = useDispatch();
@@ -316,7 +318,7 @@ export const useYieldDepositRevokeScreen = () => {
         return null;
     }
 
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const accountLabel = account.accountLabel ?? getNetworkConfig(account.symbol).name;
     const feeSelectorProps =
         revokeFeeTransaction !== null
             ? {

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -2,9 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { asEvmAddress } from '@suite-common/calldata';
+import { useServices } from '@suite-common/dependency-injection';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type FeesRootState,
     type FormDraftRootState,
@@ -222,6 +223,7 @@ const composeYieldWithdrawTransaction = async ({
     flowData,
     flowType,
 }: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { account, receiptToken, vault } = flowData;
 
     if (account.networkType !== 'ethereum') {
@@ -229,7 +231,7 @@ const composeYieldWithdrawTransaction = async ({
     }
 
     const vaultAddress = receiptToken.contractAddress ?? vault.outputToken?.address;
-    const network = getNetwork(account.symbol);
+    const network = getNetworkConfig(account.symbol);
 
     if (!vaultAddress || !network.chainId || vault.chainId !== network.chainId) {
         throw new Error('Yield withdraw cannot be composed for this vault.');

--- a/suite-native/module-earn/src/screens/EarnConsentsScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnConsentsScreen.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -31,6 +31,7 @@ import { EarnConsentsDelegatingCard } from '../components/EarnConsentsDelegating
 import { EarnConsentsEntryPeriodCard } from '../components/EarnConsentsEntryPeriodCard';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 
+
 const STAKING_LEARN_MORE_URLS: Partial<Record<string, Url>> = {
     ethereum: HELP_CENTER_ETH_STAKING,
     solana: HELP_CENTER_SOL_STAKING,
@@ -42,6 +43,7 @@ const titleStyle = prepareNativeStyle(utils => ({
 }));
 
 export const EarnConsentsScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { applyStyle } = useNativeStyles();
     const [isSecondCardExpanded, setIsSecondCardExpanded] = useState(false);
     const route = useRoute<RouteProp<RootStackParamList, RootStackRoutes.EarnConsents>>();
@@ -89,7 +91,7 @@ export const EarnConsentsScreen = () => {
         selectEntryPeriodInDaysBySymbol(state, networkSymbol),
     );
 
-    const learnMoreUrl = STAKING_LEARN_MORE_URLS[getNetwork(account.symbol).networkType];
+    const learnMoreUrl = STAKING_LEARN_MORE_URLS[getNetworkConfig(account.symbol).networkType];
 
     return (
         <Screen header={<ScreenHeader closeActionType="back" />}>

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -6,7 +6,7 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type AccountsRootState,
     selectAccountByKey,
@@ -43,10 +43,12 @@ import { useYieldSession } from '../hooks/useYieldSession';
 import { getStablecoinYieldClaimRewardsSnapshot } from '../utils/stablecoinYieldClaimSummaryUtils';
 import { getClaimFeeWarning } from '../utils/yieldClaimFeeWarningUtils';
 
+
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldClaim>;
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldClaim>;
 
 export const YieldClaimScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const { accountKey } = route.params;
@@ -235,7 +237,7 @@ export const YieldClaimScreen = () => {
         return null;
     }
 
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const accountLabel = account.accountLabel ?? getNetworkConfig(account.symbol).name;
 
     return (
         <Screen

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -6,7 +6,7 @@ import { type RouteProp, useIsFocused, useNavigation, useRoute } from '@react-na
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     getYieldApprovalAction,
     getYieldVaultContractAddress,
@@ -51,6 +51,7 @@ import { useYieldSession } from '../hooks/useYieldSession';
 import { getYieldApprovalAnalyticsType } from '../utils/yieldAnalyticsUtils';
 import { isYieldApprovalAllowanceUnlimited } from '../yieldApprovalUtils';
 
+
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDepositApproval>;
 type NavigationProps = StackNavigationProps<
     YieldStackParamList,
@@ -58,6 +59,7 @@ type NavigationProps = StackNavigationProps<
 >;
 
 export const YieldDepositApprovalScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const dispatch = useDispatch();
@@ -297,7 +299,7 @@ export const YieldDepositApprovalScreen = () => {
         return null;
     }
 
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const accountLabel = account.accountLabel ?? getNetworkConfig(account.symbol).name;
     const pendingModalAmount = approvalPendingTransaction?.isAmountUnlimited ? (
         <Translation id="earn.yieldDepositFlowScreen.approvalLimitSheet.unlimited.title" />
     ) : (

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -12,7 +12,7 @@ import {
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { Context } from '@suite-common/message-system';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getYieldVaultContractAddress, stablecoinYieldActions } from '@suite-common/wallet-core';
 import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
@@ -54,10 +54,12 @@ import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTran
 import { useYieldSession } from '../hooks/useYieldSession';
 import { isYieldApprovalAllowanceUnlimited } from '../yieldApprovalUtils';
 
+
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldDeposit>;
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldDeposit>;
 
 export const YieldDepositScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const dispatch = useDispatch();
@@ -369,7 +371,7 @@ export const YieldDepositScreen = () => {
         return null;
     }
 
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const accountLabel = account.accountLabel ?? getNetworkConfig(account.symbol).name;
     const shouldShowDepositFee = isValid && !!amountValue && !isApprovalInsufficient;
 
     return (

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -7,7 +7,7 @@ import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { useFormatters } from '@suite-common/formatters';
 import { Context } from '@suite-common/message-system';
-import { getNetwork } from '@suite-common/wallet-config';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
@@ -64,6 +64,7 @@ import { useYieldSession } from '../hooks/useYieldSession';
 import { useYieldWithdrawFees } from '../hooks/useYieldWithdrawFees';
 import { getYieldWithdrawAmountValidationError } from '../utils/yieldWithdrawUtils';
 
+
 type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.YieldWithdraw>;
 
@@ -87,6 +88,7 @@ const getYieldWithdrawFlowTypeByInputView = (
 ): YieldWithdrawFlowType => (activeView === 'secondary' ? 'redeem' : 'withdraw');
 
 export const YieldWithdrawScreen = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
     const dispatch = useDispatch();
@@ -509,7 +511,7 @@ export const YieldWithdrawScreen = () => {
     const headerTokenContract = vault.token.address
         ? toTokenAddress(vault.token.address)
         : route.params.tokenContract;
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const accountLabel = account.accountLabel ?? getNetworkConfig(account.symbol).name;
     const depositedAmountLabel = maxAmount
         ? CryptoAmountFormatter.format(maxAmount, {
               symbol: activeUnitSymbol,

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -2,7 +2,6 @@ import {
     type ChainRewardsWithFiat,
     type MerklRewardsParams,
 } from '@suite-common/earn-stablecoin-api';
-import { getNetwork } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteRewardItem } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -34,7 +33,7 @@ const getAccountChainAddressKey = (account: Account) => {
         return null;
     }
 
-    const network = getNetwork(account.symbol);
+    const network = getNetworkConfig(account.symbol);
 
     if (!network?.chainId) {
         return null;

--- a/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
+++ b/suite-native/module-home/src/screens/HomeScreen/homescreenSelectors.ts
@@ -18,7 +18,6 @@ import {
     selectHasDeviceSuiteSyncError,
     selectSuiteSyncInteraction,
 } from '@suite-common/suite-sync';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type DiscoveryRootState,
@@ -46,7 +45,7 @@ export const selectDeviceHistoryIgnoredNetworksString = createMemoizedSelector(
     networkSymbols =>
         networkSymbols.length === 0
             ? null
-            : networkSymbols.map(networkSymbol => getNetwork(networkSymbol).name).join(', '),
+            : networkSymbols.map(networkSymbol => getNetworkConfig(networkSymbol).name).join(', '),
 );
 
 export const selectShouldDisplayUpgradeFirmwareAlert = createMemoizedSelector(

--- a/suite-native/module-send/src/components/AddressInput.tsx
+++ b/suite-native/module-send/src/components/AddressInput.tsx
@@ -13,7 +13,7 @@ import { type DeviceRootState } from '@suite-common/device';
 import { selectFindNetworkSymbolForProtocolDep } from '@suite-common/networks';
 import { parseTransferUri } from '@suite-common/transfer-uri';
 import { formInputsMaxLength } from '@suite-common/validators';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     selectAccountByKey,
@@ -68,10 +68,17 @@ export const AddressInput = ({ index, accountKey, onQrNetworkMismatch }: Address
     const amountFieldName = getOutputFieldName(index, 'amount');
     const tokenFieldName = getOutputFieldName(index, 'token');
     const { setValue, control } = useFormContext<SendOutputsFormValues>();
-    const { analytics, addressValidator, findNetworkSymbolForProtocol } = useServices(
+    const {
+        analytics,
+        addressValidator,
+        findNetworkSymbolForProtocol,
+        getNetworkConfig,
+        networkModuleRepository,
+    } = useServices(
         selectNativeAnalyticsDep,
         selectAddressValidatorDep,
         selectFindNetworkSymbolForProtocolDep,
+        selectNetworkConfigDeps,
     );
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
@@ -129,7 +136,10 @@ export const AddressInput = ({ index, accountKey, onQrNetworkMismatch }: Address
     };
 
     const handleScanAddressQRCode = (qrCodeData: string) => {
-        const parsed = parseTransferUri(qrCodeData, findNetworkSymbolForProtocol);
+        const parsed = parseTransferUri(
+            { findNetworkSymbolForProtocol, getNetworkConfig, networkModuleRepository },
+            qrCodeData,
+        );
 
         // ERC-681 (Ethereum) — may switch to a matching account on another EVM network.
         const erc681 =

--- a/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
+++ b/suite-native/module-send/src/components/CorrectNetworkMessageCard.tsx
@@ -1,4 +1,6 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Card, HStack, InlineAlertBox, Text } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -24,9 +26,10 @@ export const CorrectNetworkMessageCard = ({
     symbol,
     qrNetworkSymbol,
 }: CorrectNetworkMessageCardProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { applyStyle } = useNativeStyles();
 
-    const network = getNetwork(symbol);
+    const network = getNetworkConfig(symbol);
 
     if (qrNetworkSymbol) {
         return (
@@ -36,7 +39,7 @@ export const CorrectNetworkMessageCard = ({
                     <Translation
                         id="moduleSend.outputs.recipients.qrNetworkMismatch"
                         values={{
-                            qrNetwork: getNetwork(qrNetworkSymbol).name,
+                            qrNetwork: getNetworkConfig(qrNetworkSymbol).name,
                             accountNetwork: network.name,
                         }}
                     />

--- a/suite-native/module-send/src/components/DestinationTagInput.tsx
+++ b/suite-native/module-send/src/components/DestinationTagInput.tsx
@@ -1,7 +1,9 @@
 import { useRef, useState } from 'react';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
-import { type NetworkSymbol, getNetwork, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
     AnimatedVStack,
     HStack,
@@ -38,6 +40,7 @@ interface DestinationTagInputProps {
 }
 
 export const DestinationTagInput = ({ networkSymbol }: DestinationTagInputProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const inputRef = useRef<InputType | null>(null);
     const { applyStyle } = useNativeStyles();
 
@@ -126,7 +129,7 @@ export const DestinationTagInput = ({ networkSymbol }: DestinationTagInputProps)
                         title={
                             <Translation
                                 id="moduleSend.outputs.recipients.destinationTag.warning"
-                                values={{ network: getNetwork(networkSymbol).name }}
+                                values={{ network: getNetworkConfig(networkSymbol).name }}
                             />
                         }
                     />

--- a/suite-native/module-send/src/components/FiatAmountInput.tsx
+++ b/suite-native/module-send/src/components/FiatAmountInput.tsx
@@ -1,8 +1,9 @@
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import type { DeviceRootState } from '@suite-common/device';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type TransactionsRootState,
     type WalletSettingsRootState,
@@ -32,6 +33,7 @@ export const FiatAmountInput = ({
     isDisabled = false,
     accountKey,
 }: SendAmountInputProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { setValue } = useFormContext<SendOutputsFormValues>();
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
@@ -39,7 +41,7 @@ export const FiatAmountInput = ({
         selectIsAmountInSats(state, symbol),
     );
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
-    const { decimals } = getNetwork(symbol);
+    const { decimals } = getNetworkConfig(symbol);
     const tokenDecimals = useSelector(
         (state: DeviceRootState & TokenDefinitionsRootState & TransactionsRootState) =>
             selectAccountTokenDecimals(state, accountKey, tokenContract),

--- a/suite-native/module-send/src/components/SendMaxSwitch.tsx
+++ b/suite-native/module-send/src/components/SendMaxSwitch.tsx
@@ -3,7 +3,8 @@ import { Keyboard } from 'react-native';
 import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type AccountsRootState,
     selectAccountNetworkSymbol,
@@ -34,10 +35,11 @@ export const SendMaxSwitch = ({
     tokenContract,
     maxSpendableAmount,
 }: SendMaxSwitchProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const symbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
-    const decimals = symbol && getNetwork(symbol).decimals;
+    const decimals = symbol && getNetworkConfig(symbol).decimals;
 
     const isBtcAmountInSats = useSelector(selectAreSatsAmountUnit);
     const baseCurrencyCode = useSelector(selectBaseCurrency);

--- a/suite-native/module-send/src/components/TokenOfNetworkAlertContent.tsx
+++ b/suite-native/module-send/src/components/TokenOfNetworkAlertContent.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
 import { InlineAlertBox, Text, VStack } from '@suite-native/atoms';
@@ -28,6 +29,7 @@ export const TokenOfNetworkAlertBody = ({
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
 }) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const tokenSymbol = useSelector((state: TokensRootState) =>
         selectAccountTokenSymbol(state, accountKey, tokenContract),
     );
@@ -37,7 +39,7 @@ export const TokenOfNetworkAlertBody = ({
 
     if (!tokenContract || !symbol) return null;
 
-    const networkName = getNetwork(symbol).name;
+    const networkName = getNetworkConfig(symbol).name;
 
     return (
         <VStack spacing="sp24">

--- a/suite-native/module-send/src/hooks/useSendForm.tsx
+++ b/suite-native/module-send/src/hooks/useSendForm.tsx
@@ -13,8 +13,9 @@ import {
     selectDeviceUnavailableCapabilities,
     selectIsDeviceRemembered,
 } from '@suite-common/device';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { getExcludedUtxos } from '@suite-common/transaction-search';
-import { type NetworkType, getDisplaySymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkType, getDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -76,6 +77,7 @@ import { useRequestDelayedNavigationToOutputsReview } from './useRequestDelayedN
 import { useShowDeviceDisconnectedAlert } from './useShowDeviceDisconnectedAlert';
 import { useUtxoSelection } from './useUtxoSelection';
 
+
 const getDefaultValues = ({
     tokenContract,
     isDestinationTagEnabled,
@@ -113,6 +115,7 @@ type SendFormNavigationProp = StackToStackCompositeNavigationProps<
 >;
 
 export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const debounce = useDebounce();
     const navigation = useNavigation<SendFormNavigationProp>();
@@ -157,7 +160,7 @@ export const useSendForm = (accountKey: AccountKey, tokenContract?: TokenAddress
 
     const deviceUnavailableCapabilities = useSelector(selectDeviceUnavailableCapabilities);
 
-    const network = account ? getNetwork(account.symbol) : null;
+    const network = account ? getNetworkConfig(account.symbol) : null;
 
     const networkReserve = account
         ? getNetworkReserve({

--- a/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
+++ b/suite-native/module-settings/src/screens/NetworkBackendsScreen.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { useAlert } from '@suite-native/alerts';
 import { VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -21,10 +22,11 @@ import { useNetworkExplorerForm } from '../hooks/useNetworkExplorerForm';
 export const NetworkBackendsScreen = ({
     route,
 }: StackProps<SettingsStackParamList, SettingsStackRoutes.SettingsNetworkBackends>) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { showAlert } = useAlert();
     const navigation = useNavigation();
 
-    const network = getNetwork(route.params.networkSymbol);
+    const network = getNetworkConfig(route.params.networkSymbol);
     const networkBackendForm = useNetworkBackendForm(network);
     const networkExplorerForm = useNetworkExplorerForm(network);
 

--- a/suite-native/module-stellar-token-management/src/thunks.ts
+++ b/suite-native/module-stellar-token-management/src/thunks.ts
@@ -1,7 +1,6 @@
 import { isFulfilled } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type FormDraftRootState,
     composeSendFormTransactionFeeLevelsThunk,
@@ -112,7 +111,7 @@ export const composeStellarTrustlineFeesThunk = createThunk(
     `${STELLAR_TOKEN_MODULE_PREFIX}/composeTrustlineFees`,
     async (
         { accountKey, tokenContract }: ComposeStellarTrustlineFeesParams,
-        { dispatch, getState, rejectWithValue, fulfillWithValue },
+        { dispatch, getState, rejectWithValue, fulfillWithValue, extra },
     ) => {
         const account = selectAccountByKey(getState(), accountKey);
         if (!account) {
@@ -124,7 +123,7 @@ export const composeStellarTrustlineFeesThunk = createThunk(
             return rejectWithValue('Fee info not available');
         }
 
-        const network = getNetwork(account.symbol);
+        const network = extra.services.getNetworkConfig(account.symbol);
         const normalFeeLevel = feeInfo.levels.find(level => level.label === 'normal');
         const normalFeePerUnit = normalFeeLevel?.feePerUnit ?? STELLAR_DEFAULT_FEE_STROOPS;
 

--- a/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
+++ b/suite-native/module-trading/src/components/general/MyAssetSheet/MyAssetFilterTabs.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { useTranslate } from '@suite-native/intl';
 import { type FilterItem, FilterTabs } from '@suite-native/trading-atoms';
 
@@ -19,6 +21,7 @@ const MyAssetFilterTabsContent = ({
     onSelectedNetworkFilter,
     availableNetworks,
 }: Omit<MyAssetFilterTabsProps, 'isVisible'>) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [selectedValue, setSelectedValue] = useState<NetworkSymbol | undefined>(undefined);
 
     const { translate } = useTranslate();
@@ -37,7 +40,7 @@ const MyAssetFilterTabsContent = ({
                 value: undefined,
             },
             ...availableNetworks.map(symbol => ({
-                label: getNetwork(symbol).name,
+                label: getNetworkConfig(symbol).name,
                 value: symbol,
             })),
         ],

--- a/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx
+++ b/suite-native/module-trading/src/components/general/TradeableAssetNetworkInfo.tsx
@@ -1,6 +1,7 @@
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { invariant } from '@suite-common/suite-utils';
-import { cryptoIdToNetworkSymbol } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { cryptoIdToSymbol } from '@suite-common/trading';
 import { Box, HStack, Text } from '@suite-native/atoms';
 import { NetworkIcon } from '@suite-native/icons';
 import { useTranslate } from '@suite-native/intl';
@@ -11,6 +12,7 @@ export type TradeableAssetNetworkInfoProps = {
 };
 
 export const TradeableAssetNetworkInfo = ({ asset }: TradeableAssetNetworkInfoProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { translate } = useTranslate();
 
     if (!asset) {
@@ -18,10 +20,10 @@ export const TradeableAssetNetworkInfo = ({ asset }: TradeableAssetNetworkInfoPr
     }
 
     const { cryptoId, contractAddress } = asset;
-    const symbol = cryptoIdToNetworkSymbol(cryptoId);
+    const symbol = cryptoIdToSymbol({ getNetworkConfig }, cryptoId);
     invariant(symbol, 'Symbol should be defined');
 
-    const { displaySymbol, name } = getNetwork(symbol);
+    const { displaySymbol, name } = getNetworkConfig(symbol);
     const showForNativeToken = displaySymbol === 'ETH' && symbol !== 'eth';
     const shouldShowNetwork = showForNativeToken || contractAddress;
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -4,8 +4,9 @@ import { useSelector } from 'react-redux';
 
 import type { BuyCryptoPaymentMethod, BuyTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type TradingAmountLimitProps, selectTradingBuyQuotesRequest } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useForm, useWatch } from '@suite-native/forms';
@@ -83,6 +84,7 @@ const useBuyQuotesChangeEffect = ({ getValues, setValue }: BuyFormType) => {
 };
 
 const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [asset, quote] = useWatch({ control, name: ['asset', 'quote'] });
     const symbol = getSymbolFromTradeableAsset(asset);
 
@@ -112,7 +114,7 @@ const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) 
                 isAmountInSats && truncatedCryptoAmount && symbol
                     ? convertAmountUnitsToSubunits(
                           truncatedCryptoAmount,
-                          getNetwork(symbol).decimals,
+                          getNetworkConfig(symbol).decimals,
                       )
                     : truncatedCryptoAmount;
             setValue('cryptoValue', value);

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -3,6 +3,8 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import type { ExchangeTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type TradingExchangeAmountLimitProps,
     exchangeThunks,
@@ -10,7 +12,6 @@ import {
     selectTradingExchangeProviders,
     selectTradingExchangeQuotesRequest,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useForm, useWatch } from '@suite-native/forms';
@@ -87,6 +88,7 @@ const useExchangeQuotesChangeEffect = ({ getValues, setValue }: ExchangeFormType
 };
 
 const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [selectedQuote, receiveAsset] = useWatch({
         control,
         name: ['quote', 'receiveAsset'],
@@ -107,7 +109,7 @@ const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) =
 
         const value =
             isAmountInSats && amount && symbol
-                ? convertAmountUnitsToSubunits(amount, getNetwork(symbol).decimals)
+                ? convertAmountUnitsToSubunits(amount, getNetworkConfig(symbol).decimals)
                 : amount;
         setValue('receiveCryptoAmount', value, { shouldValidate: true });
     }, [selectedQuote, isAmountInSats, symbol, setValue]);

--- a/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.tsx
+++ b/suite-native/module-trading/src/hooks/general/useAmountInputDecimals.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import { type Account, type TokenAddress } from '@suite-common/wallet-types';
 import { type TokensRootState, selectAccountTokenDecimals } from '@suite-native/tokens';
 
@@ -8,6 +9,7 @@ export const useAmountInputDecimals = (
     account?: Account,
     contractAddress?: TokenAddress,
 ): number | undefined => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const tokenDecimals = useSelector((state: TokensRootState) =>
         selectAccountTokenDecimals(state, account?.key, contractAddress),
     );
@@ -16,5 +18,5 @@ export const useAmountInputDecimals = (
         return tokenDecimals === null ? undefined : tokenDecimals;
     }
 
-    return account?.symbol ? getNetwork(account.symbol).decimals : undefined;
+    return account?.symbol ? getNetworkConfig(account.symbol).decimals : undefined;
 };

--- a/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useComposeTradingTransaction.ts
@@ -1,12 +1,14 @@
 import { useCallback } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type MessageSystemRootState } from '@suite-common/message-system';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type TradingRootStateWithDeviceAndAccounts,
     selectTradingAccountKeyByTradeType,
 } from '@suite-common/trading';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type FeesRootState,
     type FormDraftRootState,
@@ -35,6 +37,7 @@ type UseComposeTradingTransactionProps = {
 };
 
 export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTransactionProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
     const store = useStore<TradingTransactionRootState>();
 
@@ -77,7 +80,7 @@ export const useComposeTradingTransaction = ({ tradeType }: UseComposeTradingTra
                 composeTradingTransactionThunk({
                     tradeType,
                     account: sendAccount,
-                    network: getNetwork(sendAccount.symbol),
+                    network: getNetworkConfig(sendAccount.symbol),
                     feeInfo: networkFeeInfo,
                     selectedFeeLevel: draft?.selectedFee as FeeLevelLabel,
                     feePerUnit: draft?.feePerUnit,

--- a/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.ts
+++ b/suite-native/module-trading/src/hooks/general/useConvertFormValueToBaseUnit.ts
@@ -1,21 +1,20 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import {
-    type NetworkSymbol,
-    type NetworkSymbolExtended,
-    getNetwork,
-} from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol, type NetworkSymbolExtended } from '@suite-common/wallet-config';
 import { selectAreSatsAmountUnit } from '@suite-common/wallet-core';
 import { satoshiAmountToBtc } from '@suite-common/wallet-utils';
 
 export const useConvertFormValueToBaseUnit = () => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const areSatsAmountUnit = useSelector(selectAreSatsAmountUnit);
 
     const getIsAmountInSats = useCallback(
         (symbol: NetworkSymbolExtended) => {
             // this is copy of selectIsAmountInSats logic
-            const network = getNetwork(symbol as NetworkSymbol);
+            const network = getNetworkConfig(symbol as NetworkSymbol);
             const isAmountUnitSupported = !!network && network.features.includes('amount-unit');
 
             return isAmountUnitSupported && areSatsAmountUnit;

--- a/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
+++ b/suite-native/module-trading/src/hooks/general/useTradingTransaction.ts
@@ -4,7 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { isFulfilled } from '@reduxjs/toolkit';
 import type { ExchangeTrade, SellFiatTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { type MessageSystemRootState } from '@suite-common/message-system';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type TradingFulfillValue,
     type TradingRootStateWithDeviceAndAccounts,
@@ -17,7 +19,6 @@ import {
     selectTradingSellSelectedQuote,
     sellThunks,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FormDraftRootState,
@@ -82,6 +83,7 @@ export const useTradingTransaction = ({
     processResponseData,
     triggerAnalyticsTradeConfirmation,
 }: UseTradingTransactionProps): UseTradingTransactionReturnProps => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const dispatch = useDispatch();
 
     const sendAccountKey = useSelector((state: TradingRootState) =>
@@ -188,7 +190,7 @@ export const useTradingTransaction = ({
                 return false;
             }
 
-            const network = getNetwork(sendAccount.symbol);
+            const network = getNetworkConfig(sendAccount.symbol);
             const decimals = tokenDecimals ?? network.decimals;
 
             try {

--- a/suite-native/module-trading/src/hooks/sell/useSellForm.ts
+++ b/suite-native/module-trading/src/hooks/sell/useSellForm.ts
@@ -3,12 +3,13 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import type { SellFiatTrade } from 'invity-api';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
 import {
     type TradingAmountLimitProps,
     selectTradingSellQuotesRequest,
     selectValidTradingSellQuotes,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState, selectIsAmountInSats } from '@suite-common/wallet-core';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 import { useForm, useWatch } from '@suite-native/forms';
@@ -73,6 +74,7 @@ const useSellQuotesChangeEffect = ({ getValues, setValue }: SellFormType) => {
 };
 
 const useSellQuoteChangeEffect = ({ control, getValues, setValue }: SellFormType) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const [sendAsset, quote] = useWatch({ control, name: ['sendAsset', 'quote'] });
     const symbol = getSymbolFromTradeableAsset(sendAsset);
 
@@ -102,7 +104,7 @@ const useSellQuoteChangeEffect = ({ control, getValues, setValue }: SellFormType
                 isAmountInSats && truncatedCryptoAmount && symbol
                     ? convertAmountUnitsToSubunits(
                           truncatedCryptoAmount,
-                          getNetwork(symbol).decimals,
+                          getNetworkConfig(symbol).decimals,
                       )
                     : truncatedCryptoAmount;
             setValue('cryptoStringAmount', value, { shouldValidate: true });

--- a/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormEthereumNativeThunks.ts
@@ -7,7 +7,6 @@ import {
     verifyEthereumStakingCalldata,
     verifyEthereumStakingLiveState,
 } from '@suite-common/staking';
-import { getNetwork } from '@suite-common/wallet-config';
 import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import {
     ethereumGetCurrentNonceThunk,
@@ -106,7 +105,7 @@ const prepareEthereumStakingContext = (
         return failed('Ethereum account not found.');
     }
 
-    const { chainId } = getNetwork(account.symbol);
+    const { chainId } = getNetworkConfig(account.symbol);
     if (!chainId) {
         return failed(
             'Chain ID not found for network.',

--- a/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
+++ b/suite-native/staking/src/stakeFormSolanaNativeThunks.ts
@@ -1,7 +1,7 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { composeSolanaStakingTransaction, prepareSolanaStakeTxData } from '@suite-common/staking';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import {
     selectAccountByKey,
@@ -124,7 +124,7 @@ export const composeSolanaStakingTransactionFeeLevelsNativeThunk = createThunk<
     { rejectValue: SolanaStakingComposeRejectValue }
 >(
     `${STAKE_NATIVE_MODULE_PREFIX}/${COMPOSE_LOG_PREFIX}`,
-    async ({ accountKey, stakeType, amount }, { getState, rejectWithValue }) => {
+    async ({ accountKey, stakeType, amount }, { getState, rejectWithValue, extra }) => {
         if (!amount || amount === '0') return undefined;
 
         const resolved = await resolveSolanaStakingContext(getState(), accountKey);
@@ -141,7 +141,7 @@ export const composeSolanaStakingTransactionFeeLevelsNativeThunk = createThunk<
             formValues: buildSolanaStakeFormState(account, amount, stakeType),
             composeContext: {
                 account,
-                network: getNetwork(account.symbol),
+                network: extra.services.getNetworkConfig(account.symbol),
                 feeInfo,
             },
             blockchainUrl,

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -24,6 +24,7 @@ import {
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
 import { selectAllLabelsForAccount, selectIsSuiteSyncEnabled } from '@suite-common/suite-sync';
+import { type NetworkConfigDeps } from '@suite-common/wallet-config';
 import { createAccountRefreshThrottle } from '@suite-common/wallet-core';
 import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
@@ -60,6 +61,15 @@ type NativeAppDeps = {
 } & EnsureEncryptionKeyDep &
     MMKVStorageDep;
 
+const networkModules = createNetworksCompositionRoot();
+const networkModuleRepository = createNetworkModuleRepository({ networkModules });
+const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
+
+export const nativeNetworkConfigDeps: NetworkConfigDeps = {
+    networkModuleRepository,
+    getNetworkConfig,
+};
+
 export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices => {
     const platformEncryption = createNativePlatformEncryption({
         ensureEncryptionKey: deps.ensureEncryptionKey,
@@ -89,9 +99,6 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
         updateAddressLabel: suiteSync.labeling.updateAddressLabel,
         updateOutputLabel: suiteSync.labeling.updateOutputLabel,
     });
-    const networkModules = createNetworksCompositionRoot();
-    const networkModuleRepository = createNetworkModuleRepository({ networkModules });
-    const getNetworkConfig = createGetNetworkConfig({ networkModuleRepository });
     const findNetworkSymbolForProtocol = createFindNetworkSymbolForProtocol({
         getNetworkConfig,
         networkModuleRepository,

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -18,7 +18,7 @@ import { suiteSyncQuotaManagerReducer } from '@suite-common/suite-sync-quota-man
 import { prepareThpReducer } from '@suite-common/thp';
 import { createNotificationsReducer } from '@suite-common/toast-notifications';
 import { prepareTokenDefinitionsReducer } from '@suite-common/token-definitions';
-import { networkSymbolCollection } from '@suite-common/wallet-config';
+import { getNetworks } from '@suite-common/wallet-config';
 import {
     accountsRefreshTimeReducer,
     feesReducer,
@@ -81,7 +81,7 @@ import { tradingInitialState, tradingSlice } from '@suite-native/trading-state';
 import { prepareSendFormReducer } from '@suite-native/transaction-management';
 
 import { appReducer } from './appSlice';
-import { extraDependencies } from './extraDependencies';
+import { extraDependencies, nativeNetworkConfigDeps } from './extraDependencies';
 import { receivePersistTransform } from './receivePersistTransform';
 
 const transactionsReducer = prepareTransactionsReducer(extraDependencies);
@@ -109,6 +109,7 @@ const thpReducer = prepareThpReducer(extraDependencies);
 type PrepareRootReducersDeps = MMKVStorageDep;
 
 export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
+    const networkSymbols = getNetworks(nativeNetworkConfigDeps).map(network => network.symbol);
     const appSettingsPersistedReducer = preparePersistReducer({
         reducer: appSettingsReducer,
         persistedKeys: appSettingsPersistWhitelist,
@@ -123,7 +124,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
 
     const blockchainPersistedReducer = preparePersistReducer({
         reducer: blockchainReducer,
-        persistedKeys: networkSymbolCollection,
+        persistedKeys: networkSymbols,
         key: 'blockchain',
         version: 1,
         transforms: [blockchainPersistTransform],
@@ -132,7 +133,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
 
     const explorerPersistedReducer = preparePersistReducer({
         reducer: explorerReducer,
-        persistedKeys: networkSymbolCollection,
+        persistedKeys: networkSymbols,
         key: 'explorer',
         version: 1,
         transforms: [explorerPersistTransform],
@@ -209,6 +210,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         version: 4,
         migrations: {
             1: initialMigrateAppSettingsAndDiscoveryConfig({
+                ...nativeNetworkConfigDeps,
                 mmkvStorage: deps.mmkvStorage,
                 getStoredState,
             }),
@@ -304,7 +306,10 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
             4: (oldState: any /* FIXME */) => {
                 if (!oldState?.accounts) return oldState;
 
-                return { ...oldState, accounts: sortAccountsByCoin(oldState.accounts) };
+                return {
+                    ...oldState,
+                    accounts: sortAccountsByCoin(nativeNetworkConfigDeps, oldState.accounts),
+                };
             },
         },
         transforms: [walletStopPersistTransform],
@@ -581,7 +586,10 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
                     ...oldState,
                     wallet: {
                         ...oldState.wallet,
-                        accounts: sortAccountsByCoin(oldState.wallet.accounts),
+                        accounts: sortAccountsByCoin(
+                            nativeNetworkConfigDeps,
+                            oldState.wallet.accounts,
+                        ),
                     },
                 };
             },

--- a/suite-native/storage/src/migrations/account/accountV4.test.ts
+++ b/suite-native/storage/src/migrations/account/accountV4.test.ts
@@ -1,3 +1,5 @@
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
+
 import { sortAccountsByCoin } from './v4';
 
 describe('sortAccountsByCoin', () => {
@@ -10,7 +12,7 @@ describe('sortAccountsByCoin', () => {
             { symbol: 'btc', accountType: 'normal', index: 0 },
         ];
 
-        expect(sortAccountsByCoin(oldAccounts)).toEqual([
+        expect(sortAccountsByCoin(mockNetworkConfigDeps, oldAccounts)).toEqual([
             { symbol: 'btc', accountType: 'normal', index: 0 },
             { symbol: 'btc', accountType: 'normal', index: 1 },
             { symbol: 'btc', accountType: 'legacy', index: 0 },
@@ -25,7 +27,7 @@ describe('sortAccountsByCoin', () => {
             { symbol: 'deprecatedcoin', accountType: 'normal', index: 0 },
         ];
 
-        expect(sortAccountsByCoin(oldAccounts)).toEqual([
+        expect(sortAccountsByCoin(mockNetworkConfigDeps, oldAccounts)).toEqual([
             { symbol: 'deprecatedcoin', accountType: 'normal', index: 0 },
             { symbol: 'btc', accountType: 'normal', index: 0 },
         ]);
@@ -37,7 +39,7 @@ describe('sortAccountsByCoin', () => {
             { symbol: 'btc', accountType: 'normal', index: 0 },
         ];
 
-        sortAccountsByCoin(oldAccounts);
+        sortAccountsByCoin(mockNetworkConfigDeps, oldAccounts);
 
         expect(oldAccounts[0]?.symbol).toBe('eth');
     });

--- a/suite-native/storage/src/migrations/account/v4.ts
+++ b/suite-native/storage/src/migrations/account/v4.ts
@@ -1,4 +1,4 @@
-import { networkSymbolCollection, networks } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, getNetworks, isNetworkSymbol } from '@suite-common/wallet-config';
 
 type AccountLike = {
     symbol: string;
@@ -6,11 +6,13 @@ type AccountLike = {
     index: number;
 };
 
-const getNetworkOrder = (symbol: string) =>
-    (networkSymbolCollection as readonly string[]).indexOf(symbol);
+const getNetworkOrder = (deps: NetworkConfigDeps, symbol: string) =>
+    getNetworks(deps).findIndex(network => network.symbol === symbol);
 
-const getAccountTypeOrder = ({ symbol, accountType }: AccountLike) => {
-    const network = (networks as Record<string, { accountTypes: Record<string, unknown> }>)[symbol];
+const getAccountTypeOrder = (deps: NetworkConfigDeps, { symbol, accountType }: AccountLike) => {
+    if (!isNetworkSymbol(deps, symbol)) return -1;
+
+    const network = deps.getNetworkConfig(symbol);
 
     return network ? Object.keys(network.accountTypes).indexOf(accountType) : -1;
 };
@@ -19,12 +21,15 @@ const getAccountTypeOrder = ({ symbol, accountType }: AccountLike) => {
  * Mirrors `compareAccountsByCoin` from @suite-common/wallet-utils, but tolerates accounts
  * of networks missing from the current config because persisted data may predate it.
  */
-export const sortAccountsByCoin = <T extends AccountLike>(oldAccounts: T[]): T[] =>
+export const sortAccountsByCoin = <T extends AccountLike>(
+    deps: NetworkConfigDeps,
+    oldAccounts: T[],
+): T[] =>
     [...oldAccounts].sort((a, b) => {
-        const networkOrder = getNetworkOrder(a.symbol) - getNetworkOrder(b.symbol);
+        const networkOrder = getNetworkOrder(deps, a.symbol) - getNetworkOrder(deps, b.symbol);
         if (networkOrder !== 0) return networkOrder;
 
-        const accountTypeOrder = getAccountTypeOrder(a) - getAccountTypeOrder(b);
+        const accountTypeOrder = getAccountTypeOrder(deps, a) - getAccountTypeOrder(deps, b);
         if (accountTypeOrder !== 0) return accountTypeOrder;
 
         return a.index - b.index;

--- a/suite-native/storage/src/migrations/walletSettings/v1.ts
+++ b/suite-native/storage/src/migrations/walletSettings/v1.ts
@@ -1,6 +1,7 @@
 import { pipe } from '@mobily/ts-belt';
 import { type PersistedState, type getStoredState } from 'redux-persist';
 
+import { type NetworkModuleRepositoryDep } from '@suite-common/networks';
 import { type NetworkSymbol, isNetworkSymbol } from '@suite-common/wallet-config';
 import { type WalletSettings } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode, isBaseCurrencyCode } from '@trezor/blockchain-link-types';
@@ -55,8 +56,10 @@ const migrateBscNetworkSymbol = (oldEnabledDiscoveryNetworkSymbols: string[]): s
         networkSymbol === 'bnb' ? 'bsc' : networkSymbol,
     );
 
-const filterUnknownNetworkSymbols = (networkSymbols: string[]): NetworkSymbol[] =>
-    networkSymbols.filter(networkSymbol => isNetworkSymbol(networkSymbol));
+const filterUnknownNetworkSymbols = (
+    deps: NetworkModuleRepositoryDep,
+    networkSymbols: string[],
+): NetworkSymbol[] => networkSymbols.filter(networkSymbol => isNetworkSymbol(deps, networkSymbol));
 
 /**
  * Migration of discoveryConfig slice, which was declared locally in suite-native,
@@ -64,6 +67,7 @@ const filterUnknownNetworkSymbols = (networkSymbols: string[]): NetworkSymbol[] 
  * All migrations that were done on discoveryConfig are moved here
  */
 const migrateDiscoveryConfigToWalletSettings = (
+    deps: NetworkModuleRepositoryDep,
     discoveryConfig: object,
 ): NetworkSymbol[] | undefined => {
     if (!('enabledDiscoveryNetworkSymbols' in discoveryConfig)) {
@@ -77,13 +81,14 @@ const migrateDiscoveryConfigToWalletSettings = (
     return pipe(
         discoveryConfig.enabledDiscoveryNetworkSymbols,
         migrateBscNetworkSymbol,
-        filterUnknownNetworkSymbols,
+        networkSymbols => filterUnknownNetworkSymbols(deps, networkSymbols),
     );
 };
 
-export type MigrationDeps = MMKVStorageDep & {
-    getStoredState: typeof getStoredState;
-};
+export type MigrationDeps = MMKVStorageDep &
+    NetworkModuleRepositoryDep & {
+        getStoredState: typeof getStoredState;
+    };
 
 export const initialMigrateAppSettingsAndDiscoveryConfig =
     (deps: MigrationDeps) => async (walletSettingsState: unknown) => {
@@ -113,7 +118,7 @@ export const initialMigrateAppSettingsAndDiscoveryConfig =
         }
 
         if (discoveryConfig) {
-            const enabledNetworks = migrateDiscoveryConfigToWalletSettings(discoveryConfig);
+            const enabledNetworks = migrateDiscoveryConfigToWalletSettings(deps, discoveryConfig);
 
             if (enabledNetworks) {
                 newState.enabledNetworks = enabledNetworks;

--- a/suite-native/storage/src/migrations/walletSettings/walletSettingsV1.test.ts
+++ b/suite-native/storage/src/migrations/walletSettings/walletSettingsV1.test.ts
@@ -1,6 +1,7 @@
 import { type getStoredState } from 'redux-persist';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 import { PROTO } from '@trezor/connect';
 
 import { initialMigrateAppSettingsAndDiscoveryConfig } from './v1';
@@ -21,6 +22,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -44,6 +46,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoreState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -65,6 +68,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -88,6 +92,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -111,6 +116,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -132,6 +138,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -160,6 +167,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -196,6 +204,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
             });
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })({});
@@ -213,6 +222,7 @@ describe(initialMigrateAppSettingsAndDiscoveryConfig.name, () => {
         const walletSettingsState = { someProperty: 'value' };
 
         const migratedState = await initialMigrateAppSettingsAndDiscoveryConfig({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })(walletSettingsState);

--- a/suite-native/storage/src/migrations/walletSettings/walletSettingsV2.test.ts
+++ b/suite-native/storage/src/migrations/walletSettings/walletSettingsV2.test.ts
@@ -1,5 +1,7 @@
 import { type getStoredState } from 'redux-persist';
 
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
+
 import { migrateAutoEjectToWalletSettings } from './v2';
 import { createMMKVStorageMock } from '../../mmkvStorage.mock';
 
@@ -23,6 +25,7 @@ describe(migrateAutoEjectToWalletSettings.name, () => {
         };
 
         const migrated = await migrateAutoEjectToWalletSettings({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })(oldWalletSettings);
@@ -41,6 +44,7 @@ describe(migrateAutoEjectToWalletSettings.name, () => {
         };
 
         const migrated = await migrateAutoEjectToWalletSettings({
+            ...mockNetworkConfigDeps,
             getStoredState: mockGetStoredState,
             mmkvStorage: createMMKVStorageMock(),
         })(oldWalletSettings);

--- a/suite-native/tokens/src/tokensSelectors.ts
+++ b/suite-native/tokens/src/tokensSelectors.ts
@@ -3,7 +3,7 @@ import { A, pipe } from '@mobily/ts-belt';
 import type { DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector } from '@suite-common/redux-utils';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkConfigDeps, type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type TransactionsRootState,
@@ -136,8 +136,9 @@ export const selectAccountStakeTypeTransactionsWithTokenTransfers = createMemoiz
 export const selectHasDeviceAnyTokensForNetwork = (
     state: TokensRootState,
     symbol: NetworkSymbol,
+    deps: NetworkConfigDeps,
 ) => {
-    if (!isNetworkWithTokens(symbol)) {
+    if (!isNetworkWithTokens(deps, symbol)) {
         return false;
     }
 
@@ -147,10 +148,10 @@ export const selectHasDeviceAnyTokensForNetwork = (
 };
 
 export const selectNetworkSymbolsOfAccountsWithTokensAllowed = createMemoizedSelector(
-    [selectAccounts],
-    accounts =>
+    [selectAccounts, (_state, deps: NetworkConfigDeps) => deps],
+    (accounts, deps) =>
         accounts
-            .filter(a => isNetworkWithTokens(a.symbol))
+            .filter(a => isNetworkWithTokens(deps, a.symbol))
             .reduce((acc, account) => {
                 if (!acc.includes(account.symbol)) {
                     acc.push(account.symbol);

--- a/suite-native/tokens/src/utils.ts
+++ b/suite-native/tokens/src/utils.ts
@@ -1,6 +1,10 @@
 import { G, S } from '@mobily/ts-belt';
 
-import { type NetworkSymbol, getNetworkFeatures } from '@suite-common/wallet-config';
+import {
+    type NetworkConfigDeps,
+    type NetworkSymbol,
+    getNetworkFeatures,
+} from '@suite-common/wallet-config';
 
 export const getTokenName = (tokenName?: string) => {
     if (G.isNullable(tokenName) || S.isEmpty(tokenName)) return 'Unknown token';
@@ -8,5 +12,5 @@ export const getTokenName = (tokenName?: string) => {
     return tokenName;
 };
 
-export const isNetworkWithTokens = (symbol: NetworkSymbol) =>
-    getNetworkFeatures(symbol).includes('tokens');
+export const isNetworkWithTokens = (deps: NetworkConfigDeps, symbol: NetworkSymbol) =>
+    getNetworkFeatures(deps, symbol).includes('tokens');

--- a/suite-native/trading-atoms/src/components/NetworkBadge.tsx
+++ b/suite-native/trading-atoms/src/components/NetworkBadge.tsx
@@ -1,4 +1,6 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { Badge } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 
@@ -7,9 +9,10 @@ export type PlatformBadgeProps = {
 };
 
 export const NetworkBadge = ({ symbol }: PlatformBadgeProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const { translate } = useTranslate();
 
-    const networkName = getNetwork(symbol).name;
+    const networkName = getNetworkConfig(symbol).name;
 
     return (
         <Badge

--- a/suite-native/trading-state/src/selectors/commonSelectors.ts
+++ b/suite-native/trading-state/src/selectors/commonSelectors.ts
@@ -25,11 +25,7 @@ import {
     selectTradingSupportedSymbols,
     toTokenCryptoId,
 } from '@suite-common/trading';
-import {
-    getNetwork,
-    getNetworkDisplaySymbolName,
-    getNetworkType,
-} from '@suite-common/wallet-config';
+import { getNetworkDisplaySymbolName, getNetworkType } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FiatRatesRootState,
@@ -272,7 +268,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
             // TODO: Remove this filter when Cardano send is implemented (#15068)
             // Currently filtering out Cardano accounts and tokens from trading until Cardano send is supported
             const filteredAccounts = accounts.filter(account => {
-                if (!getNetwork(account.symbol).tradeCryptoId) {
+                if (!getNetworkConfig(account.symbol).tradeCryptoId) {
                     return false;
                 }
                 const networkType = getNetworkType(account.symbol);
@@ -345,7 +341,7 @@ export const selectAccountsWithTokensToSellSectionListByTradingType =
                         });
 
                     const cryptoId = toCaseAwareCryptoId(
-                        getNetwork(account.symbol).tradeCryptoId as CryptoId,
+                        getNetworkConfig(account.symbol).tradeCryptoId as CryptoId,
                     );
 
                     const accountAsset = {
@@ -470,7 +466,7 @@ export const selectAccountLabelWithNetworkFallback = (
     if (cryptoId) {
         const networkSymbol = cryptoIdToNetworkSymbol(cryptoId);
         if (networkSymbol) {
-            return getNetwork(networkSymbol).name;
+            return getNetworkConfig(networkSymbol).name;
         }
     }
 

--- a/suite-native/transaction-management/src/components/NetworkReserveBanner.tsx
+++ b/suite-native/transaction-management/src/components/NetworkReserveBanner.tsx
@@ -2,7 +2,9 @@ import { useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { selectGetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { getNetworkReserve } from '@suite-common/wallet-utils';
 import { InlineAlertBox } from '@suite-native/atoms';
@@ -22,10 +24,12 @@ type NetworkReserveBannerProps = {
 };
 
 export const NetworkReserveBanner = ({ symbol, contractAddress }: NetworkReserveBannerProps) => {
+    const { getNetworkConfig } = useServices(selectGetNetworkConfigDep);
     const navigation = useNavigation<NavigationProps>();
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     const networkReserve = getNetworkReserve({
+        getNetworkConfig,
         symbol,
         contractAddress,
         isEnabled: isNetworkReserveEnabled,
@@ -33,7 +37,7 @@ export const NetworkReserveBanner = ({ symbol, contractAddress }: NetworkReserve
 
     if (!networkReserve) return null;
 
-    const { displaySymbol } = getNetwork(symbol);
+    const { displaySymbol } = getNetworkConfig(symbol);
 
     const handleManagePress = () => {
         navigation.navigate(RootStackRoutes.SettingsScreenStack, {

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.tsx
@@ -1,7 +1,8 @@
 import { type LayoutChangeEvent, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type AccountKey,
     type FormDraftWithSendKeyPrefix,
@@ -100,6 +101,7 @@ export const ReviewOutputSummaryItem = ({
     flowType,
     prefix,
 }: ReviewOutputSummaryItemProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translate } = useTranslate();
 
     const isClearSignedTradingSwap = useSelector((state: TransactionReviewOutputsState) =>
@@ -110,7 +112,7 @@ export const ReviewOutputSummaryItem = ({
         return null;
     }
     const { state, totalSpent, fee } = summaryOutput;
-    const isNetworkSupportingTokens = isNetworkWithTokens(symbol);
+    const isNetworkSupportingTokens = isNetworkWithTokens(networkConfigDeps, symbol);
 
     return (
         <View onLayout={onLayout}>

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFee.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useRef } from 'react';
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 
-import { type NetworkSymbol, type NetworkType, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    type NetworkType,
+    getNetworkType,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type AccountKey, type FormState } from '@suite-common/wallet-types';
 import { Box, Button, useBottomSheetModal } from '@suite-native/atoms';
 import { useFormContext, useWatch } from '@suite-native/forms';
@@ -118,7 +124,8 @@ const CustomFeeContentWrapper = ({ accountKey, formDraft, onCustomFeeSet }: Cust
 const CUSTOM_FEE_UNSUPPORTED_NETWORK_TYPES: NetworkType[] = ['solana', 'tron'];
 
 export const CustomFee = ({ accountKey, symbol, formDraft, onCustomFeeSet }: CustomFeeProps) => {
-    const networkType = getNetworkType(symbol);
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const networkType = getNetworkType(networkConfigDeps, symbol);
     if (CUSTOM_FEE_UNSUPPORTED_NETWORK_TYPES.includes(networkType)) {
         return null;
     }

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeCard.tsx
@@ -1,7 +1,8 @@
 import Animated, { FadeInLeft, FadeOutLeft } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkType, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
 import { type AccountKey, isFinalPrecomposedTransaction } from '@suite-common/wallet-types';
 import { Box, Button, Card, HStack, VStack } from '@suite-native/atoms';
@@ -23,6 +24,7 @@ const cardStyle = prepareNativeStyle(utils => ({
 }));
 
 export const CustomFeeCard = ({ accountKey, onEdit, onCancel }: CustomFeeCardProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { applyStyle } = useNativeStyles();
 
     const feeLevels = useSelector(selectFeeLevels);
@@ -37,7 +39,7 @@ export const CustomFeeCard = ({ accountKey, onEdit, onCancel }: CustomFeeCardPro
         return null;
     }
 
-    const networkType = getNetworkType(symbol);
+    const networkType = getNetworkType(networkConfigDeps, symbol);
 
     return (
         <Animated.View entering={FadeInLeft.delay(300)} exiting={FadeOutLeft}>

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.tsx
@@ -1,6 +1,11 @@
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    getNetworkType,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import {
     type FeesRootState,
     selectConvertedNetworkFeeInfo,
@@ -23,12 +28,15 @@ export type CustomFeeInputsProps = {
 };
 
 export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { translate } = useTranslate();
     const feeInfo = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeInfo(state, symbol),
+        selectConvertedNetworkFeeInfo(state, symbol, networkConfigDeps),
     );
 
-    const isEip1559Fee = useSelector((state: FeesRootState) => selectIsEip1559Fee(state, symbol));
+    const isEip1559Fee = useSelector((state: FeesRootState) =>
+        selectIsEip1559Fee(state, symbol, networkConfigDeps),
+    );
     const debounce = useDebounce();
     const {
         formState: { errors },
@@ -38,7 +46,7 @@ export const CustomFeeInputs = ({ symbol }: CustomFeeInputsProps) => {
 
     const hasFeePerByteError = isNotNullOrUndefined(errors[FEE_PER_UNIT_FIELD_NAME]);
 
-    const networkType = getNetworkType(symbol);
+    const networkType = getNetworkType(networkConfigDeps, symbol);
     const feeUnits = getFeeUnits(networkType);
     const formattedFeePerUnit = `${feeInfo?.minFee} ${feeUnits}`;
 

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOption.tsx
@@ -8,7 +8,13 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol, type NetworkType, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    type NetworkType,
+    getNetworkType,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import {
     EVM_FEE_RATE_DECIMALS,
     type FeesRootState,
@@ -103,15 +109,16 @@ export const FeeOption = ({
     isLoading = false,
     onSelectedFeeLevel,
 }: FeeOptionProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const { utils, applyStyle } = useNativeStyles();
     const { control, setValue } = useContext(FormContext);
 
     const feeTimeEstimate = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeLevelTimeEstimate(state, symbol, feeKey),
+        selectConvertedNetworkFeeLevelTimeEstimate(state, symbol, feeKey, networkConfigDeps),
     );
 
     const backendFeePerUnit = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeLevelFeePerUnit(state, symbol, feeKey),
+        selectConvertedNetworkFeeLevelFeePerUnit(state, symbol, feeKey, networkConfigDeps),
     );
 
     const areFeeValuesComplete = isFinalPrecomposedTransaction(feeLevel);
@@ -140,7 +147,7 @@ export const FeeOption = ({
     );
 
     const label = feeLabelsMap[feeKey];
-    const networkType = getNetworkType(symbol);
+    const networkType = getNetworkType(networkConfigDeps, symbol);
     const feeUnits = getFeeUnits(networkType);
 
     // If trezor-connect was not able to compose the fee level (e.g. insufficient account balance), we have to mock its value.

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.tsx
@@ -1,6 +1,11 @@
 import { D, pipe } from '@mobily/ts-belt';
 
-import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    getNetworkType,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
 import { VStack } from '@suite-native/atoms';
 
@@ -33,7 +38,8 @@ export const FeeOptionsList = ({
     isLoading,
     onSelectedFeeLevel,
 }: FeeOptionsListProps) => {
-    const isBtcNetworkType = getNetworkType(symbol) === 'bitcoin';
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+    const isBtcNetworkType = getNetworkType(networkConfigDeps, symbol) === 'bitcoin';
 
     const predefinedFeeLevels = pipe(
         feeLevels,

--- a/suite-native/transaction-management/src/feesFormSchema.test.ts
+++ b/suite-native/transaction-management/src/feesFormSchema.test.ts
@@ -1,14 +1,12 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import { type FeesFormContext, feesFormValidationSchema } from './feesFormSchema';
 
-const btcSymbol = asNetworkSymbol('btc');
-const ethSymbol = asNetworkSymbol('eth');
-const adaSymbol = asNetworkSymbol('ada');
-
 describe('feesFormValidationSchema', () => {
     const createContext = (overrides: Partial<FeesFormContext> = {}): FeesFormContext => ({
-        symbol: ethSymbol,
+        ...mockNetworkConfigDeps,
+        symbol: 'eth' as NetworkSymbol,
         isEip1559Fee: false,
         networkFeeInfo: {
             minFee: 100,
@@ -42,7 +40,7 @@ describe('feesFormValidationSchema', () => {
                 customFeePerUnit: '100.50',
                 customFeeLimit: '1000',
             };
-            const context = createContext({ symbol: btcSymbol });
+            const context = createContext({ symbol: 'btc' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -87,7 +85,7 @@ describe('feesFormValidationSchema', () => {
                 customFeePerUnit: '100.50', // Valid for Bitcoin (2 decimals)
                 customFeeLimit: '1000',
             };
-            const context = createContext({ symbol: btcSymbol, minimalFeeLimit: '21000' });
+            const context = createContext({ symbol: 'btc', minimalFeeLimit: '21000' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -98,7 +96,7 @@ describe('feesFormValidationSchema', () => {
     describe('decimals validation', () => {
         it('should accept correct decimals for bitcoin', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.50' };
-            const context = createContext({ symbol: btcSymbol });
+            const context = createContext({ symbol: 'btc' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -107,10 +105,7 @@ describe('feesFormValidationSchema', () => {
 
         it('should reject too many decimals for bitcoin', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.123' };
-            const context = createContext({
-                symbol: btcSymbol,
-                translate: () => 'Too many decimals.',
-            });
+            const context = createContext({ symbol: 'btc', translate: () => 'Too many decimals.' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).rejects.toThrow(
                 'Too many decimals.',
@@ -119,7 +114,7 @@ describe('feesFormValidationSchema', () => {
 
         it('should pass for non-bitcoin/ethereum networks', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.123456789012345' };
-            const context = createContext({ symbol: adaSymbol });
+            const context = createContext({ symbol: 'ada' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,

--- a/suite-native/transaction-management/src/feesFormSchema.ts
+++ b/suite-native/transaction-management/src/feesFormSchema.ts
@@ -1,5 +1,6 @@
+import { type GetNetworkConfigDep } from '@suite-common/networks';
 import { yup } from '@suite-common/validators';
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type FeeInfo, type FeeLevelLabel } from '@suite-common/wallet-types';
 import { isDecimalsValid } from '@suite-common/wallet-utils';
 import type { UseFormReturn } from '@suite-native/forms';
@@ -8,7 +9,7 @@ import { BigNumber } from '@trezor/utils';
 
 import { getFeeDecimals } from './utils';
 
-export type FeesFormContext = {
+export type FeesFormContext = GetNetworkConfigDep & {
     symbol?: NetworkSymbol;
     networkFeeInfo?: FeeInfo;
     minimalFeeLimit?: string;
@@ -21,15 +22,15 @@ const FeeLevelLabels: Array<FeeLevelLabel> = ['economy', 'low', 'normal', 'high'
 const validateFeeDecimalLength = (value: string | undefined, context: Partial<FeesFormContext>) => {
     if (!value) return true;
 
-    const { networkFeeInfo, symbol } = context;
+    const { networkFeeInfo, symbol, getNetworkConfig } = context;
 
-    if (!symbol) return false;
+    if (!symbol || !getNetworkConfig) return false;
 
-    const { networkType } = getNetwork(symbol);
+    const { networkType } = getNetworkConfig(symbol);
 
     if (!networkFeeInfo || !networkType) return false;
 
-    const maxDecimals = getFeeDecimals({ symbol });
+    const maxDecimals = getFeeDecimals({ getNetworkConfig, symbol });
 
     if (maxDecimals === null) return true;
 
@@ -99,11 +100,12 @@ export const feesFormValidationSchema = yup.object({
 
         function (value) {
             if (!value) return true;
-            const { symbol, minimalFeeLimit, translate } = this.options.context as FeesFormContext;
+            const { symbol, minimalFeeLimit, translate, getNetworkConfig } = this.options
+                .context as FeesFormContext;
 
             if (!symbol) return true;
 
-            const { networkType } = getNetwork(symbol);
+            const { networkType } = getNetworkConfig(symbol);
 
             if (networkType !== 'ethereum' && networkType !== 'tron') return true;
 

--- a/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useCustomFee.ts
@@ -3,7 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { isRejected } from '@reduxjs/toolkit';
 
+import { useServices } from '@suite-common/dependency-injection';
 import { invariant } from '@suite-common/suite-utils';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -38,6 +40,7 @@ type UseCustomFeeProps = {
 };
 
 export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const debounce = useDebounce();
     const { translate } = useTranslate();
     const dispatch = useDispatch();
@@ -56,7 +59,7 @@ export const useCustomFee = ({ accountKey, formState }: UseCustomFeeProps) => {
     );
 
     const isEip1559Fee = useSelector((state: FeesRootState) =>
-        selectIsEip1559Fee(state, symbol ?? undefined),
+        selectIsEip1559Fee(state, symbol ?? undefined, networkConfigDeps),
     );
 
     const {

--- a/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeeCalculation.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -33,6 +35,7 @@ export const useFeeCalculation = ({
     selectedFeePerUnit,
     selectedSetMaxOutputId,
 }: UseFeeCalculationParams) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -53,7 +56,12 @@ export const useFeeCalculation = ({
         : null;
 
     const feePerUnit = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeLevelFeePerUnit(state, symbol, selectedFeeLevel),
+        selectConvertedNetworkFeeLevelFeePerUnit(
+            state,
+            symbol,
+            selectedFeeLevel,
+            networkConfigDeps,
+        ),
     );
 
     const { areFeesLoading } = useFeesFetching({

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.ts
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type NetworkType, getNetworkType } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkType,
+    getNetworkType,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -67,6 +72,7 @@ export const useFeesForm = ({
     defaultFeeLevel,
     defaultFeePerUnit,
 }: UseFeesFormProps) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -76,14 +82,15 @@ export const useFeesForm = ({
     const feeLevels = useSelector(selectFeeLevels);
 
     const networkFeeInfo = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeInfo(state, account?.symbol),
+        selectConvertedNetworkFeeInfo(state, account?.symbol, networkConfigDeps),
     );
 
     const isEip1559Fee = useSelector((state: FeesRootState) =>
-        selectIsEip1559Fee(state, account?.symbol),
+        selectIsEip1559Fee(state, account?.symbol, networkConfigDeps),
     );
 
     const trimmedFeePerUnit = getFeeValue({
+        ...networkConfigDeps,
         feeRate: defaultFeePerUnit,
         symbol: account?.symbol,
     });
@@ -97,7 +104,9 @@ export const useFeesForm = ({
         ? feeLevels.normal
         : undefined;
 
-    const networkType = account?.symbol ? getNetworkType(account.symbol) : undefined;
+    const networkType = account?.symbol
+        ? getNetworkType(networkConfigDeps, account.symbol)
+        : undefined;
 
     const form = useForm<FeesFormValues>({
         validation: feesFormValidationSchema,
@@ -109,6 +118,7 @@ export const useFeesForm = ({
             customMaxPriorityFeePerGas: normalFee?.maxPriorityFeePerGas,
         },
         context: {
+            ...networkConfigDeps,
             networkFeeInfo,
             symbol: account?.symbol,
             minimalFeeLimit,

--- a/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.ts
@@ -1,5 +1,7 @@
 import { useSelector } from 'react-redux';
 
+import { useServices } from '@suite-common/dependency-injection';
+import { selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -22,6 +24,7 @@ export const useTronFeeBreakdown = ({
     accountKey,
     feeLimitSunOverride,
 }: UseTronFeeBreakdownParams) => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -34,6 +37,7 @@ export const useTronFeeBreakdown = ({
     if (account?.networkType !== 'tron') return null;
 
     const breakdown = calculateTronFeeBreakdown(
+        networkConfigDeps,
         feeLevels.normal,
         account.misc?.tronResources,
         account.symbol,

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol, selectNetworkConfigDeps } from '@suite-common/wallet-config';
 import { selectIsNetworkReserveEnabled } from '@suite-common/wallet-core';
 import { getNetworkReserve } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
@@ -20,11 +21,13 @@ export const useIsNetworkReserveBannerVisible = ({
     balance,
     maxAmount,
 }: UseIsNetworkReserveBannerVisibleParams): boolean => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
     const isNetworkReserveEnabled = useSelector(selectIsNetworkReserveEnabled);
 
     if (!symbol) return false;
 
     const networkReserve = getNetworkReserve({
+        ...networkConfigDeps,
         symbol,
         contractAddress,
         isEnabled: isNetworkReserveEnabled,

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.tsx
@@ -1,6 +1,11 @@
 import { type ReactNode, useMemo } from 'react';
 
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type NetworkSymbol,
+    getNetworkDisplaySymbol,
+    selectNetworkConfigDeps,
+} from '@suite-common/wallet-config';
 import { type PrecomposedTransactionError } from '@suite-common/wallet-types';
 import { Translation } from '@suite-native/intl';
 import { isArrayMember } from '@trezor/utils';
@@ -34,13 +39,17 @@ export const isPrecomposedTransactionError = (
 export const usePrecomposedTransactionError = ({
     error,
     networkSymbol,
-}: UsePrecomposedTransactionErrorProps): ReactNode | null =>
-    useMemo(() => {
+}: UsePrecomposedTransactionErrorProps): ReactNode | null => {
+    const networkConfigDeps = useServices(selectNetworkConfigDeps);
+
+    return useMemo(() => {
         if (!error || !isPrecomposedTransactionError(error)) {
             return null;
         }
 
-        const networkDisplaySymbol = networkSymbol ? getNetworkDisplaySymbol(networkSymbol) : '';
+        const networkDisplaySymbol = networkSymbol
+            ? getNetworkDisplaySymbol(networkConfigDeps, networkSymbol)
+            : '';
 
         switch (error) {
             case 'AMOUNT_NOT_ENOUGH_CURRENCY_FEE':
@@ -90,4 +99,5 @@ export const usePrecomposedTransactionError = ({
                     <Translation id="transactionManagement.precomposedTransaction.errors.amountIsNotEnough" />
                 );
         }
-    }, [error, networkSymbol]);
+    }, [error, networkConfigDeps, networkSymbol]);
+};

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
@@ -1,5 +1,4 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { explorerInitialState } from '@suite-common/wallet-core';
+import { createExplorerInitialState } from '@suite-common/wallet-core';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { act } from '@suite-native/test-utils';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
@@ -7,15 +6,15 @@ import { type WalletAccountTransaction, mockTransaction } from '@suite-native/to
 
 import { useTransactionDetails } from './useTransactionDetails';
 
+const explorerInitialState = createExplorerInitialState();
+
 const mockOpenLink = jest.fn();
-const btcSymbol = asNetworkSymbol('btc');
-const ethSymbol = asNetworkSymbol('eth');
 
 jest.mock('@suite-native/link', () => ({
     useOpenLink: () => mockOpenLink,
 }));
 
-const ACCOUNT_KEY = mockAccountKey({ symbol: btcSymbol, descriptor: 'testDescriptor' });
+const ACCOUNT_KEY = mockAccountKey({ symbol: 'btc', descriptor: 'testDescriptor' });
 const TXID = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
 const TOKEN_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 
@@ -28,7 +27,7 @@ const pendingTransaction: WalletAccountTransaction = {
 
 const transactionWithToken: WalletAccountTransaction = {
     ...confirmedTransaction,
-    symbol: ethSymbol,
+    symbol: 'eth',
     tokens: [
         {
             contract: TOKEN_CONTRACT,

--- a/suite-native/transaction-management/src/thunks.ts
+++ b/suite-native/transaction-management/src/thunks.ts
@@ -2,7 +2,7 @@ import { D, pipe } from '@mobily/ts-belt';
 import { isFulfilled, isRejected } from '@reduxjs/toolkit';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { toNetwork } from '@suite-common/wallet-config';
 import {
     composeSendFormTransactionFeeLevelsThunk,
     selectAccountByKey,
@@ -49,13 +49,17 @@ export const calculateFeeLevelsMaxAmountThunk = createThunk<
     `${TRANSACTION_MANAGEMENT_PREFIX}/calculateMaxAmountThunk`,
     async (
         { formState, accountKey },
-        { dispatch, getState, rejectWithValue, fulfillWithValue },
+        { dispatch, getState, rejectWithValue, fulfillWithValue, extra },
     ) => {
         const account = selectAccountByKey(getState(), accountKey);
         if (!account) throw new Error('Account not found.');
 
-        const networkFeeInfo = selectConvertedNetworkFeeInfo(getState(), account.symbol);
-        const network = getNetwork(account.symbol);
+        const networkFeeInfo = selectConvertedNetworkFeeInfo(
+            getState(),
+            account.symbol,
+            extra.services,
+        );
+        const network = toNetwork(account.symbol, extra.services.getNetworkConfig(account.symbol));
 
         if (!networkFeeInfo) throw new Error('Network fees not found.');
 
@@ -111,10 +115,10 @@ export const calculateCustomFeeLevelThunk = createThunk<
             customMaxFeePerGas,
             customMaxPriorityFeePerGas,
         },
-        { dispatch, getState, fulfillWithValue, rejectWithValue },
+        { dispatch, getState, fulfillWithValue, rejectWithValue, extra },
     ) => {
         const account = selectAccountByKey(getState(), accountKey);
-        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account?.symbol);
+        const feeInfo = selectConvertedNetworkFeeInfo(getState(), account?.symbol, extra.services);
         if (!account) {
             return rejectWithValue('Account not found.');
         }
@@ -123,7 +127,7 @@ export const calculateCustomFeeLevelThunk = createThunk<
             return rejectWithValue('Fee info not found.');
         }
 
-        const network = getNetwork(account.symbol);
+        const network = toNetwork(account.symbol, extra.services.getNetworkConfig(account.symbol));
 
         // make a copy of the form state to avoid mutating the original state
         const formStateCopy = { ...formState };

--- a/suite-native/transaction-management/src/utils.test.ts
+++ b/suite-native/transaction-management/src/utils.test.ts
@@ -1,40 +1,49 @@
-import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { mockNetworkConfigDeps } from '@suite-common/wallet-config/mocks';
 
 import { getFeeDecimals, getFeeValue } from './utils';
-
-const btcSymbol = asNetworkSymbol('btc');
-const adaSymbol = asNetworkSymbol('ada');
-const solSymbol = asNetworkSymbol('sol');
 
 describe('utils', () => {
     describe('getFeeDecimals', () => {
         it.each(['eth', 'pol', 'bsc', 'arb', 'base', 'op', 'etc', 'tsep', 'thod'])(
             'should return 9 decimals for Ethereum network: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBe(9);
+                expect(
+                    getFeeDecimals({ ...mockNetworkConfigDeps, symbol: symbol as NetworkSymbol }),
+                ).toBe(9);
             },
         );
 
         it.each(['btc', 'ltc', 'bch', 'doge', 'zec', 'test', 'regtest'])(
             'should return 2 decimals for Bitcoin network: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBe(2);
+                expect(
+                    getFeeDecimals({ ...mockNetworkConfigDeps, symbol: symbol as NetworkSymbol }),
+                ).toBe(2);
             },
         );
 
         it.each(['ada', 'sol', 'xrp', 'xlm', 'dsol', 'txrp', 'txlm'])(
             'should return null for other network type: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBeNull();
+                expect(
+                    getFeeDecimals({ ...mockNetworkConfigDeps, symbol: symbol as NetworkSymbol }),
+                ).toBeNull();
             },
         );
     });
 
     describe('getFeeValue', () => {
         it('should return undefined when feeRate or symbol is missing', () => {
-            expect(getFeeValue({ feeRate: undefined, symbol: btcSymbol })).toBeUndefined();
-            expect(getFeeValue({ feeRate: '', symbol: btcSymbol })).toBeUndefined();
-            expect(getFeeValue({ feeRate: '100', symbol: undefined })).toBeUndefined();
+            expect(
+                getFeeValue({ ...mockNetworkConfigDeps, feeRate: undefined, symbol: 'btc' }),
+            ).toBeUndefined();
+            expect(
+                getFeeValue({ ...mockNetworkConfigDeps, feeRate: '', symbol: 'btc' }),
+            ).toBeUndefined();
+            expect(
+                getFeeValue({ ...mockNetworkConfigDeps, feeRate: '100', symbol: undefined }),
+            ).toBeUndefined();
         });
 
         it.each([
@@ -44,7 +53,13 @@ describe('utils', () => {
         ])(
             'should round down Bitcoin fees to 2 decimals: %s -> %s (%s)',
             (feeRate, symbol, expected) => {
-                expect(getFeeValue({ feeRate, symbol: asNetworkSymbol(symbol) })).toBe(expected);
+                expect(
+                    getFeeValue({
+                        ...mockNetworkConfigDeps,
+                        feeRate,
+                        symbol: symbol as NetworkSymbol,
+                    }),
+                ).toBe(expected);
             },
         );
 
@@ -55,25 +70,43 @@ describe('utils', () => {
         ])(
             'should round down Ethereum fees to 9 decimals: %s -> %s (%s)',
             (feeRate, symbol, expected) => {
-                expect(getFeeValue({ feeRate, symbol: asNetworkSymbol(symbol) })).toBe(expected);
+                expect(
+                    getFeeValue({
+                        ...mockNetworkConfigDeps,
+                        feeRate,
+                        symbol: symbol as NetworkSymbol,
+                    }),
+                ).toBe(expected);
             },
         );
 
         it('should return original value for networks without decimal limits', () => {
-            expect(getFeeValue({ feeRate: '100.123456789012345', symbol: adaSymbol })).toBe(
-                '100.123456789012345',
-            );
-            expect(getFeeValue({ feeRate: '0.000000000000001', symbol: solSymbol })).toBe(
-                '0.000000000000001',
-            );
+            expect(
+                getFeeValue({
+                    ...mockNetworkConfigDeps,
+                    feeRate: '100.123456789012345',
+                    symbol: 'ada',
+                }),
+            ).toBe('100.123456789012345');
+            expect(
+                getFeeValue({
+                    ...mockNetworkConfigDeps,
+                    feeRate: '0.000000000000001',
+                    symbol: 'sol',
+                }),
+            ).toBe('0.000000000000001');
         });
 
         it.each(['btc', 'ltc', 'bch', 'doge', 'zec', 'test', 'regtest'])(
             'should work consistently for Bitcoin network variant: %s',
             symbol => {
-                expect(getFeeValue({ feeRate: '100.999', symbol: asNetworkSymbol(symbol) })).toBe(
-                    '100.99',
-                );
+                expect(
+                    getFeeValue({
+                        ...mockNetworkConfigDeps,
+                        feeRate: '100.999',
+                        symbol: symbol as NetworkSymbol,
+                    }),
+                ).toBe('100.99');
             },
         );
 
@@ -82,8 +115,9 @@ describe('utils', () => {
             symbol => {
                 expect(
                     getFeeValue({
+                        ...mockNetworkConfigDeps,
                         feeRate: '100.9999999999999',
-                        symbol: asNetworkSymbol(symbol),
+                        symbol: symbol as NetworkSymbol,
                     }),
                 ).toBe('100.999999999');
             },

--- a/suite-native/transaction-management/src/utils.ts
+++ b/suite-native/transaction-management/src/utils.ts
@@ -1,8 +1,12 @@
-import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import type { GetNetworkConfigDep } from '@suite-common/networks';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { BigNumber, isNotNull } from '@trezor/utils';
 
-export const getFeeDecimals = ({ symbol }: { symbol: NetworkSymbol }) => {
-    const network = getNetwork(symbol);
+export const getFeeDecimals = ({
+    symbol,
+    getNetworkConfig,
+}: { symbol: NetworkSymbol } & GetNetworkConfigDep) => {
+    const network = getNetworkConfig(symbol);
 
     switch (network.networkType) {
         case 'ethereum': {
@@ -21,15 +25,16 @@ export const getFeeDecimals = ({ symbol }: { symbol: NetworkSymbol }) => {
 export const getFeeValue = ({
     feeRate,
     symbol,
+    getNetworkConfig,
 }: {
     feeRate: string | undefined;
     symbol: NetworkSymbol | undefined;
-}) => {
+} & GetNetworkConfigDep) => {
     if (!feeRate || !symbol) {
         return undefined;
     }
 
-    const decimals = getFeeDecimals({ symbol });
+    const decimals = getFeeDecimals({ symbol, getNetworkConfig });
 
     if (isNotNull(decimals)) {
         return new BigNumber(feeRate).decimalPlaces(decimals, 1 /*ROUND_DOWN*/).toFixed();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10318,7 +10318,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/dependency-injection@workspace:*, @suite-common/dependency-injection@workspace:suite-common/dependency-injection":
+"@suite-common/dependency-injection@workspace:*, @suite-common/dependency-injection@workspace:^, @suite-common/dependency-injection@workspace:suite-common/dependency-injection":
   version: 0.0.0-use.local
   resolution: "@suite-common/dependency-injection@workspace:suite-common/dependency-injection"
   dependencies:
@@ -10397,8 +10397,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/earn-stablecoin-api@workspace:suite-common/earn-stablecoin-api"
   dependencies:
+    "@suite-common/dependency-injection": "workspace:^"
     "@suite-common/earn-stablecoin-defs": "workspace:^"
     "@suite-common/http-client": "workspace:^"
+    "@suite-common/networks": "workspace:^"
     "@suite-common/react-query": "workspace:^"
     "@suite-common/schemas": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
@@ -10472,6 +10474,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/fiat-services@workspace:suite-common/fiat-services"
   dependencies:
+    "@suite-common/networks": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
@@ -10537,7 +10540,9 @@ __metadata:
   dependencies:
     "@formatjs/intl": "npm:4.1.2"
     "@mobily/ts-belt": "npm:^3.13.1"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/discreet-mode": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
@@ -10598,6 +10603,7 @@ __metadata:
   resolution: "@suite-common/icons@workspace:suite-common/icons"
   dependencies:
     "@suite-common/http-client": "workspace:^"
+    "@suite-common/networks": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
     "@trezor/network-ethereum-suite-common": "workspace:*"
     chalk: "npm:^5.6.2"
@@ -10706,7 +10712,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@suite-common/networks@workspace:*, @suite-common/networks@workspace:suite-common/networks":
+"@suite-common/networks@workspace:*, @suite-common/networks@workspace:^, @suite-common/networks@workspace:suite-common/networks":
   version: 0.0.0-use.local
   resolution: "@suite-common/networks@workspace:suite-common/networks"
   dependencies:
@@ -10817,6 +10823,7 @@ __metadata:
   dependencies:
     "@suite-common/calldata": "workspace:*"
     "@suite-common/earn-staking-api": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-constants": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -11103,6 +11110,7 @@ __metadata:
   dependencies:
     "@mobily/ts-belt": "npm:^3.13.1"
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
@@ -11163,8 +11171,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/transaction-search@workspace:suite-common/transaction-search"
   dependencies:
+    "@suite-common/networks": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
-    "@suite-common/wallet-config": "workspace:^"
+    "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
@@ -11191,6 +11200,8 @@ __metadata:
   resolution: "@suite-common/tx-simulation@workspace:suite-common/tx-simulation"
   dependencies:
     "@blockaid/client": "npm:0.65.0"
+    "@suite-common/dependency-injection": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/react-query": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-constants": "workspace:*"
@@ -11206,6 +11217,7 @@ __metadata:
   resolution: "@suite-common/validators@workspace:suite-common/validators"
   dependencies:
     "@suite-common/address": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/wallet-config": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/network-solana": "workspace:*"
@@ -11246,11 +11258,13 @@ __metadata:
     "@suite-common/analytics": "workspace:*"
     "@suite-common/bluetooth": "workspace:*"
     "@suite-common/calldata": "workspace:*"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/earn-stablecoin-api": "workspace:*"
     "@suite-common/earn-staking-api": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
     "@suite-common/firmware": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/react-query": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/schemas": "workspace:*"
@@ -11317,6 +11331,7 @@ __metadata:
     "@suite-common/calldata": "workspace:*"
     "@suite-common/earn-staking-api": "workspace:*"
     "@suite-common/fiat-services": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
@@ -16884,9 +16899,11 @@ __metadata:
     "@storybook/addon-links": "npm:^10.3.4"
     "@storybook/react": "npm:^10.3.4"
     "@storybook/react-webpack5": "npm:^10.3.4"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/feedback": "workspace:*"
     "@suite-common/icons": "workspace:*"
     "@suite-common/jsonl": "workspace:*"
+    "@suite-common/networks": "workspace:*"
     "@suite-common/suite-constants": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"


### PR DESCRIPTION
## Description

Completes the migration by wiring the shared network configuration service through Native state dependencies and updating Native consumers across accounts, trading, earn, send, formatting, storage, and transaction management. The resulting top-of-stack tree is identical to the original combined snapshot.\n\nThis final platform layer changes 97 files with 675 additions and 312 deletions.