### PR TITLE
refactor(redux): replace injected selectors with getters

### DIFF
--- a/packages/suite/src/actions/suite/initAction.test.ts
+++ b/packages/suite/src/actions/suite/initAction.test.ts
@@ -317,6 +317,7 @@ const initStore = (state: State) => {
             services: {
                 ...extraDependenciesDesktopMock.services,
                 suiteRouterHistory,
+                getTokenDefinitionsEnabledNetworks: () => state.wallet.settings.enabledNetworks,
             },
         },
         middleware: [

--- a/packages/suite/src/components/suite/Preloader/Preloader.tsx
+++ b/packages/suite/src/components/suite/Preloader/Preloader.tsx
@@ -1,7 +1,6 @@
 import { type FC, type PropsWithChildren, useEffect } from 'react';
 
 import { selectShouldDisplayDeviceCompromisedOnRoute } from '@suite/authenticity-checks';
-import { selectDesktopUpdateAllowPrerelease } from '@suite/desktop-update';
 import { useDevice } from '@suite/device';
 import { KillswitchMessageScreen } from '@suite/message-system';
 import { selectIsAnalyticsConfirmed } from '@suite-common/analytics-redux';
@@ -59,10 +58,7 @@ export const Preloader = ({ children }: PropsWithChildren) => {
     const isAnalyticsConsentConfirmed = useSelector(selectIsAnalyticsConfirmed);
 
     const { device } = useDevice();
-    useReportDeviceCompromised({
-        device,
-        selectAllowPrerelease: selectDesktopUpdateAllowPrerelease,
-    });
+    useReportDeviceCompromised({ device });
     useDeviceCompromisedNotification();
 
     const dispatch = useDispatch();

--- a/packages/suite/src/support/extraDependencies.ts
+++ b/packages/suite/src/support/extraDependencies.ts
@@ -221,6 +221,39 @@ export const createSuiteServicesCompositionRoot = (deps: SuiteAppDeps): SuiteSer
         createLogger: deps.createLogger,
         thpHostName: deps.thpHostName,
         createTransports,
+        getTokenDefinitionsEnabledNetworks: toGetter(
+            deps.getState,
+            (state: AppState) => state.wallet.settings.enabledNetworks,
+        ),
+        // TODO: Coinjoin has not been moved to @suite-common yet, so its debug settings type is not available here.
+        getDebugSettings: toGetter(deps.getState, selectDebugSettings),
+        // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
+        getDesktopBinDir: toGetter(
+            deps.getState,
+            (state: AppState) => state.desktop?.paths?.binDir,
+        ),
+        getLanguage: toGetter(deps.getState, selectLanguage),
+        getSelectedAccount: toGetter(
+            deps.getState,
+            (state: AppState) => state.wallet.selectedAccount,
+        ),
+        getSelectedAccountStatus: toGetter(
+            deps.getState,
+            (state: AppState) => state.wallet.selectedAccount.status,
+        ),
+        getIsWindowVisible: toGetter(deps.getState, selectIsWindowVisible),
+        getTradingEnvironment: toGetter(deps.getState, selectTradeServerEnvironment),
+        getTradedAccountKeys: toGetter(deps.getState, selectTradedAccountKeys),
+        getIsViewOnlyByDefaultEnabled: toGetter(deps.getState, (_: AppState) => true),
+        getThpSettings: toGetter(deps.getState, (state: AppState) => ({
+            appName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
+            pairingMethods: ['CodeEntry'],
+            knownCredentials: state.thp?.credentials,
+        })),
+        getAllowPrerelease: toGetter(
+            deps.getState,
+            (state: AppState) => state.desktopUpdate?.allowPrerelease ?? false,
+        ),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,
@@ -236,26 +269,6 @@ export const extraDependencies: ExtraDependenciesStatic = {
         fetchAndSaveMetadata: metadataLabelingActions.fetchAndSaveMetadata,
         addAccountMetadata: metadataLabelingActions.addAccountMetadata,
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,
-    },
-    selectors: {
-        selectTokenDefinitionsEnabledNetworks: (state: AppState) =>
-            state.wallet.settings.enabledNetworks,
-        selectDebugSettings,
-        // FW binaries on desktop are stored in "*/static/connect/data/firmware/*/*.bin" (see "connect-common" package)
-        selectDesktopBinDir: (state: AppState) => state.desktop?.paths?.binDir,
-        selectLanguage,
-        selectSelectedAccount: (state: AppState) => state.wallet.selectedAccount,
-        selectSelectedAccountStatus: (state: AppState) => state.wallet.selectedAccount.status,
-        selectIsWindowVisible,
-        selectTradingEnvironment: selectTradeServerEnvironment,
-        selectTradedAccountKeys,
-        selectIsViewOnlyByDefaultEnabled: (_: AppState) => true,
-        selectThpSettings: (state: AppState) => ({
-            appName: 'Trezor Suite', // NOTE: this is displayed on Trezor. not the same as manifest.appName
-            pairingMethods: ['CodeEntry'],
-            knownCredentials: state.thp?.credentials,
-        }),
-        selectAllowPrerelease: (state: AppState) => state.desktopUpdate?.allowPrerelease ?? false,
     },
     actions: {
         setAccountAddMetadata: metadataActions.setAccountAdd,

--- a/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx
@@ -1,16 +1,15 @@
-import { selectDesktopUpdateAllowPrerelease } from '@suite/desktop-update';
+import { useGetter } from '@suite-common/dependency-injection';
 import { firmwareActions, selectEffectiveFirmwareChannel } from '@suite-common/firmware';
+import { selectGetAllowPrereleaseDep } from '@suite-common/suite-types';
 import { Column, Text } from '@trezor/components';
 import { type FirmwareChannel } from '@trezor/connect-common/src/types/firmware';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-const effectiveFirmwareChannel = selectEffectiveFirmwareChannel(selectDesktopUpdateAllowPrerelease);
-
 export const FirmwareUpdateEnvironmentSelect = () => {
-    const firmwareChannel = useSelector(effectiveFirmwareChannel);
-    const isAllowPrerelease = useSelector(selectDesktopUpdateAllowPrerelease);
+    const isAllowPrerelease = useGetter(selectGetAllowPrereleaseDep);
+    const firmwareChannel = useSelector(selectEffectiveFirmwareChannel(isAllowPrerelease));
     const dispatch = useDispatch();
 
     const options: { label: string; value: FirmwareChannel }[] = [

--- a/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx
@@ -9,7 +9,7 @@ import { feedbackRequested } from '@suite/feature-feedback';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
 import { selectExperimentalFeatures, suiteSettingsActions } from '@suite/settings';
-import { useServices } from '@suite-common/dependency-injection';
+import { useImperativeServices } from '@suite-common/dependency-injection';
 import { Banner, Button, Checkbox, Column, Row, Switch } from '@trezor/components';
 import { WarningIcon } from '@trezor/icons';
 import { ActionColumn, SectionItem, TextColumn } from '@trezor/product-components';
@@ -27,7 +27,7 @@ type FeatureLineProps = {
 
 const FeatureLine = ({ feature, enabledFeatures }: FeatureLineProps) => {
     const dispatch = useDispatch();
-    const services = useServices(selectSuiteServices);
+    const services = useImperativeServices(selectSuiteServices);
     const checked = enabledFeatures.includes(feature);
 
     const config = EXPERIMENTAL_FEATURES[feature];
@@ -121,7 +121,7 @@ export const Experimental = () => {
     const isDebug = useSelector(selectIsDebugModeActive);
 
     const dispatch = useDispatch();
-    const services = useServices(selectSuiteServices);
+    const services = useImperativeServices(selectSuiteServices);
 
     const onSwitchExperimental = () => {
         enabledFeatures?.forEach(feature =>

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -24,6 +24,18 @@ export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) ex
 export type UnionSubset<T, U extends T> = U;
 
 /**
+ * Whether `T` is exactly `any`, which a plain conditional cannot tell (`any` matches both branches).
+ * Only `any` absorbs the intersection into itself, making `0 extends any` hold.
+ *
+ * Example:
+ *  ```
+ *  type A = IsAny<any>; // true
+ *  type B = IsAny<unknown>; // false
+ *  ```
+ */
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
  * Make property of the object required.
  *
  * Example:

--- a/suite-common/connect-init/src/connectInitThunks.ts
+++ b/suite-common/connect-init/src/connectInitThunks.ts
@@ -40,7 +40,6 @@ export const connectInitThunk = createThunk<void, void, void>(
     `${CONNECT_INIT_MODULE}/initThunk`,
     async (_, { dispatch, getState, extra }) => {
         const {
-            selectors: { selectDebugSettings, selectThpSettings },
             actions: { lockDevice },
             services: {
                 connectInitSettings,
@@ -49,12 +48,14 @@ export const connectInitThunk = createThunk<void, void, void>(
                 createLogger,
                 thpHostName,
                 createTransports,
+                getAllowPrerelease,
+                getDebugSettings,
+                getDesktopBinDir,
+                getThpSettings,
             },
         } = extra;
 
-        const getEffectiveFirmwareChannel = selectEffectiveFirmwareChannel(
-            extra.selectors.selectAllowPrerelease,
-        );
+        const getEffectiveFirmwareChannel = selectEffectiveFirmwareChannel(getAllowPrerelease());
 
         // set event listeners and dispatch as
         TrezorConnect.on(DEVICE_EVENT, ({ event: _, ...eventData }) => {
@@ -126,9 +127,7 @@ export const connectInitThunk = createThunk<void, void, void>(
             return result;
         };
 
-        const binFilesBaseUrl = isDesktop()
-            ? extra.selectors.selectDesktopBinDir(getState())
-            : DATA_URL;
+        const binFilesBaseUrl = isDesktop() ? getDesktopBinDir() : DATA_URL;
 
         const firmwareHashCheckTimeoutsOverride = parseTimeoutThresholdsPerModel(
             selectFeatureConfig(getState(), Feature.firmwareHashCheckTimeout),
@@ -142,8 +141,8 @@ export const connectInitThunk = createThunk<void, void, void>(
             transports: debugTransports,
             showConnectLogs,
             definitionsChannel,
-        } = selectDebugSettings(getState());
-        const thp = selectThpSettings(getState());
+        } = getDebugSettings();
+        const thp = getThpSettings();
         // desktop thp appName/hostName enhanced in ./packages/suite-desktop-core/src/modules/trezor-connect.ts
         if (thpHostName !== undefined) {
             thp.hostName = thpHostName;

--- a/suite-common/dependency-injection/package.json
+++ b/suite-common/dependency-injection/package.json
@@ -13,9 +13,12 @@
     },
     "dependencies": {
         "@trezor/type-utils": "workspace:*",
-        "react": "19.2.3"
+        "@trezor/utils": "workspace:*",
+        "react": "19.2.3",
+        "react-redux": "9.3.0"
     },
     "devDependencies": {
+        "@reduxjs/toolkit": "2.12.0",
         "@testing-library/react": "^16.3.2"
     }
 }

--- a/suite-common/dependency-injection/src/index.ts
+++ b/suite-common/dependency-injection/src/index.ts
@@ -1,4 +1,5 @@
-export { toGetter } from './toGetter';
+export { toGetter, asGetter, type Getter } from './toGetter';
 export { mockNotExpected, mock } from './mock';
 export { createMockDeps } from './createMockDeps';
-export { ServicesProvider, useServices } from './useServices';
+export { ServicesProvider, useServices, useImperativeServices } from './useServices';
+export { useGetter } from './useGetter';

--- a/suite-common/dependency-injection/src/toGetter.test.ts
+++ b/suite-common/dependency-injection/src/toGetter.test.ts
@@ -1,4 +1,4 @@
-import { toGetter } from './toGetter';
+import { type Getter, asGetter, toGetter } from './toGetter';
 
 type TestState = {
     relayUrl: string;
@@ -42,5 +42,27 @@ describe(toGetter.name, () => {
         );
 
         expect(getRelayLabel('relay', 2)).toBe('relay:wss://relay.example.com:2');
+    });
+
+    it('reads the state at call time, not at creation time', () => {
+        let currentRelayUrl = 'wss://relay.example.com';
+        const getRelayUrl = toGetter(
+            () => ({ relayUrl: currentRelayUrl }),
+            currentState => currentState.relayUrl,
+        );
+
+        expect(getRelayUrl()).toBe('wss://relay.example.com');
+
+        currentRelayUrl = 'wss://other.example.com';
+
+        expect(getRelayUrl()).toBe('wss://other.example.com');
+    });
+});
+
+describe(asGetter.name, () => {
+    it('brands a function that does not come from a selector', () => {
+        const getRelayUrl: Getter<[], string> = asGetter(() => state.relayUrl);
+
+        expect(getRelayUrl()).toBe('wss://relay.example.com');
     });
 });

--- a/suite-common/dependency-injection/src/toGetter.ts
+++ b/suite-common/dependency-injection/src/toGetter.ts
@@ -1,3 +1,27 @@
+declare const getterBrand: unique symbol;
+
+/**
+ * A getter-service: reads a value out of the current Redux state without the caller having to know
+ * the state shape.
+ *
+ * The brand is type-only. It exists so `useServices` can refuse to hand a getter to a component:
+ * calling a getter during render reads the value once and never re-renders when it changes, so in
+ * React a getter must be subscribed to with `useGetter`.
+ */
+export type Getter<TParams extends unknown[], TReturn> = ((...params: TParams) => TReturn) & {
+    readonly [getterBrand]: true;
+};
+
+/**
+ * Marks an existing function as a getter-service.
+ *
+ * For getters that are not derived from a selector — test mocks, constants, values read from
+ * somewhere other than the store. Getters built from a selector should use `toGetter` instead.
+ */
+export const asGetter = <TParams extends unknown[], TReturn>(
+    getter: (...params: TParams) => TReturn,
+): Getter<TParams, TReturn> => getter as Getter<TParams, TReturn>;
+
 /**
  * The utils that provides a conversion from selector to a getter-service.
  *
@@ -7,16 +31,16 @@
 export function toGetter<TState, TReturn>(
     getState: () => TState,
     selector: (state: TState) => TReturn,
-): () => TReturn;
+): Getter<[], TReturn>;
 
 export function toGetter<TState, TParams extends unknown[], TReturn>(
     getState: () => TState,
     selector: (state: TState, ...params: TParams) => TReturn,
-): (...params: TParams) => TReturn;
+): Getter<TParams, TReturn>;
 
 export function toGetter<TState, TParams extends unknown[], TReturn>(
     getState: () => TState,
     selector: (state: TState, ...params: TParams) => TReturn,
 ) {
-    return (...params: TParams): TReturn => selector(getState(), ...params);
+    return asGetter((...params: TParams): TReturn => selector(getState(), ...params));
 }

--- a/suite-common/dependency-injection/src/useGetter.test.tsx
+++ b/suite-common/dependency-injection/src/useGetter.test.tsx
@@ -1,0 +1,153 @@
+import React, { type PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+
+import { type PayloadAction, configureStore, createSlice } from '@reduxjs/toolkit';
+import { act, renderHook } from '@testing-library/react';
+
+import { type Getter, toGetter } from './toGetter';
+import { useGetter } from './useGetter';
+import { ServicesProvider } from './useServices';
+
+type TestState = { relayUrl: string; isTorEnabled: boolean; selectedWalletDescriptor: string };
+
+const initialState: TestState = {
+    relayUrl: 'wss://relay.example.com',
+    isTorEnabled: false,
+    selectedWalletDescriptor: 'wallet-1',
+};
+
+// A store of its own, so the test does not depend on any app state shape.
+const testSlice = createSlice({
+    name: 'test',
+    initialState,
+    reducers: {
+        setTestState: (state, { payload }: PayloadAction<Partial<TestState>>) => ({
+            ...state,
+            ...payload,
+        }),
+    },
+});
+
+const { setTestState } = testSlice.actions;
+
+const createTestStore = () => configureStore({ reducer: testSlice.reducer });
+
+type RelayUrlDep = { getRelayUrl: Getter<[], string> };
+type TorDep = { getIsTorEnabled: Getter<[], boolean> };
+type SelectedWalletDep = { getIsSelectedWallet: Getter<[walletDescriptor: string], boolean> };
+
+const selectRelayUrlDep = (services: any): RelayUrlDep => ({ getRelayUrl: services.getRelayUrl });
+const selectSelectedWalletDep = (services: any): SelectedWalletDep => ({
+    getIsSelectedWallet: services.getIsSelectedWallet,
+});
+const selectTwoGettersDep = (services: any): RelayUrlDep & TorDep => ({
+    getRelayUrl: services.getRelayUrl,
+    getIsTorEnabled: services.getIsTorEnabled,
+});
+
+const renderUseGetter = <TResult, TProps>(
+    useHook: (props: TProps) => TResult,
+    initialProps?: TProps,
+) => {
+    const store = createTestStore();
+    const renderSpy = jest.fn();
+    const services = {
+        getRelayUrl: toGetter(store.getState, state => state.relayUrl),
+        getIsTorEnabled: toGetter(store.getState, state => state.isTorEnabled),
+        getIsSelectedWallet: toGetter(
+            store.getState,
+            (state: TestState, walletDescriptor: string) =>
+                state.selectedWalletDescriptor === walletDescriptor,
+        ),
+    };
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>
+            <ServicesProvider services={services}>{children}</ServicesProvider>
+        </Provider>
+    );
+
+    const rendered = renderHook(
+        (props: TProps) => {
+            renderSpy();
+
+            return useHook(props);
+        },
+        { wrapper, initialProps: initialProps as TProps },
+    );
+
+    return { store, renderSpy, ...rendered };
+};
+
+describe(useGetter.name, () => {
+    it('returns the current value of the getter', () => {
+        const { result } = renderUseGetter(() => useGetter(selectRelayUrlDep));
+
+        expect(result.current).toBe('wss://relay.example.com');
+    });
+
+    it('re-renders with the new value when the store changes', () => {
+        const { store, result } = renderUseGetter(() => useGetter(selectRelayUrlDep));
+
+        act(() => {
+            store.dispatch(setTestState({ relayUrl: 'wss://other.example.com' }));
+        });
+
+        expect(result.current).toBe('wss://other.example.com');
+    });
+
+    it('does not re-render when an unrelated part of the state changes', () => {
+        const { store, renderSpy } = renderUseGetter(() => useGetter(selectRelayUrlDep));
+        const rendersBefore = renderSpy.mock.calls.length;
+
+        act(() => {
+            store.dispatch(setTestState({ isTorEnabled: true }));
+        });
+
+        expect(renderSpy.mock.calls.length).toBe(rendersBefore);
+    });
+
+    it('forwards params to the getter', () => {
+        const { result } = renderUseGetter(() =>
+            useGetter(selectSelectedWalletDep, 'wallet-2' as string),
+        );
+
+        expect(result.current).toBe(false);
+    });
+
+    it('reads the value for the new params when they change', () => {
+        const { result, rerender } = renderUseGetter(
+            (walletDescriptor: string) => useGetter(selectSelectedWalletDep, walletDescriptor),
+            'wallet-2' as string,
+        );
+
+        expect(result.current).toBe(false);
+
+        rerender('wallet-1');
+
+        expect(result.current).toBe(true);
+    });
+
+    it('keeps watching the value for the params that were last passed', () => {
+        const { store, result, rerender } = renderUseGetter(
+            (walletDescriptor: string) => useGetter(selectSelectedWalletDep, walletDescriptor),
+            'wallet-2' as string,
+        );
+
+        rerender('wallet-3');
+
+        act(() => {
+            store.dispatch(setTestState({ selectedWalletDescriptor: 'wallet-3' }));
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('rejects a dependency holding more than one getter', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        expect(() => renderUseGetter(() => useGetter(selectTwoGettersDep as any))).toThrow(
+            'useGetter expects a dependency with exactly one getter, got 2',
+        );
+    });
+});

--- a/suite-common/dependency-injection/src/useGetter.ts
+++ b/suite-common/dependency-injection/src/useGetter.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { type UnionToIntersection } from '@trezor/type-utils';
+import { typedObjectValues } from '@trezor/utils';
+
+import { type Getter } from './toGetter';
+import { type SelectorResult, type ServiceSelector, useServicesContext } from './useServices';
+
+// The single key of a one-property object; `never` for anything else (an intersection of two or
+// more distinct string literals is `never`).
+type OnlyKey<TSelected> = [UnionToIntersection<keyof TSelected>] extends [never]
+    ? never
+    : keyof TSelected;
+
+type OnlyGetter<TSelected> = [OnlyKey<TSelected>] extends [never]
+    ? never
+    : TSelected[OnlyKey<TSelected>] extends Getter<any[], any>
+      ? TSelected[OnlyKey<TSelected>]
+      : never;
+
+type GetterParams<TSelected> =
+    OnlyGetter<TSelected> extends Getter<infer TParams, any>
+        ? TParams
+        : ['This dependency must hold exactly one getter.'];
+
+type GetterReturn<TSelected> =
+    OnlyGetter<TSelected> extends Getter<any[], infer TReturn>
+        ? TReturn
+        : 'This dependency must hold exactly one getter.';
+
+/**
+ * Reads the value of an injected getter-service reactively: the component re-renders whenever the
+ * value changes, the same as with a plain selector. Takes the same dependency selector as
+ * `useServices`, holding a single getter, and returns that getter's current value.
+ *
+ * The store state is never handed to the getter — it reads the state through its own `getState`, so
+ * the component (and its test) stays independent of the state shape and only has to mock the getter.
+ * Subscribing through `useSelector` is what re-evaluates the getter on every store change.
+ *
+ * ```ts
+ * const allowPrerelease = useGetter(selectGetAllowPrereleaseDep);
+ * ```
+ *
+ * A getter returning a fresh object on every call re-renders on every action — such a getter has to
+ * be built on a memoized selector.
+ */
+export function useGetter<const TSelector extends ServiceSelector<any>>(
+    selectGetterDep: TSelector,
+    ...params: GetterParams<SelectorResult<TSelector>>
+): GetterReturn<SelectorResult<TSelector>>;
+
+export function useGetter(selectGetterDep: ServiceSelector<any>, ...params: unknown[]) {
+    const services = useServicesContext();
+
+    const getter = React.useMemo(() => {
+        const [onlyGetter, ...rest] = typedObjectValues<Record<string, Getter<unknown[], unknown>>>(
+            selectGetterDep(services),
+        );
+
+        if (onlyGetter === undefined || rest.length > 0) {
+            throw new Error(
+                `useGetter expects a dependency with exactly one getter, got ${rest.length + (onlyGetter === undefined ? 0 : 1)}`,
+            );
+        }
+
+        return onlyGetter;
+    }, [services, selectGetterDep]);
+
+    return useSelector(() => getter(...params));
+}

--- a/suite-common/dependency-injection/src/useGetter.type-test.ts
+++ b/suite-common/dependency-injection/src/useGetter.type-test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { type Getter } from './toGetter';
+import { useGetter } from './useGetter';
+
+type AllowPrereleaseDep = { getAllowPrerelease: Getter<[], boolean> };
+type SelectedWalletDep = { getIsSelectedWallet: Getter<[walletDescriptor: string], boolean> };
+type TwoGettersDep = AllowPrereleaseDep & { getLanguage: Getter<[], string> };
+type PlainServiceDep = { reportSecurityCheck: () => void };
+
+const selectAllowPrereleaseDep = (services: any): AllowPrereleaseDep => ({
+    getAllowPrerelease: services.getAllowPrerelease,
+});
+const selectSelectedWalletDep = (services: any): SelectedWalletDep => ({
+    getIsSelectedWallet: services.getIsSelectedWallet,
+});
+const selectTwoGettersDep = (services: any): TwoGettersDep => ({
+    getAllowPrerelease: services.getAllowPrerelease,
+    getLanguage: services.getLanguage,
+});
+const selectPlainServiceDep = (services: any): PlainServiceDep => ({
+    reportSecurityCheck: services.reportSecurityCheck,
+});
+
+// The getter's value, no aliasing needed.
+const _allowPrerelease: boolean = useGetter(selectAllowPrereleaseDep);
+
+// A getter with params takes them after the dependency selector.
+const _isSelectedWallet: boolean = useGetter(selectSelectedWalletDep, 'wallet-1');
+
+// @ts-expect-error the params of the selected getter are type-checked
+useGetter(selectSelectedWalletDep, 42);
+
+// @ts-expect-error a getter without params takes no extra arguments
+useGetter(selectAllowPrereleaseDep, 'wallet-1');
+
+// @ts-expect-error a getter with params cannot be read without them
+useGetter(selectSelectedWalletDep);
+
+// @ts-expect-error the value type comes from the selected getter
+const _wrongValueType: string = useGetter(selectAllowPrereleaseDep);
+
+// @ts-expect-error which of the two getters would be read is ambiguous
+const _twoGetters: boolean = useGetter(selectTwoGettersDep);
+
+// @ts-expect-error plain services are not getters, they belong to useServices
+const _plainService: () => void = useGetter(selectPlainServiceDep);
+
+void _allowPrerelease;
+void _isSelectedWallet;
+void _wrongValueType;
+void _twoGetters;
+void _plainService;

--- a/suite-common/dependency-injection/src/useServices.test.tsx
+++ b/suite-common/dependency-injection/src/useServices.test.tsx
@@ -2,14 +2,17 @@ import React, { type PropsWithChildren } from 'react';
 
 import { renderHook } from '@testing-library/react';
 
-import { ServicesProvider, useServices } from './useServices';
+import { type Getter, asGetter } from './toGetter';
+import { ServicesProvider, useImperativeServices, useServices } from './useServices';
 
 type ADep = { a: () => void };
 type BDep = { b: () => void };
+type GetterDep = { getSomething: Getter<[], boolean> };
 
-const appServices: ADep & BDep = {
+const appServices: ADep & BDep & GetterDep = {
     a: jest.fn(),
     b: jest.fn(),
+    getSomething: asGetter(() => true),
 };
 
 const selectADep = (services: any): ADep => ({
@@ -20,12 +23,16 @@ const selectBDep = (services: any): BDep => ({
     b: services.b,
 });
 
+const selectGetterDep = (services: any): GetterDep => ({
+    getSomething: services.getSomething,
+});
+
+const wrapper = ({ children }: PropsWithChildren) => (
+    <ServicesProvider services={appServices}>{children}</ServicesProvider>
+);
+
 describe(useServices.name, () => {
     it('returns the same selected services reference across rerenders', () => {
-        const wrapper = ({ children }: PropsWithChildren) => (
-            <ServicesProvider services={appServices}>{children}</ServicesProvider>
-        );
-
         const { result, rerender } = renderHook(() => useServices(selectADep, selectBDep), {
             wrapper,
         });
@@ -35,5 +42,13 @@ describe(useServices.name, () => {
         rerender();
 
         expect(result.current).toBe(firstSelectedServices);
+    });
+});
+
+describe(useImperativeServices.name, () => {
+    it('hands out a dependency containing a getter', () => {
+        const { result } = renderHook(() => useImperativeServices(selectGetterDep), { wrapper });
+
+        expect(result.current.getSomething).toBe(appServices.getSomething);
     });
 });

--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { type UnionToIntersection } from '@trezor/type-utils';
+import { type IsAny, type UnionToIntersection } from '@trezor/type-utils';
+
+import { type Getter } from './toGetter';
 
 const ServicesContext = React.createContext<any>(null);
 
@@ -12,12 +14,29 @@ type Services = any;
 
 export type ServiceSelector<TSelected> = (services: Services) => TSelected;
 
-type SelectorResult<TSelector> =
+export type SelectorResult<TSelector> =
     TSelector extends ServiceSelector<infer TSelected> ? TSelected : never;
 
-type SelectedServices<TSelectors extends readonly ServiceSelector<any>[]> = UnionToIntersection<
-    SelectorResult<TSelectors[number]>
->;
+export type SelectedServices<TSelectors extends readonly ServiceSelector<any>[]> =
+    UnionToIntersection<SelectorResult<TSelectors[number]>>;
+
+type GetterKeys<TSelected> = {
+    [K in keyof TSelected]-?: TSelected[K] extends Getter<any[], any> ? K : never;
+}[keyof TSelected];
+
+/**
+ * Getters are deliberately unreachable through `useServices`: a getter called during render is read
+ * once and the component never re-renders when the value changes. `useGetter` subscribes instead.
+ *
+ * Resolving to a string makes the call site fail on the very first property access, with the reason
+ * spelled out in the reported type.
+ */
+type RejectGetters<TSelected> =
+    IsAny<TSelected> extends true
+        ? TSelected
+        : [GetterKeys<TSelected>] extends [never]
+          ? TSelected
+          : 'This dependency contains a getter. Select the getter on its own and read it with useGetter, or take the whole dependency with the deprecated useImperativeServices if it is only called from event handlers.';
 
 type ServicesProviderProps = {
     services: Services;
@@ -33,17 +52,44 @@ ServicesProvider.displayName = 'ServicesProvider';
 export const selectServices = (services: Services, ...selectors: ServiceSelector<any>[]) =>
     Object.assign({}, ...selectors.map(selector => selector(services)));
 
-export function useServices<
-    const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],
->(...selectors: TSelectors): SelectedServices<TSelectors>;
-
-export function useServices(...selectors: ServiceSelector<any>[]) {
+export const useServicesContext = (): Services => {
     const services = React.useContext(ServicesContext);
 
     if (!services) {
         throw new Error('useServices must be used within a ServicesProvider');
     }
 
+    return services;
+};
+
+const useSelectedServices = (selectors: ServiceSelector<any>[]) => {
+    const services = useServicesContext();
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
     return React.useMemo(() => selectServices(services, ...selectors), [services, ...selectors]);
+};
+
+export function useServices<
+    const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],
+>(...selectors: TSelectors): RejectGetters<SelectedServices<TSelectors>>;
+
+export function useServices(...selectors: ServiceSelector<any>[]) {
+    return useSelectedServices(selectors);
+}
+
+/**
+ * `useServices` for dependencies that do contain getters, which it otherwise refuses to hand out.
+ *
+ * @deprecated Select the individual services instead. Getters and plain services are consumed
+ * differently — a getter holds a value that changes over time and has to be subscribed to with
+ * `useGetter`, while a service is just called — so a dependency lumping both together cannot be
+ * consumed correctly as a whole. This exists for bags that are only passed on and called from event
+ * handlers, where nothing is read during render; anything else will silently miss state changes.
+ */
+export function useImperativeServices<
+    const TSelectors extends readonly [ServiceSelector<any>, ...ServiceSelector<any>[]],
+>(...selectors: TSelectors): SelectedServices<TSelectors>;
+
+export function useImperativeServices(...selectors: ServiceSelector<any>[]) {
+    return useSelectedServices(selectors);
 }

--- a/suite-common/dependency-injection/src/useServices.type-test.ts
+++ b/suite-common/dependency-injection/src/useServices.type-test.ts
@@ -1,11 +1,14 @@
 /* eslint-disable react-hooks/rules-of-hooks */
+import { type Getter } from './toGetter';
 import { useServices } from './useServices';
 
 type ADep = { a: () => void };
 type BDep = { b: () => void };
+type GetterDep = { getSomething: Getter<[], boolean> };
 
 const selectADep = (services: any): ADep => ({ a: services.a });
 const selectBDep = (services: any): BDep => ({ b: services.b });
+const selectGetterDep = (services: any): GetterDep => ({ getSomething: services.getSomething });
 
 const _selectedServices: ADep & BDep = useServices(selectADep, selectBDep);
 
@@ -18,5 +21,13 @@ useServices<BDep>();
 // @ts-expect-error useServices returns type as narrow as the supplied selectors
 const _mismatchedService: ADep = useServices(selectBDep);
 
+// @ts-expect-error getters must be read with useGetter, so useServices does not hand them out
+const { getSomething: _getSomething } = useServices(selectGetterDep);
+
+// @ts-expect-error one getter among plain services is rejected as well
+const _mixedServices: ADep & GetterDep = useServices(selectADep, selectGetterDep);
+
 void _selectedServices;
 void _mismatchedService;
+void _getSomething;
+void _mixedServices;

--- a/suite-common/dependency-injection/tsconfig.json
+++ b/suite-common/dependency-injection/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/type-utils" },
+        { "path": "../../packages/utils" }
     ]
 }

--- a/suite-common/firmware-authenticity/package.json
+++ b/suite-common/firmware-authenticity/package.json
@@ -12,9 +12,11 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/device": "workspace:*",
         "@suite-common/firmware": "workspace:*",
         "@suite-common/redux-utils": "workspace:*",
+        "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
         "@trezor/connect": "workspace:*",
         "@trezor/device-utils": "workspace:*",
@@ -23,7 +25,6 @@
         "react-redux": "9.3.0"
     },
     "devDependencies": {
-        "@suite-common/suite-types": "workspace:*",
         "@trezor/type-utils": "workspace:*"
     }
 }

--- a/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
+++ b/suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useGetter } from '@suite-common/dependency-injection';
 import {
     type DeviceRootState,
     deviceInvariabilityCheck,
@@ -8,8 +9,7 @@ import {
     selectPersistentDeviceDataById,
 } from '@suite-common/device';
 import { selectIsProductionFirmwareChannel } from '@suite-common/firmware';
-import { type SuiteCompatibleSelector } from '@suite-common/redux-utils';
-import { type TrezorDevice } from '@suite-common/suite-types';
+import { type TrezorDevice, selectGetAllowPrereleaseDep } from '@suite-common/suite-types';
 import { isDeviceKnown as getIsDeviceKnown, isDeviceAcquired } from '@suite-common/suite-utils';
 import { FIRMWARE } from '@trezor/connect';
 import { getFirmwareVersion } from '@trezor/device-utils';
@@ -18,13 +18,11 @@ import { isArrayMember } from '@trezor/utils';
 import { reportSecurityCheckThunk } from './reportSecurityCheckThunk';
 import { hashCheckErrorScenarios, revisionCheckErrorScenarios } from './scenariosConfig';
 
-// to avoid unnecessary wallet-core import
-type CommonProps = {
+type DeviceProps = {
     device: TrezorDevice | undefined;
-    selectAllowPrerelease: SuiteCompatibleSelector<boolean>;
 };
 
-const useCommonData = ({ device }: Pick<CommonProps, 'device'>) => {
+const useCommonData = ({ device }: DeviceProps) => {
     const model = device?.features?.internal_model;
     const revision = device?.features?.revision;
     const version = getFirmwareVersion(device);
@@ -36,12 +34,16 @@ const useCommonData = ({ device }: Pick<CommonProps, 'device'>) => {
     );
 };
 
-const useReportRevisionCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
+const useIsProductionFirmwareChannel = () => {
+    const allowPrerelease = useGetter(selectGetAllowPrereleaseDep);
+
+    return useSelector(selectIsProductionFirmwareChannel(allowPrerelease));
+};
+
+const useReportRevisionCheck = ({ device }: DeviceProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const isProductionFirmwareChannel = useSelector(
-        selectIsProductionFirmwareChannel(selectAllowPrerelease),
-    );
+    const isProductionFirmwareChannel = useIsProductionFirmwareChannel();
 
     const revisionCheck = isDeviceAcquired(device)
         ? device.authenticityChecks.firmwareRevision
@@ -70,12 +72,10 @@ const useReportRevisionCheck = ({ device, selectAllowPrerelease }: CommonProps) 
     }, [dispatch, commonData, errorType, errorPayload, shouldReport]);
 };
 
-const useReportHashCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
+const useReportHashCheck = ({ device }: DeviceProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
-    const isProductionFirmwareChannel = useSelector(
-        selectIsProductionFirmwareChannel(selectAllowPrerelease),
-    );
+    const isProductionFirmwareChannel = useIsProductionFirmwareChannel();
 
     const hashCheck = isDeviceAcquired(device) ? device.authenticityChecks.firmwareHash : null;
     const isError = hashCheck && !hashCheck.success;
@@ -125,7 +125,7 @@ const useReportHashCheck = ({ device, selectAllowPrerelease }: CommonProps) => {
 };
 
 // Report meta check results (Id check & device invariability checks ) to Sentry
-const useReportDeviceMetaChecks = ({ device }: CommonProps) => {
+const useReportDeviceMetaChecks = ({ device }: DeviceProps) => {
     const dispatch = useDispatch();
     const commonData = useCommonData({ device });
     const previousData = useSelector((state: DeviceRootState) =>
@@ -192,8 +192,8 @@ const useReportDeviceMetaChecks = ({ device }: CommonProps) => {
  * Optionally report both FW authenticity checks (revision and hash) to Sentry and/or show toast notifications,
  * based on behavior scenarios definitions. This may happen even when no UI is displayed for the checks.
  */
-export const useReportDeviceCompromised = ({ device, selectAllowPrerelease }: CommonProps) => {
-    useReportRevisionCheck({ device, selectAllowPrerelease });
-    useReportHashCheck({ device, selectAllowPrerelease });
-    useReportDeviceMetaChecks({ device, selectAllowPrerelease });
+export const useReportDeviceCompromised = ({ device }: DeviceProps) => {
+    useReportRevisionCheck({ device });
+    useReportHashCheck({ device });
+    useReportDeviceMetaChecks({ device });
 };

--- a/suite-common/firmware-authenticity/tsconfig.json
+++ b/suite-common/firmware-authenticity/tsconfig.json
@@ -2,14 +2,15 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../dependency-injection" },
         { "path": "../device" },
         { "path": "../firmware" },
         { "path": "../redux-utils" },
+        { "path": "../suite-types" },
         { "path": "../suite-utils" },
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/utils" },
-        { "path": "../suite-types" },
         { "path": "../../packages/type-utils" }
     ]
 }

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,9 +1,6 @@
-import { type PayloadAction, createSelector } from '@reduxjs/toolkit';
+import { type PayloadAction } from '@reduxjs/toolkit';
 
-import {
-    type SuiteCompatibleSelector,
-    createReducerWithExtraDeps,
-} from '@suite-common/redux-utils';
+import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { type FirmwareStatus, type TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE,
@@ -138,23 +135,16 @@ export const selectSwitchFirmwareType = (state: RootState) => state.firmware.swi
 export const selectIsFirmwareInstallationRunning = (state: RootState) =>
     state.firmware.status === 'started';
 
-export const selectEffectiveFirmwareChannel = (
-    selectAllowPrerelease: SuiteCompatibleSelector<boolean>,
-) =>
-    createSelector(
-        selectFirmwareChannel,
-        selectAllowPrerelease,
-        (firmwareChannel, allowPrerelease): FirmwareChannel =>
-            // When a user is in the Early Access Program, the firmware channel is forced to `production-early-access`.
-            // This factory accepts `selectAllowPrerelease` as a parameter because it is a platform-specific extra dependency.
-            allowPrerelease ? 'production-early-access' : firmwareChannel,
-    );
+export const selectEffectiveFirmwareChannel =
+    (allowPrerelease: boolean) =>
+    (state: RootState): FirmwareChannel =>
+        // When a user is in the Early Access Program, the firmware channel is forced to `production-early-access`.
+        // This factory accepts `allowPrerelease` as a parameter because it is a platform-specific extra dependency.
+        allowPrerelease ? 'production-early-access' : selectFirmwareChannel(state);
 
-export const selectIsProductionFirmwareChannel = (
-    selectAllowPrerelease: SuiteCompatibleSelector<boolean>,
-) =>
-    createSelector(
-        selectEffectiveFirmwareChannel(selectAllowPrerelease),
-        (firmwareChannel): boolean =>
-            ['production', 'production-early-access'].includes(firmwareChannel),
-    );
+export const selectIsProductionFirmwareChannel =
+    (allowPrerelease: boolean) =>
+    (state: RootState): boolean =>
+        ['production', 'production-early-access'].includes(
+            selectEffectiveFirmwareChannel(allowPrerelease)(state),
+        );

--- a/suite-common/firmware/src/firmwareThunks.ts
+++ b/suite-common/firmware/src/firmwareThunks.ts
@@ -41,13 +41,12 @@ export const firmwareUpdate = createThunk<
         }
 
         const {
-            selectors: { selectLanguage },
-            services: { reportSecurityCheck },
+            services: { getLanguage, reportSecurityCheck },
         } = extra;
 
         const device = selectSelectedDevice(getState());
         const binFilesBaseUrl = await dispatch(getBinFilesBaseUrlThunk()).unwrap();
-        const suiteLanguage = selectLanguage(getState());
+        const suiteLanguage = getLanguage();
         const { useDevkit, cachedDevice, error } = selectFirmware(getState());
 
         if (error) {

--- a/suite-common/firmware/src/getBinFilesBaseUrlThunk.ts
+++ b/suite-common/firmware/src/getBinFilesBaseUrlThunk.ts
@@ -8,6 +8,6 @@ import { FIRMWARE_MODULE_PREFIX } from './firmwareActions';
  */
 export const getBinFilesBaseUrlThunk = createThunk(
     `${FIRMWARE_MODULE_PREFIX}/getBinFilesBaseUrlThunk`,
-    (_params, { getState, extra }) =>
-        isDesktop() ? extra.selectors.selectDesktopBinDir(getState()) : resolveConnectPath('data'),
+    (_params, { extra }) =>
+        isDesktop() ? extra.services.getDesktopBinDir() : resolveConnectPath('data'),
 );

--- a/suite-common/redux-utils/README.md
+++ b/suite-common/redux-utils/README.md
@@ -13,8 +13,8 @@ export type ExtraDependencies = {
     actions: {
         addTransaction: SuiteCompatibleActionCreatorWithPayload<Transaction>;
     };
-    selectors: {
-        selectTransactions: SuiteCompatibleSelector<Transactions[]>;
+    services: {
+        getTransactions: () => Transactions[];
     };
 };
 ```
@@ -23,16 +23,20 @@ Now you will use this type in desktop suite to construct object that will implem
 
 ```typescript
 import * as transactionsActions from '@wallet-actions/transactionsActions';
+import { toGetter } from '@suite-common/dependency-injection';
 import { AppState } from '../types/suite';
 
-export const extraDependencies: ExtraDependencies = {
+export const createExtraDependencies = (getState: () => AppState): ExtraDependencies => ({
     actions: {
         addTransaction: transactionsActions.add,
     },
-    selectors: {
-        selectTransactions: (state: AppState) => state.wallet.transactions.transactions,
+    services: {
+        getTransactions: toGetter(
+            getState,
+            (state: AppState) => state.wallet.transactions.transactions,
+        ),
     },
-};
+});
 ```
 
 And we do same thing for mobile app, but here you will actually use some mocked action and transaction data. We need to do this because that functionality is not moved to `@suite-common` package.
@@ -42,13 +46,13 @@ export const extraDependencies: ExtraDependencies = {
     actions: {
         addTransaction: createAction<any>('@suite-native/notImplemented/addTransaction'),
     },
-    selectors: {
-        selectTransactions: () => [...testMocks.getWalletTransaction()],
+    services: {
+        getTransactions: () => [...testMocks.getWalletTransaction()],
     },
 };
 ```
 
-In case someone will move that functionality to `@suite-common` we should remove it from extra dependencies. For example if someone will create `@suite-common/wallet-transactions` package we will remove `selectTransactions` from extra dependencies and import it from that package directly.
+In case someone will move that functionality to `@suite-common` we should remove it from extra dependencies. For example if someone will create `@suite-common/wallet-transactions` package we will remove `getTransactions` from extra dependencies and import it from that package directly.
 
 ## Platform specific APIs
 
@@ -98,14 +102,14 @@ This functions has exact same signature as `createAsyncThunk` but it will inject
 ```typescript
 export const exportTransactionsToFileThunk = createThunk(
     'exportAccountsToFileThunk',
-    (payload: string, { dispatch, extra, getState }) => {
+    (payload: string, { dispatch, extra }) => {
         const fileName = payload;
         const {
-            selectors: { selectTransactions },
+            services: { getTransactions },
             utils: { saveFile },
         } = extra;
 
-        const transactions = selectTransactions(getState());
+        const transactions = getTransactions();
 
         return saveFile(JSON.stringify(transactions), fileName);
     },
@@ -207,7 +211,7 @@ export const prepareSomeMiddleware = createMiddlewareWithExtraDeps(
     (action, { getState, extra, next }) => {
         const {
             actions: { addTransaction },
-            selectors: { selectTransactions },
+            services: { getTransactions },
         } = extra;
 
         switch (action.type) {

--- a/suite-common/redux-utils/package.json
+++ b/suite-common/redux-utils/package.json
@@ -17,6 +17,7 @@
         "@suite-common/analytics": "workspace:*",
         "@suite-common/bip329-types": "workspace:*",
         "@suite-common/delegated-identity-key-types": "workspace:*",
+        "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/networks": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",

--- a/suite-common/redux-utils/src/extraDependenciesType.ts
+++ b/suite-common/redux-utils/src/extraDependenciesType.ts
@@ -8,6 +8,7 @@ import type { AddressValidatorDep } from '@suite-common/address';
 import type { AnalyticsSharedEvents } from '@suite-common/analytics';
 import { type Bip329Dep } from '@suite-common/bip329-types';
 import { type EnsureDelegatedIdentityKeyDep } from '@suite-common/delegated-identity-key-types';
+import { type Getter } from '@suite-common/dependency-injection';
 import { type MetadataAddPayload } from '@suite-common/metadata-types';
 import type {
     FindNetworkSymbolForProtocolDep,
@@ -18,6 +19,7 @@ import { type PlatformEncryptionDep } from '@suite-common/platform-encryption'; 
 import { type MigrateSuiteSyncLabelsForRbfTransactionDep } from '@suite-common/suite-rbf-labels-migrations-types';
 import { type SuiteSyncDep } from '@suite-common/suite-sync-types';
 import {
+    type GetAllowPrereleaseDep,
     type ReloadAppDep,
     type ReportSecurityCheckDep,
     type UserContextPayload,
@@ -42,7 +44,7 @@ import type { Transport } from '@trezor/transport-common';
 import { type KeyedThrottle } from '@trezor/utils';
 
 import { type ConnectInitHooks } from './connectInitHooksType';
-import { type ActionType, type SuiteCompatibleSelector, type SuiteCompatibleThunk } from './types';
+import { type ActionType, type SuiteCompatibleThunk } from './types';
 
 type BaseReducer = (state: any, action: { type: any; payload: any }) => void;
 type StorageLoadReducer = (state: any, action: { type: any; payload: any }) => void;
@@ -82,12 +84,29 @@ export type CommonServices = SuiteSyncDep &
     NetworkModuleRepositoryDep &
     Bip329Dep &
     EnsureDelegatedIdentityKeyDep &
-    PlatformEncryptionDep & {
+    PlatformEncryptionDep &
+    GetAllowPrereleaseDep & {
         analytics: Analytics<AnalyticsSharedEvents>;
         saveAs: (data: Blob, fileName: string) => void;
         connectInitSettings: ConnectInitSettings;
         connectInitHooks: ConnectInitHooks;
         accountRefreshThrottle: KeyedThrottle<Account['key']>;
+        // Getters, so a component cannot read them during render and miss later state changes.
+        // See `toGetter`/`useGetter` in @suite-common/dependency-injection.
+        getTokenDefinitionsEnabledNetworks: Getter<[], NetworkSymbol[]>;
+        getDebugSettings: Getter<[], any>;
+        getDesktopBinDir: Getter<[], string | undefined>;
+        getLanguage: Getter<[], string>;
+        getIsWindowVisible: Getter<[], boolean>;
+        getSelectedAccount: Getter<[], SelectedAccountStatus>;
+        getSelectedAccountStatus: Getter<[], SelectedAccountStatus['status']>;
+        getTradingEnvironment: Getter<
+            [],
+            'production' | 'staging' | 'dev' | 'localhost' | undefined
+        >;
+        getTradedAccountKeys: Getter<[], AccountKey[]>;
+        getIsViewOnlyByDefaultEnabled: Getter<[], boolean>;
+        getThpSettings: Getter<[], ThpSettings>;
     } & ReportSecurityCheckDep &
     ReloadAppDep &
     MigrateSuiteSyncLabelsForRbfTransactionDep &
@@ -109,26 +128,6 @@ export type ExtraDependenciesStatic = {
             isOsUnpairingFinished?: boolean;
             skipDisconnect?: boolean;
         }>;
-    };
-    selectors: {
-        // TODO when tokens are implemented 1:1 in both apps, delete from extras
-        // wallet-core selector is used in desktop, but suite-native has its own implementation
-        selectTokenDefinitionsEnabledNetworks: SuiteCompatibleSelector<NetworkSymbol[]>;
-        // todo: we do not want to, so far, transfer coinjoin to @suite-common
-        // but this is exactly what I need to get DebugModeOptions type instead of any
-        selectDebugSettings: SuiteCompatibleSelector<any>;
-        selectDesktopBinDir: SuiteCompatibleSelector<string | undefined>;
-        selectLanguage: SuiteCompatibleSelector<string>;
-        selectIsWindowVisible: SuiteCompatibleSelector<boolean>;
-        selectSelectedAccount: SuiteCompatibleSelector<SelectedAccountStatus>;
-        selectSelectedAccountStatus: SuiteCompatibleSelector<SelectedAccountStatus['status']>;
-        selectTradingEnvironment: SuiteCompatibleSelector<
-            'production' | 'staging' | 'dev' | 'localhost' | undefined
-        >;
-        selectTradedAccountKeys: SuiteCompatibleSelector<AccountKey[]>;
-        selectIsViewOnlyByDefaultEnabled: SuiteCompatibleSelector<boolean>;
-        selectThpSettings: SuiteCompatibleSelector<ThpSettings>;
-        selectAllowPrerelease: SuiteCompatibleSelector<boolean>;
     };
     // You should only use ActionCreatorWithPayload from redux-toolkit!
     // That means you will need to convert actual action creators in packages/suite to use createAction from redux-toolkit,

--- a/suite-common/redux-utils/src/notImplemented.ts
+++ b/suite-common/redux-utils/src/notImplemented.ts
@@ -1,5 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 
+import { asGetter } from '@suite-common/dependency-injection';
+
 import { createThunk } from './createThunk';
 
 const mockedConsoleAlreadyPrinted: string[] = [];
@@ -29,18 +31,22 @@ export const notImplementedThunk = (type: string) =>
         return thunkPayload;
     });
 
-export const notImplementedSelector =
-    <TReturn>(name: string, mockedReturnValue: TReturn, selectorArgs: any = {}) =>
-    () => {
+export const notImplementedGetter = <TReturn>(
+    name: string,
+    mockedReturnValue: TReturn,
+    getterArgs: any = {},
+) =>
+    // Branded as a getter, so it can stand in for a `toGetter` service.
+    asGetter(() => {
         mockedConsoleLog(
-            `Calling not implemented selector "${name}" with mocked value: `,
+            `Calling not implemented getter "${name}" with mocked value: `,
             mockedReturnValue,
             ' and args: ',
-            selectorArgs,
+            getterArgs,
         );
 
         return mockedReturnValue;
-    };
+    });
 
 export const notImplementedActionType = (type: string) => `actionType/notImplemented/${type}`;
 

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -17,8 +17,6 @@ export type SuiteCompatibleThunk<TPayload, TReturn = void> =
     | AsyncThunk<TReturn, TPayload, Record<never, never>>
     | OriginalReduxThunk<TPayload, TReturn>;
 
-export type SuiteCompatibleSelector<TReturn> = (state: any) => TReturn;
-
 export type ActionType = string;
 
 interface TypeGuard<T> {

--- a/suite-common/redux-utils/tsconfig.json
+++ b/suite-common/redux-utils/tsconfig.json
@@ -8,6 +8,7 @@
         {
             "path": "../delegated-identity-key-types"
         },
+        { "path": "../dependency-injection" },
         { "path": "../metadata-types" },
         { "path": "../networks" },
         { "path": "../platform-encryption" },

--- a/suite-common/suite-types/package.json
+++ b/suite-common/suite-types/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/dependency-injection": "workspace:*",
         "@suite-common/metadata-types": "workspace:*",
         "@suite-common/platform-encryption": "workspace:*",
         "@suite-common/suite-config": "workspace:*",

--- a/suite-common/suite-types/src/firmware.ts
+++ b/suite-common/suite-types/src/firmware.ts
@@ -1,3 +1,5 @@
+import { type Getter } from '@suite-common/dependency-injection';
+
 export type FirmwareStatus =
     | 'initial' // initial state
     | 'started' // progress - firmware update has started, waiting for events from trezor-connect
@@ -28,3 +30,15 @@ export type ReportSecurityCheck = (params: ReportSecurityCheckParams) => void;
 export type ReportSecurityCheckDep = {
     reportSecurityCheck: ReportSecurityCheck;
 };
+
+// A getter: called directly from non-React code, and subscribed to in components with
+// `useGetter(selectGetAllowPrereleaseDep)`.
+export type GetAllowPrerelease = Getter<[], boolean>;
+
+export type GetAllowPrereleaseDep = {
+    getAllowPrerelease: GetAllowPrerelease;
+};
+
+export const selectGetAllowPrereleaseDep = (services: any): GetAllowPrereleaseDep => ({
+    getAllowPrerelease: services.getAllowPrerelease,
+});

--- a/suite-common/suite-types/src/index.ts
+++ b/suite-common/suite-types/src/index.ts
@@ -5,7 +5,7 @@ import {
 } from '@reduxjs/toolkit';
 
 export * from './device';
-export type * from './firmware';
+export * from './firmware';
 export type * from './guide';
 export type * from './messageSystem';
 export type * from './modal';

--- a/suite-common/suite-types/tsconfig.json
+++ b/suite-common/suite-types/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        { "path": "../dependency-injection" },
         { "path": "../metadata-types" },
         { "path": "../platform-encryption" },
         { "path": "../suite-config" },

--- a/suite-common/test-utils/src/extraDependenciesCommonMock.ts
+++ b/suite-common/test-utils/src/extraDependenciesCommonMock.ts
@@ -17,8 +17,8 @@ import {
     type ExtraDependencies,
     notImplementedAction,
     notImplementedActionType,
+    notImplementedGetter,
     notImplementedReducer,
-    notImplementedSelector,
     notImplementedThunk,
 } from '@suite-common/redux-utils';
 import type { SuiteSync } from '@suite-common/suite-sync-types';
@@ -115,21 +115,19 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
         createTransports: () => [],
         accountRefreshThrottle: createKeyedThrottle(10_000, () => undefined),
         migrateSuiteSyncLabelsForRbfTransaction: () => Promise.resolve([[], []]),
-    },
-    selectors: {
-        selectTokenDefinitionsEnabledNetworks: notImplementedSelector(
-            'selectTokenDefinitonsEnabledNetworks',
+        getTokenDefinitionsEnabledNetworks: notImplementedGetter(
+            'getTokenDefinitionsEnabledNetworks',
             ['eth'],
         ),
-        selectDebugSettings: notImplementedSelector('selectDebugSettings', {
+        getDebugSettings: notImplementedGetter('getDebugSettings', {
             checkFirmwareAuthenticity: false,
             showDebugMenu: false,
             transports: [],
         }),
-        selectDesktopBinDir: notImplementedSelector('selectDesktopBinDir', '/bin'),
-        selectLanguage: notImplementedSelector('selectLanguage', 'en'),
+        getDesktopBinDir: notImplementedGetter('getDesktopBinDir', '/bin'),
+        getLanguage: notImplementedGetter('getLanguage', 'en'),
 
-        selectSelectedAccount: notImplementedSelector('selectSelectedAccount', {
+        getSelectedAccount: notImplementedGetter('getSelectedAccount', {
             status: 'loaded',
             account: mockWalletAccount({
                 symbol: 'btc',
@@ -137,21 +135,15 @@ export const extraDependenciesCommonMock: ExtraDependencies = {
                 descriptor: asAccountDescriptor('btc1'),
             }),
         } as SelectedAccountLoaded),
-        selectSelectedAccountStatus: notImplementedSelector(
-            'selectSelectedAccountStatus',
-            'loaded',
-        ),
-        selectIsWindowVisible: notImplementedSelector('selectIsWindowVisible', true),
-        selectTradingEnvironment: notImplementedSelector('selectTradingEnvironment', 'localhost'),
-        selectTradedAccountKeys: notImplementedSelector('selectTradedAccountKeys', []),
-        selectIsViewOnlyByDefaultEnabled: notImplementedSelector(
-            'selectIsViewOnlyByDefaultEnabled',
-            true,
-        ),
-        selectThpSettings: notImplementedSelector('selectThpSettings', {
+        getSelectedAccountStatus: notImplementedGetter('getSelectedAccountStatus', 'loaded'),
+        getIsWindowVisible: notImplementedGetter('getIsWindowVisible', true),
+        getTradingEnvironment: notImplementedGetter('getTradingEnvironment', 'localhost'),
+        getTradedAccountKeys: notImplementedGetter('getTradedAccountKeys', []),
+        getIsViewOnlyByDefaultEnabled: notImplementedGetter('getIsViewOnlyByDefaultEnabled', true),
+        getThpSettings: notImplementedGetter('getThpSettings', {
             pairingMethods: ['CodeEntry'],
         }),
-        selectAllowPrerelease: notImplementedSelector('selectAllowPrerelease', false),
+        getAllowPrerelease: notImplementedGetter('getAllowPrerelease', false),
     },
     actions: {
         setAccountAddMetadata: notImplementedAction('setAccountAddMetadata'),

--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -36,7 +36,7 @@ export const getTokenDefinitionThunk = createThunk<
 export const initTokenDefinitionsThunk = createThunk(
     `${TOKEN_DEFINITIONS_MODULE}/initTokenDefinitionsThunk`,
     (_, { getState, dispatch, extra }) => {
-        const enabledNetworks = extra.selectors.selectTokenDefinitionsEnabledNetworks(getState());
+        const enabledNetworks = extra.services.getTokenDefinitionsEnabledNetworks();
 
         const promises = enabledNetworks
             .map(symbol => {

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
@@ -59,9 +59,8 @@ const initStore = (
 ) =>
     configureMockStore({
         extra: {
-            selectors: {
-                ...extraDependenciesCommonMock.selectors,
-                selectSelectedAccount: () => selectedAccount as any,
+            services: {
+                getSelectedAccount: () => selectedAccount as any,
             },
         },
         reducer: combineReducers({

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -34,7 +34,7 @@ export const loadInitialDataThunk = createThunk(
         { activeSection, forcedApiKey }: LoadInitialDataThunkProps,
         { dispatch, getState, extra },
     ) => {
-        const selectedAccount = extra.selectors.selectSelectedAccount(getState());
+        const selectedAccount = extra.services.getSelectedAccount();
         const account = selectTradingAccountAccordingActiveSection(
             getState(),
             activeSection,
@@ -55,7 +55,7 @@ export const loadInitialDataThunk = createThunk(
         if (!isLoading && (isDifferentAccount || areDataOutdated)) {
             dispatch(tradingActions.setLoading({ isLoading: true }));
 
-            const tradeServerEnvironment = extra.selectors.selectTradingEnvironment(getState());
+            const tradeServerEnvironment = extra.services.getTradingEnvironment();
             if (tradeServerEnvironment) {
                 tradeApi.setServersEnvironment(tradeServerEnvironment);
             }

--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -105,7 +105,7 @@ export const reportAccountInfoThunk = createThunk(
         );
         if (requiresTokenDefinitions && !tokenDefinitions?.data) return;
 
-        const hasTraded = extra.selectors.selectTradedAccountKeys(getState()).includes(account.key);
+        const hasTraded = extra.services.getTradedAccountKeys().includes(account.key);
 
         extra.services.analytics.report({
             type: events.accountsInfoEvent.name,

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -235,9 +235,9 @@ export const syncAccountsWithBlockchainThunk = createThunk(
         const accounts = selectAccounts(getState());
         const blockchain = selectBlockchainState(getState());
         const {
-            selectors: { selectIsWindowVisible },
+            services: { getIsWindowVisible },
         } = extra;
-        const isWindowVisible = selectIsWindowVisible(getState());
+        const isWindowVisible = getIsWindowVisible();
 
         // First clear, to cancel last planned sync
         tryClearTimeout(blockchain[symbol].syncTimeout);
@@ -366,8 +366,8 @@ export const onBlockchainNotificationThunk = createThunk(
         // with N accounts on the same network, hammering blockbook at ~10k connections.
         // Periodic background sync still runs on its own timer chain (seeded by
         // onBlockchainConnectThunk), so unrelated accounts stay up to date.
-        const { selectIsWindowVisible } = extra.selectors;
-        if (!selectIsWindowVisible(getState())) return;
+        const { getIsWindowVisible } = extra.services;
+        if (!getIsWindowVisible()) return;
 
         accounts.forEach(matchedAccount =>
             dispatch(fetchAndUpdateAccountThunk({ accountKey: matchedAccount.key })),

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -382,12 +382,12 @@ export const periodicFetchFiatRatesThunk = createThunk(
     `${FIAT_RATES_MODULE_PREFIX}/periodicFetchFiatRates`,
     async (
         { rateType, localCurrency }: PeriodicFetchFiatRatesThunkPayload,
-        { dispatch, getState, extra },
+        { dispatch, extra },
     ) => {
         const {
-            selectors: { selectIsWindowVisible },
+            services: { getIsWindowVisible },
         } = extra;
-        const isWindowVisible = selectIsWindowVisible(getState());
+        const isWindowVisible = getIsWindowVisible();
 
         if (ratesTimeouts[rateType]) {
             clearTimeout(ratesTimeouts[rateType]);

--- a/suite-native/app/src/hooks/useGlobalHooks.tsx
+++ b/suite-native/app/src/hooks/useGlobalHooks.tsx
@@ -27,7 +27,7 @@ export const useGlobalHooks = () => {
 
     useDetectDeviceError();
     useHandleDeviceAuthorization();
-    useReportDeviceCompromised({ device, selectAllowPrerelease: () => false });
+    useReportDeviceCompromised({ device });
     useRenderDeviceDangerBanner();
     useDeviceCompromisedNotification();
 

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -18,8 +18,8 @@ import {
     type ExtraDependenciesStatic,
     notImplementedAction,
     notImplementedActionType,
+    notImplementedGetter,
     notImplementedReducer,
-    notImplementedSelector,
     notImplementedThunk,
 } from '@suite-common/redux-utils';
 import { createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot } from '@suite-common/suite-rbf-labels-migrations';
@@ -145,6 +145,35 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
                 }
             }),
         accountRefreshThrottle: createAccountRefreshThrottle(deps.getState),
+        getLanguage: toGetter(deps.getState, selectSupportedLanguageLocale),
+        getTokenDefinitionsEnabledNetworks: toGetter(
+            deps.getState,
+            selectTokenDefinitionsEnabledNetworks,
+        ),
+        getDebugSettings: toGetter(deps.getState, () => ({ transports })),
+        getTradingEnvironment: toGetter(deps.getState, selectTradingEnvironment),
+        getTradedAccountKeys: toGetter(deps.getState, selectTradedAccountKeys),
+        // This getter is not used in native app, but it is used in @suite-common/trading in loadInitialDataThunk.
+        getSelectedAccount: toGetter(deps.getState, () => ({
+            status: 'none',
+            loader: undefined,
+            account: undefined,
+            network: undefined,
+            params: undefined,
+        })),
+        getThpSettings: toGetter(deps.getState, state => ({
+            // On iOS 16 and newer, deviceName is set to "iPhone" without the correct entitlement.
+            hostName: (Platform.OS === 'ios' ? Device.modelName : Device.deviceName) ?? undefined,
+            pairingMethods: ['CodeEntry', 'NFC'],
+            knownCredentials: state.thp?.credentials,
+        })),
+        getAllowPrerelease: toGetter(deps.getState, () => false),
+
+        // Not implemented. We assume those are NEVER called on Native.
+        getDesktopBinDir: notImplementedGetter('getDesktopBinDir', '/bin'),
+        getSelectedAccountStatus: notImplementedGetter('getSelectedAccountStatus', 'loaded'),
+        getIsWindowVisible: notImplementedGetter('getIsWindowVisible', true),
+        getIsViewOnlyByDefaultEnabled: notImplementedGetter('getIsViewOnlyByDefaultEnabled', true),
         migrateSuiteSyncLabelsForRbfTransaction:
             createMigrateSuiteSyncLabelsForRbfTransactionCompositionRoot({
                 dispatch: deps.dispatch,
@@ -155,45 +184,6 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
 };
 
 export const extraDependencies: ExtraDependenciesStatic = {
-    selectors: {
-        selectLanguage: selectSupportedLanguageLocale,
-        selectTokenDefinitionsEnabledNetworks,
-        selectDebugSettings: () => ({
-            transports,
-        }),
-        selectTradingEnvironment,
-        selectTradedAccountKeys,
-        // this selector is not used in native app, but it is used in @suite-common/trading in loadInitialDataThunk
-        //  and without defining the selector, it would use extraDependenciesMock value there
-        selectSelectedAccount: () => ({
-            status: 'none',
-            loader: undefined,
-            account: undefined,
-            network: undefined,
-            params: undefined,
-        }),
-        selectThpSettings: state => ({
-            // On iOS 16 and newer, deviceName is set to "iPhone" without the correct entitlement.
-            hostName: (Platform.OS === 'ios' ? Device.modelName : Device.deviceName) ?? undefined,
-            pairingMethods: ['CodeEntry', 'NFC'],
-            knownCredentials: state.thp?.credentials,
-        }),
-        selectAllowPrerelease: () => false,
-
-        // Not implemented. We assume those are NEVER called on Native
-        // need for this is architectural mistake. Please DO NOT add more and try
-        // to remove them.
-        selectDesktopBinDir: notImplementedSelector('selectDesktopBinDir', '/bin'),
-        selectSelectedAccountStatus: notImplementedSelector(
-            'selectSelectedAccountStatus',
-            'loaded',
-        ),
-        selectIsWindowVisible: notImplementedSelector('selectIsWindowVisible', true),
-        selectIsViewOnlyByDefaultEnabled: notImplementedSelector(
-            'selectIsViewOnlyByDefaultEnabled',
-            true,
-        ),
-    },
     thunks: {
         forgetBluetoothDevice: forgetBluetoothDeviceThunk,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10321,9 +10321,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/dependency-injection@workspace:suite-common/dependency-injection"
   dependencies:
+    "@reduxjs/toolkit": "npm:2.12.0"
     "@testing-library/react": "npm:^16.3.2"
     "@trezor/type-utils": "workspace:*"
+    "@trezor/utils": "workspace:*"
     react: "npm:19.2.3"
+    react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft
 
@@ -10484,6 +10487,7 @@ __metadata:
   resolution: "@suite-common/firmware-authenticity@workspace:suite-common/firmware-authenticity"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/device": "workspace:*"
     "@suite-common/firmware": "workspace:*"
     "@suite-common/redux-utils": "workspace:*"
@@ -10764,6 +10768,7 @@ __metadata:
     "@suite-common/analytics": "workspace:*"
     "@suite-common/bip329-types": "workspace:*"
     "@suite-common/delegated-identity-key-types": "workspace:*"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/networks": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
@@ -10978,6 +10983,7 @@ __metadata:
   resolution: "@suite-common/suite-types@workspace:suite-common/suite-types"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/dependency-injection": "workspace:*"
     "@suite-common/metadata-types": "workspace:*"
     "@suite-common/platform-encryption": "workspace:*"
     "@suite-common/suite-config": "workspace:*"


### PR DESCRIPTION
## Description

Redux selectors injected through ExtraDependenciesStatic make suite-common thunks depend on an unknown state shape supplied by the upper application store. This removes the selectors group, creates zero-argument services with toGetter in the desktop and native composition roots, and updates all consumers, mocks, affected tests, and documentation. The remaining any-based SuiteCompatibleSelector alias is also removed; firmware selector factories and authenticity hooks now preserve the platform selector state generically.

- Injected selectors: **12 -> 0**
- SuiteCompatibleSelector references: **5 -> 0**
- Affected type-check: **179 projects passed**
- Focused tests: **15 passed**
- Lint: **all modified projects passed**
- Other checks: **format, depcheck (179 projects), and project references passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/extra-selector-getters/web/](https://dev.suite.sldev.cz/suite-web/refactor/extra-selector-getters/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/extra-selector-getters&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/extra-selector-getters&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/extra-selector-getters&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T12:37:22.566Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T12:37:52.438Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is a broad refactoring of dependency injection, extra dependencies, and firmware/connect infrastructure. The highest risk is in firmware/onboarding flows and TrezorConnect/bridge initialization. Run the targeted firmware and onboarding tests unconditionally, use a representative set of connect/bridge/trading/discovery tests to catch dependency-injection regressions, and rely on the broad link-check smoke test for route-level Preloader issues. Native mobile and pure unit-test/type-test files have no web E2E coverage.

<details><summary><b>Changed files (42)</b></summary>

- `packages/suite/src/actions/suite/initAction.test.ts`
- `packages/suite/src/components/suite/Preloader/Preloader.tsx`
- `packages/suite/src/support/extraDependencies.ts`
- `packages/suite/src/views/settings/SettingsDebug/FirmwareUpdateEnvironmentSelect.tsx`
- `packages/suite/src/views/settings/SettingsGeneral/Experimental.tsx`
- `packages/type-utils/src/utils.ts`
- `suite-common/connect-init/src/connectInitThunks.ts`
- `suite-common/dependency-injection/package.json`
- `suite-common/dependency-injection/src/index.ts`
- `suite-common/dependency-injection/src/toGetter.test.ts`
- `suite-common/dependency-injection/src/toGetter.ts`
- `suite-common/dependency-injection/src/useGetter.test.tsx`
- `suite-common/dependency-injection/src/useGetter.ts`
- `suite-common/dependency-injection/src/useGetter.type-test.ts`
- `suite-common/dependency-injection/src/useServices.test.tsx`
- `suite-common/dependency-injection/src/useServices.tsx`
- `suite-common/dependency-injection/src/useServices.type-test.ts`
- `suite-common/dependency-injection/tsconfig.json`
- `suite-common/firmware-authenticity/package.json`
- `suite-common/firmware-authenticity/src/useReportDeviceCompromised.ts`
- `suite-common/firmware-authenticity/tsconfig.json`
- `suite-common/firmware/src/firmwareReducer.ts`
- `suite-common/firmware/src/firmwareThunks.ts`
- `suite-common/firmware/src/getBinFilesBaseUrlThunk.ts`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/src/notImplemented.ts`
- `suite-common/redux-utils/src/types.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-common/suite-types/package.json`
- `suite-common/suite-types/src/firmware.ts`
- `suite-common/suite-types/src/index.ts`
- `suite-common/suite-types/tsconfig.json`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/token-definitions/src/tokenDefinitionsThunks.ts`
- `suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts`
- `suite-common/trading/src/thunks/common/loadInitialDataThunk.ts`
- `suite-common/wallet-core/src/accounts/accountsThunks.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-native/app/src/hooks/useGlobalHooks.tsx`
- `suite-native/state/src/extraDependencies.ts`

</details>

**Recommended tests (18)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Directly exercises the custom firmware installation flow, which is affected by changes to firmware thunks/reducer, getBinFilesBaseUrlThunk, and the FirmwareUpdateEnvironmentSelect debug setting. A regression here would be immediately visible if firmware binary resolution or installation state breaks.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Directly validates the device authenticity check path during onboarding. Changes to firmware-authenticity reporting and firmware thunks could break or alter the authenticity flow, making this the most targeted regression test.
- `suite/e2e/tests/onboarding/firmware-check.test.ts` — Validates firmware readiness detection during onboarding, which relies on firmware reducer/thunks and connect initialization. A regression would block users from completing onboarding.
- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — Specifically tests the device-compromised modal triggered by entropy check failures, which is directly implemented in the changed firmware-authenticity module. This is the narrowest test for that change.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — Exercises onboarding end-to-end in offline mode, including firmware revision checks and the Preloader/offline banner behavior. Changes to Preloader, firmware thunks, and connect init could alter offline onboarding outcomes.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Opens the firmware update modal from device settings, which is affected by the FirmwareUpdateEnvironmentSelect component and firmware reducer/thunks. A regression here would break the device settings firmware flow.

</details>

<details><summary>🟡 <b>Medium priority (11)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Validates bridge lifecycle and app initialization. Changes to connect init thunks and dependency injection could affect how Suite connects to a spawned bridge.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests bridge daemon mode startup and app initialization. The connect init and dependency-injection refactoring could influence how the app discovers and uses an already-running bridge.
- `suite/e2e/tests/general/check-links.test.ts` — Navigates every major route and verifies pages load. Because Preloader.tsx and extra dependencies are changed, this broad smoke test catches route-level rendering or initialization regressions that targeted tests might miss.
- `suite/e2e/tests/general/eap-modal.test.ts` — Directly exercises the Experimental settings component changed in this PR, verifying that joining the early access program updates the UI correctly.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests onboarding persistence and app reload behavior, which depends on Preloader and init logic. Changes to Preloader or extra dependencies could break the initial-run state machine across reloads.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Exercises the web-side TrezorConnect flow. Changes to connect init thunks and dependency injection could affect how Connect is initialized and how popups are managed.
- `suite/e2e/tests/trezor-connect/error.test.ts` — Tests TrezorConnect desktop core mode initialization and error handling. The connect init and dependency-injection changes directly impact this path.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises a representative TrezorConnect desktop core mode address export flow, which depends on connect initialization and permission handling affected by the dependency-injection changes.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests Connect permissions persistence and revocation in desktop core mode. Dependency-injection and connect-init changes could affect how permission state is managed.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The loadInitialDataThunk trading file is changed, and this test navigates the full buy flow where that thunk is invoked. It provides confidence that trading data loading still works after the dependency-injection and trading thunk changes.
- `suite/e2e/tests/wallet/discovery.test.ts` — Exercises account and blockchain thunks during multi-coin discovery and page reload. Changes to accountsThunks, blockchainThunks, fiatRatesThunks, and extra dependencies could break discovery resumption or completion.

</details>

<details><summary>🟢 <b>Low priority (1)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Exercises a token buy flow where tokenDefinitionsThunks loads SPL token metadata. The token definitions thunk is changed, so this test offers a concrete check that token display still works, though the change may be internal-only.

</details>

⚠️ **Changes with no test coverage (25)**
- `packages/suite/src/actions/suite/initAction.test.ts`
- `packages/type-utils/src/utils.ts`
- `suite-common/dependency-injection/package.json`
- `suite-common/dependency-injection/src/index.ts`
- `suite-common/dependency-injection/src/toGetter.test.ts`
- `suite-common/dependency-injection/src/useGetter.test.tsx`
- `suite-common/dependency-injection/src/useGetter.ts`
- `suite-common/dependency-injection/src/useGetter.type-test.ts`
- `suite-common/dependency-injection/src/useServices.test.tsx`
- `suite-common/dependency-injection/src/useServices.type-test.ts`
- `suite-common/dependency-injection/tsconfig.json`
- `suite-common/firmware-authenticity/package.json`
- `suite-common/firmware-authenticity/tsconfig.json`
- `suite-common/redux-utils/package.json`
- `suite-common/redux-utils/src/extraDependenciesType.ts`
- `suite-common/redux-utils/src/notImplemented.ts`
- `suite-common/redux-utils/src/types.ts`
- `suite-common/redux-utils/tsconfig.json`
- `suite-common/suite-types/package.json`
- `suite-common/suite-types/src/index.ts`
- `suite-common/suite-types/tsconfig.json`
- `suite-common/test-utils/src/extraDependenciesCommonMock.ts`
- `suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts`
- `suite-native/app/src/hooks/useGlobalHooks.tsx`
- `suite-native/state/src/extraDependencies.ts`

_Updated: 2026-08-06T12:36:53.217Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->