### PR TITLE
test(suite): migrate next swap tests to minimalistic mock

### DIFF
--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -7,7 +7,11 @@ import { TradingChainBackend, createTradingChainBackend } from './tradingChainBa
 import { tradeEndpoint } from '../../../fixtures/trading';
 import { step } from '../../common';
 
-export type CapturedLiveTrade = ExchangeTrade & { sendAddress: string; exchange: string };
+export type CapturedLiveTrade = ExchangeTrade & {
+    sendAddress: string;
+    exchange: string;
+    sendStringAmount: string;
+};
 
 type TradeFlow = 'buy' | 'sell' | 'swap';
 type TradeEndpoints = {
@@ -71,6 +75,16 @@ export class TradingMockNew {
         return TRADE_ENDPOINTS[this.tradeFlow];
     }
 
+    // Txid of the broadcast blocked by the backend (source of truth for post-send assertions).
+    get lastBroadcastTxid(): string {
+        const txid = this.backend?.lastBroadcastTxid;
+        if (!txid) {
+            throw new Error('Backend has not recorded a broadcast yet (is startBackend set up?)');
+        }
+
+        return txid;
+    }
+
     // Sell + swap only; call before discovery.
     @step()
     async startBackend(symbol: NetworkSymbol): Promise<{ type: BackendType; url: string }> {
@@ -95,16 +109,6 @@ export class TradingMockNew {
             body.tradeForm.form.formAction = returnUrl;
             await route.fulfill({ response, json: body });
         });
-    }
-
-    // Txid of the broadcast blocked by the backend (source of truth for post-send assertions).
-    get lastBroadcastTxid(): string {
-        const txid = this.backend?.lastBroadcastTxid;
-        if (!txid) {
-            throw new Error('Backend has not recorded a broadcast yet (is startBackend set up?)');
-        }
-
-        return txid;
     }
 
     @step()
@@ -133,8 +137,10 @@ export class TradingMockNew {
     async waitForLiveTrade() {
         const response = await this.page.waitForResponse(this.endpoints.trade);
         const trade = (await response.json()) as ExchangeTrade;
-        if (!trade.sendAddress || !trade.exchange) {
-            throw new Error('Live trade response is missing sendAddress or exchange');
+        if (!trade.sendAddress || !trade.exchange || !trade.sendStringAmount) {
+            throw new Error(
+                'Live trade response is missing sendAddress, exchange or sendStringAmount',
+            );
         }
 
         this.capturedTrade = trade as CapturedLiveTrade;

--- a/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
+++ b/suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts
@@ -1,0 +1,165 @@
+import { localizeNumber } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+import { getCompanyNameFromList } from '../../fixtures/trading';
+import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
+import { formatAddressWithNewlines } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import { transformAddress } from '../../support/testExtends/customMatchers';
+
+const sendAmount = '0.001';
+const formattedSendAmount = `${localizeNumber(sendAmount)} BTC`;
+const sendAccountLabel = 'Bitcoin #1';
+const receiveAccountLabel = 'Ethereum #1';
+const receiveTokenSymbol = 'USDC';
+
+test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+
+    test.beforeEach(
+        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            const btcBackend = await tradingMockNew.startBackend('btc');
+
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'btc', backend: btcBackend }, 'eth'],
+            });
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'btc' });
+        },
+    );
+
+    test('Swap BTC to ETH USDC token', async ({
+        tradingPage,
+        page,
+        device,
+        devicePrompt,
+        tradingMockNew,
+    }) => {
+        await test.step('Fill in a Swap form', async () => {
+            await tradingPage.fillSwapForm({
+                amount: sendAmount,
+                sellAsset: {
+                    networkSymbol: 'btc',
+                },
+                buyAsset: {
+                    searchFilter: receiveTokenSymbol,
+                    networkFilter: 'eth',
+                    networkSymbol: 'eth',
+                    tokenSymbol: receiveTokenSymbol,
+                },
+                selectReceiveAddress: async () => {
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'eth');
+                },
+            });
+        });
+
+        let receiveAmount: string;
+        let providerName: string;
+        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
+
+        await test.step('Confirm the Swap trade', async () => {
+            receiveAmount = await tradingPage.quotes.getBestOfferAmount();
+            await tradingPage.fees.waitToBeCalculated();
+            liveTradePromise = tradingMockNew.waitForLiveTrade();
+            await tradingPage.swapBestOfferButton.click();
+        });
+
+        await test.step('Open modal and verify recipient on prompt and device', async () => {
+            await tradingPage.confirmation.openConfirmAndSendModal();
+            await liveTradePromise;
+            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
+
+            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        transformAddress(tradingMockNew.liveTrade.sendAddress, 'fourTetragrams'),
+                    ],
+                    actions: { right_button: 'Continue' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify amount on prompt and device', async () => {
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
+                formattedSendAmount,
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [['Amount'], [formattedSendAmount]],
+                    actions: { right_button: 'Confirm' },
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify total and fee on prompt and device', async () => {
+            // The BTC fee is live; derive the total from it and crosscheck modal against device.
+            await expect(devicePrompt.cryptoAmountOf('fee')).toHaveText(/\d/);
+            const reviewFee = await devicePrompt.cryptoAmountOf('fee').innerText();
+            const totalAmount = new BigNumber(reviewFee).plus(sendAmount).toString();
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('total')).toHaveText(
+                `${totalAmount} BTC`,
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [
+                        ['Total amount'],
+                        [`${totalAmount} BTC`],
+                        ['incl. Transaction fee'],
+                        [`${reviewFee} BTC`],
+                    ],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await expect(devicePrompt.sendButton).toBeEnabled();
+        });
+
+        await test.step('Send crypto to provider (broadcast blocked by mock)', async () => {
+            await tradingMockNew.setStatus('SENDING');
+            await page.clock.install();
+            await devicePrompt.sendButton.click();
+
+            await tradingPage.verifySwapToast({
+                sendAccount: sendAccountLabel,
+                receiveAccount: receiveAccountLabel,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
+                receiveAmount,
+            });
+        });
+
+        for (const step of swapStatusFlow) {
+            await test.step(`Wait for status change to ${step.status}`, async () => {
+                await tradingMockNew.advanceStatus(step.status);
+                const values = step.translationValues?.(providerName);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    step.translationKey,
+                    { values },
+                );
+            });
+        }
+
+        await test.step('Verify transaction detail values', async () => {
+            await expect(tradingPage.confirmation.sendCryptoAmount).toHaveText(formattedSendAmount);
+            await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
+                `${receiveAmount} ${receiveTokenSymbol}`,
+            );
+            await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+        });
+    });
+});

