### PR TITLE
fix(ci): restore `all` matrix filter in connect test matrix generator

### DIFF
--- a/scripts/ci/connect-test-matrix-generator.js
+++ b/scripts/ci/connect-test-matrix-generator.js
@@ -239,7 +239,9 @@ const filterCartesianResultByArgs = () => {
     return cartesian.filter(m =>
         Object.keys(m).every(key => {
             const filterBy = parsedArgs[key];
-            if (filterBy === 'all') {
+            // CLI args parse into arrays, so `all` arrives as `['all']`
+            const filterValues = Array.isArray(filterBy) ? filterBy : [filterBy];
+            if (filterValues.includes('all')) {
                 // experimental methods are opt-in; they never run as part of `all`
                 if (key === 'groups' && getValue(m[key]) === 'experimental') {
                     return false;


### PR DESCRIPTION
## Description

PR #30786 changed the connect test matrix generator's CLI arg parser to wrap single values in arrays, so `--groups=all` (and any `--<key>=all`) started parsing to `['all']` instead of the string `'all'`. The filter's `filterBy === 'all'` special case then never matched, so every group was filtered out and the generator emitted an empty `include` — failing the workflow with *"matrix must define at least one vector"* (`.github/workflows/test-connect.yml` PR-check). This normalizes the filter value to an array before checking for `all`, restoring the daily/nightly/all-fws/all-models/all-transports matrices.

## Notes for QA

CI-only change 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is `scripts/ci/connect-test-matrix-generator.js`, a CI infrastructure script that generates a test matrix and does not affect application runtime behavior. There is no evidence from the LLM analysis or static coverage that any of the 81 E2E tests exercise this script, and none of the listed tests depend on matrix-generator output. Running the application E2E suite would provide little value; validation should instead come from CI pipeline checks or script-level unit tests for the generator.

<details><summary><b>Changed files (1)</b></summary>

- `scripts/ci/connect-test-matrix-generator.js`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `scripts/ci/connect-test-matrix-generator.js`

_Updated: 2026-08-05T08:30:05.811Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cairo-v1/web/](https://dev.suite.sldev.cz/suite-web/cairo-v1/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cairo-v1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cairo-v1&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T08:32:56.441Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T08:32:46.202Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->