### PR TITLE
refactor(suite): use selectSupportedDeviceLanguages in ChangeLanguage

### DIFF
--- a/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
+++ b/packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx
@@ -1,13 +1,14 @@
+import { useMemo } from 'react';
+
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { Anchor, SettingsAnchor } from '@suite/router';
-import { LANGUAGES, type Locale } from '@suite-common/suite-types';
+import { selectSupportedDeviceLanguages } from '@suite-common/device';
+import { type Locale } from '@suite-common/suite-types';
 import { ActionColumn, ActionSelect, SectionItem, TextColumn } from '@trezor/product-components';
 
 import { changeLanguage } from 'src/actions/settings/deviceSettingsActions';
-import { useDispatch } from 'src/hooks/suite';
-
-const BASE_TRANSLATIONS = [{ value: 'en-US', label: LANGUAGES['en-US'].name as string }];
+import { useDispatch, useSelector } from 'src/hooks/suite';
 
 interface ChangeLanguageProps {
     isDeviceLocked: boolean;
@@ -17,32 +18,24 @@ export const ChangeLanguage = ({ isDeviceLocked }: ChangeLanguageProps) => {
     const { device } = useDevice();
     const dispatch = useDispatch();
 
+    const supportedDeviceLanguages = useSelector(selectSupportedDeviceLanguages);
+
     const onChange = ({ value }: { value: Locale }) => {
-        dispatch(changeLanguage({ device, language: `${value}` }));
+        dispatch(changeLanguage({ device, language: value }));
     };
 
-    const isSupportedDevice = device?.features?.capabilities?.includes('Capability_Translations');
+    const languageOptions = useMemo(
+        () =>
+            supportedDeviceLanguages.map(({ value, label, isBeta }) => ({
+                value,
+                label: label + (isBeta ? ' (beta)' : ''),
+            })),
+        [supportedDeviceLanguages],
+    );
 
-    const deviceSupportedTranslations = Object.keys(device?.availableTranslations ?? {})
-        .map(it => {
-            if (!LANGUAGES[it as Locale]) {
-                console.error('LANGUAGES[it as Locale] not found', it);
-
-                return null;
-            }
-
-            return {
-                value: it,
-                label: `${LANGUAGES[it as Locale].name} (beta)`,
-            };
-        })
-        .filter((lang): lang is { value: string; label: string } => Boolean(lang));
-
-    if (isSupportedDevice !== true || deviceSupportedTranslations.length === 0) {
+    if (supportedDeviceLanguages.length <= 1) {
         return null;
     }
-
-    const languageOptions = BASE_TRANSLATIONS.concat(deviceSupportedTranslations);
 
     const selectedValue = languageOptions.find(
         option => option.value === device?.features?.language,


### PR DESCRIPTION
## Description

The `selectSupportedDeviceLanguages` selector used in the `ChangeLanguage` to avoid code duplication and have a single source of truth.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/suite/firmware-languages/web/](https://dev.suite.sldev.cz/suite-web/refactor/suite/firmware-languages/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/suite/firmware-languages&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/suite/firmware-languages&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:21:35.293Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:21:23.899Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a device-language component inside SettingsDevice, and the static coverage maps it to 97 tests, indicating it is a broadly shared page dependency. No E2E test directly exercises device language change, so the best strategy is to run a small, representative set of device-settings tests that load this page and would catch rendering or interaction regressions. I recommend the device-settings tests for T2T1, T3B1, T1B1, safety checks, and passphrase toggle.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/views/settings/SettingsDevice/ChangeLanguage.tsx`

</details>

**Recommended tests (5)**

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/t2t1-device-settings.test.ts` — This test extensively exercises the Settings > Device page (name, rotation, firmware, wipe, homescreen), which is the page that renders ChangeLanguage.tsx. A regression in the component could break the device settings page rendering or interactions.
- `suite/e2e/tests/settings/t3b1-device-settings.test.ts` — Tests device settings interactions on T3B1 (name, background, wipe, firmware modal), loading the same SettingsDevice view where ChangeLanguage.tsx lives, making it a good smoke test for page-level regressions.
- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — Navigates to device settings to change PIN and homescreen on T1B1, so it renders the device settings page containing ChangeLanguage.tsx and can catch rendering or layout regressions.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Opens the Safety Checks modal from device settings and verifies radio button selection and persistence; it loads the device settings page and would fail if ChangeLanguage.tsx caused the page to render incorrectly.
- `suite/e2e/tests/settings/passphrase.test.ts` — Navigates to Settings > Device to toggle passphrase protection, which is the same device settings route where ChangeLanguage.tsx is mounted, so it serves as a focused page-load regression check.

</details>

_Updated: 2026-08-05T13:46:02.808Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->