### PR TITLE
fix(scripts): look up PR by current branch in slack PR message script

### DIFF
--- a/scripts/generate-slack-pr-message.sh
+++ b/scripts/generate-slack-pr-message.sh
@@ -141,8 +141,10 @@ check_branch
 # Determine platform icon
 ICON=$(get_platform_icon "$1")
 
-# Read PR info based on current branch
-if ! PR_JSON=$(gh pr view --json title,changedFiles,additions,deletions,url 2>&1); then
+# Pass the branch name explicitly. Without it, gh searches for a PR opened from
+# the branch's upstream instead, which is develop for branches created from
+# origin/develop, so no PR is found.
+if ! PR_JSON=$(gh pr view "$CURRENT_BRANCH" --json title,changedFiles,additions,deletions,url 2>&1); then
     echo -e "\033[0;31mError: Failed to fetch PR information.
 $PR_JSON
 Make sure you have a PR open for the current branch.\033[0m


### PR DESCRIPTION
<!--- Dev tooling only, no app code touched. -->

## Description

`scripts/generate-slack-pr-message.sh` fails with `no pull requests found for branch develop` on a perfectly normal feature branch that has an open PR.

### Why

`gh pr view` with no argument does **not** look up the PR by the checked-out branch name. It looks it up by the branch's **upstream** (`branch.<name>.merge`). So the result depends on how the branch was created:

| branch created from | upstream recorded | `gh pr view` searches for a PR opened from |
| --- | --- | --- |
| local `develop` | *(none)* — gh falls back to the branch name | `my-branch` ✅ |
| `origin/develop` | `origin/develop` | `develop` ❌ |

Both rows are git's documented default: `branch.autoSetupMerge=true` records an upstream only when the start point is a remote-tracking ref. No misconfiguration is involved.

### Why this shows up when working in a git worktree

In a single checkout you naturally branch off the **local** `develop`:

```bash
git switch develop && git pull && git switch -c my-branch   # upstream: none -> script works
```

That is not available in a second worktree: `develop` is checked out in the main one, and git refuses to check out the same branch twice.

```
fatal: 'develop' is already used by worktree at '/home/you/git/trezor-suite'
```

So in a worktree you branch off the **remote-tracking ref** instead — either directly, or as the `git worktree add` start point:

```bash
git switch -c my-branch origin/develop               # upstream: origin/develop -> script breaks
git worktree add ../wt -b my-branch origin/develop   # same result
```

Every branch created that way records `develop` as its upstream, so the script asked GitHub for a PR whose source branch is `develop` and found none. It looks like the script is broken in worktrees, but the real trigger is only the start point that a worktree pushes you towards.

### Fix

Pass `"$CURRENT_BRANCH"` (already set by `check_branch`) to `gh pr view`, which makes the lookup independent of tracking configuration. No new git calls, and no change in behaviour for branches that are tracked correctly.

## Notes for QA

Dev tooling only — not shipped in any app, no runtime impact, nothing to test in Suite.

To reproduce, on any branch that has an open PR:

```bash
git branch --set-upstream-to=origin/develop      # simulate what a worktree branch gets
./scripts/generate-slack-pr-message.sh           # before: "no pull requests found for branch develop"
                                                 # after:  prints the Slack message for your PR
git branch --set-upstream-to=origin/$(git branch --show-current)   # restore
```

Verified: correct PR found with a deliberately broken upstream; correctly-tracked branches unaffected; `shellcheck` clean.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/slack-pr-message-branch-lookup/web/](https://dev.suite.sldev.cz/suite-web/fix/slack-pr-message-branch-lookup/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/slack-pr-message-branch-lookup&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/slack-pr-message-branch-lookup&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T11:41:29.039Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T11:41:11.691Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->