### PR TITLE
fix(suite-desktop): max button behaviour with small amounts

### DIFF
--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,9 +1,14 @@
 import { configureMockStore } from '@suite-common/test-utils';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { type YieldFlowDisplayToken, accountsActions } from '@suite-common/wallet-core';
+import {
+    type YieldFlowDisplayToken,
+    accountsActions,
+    stablecoinYieldActions,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
+import { PUSH_TRANSACTION_FAILED_CAUSE } from './stablecoin-yield/signingHelpers';
 import { submitWrapNativeTokenThunk } from './wrapNativeTokenThunks';
 
 const mockComposeYieldWrapTransactionThunk = jest.fn();
@@ -21,6 +26,7 @@ jest.mock('@suite/modal', () => ({
 }));
 
 jest.mock('./stablecoin-yield/signingHelpers', () => ({
+    ...jest.requireActual('./stablecoin-yield/signingHelpers'),
     sendYieldTransaction: (payload: unknown) => mockSendYieldTransaction(payload),
 }));
 
@@ -34,6 +40,11 @@ const token: YieldFlowDisplayToken & { contractAddress: string } = {
 };
 
 describe('submitWrapNativeTokenThunk', () => {
+    beforeAll(() => {
+        // The thunk logs every caught failure; the expected ones would clutter the test output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
@@ -201,5 +212,98 @@ describe('submitWrapNativeTokenThunk', () => {
             .unwrap();
 
         expect(getTrackedTokenUpdates(store)).toHaveLength(0);
+    });
+
+    describe('failure reporting', () => {
+        const yieldFlow = { flowKey: 'yield-flow', flowType: 'deposit' } as const;
+
+        const acceptModalAndFailWith = (error: Error) => {
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn() }),
+            );
+            mockSendYieldTransaction.mockRejectedValue(error);
+        };
+
+        const getFlowErrors = (store: ReturnType<typeof configureMockStore>) =>
+            store
+                .getActions()
+                .filter(action => action.type === stablecoinYieldActions.setError.type);
+
+        it('reports a push failure on the deposit step it was started from', async () => {
+            acceptModalAndFailWith(
+                new Error('push failed', { cause: PUSH_TRANSACTION_FAILED_CAUSE }),
+            );
+            const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+            await store
+                .dispatch(
+                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
+                )
+                .unwrap();
+
+            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
+                ...yieldFlow,
+                error: 'TR_EARN_YIELD_ERROR_PUSH_FAILED',
+            });
+        });
+
+        it('falls back to the generic error for an unrecognised failure', async () => {
+            acceptModalAndFailWith(new Error('boom'));
+            const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+            await store
+                .dispatch(
+                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
+                )
+                .unwrap();
+
+            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
+                error: 'TR_EARN_YIELD_ERROR_GENERIC',
+            });
+        });
+
+        it('still shows the signing toast, the only feedback a standalone wrap gets', async () => {
+            acceptModalAndFailWith(new Error('boom'));
+            const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+            await store
+                .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
+                .unwrap();
+
+            const signErrorToast = store
+                .getActions()
+                .find(action => action.payload?.type === 'sign-tx-error');
+
+            expect(signErrorToast?.payload).toMatchObject({ error: 'boom' });
+        });
+
+        it('does not report a flow error for a standalone wrap', async () => {
+            acceptModalAndFailWith(new Error('boom'));
+            const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+            await store
+                .dispatch(submitWrapNativeTokenThunk({ account, token, wrapAmount: '1' }))
+                .unwrap();
+
+            expect(getFlowErrors(store)).toHaveLength(0);
+        });
+
+        it('reports a compose failure on the deposit step it was started from', async () => {
+            mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
+                unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
+            }));
+            const store = configureMockStore({ extra: {}, preloadedState: {} });
+
+            await store
+                .dispatch(
+                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
+                )
+                .unwrap();
+
+            expect(getFlowErrors(store)[0]?.payload).toMatchObject({
+                ...yieldFlow,
+                error: 'TR_EARN_YIELD_ERROR_GENERIC',
+            });
+        });
     });
 });

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -6,11 +6,15 @@ import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config
 import {
     type YieldFlowDisplayToken,
     composeYieldWrapTransactionThunk,
+    setYieldError,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
 
-import { sendYieldTransaction } from './stablecoin-yield/signingHelpers';
+import {
+    getYieldErrorTranslationKey,
+    sendYieldTransaction,
+} from './stablecoin-yield/signingHelpers';
 import { addToken } from './tokenActions';
 
 const WRAP_NATIVE_TOKEN_PREFIX = '@wallet/wrap-native-token';
@@ -43,6 +47,12 @@ export const submitWrapNativeTokenThunk = createThunk(
                         error: `Failed to compose wrap transaction (${result.reason}).`,
                     }),
                 );
