### PR TITLE
fix(suite-desktop): improve deposit flow reliance and errors handling

### DIFF
--- a/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx
@@ -35,12 +35,20 @@ export const YieldDeposit = ({ account, vault }: YieldDepositProps) => {
         return null;
     }
 
+    // Every step — the allowance read, the approval, the deposit calldata — needs this address,
+    // so without it the flow can only fail, and even the allowance retry never succeeds.
+    const hasVaultTokenContract = !!yieldDepositContextValues.token.contractAddress;
+
     return (
         <AllowanceContext.Provider value={allowanceContextValue}>
             <Column gap={24}>
                 <ContextMessage context={Context.getEarnYield('deposit')} />
-                {isDisabled ? (
-                    <YieldDisabledBanner type="deposit" content={content} variant={variant} />
+                {isDisabled || !hasVaultTokenContract ? (
+                    <YieldDisabledBanner
+                        type="deposit"
+                        content={isDisabled ? content : undefined}
+                        variant={isDisabled ? variant : undefined}
+                    />
                 ) : (
                     <YieldDepositContext.Provider value={yieldDepositContextValues}>
                         <FormProvider {...yieldDepositContextValues.methods}>

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -92,6 +92,7 @@ export const YieldDepositForm = () => {
         flowType: 'deposit',
         isWrappedNativeVault: flow.isWrappedNativeVault,
     });
+    const hasAllowanceError = allowanceStatus === 'error';
 
     // Wrapping into the gas reserve is allowed (Max keeps it aside, but a manual entry may not),
     // so recommend keeping it rather than blocking. `isAmountTooHigh` only fires above the full
@@ -267,7 +268,7 @@ export const YieldDepositForm = () => {
                                 />
                             )}
 
-                            {allowanceStatus === 'error' && (
+                            {hasAllowanceError && (
                                 <Banner
                                     icon
                                     intent="warning"
@@ -368,7 +369,7 @@ export const YieldDepositForm = () => {
                                         }
                                         approvedAmount={allowanceAmount || undefined}
                                         isApprovedAmountLoading={allowanceStatus === 'loading'}
-                                        hasApprovedAmountError={allowanceStatus === 'error'}
+                                        hasApprovedAmountError={hasAllowanceError}
                                         approvalAction={approvalAction}
                                         canRevokeAllowance={canRevokeAllowance}
                                         warning={
@@ -380,7 +381,6 @@ export const YieldDepositForm = () => {
                                         }
                                         isDisabled={
                                             isAmountEmpty ||
-                                            (flow.isWrappedNativeVault && isAmountTooHigh) ||
                                             isAmountInvalidDecimals ||
                                             isSubmittingApprove ||
                                             !!approvalPendingTransaction
@@ -390,8 +390,12 @@ export const YieldDepositForm = () => {
                                         fiatToggle={fiatToggle}
                                         onMaxClick={handleMaxClick}
                                         onApprovalSubmit={handleOnApprovalSubmit}
+                                        // An unreadable allowance coerces to '0', which would
+                                        // otherwise hide Skip just when it is the only way on.
                                         onSkip={
-                                            canRevokeAllowance ? handleOnSkipApprove : undefined
+                                            canRevokeAllowance || hasAllowanceError
+                                                ? handleOnSkipApprove
+                                                : undefined
                                         }
                                         onRevoke={handleOnRevoke}
                                         onPendingTxClick={openPendingTransaction}
@@ -403,7 +407,7 @@ export const YieldDepositForm = () => {
                                             token={token}
                                             amount={allowanceAmount}
                                             isLoading={allowanceStatus === 'loading'}
-                                            hasError={allowanceStatus === 'error'}
+                                            hasError={hasAllowanceError}
                                         />
                                     ),
                             },

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -52,6 +52,7 @@ import {
     getYieldModifyAmountInput,
     getYieldUnwrapDefaultAmount,
     isAmountGreaterThan,
+    shouldInitializeYieldAllowance,
 } from '../yieldFlowUtils';
 
 type UseYieldFlowProps = {
@@ -277,6 +278,9 @@ export const useYieldFlow = ({
                     token: currentToken,
                     receiptToken: currentReceiptToken,
                 },
+                // Only the approve step may auto-advance on a sufficient allowance; from the
+                // action step this would undo a "modify approval" click made mid-read.
+                shouldSkipApprovalStep: sessionRef.current.step === 'approve',
             }),
         );
 
@@ -298,15 +302,20 @@ export const useYieldFlow = ({
                     initAllowancePromiseRef.current = null;
                 }
             });
-    }, [allowanceFlowDataRef, analytics, dispatch, flowKey, flowType]);
+    }, [allowanceFlowDataRef, analytics, dispatch, flowKey, flowType, sessionRef]);
 
     useEffect(() => {
-        const canInitializeAllowance =
-            !isWrappedNativeVault || (session.isWrappedNativeVault && session.step === 'approve');
-
-        if (allowanceStatus !== 'idle' || !canInitializeAllowance) {
+        if (
+            !shouldInitializeYieldAllowance({
+                isWrappedNativeVault,
+                hasWrappedNativeSession: session.isWrappedNativeVault,
+                step: session.step,
+                allowanceStatus,
+            })
+        ) {
             return;
         }
+
         runInitAllowance();
     }, [
         allowanceStatus,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -250,8 +250,10 @@ export const YieldWithdrawForm = () => {
                                     }
                                     isPending={isSubmittingAction}
                                     pendingTransaction={withdrawPendingTransaction}
+                                    // Toggling the unit switches `flowType`, disposing the
+                                    // session — mid-submit that drops a broadcast transaction.
                                     unitToggle={
-                                        canToggleWithdrawUnit
+                                        canToggleWithdrawUnit && !isSubmittingAction
                                             ? {
                                                   otherTokenSymbol: otherUnitTokenSymbol,
                                                   onClick: handleToggleWithdrawInputUnit,

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -7,6 +7,7 @@ import {
     getYieldFlowSteps,
     getYieldMaxFiatInputValue,
     getYieldUnwrapDefaultAmount,
+    shouldInitializeYieldAllowance,
 } from './yieldFlowUtils';
 
 // Checksummed WETH address; the helper lower-cases it for the (evm) rate key.
@@ -307,6 +308,79 @@ describe('yieldFlowUtils', () => {
             expect(getYieldCryptoInputValue({ fiat: '100', rate: undefined, decimals: 6 })).toBe(
                 '',
             );
+        });
+    });
+
+    describe('shouldInitializeYieldAllowance', () => {
+        const wrappedNativeParams = {
+            isWrappedNativeVault: true,
+            hasWrappedNativeSession: true,
+            step: 'approve',
+            allowanceStatus: 'idle',
+        } as const;
+
+        it('reads the allowance for a plain ERC-20 vault on any step', () => {
+            const erc20Params = {
+                isWrappedNativeVault: false,
+                hasWrappedNativeSession: false,
+                allowanceStatus: 'idle',
+            } as const;
+
+            expect(shouldInitializeYieldAllowance({ ...erc20Params, step: 'approve' })).toBe(true);
+            expect(shouldInitializeYieldAllowance({ ...erc20Params, step: 'action' })).toBe(true);
+        });
+
+        it('reads the allowance only when it is idle', () => {
+            expect(
+                shouldInitializeYieldAllowance({
+                    ...wrappedNativeParams,
+                    allowanceStatus: 'loading',
+                }),
+            ).toBe(false);
+            expect(
+                shouldInitializeYieldAllowance({
+                    ...wrappedNativeParams,
+                    allowanceStatus: 'loaded',
+                }),
+            ).toBe(false);
+            expect(
+                shouldInitializeYieldAllowance({
+                    ...wrappedNativeParams,
+                    allowanceStatus: 'error',
+                }),
+            ).toBe(false);
+        });
+
+        it('skips the read on the wrap step, before the amount to approve is known', () => {
+            expect(shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'wrap' })).toBe(
+                false,
+            );
+        });
+
+        it('reads the allowance on the approve step of a wrapped-native deposit', () => {
+            expect(shouldInitializeYieldAllowance(wrappedNativeParams)).toBe(true);
+        });
+
+        // Otherwise the status stays idle for the rest of the flow and the banner never returns.
+        it('re-reads the allowance on the action step of a wrapped-native deposit', () => {
+            expect(shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'action' })).toBe(
+                true,
+            );
+        });
+
+        it('skips the read until the session reports the wrapped-native shape', () => {
+            expect(
+                shouldInitializeYieldAllowance({
+                    ...wrappedNativeParams,
+                    hasWrappedNativeSession: false,
+                }),
+            ).toBe(false);
+        });
+
+        it('skips the read once the flow is complete', () => {
+            expect(
+                shouldInitializeYieldAllowance({ ...wrappedNativeParams, step: 'complete' }),
+            ).toBe(false);
         });
     });
 });

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -1,5 +1,6 @@
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
+    type YieldAllowanceStatus,
     type YieldFlowDisplayToken,
     type YieldFlowStepId,
     type YieldFlowToken,
