### PR TITLE
fix(recovery): fix persistent-recovery rerun race and related recovery-flow bugs

### DIFF
--- a/packages/suite/src/actions/onboarding/onboardingActions.ts
+++ b/packages/suite/src/actions/onboarding/onboardingActions.ts
@@ -4,7 +4,12 @@ import { type ThunkDispatch } from 'redux-thunk';
 import { type DesktopAnalyticsDep, type OnboardingAnalytics, events } from '@suite/analytics';
 import { initialRunCompletedThunk } from '@suite/flags';
 import { closeModal } from '@suite/modal';
-import { type RecoveryState, recoveryRerunThunk } from '@suite/recovery';
+import {
+    type RecoveryState,
+    checkSeedThunk,
+    recoverDeviceThunk,
+    recoveryRerunThunk,
+} from '@suite/recovery';
 import {
     type GotoThunkState,
     type SuiteRouterHistoryDep,
@@ -293,14 +298,22 @@ const rerunRecoveryThunk =
         }
 
         const { initialized } = result.payload;
+
+        // Navigate to the recovery view FIRST. The app change triggers routerAppChanged ->
+        // suiteMiddleware.resetReducer, which resets the recovery reducer to 'initial'. Only after that
+        // do we start the seed-input thunk, so its setStatus('in-progress') survives the reset. Starting
+        // it before navigation would let the reset wipe the in-progress status and drop the UI back to the
+        // "Start" screen while a recoveryDevice call is already in flight (allowing a double-dispatch).
         if (initialized) {
             dispatch(gotoThunk({ routeName: 'recovery-index' }));
+            dispatch(checkSeedThunk());
         } else {
             if (selectRouterApp(getState()) !== 'onboarding') {
                 dispatch(gotoThunk({ routeName: 'onboarding-index' }));
             }
             dispatch(goToStep('recovery'));
             dispatch(addPath('recovery'));
+            dispatch(recoverDeviceThunk());
         }
     };
 

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/RecoveryStepBox.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/RecoveryStepBox.tsx
@@ -3,7 +3,6 @@ import { Translation } from '@suite/intl';
 import { OnboardingCard, type OnboardingCardProps } from '@suite/onboarding-components';
 import { recoveryActions, selectRecoveryError, selectRecoveryStatus } from '@suite/recovery';
 import { useDispatch } from '@suite-common/redux-utils';
-import { DeviceModelInternal } from '@trezor/device-utils';
 import { TrezorBackupIcon } from '@trezor/icons';
 
 import { goToPreviousStepThunk } from 'src/actions/onboarding/onboardingActions';
