### PR TITLE
chore(deps): bump QA-owned deps, pin claude-code exact

### DIFF
--- a/packages/e2e-utils/package.json
+++ b/packages/e2e-utils/package.json
@@ -36,8 +36,8 @@
         "zod": "4.3.6"
     },
     "devDependencies": {
-        "@anthropic-ai/claude-code": "^2.1.179",
-        "@currents/mcp": "^2.3.2",
+        "@anthropic-ai/claude-code": "2.1.216",
+        "@currents/mcp": "^2.3.3",
         "@currents/playwright": "^2.5.0",
         "@playwright/test": "1.61.1",
         "@trezor/node-utils": "workspace:*",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -17,7 +17,7 @@
         "eslint-plugin-jest": "^29.16.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-local-rules": "^3.0.2",
-        "eslint-plugin-playwright": "^2.10.4",
+        "eslint-plugin-playwright": "^2.10.5",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.8.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -209,7 +209,7 @@
         "@types/react-dom": "19.2.3",
         "@types/redux-logger": "^3.0.13",
         "@types/semver": "^7.7.0",
-        "jest-canvas-mock": "^2.5.2",
+        "jest-canvas-mock": "^2.5.8",
         "jest-watch-typeahead": "3.0.1",
         "postcss-styled-syntax": "^0.7.1",
         "stylelint": "^17.1.1",

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -28,7 +28,6 @@ jest-extended
 jest-junit
 jest-watch-typeahead
 minimist
-react-intl
 ts-jest
 uri-scheme
 xml2js

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -212,7 +212,7 @@
         "react-native-performance": "^5.1.4",
         "ts-jest": "29.4.1",
         "tsx": "^4.21.0",
-        "uri-scheme": "^2.0.18"
+        "uri-scheme": "^2.2.0"
     },
     "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,74 +52,74 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-darwin-arm64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-darwin-arm64@npm:2.1.179"
+"@anthropic-ai/claude-code-darwin-arm64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-darwin-arm64@npm:2.1.216"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-darwin-x64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-darwin-x64@npm:2.1.179"
+"@anthropic-ai/claude-code-darwin-x64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-darwin-x64@npm:2.1.216"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-linux-arm64-musl@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-linux-arm64-musl@npm:2.1.179"
+"@anthropic-ai/claude-code-linux-arm64-musl@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-linux-arm64-musl@npm:2.1.216"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-linux-arm64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-linux-arm64@npm:2.1.179"
+"@anthropic-ai/claude-code-linux-arm64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-linux-arm64@npm:2.1.216"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-linux-x64-musl@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-linux-x64-musl@npm:2.1.179"
+"@anthropic-ai/claude-code-linux-x64-musl@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-linux-x64-musl@npm:2.1.216"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-linux-x64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-linux-x64@npm:2.1.179"
+"@anthropic-ai/claude-code-linux-x64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-linux-x64@npm:2.1.216"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-win32-arm64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-win32-arm64@npm:2.1.179"
+"@anthropic-ai/claude-code-win32-arm64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-win32-arm64@npm:2.1.216"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code-win32-x64@npm:2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code-win32-x64@npm:2.1.179"
+"@anthropic-ai/claude-code-win32-x64@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code-win32-x64@npm:2.1.216"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@anthropic-ai/claude-code@npm:^2.1.179":
-  version: 2.1.179
-  resolution: "@anthropic-ai/claude-code@npm:2.1.179"
+"@anthropic-ai/claude-code@npm:2.1.216":
+  version: 2.1.216
+  resolution: "@anthropic-ai/claude-code@npm:2.1.216"
   dependencies:
-    "@anthropic-ai/claude-code-darwin-arm64": "npm:2.1.179"
-    "@anthropic-ai/claude-code-darwin-x64": "npm:2.1.179"
-    "@anthropic-ai/claude-code-linux-arm64": "npm:2.1.179"
-    "@anthropic-ai/claude-code-linux-arm64-musl": "npm:2.1.179"
-    "@anthropic-ai/claude-code-linux-x64": "npm:2.1.179"
-    "@anthropic-ai/claude-code-linux-x64-musl": "npm:2.1.179"
-    "@anthropic-ai/claude-code-win32-arm64": "npm:2.1.179"
-    "@anthropic-ai/claude-code-win32-x64": "npm:2.1.179"
+    "@anthropic-ai/claude-code-darwin-arm64": "npm:2.1.216"
+    "@anthropic-ai/claude-code-darwin-x64": "npm:2.1.216"
+    "@anthropic-ai/claude-code-linux-arm64": "npm:2.1.216"
+    "@anthropic-ai/claude-code-linux-arm64-musl": "npm:2.1.216"
+    "@anthropic-ai/claude-code-linux-x64": "npm:2.1.216"
+    "@anthropic-ai/claude-code-linux-x64-musl": "npm:2.1.216"
+    "@anthropic-ai/claude-code-win32-arm64": "npm:2.1.216"
+    "@anthropic-ai/claude-code-win32-x64": "npm:2.1.216"
   dependenciesMeta:
     "@anthropic-ai/claude-code-darwin-arm64":
       optional: true