+
+                // A wrap started from the deposit flow needs the failure on the step itself; the
+                // toast alone leaves the flow looking idle.
+                if (yieldFlow) {
+                    setYieldError({ dispatch, ...yieldFlow });
+                }
 
                 return undefined;
             }
@@ -141,6 +151,17 @@ export const submitWrapNativeTokenThunk = createThunk(
                     error: error instanceof Error ? error.message : String(error),
                 }),
             );
+
+            // Same reasoning as the compose failure above. A push failure in particular means the
+            // transaction was already signed, which is worth saying rather than leaving the step
+            // looking idle.
+            if (yieldFlow) {
+                setYieldError({
+                    dispatch,
+                    ...yieldFlow,
+                    error: getYieldErrorTranslationKey(error),
+                });
+            }
 
             return undefined;
         }

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -93,12 +93,9 @@ export const YieldDepositForm = () => {
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
 
-    // Wrapping into the gas reserve is allowed (Max keeps it aside, but a manual entry may not),
-    // so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the full
-    // balance now, and `shouldRecommendWrapReserve` already excludes that over-balance case.
-    // Wrapping into the gas reserve is allowed (Max fills the full balance), so recommend keeping
-    // it rather than blocking. `isAmountTooHigh` only fires above the full balance, and
-    // `shouldRecommendWrapReserve` already excludes that over-balance case.
+    // Wrapping into the gas reserve is allowed — Max keeps it aside only while the balance covers
+    // it — so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the
+    // full balance, and `shouldRecommendWrapReserve` already excludes that over-balance case.
     const showWrapReserveRecommendation =
         flow.currentStep === 'wrap' &&
         !isAmountInvalidDecimals &&

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -18,7 +18,7 @@ import {
     type YieldFlowToken,
     type YieldPendingTransactionState,
     type YieldPositionFlowType,
-    getWrappableNativeBalance,
+    getMaxWrapAmount,
     handleYieldApproveCancelThunk,
     handleYieldApproveSuccessTxidThunk,
     initYieldAllowanceThunk,
@@ -193,9 +193,10 @@ export const useYieldFlow = ({
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
             if (session.step === 'wrap') {
-                // Max leaves the gas reserve aside; the field still shows the full balance and the
-                // user may wrap up to it (see `amountTooHighThreshold`), with a recommendation.
-                return getWrappableNativeBalance(account.formattedBalance);
+                // Max leaves the gas reserve aside while the balance covers it, otherwise it fills
+                // the whole balance. Either way the field shows the full balance and the user may
+                // wrap up to it (see `amountTooHighThreshold`), with a recommendation.
+                return getMaxWrapAmount(account.formattedBalance);
             }
 
             return token?.balance ?? '';
@@ -825,9 +826,9 @@ export const useYieldFlow = ({
         !liveAmount || !isAmountGreaterThan({ amount: liveAmount, threshold: '0' });
     const allowanceAmount = session.approval.allowanceAmount ?? '0';
     const canRevokeAllowance = isAmountGreaterThan({ amount: allowanceAmount, threshold: '0' });
-    // On the wrap step the hard cap is the full native balance: `maxAmount` only holds the gas
-    // reserve aside for the Max button, and manually eating into it is a non-blocking
-    // recommendation rather than an "insufficient funds" error.
+    // On the wrap step the hard cap is the full native balance: `maxAmount` holds the gas reserve
+    // aside for the Max button only while the balance covers it, and manually eating into the
+    // reserve is a non-blocking recommendation rather than an "insufficient funds" error.
     const amountTooHighThreshold =
         flowType === 'deposit' && session.step === 'wrap' ? account.formattedBalance : maxAmount;
     const isAmountTooHigh = isAmountGreaterThan({

--- a/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
+++ b/packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx
@@ -11,7 +11,7 @@ import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowFormValues,
-    getWrappableNativeBalance,
+    getMaxWrapAmount,
     shouldRecommendWrapReserve,
 } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
@@ -67,9 +67,10 @@ export const WrapNativeToken = ({ account, token }: WrapNativeTokenProps) => {
         decimals: token.decimals,
     };
 
-    // Max leaves the gas reserve aside, but the field shows the full balance and the user may wrap
-    // up to it; eating into the reserve only triggers a non-blocking recommendation.
-    const maxWrapAmount = getWrappableNativeBalance(account.formattedBalance);
+    // Max leaves the gas reserve aside while the balance covers it, otherwise it fills the whole
+    // balance. The field shows the full balance and the user may wrap up to it; eating into the
+    // reserve only triggers a non-blocking recommendation.
+    const maxWrapAmount = getMaxWrapAmount(account.formattedBalance);
 
     const { fiatToggle, setMaxAmount } = useYieldFiatInput({
         methods,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -9,6 +9,7 @@ import {
     buildYieldUnwrapTransactionData,
     buildYieldWithdrawCalldata,
     buildYieldWrapTransactionData,
+    getMaxWrapAmount,
     getNextYieldFlowStep,
     getWrappableNativeBalance,
     getYieldDepositableBalance,
@@ -409,6 +410,42 @@ describe('stablecoinYieldUtils', () => {
 
         it('treats an empty balance as zero', () => {
             expect(getWrappableNativeBalance('')).toBe('0');
+        });
+    });
+
+    describe('getMaxWrapAmount', () => {
+        it('keeps the gas reserve aside when the balance covers it', () => {
+            expect(getMaxWrapAmount('0.2')).toBe('0.195');
+        });
+
+        it('offers the whole balance when it does not cover the reserve', () => {
+            expect(getMaxWrapAmount('0.003')).toBe('0.003');
+        });
+
+        it('offers the whole balance when it exactly matches the reserve', () => {
+            expect(getMaxWrapAmount('0.005')).toBe('0.005');
+        });
+
+        // Max must offer an amount that is both usable and flagged, otherwise the button reads as
+        // dead — the regression behind trezor/trezor-suite#30842.
+        it('offers an amount that triggers the reserve recommendation', () => {
+            expect(shouldRecommendWrapReserve(getMaxWrapAmount('0.003'), '0.003')).toBe(true);
+        });
+
+        it('treats an empty balance as zero', () => {
+            expect(getMaxWrapAmount('')).toBe('0');
+        });
+
+        it('returns zero for a zero balance', () => {
+            expect(getMaxWrapAmount('0')).toBe('0');
+        });
+
+        it('returns zero for a negative balance', () => {
+            expect(getMaxWrapAmount('-1')).toBe('0');
+        });
+
+        it('returns zero for non-numeric input', () => {
+            expect(getMaxWrapAmount('abc')).toBe('0');
         });
     });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts
@@ -384,6 +384,25 @@ export const getWrappableNativeBalance = (nativeFormattedBalance: string): strin
     ).toString();
 
 /**
+ * Amount the wrap step's "Max" button fills in: the balance minus `WETH_WRAP_GAS_RESERVE` while
+ * that leaves something to wrap, otherwise the whole balance. A balance at or below the reserve
+ * has nothing to keep aside, and offering `0` reads as a dead button
+ * (trezor/trezor-suite#30842). Wrapping it all is allowed, and `shouldRecommendWrapReserve` then
+ * surfaces the non-blocking recommendation to keep some native coin for the follow-up fees.
+ */
+export const getMaxWrapAmount = (nativeFormattedBalance: string): string => {
+    const balance = new BigNumber(nativeFormattedBalance || '0');
+
+    if (!balance.isFinite() || balance.lte(0)) {
+        return '0';
+    }
+
+    const wrappableBalance = new BigNumber(getWrappableNativeBalance(nativeFormattedBalance));
+
+    return wrappableBalance.gt(0) ? wrappableBalance.toString() : balance.toString();
+};
+
+/**
  * Whether wrapping `amountInput` out of `nativeFormattedBalance` would leave at most
  * `WETH_WRAP_GAS_RESERVE` behind — i.e. no safety margin above the reserve needed for the
  * follow-up approve + deposit fees. Used to surface a non-blocking recommendation to keep a


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Tweaks logic of max button (when it's below min-dust amount) to let users do what they want

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30842

## Screenshots:


<img width="624" height="710" alt="Screenshot 2026-08-05 at 8 25 48" src="https://github.com/user-attachments/assets/f01aebda-beb2-48f1-adda-db9284991317" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/fix-deposit-yield-max-below-dust/web/](https://dev.suite.sldev.cz/suite-web/feat/fix-deposit-yield-max-below-dust/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files focus on Earn stablecoin-yield logic, yield-deposit UI, and native-token wrapping thunks/components. None of the 159 candidate E2E tests directly exercise these flows; the static mappings to 134 tests are broad transitive imports and do not represent real functional coverage. Rely on the updated unit tests for confidence, and consider adding dedicated E2E coverage for yield deposit and wrap flows.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (5)**
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/wrap/WrapNativeToken.tsx`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.ts`

_Updated: 2026-08-05T06:31:28.532Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/fix-deposit-yield-max-below-dust&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/fix-deposit-yield-max-below-dust&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fix-deposit-yield-max-below-dust&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T06:32:52.053Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T06:32:21.913Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->