### PR TITLE
fix(suite-desktop): displayed underlying asset for native assets vaults

### DIFF
--- a/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
+++ b/packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx
@@ -11,7 +11,10 @@ import {
 import { selectTradingCoinSymbolByCryptoId, toTokenCryptoId } from '@suite-common/trading';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
-import { getContractAddressForNetworkSymbol } from '@suite-common/wallet-utils';
+import {
+    getContractAddressForNetworkSymbol,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-utils';
 import { MORPHO_DISCLAIMER_URL, TREZOR_SUITE_TOS_URL } from '@trezor/urls';
 
 import { useSelector } from 'src/hooks/suite';
@@ -65,7 +68,9 @@ export const YieldEarnProviderConsentModal = ({
         yieldContext,
     });
     const displaySymbol = getNetworkDisplaySymbol(account.symbol);
-    const depositSymbol = tokenSymbolFromAccount ?? tokenSymbolFromTrading ?? displaySymbol;
+    const depositSymbol = isWrappedNativeToken(account.symbol, normalizedTokenContractAddress)
+        ? displaySymbol
+        : (tokenSymbolFromAccount ?? tokenSymbolFromTrading ?? displaySymbol);
     const providerName = getEarnProviderName(provider);
 
     const handleOnConfirm = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Display an underlying asset name

## Notes for QA

Should only affect eth vaults 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30831

## Screenshots:

| Deposit USDT | Deposit ETH |
|--------|--------|
| <img width="656" height="559" alt="Screenshot 2026-08-05 at 0 02 50" src="https://github.com/user-attachments/assets/9f6a4217-0387-4ba1-9b8b-68077b240d4b" /> | <img width="721" height="582" alt="Screenshot 2026-08-05 at 0 02 44" src="https://github.com/user-attachments/assets/809b5b4a-11f7-42ca-9eb3-25d417820adc" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is isolated to the Earn provider consent modal used when users first acknowledge staking provider terms. Risk is focused on the staking initiation flows for ADA, ETH, and SOL. I recommend running the three initial-stake tests as high priority because they directly click through the consent modal, plus the two stake-more tests as medium-priority regression guards for the same form infrastructure. No other tests have concrete evidence of being affected by this modal change.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/earn/modals/EarnProviderConsent/YieldEarnProviderConsentModal.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test explicitly initiates Cardano staking and acknowledges Everstake terms, which directly exercises the EarnProviderConsent modal behavior. A regression here would be immediately visible in the first-time staking flow.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — The test opens the ETH staking form and acknowledges Everstake terms before staking, making it the most direct end-to-end coverage for the changed consent modal. It verifies the modal's acknowledge checkbox and continuation flow.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test starts Solana staking and acknowledges Everstake terms, exercising the same EarnProviderConsent modal on the SOL staking flow. It ensures the modal works across different staking networks.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/stake-more.test.ts` — The test reuses the ETH staking form where provider consent state and modal logic may still apply when initiating additional stakes, providing a regression guard for consent persistence and modal interactions.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Similar to the ETH stake-more test, this exercises the Solana staking form again and can catch regressions in how the consent modal state is reused or re-triggered for subsequent stakes.

</details>

_Updated: 2026-08-04T22:07:30.522Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tweak-vault-deposit-asset/web/](https://dev.suite.sldev.cz/suite-web/fix/tweak-vault-deposit-asset/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tweak-vault-deposit-asset&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tweak-vault-deposit-asset&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-04T22:10:08.156Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-04T22:09:56.096Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->