@@ -139,7 +139,7 @@ __metadata:
       optional: true
   bin:
     claude: bin/claude.exe
-  checksum: 10/8087c6380ca5f9c139e5ef86bb184087252d1909753079643f621b331e1e7acea76b78657bc2336e8a99af4301cab59898e463a8dd13f9be8d97229770f22788
+  checksum: 10/f1b6cfcbf398b3b045090d9c1dbe937400026dd47e9f84ec48a975d82101627ce139af3fcca1ea279ae5203a0193b4fa92544a350e09819f77330bbb2f6186c9
   languageName: node
   linkType: hard
 
@@ -2313,9 +2313,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@currents/mcp@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "@currents/mcp@npm:2.3.2"
+"@currents/mcp@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "@currents/mcp@npm:2.3.3"
   dependencies:
     "@modelcontextprotocol/sdk": "npm:^1.28.0"
     commander: "npm:^12.1.0"
@@ -2324,7 +2324,7 @@ __metadata:
     zod: "npm:^4.3.5"
   bin:
     mcp: dist/index.mjs
-  checksum: 10/9424eb0e153d56b99302159964367d35a0ed18fbe9df0a609b7745784f1a01939cf7ec255775fdef4dd7540d54eef6a79dba2feeeeb73b412c20f0bf0412a601
+  checksum: 10/bd9f66a798badada71dce0950fb6c509473d164dd4a3ffff99891c0ddc06c4e5232e0c2b7457b40c109498e4592164f83a0d88cf771062da159b71a506a78f31
   languageName: node
   linkType: hard
 
@@ -11798,7 +11798,7 @@ __metadata:
     stream-http: "npm:^3.2.0"
     ts-jest: "npm:29.4.1"
     tsx: "npm:^4.21.0"
-    uri-scheme: "npm:^2.0.18"
+    uri-scheme: "npm:^2.2.0"
     vm-browserify: "npm:^1.1.2"
     xml2js: "npm:^0.6.2"
   languageName: unknown
@@ -16789,9 +16789,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@trezor/e2e-utils@workspace:packages/e2e-utils"
   dependencies:
-    "@anthropic-ai/claude-code": "npm:^2.1.179"
+    "@anthropic-ai/claude-code": "npm:2.1.216"
     "@anthropic-ai/sdk": "npm:0.100.0"
-    "@currents/mcp": "npm:^2.3.2"
+    "@currents/mcp": "npm:^2.3.3"
     "@currents/playwright": "npm:^2.5.0"
     "@octokit/rest": "npm:^21.1.1"
     "@playwright/test": "npm:1.61.1"
@@ -16835,7 +16835,7 @@ __metadata:
     eslint-plugin-jest: "npm:^29.16.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-local-rules: "npm:^3.0.2"
-    eslint-plugin-playwright: "npm:^2.10.4"
+    eslint-plugin-playwright: "npm:^2.10.5"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^7.1.1"
     globals: "npm:^17.8.0"
@@ -17690,7 +17690,7 @@ __metadata:
     history: "npm:^5.3.0"
     idb: "npm:^8.0.3"
     immer: "npm:11.1.8"
-    jest-canvas-mock: "npm:^2.5.2"
+    jest-canvas-mock: "npm:^2.5.8"
     jest-watch-typeahead: "npm:3.0.1"
     lottie-react: "npm:2.4.1"
     pako: "npm:^2.1.0"
@@ -26823,14 +26823,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-playwright@npm:^2.10.4":
-  version: 2.10.4
-  resolution: "eslint-plugin-playwright@npm:2.10.4"
+"eslint-plugin-playwright@npm:^2.10.5":
+  version: 2.10.5
+  resolution: "eslint-plugin-playwright@npm:2.10.5"
   dependencies:
     globals: "npm:^17.3.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10/1857729c808531fe010fc66c37228b21be327b278380fc02b02e53b137fe1bbb911f15a9ea1592340b9809498a8f899d6066aafbffb54bccb962ca7967b6dd29
+  checksum: 10/c6b35fa3d004930ad62e11636f98fb195599177f537b558f695e12378283339bf2b7f6544effd532c63759ca1b4cd13bb32a55a92ef307958ad432fad99a7516
   languageName: node
   linkType: hard
 
@@ -31930,13 +31930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-canvas-mock@npm:^2.5.2":
-  version: 2.5.2
-  resolution: "jest-canvas-mock@npm:2.5.2"
+"jest-canvas-mock@npm:^2.5.8":
+  version: 2.5.8
+  resolution: "jest-canvas-mock@npm:2.5.8"
   dependencies:
     cssfontparser: "npm:^1.2.1"
     moo-color: "npm:^1.0.2"
-  checksum: 10/094e2e1c773c658fab7e91e9279027fc38a55060865b5b6a3c9acc47fc912fb9d3451ab4fdf544d016578f77b975626707c3a62e396575aa878f46d939c7ca5e
+  checksum: 10/44d04607a91cadf5042baaf49483df9aae530aad2948e8c9c0235a571ec9b0d9141cefc0f1bb1ee22232682e327817fef0510a73c97d135f3f8fc687ea7aa897
   languageName: node
   linkType: hard
 