--- a/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
+++ b/suite/e2e/tests/trading/swap-eth-to-sol.test.ts
@@ -1,0 +1,139 @@
+import { getCryptoId } from '@suite-common/trading';
+import { localizeNumber } from '@suite-common/wallet-utils';
+
+import { getCompanyNameFromList } from '../../fixtures/trading';
+import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
+import { formatAddressWithNewlines } from '../../support/common';
+import { expect, test } from '../../support/fixtures';
+import { transformAddress } from '../../support/testExtends/customMatchers';
+
+const sendAmount = '0.01';
+const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
+const sendAccountLabel = 'Ethereum #1';
+const receiveAccountLabel = 'Solana #1';
+
+test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
+
+    test.beforeEach(
+        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            const ethBackend = await tradingMockNew.startBackend('eth');
+
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'eth', backend: ethBackend }, 'sol'],
+            });
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'eth' });
+        },
+    );
+
+    test('Swap ETH to SOL', async ({ tradingPage, page, device, devicePrompt, tradingMockNew }) => {
+        await test.step('Fill in a Swap form', async () => {
+            await tradingPage.fillSwapForm({
+                amount: sendAmount,
+                sellAsset: {
+                    networkSymbol: 'eth',
+                },
+                buyAsset: {
+                    searchFilter: 'Solana',
+                    assetCryptoId: getCryptoId('sol'),
+                },
+                selectReceiveAddress: async () => {
+                    await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'sol');
+                },
+            });
+        });
+
+        let receiveAmount: string;
+        let providerName: string;
+        let liveTradePromise: ReturnType<typeof tradingMockNew.waitForLiveTrade>;
+
+        await test.step('Confirm the Swap trade', async () => {
+            receiveAmount = await tradingPage.quotes.getBestOfferAmount();
+            await expect(tradingPage.fees.maximumFeeAmountToBeCalculated).toBeHidden();
+            liveTradePromise = tradingMockNew.waitForLiveTrade();
+            await tradingPage.swapBestOfferButton.click();
+        });
+
+        await test.step('Open modal and verify recipient on prompt and device', async () => {
+            await tradingPage.confirmation.openConfirmAndSendModal();
+            await liveTradePromise;
+            providerName = getCompanyNameFromList(tradingMockNew.liveTrade.exchange, 'swapList');
+
+            await expect(devicePrompt.headerParagraph).toContainText(sendAccountLabel);
+            await expect(devicePrompt.outputValueOf('address')).toHaveText(
+                formatAddressWithNewlines(tradingMockNew.liveTrade.sendAddress),
+            );
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                    actions: { right_button: 'Continue' },
+                },
+                T3T1: {
+                    header: { title: 'Address', subtitle: 'Recipient' },
+                    body: [transformAddress(tradingMockNew.liveTrade.sendAddress, 'evmTetragrams')],
+                },
+            });
+            await devicePrompt.waitForPromptAndConfirm();
+        });
+
+        await test.step('Verify amount and fee on prompt and device', async () => {
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('amount')).toHaveText(
+                formattedSendAmount,
+            );
+            // The EVM max fee is live; we just crosscheck modal and device.
+            const reviewFee = await devicePrompt.cryptoAmountOf('fee').innerText();
+            const maxFeeWrapped = device.wrapText(`${reviewFee} ETH`, { isAmount: true });
+            await expect(device).toShowOnDisplay({
+                T3W1: {
+                    header: { title: 'Send' },
+                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                    actions: { right_button: 'Hold to sign' },
+                },
+                T3T1: {
+                    header: { title: 'Summary' },
+                    body: [['Amount'], [formattedSendAmount], ['Maximum fee'], maxFeeWrapped],
+                },
+            });
+            await devicePrompt.waitForFinalPromptAndConfirm();
+            await expect(devicePrompt.sendButton).toBeEnabled();
+        });
+
+        await test.step('Send crypto to provider (broadcast blocked by mock)', async () => {
+            await tradingMockNew.setStatus('SENDING');
+            await page.clock.install();
+            await devicePrompt.sendButton.click();
+
+            await tradingPage.verifySwapToast({
+                sendAccount: sendAccountLabel,
+                receiveAccount: receiveAccountLabel,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
+                receiveAmount,
+            });
+        });
+
+        for (const step of swapStatusFlow) {
+            await test.step(`Wait for status change to ${step.status}`, async () => {
+                await tradingMockNew.advanceStatus(step.status);
+                const values = step.translationValues?.(providerName);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    step.translationKey,
+                    { values },
+                );
+            });
+        }
+
+        await test.step('Verify transaction detail values', async () => {
+            await expect(tradingPage.confirmation.sendCryptoAmount).toHaveText(formattedSendAmount);
+            await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
+                `${receiveAmount} SOL`,
+            );
+            await expect(tradingPage.confirmation.provider).toHaveText(providerName);
+        });
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## test(suite): add remaining swap tests based on minimalistic mock