@@ -94,6 +95,41 @@ export const getYieldUnwrapDefaultAmount = ({
     }
 
     return withdrawnAssetAmount;
+};
+
+type ShouldInitializeYieldAllowanceParams = {
+    isWrappedNativeVault: boolean;
+    /** Whether the Redux session already reflects that shape; false until `initSession` lands. */
+    hasWrappedNativeSession: boolean;
+    step: YieldFlowStepId;
+    allowanceStatus: YieldAllowanceStatus;
+};
+
+/**
+ * Whether the on-chain allowance should be read now.
+ *
+ * A wrapped-native deposit must not read it before the wrap step resolves: the amount to approve
+ * is only known then, and a leftover dust allowance would otherwise auto-skip the approve step
+ * (see trezor/trezor-suite#30551). From the approve step onwards it must be read again whenever
+ * it is invalidated — including on the action step, which a confirmed approval invalidates.
+ * Leaving it idle there hides the fetch-failure banner and permanently disables the
+ * insufficient-approval warning.
+ */
+export const shouldInitializeYieldAllowance = ({
+    isWrappedNativeVault,
+    hasWrappedNativeSession,
+    step,
+    allowanceStatus,
+}: ShouldInitializeYieldAllowanceParams): boolean => {
+    if (allowanceStatus !== 'idle') {
+        return false;
+    }
+
+    if (!isWrappedNativeVault) {
+        return true;
+    }
+
+    return hasWrappedNativeSession && (step === 'approve' || step === 'action');
 };
 
 export type YieldFiatRateToken = {

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
@@ -64,6 +64,10 @@ const getStep = (store: ReturnType<typeof initStore>) =>
     selectStablecoinYieldSession(store.getState() as StablecoinYieldRootState, 'deposit', FLOW_KEY)
         .step;
 
+const getApproval = (store: ReturnType<typeof initStore>) =>
+    selectStablecoinYieldSession(store.getState() as StablecoinYieldRootState, 'deposit', FLOW_KEY)
+        .approval;
+
 // Seed a wrapped-native deposit session sitting on the `approve` step, with the
 // just-wrapped amount stored in `session.action.amount` (mirrors the wrap→approve
 // transition produced by resolveWrappedNativeStep after the wrap tx confirms).
@@ -160,6 +164,81 @@ describe('initYieldAllowanceThunk', () => {
             .dispatch(initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }))
             .unwrap();
 
+        expect(getStep(store)).toBe('approve');
+    });
+
+    it('holds the step when skipping is opted out of, even on a covering allowance', async () => {
+        (fetchAllowance as jest.Mock).mockResolvedValue(toSubunits('0.3'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+
+        await store
+            .dispatch(
+                initYieldAllowanceThunk({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    flowData,
+                    shouldSkipApprovalStep: false,
+                }),
+            )
+            .unwrap();
+
+        expect(getStep(store)).toBe('approve');
+        expect(getApproval(store).allowanceAmount).toBe('0.3');
+    });
+
+    it('refreshes the allowance on the action step without moving the flow', async () => {
+        (fetchAllowance as jest.Mock).mockResolvedValue(toSubunits('0.3'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+        store.dispatch(
+            stablecoinYieldActions.completeApproval({
+                flowType: 'deposit',
+                flowKey: FLOW_KEY,
+                amount: WRAPPED_AMOUNT,
+            }),
+        );
+        store.dispatch(
+            stablecoinYieldActions.invalidateAllowance({ flowType: 'deposit', flowKey: FLOW_KEY }),
+        );
+        expect(getStep(store)).toBe('action');
+
+        await store
+            .dispatch(
+                initYieldAllowanceThunk({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                    flowData,
+                    shouldSkipApprovalStep: false,
+                }),
+            )
+            .unwrap();
+
+        expect(getStep(store)).toBe('action');
+        expect(getApproval(store).allowanceStatus).toBe('loaded');
+        expect(getApproval(store).allowanceAmount).toBe('0.3');
+    });
+
+    it('records an error and rethrows when the allowance cannot be read', async () => {
+        (fetchAllowance as jest.Mock).mockRejectedValue(new Error('rpc unavailable'));
+
+        const store = initStore();
+        seedWrappedDepositAtApprove(store, WRAPPED_AMOUNT);
+
+        // `unwrap` rethrows redux's serialized error, which is a plain object rather than an
+        // Error instance — hence matching on the shape instead of `toThrow`.
+        await expect(
+            store
+                .dispatch(
+                    initYieldAllowanceThunk({ flowType: 'deposit', flowKey: FLOW_KEY, flowData }),
+                )
+                .unwrap(),
+        ).rejects.toMatchObject({ message: 'rpc unavailable' });
+
+        expect(getApproval(store).allowanceStatus).toBe('error');
+        expect(getApproval(store).allowanceAmount).toBeNull();
         expect(getStep(store)).toBe('approve');
     });
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -431,4 +431,91 @@ describe('stablecoinYieldReducer', () => {
             });
         });
     });