@@ -46466,12 +46466,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uri-scheme@npm:^2.0.18":
-  version: 2.0.18
-  resolution: "uri-scheme@npm:2.0.18"
+"uri-scheme@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "uri-scheme@npm:2.2.0"
   bin:
     uri-scheme: cli.js
-  checksum: 10/a865b48f02d37964373c944019a0c76650b59d5be84c4629d8a82c4b3eb456ae2b4c24ab6b411f0ccb25d9dcffbadde0a803497b85ceb2257af4248adc4dd0de
+  checksum: 10/6fb530adea94dae66f150c8930c67fd27667253143e88dd01f38c4a75f77edf9ee58b5c2c33eee7207662081b1f90db224b12c33edd8c4f3111300bc9e3714a5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Tier-1 (zero-risk) slice of the QA dependency audit — patch/minor bumps that sit inside existing ranges, plus one pinning change.

| Package | Change |
|---|---|
| `eslint-plugin-playwright` | `^2.10.4` → `^2.10.5` |
| `jest-canvas-mock` | `^2.5.2` → `^2.5.8` |
| `uri-scheme` | `^2.0.18` → `^2.2.0` |
| `@currents/mcp` | `^2.3.2` → `^2.3.3` |
| `@anthropic-ai/claude-code` | `^2.1.179` → `2.1.216` (now exact) |

`@anthropic-ai/claude-code` is pinned rather than caret-ranged: it ships ~40 releases a month and its failure mode in CI is a mid-run parse error, so the version should move deliberately. 2.1.216 also carries the `claude -p` fix for dropped output on mid-stream API errors — the exact invocation used by `llmTestSelector` and `llmTestAnalyzer`.

Also drops `react-intl` from `scripts/list-outdated-dependencies/qa-dependencies.txt`. It is listed in both `qa-` and `growth-dependencies.txt`, so both teams were getting the same 14-workspace major bump in their monthly issue; growth owns the formatjs/i18n stack.

## Notes for QA

Nothing user-facing — all five are dev/test tooling.

Verified locally:

- `lint:js` passes for `@trezor/suite-e2e`, `@trezor/e2e-utils`, `@suite-native/app`, `@trezor/suite`, `@suite-common/walletconnect`, `@trezor/transport-test` — this is the real check on the eslint plugin bump, since the playwright rules apply via the `e2e/**` and flat globs in `packages/eslint/src/index.mjs`. No new violations.
- `type-check` passes for the touched projects plus their dependency graph.
- `jest-canvas-mock` is a `setupFiles` entry for every `packages/suite` test, so a single test file proves it loads — `protocolMiddleware.test.ts` passes.
- `yarn install --immutable` passes.

Not verifiable outside CI: `uri-scheme` is only invoked as a subprocess inside a detox test (`suite-native/app/e2e/tests/deeplinkPopup.test.ts`), so it needs one Android e2e run. It is a minor bump of an Expo CLI helper.

Note this branch was cut from a develop that is now ~21 commits behind; happy to rebase if the lockfile conflicts.

## Related Issue

Resolve <!--- link the monthly QA deps issue here -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All four changed files are package.json manifests, so the primary risk is dependency or build/runtime breakage rather than feature logic changes. packages/suite/package.json is the only changed file that directly affects the web/desktop Suite app under E2E test; the other three are either linting configuration, native app packaging, or test utilities with no specific runtime impact in this test suite. The recommended strategy is a small, fast smoke set covering app load, onboarding, and the version page, plus one broader route-checking test for confidence.

<details><summary><b>Changed files (4)</b></summary>

- `packages/e2e-utils/package.json`
- `packages/eslint/package.json`
- `packages/suite/package.json`
- `suite-native/app/package.json`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — This is a core smoke test that verifies the Suite web app loads correctly in Firefox. A package.json change in packages/suite could introduce a dependency or build regression that prevents the app from initializing, making this a fast, high-value guard.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Onboarding is the first user-facing flow after app load and exercises core initialization, analytics, settings, and wallet rendering. Dependency changes from packages/suite/package.json are most likely to surface here.
- `suite/e2e/tests/suite/version-page.test.ts` — The /version page displays the app version and commit hash, which are derived from package/build metadata. A change to packages/suite/package.json directly risks breaking this page or its version rendering.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates across nearly every route in the Suite web app and verifies pages load without broken links. It provides broad regression coverage if a package/dependency change affects routing or page rendering, though it is slower than the targeted smoke tests.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/e2e-utils/package.json`
- `packages/eslint/package.json`
- `suite-native/app/package.json`

_Updated: 2026-08-14T07:54:36.151Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/qa-bump-dep/web/](https://dev.suite.sldev.cz/suite-web/qa-bump-dep/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=qa-bump-dep&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=qa-bump-dep&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=qa-bump-dep&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T10:40:44.862Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-14T07:56:55.810Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->