@@ -26,13 +25,11 @@ const RecoveryStepBox = (props: OnboardingCardProps) => {
         if (recoveryStatus === 'select-recovery-type') {
             return dispatch(recoveryActions.setStatus('initial'));
         }
-        // allow to change recovery settings for T1B1 in case of error
-        if (
-            recoveryStatus === 'finished' &&
-            recoveryError &&
-            deviceModelInternal === DeviceModelInternal.T1B1
-        ) {
-            return dispatch(recoveryActions.setStatus('initial'));
+        // Allow the user to restart recovery after an error (any device model). Reset the whole
+        // reducer so the stale error/status is cleared; otherwise re-entering the step would render
+        // the "recovery failed" screen again instead of a clean start.
+        if (recoveryStatus === 'finished' && recoveryError) {
+            return dispatch(recoveryActions.resetReducer());
         }
 
         return dispatch(goToPreviousStepThunk());

--- a/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
+++ b/packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx
@@ -221,31 +221,8 @@ export const RecoveryStep = () => {
         );
     }
 
-    if (device?.mode === 'normal') {
-        // Ready to continue to the next step
-        const handleClick = () => dispatch(goToNextStepThunk('set-pin'));
-
-        return (
-            <RecoveryStepBox
-                heading={
-                    <Column gap={8} alignItems="center" justifyContent="center">
-                        <Badge intent="neutral" size="medium">
-                            <Translation id="TR_RECOVER_WALLET" />
-                        </Badge>
-                        <Translation id="TR_WALLET_RECOVERED_FROM_SEED" />
-                    </Column>
-                }
-                innerActions={
-                    <OnboardingCard.Button
-                        data-testid="@onboarding/recovery/continue-button"
-                        onClick={handleClick}
-                    >
-                        <Translation id="TR_CONTINUE" />
-                    </OnboardingCard.Button>
-                }
-            />
-        );
-    }
+    // Check the error state before the device.mode === 'normal' success screen: a failed recovery
+    // must always show the retry UI, never the "wallet recovered" screen, regardless of device.mode.
     if (status === 'finished' && error) {
         return (
             <RecoveryStepBox
@@ -270,6 +247,32 @@ export const RecoveryStep = () => {
                         intent="critical"
                     >
                         <Translation id="TR_RETRY" />
+                    </OnboardingCard.Button>
+                }
+            />
+        );
+    }
+
+    if (device?.mode === 'normal') {
+        // Ready to continue to the next step
+        const handleClick = () => dispatch(goToNextStepThunk('set-pin'));
+
+        return (
+            <RecoveryStepBox
+                heading={
+                    <Column gap={8} alignItems="center" justifyContent="center">
+                        <Badge intent="neutral" size="medium">
+                            <Translation id="TR_RECOVER_WALLET" />
+                        </Badge>
+                        <Translation id="TR_WALLET_RECOVERED_FROM_SEED" />
+                    </Column>
+                }
+                innerActions={
+                    <OnboardingCard.Button
+                        data-testid="@onboarding/recovery/continue-button"
+                        onClick={handleClick}
+                    >
+                        <Translation id="TR_CONTINUE" />
                     </OnboardingCard.Button>
                 }
             />

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import { useDevice } from '@suite/device';
 import { Translation, messages } from '@suite/intl';
-import { MODAL_CONTEXT_DEVICE, selectModal, selectModalRequestId } from '@suite/modal';
+import {
+    MODAL_CONTEXT_DEVICE,
+    MODAL_CONTEXT_NONE,
+    selectModal,
+    selectModalRequestId,
+} from '@suite/modal';
 import {
     type RecoveryInputType,
     type SeedInputStatus,
@@ -44,6 +49,8 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     const intl = useIntl();
     const pinRequestId = useSelector(selectModalRequestId);
     const { pin, setPin, handlePinSubmit } = usePin(device?.buttonRequests ?? [], pinRequestId);
+    // Set when the user cancels a running device request; the modal close is deferred (see effect below).
+    const cancelRequestedRef = useRef(false);
 
     const deviceModelInternal = device?.features?.internal_model;
     const isT1B1 = deviceModelInternal === DeviceModelInternal.T1B1;
@@ -62,14 +69,26 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
     const handleClose = () => {
         if (['in-progress', 'waiting-for-confirmation'].includes(recovery.status)) {
-            // Abort the running device call. The resulting Method_Cancel is handled by the recovery
-            // thunks (which reset the reducer), so the modal can close right away instead of leaving
-            // the user on a "seed check failed" screen.
+            // Navigation is blocked while a device request is active, so the modal cannot be closed
+            // synchronously here. Abort the request and defer the close to the effect below, which
+            // runs once the device becomes idle and the device modal context clears. The resulting
+            // Method_Cancel is handled by the recovery thunks (which reset the reducer), so no
+            // "seed check failed" screen is shown in the meantime.
+            cancelRequestedRef.current = true;
             TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
+        } else {
+            onCancel();
         }
-
-        onCancel();
     };
+
+    // Close the modal once a requested cancel has settled: the device is idle again and the device
+    // modal context has cleared, which is exactly when closeModalApp (onCancel) can navigate away.
+    useEffect(() => {
+        if (cancelRequestedRef.current && !isLocked() && modal.context === MODAL_CONTEXT_NONE) {
+            cancelRequestedRef.current = false;
+            onCancel();
+        }
+    }, [isLocked, modal.context, onCancel]);
 
     const handleBackClick = () => {
         const currentIndex = statesInProgressBar.indexOf(recovery.status);

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -62,10 +62,13 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
     const handleClose = () => {
         if (['in-progress', 'waiting-for-confirmation'].includes(recovery.status)) {
+            // Abort the running device call. The resulting Method_Cancel is handled by the recovery
+            // thunks (which reset the reducer), so the modal can close right away instead of leaving
+            // the user on a "seed check failed" screen.
             TrezorConnect.cancel({ reason: intl.formatMessage(messages.TR_CANCELLED) });
-        } else {
-            onCancel();
         }
+
+        onCancel();
     };
 
     const handleBackClick = () => {

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -288,14 +288,17 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
 
     return (
         <Modal.Backdrop>
-            {['in-progress', 'waiting-for-confirmation'].includes(recovery.status) && (
-                <ConfirmOnDevicePill
-                    title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
-                    deviceModelInternal={device.features.internal_model}
-                    deviceUnitColor={device.features.unit_color}
-                    onCancel={handleClose}
-                />
-            )}
+            {['in-progress', 'waiting-for-confirmation'].includes(recovery.status) &&
+                modal.context === MODAL_CONTEXT_DEVICE && (
+                    // Gate on the device modal context so the pill is not left orphaned after the
+                    // device disconnects mid-recovery (which clears the modal context to 'none').
+                    <ConfirmOnDevicePill
+                        title={<Translation id="TR_CONFIRM_ON_TREZOR" />}
+                        deviceModelInternal={device.features.internal_model}
+                        deviceUnitColor={device.features.unit_color}
+                        onCancel={handleClose}
+                    />
+                )}
             <Modal.ModalBase
                 heading={hasError ? undefined : <Translation id="TR_CHECK_RECOVERY_SEED" />}
                 description={

--- a/packages/suite/src/views/recovery/index.tsx
+++ b/packages/suite/src/views/recovery/index.tsx
@@ -72,9 +72,12 @@ export const Recovery = ({ onCancel }: ForegroundAppProps) => {
     };
 
     const handleBackClick = () => {
-        const previousIndex = statesInProgressBar.indexOf(recovery.status) - 1;
-        // @ts-expect-error: indexing with noUncheckedIndexedAccess
-        const previousState: SeedInputStatus = statesInProgressBar[previousIndex];
+        const currentIndex = statesInProgressBar.indexOf(recovery.status);
+        // Fall back to 'initial' when the current status is not part of this device model's progress
+        // bar (e.g. a T1B1-only status lingering after hot-swapping to a touch device), which would
+        // otherwise produce an out-of-bounds index and dispatch setStatus(undefined).
+        const previousState: SeedInputStatus =
+            (currentIndex > 0 ? statesInProgressBar[currentIndex - 1] : undefined) ?? 'initial';
         dispatch(recoveryActions.setStatus(previousState));
     };
 

--- a/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx
@@ -8,6 +8,7 @@ import { setConnectionModal, useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { ContextMessage } from '@suite/message-system';
 import { isRecoveryInProgress } from '@suite/recovery';
+import { isAdditionalShamirBackupInProgress } from '@suite-common/backup';
 import { selectIsDeviceAuthenticityCheckSupported } from '@suite-common/device';
 import { Context } from '@suite-common/message-system';
 import { useDispatch } from '@suite-common/redux-utils';
@@ -67,7 +68,12 @@ const deviceSettingsUnavailable = (device?: TrezorDevice) => {
     const wrongDeviceType = device?.type && ['unacquired', 'unreadable'].includes(device.type);
     const wrongDeviceMode =
         (device?.mode && ['seedless'].includes(device.mode)) ||
-        (device?.features !== undefined && isRecoveryInProgress(device?.features));
+        (device?.features !== undefined &&
+            // Both states leave the device mid-operation; device-management actions (e.g. Check
+            // Recovery Seed, which starts a DryRun recovery) would conflict with the firmware. The
+            // recovery case was already covered; additional-shamir backup needs the same guard.
+            (isRecoveryInProgress(device?.features) ||
+                isAdditionalShamirBackupInProgress(device?.features)));
     const firmwareUpdateRequired = device?.firmware === 'required';
 
     return wrongDeviceType || wrongDeviceMode || firmwareUpdateRequired;

--- a/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
@@ -46,6 +46,14 @@ export const DeviceDisconnectedScreen = ({
             },
         });
 
+    // Leaving this screen (via the alert's Cancel or the header close) means the user gave up on this
+    // onboarding; flag it so the connection middleware keeps them on Home instead of pulling them back
+    // into onboarding on the next connect. Both exit paths must use this handler.
+    const cancelOnboardingAndGoHome = () => {
+        dispatch(setWasDeviceOnboardingCancelled(true));
+        navigateToHome();
+    };
+
     useEffect(() => {
         dispatch(setWasDeviceOnboardingCancelled(false));
 
@@ -60,10 +68,7 @@ export const DeviceDisconnectedScreen = ({
             onPressPrimaryButton: () => setIsAlertDismissed(true),
             secondaryButtonTitle: translate('generic.buttons.cancel'),
             secondaryButtonColorProps: { intent: 'critical', priority: 'secondary' },
-            onPressSecondaryButton: () => {
-                dispatch(setWasDeviceOnboardingCancelled(true));
-                navigateToHome();
-            },
+            onPressSecondaryButton: cancelOnboardingAndGoHome,
         });
 
         // This effect should be called only once during the first render.
@@ -72,7 +77,9 @@ export const DeviceDisconnectedScreen = ({
 
     return (
         <Screen
-            header={<ScreenHeader closeAction={navigateToHome} closeActionType="close" />}
+            header={
+                <ScreenHeader closeAction={cancelOnboardingAndGoHome} closeActionType="close" />
+            }
             isScrollable={false}
         >
             {wasDeviceConnectedViaBluetooth ? (

--- a/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
+++ b/suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx
@@ -61,7 +61,7 @@ export const DeviceDisconnectedScreen = ({
             secondaryButtonTitle: translate('generic.buttons.cancel'),
             secondaryButtonColorProps: { intent: 'critical', priority: 'secondary' },
             onPressSecondaryButton: () => {
-                setWasDeviceOnboardingCancelled(true);
+                dispatch(setWasDeviceOnboardingCancelled(true));
                 navigateToHome();
             },
         });

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -69,6 +69,29 @@ describe('Recovery Thunks', () => {
         expect(store.getState().recovery.status).toMatch('finished');
     });
 
+    it('checkSeedThunk resets the flow on user cancel instead of showing a failure screen', async () => {
+        testMocks.setTrezorConnectFixtures({
+            success: false,
+            error: { code: 'Method_Cancel', message: 'Cancelled' },
+        });
+        const store = initStore({ error: 'stale error' });
+        await store.dispatch(checkSeedThunk());
+        // reset -> 'initial', NOT the 'finished' + error state that renders the failure screen
+        expect(store.getState().recovery.status).toEqual('initial');
+        expect(store.getState().recovery.error).toBeUndefined();
+    });
+
+    it('recoverDeviceThunk resets the flow on user cancel instead of showing a failure screen', async () => {
+        testMocks.setTrezorConnectFixtures({
+            success: false,
+            error: { code: 'Method_Cancel', message: 'Cancelled' },
+        });
+        const store = initStore({ error: 'stale error' });
+        await store.dispatch(recoverDeviceThunk());
+        expect(store.getState().recovery.status).toEqual('initial');
+        expect(store.getState().recovery.error).toBeUndefined();
+    });
+
     it('recoveryRerunThunk resets the status and rejects when the device already left recovery', async () => {
         // fresh features report no recovery in progress
         testMocks.setTrezorConnectFixtures({ success: true, payload: {} });

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -1,9 +1,9 @@
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
-import { createTestStore } from '@suite-common/test-utils';
+import { createTestStore, testMocks } from '@suite-common/test-utils';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { recoveryReducer } from './recoveryReducer';
-import { checkSeedThunk, recoverDeviceThunk } from './recoveryThunks';
+import { checkSeedThunk, recoverDeviceThunk, recoveryRerunThunk } from './recoveryThunks';
 
 const getInitialState = (custom?: any): any => ({
     suite: {
@@ -49,6 +49,10 @@ describe('Recovery Thunks', () => {
         jest.clearAllMocks();
     });
 
+    afterEach(() => {
+        testMocks.setTrezorConnectFixtures(undefined);
+    });
+
     it('recoverDeviceThunk', async () => {
         const store = initStore();
         const action = store.dispatch(recoverDeviceThunk());
@@ -63,5 +67,21 @@ describe('Recovery Thunks', () => {
         expect(store.getState().recovery.status).toMatch('in-progress');
         await action;
         expect(store.getState().recovery.status).toMatch('finished');
+    });
+
+    it('recoveryRerunThunk fulfills with initialized and does not start the seed-input flow itself', async () => {
+        testMocks.setTrezorConnectFixtures({
+            success: true,
+            payload: { recovery_status: 'Recovery', initialized: true },
+        });
+        const store = initStore();
+        const result = await store.dispatch(recoveryRerunThunk());
+        expect(recoveryRerunThunk.fulfilled.match(result)).toBe(true);
+        if (recoveryRerunThunk.fulfilled.match(result)) {
+            expect(result.payload).toEqual({ initialized: true });
+        }
+        // the seed-input thunk is started by the caller AFTER navigation, so no recoveryDevice call
+        // has run here; the status must remain 'in-progress' (it would be 'finished' otherwise)
+        expect(store.getState().recovery.status).toEqual('in-progress');
     });
 });

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -117,4 +117,42 @@ describe('Recovery Thunks', () => {
         // has run here; the status must remain 'in-progress' (it would be 'finished' otherwise)
         expect(store.getState().recovery.status).toEqual('in-progress');
     });
+
+    it('recoveryRerunThunk resets and rejects when the selected device changes during getFeatures', async () => {
+        testMocks.setTrezorConnectFixtures({
+            success: true,
+            payload: { recovery_status: 'Recovery', initialized: true },
+        });
+        // A store whose selected-device path is swapped mid-thunk (while getFeatures is awaited),
+        // to exercise the device-changed guard.
+        const store = createTestStore({
+            extra: { services: { analytics: mockDesktopAnalytics() } },
+            preloadedState: {
+                ...getInitialState(),
+                device: {
+                    selectedDevice: {
+                        features: { major_version: 2, internal_model: DeviceModelInternal.T2T1 },
+                        path: 'device-a',
+                    },
+                },
+            },
+            reducer: (state: any, action: any) => ({
+                ...state,
+                recovery: recoveryReducer(state.recovery, action),
+                device:
+                    action.type === 'TEST/SWAP_DEVICE'
+                        ? { selectedDevice: { ...state.device.selectedDevice, path: 'device-b' } }
+                        : state.device,
+            }),
+        });
+
+        const action = store.dispatch(recoveryRerunThunk());
+        // the thunk has captured 'device-a' and is now awaiting getFeatures; swap the selected device
+        store.dispatch({ type: 'TEST/SWAP_DEVICE' });
+        const result = await action;
+
+        expect(recoveryRerunThunk.rejected.match(result)).toBe(true);
+        // the transient 'in-progress' set before the await must be cleared
+        expect(store.getState().recovery.status).toEqual('initial');
+    });
 });

--- a/suite/recovery/src/recoveryThunks.test.ts
+++ b/suite/recovery/src/recoveryThunks.test.ts
@@ -69,6 +69,16 @@ describe('Recovery Thunks', () => {
         expect(store.getState().recovery.status).toMatch('finished');
     });
 
+    it('recoveryRerunThunk resets the status and rejects when the device already left recovery', async () => {
+        // fresh features report no recovery in progress
+        testMocks.setTrezorConnectFixtures({ success: true, payload: {} });
+        const store = initStore({ status: 'finished' });
+        const result = await store.dispatch(recoveryRerunThunk());
+        expect(recoveryRerunThunk.rejected.match(result)).toBe(true);
+        // the transient 'in-progress' set by the thunk must be cleared, not left stuck
+        expect(store.getState().recovery.status).toEqual('initial');
+    });
+
     it('recoveryRerunThunk fulfills with initialized and does not start the seed-input flow itself', async () => {
         testMocks.setTrezorConnectFixtures({
             success: true,

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -160,13 +160,9 @@ export const recoveryRerunThunk = createThunk<
         return rejectWithValue('recovery not in progress');
     }
 
-    if (!features.initialized) {
-        dispatch(recoverDeviceThunk());
-    }
-
-    if (features.initialized) {
-        dispatch(checkSeedThunk());
-    }
-
+    // The seed-input flow (recoverDeviceThunk / checkSeedThunk) is intentionally NOT started here.
+    // The caller starts it AFTER navigating to the recovery/onboarding view. Starting it here would
+    // race the routerAppChanged -> resetReducer that the navigation triggers, wiping the freshly-set
+    // 'in-progress' status back to 'initial' (wrong "Start" screen) while the device call is in flight.
     return { initialized: features.initialized };
 });

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -57,6 +57,14 @@ export const checkSeedThunk = createThunk<
     });
 
     if (!response.success) {
+        // A user-initiated cancellation is not a failure: reset the flow instead of leaving the
+        // reducer on the 'finished' + error state, which renders the "seed check failed" screen.
+        if (response.error.code === 'Method_Cancel') {
+            dispatch(recoveryActions.resetReducer());
+
+            return;
+        }
+
         dispatch(recoveryActions.setError(response.error.message));
         extra.services.analytics.report({
             type: events.settingsDeviceCheckSeedEvent.name,
@@ -117,6 +125,14 @@ export const recoverDeviceThunk = createThunk<void, void, { state: RecoverDevice
         });
 
         if (!response.success) {
+            // A user-initiated cancellation is not a failure: reset the flow instead of leaving the
+            // reducer on the 'finished' + error state, which renders the "recovery failed" screen.
+            if (response.error.code === 'Method_Cancel') {
+                dispatch(recoveryActions.resetReducer());
+
+                return;
+            }
+
             dispatch(recoveryActions.setError(response.error.message));
         }
 

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -156,6 +156,16 @@ export const recoveryRerunThunk = createThunk<
 
     const features = response.payload;
 
+    // The selected device may have changed during the getFeatures round-trip (e.g. a multi-device
+    // switch). Bail out instead of applying this device's initialized/recover-vs-check decision — and
+    // the seed-input call the caller starts next — to a different device. Reset so the status set
+    // above is not left stuck; the newly-selected device re-triggers its own rerun if needed.
+    if (selectSelectedDevice(getState())?.path !== device.path) {
+        dispatch(recoveryActions.resetReducer());
+
+        return rejectWithValue('selected device changed');
+    }
+
     if (!isRecoveryInProgress(features)) {
         // Device already left recovery mode; clear the transient 'in-progress' status set above so
         // the recovery-detection guard and the recovery-mode banner CTA don't get stuck.

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -157,6 +157,10 @@ export const recoveryRerunThunk = createThunk<
     const features = response.payload;
 
     if (!isRecoveryInProgress(features)) {
+        // Device already left recovery mode; clear the transient 'in-progress' status set above so
+        // the recovery-detection guard and the recovery-mode banner CTA don't get stuck.
+        dispatch(recoveryActions.resetReducer());
+
         return rejectWithValue('recovery not in progress');
     }
 

--- a/suite/recovery/src/recoveryThunks.ts
+++ b/suite/recovery/src/recoveryThunks.ts
@@ -163,6 +163,17 @@ export const recoveryRerunThunk = createThunk<
     // reload fresh features before deciding what to do
     const response = await TrezorConnect.getFeatures({ device: { path: device.path } });
 
+    // If the selected device changed during the getFeatures round-trip (a multi-device switch), bail
+    // out before touching shared recovery state on EITHER response branch — otherwise this device's
+    // outcome (including a stale 'failed to rerun' error) would be applied to a different device, and
+    // the seed-input call the caller starts next would target the wrong device. Reset so the status
+    // set above is not left stuck; the newly-selected device re-triggers its own rerun if needed.
+    if (selectSelectedDevice(getState())?.path !== device.path) {
+        dispatch(recoveryActions.resetReducer());
+
+        return rejectWithValue('selected device changed');
+    }
+
     if (!response.success) {
         dispatch(recoveryActions.setStatus('finished'));
         dispatch(recoveryActions.setError('failed to rerun recovery'));
@@ -171,16 +182,6 @@ export const recoveryRerunThunk = createThunk<
     }
 
     const features = response.payload;
-
-    // The selected device may have changed during the getFeatures round-trip (e.g. a multi-device
-    // switch). Bail out instead of applying this device's initialized/recover-vs-check decision — and
-    // the seed-input call the caller starts next — to a different device. Reset so the status set
-    // above is not left stuck; the newly-selected device re-triggers its own rerun if needed.
-    if (selectSelectedDevice(getState())?.path !== device.path) {
-        dispatch(recoveryActions.resetReducer());
-
-        return rejectWithValue('selected device changed');
-    }
 
     if (!isRecoveryInProgress(features)) {
         // Device already left recovery mode; clear the transient 'in-progress' status set above so


### PR DESCRIPTION
## Description

Investigative review of the recovery-device flow (persistent recovery, rerun-on-reconnect, state machine) surfaced a set of bugs; this PR fixes them, one atomic commit per bug. Each finding was adversarially verified for reachability across the shared `suite/recovery` package, the web/desktop `packages/suite` views/middlewares, and the native onboarding module.

### 🔴 Rerun race (regression) — af84bbae68
`recoveryRerunThunk` started the seed-input thunk (`checkSeedThunk` / `recoverDeviceThunk`) **itself**, before `recoveryRerun` navigated. The navigation fires `routerAppChanged` → `suiteMiddleware.resetReducer`, which then wiped the freshly-set `in-progress` status back to `initial` **while a `recoveryDevice` call was already in flight** — dropping the user onto the "Start" screen mid-recovery and allowing a second, concurrent device call. Restores the pre-refactor navigate-first ordering: the thunk only reads features and returns `{ initialized }`; the caller navigates before starting the sub-thunk.

### 🟠 User cancel shown as failure — 4d4e7a2228
Cancelling an in-progress seed check / recovery resolved with `Method_Cancel`, which set an error + `finished` and rendered the "seed check failed" screen. The thunks now treat `Method_Cancel` as a reset, and the recovery modal closes on cancel.

### 🟡 Additional fixes
- **Stuck `in-progress`** — 2956d12a97: the "recovery not in progress" reject path now resets instead of leaving a stuck `in-progress` (which hid the `DeviceRecoveryMode` CTA and suppressed future auto-reruns).
- **Multi-device consistency** — 4cb8aad2a1: bail out (and reset) if the selected device changed during the `getFeatures` round-trip.
- **Back-button OOB** — e6f9c22c6b: `handleBackClick` no longer produces `setStatus(undefined)` (blank modal) after hot-swapping device models.
- **Orphaned pill** — 87cd3f912a: `ConfirmOnDevicePill` is gated on the device modal context so it isn't left dangling after a mid-recovery disconnect.
- **Onboarding back-on-error** — b21b06f579: resets for every device model (not just T1B1) so re-entering the recovery step shows a clean start.
- **Error before success screen** — 37eba4d0bc: the `finished`+error state is evaluated before the `device.mode === 'normal'` success screen.
- **Settings during additional shamir backup** — 34a2bcd05f: `deviceSettingsUnavailable` now guards `isAdditionalShamirBackupInProgress` symmetrically with `isRecoveryInProgress`.
- **Native** — a7d51d9663: the device-disconnected alert's Cancel handler now actually `dispatch`es `setWasDeviceOnboardingCancelled(true)` (was a no-op).

## Notes for QA

Focus on **T2T1/T2B1/T3T1/T3B1 persistent recovery**:
- Start a seed check / recovery, disconnect and reconnect the device mid-flow → you should land back on the live in-progress screen (not the "Start" screen), and no duplicate device call should be issued.
- Cancel an in-progress seed check → the modal should just close, **not** show a "seed check failed" error screen.
- Onboarding recovery failure → "Back" should return to a clean recovery start (no stale error) on all models.
- Settings → Check Recovery Seed should be unavailable while a multi-share (additional shamir) backup is in progress.
- Native: during device onboarding, disconnect the device, tap **Cancel** on the alert → reconnecting the (still-uninitialized) device should leave you on Home, not pull you back into onboarding.

Regression tests added for the thunk-level cancel handling and the rerun reject/fulfil paths; existing e2e `t2t1-recovery-persistence` covers the reconnect flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/fix-recovery-device-flow/web/](https://dev.suite.sldev.cz/suite-web/mroz22/fix-recovery-device-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on onboarding recovery UI, the recovery view, recovery thunks, and the device settings page that hosts the recovery dry-run entry point. The highest risk is broken recovery flows during onboarding or from Device settings. I recommend a tight set of recovery and dry-run tests across T1B1/T2T1, plus a couple of Device settings smoke tests. The suite-native disconnected screen and the recoveryThunks unit test have no E2E coverage in the available suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/actions/onboarding/onboardingActions.ts`
- `packages/suite/src/views/onboarding/steps/RecoveryStep/RecoveryStepBox.tsx`
- `packages/suite/src/views/onboarding/steps/RecoveryStep/index.tsx`
- `packages/suite/src/views/recovery/index.tsx`
- `packages/suite/src/views/settings/SettingsDevice/SettingsDevice.tsx`
- `suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx`
- `suite/recovery/src/recoveryThunks.test.ts`
- `suite/recovery/src/recoveryThunks.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-fail.test.ts` — This test exercises the onboarding recovery retry flow after a device disconnect, which directly uses the changed RecoveryStep UI components and onboarding recovery actions.
- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-success.test.ts` — It walks through the full T1B1 recovery flow during onboarding, relying on RecoveryStep rendering and onboarding action state transitions that were modified.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-fail.test.ts` — Validates recovery disconnect/retry behavior on T2T1 during onboarding, hitting the same recovery step components and recovery state handling changed in this PR.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Covers recovery resumption after page reload and device reconnect during onboarding, which is sensitive to the recovery UI and underlying recovery thunks.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-success.test.ts` — Tests the standard T2T1 recovery success path through the onboarding recovery step, directly exercising the changed recovery UI and actions.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Runs the recovery dry-run flow from Device settings, which opens the changed recovery view and relies on the changed recovery thunks; it also tests reconnect/reload resilience.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — Covers the device-settings recovery dry-run path specifically for T1B1, including PIN entry and mnemonic input, so it exercises the changed recovery UI and thunks on a different device model.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — Validates the recovery dry-run flow from Device settings for T2T1, directly using the changed recovery view and thunks, including disconnect/reload recovery.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-recovery-advanced.test.ts` — Tests advanced recovery option selection and mid-flow disconnect handling on T1B1, adding coverage for RecoveryStep UI variations beyond the standard/fail paths.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Navigates to and interacts with the Device settings page where the changed SettingsDevice component is rendered, providing a smoke test for the settings device view.
- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — Exercises multiple Device settings interactions on T2T1, so it will surface regressions in the changed SettingsDevice component layout or navigation.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-native/module-device-onboarding/src/screens/DeviceDisconnectedScreen.tsx`
- `suite/recovery/src/recoveryThunks.test.ts`

_Updated: 2026-09-06T06:19:58.520Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/fix-recovery-device-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/fix-recovery-device-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-06T06:21:12.663Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-06T06:21:36.438Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->