+
+    describe('allowance lifecycle', () => {
+        const sessionPayload = { flowType: 'deposit', flowKey: FLOW_KEY } as const;
+
+        const loadAllowance = (state: StablecoinYieldState, amount: string) =>
+            stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.setInitializedAllowance({ ...sessionPayload, amount }),
+            );
+
+        it('stores the read allowance', () => {
+            const state = loadAllowance(initSession('deposit'), '100');
+
+            expect(getSession(state, 'deposit')?.approval.allowanceAmount).toBe('100');
+            expect(getSession(state, 'deposit')?.approval.allowanceStatus).toBe('loaded');
+        });
+
+        it('clears the amount when the read fails', () => {
+            const state = stablecoinYieldReducer(
+                loadAllowance(initSession('deposit'), '100'),
+                stablecoinYieldActions.setAllowanceError(sessionPayload),
+            );
+
+            expect(getSession(state, 'deposit')?.approval.allowanceAmount).toBeNull();
+            expect(getSession(state, 'deposit')?.approval.allowanceStatus).toBe('error');
+        });
+
+        it('keeps the last amount when the allowance is only invalidated', () => {
+            const state = stablecoinYieldReducer(
+                loadAllowance(initSession('deposit'), '100'),
+                stablecoinYieldActions.invalidateAllowance(sessionPayload),
+            );
+
+            expect(getSession(state, 'deposit')?.approval.allowanceAmount).toBe('100');
+            expect(getSession(state, 'deposit')?.approval.allowanceStatus).toBe('idle');
+        });
+
+        it('reports a zero allowance as loaded after a revoke', () => {
+            const state = stablecoinYieldReducer(
+                loadAllowance(initSession('deposit'), '100'),
+                stablecoinYieldActions.revokeSuccess(sessionPayload),
+            );
+
+            expect(getSession(state, 'deposit')?.approval.allowanceAmount).toBe('0');
+            expect(getSession(state, 'deposit')?.approval.allowanceStatus).toBe('loaded');
+        });
+
+        // A confirmed approval dispatches these two back to back — the state the read must catch.
+        it('leaves a wrapped-native deposit on the action step with an idle allowance', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    loadAllowance(initSession('deposit', true), '100'),
+                    stablecoinYieldActions.resolveWrappedNativeStep({
+                        ...sessionPayload,
+                        step: 'wrap',
+                    }),
+                ),
+                stablecoinYieldActions.completeApproval({ ...sessionPayload, amount: '0.2' }),
+            );
+            const invalidated = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.invalidateAllowance(sessionPayload),
+            );
+
+            expect(getSession(invalidated, 'deposit')?.step).toBe('action');
+            expect(getSession(invalidated, 'deposit')?.approval.allowanceStatus).toBe('idle');
+        });
+
+        it('refuses to return to the wrap step while the allowance is being read', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit', true),
+                    stablecoinYieldActions.resolveWrappedNativeStep({
+                        ...sessionPayload,
+                        step: 'wrap',
+                    }),
+                ),
+                stablecoinYieldActions.startInitializingAllowance(sessionPayload),
+            );
+            const returned = stablecoinYieldReducer(
+                state,
+                stablecoinYieldActions.returnToWrapStep(sessionPayload),
+            );
+
+            expect(getSession(returned, 'deposit')?.step).toBe('approve');
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It wasn't possible to approve more than existing amount. If user approves more than existing amount on the next step he'd see clamped value of approve and available weth

