### PR TITLE
fix(suite): remove fiat entry from yield withdraw flow

### DIFF
--- a/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
+++ b/packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx
@@ -130,6 +130,15 @@ export const YieldAmountCard = ({
         </TextButton>
     ) : undefined;
 
+    const unitSwitch = unitToggle ? (
+        <TextButton type="button" size="small" onClick={unitToggle.onClick} isUnderlined>
+            <Translation
+                id="TR_EARN_YIELD_ENTER_AMOUNT_IN_TOKEN"
+                values={{ tokenSymbol: unitToggle.otherTokenSymbol }}
+            />
+        </TextButton>
+    ) : undefined;
+
     const activeError = isFiatMode ? errors.fiatInput : errors.amountInput;
 
     return (
@@ -139,24 +148,8 @@ export const YieldAmountCard = ({
                     <Text typographyStyle="body-md">
                         <Translation id={heading?.amountLabelTranslationId ?? 'AMOUNT'} />
                     </Text>
-                    {fiatSwitch}
+                    {unitSwitch ?? fiatSwitch}
                 </Row>
-                {/* Only the withdraw flow passes a unit toggle; it gets its own row below the label. */}
-                {unitToggle && (
-                    <Row justifyContent="flex-end" width="100%">
-                        <TextButton
-                            type="button"
-                            size="small"
-                            onClick={unitToggle.onClick}
-                            isUnderlined
-                        >
-                            <Translation
-                                id="TR_EARN_YIELD_ENTER_AMOUNT_IN_TOKEN"
-                                values={{ tokenSymbol: unitToggle.otherTokenSymbol }}
-                            />
-                        </TextButton>
-                    </Row>
-                )}
                 {isFiatMode ? (
                     <NumberInput
                         name="fiatInput"

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -261,7 +261,6 @@ export const YieldWithdrawForm = () => {
                                               }
                                             : undefined
                                     }
-                                    fiatToggle={fiatToggle}
                                     onMaxClick={handleMaxClick}
                                     onSubmit={handleOnWithdraw}
                                     onPendingTxClick={openPendingTransaction}

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -222,7 +222,7 @@ describe('yieldFlowUtils', () => {
             ).toEqual({ symbol: 'eth' });
         });
 
-        it('prices deposit/withdraw by the asset token contract address (lower-cased)', () => {
+        it('prices deposit by the asset token contract address (lower-cased)', () => {
             expect(
                 getYieldFiatRateToken({
                     step: 'action',
@@ -231,7 +231,9 @@ describe('yieldFlowUtils', () => {
                     token: ethToken,
                 }),
             ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
+        });
 
+        it('returns null when fiat entry is impossible (withdraw flow or no token address)', () => {
             expect(
                 getYieldFiatRateToken({
                     step: 'action',
@@ -239,10 +241,8 @@ describe('yieldFlowUtils', () => {
                     accountSymbol: 'eth',
                     token: ethToken,
                 }),
-            ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
-        });
+            ).toBeNull();
 
-        it('returns null when fiat entry is impossible (redeeming shares or no token address)', () => {
             expect(
                 getYieldFiatRateToken({
                     step: 'action',

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.ts
@@ -7,6 +7,7 @@ import {
     type YieldPositionFlowType,
     type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
+    isYieldWithdrawFlow,
 } from '@suite-common/wallet-core';
 import { type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
 import {
@@ -147,8 +148,8 @@ type YieldFiatRateTokenParams = {
 /**
  * The token whose fiat rate prices the amount currently being entered:
  * - wrap/unwrap operate on the native coin (priced by the account's native symbol),
- * - redeem enters share units, which have no direct fiat price → no fiat entry,
- * - deposit/withdraw/approve enter the vault asset token (priced by its contract address).
+ * - withdraw/redeem have no fiat entry,
+ * - deposit/approve enter the vault asset token (priced by its contract address).
  *
  * Returns `null` when fiat entry is not possible for the current step.
  */
@@ -162,7 +163,7 @@ export const getYieldFiatRateToken = ({
         return { symbol: accountSymbol };
     }
 
-    if (flowType === 'redeem') {
+    if (isYieldWithdrawFlow(flowType)) {
         return null;
     }
 


### PR DESCRIPTION
## Description

The yield withdraw flow's amount card showed two stacked "Enter amount in X" switches at once: the asset/share unit toggle (e.g. trSHETHp) and the crypto/fiat toggle (e.g. USD). This removes fiat entry from the withdraw flow, so only the unit toggle remains.

Implemented in `getYieldFiatRateToken`, which now returns `null` for both withdraw-flow types (`withdraw` and `redeem`, which already had no fiat entry). The unwrap step of the withdraw flow and the whole deposit flow keep fiat entry, and the approximate fiat value under the amount input stays.

## Notes for QA

- Earn → yield vault → Withdraw: the amount card offers only "Enter amount in <share/asset token>", no "Enter amount in USD"; the ≈ fiat value under the input is still shown.
- WETH vault withdraw → unwrap step: "Enter amount in USD" is still available there.
- Deposit flow (incl. wrap and approve steps): fiat entry unchanged.

## Related Issue

Resolve #30874

## Screenshots:

<img width="653" height="534" alt="Screenshot 2026-08-05 at 15 41 04" src="https://github.com/user-attachments/assets/636c3f98-89fd-45c8-90cc-0835386a3466" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in earn/yield components used for staking amount display, withdraw/claim forms, and yield flow calculations. Despite broad static coverage due to transitive imports, the real user-facing risk is in staking unstake/claim flows. I recommend running a focused set of staking tests covering ADA, ETH, and SOL unstake/claim scenarios first, supplemented by stake dashboard tests to catch amount display regressions.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/yield/common/YieldAmountCard.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`
- `packages/suite/src/components/earn/yield/yieldFlowUtils.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises the yield claim flow where YieldAmountCard displays reward amounts and YieldWithdrawForm/claim logic is invoked. A regression in amount formatting or claim submission would be immediately visible here.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Walks through the ADA unstake/withdraw flow, rendering staking dashboard amounts and the withdraw form. Directly covers YieldAmountCard and YieldWithdrawForm behavior for Cardano.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Covers the ETH unstake and claim flow including the withdraw form, fee display, and amount calculations. Changes to yieldFlowUtils or YieldWithdrawForm would likely manifest here.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Validates Solana unstake and claim flows, including the claim card/amount display and withdraw confirmation. Directly depends on the changed yield components.

</details>

<details><summary>🟡 <b>Medium priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Renders the post-staking dashboard with reward amounts and action buttons. Uses YieldAmountCard for amount display and shares staking state infrastructure with the changed code.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Displays staking dashboard amounts and progress indicators after ETH staking. YieldAmountCard changes could affect how pending/staked amounts are shown.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Exercises staking amount display after staking additional ETH. Shares YieldAmountCard and yield calculation utilities with the changed files.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Covers Solana staking dashboard and progress indicators, which rely on YieldAmountCard and yield flow utilities for amount formatting.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — Validates Solana staking dashboard amounts and reward list rendering, which depend on YieldAmountCard and related utility logic.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Displays staking amounts and pending/staked states on the Solana dashboard, sharing YieldAmountCard and yield utilities with the changed code.
- `suite/e2e/tests/staking/staking-form.test.ts` — Tests ETH staking form validation and amount calculations. While focused on staking input, it shares yield flow logic and could be affected by utility changes.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts`

_Updated: 2026-08-05T13:39:47.925Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-fiat-entry/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-fiat-entry/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-withdraw-fiat-entry&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-withdraw-fiat-entry&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:41:59.046Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T13:42:06.130Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->