### PR TITLE
refactor(dependency-injection): reuse union intersection utility

### DIFF
--- a/suite-common/dependency-injection/src/useServices.tsx
+++ b/suite-common/dependency-injection/src/useServices.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { type UnionToIntersection } from '@trezor/type-utils';
+
 const ServicesContext = React.createContext<any>(null);
 
 // This is intentional `any`. Services cannot be known in advance,
@@ -12,12 +14,6 @@ export type ServiceSelector<TSelected> = (services: Services) => TSelected;
 
 type SelectorResult<TSelector> =
     TSelector extends ServiceSelector<infer TSelected> ? TSelected : never;
-
-type UnionToIntersection<TUnion> = (
-    TUnion extends unknown ? (value: TUnion) => void : never
-) extends (value: infer TIntersection) => void
-    ? TIntersection
-    : never;
 
 type SelectedServices<TSelectors extends readonly ServiceSelector<any>[]> = UnionToIntersection<
     SelectorResult<TSelectors[number]>


### PR DESCRIPTION
## Description

The dependency-injection package locally redefined `UnionToIntersection` even though it already depends on `@trezor/type-utils`, which exports the same transformation. This replaces the duplicate declaration with the shared type import while preserving `useServices` selector intersection inference.

- Local helper: **6 lines -> 0**
- Net source change: **-4 lines**
- Validation: **3 suites / 5 tests passed; package lint passed**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The single changed file is a global dependency-injection hook statically referenced by 134 tests, indicating a broad but non-specific blast radius. Rather than running the full suite, a small set of smoke tests covering initial app load, onboarding, basic settings, and wallet discovery is sufficient to catch regressions in service resolution without excessive runtime.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/dependency-injection/src/useServices.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/suite/initial-run.test.ts` — The initial-run/onboarding flow is the first user-facing code path that renders after app start, so a regression in the global dependency-injection hook would likely surface here as failed component rendering or stuck onboarding screens.
- `suite/e2e/tests/browser/firefox.test.ts` — This is a minimal smoke test that verifies the Suite application loads successfully in Firefox; if useServices changed in a way that breaks service resolution at bootstrap, verifySuiteIsLoaded would fail.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — This test exercises a realistic end-to-end flow (onboarding, settings, device switcher, wallet discovery) that relies on multiple injected services, so it can catch integration-level regressions in service wiring.
- `suite/e2e/tests/settings/general.test.ts` — Settings changes trigger analytics and state-management services; this test verifies those services still report events correctly after the dependency-injection change.

</details>

_Updated: 2026-08-05T07:49:01.930Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/use-shared-union-to-intersection/web/](https://dev.suite.sldev.cz/suite-web/refactor/use-shared-union-to-intersection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/use-shared-union-to-intersection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/use-shared-union-to-intersection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/use-shared-union-to-intersection&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:51:38.342Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T07:51:24.663Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->