### PR TITLE
Chore(deps): fix runtime affecting high dependabot alerts

### DIFF
--- a/packages/suite-data/package.json
+++ b/packages/suite-data/package.json
@@ -35,7 +35,7 @@
         "css-loader": "^7.1.3",
         "fs-extra": "^11.3.1",
         "postcss-loader": "^8.2.0",
-        "simple-git": "^3.32.3",
+        "simple-git": "^3.36.0",
         "style-loader": "^4.0.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -47570,17 +47570,17 @@ __metadata:
   linkType: hard
 
 "ws@npm:^6.2.3":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
+  version: 6.2.4
+  resolution: "ws@npm:6.2.4"
   dependencies:
     async-limiter: "npm:~1.0.0"
-  checksum: 10/19f8d1608317f4c98f63da6eebaa85260a6fe1ba459cbfedd83ebe436368177fb1e2944761e2392c6b7321cbb7a375c8a81f9e1be35d555b6b4647eb61eadd46
+  checksum: 10/5ec88106f4f97fb175837a476e186b889ec8c57a5ee7c511c852fc1d129ad55cd1c1f45092af2df7419c1394f2000f9b1b6f68f2fcfe52d04d8882aafa1b3838
   languageName: node
   linkType: hard
 
 "ws@npm:^7, ws@npm:^7.0.0, ws@npm:^7.5.1, ws@npm:^7.5.10, ws@npm:^7.5.3":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -47589,7 +47589,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  checksum: 10/486141e4a01bb75883f9ba39317309c2427e24db1cb75e340fad6e5886b65c03d994a34209f0e4ba06dd6cb9ec95dd1b6a09c52c05eed9a34d6376f4fbbf617c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8806,19 +8806,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@simple-git/args-pathspec@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@simple-git/args-pathspec@npm:1.0.2"
-  checksum: 10/8ff2289110aa1c556aadb67da55c01f9430af6a647a9e4823aa023c59b11d3406819cfaead8a9c71c7fd44231271be9e71179ec817b6a3cb99d1da36cd17788e
+"@simple-git/args-pathspec@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/args-pathspec@npm:1.0.3"
+  checksum: 10/74bcc00123cd0da800fc5a6417f83f2f4fce66eb38749efc2ca3b6e4c431c6edaabe80c5834714c155f6ba07582069b182420eda27a601353fb5a3b48917d7e0
   languageName: node
   linkType: hard
 
-"@simple-git/argv-parser@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "@simple-git/argv-parser@npm:1.0.3"
+"@simple-git/argv-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@simple-git/argv-parser@npm:1.1.1"
   dependencies:
-    "@simple-git/args-pathspec": "npm:^1.0.2"
-  checksum: 10/cfb11a054a854135d8262a7aae4b2bd1d2108f3763437080e60dcd9498f32b626857f752bb8b6c6d285cc120a7f221c6a3b2556df9c55c1b30ae136a3ba8e1be
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+  checksum: 10/89f49ee1e9a936318d443a21b04fa8adcd7a3fa4d2d9ebc947d6d4f347d65db5fbcfec37f3d75711f2724d7886506f3003144735e244e1eea6badef58696d99f
   languageName: node
   linkType: hard
 
@@ -17013,7 +17013,7 @@ __metadata:
     fs-extra: "npm:^11.3.1"
     postcss-loader: "npm:^8.2.0"
     semver: "npm:^7.7.1"
-    simple-git: "npm:^3.32.3"
+    simple-git: "npm:^3.36.0"
     style-loader: "npm:^4.0.0"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
@@ -42947,16 +42947,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.32.3":
-  version: 3.35.2
-  resolution: "simple-git@npm:3.35.2"
+"simple-git@npm:^3.36.0":
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
-    "@simple-git/args-pathspec": "npm:^1.0.2"
-    "@simple-git/argv-parser": "npm:^1.0.3"
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
     debug: "npm:^4.4.0"