Closes the Phase B derangement matrix from `docs/e2e-mocking-target-state.md` with the
last two swap flows on `TradingMockNew` (live backends + live Invity, only the broadcast
and the post-send watch are mocked):

- **⑤ `swap-eth-to-sol`** — ETH → SOL, native-coin source on the ETH adapter.
- **③ `swap-btc-to-eth-token`** — BTC → ETH USDC, **first use of the BTC adapter**.

Every tradeable entity (BTC, ETH, ETH token, SOL, SOL token) now sends exactly once and
receives exactly once, and all three chain adapters are exercised by a real test.

③ is also the first test in the suite to complete a **BTC signing without broadcasting** —
the thing `sell-bitcoin.test.ts` gave up on ("we don't know how to mock the send request and
actually not send the crypto"). Phase C (sell) inherits it.

### Mock changes

- `waitForLiveTrade` now also requires `sendStringAmount`, and the swap toast is asserted
  against **that captured value** instead of the amount the test typed. The toast renders
  `trade.sendStringAmount` verbatim and providers disagree on padding for the same amount
  (`sideshift` → `"0.01"`, `sideshiftfr` → `"0.010000000000000000"`), so comparing against
  the typed amount only passes while a trimming provider wins the best offer.
- New `toHaveTextEqualTo` matcher (numeric text comparison), kept for future use.

### Verification

Both tests green locally on **web and desktop × T3W1 and T3T1**. Send amounts (0.01 ETH,
0.001 BTC) were picked from a live quote probe for maximum provider depth — 6 and 8 usable
CEX quotes respectively, all non-DEX — and fit the trading wallet's funding (0.0376 ETH,
0.00178 BTC).

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/minimalist-mock-phase-B-2/web/](https://dev.suite.sldev.cz/suite-web/minimalist-mock-phase-B-2/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=minimalist-mock-phase-B-2&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=minimalist-mock-phase-B-2&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-14T14:23:35.007Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-14T14:24:10.369Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->