### PR TITLE
chore(message-system): remove wallet recovering info message

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-08-04T17:00:00+00:00",
-    "sequence": 151,
+    "timestamp": "2026-08-04T22:00:00+00:00",
+    "sequence": 152,
     "actions": [
         {
             "conditions": [
@@ -1113,36 +1113,6 @@
                     }
                 },
                 "context": { "domain": ["accounts.coinjoin", "accounts.btc.coinjoin"] }
-            }
-        },
-        {
-            "conditions": [
-                {
-                    "duration": {
-                        "from": "2026-08-04T00:00:00.000Z",
-                        "to": "2026-08-25T22:00:00.000Z"
-                    },
-                    "environment": {
-                        "desktop": "*",
-                        "mobile": "*",
-                        "web": "*"
-                    }
-                }
-            ],
-            "message": {
-                "id": "1ae436e7-bb03-41a0-b173-86d40b9f112c",
-                "priority": 92,
-                "dismissible": true,
-                "variant": "info",
-                "category": "banner",
-                "content": {
-                    "en": "Recovered your wallet? A wallet created elsewhere may not have the same security as one created on your Trezor. If you are unsure, we recommend setting up a new wallet here and moving your funds to it.",
-                    "cs": "Obnovili jste svou peněženku? Peněženka vytvořená jinde nemusí mít stejné zabezpečení jako peněženka vytvořená na vašem Trezoru. Pokud si nejste jisti, doporučujeme zde nastavit novou peněženku a převést do ní své prostředky.",
-                    "es": "¿Has recuperado tu cartera? Una cartera creada en otro lugar puede no tener la misma seguridad que una creada en tu Trezor. Si tienes dudas, te recomendamos configurar una nueva cartera aquí y transferir tus fondos a ella.",
-                    "de": "Wallet wiederhergestellt? Eine anderswo erstellte Wallet bietet möglicherweise nicht dieselbe Sicherheit wie eine auf deinem Trezor erstellte. Wenn du unsicher bist, empfehlen wir, hier eine neue Wallet einzurichten und deine Gelder darauf zu übertragen.",
-                    "fr": "Vous avez récupéré votre portefeuille ? Un portefeuille créé ailleurs peut ne pas offrir la même sécurité qu'un portefeuille créé sur votre Trezor. En cas de doute, nous vous recommandons de configurer un nouveau portefeuille ici et d'y transférer vos fonds.",
-                    "pt": "Recuperou a sua carteira? Uma carteira criada noutro local pode não ter a mesma segurança que uma criada no seu Trezor. Se não tiver a certeza, recomendamos configurar uma nova carteira aqui e transferir os seus fundos para ela."
-                }
             }
         },
         {


### PR DESCRIPTION
## Description

Removing the global info banner recommending wallet recreation if the user did not created wallet using Trezor or is unsure. 

## Notes for QA

Check that the message is not displayed 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a global message-system JSON config with no direct static test mapping. No E2E test explicitly asserts the contents of this config, but two tests reference the remote message system mock as part of their setup. Running those provides a low-cost sanity check that Suite initialization and connect flows still behave with the updated config.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This migration test sets up a mock for the remote message system and exercises Suite startup/initialization across versions. A change to the message-system config could affect how the app initializes or how the mock is applied, so running this validates that migration setup still works.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — The test source hints explicitly include a remote message system mock. Changes to the message-system config could alter the mocked environment or Suite loading behavior that the webextension connect flow depends on.

</details>

_Updated: 2026-08-04T21:13:13.626Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-message-hide-wallet-recovering-message/web/](https://dev.suite.sldev.cz/suite-web/chore/message-message-hide-wallet-recovering-message/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-message-hide-wallet-recovering-message&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-message-hide-wallet-recovering-message&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-message-hide-wallet-recovering-message&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:15:46.143Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:15:06.668Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->