## Notes for QA

Makes sense to also check flow robustness by disabling some network responses or slowing it down

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30832

## Screenshots:

| Header | Header |
|--------|--------|
| <img width="667" height="735" alt="Screenshot 2026-08-05 at 9 42 59" src="https://github.com/user-attachments/assets/4fb2a2e9-74a6-46d4-93ee-689ae03e643b" /> | <img width="556" height="637" alt="Screenshot 2026-08-05 at 9 49 07" src="https://github.com/user-attachments/assets/103aaadf-9808-449a-8174-9364c1206934" /> | 


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/harden-yield-flow/web/](https://dev.suite.sldev.cz/suite-web/feat/harden-yield-flow/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the earn/yield deposit and withdraw UI and stablecoin-yield state unit tests. No existing E2E test directly exercises the stablecoin yield flow, and the static mappings for the changed components are extremely broad/global, so they are not reliable selectors. The best available E2E guard is check-links, which at least confirms the affected /earn/yield routes still render and have no broken links. Functional correctness should be validated by the accompanying unit tests rather than the E2E suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/earn/yield/deposit/YieldDeposit.tsx`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to /earn/yield/deposit and /earn/yield/withdraw and verifies that each route loads and all links return HTTP 200. Changes to YieldDeposit, YieldDepositForm, YieldWithdrawForm, useYieldFlow, or yieldFlowUtils could cause these earn routes to fail to render or throw, so check-links provides a coarse regression guard for route-level breakage.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`

_Updated: 2026-08-05T08:00:00.315Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/harden-yield-flow&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/harden-yield-flow&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/harden-yield-flow&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T08:01:04.124Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->