### PR TITLE
Centralized app name

### DIFF
--- a/packages/suite-desktop-core/src/libs/constants.ts
+++ b/packages/suite-desktop-core/src/libs/constants.ts
@@ -1,14 +1,7 @@
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isCodesignBuild } from '@trezor/env-utils';
 
-const getAppName = () => {
-    const appName = 'Trezor Suite';
-
-    if (!isCodesignBuild()) {
-        return `${appName} ${isDevEnv ? 'Local' : 'Dev'}`;
-    }
-
-    return appName;
-};
-
-export const APP_NAME = getAppName();
+export const APP_NAME_BARE = 'Trezor Suite';
+export const APP_NAME = `${APP_NAME_BARE}${
+    isCodesignBuild() ? '' : ` ${isDevEnv ? 'Local' : 'Dev'}`
+}`;

--- a/packages/suite-desktop-core/src/modules/tray.ts
+++ b/packages/suite-desktop-core/src/modules/tray.ts
@@ -10,6 +10,7 @@ import { type Status, type TraySettings } from '@trezor/suite-desktop-api';
 
 import { app, ipcMain } from '../typed-electron';
 import { type ModuleInitBackground, mainThreadEmitter } from './module';
+import { APP_NAME_BARE } from '../libs/constants';
 
 export const SERVICE_NAME = 'tray';
 
@@ -51,7 +52,7 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
                 getPlatformIcon(),
             );
             tray = new Tray(iconPath);
-            tray.setToolTip('Trezor Suite');
+            tray.setToolTip(APP_NAME_BARE);
         }
         const contextMenu = Menu.buildFromTemplate([
             {
@@ -71,7 +72,7 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
                 type: 'separator',
             },
             {
-                label: 'Launch Trezor Suite',
+                label: `Launch ${APP_NAME_BARE}`,
                 click: () => mainThreadEmitter.emit('app/show'),
             },
             {
@@ -111,14 +112,14 @@ export const initBackground: ModuleInitBackground = ({ store, mainWindowProxy })
             state.devices += 1;
             tray?.displayBalloon({
                 iconType: 'info',
-                title: 'Trezor Suite',
+                title: APP_NAME_BARE,
                 content: `Device ${event.payload.name} connected`,
             });
         } else if (event.type === DEVICE.DISCONNECT && state.devices > 0) {
             state.devices -= 1;
             tray?.displayBalloon({
                 iconType: 'info',
-                title: 'Trezor Suite',
+                title: APP_NAME_BARE,
                 content: `Device ${event.payload.name} disconnected`,
             });
         }


### PR DESCRIPTION
## Description

Tiny refactor

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to suite-desktop-core internals (tray module and a constants file) and none of the 102 candidate tests describe explicit tray coverage. The strongest available signal comes from desktop lifecycle and focus-IPC tests. I recommend running those as a targeted smoke check; if they pass, the risk of a critical desktop startup or focus regression is low.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite-desktop-core/src/libs/constants.ts`
- `packages/suite-desktop-core/src/modules/tray.ts`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — This test exercises Electron main-process focus/visibility IPC (app/focus, appIsVisible) and confirm-on-device prompts in the desktop app. The tray module often coordinates window show/hide and focus behavior, so a regression in tray.ts or its constants could plausibly affect whether Suite is brought to the foreground during connect flows.
- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Launches the Electron app in daemon mode and verifies the app initializes and manages the bridge lifecycle without a persistent UI window. Tray initialization logic typically runs during desktop app startup, so this smoke test can catch gross failures caused by tray.ts or its constants in a headless/daemon context.

</details>

_Updated: 2026-08-05T09:07:59.108Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/app-name/web/](https://dev.suite.sldev.cz/suite-web/refactor/app-name/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/app-name&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/app-name&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T09:09:40.292Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T09:09:28.152Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->