### PR TITLE
fix(suite-desktop): hide fiat summary for fiat input

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -217,7 +217,9 @@ export const YieldAmountCard = ({
                                 </Button>
                             )}
                         </Row>
-                        {approxFiat && (
+                        {/* In fiat mode the user already types the fiat amount, so converting
+                        it back would just restate the input. */}
+                        {approxFiat && !isFiatMode && (
                             <BaseCurrencyValue
                                 amount={amountInput ?? ''}
                                 symbol={approxFiat.symbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Just not displaying the fiat summary component if fiat input mode. 

## Notes for QA

To be consistent with staking flow

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30830

## Screenshots:

| Fiat | Weth |
|--------|--------|
| <img width="644" height="373" alt="Screenshot 2026-08-04 at 23 37 11" src="https://github.com/user-attachments/assets/657203d4-09c8-414b-8a14-72f8dea34c2f" /> | <img width="611" height="351" alt="Screenshot 2026-08-04 at 23 37 09" src="https://github.com/user-attachments/assets/f9603052-f267-4615-9e50-370f14f75ee6" /> |
| <img width="610" height="356" alt="Screenshot 2026-08-04 at 23 37 00" src="https://github.com/user-attachments/assets/401d8411-a903-4a7b-bc07-027288b0525a" /> | <img width="668" height="383" alt="Screenshot 2026-08-04 at 23 36 57" src="https://github.com/user-attachments/assets/bf296b11-bf86-4f5e-ac6c-0e006524804a" /> | 
| <img width="567" height="677" alt="Screenshot 2026-08-04 at 23 40 45" src="https://github.com/user-attachments/assets/3067a367-df0e-481f-a359-2965629cd8ba" /> | <img width="592" height="716" alt="Screenshot 2026-08-04 at 23 37 31" src="https://github.com/user-attachments/assets/10af4396-7f65-4d3a-8a26-e12654128392" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared yield/staking amount display component, so its static coverage map includes 133 tests via transitive imports. The real risk is narrow: incorrect rendering of staking/yield amounts across networks. Three high-priority staking tests covering ADA, ETH, and SOL reward/staked amount UI provide strong confidence without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test directly verifies Cardano reward amount display, claim reward modal amounts, and post-claim balance updates in the staking/yield UI — the exact surface where YieldAmountCard renders yield values.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers the Ethereum staking dashboard progression from empty state through pending, staked, and reward amounts, exercising the yield amount card across multiple states.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Validates Solana staking dashboard amounts (staked, rewards, unstaking) and reward list rendering, which are displayed via shared yield amount components.

</details>

_Updated: 2026-08-04T21:46:34.991Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/hide-fiat-summary-stablecoin-flows/web/](https://dev.suite.sldev.cz/suite-web/feat/hide-fiat-summary-stablecoin-flows/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/hide-fiat-summary-stablecoin-flows&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/hide-fiat-summary-stablecoin-flows&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:48:56.456Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| sol staking > display stake rewards on SOL staking account | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T21:48:39.178Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->