### PR TITLE
feat(native): activity center screen with navigation and unseen indicator

### DIFF
--- a/networks/network-module/network-module-suite-common-types/tsconfig.lib.json
+++ b/networks/network-module/network-module-suite-common-types/tsconfig.lib.json
@@ -6,8 +6,6 @@
     },
     "include": ["./src"],
     "references": [
-        {
-            "path": "../../../packages/type-utils"
-        }
+        { "path": "../../../packages/type-utils" }
     ]
 }

--- a/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx
@@ -10,12 +10,11 @@ import {
 import { type Route, selectRouteName } from '@suite/router';
 import { useServices } from '@suite-common/dependency-injection';
 import { selectHasBitcoinOnlyFirmware } from '@suite-common/device';
-import { isTransactionNotification } from '@suite-common/toast-notifications';
+import { selectHasUnseenNotifications } from '@suite-common/toast-notifications';
 import { Column } from '@trezor/components';
 import { BellIcon, GearSixIcon, HouseIcon, PiggyBankIcon, RepeatIcon } from '@trezor/icons';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
-import { type AppState } from 'src/reducers/store';
 import { useResponsiveContext } from 'src/support/suite/ResponsiveContext';
 
 import { NavigationItem, type NavigationItemProps } from './NavigationItem';
@@ -33,11 +32,6 @@ type NavigationProps = {
 };
 
 const newContentIndicatorIntro = { hasPlayed: false };
-
-const selectHasUnseenNotifications = (state: AppState) =>
-    state.notifications.some(
-        notification => !notification.seen && isTransactionNotification(notification),
-    );
 
 export const Navigation = ({ children }: NavigationProps) => {
     const { isSidebarCollapsed } = useResponsiveContext();

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -1,10 +1,14 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
+import { isTransactionNotification } from './notificationsUtils';
 import { type NotificationsRootState, type ToastPayload } from './types';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NotificationsRootState>();
 
 export const selectNotifications = (state: NotificationsRootState) => state.notifications;
+
+export const selectHasUnseenNotifications = (state: NotificationsRootState): boolean =>
+    state.notifications.some(n => !n.seen && isTransactionNotification(n));
 
 export const selectVisibleNotificationsByType = createMemoizedSelector(
     [

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -8,7 +8,7 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<NotificationsRoot
 export const selectNotifications = (state: NotificationsRootState) => state.notifications;
 
 export const selectHasUnseenNotifications = (state: NotificationsRootState): boolean =>
-    state.notifications.some(n => !n.seen && isTransactionNotification(n));
+    state.notifications?.some(n => !n.seen && isTransactionNotification(n)) ?? false;
 
 export const selectVisibleNotificationsByType = createMemoizedSelector(
     [

--- a/suite-native/activity-center/src/components/ActivityCenterButton.tsx
+++ b/suite-native/activity-center/src/components/ActivityCenterButton.tsx
@@ -1,8 +1,15 @@
 import { useState } from 'react';
 
+import { useNavigation } from '@react-navigation/native';
+import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
+
 import { AnimatedPressable, Box, useButtonPressAnimatedStyle } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
-import { useToast } from '@suite-native/toasts';
+import {
+    ActivityCenterStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+} from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { NotificationDot } from './NotificationDot';
@@ -36,7 +43,7 @@ export const ActivityCenterButton = ({
 }: ActivityCenterButtonProps) => {
     const [isPressed, setIsPressed] = useState(false);
     const { applyStyle } = useNativeStyles();
-    const { showToast } = useToast();
+    const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
     const animatedPressStyle = useButtonPressAnimatedStyle(
         isPressed,
@@ -45,7 +52,10 @@ export const ActivityCenterButton = ({
         'surfaceFillActionPressed',
     );
 
-    const handlePress = () => showToast({ intent: 'info', message: 'Coming soon' });
+    const handlePress = () =>
+        navigation.navigate(RootStackRoutes.ActivityCenterStack, {
+            screen: ActivityCenterStackRoutes.ActivityCenter,
+        });
 
     return (
         <AnimatedPressable

--- a/suite-native/activity-center/tsconfig.json
+++ b/suite-native/activity-center/tsconfig.json
@@ -4,7 +4,7 @@
     "references": [
         { "path": "../atoms" },
         { "path": "../icons" },
-        { "path": "../toasts" },
+        { "path": "../navigation" },
         { "path": "../../packages/styles-native" }
     ]
 }

--- a/suite-native/app/package.json
+++ b/suite-native/app/package.json
@@ -70,6 +70,7 @@
         "@suite-native/message-system": "workspace:*",
         "@suite-native/module-accounts-import": "workspace:*",
         "@suite-native/module-accounts-management": "workspace:*",
+        "@suite-native/module-activity-center": "workspace:*",
         "@suite-native/module-add-accounts": "workspace:*",
         "@suite-native/module-authenticity-checks": "workspace:*",
         "@suite-native/module-authorize-device": "workspace:*",

--- a/suite-native/app/src/navigation/RootStackNavigator.tsx
+++ b/suite-native/app/src/navigation/RootStackNavigator.tsx
@@ -10,6 +10,7 @@ import {
     AccountDetailScreen,
     AccountSettingsScreen,
 } from '@suite-native/module-accounts-management';
+import { ActivityCenterStackNavigator } from '@suite-native/module-activity-center';
 import { AddCoinAccountStackNavigator } from '@suite-native/module-add-accounts';
 import { DeviceCompromisedModalScreen } from '@suite-native/module-authenticity-checks';
 import { AuthorizeDeviceStackNavigator } from '@suite-native/module-authorize-device';
@@ -279,6 +280,11 @@ export const RootStackNavigator = () => {
                 name={RootStackRoutes.BootloaderMode}
                 component={BootloaderModeScreen}
             />
+            <RootStack.Screen
+                name={RootStackRoutes.ActivityCenterStack}
+                component={ActivityCenterStackNavigator}
+            />
+
             {/* Navigation flows that start by push from bottom animation on the first screen of its stack. */}
             <RootStack.Group screenOptions={{ animation: 'slide_from_bottom' }}>
                 <RootStack.Screen

--- a/suite-native/app/tsconfig.json
+++ b/suite-native/app/tsconfig.json
@@ -54,6 +54,7 @@
         {
             "path": "../module-accounts-management"
         },
+        { "path": "../module-activity-center" },
         { "path": "../module-add-accounts" },
         {
             "path": "../module-authenticity-checks"

--- a/suite-native/atoms/src/SubTabs.tsx
+++ b/suite-native/atoms/src/SubTabs.tsx
@@ -51,7 +51,6 @@ const iconSizeBySize = {
 
 const tabsStyle = prepareNativeStyle(({ spacings }) => ({
     gap: spacings.sp12,
-    paddingHorizontal: spacings.sp16,
 }));
 
 const tabStyle = prepareNativeStyle<SubTabStyleProps>((utils, { isActive, size }) => ({

--- a/suite-native/atoms/src/SubTabs.tsx
+++ b/suite-native/atoms/src/SubTabs.tsx
@@ -16,6 +16,7 @@ export type SubTabItem<TValue> = {
     value: TValue;
     icon?: IconName;
     testID?: string;
+    accessory?: ReactNode;
 };
 
 export type SubTabsProps<TValue> = {
@@ -116,6 +117,7 @@ const SubTab = ({ isActive, item, onPress, size }: SubTabProps) => {
             >
                 {item.label}
             </Text>
+            {item.accessory}
         </PressableOpacity>
     );
 };

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -20,6 +20,7 @@
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
+        "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:^",
         "@suite-native/activity-center": "workspace:*",

--- a/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
@@ -1,3 +1,6 @@
+import { useSelector } from 'react-redux';
+
+import { selectHasUnseenNotifications } from '@suite-common/toast-notifications';
 import { ActivityCenterButton } from '@suite-native/activity-center';
 import { HStack, ScreenHeaderWrapper } from '@suite-native/atoms';
 import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
@@ -6,12 +9,15 @@ import { DeviceManager } from './DeviceManager';
 
 export const DeviceManagerScreenHeader = () => {
     const isActivityCenterEnabled = useFeatureFlag(FeatureFlag.IsActivityCenterEnabled);
+    const hasUnseenNotifications = useSelector(selectHasUnseenNotifications);
 
     return (
         <ScreenHeaderWrapper>
             <HStack spacing="sp12">
                 <DeviceManager />
-                {isActivityCenterEnabled && <ActivityCenterButton />}
+                {isActivityCenterEnabled && (
+                    <ActivityCenterButton hasUnseenNotifications={hasUnseenNotifications} />
+                )}
             </HStack>
         </ScreenHeaderWrapper>
     );

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -19,6 +19,9 @@
             "path": "../../suite-common/suite-utils"
         },
         {
+            "path": "../../suite-common/toast-notifications"
+        },
+        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -4344,6 +4344,15 @@ export const messages = {
             banner: 'Change your networks anytime in Settings.',
         },
     },
+    moduleActivityCenter: {
+        title: 'Activity',
+        screenHeader: 'Activity Center',
+        tabs: {
+            notifications: 'Notifications',
+            system: 'System',
+            releaseNotes: 'Release notes',
+        },
+    },
     biometricsButton: 'Unlock with biometrics',
     search: {
         noResults: 'No results',

--- a/suite-native/module-activity-center/package.json
+++ b/suite-native/module-activity-center/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@suite-native/activity-center",
+    "name": "@suite-native/module-activity-center",
     "version": "1.0.0",
     "private": true,
     "license": "See LICENSE.md in repo root",
@@ -12,13 +12,13 @@
         "type-check": "yarn g:tsc --build"
     },
     "dependencies": {
-        "@react-navigation/native": "7.1.28",
         "@react-navigation/native-stack": "7.12.0",
+        "@suite-common/toast-notifications": "workspace:*",
+        "@suite-native/activity-center": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/icons": "workspace:*",
+        "@suite-native/intl": "workspace:*",
         "@suite-native/navigation": "workspace:*",
-        "@trezor/styles-native": "workspace:*",
         "react": "19.2.3",
-        "react-native": "0.85.3"
+        "react-redux": "9.3.0"
     }
 }

--- a/suite-native/module-activity-center/src/index.ts
+++ b/suite-native/module-activity-center/src/index.ts
@@ -1,0 +1,1 @@
+export * from './navigation/ActivityCenterStackNavigator';

--- a/suite-native/module-activity-center/src/navigation/ActivityCenterStackNavigator.tsx
+++ b/suite-native/module-activity-center/src/navigation/ActivityCenterStackNavigator.tsx
@@ -1,0 +1,20 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import {
+    type ActivityCenterStackParamList,
+    ActivityCenterStackRoutes,
+    stackNavigationOptionsConfig,
+} from '@suite-native/navigation';
+
+import { ActivityCenterScreen } from '../screens/ActivityCenterScreen';
+
+const ActivityCenterStack = createNativeStackNavigator<ActivityCenterStackParamList>();
+
+export const ActivityCenterStackNavigator = () => (
+    <ActivityCenterStack.Navigator screenOptions={stackNavigationOptionsConfig}>
+        <ActivityCenterStack.Screen
+            name={ActivityCenterStackRoutes.ActivityCenter}
+            component={ActivityCenterScreen}
+        />
+    </ActivityCenterStack.Navigator>
+);

--- a/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
+++ b/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { selectHasUnseenNotifications } from '@suite-common/toast-notifications';
+import { NotificationDot } from '@suite-native/activity-center';
+import { type SubTabItem, SubTabs, Text, VStack } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
+
+type ActivityCenterTab = 'notifications' | 'system' | 'releaseNotes';
+
+export const ActivityCenterScreen = () => {
+    const hasUnseenNotifications = useSelector(selectHasUnseenNotifications);
+    const [activeTab, setActiveTab] = useState<ActivityCenterTab>('notifications');
+
+    const tabs: SubTabItem<ActivityCenterTab>[] = [
+        {
+            value: 'notifications',
+            label: <Translation id="moduleActivityCenter.tabs.notifications" />,
+            accessory: hasUnseenNotifications ? <NotificationDot /> : undefined,
+        },
+        { value: 'system', label: <Translation id="moduleActivityCenter.tabs.system" /> },
+        {
+            value: 'releaseNotes',
+            label: <Translation id="moduleActivityCenter.tabs.releaseNotes" />,
+        },
+    ];
+
+    return (
+        <Screen
+            header={
+                <DynamicScreenHeader
+                    title={<Translation id="moduleActivityCenter.title" />}
+                    marginBottom="sp16"
+                />
+            }
+        >
+            <VStack>
+                <SubTabs items={tabs} value={activeTab} onChange={setActiveTab} />
+                <Text>WIP: content of the tabs will be implemented in the followup.</Text>
+            </VStack>
+        </Screen>
+    );
+};

--- a/suite-native/module-activity-center/tsconfig.json
+++ b/suite-native/module-activity-center/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": { "outDir": "libDev" },
+    "references": [
+        {
+            "path": "../../suite-common/toast-notifications"
+        },
+        { "path": "../activity-center" },
+        { "path": "../atoms" },
+        { "path": "../intl" },
+        { "path": "../navigation" }
+    ]
+}

--- a/suite-native/module-send/tsconfig.json
+++ b/suite-native/module-send/tsconfig.json
@@ -10,9 +10,7 @@
         {
             "path": "../../suite-common/formatters"
         },
-        {
-            "path": "../../suite-common/networks"
-        },
+        { "path": "../../suite-common/networks" },
         {
             "path": "../../suite-common/suite-sync"
         },

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { EdgeFades, HStack, type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { Box, EdgeFades, HStack, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -68,10 +68,12 @@ export const HeaderTabs = () => {
 
     return (
         <>
-            <HStack spacing={0}>
-                <SubTabs items={data} onChange={onTabPress} value={activeTab} />
-                <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
-            </HStack>
+            <Box paddingHorizontal="sp16">
+                <HStack spacing={0}>
+                    <SubTabs items={data} onChange={onTabPress} value={activeTab} />
+                    <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
+                </HStack>
+            </Box>
         </>
     );
 };

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -67,13 +67,11 @@ export const HeaderTabs = () => {
     };
 
     return (
-        <>
-            <Box paddingHorizontal="sp16">
-                <HStack spacing={0}>
-                    <SubTabs items={data} onChange={onTabPress} value={activeTab} />
-                    <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
-                </HStack>
-            </Box>
-        </>
+        <Box paddingHorizontal="sp16">
+            <HStack spacing={0}>
+                <SubTabs items={data} onChange={onTabPress} value={activeTab} />
+                <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
+            </HStack>
+        </Box>
     );
 };

--- a/suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeader.tsx
+++ b/suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeader.tsx
@@ -1,11 +1,14 @@
 import { type ReactNode } from 'react';
 
+import { type NativeSpacing } from '@trezor/theme';
+
 import { useDynamicHeader } from './DynamicScreenHeaderContext';
 import { ScreenHeader, type ScreenHeaderProps } from '../ScreenHeader';
 
 export type DynamicScreenHeaderProps = {
     subtitle?: ReactNode;
     isCompactOnly?: boolean;
+    marginBottom?: NativeSpacing;
 } & ScreenHeaderProps;
 
 export const DynamicScreenHeader = ({

--- a/suite-native/navigation/src/components/DynamicHeader/DynamicScrollableScreenContentHeader.tsx
+++ b/suite-native/navigation/src/components/DynamicHeader/DynamicScrollableScreenContentHeader.tsx
@@ -2,17 +2,20 @@ import { type ReactNode } from 'react';
 import { type LayoutChangeEvent } from 'react-native';
 
 import { Text, VStack } from '@suite-native/atoms';
+import { type NativeSpacing } from '@trezor/theme';
 
 import { useDynamicHeader } from './DynamicScreenHeaderContext';
 import { type ScreenHeaderProps } from '../ScreenHeader';
 
 type DynamicScrollableScreenContentHeaderProps = {
     subtitle?: ReactNode;
+    marginBottom?: NativeSpacing;
 } & Pick<ScreenHeaderProps, 'title'>;
 
 export const DynamicScrollableScreenContentHeader = ({
     title,
     subtitle,
+    marginBottom = 'sp32',
 }: DynamicScrollableScreenContentHeaderProps) => {
     const { setScrollableHeaderHeight } = useDynamicHeader();
 
@@ -22,7 +25,7 @@ export const DynamicScrollableScreenContentHeader = ({
     };
 
     return (
-        <VStack paddingHorizontal="sp16" marginTop="sp16" marginBottom="sp32">
+        <VStack paddingHorizontal="sp16" marginTop="sp16" marginBottom={marginBottom}>
             <Text variant="headline-md" onLayout={handleLayout}>
                 {title}
             </Text>

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -18,6 +18,7 @@ import { type DeviceModelInternal } from '@trezor/device-utils';
 import {
     type AccountsImportStackRoutes,
     type AccountsStackRoutes,
+    type ActivityCenterStackRoutes,
     type AddCoinAccountStackRoutes,
     type AppTabsRoutes,
     type AuthorizeDeviceStackRoutes,
@@ -545,6 +546,11 @@ export type RootStackParamList = {
     };
     [RootStackRoutes.TradingHistory]: undefined;
     [RootStackRoutes.TradingBuyPreview]: undefined;
+    [RootStackRoutes.ActivityCenterStack]: NavigatorScreenParams<ActivityCenterStackParamList>;
+};
+
+export type ActivityCenterStackParamList = {
+    [ActivityCenterStackRoutes.ActivityCenter]: undefined;
 };
 
 export type TransactionDetailStackParamList = {

--- a/suite-native/navigation/src/routes.ts
+++ b/suite-native/navigation/src/routes.ts
@@ -51,6 +51,11 @@ export enum RootStackRoutes {
     ReceiveAccounts = 'ReceiveAccounts',
     TradingHistory = 'TradingHistory',
     TradingBuyPreview = 'TradingBuyPreview',
+    ActivityCenterStack = 'ActivityCenterStack',
+}
+
+export enum ActivityCenterStackRoutes {
+    ActivityCenter = 'ActivityCenter',
 }
 
 export enum AppTabsRoutes {

--- a/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
@@ -1,5 +1,5 @@
 import { type TradingType } from '@suite-common/trading';
-import { type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { Box, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 
 export type TradingHistoryFilter = TradingType | 'all';
@@ -36,11 +36,13 @@ const items: SubTabItem<TradingHistoryFilter>[] = [
 ];
 
 export const TradingHistoryTabs = ({ value, onChange }: TradingHistoryTabsProps) => (
-    <SubTabs
-        items={items}
-        onChange={onChange}
-        size="large"
-        testID="@trading/history/tabs"
-        value={value}
-    />
+    <Box paddingHorizontal="sp16">
+        <SubTabs
+            items={items}
+            onChange={onChange}
+            size="large"
+            testID="@trading/history/tabs"
+            value={value}
+        />
+    </Box>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11417,9 +11417,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-native/activity-center@workspace:suite-native/activity-center"
   dependencies:
+    "@react-navigation/native": "npm:7.1.28"
+    "@react-navigation/native-stack": "npm:7.12.0"
     "@suite-native/atoms": "workspace:*"
     "@suite-native/icons": "workspace:*"
-    "@suite-native/toasts": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
     "@trezor/styles-native": "workspace:*"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
@@ -11611,6 +11613,7 @@ __metadata:
     "@suite-native/message-system": "workspace:*"
     "@suite-native/module-accounts-import": "workspace:*"
     "@suite-native/module-accounts-management": "workspace:*"
+    "@suite-native/module-activity-center": "workspace:*"
     "@suite-native/module-add-accounts": "workspace:*"
     "@suite-native/module-authenticity-checks": "workspace:*"
     "@suite-native/module-authorize-device": "workspace:*"
@@ -12073,6 +12076,7 @@ __metadata:
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:^"
     "@suite-native/activity-center": "workspace:*"
@@ -12656,6 +12660,21 @@ __metadata:
     react-hook-form: "npm:^7.77.0"
     react-native: "npm:0.85.3"
     react-native-reanimated: "npm:4.3.1"
+    react-redux: "npm:9.3.0"
+  languageName: unknown
+  linkType: soft
+
+"@suite-native/module-activity-center@workspace:*, @suite-native/module-activity-center@workspace:suite-native/module-activity-center":
+  version: 0.0.0-use.local
+  resolution: "@suite-native/module-activity-center@workspace:suite-native/module-activity-center"
+  dependencies:
+    "@react-navigation/native-stack": "npm:7.12.0"
+    "@suite-common/toast-notifications": "workspace:*"
+    "@suite-native/activity-center": "workspace:*"
+    "@suite-native/atoms": "workspace:*"
+    "@suite-native/intl": "workspace:*"
+    "@suite-native/navigation": "workspace:*"
+    react: "npm:19.2.3"
     react-redux: "npm:9.3.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

- Adds `ActivityCenterScreen` with three placeholder tabs (Notifications, System, Release notes)
- Registers `ActivityCenterStackNavigator` in the root stack (`slide_from_bottom` presentation)
- Extracts `selectHasUnseenNotifications` from a local inline selector in the desktop `Navigation.tsx` to a shared selector in `@suite-common/toast-notifications` 
- SubTabs improvements:
  - Adds `accessory?: ReactNode` to `SubTabItem` in `@suite-native/atoms` for inline per-tab badges 
  - Removes hardcoded `paddingHorizontal` from `SubTabs.tabsStyle` and applies it at each callsite instead
- DynamicScreenHeader improvements:
  - Adds `marginBottom` prop to `DynamicScrollableScreenContentHeader` (default `sp32`) so the Activity Center screen can use `sp16`

## Notes for QA

- Enable the feature flag: `EXPO_PUBLIC_FF_IS_ACTIVITY_CENTER_ENABLED=true`
- Bell button appears in the home header → tap opens the Activity Center screen sliding up from bottom
- Screen shows "Activity" title (dynamic header collapses on scroll) and three SubTabs

## Related Issue

Resolve #30753

## Screenshots:

https://github.com/user-attachments/assets/7e96f53d-4c4d-4d04-bc5d-992c3d2d7d46



<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is overwhelmingly suite-native (mobile) files, which are not exercised by the web/desktop Playwright E2E suite at all. The only web-side files are a shared sidebar navigation component and a notification selector, both broad utilities used transitively by many tests. Risk to the web E2E suite is therefore low and indirect; two medium-priority sanity tests are sufficient, and all native/tsconfig files should be considered uncovered.

<details><summary><b>Changed files (26)</b></summary>

- `networks/network-module/network-module-suite-common-types/tsconfig.lib.json`
- `packages/suite/src/components/suite/layouts/SuiteLayout/Sidebar/Navigation.tsx`
- `suite-common/toast-notifications/src/notificationsSelectors.ts`
- `suite-native/activity-center/package.json`
- `suite-native/activity-center/src/components/ActivityCenterButton.tsx`
- `suite-native/activity-center/tsconfig.json`
- `suite-native/app/package.json`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/app/tsconfig.json`
- `suite-native/atoms/src/SubTabs.tsx`
- `suite-native/device-manager/package.json`
- `suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx`
- `suite-native/device-manager/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-activity-center/package.json`
- `suite-native/module-activity-center/src/index.ts`
- `suite-native/module-activity-center/src/navigation/ActivityCenterStackNavigator.tsx`
- `suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx`
- `suite-native/module-activity-center/tsconfig.json`
- `suite-native/module-send/tsconfig.json`
- `suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx`
- `suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeader.tsx`
- `suite-native/navigation/src/components/DynamicHeader/DynamicScrollableScreenContentHeader.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`
- `suite-native/trading-history/src/components/TradingHistoryTabs.tsx`

</details>

**Recommended tests (2)**

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — Navigation.tsx is part of SuiteLayout and renders the sidebar navigation. This test verifies that all major app routes load and that the Suite layout content attaches, so a crash or major regression in the sidebar navigation component would likely be caught here.
- `suite/e2e/tests/settings/passphrase.test.ts` — This test explicitly asserts the '@toast/settings-applied' toast appears and disappears after enabling passphrase protection. A change to notification selectors could affect which toasts are selected and rendered, making this a targeted sanity check.

</details>

⚠️ **Changes with no test coverage (24)**
- `networks/network-module/network-module-suite-common-types/tsconfig.lib.json`
- `suite-native/activity-center/package.json`
- `suite-native/activity-center/src/components/ActivityCenterButton.tsx`
- `suite-native/activity-center/tsconfig.json`
- `suite-native/app/package.json`
- `suite-native/app/src/navigation/RootStackNavigator.tsx`
- `suite-native/app/tsconfig.json`
- `suite-native/atoms/src/SubTabs.tsx`
- `suite-native/device-manager/package.json`
- `suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx`
- `suite-native/device-manager/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-activity-center/package.json`
- `suite-native/module-activity-center/src/index.ts`
- `suite-native/module-activity-center/src/navigation/ActivityCenterStackNavigator.tsx`
- `suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx`
- `suite-native/module-activity-center/tsconfig.json`
- `suite-native/module-send/tsconfig.json`
- `suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx`
- `suite-native/navigation/src/components/DynamicHeader/DynamicScreenHeader.tsx`
- `suite-native/navigation/src/components/DynamicHeader/DynamicScrollableScreenContentHeader.tsx`
- `suite-native/navigation/src/navigators.ts`
- `suite-native/navigation/src/routes.ts`
- `suite-native/trading-history/src/components/TradingHistoryTabs.tsx`

_Updated: 2026-08-06T08:28:21.093Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native/activity-center-module/web/](https://dev.suite.sldev.cz/suite-web/feat/native/activity-center-module/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native/activity-center-module&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native/activity-center-module&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/activity-center-module&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T08:28:50.128Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T08:28:44.196Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->