### PR TITLE
feat(suite): add MEV protection message system gating for yield flows

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/earn-stablecoin/src/signing';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin/src/tx-simulation';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
@@ -246,11 +247,14 @@ export const claimMerklRewardsThunk = createThunk(
                 }
 
                 const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
+                const isMevProtectionFeatureEnabled =
+                    selectIsMevProtectionFeatureEnabled(getState());
+
                 const pushResponse = await TrezorConnect.pushTransaction({
                     tx: getMevProtectedTxData(
                         account.symbol,
                         signingResponse.payload.serializedTx,
-                        isMevProtectionEnabled,
+                        isMevProtectionEnabled && isMevProtectionFeatureEnabled,
                     ),
                     coin: account.symbol,
                     identity: getAccountIdentity(account),

--- a/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts
@@ -1,6 +1,7 @@
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin/src/signing';
+import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import {
     type YieldFlowDisplayToken,
     type YieldFlowType,
@@ -148,11 +149,13 @@ export const sendYieldTransaction = async ({
         }
 
         const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());
+        const isMevProtectionFeatureEnabled = selectIsMevProtectionFeatureEnabled(getState());
+
         const pushResponse = await TrezorConnect.pushTransaction({
             tx: getMevProtectedTxData(
                 account.symbol,
                 signingResponse.payload.serializedTx,
-                isMevProtectionEnabled,
+                isMevProtectionEnabled && isMevProtectionFeatureEnabled,
             ),
             coin: account.symbol,
             identity: getAccountIdentity(account),


### PR DESCRIPTION
## Description

Add MEV protection message system gating for yield flows.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30861

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are narrow, feature-specific stablecoin-yield actions (claimMerklRewardsThunk.ts and signingHelpers.ts). None of the 133 analyzed E2E tests describe or exercise stablecoin-yield / Merkl reward-claim flows. The static coverage mapping to 134 tests is over-broad and almost certainly due to transitive imports from shared action/index modules, so those tests do not provide meaningful coverage for this change. No E2E tests are recommended; confidence should come from unit/integration tests and manual QA for the stablecoin-yield claim flow.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/signingHelpers.ts`

</details>

_No test recommendations found._

_Updated: 2026-08-05T09:20:25.450Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/mev-protection-yield/web/](https://dev.suite.sldev.cz/suite-web/feat/mev-protection-yield/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/mev-protection-yield&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/mev-protection-yield&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T09:21:38.467Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T09:21:16.711Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->