### PR TITLE
chore(deps): fix 5 more high-severity Dependabot vulnerabilities (batch 3, stacked)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,6 +21,8 @@ npmPreapprovedPackages:
   - "@types/invity-api@*"
   # 16.0.1 (the newest gate-passing release) pins vulnerable axios 1.16.1; 16.1.0 pins patched 1.18.0
   - "@stellar/stellar-sdk@16.1.0"
+  # security fix younger than the age gate: patched version for GHSA-7p8r-x3mc-p8w7
+  - "fast-uri@3.1.5"
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -23,6 +23,9 @@ npmPreapprovedPackages:
   - "@stellar/stellar-sdk@16.1.0"
   # security fix younger than the age gate: patched version for GHSA-7p8r-x3mc-p8w7
   - "fast-uri@3.1.5"
+  # security fix younger than the age gate: patched versions for GHSA-vxpw-j846-p89q / GHSA-4cwx-7wf7-3272 et al.
+  - "undici@6.28.0"
+  - "undici@7.29.0"
 
 plugins:
   - checksum: 5e73a1acbb9741fce1e8335e243c9480ea2107b9b4b65ed7643785ddea9e3019aee254a92a853b1cd71023b16fff5b7d3afd5256fe57cd35a54f8785b8c30281

--- a/package.json
+++ b/package.json
@@ -133,7 +133,9 @@
         "### Force axios >=1.18.0 to fix GHSA-gcfj-64vw-6mp9 (nx@23.0.0 pins the vulnerable 1.16.0)": "1.0.0",
         "axios": "1.18.1",
         "### Force form-data >=4.0.6 to fix GHSA-hmw2-7cc7-3qxx (nx@23.0.0 pins the vulnerable 4.0.5)": "1.0.0",
-        "form-data": "4.0.6"
+        "form-data": "4.0.6",
+        "### Force the js-yaml 4.2.0 exact pin to patched 4.3.0 for GHSA-52cp-r559-cp3m (scoped so the 3.x line is untouched)": "1.0.0",
+        "js-yaml@4.2.0": "4.3.0"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,9 @@
         "@types/react": "19.2.14",
         "react-dom": "19.2.3",
         "expo-modules-core": "patch:expo-modules-core@npm%3A56.0.13#~/.yarn/patches/expo-modules-core-npm-56.0.13-6a0e36c09c.patch",
-        "react-test-renderer": "19.2.3"
+        "react-test-renderer": "19.2.3",
+        "### Force axios >=1.18.0 to fix GHSA-gcfj-64vw-6mp9 (nx@23.0.0 pins the vulnerable 1.16.0)": "1.0.0",
+        "axios": "1.18.1"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,9 @@
         "expo-modules-core": "patch:expo-modules-core@npm%3A56.0.13#~/.yarn/patches/expo-modules-core-npm-56.0.13-6a0e36c09c.patch",
         "react-test-renderer": "19.2.3",
         "### Force axios >=1.18.0 to fix GHSA-gcfj-64vw-6mp9 (nx@23.0.0 pins the vulnerable 1.16.0)": "1.0.0",
-        "axios": "1.18.1"
+        "axios": "1.18.1",
+        "### Force form-data >=4.0.6 to fix GHSA-hmw2-7cc7-3qxx (nx@23.0.0 pins the vulnerable 4.0.5)": "1.0.0",
+        "form-data": "4.0.6"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28074,9 +28074,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10/1c1ff8e7b6f7b38e997b1528aa2c97e290e0173d51250bfe4e11a303e454fc297a287555b5cb2ded59dbfce7876855fb15994a1a6b439f2497a2b8926513e397
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -32920,26 +32920,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.2.0, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:4.3.0, js-yaml@npm:^4.0.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/51de2067a2b44b07ba5206132e56005f8b568ff279bb4d2f645068958c56fa4827d40a6841c983234671fa0a134bf094d0b0717873c2a3d319185297af145a6d
+  checksum: 10/2bcec3a8118d7f744badeb04e14366578d234a736f353d41fe35d2305e4ce2409a8e041d277f07cd6bbc8aaa12128d650a68ce43247072519bede20962d2126f
   languageName: node
   linkType: hard
 
 "js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
+  checksum: 10/2fdf3a1453ed93a8e06d6ca8054c0bec145cf40ab51f305d1071736a03668b95e40f47cfd0239d7d50019b4780a18cdaca3c935def935594c9876964c49f1185
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -45570,16 +45570,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.18.2, undici@npm:^6.22.0":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10/4f84e6045520eef9ba8eabb96360b50c759f59905c1703b12187c2dbcc6d1584c5d7ecddeb45b0ed6cac84ca2d132b21bfd8a38f77fa30378b1ac5d2ae390fd9
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10/672a7a53bd1f6c80edb73b357ab36e98ef9e474024c442aab2b8ea2bc32f1103cab05525c78661ae724f3e1340e23d03efb9730fba28e76218ab0ec52e15d75a
   languageName: node
   linkType: hard
 
 "undici@npm:^7.24.4":
