### PR TITLE
fix(suite): reconnect after setting custom backend

### DIFF
--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.test.ts
@@ -1,0 +1,58 @@
+import { combineReducers } from '@reduxjs/toolkit';
+
+import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import TrezorConnect from '@trezor/connect';
+
+import { blockchainInitialState, prepareBlockchainReducer } from './blockchainReducer';
+import { setCustomBackendThunk } from './blockchainThunks';
+
+const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
+const electrumUrl = '127.0.0.1:50001:t';
+
+const initStore = () =>
+    configureMockStore({
+        reducer: combineReducers({
+            wallet: combineReducers({
+                blockchain: blockchainReducer,
+            }),
+        }),
+        preloadedState: {
+            wallet: {
+                blockchain: {
+                    ...blockchainInitialState,
+                    btc: {
+                        ...blockchainInitialState.btc,
+                        backends: {
+                            selected: 'electrum' as const,
+                            urls: { electrum: [electrumUrl] },
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+describe(setCustomBackendThunk.name, () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    it('requests a connection after applying a custom backend', async () => {
+        const setCustomBackend = jest
+            .spyOn(TrezorConnect, 'blockchainSetCustomBackend')
+            .mockResolvedValue({ success: true, payload: true });
+        const reconnect = jest
+            .spyOn(TrezorConnect, 'blockchainUnsubscribeFiatRates')
+            .mockResolvedValue({ success: true, payload: true });
+        const store = initStore();
+
+        await store.dispatch(setCustomBackendThunk('btc'));
+
+        expect(setCustomBackend).toHaveBeenCalledWith({
+            coin: 'btc',
+            blockchainLink: { type: 'electrum', url: [electrumUrl] },
+        });
+        expect(reconnect).toHaveBeenCalledWith({ coin: 'btc', identity: undefined });
+        expect(setCustomBackend.mock.invocationCallOrder[0]).toBeLessThan(
+            reconnect.mock.invocationCallOrder[0],
+        );
+    });
+});

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -111,11 +111,14 @@ export const setCustomBackendThunk = createThunk<
     unknown,
     NetworkSymbol,
     { state: SetCustomBackendThunkState }
->(`${BLOCKCHAIN_MODULE_PREFIX}/setCustomBackendThunk`, (symbol, { getState }) => {
+>(`${BLOCKCHAIN_MODULE_PREFIX}/setCustomBackendThunk`, async (symbol, { dispatch, getState }) => {
     const blockchain = selectBlockchainState(getState());
     const backends = [getBackendFromSettings(symbol, blockchain[symbol].backends)];
+    const result = await setBackendsToConnect(backends);
 
-    return setBackendsToConnect(backends);
+    await dispatch(reconnectBlockchainThunk({ symbol }));
+
+    return result;
 });
 
 export type InitBlockchainThunkState = AccountsRootState &

--- a/suite-native/module-settings/src/hooks/useNetworkBackendForm.ts
+++ b/suite-native/module-settings/src/hooks/useNetworkBackendForm.ts
@@ -16,7 +16,6 @@ import {
 import {
     type BlockchainRootState,
     blockchainActions,
-    reconnectBlockchainThunk,
     selectNetworkBlockchainInfo,
 } from '@suite-common/wallet-core';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
@@ -119,7 +118,6 @@ export const useNetworkBackendForm = ({ symbol, backendOptions }: Network) => {
                 urls: serverType !== 'default' ? [serverAddress] : [],
             }),
         );
-        dispatch(reconnectBlockchainThunk({ symbol }));
         analytics.report({
             type: events.settingsChangeCoinBackendEvent.name,
             payload: { symbol, type: serverType },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a custom-backend recovery failure that occurs after a failed backend instance has been removed. Saving a reachable replacement endpoint updated the backend configuration, but `reconnectAllBackends()` had no remaining instance to reconnect, leaving Suite in `connected: false` until another blockchain request was made.

The shared `setCustomBackendThunk` now:

1. Awaits `blockchainSetCustomBackend`.
2. Dispatches and awaits the existing `reconnectBlockchainThunk`.
3. Returns the original backend-setting result.

This uses the established inexpensive reconnect operation that emits `BLOCKCHAIN.CONNECT` or `BLOCKCHAIN.ERROR` and creates a backend instance when one does not exist.

The Native backend form previously dispatched its own reconnect immediately after the backend-setting action. That request could race with asynchronous configuration and became redundant after centralizing the ordered reconnect in the shared thunk, so it has been removed.

A co-located wallet-core regression test verifies the backend payload, the reconnect request, and their invocation order.

## Notes for QA

Primary regression scenario on Desktop:

1. Enable Bitcoin and select a custom Electrum backend.
2. Save `127.0.0.1:9:t` and wait for the connection failure.
3. Replace it with a reachable Electrum endpoint.
4. Confirm the settings.
5. Open Connection Info without clicking another reconnect action or loading an account.
6. Verify Suite reports the reachable backend as connected.

Please also verify:

- Switching between default and custom backends still reconnects normally.
- An unreachable replacement continues to emit and display the connection error.
- Native backend changes reconnect once after the new backend configuration is applied.

Validation performed:

- Focused wallet-core regression test: 1 passed.
- Existing Suite blockchain action tests: 46 passed.
- ESLint and Prettier passed for all changed files.
- Linux Desktop production AppImage built and passed an invalid-to-valid backend recovery smoke test.

## Related Issue

Resolve #30844

## Screenshots:

Not included. This changes connection sequencing and state recovery; it does not introduce a visual change.