### PR TITLE
fix(suite-desktop): double-check nonces origination

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx
@@ -16,7 +16,7 @@ import {
     findChainedTransactions,
     getPendingEvmNonceStatus,
     isPending,
-    isSentTransaction,
+    isSignedByAccount,
     isTransactionBumpable,
     isTransactionCancellable,
 } from '@suite-common/wallet-utils';
@@ -151,7 +151,7 @@ export const TxDetailModal = ({
     // Computed once here and threaded down through DetailModal/BumpFeeModal/CancelTransactionModal
     // to TxDetailModalBase, instead of each of those independently re-fetching/recomputing it.
     const evmNonce = network.networkType === 'ethereum' ? tx.ethereumSpecific?.nonce : undefined;
-    const pendingEvmNonce = isPending(tx) && isSentTransaction(tx) ? evmNonce : undefined;
+    const pendingEvmNonce = isPending(tx) && isSignedByAccount(tx) ? evmNonce : undefined;
     const nonceStatus =
         pendingEvmNonce !== undefined && fetchedNonceInfo
             ? getPendingEvmNonceStatus(pendingEvmNonce, fetchedNonceInfo)

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx
@@ -17,7 +17,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import {
     formatNetworkAmount,
     getPendingEvmNonceStatus,
-    isSentTransaction,
+    isSignedByAccount,
     isTransactionBumpable,
     isTransactionCancellable,
     isTxFeePaid,
@@ -105,11 +105,11 @@ export const TransactionItem = memo(
         const evmNonce =
             network.networkType === 'ethereum' ? transaction.ethereumSpecific?.nonce : undefined;
 
-        // Gated on `isSentTransaction` to match the filter `getEvmNonceInfo` uses when building
-        // `fetchedNonceInfo` — a tx type it doesn't count (e.g. a pending contract deployment)
-        // isn't reflected in those bounds, so comparing its nonce against them would produce a
-        // false gap/superseded reading.
-        const pendingEvmNonce = isPending && isSentTransaction(transaction) ? evmNonce : undefined;
+        // Gated on `isSignedByAccount` to match the filter `getEvmNonceInfo` uses when building
+        // `fetchedNonceInfo` — a tx it doesn't count (e.g. a stranger's transfer out of the account,
+        // which carries that stranger's nonce) isn't reflected in those bounds, so comparing its
+        // nonce against them would produce a false gap/superseded reading.
+        const pendingEvmNonce = isPending && isSignedByAccount(transaction) ? evmNonce : undefined;
 
         // A pending EVM tx can be stuck two ways: its nonce is above the next free nonce (a lower
         // nonce is missing — a gap), or below the confirmed nonce (that slot was already mined by

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx
@@ -11,7 +11,7 @@ import {
     isEip1559,
     isInteger,
     isPending,
-    isSentTransaction,
+    isSignedByAccount,
 } from '@suite-common/wallet-utils';
 import { Card, Column, H4, IconButton, Input, Note, Row, TextButton } from '@trezor/components';
 import { InfoIcon, WarningIcon, XIcon } from '@trezor/icons';
@@ -87,7 +87,7 @@ export const EthereumNonce = ({ displayNonce, confirmedNonce, onCancel }: Ethere
 
     const error = errors.ethereumNonce;
 
-    const pendingSentTxs = transactions.filter(isPending).filter(isSentTransaction);
+    const pendingSentTxs = transactions.filter(isPending).filter(isSignedByAccount);
 
     const pendingNonces = pendingSentTxs
         .map(tx => tx.ethereumSpecific?.nonce)

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
@@ -62,10 +62,14 @@ const Harness = ({ displayNonce, confirmedNonce }: Props) => {
     );
 };
 
-// Pending tx occupying nonce 6 (gas in Wei), the replacement target for the fee-bump button.
+// Pending tx occupying nonce 6 (gas in Wei), the replacement target for the fee-bump button. The
+// account's own txs are recognized by authorship (an input belonging to the account), not by `type`
+// — see isSignedByAccount — so `details.vin` has to say the account signed it.
 const pendingAtNonce6 = {
     type: 'sent',
     blockHeight: 0,
+    descriptor: ethAccount.descriptor,
+    details: { vin: [{ n: 0, isAddress: true, isAccountOwned: true }] },
     ethereumSpecific: { nonce: 6, maxFeePerGas: '50000000000', maxPriorityFeePerGas: '5000000000' },
 } as any;
 

--- a/suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts
+++ b/suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts
@@ -15,9 +15,13 @@ type EvmGas = {
     maxPriorityFeePerGas?: string;
 };
 
+export const FOREIGN_SIGNER = '0x0F6666bC699aec39b846E898473e9CAec5a6b821';
+
 /**
  * Minimal EVM `WalletAccountTransaction` for nonce/fee unit tests. Only the fields the code under
- * test reads (`type`, `blockHeight` -> isPending, `ethereumSpecific`) are meaningful.
+ * test reads (`type`, `blockHeight` -> isPending, `ethereumSpecific`, and `details.vin` ->
+ * isSignedByAccount) are meaningful. `signer` defaults to the account itself; pass a foreign address
+ * for a transaction that merely names the account, which must not count toward its nonces.
  */
 export const evmTx = (
     nonce: number,
@@ -25,12 +29,30 @@ export const evmTx = (
         confirmed = true,
         type = 'sent',
         gas,
-    }: { confirmed?: boolean; type?: WalletAccountTransaction['type']; gas?: EvmGas } = {},
+        signer = ethAccount.descriptor,
+    }: {
+        confirmed?: boolean;
+        type?: WalletAccountTransaction['type'];
+        gas?: EvmGas;
+        signer?: string;
+    } = {},
 ): WalletAccountTransaction =>
     ({
         type,
         txid: `0x${nonce}`,
         blockHeight: confirmed ? 100 : 0,
+        descriptor: ethAccount.descriptor,
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    isAddress: true,
+                    addresses: [signer],
+                    isAccountOwned: signer === ethAccount.descriptor || undefined,
+                },
+            ],
+            vout: [],
+        },
         ethereumSpecific: {
             status: confirmed ? 1 : -1,
             nonce,

--- a/suite-common/wallet-core/src/send/resolveEthereumNonce.test.ts
+++ b/suite-common/wallet-core/src/send/resolveEthereumNonce.test.ts
@@ -1,7 +1,7 @@
 import { type RbfTransactionParams } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
-import { type EthAccount, ethAccount, evmTx } from './__fixtures__/evmFixtures';
+import { type EthAccount, FOREIGN_SIGNER, ethAccount, evmTx } from './__fixtures__/evmFixtures';
 import { resolveEthereumNonce } from './sendFormEthereumThunks';
 
 const rbf = (ethereumNonce: number) =>
@@ -82,6 +82,22 @@ describe('resolveEthereumNonce', () => {
         const result = await resolveEthereumNonce({
             selectedAccount: accountWithNonce(3),
             accountTransactions: [evmTx(99, { confirmed: false, type: 'recv' })],
+            fetchConfirmedNonce: false,
+        });
+
+        expect(result).toEqual({ nonce: '3', confirmedNonce: '3' });
+    });
+
+    it('ignores a transaction the account did not sign, however it is labelled', async () => {
+        // A stranger's token transfer *out of* the account is labelled 'sent' and indexed against
+        // the account, but carries the stranger's nonce. Counting it offered a nonce one slot too
+        // high, which cannot be mined until the skipped slot is filled.
+        const result = await resolveEthereumNonce({
+            selectedAccount: accountWithNonce(3),
+            accountTransactions: [
+                evmTx(3, { confirmed: true, signer: FOREIGN_SIGNER }),
+                evmTx(4, { confirmed: false, signer: FOREIGN_SIGNER }),
+            ],
             fetchConfirmedNonce: false,
         });
 

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts
@@ -79,12 +79,18 @@ describe('selectTransactionsWithMissingRates', () => {
 describe('selectEvmPrivatePendingHint', () => {
     const HINT_ACCOUNT_KEY = 'account-hint' as AccountKey;
 
+    const HINT_DESCRIPTOR = '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b';
+
+    // The hint declares the account's *own* pending txs, which is decided by authorship (an input
+    // belonging to the account), not by the display type — see isSignedByAccount.
     const pendingSentTx = (nonce: number): WalletAccountTransaction =>
         ({
             txid: `pending-${nonce}`,
             type: 'sent',
             blockHeight: -1,
+            descriptor: HINT_DESCRIPTOR,
             ethereumSpecific: { nonce },
+            details: { vin: [{ addresses: [HINT_DESCRIPTOR], isAccountOwned: true }] },
         }) as unknown as WalletAccountTransaction;
 
     const getHintState = (

--- a/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts
@@ -801,6 +801,70 @@ export const getRbfParams = [
         result: undefined,
     },
     {
+        // A stranger's transfer out of the account is labelled 'sent' as well, but replacing it
+        // would re-sign at the stranger's nonce, so it must not be offered as replaceable.
+        description: 'ethereum tx signed by somebody else',
+        account: {
+            networkType: 'ethereum',
+            descriptor: '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b',
+        },
+        tx: {
+            type: 'sent',
+            txid: '0xabcd',
+            rbf: true,
+            blockHeight: -1,
+            ethereumSpecific: { nonce: 45, gasLimit: 21000, gasPrice: '1000000000' },
+            details: {
+                vin: [{ addresses: ['0x0F6666bC699aec39b846E898473e9CAec5a6b821'] }],
+                vout: [{ isAddress: true, addresses: ['0xdead'] }],
+            },
+        },
+        result: undefined,
+    },
+    {
+        description: 'ethereum tx signed by the account itself',
+        account: {
+            networkType: 'ethereum',
+            symbol: 'eth',
+            descriptor: '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b',
+        },
+        tx: {
+            type: 'sent',
+            txid: '0xbeef',
+            rbf: true,
+            blockHeight: -1,
+            ethereumSpecific: { nonce: 45, gasLimit: 21000, gasPrice: '1000000000' },
+            details: {
+                // Lower-cased, as blockbook may report it — authorship must still match.
+                vin: [{ addresses: ['0x37567e60ab231b7d7f26b5b34fdd719098e4ee1b'] }],
+                vout: [
+                    {
+                        isAddress: true,
+                        addresses: ['0xfAEEEB8Fd7D41a6a8223DD36D347DBe56c13fe61'],
+                        value: '1000000000000000000',
+                    },
+                ],
+            },
+        },
+        result: {
+            type: 'ethereum',
+            txid: '0xbeef',
+            outputs: [
+                {
+                    type: 'payment',
+                    address: '0xfAEEEB8Fd7D41a6a8223DD36D347DBe56c13fe61',
+                    amount: '1000000000000000000',
+                    formattedAmount: '1',
+                },
+            ],
+            ethereumNonce: 45,
+            transactionData: '',
+            gasPrice: '1',
+            maxFeePerGas: '',
+            maxPriorityFeePerGas: '',
+        },
+    },
+    {
         description: 'invalid tx (rbf false)',
         account: { networkType: 'bitcoin' },
         tx: { type: 'sent', rbf: false },

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -1,5 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
-import { type WalletAccountTransaction } from '@suite-common/wallet-types';
+import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import * as fixtures from './__fixtures__/transactionUtils';
 import {
@@ -21,12 +21,57 @@ import {
     groupTokensTransactionsByContractAddress,
     groupTransactionsByDate,
     isPending,
+    isSignedByAccount,
     isTransactionCancellable,
     parseTransactionDateKey,
     parseTransactionMonthKey,
 } from './transactionUtils';
 
 const { getWalletTransaction } = testMocks;
+
+const ACCOUNT_DESCRIPTOR = '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b';
+// A stranger who signed (and paid for) a transaction that blockbook indexes against the account
+// because one of its token transfers names the account as the sender.
+const FOREIGN_SIGNER = '0x0F6666bC699aec39b846E898473e9CAec5a6b821';
+
+type EvmTransactionParams = {
+    nonce: number;
+    blockHeight?: number;
+    type?: WalletAccountTransaction['type'];
+    txid?: string;
+};
+
+// Nonce derivation keys off authorship, so an EVM fixture has to say who signed it. `isAccountOwned`
+// is set exactly as enhanceVinVout would set it at transform time.
+const getEvmTransaction = (
+    signer: string,
+    { nonce, blockHeight = 100, type = 'sent', txid }: EvmTransactionParams,
+) =>
+    getWalletTransaction({
+        descriptor: asAccountDescriptor(ACCOUNT_DESCRIPTOR),
+        symbol: 'eth',
+        type,
+        blockHeight,
+        ...(txid ? { txid } : {}),
+        ethereumSpecific: { nonce } as any,
+        details: {
+            ...getWalletTransaction().details,
+            vin: [
+                {
+                    n: 0,
+                    isAddress: true,
+                    addresses: [signer],
+                    isAccountOwned: signer === ACCOUNT_DESCRIPTOR || undefined,
+                },
+            ],
+        },
+    });
+
+const getOwnEvmTransaction = (params: EvmTransactionParams) =>
+    getEvmTransaction(ACCOUNT_DESCRIPTOR, params);
+
+const getForeignEvmTransaction = (params: EvmTransactionParams) =>
+    getEvmTransaction(FOREIGN_SIGNER, params);
 
 describe('transaction utils', () => {
     describe('parseTransactionDateKey', () => {
@@ -173,24 +218,18 @@ describe('transaction utils', () => {
     describe('getTransactionWithLowestNonce', () => {
         it('ethereum network', () => {
             const transactionGroups = {
-                '2019-10-3': [getWalletTransaction({ ethereumSpecific: { nonce: 1 } as any })],
-                '2019-10-4': [
-                    getWalletTransaction({
-                        ethereumSpecific: { nonce: 0 },
-                    } as any),
-                ],
+                '2019-10-3': [getOwnEvmTransaction({ nonce: 1 })],
+                '2019-10-4': [getOwnEvmTransaction({ nonce: 0 })],
                 '2019-8-14': [
-                    getWalletTransaction({ ethereumSpecific: { nonce: 2 } as any }),
-                    getWalletTransaction({ ethereumSpecific: { nonce: 3 } as any }),
+                    getOwnEvmTransaction({ nonce: 2 }),
+                    getOwnEvmTransaction({ nonce: 3 }),
                 ],
             };
 
             const transactionWithLowestNonce: WalletAccountTransaction | null =
                 getTransactionWithLowestNonce(transactionGroups);
 
-            expect(transactionWithLowestNonce).toStrictEqual(
-                getWalletTransaction({ ethereumSpecific: { nonce: 0 } as any }),
-            );
+            expect(transactionWithLowestNonce).toStrictEqual(getOwnEvmTransaction({ nonce: 0 }));
         });
 
         it('non ethereum network', () => {
@@ -206,29 +245,18 @@ describe('transaction utils', () => {
             expect(transactionWithLowestNonce).toStrictEqual(null);
         });
 
-        it('returns sent tx with the lowest nonce across multiple dates, ignoring recv txs', () => {
-            const recvTx = getWalletTransaction({
-                type: 'recv',
-                ethereumSpecific: { nonce: 0 } as any,
-            });
+        it('returns the own tx with the lowest nonce across multiple dates, ignoring txs the account did not sign', () => {
+            const recvTx = getForeignEvmTransaction({ nonce: 0, type: 'recv' });
+            // A stranger's transfer *out of* the account: labelled 'sent', but its nonce is the
+            // stranger's, so it must not steal the bump-fee slot from our own lowest-nonce tx.
+            const foreignSentTx = getForeignEvmTransaction({ nonce: 0 });
 
-            const sentTxLow = getWalletTransaction({
-                type: 'sent',
-                ethereumSpecific: { nonce: 1 } as any,
-            });
-
-            const sentTxHigh = getWalletTransaction({
-                type: 'sent',
-                ethereumSpecific: { nonce: 5 } as any,
-            });
-
-            const sentTxMid = getWalletTransaction({
-                type: 'sent',
-                ethereumSpecific: { nonce: 3 } as any,
-            });
+            const sentTxLow = getOwnEvmTransaction({ nonce: 1 });
+            const sentTxHigh = getOwnEvmTransaction({ nonce: 5 });
+            const sentTxMid = getOwnEvmTransaction({ nonce: 3 });
 
             const transactionGroups = {
-                '2019-10-2': [recvTx], // nonce = 0 (should be ignored)
+                '2019-10-2': [recvTx, foreignSentTx], // nonce = 0 (should be ignored)
                 '2019-10-3': [sentTxHigh], // nonce = 5
                 '2019-10-4': [sentTxMid, sentTxLow], // nonce = 3 and 1 (should return 1)
             };
@@ -238,18 +266,12 @@ describe('transaction utils', () => {
             expect(result).toBe(sentTxLow);
         });
 
-        it('returns null when all transactions are of type recv', () => {
-            const recvTx1 = getWalletTransaction({
-                type: 'recv',
-                ethereumSpecific: { nonce: 1 } as any,
-            });
-            const recvTx2 = getWalletTransaction({
-                type: 'recv',
-                ethereumSpecific: { nonce: 2 } as any,
-            });
-
+        it('returns null when the account signed none of the transactions', () => {
             const transactionGroups = {
-                '2019-10-04': [recvTx1, recvTx2],
+                '2019-10-04': [
+                    getForeignEvmTransaction({ nonce: 1, type: 'recv' }),
+                    getForeignEvmTransaction({ nonce: 2 }),
+                ],
             };
 
             const result = getTransactionWithLowestNonce(transactionGroups);
@@ -449,13 +471,56 @@ describe('transaction utils', () => {
         });
     });
 
-    describe('getEvmNonceInfo', () => {
-        const pendingSentTx = (nonce: number) =>
+    describe('isSignedByAccount', () => {
+        const withVin = (vin: WalletAccountTransaction['details']['vin']) =>
             getWalletTransaction({
-                blockHeight: -1,
-                type: 'sent',
-                ethereumSpecific: { nonce } as any,
+                descriptor: asAccountDescriptor(ACCOUNT_DESCRIPTOR),
+                details: { ...getWalletTransaction().details, vin },
             });
+
+        it('an input flagged as owned by the account means the account signed it', () => {
+            expect(
+                isSignedByAccount(withVin([{ n: 0, isAddress: true, isAccountOwned: true }])),
+            ).toBe(true);
+        });
+
+        it('matches the descriptor regardless of EIP-55 casing', () => {
+            expect(
+                isSignedByAccount(
+                    withVin([
+                        {
+                            n: 0,
+                            isAddress: true,
+                            addresses: [ACCOUNT_DESCRIPTOR.toLowerCase()],
+                        },
+                    ]),
+                ),
+            ).toBe(true);
+        });
+
+        it('matches when only one of several inputs belongs to the account', () => {
+            expect(
+                isSignedByAccount(
+                    withVin([
+                        { n: 0, isAddress: true, addresses: [FOREIGN_SIGNER] },
+                        { n: 1, isAddress: true, addresses: [ACCOUNT_DESCRIPTOR] },
+                    ]),
+                ),
+            ).toBe(true);
+        });
+
+        it('a transaction signed by somebody else does not belong to the account', () => {
+            const foreignVin = [{ n: 0, isAddress: true, addresses: [FOREIGN_SIGNER] }];
+            expect(isSignedByAccount(withVin(foreignVin))).toBe(false);
+        });
+
+        it('no inputs means no proof of authorship', () => {
+            expect(isSignedByAccount(withVin([]))).toBe(false);
+        });
+    });
+
+    describe('getEvmNonceInfo', () => {
+        const pendingSentTx = (nonce: number) => getOwnEvmTransaction({ nonce, blockHeight: -1 });
 
         it('no pending txs: nextNonce = accountNonce', () => {
             expect(getEvmNonceInfo(41, [])).toEqual({
@@ -523,11 +588,7 @@ describe('transaction utils', () => {
         it('stale pending record superseded by a locally-confirmed tx at the same nonce is ignored', () => {
             // nonce 41's replacement (e.g. a speed-up) confirmed locally, but the original pending
             // record for 41 was never swept — it must not count toward the pending nonce pool.
-            const confirmedTx41 = getWalletTransaction({
-                blockHeight: 100,
-                type: 'sent',
-                ethereumSpecific: { nonce: 41 } as any,
-            });
+            const confirmedTx41 = getOwnEvmTransaction({ nonce: 41 });
             const transactions = [confirmedTx41, pendingSentTx(41), pendingSentTx(42)];
             expect(getEvmNonceInfo(41, transactions)).toEqual({
                 confirmedNonce: 42,
@@ -536,27 +597,49 @@ describe('transaction utils', () => {
                 confirmedNonces: [41],
             });
         });
+
+        it('locally-confirmed nonces raise the floor only contiguously', () => {
+            // 41 and 42 are ours and confirmed, so the true nonce is at least 43. An own tx at 90 is
+            // not contiguous with them (a corrupted record, or the list is missing 43-89), so the
+            // floor must stop at 43 instead of jumping to the maximum.
+            const transactions = [
+                getOwnEvmTransaction({ nonce: 41 }),
+                getOwnEvmTransaction({ nonce: 42 }),
+                getOwnEvmTransaction({ nonce: 90 }),
+            ];
+            expect(getEvmNonceInfo(41, transactions)).toMatchObject({
+                confirmedNonce: 43,
+                nextNonce: 43,
+            });
+        });
+
+        it("a foreign signer's nonce cannot inflate the fallback nonce", () => {
+            // The 2026-08-02 incident on the fallback path: a fake-token airdrop signed by a
+            // stranger at their nonce 288130 emits a transfer *out of* the account, so it is
+            // labelled 'sent' and indexed against the account. Keying off the label offered
+            // nonce 288131, which can never be mined.
+            const transactions = [
+                getForeignEvmTransaction({ nonce: 288130 }),
+                getForeignEvmTransaction({ nonce: 45 }),
+            ];
+            expect(getEvmNonceInfo(45, transactions)).toEqual({
+                confirmedNonce: 45,
+                nextNonce: 45,
+                pendingNonces: [],
+                confirmedNonces: [],
+            });
+        });
     });
 
     describe('getEvmPrivatePendingHint', () => {
-        const pendingTx = (
-            nonce: number,
-            {
-                type = 'sent',
-                txid = `0x${nonce}`,
-            }: { type?: WalletAccountTransaction['type']; txid?: string } = {},
-        ) =>
-            getWalletTransaction({
-                txid,
-                blockHeight: -1,
-                type,
-                ethereumSpecific: { nonce } as any,
-            });
+        const pendingTx = (nonce: number, { txid = `0x${nonce}` }: { txid?: string } = {}) =>
+            getOwnEvmTransaction({ nonce, blockHeight: -1, txid });
 
         it('returns undefined when there is no pending own-nonce tx', () => {
             expect(getEvmPrivatePendingHint([])).toBeUndefined();
             // an incoming pending tx does not consume our nonce and must not be declared
-            expect(getEvmPrivatePendingHint([pendingTx(41, { type: 'recv' })])).toBeUndefined();
+            const incoming = getForeignEvmTransaction({ nonce: 41, blockHeight: -1, type: 'recv' });
+            expect(getEvmPrivatePendingHint([incoming])).toBeUndefined();
         });
 
         it('declares a local pending nonce and its txid', () => {
@@ -566,13 +649,17 @@ describe('transaction utils', () => {
             });
         });
 
-        it('declares all pending sent/self/contract nonces and their txids', () => {
+        it('declares every pending nonce the account signed, whatever the tx is labelled', () => {
             const transactions = [
-                pendingTx(43, { type: 'contract' }),
-                pendingTx(41, { type: 'sent' }),
-                pendingTx(42, { type: 'self' }),
-                pendingTx(40, { type: 'recv' }), // ignored — not an own-nonce-consuming tx
-                pendingTx(44, { type: 'sent' }),
+                getOwnEvmTransaction({
+                    nonce: 43,
+                    blockHeight: -1,
+                    txid: '0x43',
+                    type: 'contract',
+                }),
+                pendingTx(41),
+                getOwnEvmTransaction({ nonce: 42, blockHeight: -1, txid: '0x42', type: 'self' }),
+                pendingTx(44),
             ];
             expect(getEvmPrivatePendingHint(transactions)).toEqual({
                 nonces: [41, 42, 43, 44],
@@ -580,13 +667,19 @@ describe('transaction utils', () => {
             });
         });
 
+        it('never declares a pending tx the account did not sign', () => {
+            // A stranger's mempool transferFrom(account, …) is labelled 'sent' and indexed against
+            // the account. Declaring its nonce would have blockbook report a pending nonce the
+            // account never used, and its txid is not ours to declare either.
+            const transactions = [
+                getForeignEvmTransaction({ nonce: 40, blockHeight: -1, txid: '0x40' }),
+                getForeignEvmTransaction({ nonce: 45, blockHeight: -1, txid: '0x45' }),
+            ];
+            expect(getEvmPrivatePendingHint(transactions)).toBeUndefined();
+        });
+
         it('excludes the nonce and txid of a tx that is already locally confirmed', () => {
-            const confirmedTx41 = getWalletTransaction({
-                txid: '0x41-confirmed',
-                blockHeight: 100,
-                type: 'sent',
-                ethereumSpecific: { nonce: 41 } as any,
-            });
+            const confirmedTx41 = getOwnEvmTransaction({ nonce: 41, txid: '0x41-confirmed' });
             const transactions = [confirmedTx41, pendingTx(41), pendingTx(42)];
             expect(getEvmPrivatePendingHint(transactions)).toEqual({
                 nonces: [42],
@@ -608,12 +701,7 @@ describe('transaction utils', () => {
     });
 
     describe('getEvmNonceInfoFromConfirmedNonce', () => {
-        const pendingSentTx = (nonce: number) =>
-            getWalletTransaction({
-                blockHeight: -1,
-                type: 'sent',
-                ethereumSpecific: { nonce } as any,
-            });
+        const pendingSentTx = (nonce: number) => getOwnEvmTransaction({ nonce, blockHeight: -1 });
 
         it('no pending txs: nextNonce = confirmedNonce', () => {
             expect(getEvmNonceInfoFromConfirmedNonce(1418, [])).toEqual({
@@ -649,11 +737,7 @@ describe('transaction utils', () => {
             // highest locally-confirmed nonce) must NOT apply here — a single malformed/corrupted
             // local tx record with a huge nonce must not push a trusted, backend-fetched
             // confirmedNonce upward.
-            const corruptedConfirmedTx = getWalletTransaction({
-                blockHeight: 100,
-                type: 'sent',
-                ethereumSpecific: { nonce: 335753 } as any,
-            });
+            const corruptedConfirmedTx = getOwnEvmTransaction({ nonce: 335753 });
             expect(getEvmNonceInfoFromConfirmedNonce(1418, [corruptedConfirmedTx])).toEqual({
                 confirmedNonce: 1418,
                 nextNonce: 1418,
@@ -663,11 +747,7 @@ describe('transaction utils', () => {
         });
 
         it('stale pending record superseded by a locally-confirmed tx at the same nonce is ignored', () => {
-            const confirmedTx1418 = getWalletTransaction({
-                blockHeight: 100,
-                type: 'sent',
-                ethereumSpecific: { nonce: 1418 } as any,
-            });
+            const confirmedTx1418 = getOwnEvmTransaction({ nonce: 1418 });
             const transactions = [confirmedTx1418, pendingSentTx(1418), pendingSentTx(1419)];
             expect(getEvmNonceInfoFromConfirmedNonce(1419, transactions)).toEqual({
                 confirmedNonce: 1419,
@@ -683,17 +763,61 @@ describe('transaction utils', () => {
             // backend confirmedNonce still lags at 1418. The just-confirmed slot must still advance
             // nextNonce past the contiguous pending 1419/1420, otherwise those higher pending txs
             // would momentarily read as a nonce gap and flash a false warning in the tx list.
-            const confirmedTx1418 = getWalletTransaction({
-                blockHeight: 100,
-                type: 'sent',
-                ethereumSpecific: { nonce: 1418 } as any,
-            });
+            const confirmedTx1418 = getOwnEvmTransaction({ nonce: 1418 });
             const transactions = [confirmedTx1418, pendingSentTx(1419), pendingSentTx(1420)];
             expect(getEvmNonceInfoFromConfirmedNonce(1418, transactions)).toEqual({
                 confirmedNonce: 1418,
                 nextNonce: 1421,
                 pendingNonces: [1419, 1420],
                 confirmedNonces: [1418],
+            });
+        });
+
+        it('a confirmed tx signed by somebody else does not occupy a nonce slot', () => {
+            // The 2026-08-02 incident: a fake-USDC airdrop signed by a stranger at *their* nonce 45
+            // emits a transfer out of the account, so blockbook indexes it against the account and
+            // Suite labels it 'sent'. Counting it made Suite offer 46 while 45 was free, stranding
+            // the send in a permanent nonce gap.
+            const foreignTxAtNonce45 = getForeignEvmTransaction({ nonce: 45 });
+            expect(getEvmNonceInfoFromConfirmedNonce(45, [foreignTxAtNonce45])).toEqual({
+                confirmedNonce: 45,
+                nextNonce: 45,
+                pendingNonces: [],
+                confirmedNonces: [],
+            });
+        });
+
+        it('a pending tx signed by somebody else does not occupy a nonce slot', () => {
+            // Same vector from the mempool: a transferFrom(account, …) call whose `from` argument
+            // blockbook takes at face value, indexed against the account with the caller's nonce.
+            const foreignPendingTx = getForeignEvmTransaction({ nonce: 45, blockHeight: -1 });
+            expect(getEvmNonceInfoFromConfirmedNonce(45, [foreignPendingTx])).toEqual({
+                confirmedNonce: 45,
+                nextNonce: 45,
+                pendingNonces: [],
+                confirmedNonces: [],
+            });
+        });
+
+        it("the account's own failed tx occupies its nonce", () => {
+            // isTxFailed rewrites type to 'failed', which the old type-based filter dropped — but a
+            // reverted tx consumes its nonce like any other.
+            const ownFailedTx = getOwnEvmTransaction({ nonce: 45, type: 'failed' });
+            expect(getEvmNonceInfoFromConfirmedNonce(45, [ownFailedTx])).toEqual({
+                confirmedNonce: 45,
+                nextNonce: 46,
+                pendingNonces: [],
+                confirmedNonces: [45],
+            });
+        });
+
+        it("the account's own contract deployment occupies its nonce", () => {
+            const ownContractTx = getOwnEvmTransaction({ nonce: 45, type: 'contract' });
+            expect(getEvmNonceInfoFromConfirmedNonce(45, [ownContractTx])).toEqual({
+                confirmedNonce: 45,
+                nextNonce: 46,
+                pendingNonces: [],
+                confirmedNonces: [45],
             });
         });
     });

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -70,11 +70,28 @@ export const isPending = (tx: WalletAccountTransaction | AccountTransaction) => 
     return !!tx && (!tx.blockHeight || tx.blockHeight < 0);
 };
 
-// Also matches 'contract': a contract-deployment tx is signed and broadcast from the account's own
-// address and consumes an EVM nonce exactly like a plain send, so it must count toward the same
-// nonce pool (see getEvmNonceInfo) even though blockbook classifies it under a distinct type.
-export const isSentTransaction = (tx: WalletAccountTransaction | AccountTransaction) =>
-    ['sent', 'self', 'contract'].includes(tx.type);
+// isAccountOwned is set by enhanceVinVout at transform time; the descriptor comparison is the
+// fallback for records where it is absent, and is case-insensitive because EVM addresses reach us in
+// mixed EIP-55 casing (cf. isOutgoing in blockchain-link-utils).
+const isSignedByDescriptor = (details: AccountTransaction['details'], descriptor: string) =>
+    !!details?.vin?.some(
+        vin =>
+            vin.isAccountOwned ||
+            vin.addresses?.some(address => address.toLowerCase() === descriptor.toLowerCase()),
+    );
+
+/**
+ * Whether the account itself signed (and paid for) the transaction.
+ *
+ * Deliberately not `tx.type`, which is a display label: it reads 'sent' for any transaction moving
+ * value out of the account — including one signed by a stranger, since an ERC-20 Transfer log or a
+ * transferFrom(account, …) call may name any `from` — and 'failed' for the account's own reverted
+ * sends. EVM nonce arithmetic needs authorship instead: a foreign transaction carries the *signer's*
+ * nonce, which says nothing about this account, while an own failed or contract-deployment
+ * transaction consumes a nonce exactly like a plain send.
+ */
+export const isSignedByAccount = (tx: Pick<WalletAccountTransaction, 'details' | 'descriptor'>) =>
+    isSignedByDescriptor(tx.details, tx.descriptor);
 
 // Shared by the transaction list and its detail modal so both agree on which pending transactions
 // offer a cancel action. Cancelling replaces the tx with a 0-value self-send at the same
@@ -111,7 +128,7 @@ export type EvmNonceInfo = {
 };
 
 export const getOwnEvmNonceSets = (transactions: WalletAccountTransaction[]) => {
-    const ownNonceTxs = transactions.filter(isSentTransaction);
+    const ownNonceTxs = transactions.filter(isSignedByAccount);
 
     // A nonce that's confirmed locally is ground truth. If a stale "pending" record for the same
     // nonce also lingers (e.g. a speed-up/cancel replacement got confirmed but the original's
@@ -157,10 +174,12 @@ export const getEvmNonceInfo = (
 
     // accountNonce (e.g. account.misc.nonce) can lag behind the local tx list if it hasn't been
     // refreshed since a confirmed tx was locally picked up. A locally confirmed nonce proves a
-    // higher true nonce exists, so it's a floor accountNonce can't be below. When no confirmed
-    // nonce is locally known this is 0, so it never lowers accountNonce.
-    const maxLocalConfirmedNonce = confirmedNonces.size > 0 ? Math.max(...confirmedNonces) + 1 : 0;
-    const effectiveAccountNonce = Math.max(accountNonce, maxLocalConfirmedNonce);
+    // higher true nonce exists, so it's a floor accountNonce can't be below. The floor walks up
+    // contiguously rather than jumping to max(confirmedNonces): an isolated outlier (a corrupted
+    // record, or a nonce that never belonged to this account) is then never reached — see
+    // getEvmNonceInfoFromConfirmedNonce for the same reasoning.
+    let effectiveAccountNonce = accountNonce;
+    while (confirmedNonces.has(effectiveAccountNonce)) effectiveAccountNonce += 1;
 
     // effectiveAccountNonce may still overstate reality via blockbook's pending nonce
     // (eth_getTransactionCount("pending")), which already advances past consecutive mempool txs —
@@ -239,7 +258,7 @@ export const getEvmPrivatePendingHint = (
         ...new Set(
             transactions
                 .filter(isPending)
-                .filter(isSentTransaction)
+                .filter(isSignedByAccount)
                 .filter(tx => {
                     const nonce = tx.ethereumSpecific?.nonce;
 
@@ -939,6 +958,10 @@ const getEthereumRbfParams = (
     if (
         account.networkType !== 'ethereum' ||
         tx.type === 'recv' ||
+        // Replacing a transaction means re-signing at its nonce, which only makes sense for a
+        // transaction the account signed itself. A third-party transfer out of the account is
+        // labelled 'sent' too (see isSignedByAccount) and carries the other signer's nonce.
+        !isSignedByDescriptor(tx.details, account.descriptor) ||
         !tx.ethereumSpecific ||
         !isPending(tx) ||
         !tx.rbf
@@ -1186,7 +1209,7 @@ export const getTransactionWithLowestNonce = (
 ): WalletAccountTransaction | null => {
     const txs = Object.values(transactionGroups)
         .flat()
-        .filter(tx => tx.ethereumSpecific && isSentTransaction(tx));
+        .filter(tx => tx.ethereumSpecific && isSignedByAccount(tx));
 
     if (txs.length === 0) return null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Previous check wasn't robust enough and with this one we ensure that sender is the same in list of pending transactions

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

Should work exactly the same way as before

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set focuses on transaction display components (TransactionItem, TxDetailModal), transaction utilities, and Ethereum nonce handling. The highest-risk user-facing regressions are broken transaction list/detail rendering and ETH/Base send failures due to nonce changes. Recommend running the three high-priority tests unconditionally, supplemented by medium-priority EVM send/swap and transaction-list pagination/label tests for broader confidence.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/TxDetailModal.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionItem.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonce.tsx`
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts`
- `suite-common/wallet-core/src/send/resolveEthereumNonce.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts`
- `suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises the Ethereum send form where EthereumNonce.tsx is rendered; changes to nonce validation/UI or EVM transaction utilities would surface here through custom fee and send confirmation flows.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Covers transaction list rendering (TransactionItem.tsx) and explicitly opens the transaction detail modal (TxDetailModal.tsx) to verify the txid; a regression in transaction display or detail modal would be caught immediately.
- `suite/e2e/tests/wallet/transactions.test.ts` — Iterates over graph ranges and verifies the transaction list/summary UI that relies on TransactionItem.tsx and transaction utility-derived data; directly tests transaction rendering behavior.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Inferred relevance: Base is an EVM L2 network, so its send form uses the same EthereumOptions/EthereumNonce component and EVM transaction utilities as Ethereum sends.
- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Adds labels to transaction outputs and verifies them in the transaction list UI; changes to TransactionItem.tsx rendering could affect how output labels are displayed or exported.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates paginated transaction lists and checks specific transaction addresses render correctly; regression in TransactionItem.tsx would likely break these assertions.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Shares EVM send/fee infrastructure with the Ethereum send flow and verifies gas limit/fee rendering; indirectly covers EVM transaction utilities touched in this change set.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx`
- `suite-common/wallet-core/src/send/__fixtures__/evmFixtures.ts`
- `suite-common/wallet-core/src/send/resolveEthereumNonce.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.test.ts`
- `suite-common/wallet-utils/src/__fixtures__/transactionUtils.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`

_Updated: 2026-08-05T14:15:42.546Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/nonces-affect/web/](https://dev.suite.sldev.cz/suite-web/fix/nonces-affect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/nonces-affect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/nonces-affect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/nonces-affect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:17:54.473Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:17:32.288Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->