-  version: 7.26.0
-  resolution: "undici@npm:7.26.0"
-  checksum: 10/c55b8f8e378dce6e645853faf0834d66b9f470c6ee1430c6e2b7971d831de36081f7e2e21ac1fc11297657d7c856241b0bf746b2a24f1277f8d156df9c181ba7
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10/ca73639071bdcbc41e57be1800847fa18f86f8fbf7a5641ff9899f7bbb6f5cecdd593e225f5fd94e31703dcbfaea4a722a3b81cab90c5c4e2b406aec1ae55732
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20915,30 +20915,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.0":
-  version: 1.16.0
-  resolution: "axios@npm:1.16.0"
-  dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
-  languageName: node
-  linkType: hard
-
-"axios@npm:1.18.0":
-  version: 1.18.0
-  resolution: "axios@npm:1.18.0"
-  dependencies:
-    follow-redirects: "npm:^1.16.0"
-    form-data: "npm:^4.0.5"
-    https-proxy-agent: "npm:^5.0.1"
-    proxy-from-env: "npm:^2.1.0"
-  checksum: 10/586a1a9534531c6ec4ee8fbab07a536ecaa8d29bd16b40ab0f9fce361fcd24da1538a54aadde0562f08f30b55bf80f9b7ededf1987e6506f722e1fb338b09d5d
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.13.6, axios@npm:^1.16.0":
+"axios@npm:1.18.1":
   version: 1.18.1
   resolution: "axios@npm:1.18.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -28662,20 +28662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+"form-data@npm:4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -36339,7 +36326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:2.1.35, mime-types@npm:^2.1.18, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
## Description

> **Stacked** on the HIGH batch-2 PR (base branch `mroz22/fix-high-dependabot-vulns-2`), which is stacked on batch-1 (#30856). Review/merge those first. This PR only adds the 5 commits below.

Fixes 5 more **high**-severity Dependabot alerts, one vulnerability per commit. These were previously blocked by the repo's 14-day `npmMinimalAgeGate` or by exact version pins; each is handled explicitly.

| Package | Advisory(ies) | Fix |
|---------|---------------|-----|
| `fast-uri` `3.1.4 → 3.1.5` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) | Patched version is <14 days old → added to `npmPreapprovedPackages`, then re-resolved. |
| `undici` `6.24.1/7.26.0 → 6.28.0/7.29.0` | [GHSA-vxpw-j846-p89q](https://github.com/advisories/GHSA-vxpw-j846-p89q), [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272), [GHSA-hm92-r4w5-c3mj](https://github.com/advisories/GHSA-hm92-r4w5-c3mj), [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g) | Patched versions <14 days old → `npmPreapprovedPackages`, then re-resolved. |
| `axios` → `1.18.1` | [GHSA-gcfj-64vw-6mp9](https://github.com/advisories/GHSA-gcfj-64vw-6mp9) | `nx@23.0.0` pins the vulnerable `1.16.0` exactly → `resolutions` override forces the patched `1.18.1` (collapses to one copy). |
| `form-data` → `4.0.6` | [GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) | `nx@23.0.0` pins the vulnerable `4.0.5` exactly → `resolutions` override forces the patched `4.0.6`. |
| `js-yaml` `3.14.2/4.2.0 → 3.15.0/4.3.0` | [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | `^3.x`/`^4.x` carets re-resolved; a transitive `4.2.0` exact pin forced to `4.3.0` via a **version-scoped** resolution (3.x line untouched). |

All are transitive dev/tooling/test dependencies — no production runtime code is changed.

**On the age gate & exceptions:** the repo enforces `npmMinimalAgeGate: 20160` (14 days) to defend against freshly-published malicious versions, with a `npmPreapprovedPackages` allowlist for deliberate exceptions (already used for `@stellar/stellar-sdk`). The patched `fast-uri`/`undici` releases are legitimate upstream security patches younger than 14 days, so they are added to that allowlist — mirroring the existing pattern.

After the bumps:
- Every listed package resolves to a patched version; no copy remains in a vulnerable range.
- `yarn install --immutable` passes; `yarn dedupe --check` passes.

## Notes for QA

Dependency-only changes to transitive dev/build/test tooling. No product behavior change expected. CI validates the build and lockfile gates.

## Related Issue

Addresses these open **high** Dependabot alerts: `fast-uri` (GHSA-7p8r-x3mc-p8w7), `undici` (GHSA-vxpw-j846-p89q, GHSA-4cwx-7wf7-3272, GHSA-hm92-r4w5-c3mj, GHSA-vmh5-mc38-953g), `axios` (GHSA-gcfj-64vw-6mp9), `form-data` (GHSA-hmw2-7cc7-3qxx), `js-yaml` (GHSA-52cp-r559-cp3m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