-  checksum: 10/4bfb2ac73041db774e8cfaefbc97e4cacf2725d955e458e135647209829336505223128f928aac9f86b92e30d0e7c4128daad0268a1303c2d88fda8be1fda0d1
+  checksum: 10/79a745464798bce17fc5c286ff4a44ba07d368a745d03d31f3c3cef51bd63b98dc29e72f55dda087b64e5db90e5e9f91a7429543ddf08d105d9a069c525e6818
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -45570,16 +45570,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.18.2, undici@npm:^6.22.0":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10/4f84e6045520eef9ba8eabb96360b50c759f59905c1703b12187c2dbcc6d1584c5d7ecddeb45b0ed6cac84ca2d132b21bfd8a38f77fa30378b1ac5d2ae390fd9
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
   languageName: node
   linkType: hard
 
 "undici@npm:^7.24.4":
-  version: 7.26.0
-  resolution: "undici@npm:7.26.0"
-  checksum: 10/c55b8f8e378dce6e645853faf0834d66b9f470c6ee1430c6e2b7971d831de36081f7e2e21ac1fc11297657d7c856241b0bf746b2a24f1277f8d156df9c181ba7
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fix High dependabot alerts that affect runtime: 

- **[Dependabot/691](https://github.com/trezor/trezor-suite/security/dependabot/691)**: updated `simple-git` from `^3.32.3` to `^3.36.0` in `@trezor/suite-data` to fix **CVE-2026-6951 / GHSA-hffm-xvc3-vprc**
- **[Dependabot/804](https://github.com/trezor/trezor-suite/security/dependabot/804)**: updated transitive `undici` resolutions to `6.27.0` and `7.28.0` to fix **CVE-2026-12151 / GHSA-vxpw-j846-p89q**
- **[Dependabot/774](https://github.com/trezor/trezor-suite/security/dependabot/774)**: updated transitive `ws` resolutions from vulnerable `6.2.3` / `7.5.10` to `6.2.4` / `7.5.11` to fix **CVE-2026-48779 / GHSA-96hv-2xvq-fx4p**

Not done (blocked by pinned versions):

- **[Dependabot/877](https://github.com/trezor/trezor-suite/security/dependabot/877)**: updated transitive `postcss` resolutions from vulnerable `8.4.31` / `8.4.49` to `8.5.15` to fix **CVE-2026-45623 / GHSA-6g55-p6wh-862q**

Axios: after 01a92b2c the vunlerable version is not used in runtime. The other uses are again pinned :disappointed: 

## Notes for QA

Just see that there are no obvious failures, no dedicated QA is necessary.

Axios: stellar works

Other things are covered by tests.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is packages/suite-data/package.json, which likely governs static assets, translations, and build metadata. No static test coverage mapping was available, so I inferred two small, focused smoke tests: one that exercises a suite-data translation file and one that hits the metadata-driven /version page. These should catch regressions in asset serving or build-time data without running the full suite. If the actual diff touches specific assets (e.g., firmware binaries, browser gate pages), the selection should be expanded.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-data/package.json`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — This test explicitly loads the Spanish translation file from @trezor/suite-data/files/translations/es-ES.json and asserts localized onboarding text. A change to suite-data/package.json could alter how translation assets are built, resolved, or served, so this test is a targeted smoke check for that path.
- `suite/e2e/tests/suite/version-page.test.ts` — The /version route displays the suite version and commit hash, which are injected from package/build metadata. Since suite-data/package.json controls static data and asset handling, this test verifies that the metadata-driven page still renders correctly after the change.

</details>

_Updated: 2026-08-05T10:12:02.447Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/fix-runtime-affecting-high-dependabot-alerts/web/](https://dev.suite.sldev.cz/suite-web/chore/fix-runtime-affecting-high-dependabot-alerts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fix-runtime-affecting-high-dependabot-alerts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fix-runtime-affecting-high-dependabot-alerts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T10:14:51.160Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Navigation > Navigate to | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T10:14:29.862Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->