### PR TITLE
feat(suite): report settings/networks/explorer analytics event

### DIFF
--- a/packages/suite/src/hooks/settings/useExplorerForm.ts
+++ b/packages/suite/src/hooks/settings/useExplorerForm.ts
@@ -3,18 +3,18 @@ import { useForm, useWatch } from 'react-hook-form';
 
 import { useTranslation } from '@suite/intl';
 import { type Explorer, type NetworkSymbol } from '@suite-common/wallet-config';
-import { explorerActions, selectNetworkExplorers } from '@suite-common/wallet-core';
-import { isUrl } from '@trezor/utils';
+import { selectNetworkExplorers, setNetworkExplorerThunk } from '@suite-common/wallet-core';
+import { deepEqual, isUrl } from '@trezor/utils';
 
 import { useDispatch, useSelector } from '../suite';
 
 const useExplorerInput = (currentValues: Explorer) => {
     const {
         register,
-        formState: { errors },
+        formState: { isDirty, errors },
         trigger,
         control,
-        setValue,
+        reset,
     } = useForm<Explorer>({
         mode: 'onChange',
         defaultValues: currentValues,
@@ -67,7 +67,8 @@ const useExplorerInput = (currentValues: Explorer) => {
 
         trigger,
         register,
-        setValue,
+        reset,
+        isDirty,
         errors,
 
         fields: {
@@ -132,17 +133,13 @@ export const useExplorerForm = (symbol: NetworkSymbol) => {
     );
 
     const save = () => {
-        dispatch(explorerActions.setExplorer({ symbol, explorer }));
+        if (input.isDirty) {
+            dispatch(setNetworkExplorerThunk({ symbol, explorer }));
+        }
     };
 
     const setDefaultValues = () => {
-        input.setValue('base', explorerConfig.default.base);
-        input.setValue('tx', explorerConfig.default.tx);
-        input.setValue('address', explorerConfig.default.address);
-        input.setValue('token', explorerConfig.default.token);
-        input.setValue('nft', explorerConfig.default.nft);
-        input.setValue('queryString', explorerConfig.default.queryString);
-
+        input.reset(explorerConfig.default, { keepDefaultValues: true });
         input.trigger();
     };
 
@@ -157,7 +154,7 @@ export const useExplorerForm = (symbol: NetworkSymbol) => {
     return {
         save,
         setDefaultValues,
-        usesDefaultExplorer: explorerConfig.custom === undefined,
+        usesDefaultExplorer: deepEqual(explorer, explorerConfig.default),
         explorerConfig,
         input,
         isValid,


### PR DESCRIPTION
Report the explorer event on Desktop only when the saved explorer configuration actually differs from the stored one, so a backend-only Confirm or a purely cosmetic edit emits nothing.

Extract the explorer normalization out of the reducer into pure helpers shared via wallet-core, so the same comparison can be reused on Mobile.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

Tracks the switching between custom and default network explorer when switching it in the network advanced settings.

## Related Issue

Resolve #30588

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/30588-network-explorer-tracking-desktop/web/](https://dev.suite.sldev.cz/suite-web/30588-network-explorer-tracking-desktop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared settings hook for blockchain explorer/backend form state. Although it is statically mapped to 135 tests, most are indirect consumers. The real risk is localized to the coin backend configuration UI and discovery flows that rely on custom backends. Running the three targeted backend-related tests provides high confidence with minimal runtime.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/hooks/settings/useExplorerForm.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test directly exercises the custom blockbook backend configuration flow for BTC and ETH, including entering custom backend URLs, verifying successful connection, and handling invalid URLs. A change to useExplorerForm would most likely affect this exact UI flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — The test configures a custom Blockbook backend for ETH and verifies the custom backend indicator appears. It touches the same coin settings backend configuration area as useExplorerForm, though it is a broader coins settings test.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test configures custom Blockbook backends for BTC and LTC and verifies discovery completes successfully. Since useExplorerForm manages explorer/backend form state, a regression here could affect how custom backends are persisted and used during discovery.

</details>

_Updated: 2026-08-11T18:47:04.705Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=30588-network-explorer-tracking-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=30588-network-explorer-tracking-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=30588-network-explorer-tracking-desktop&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T18:49:31.772Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T18:49:20.482Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
