### PR TITLE
Bump beta version to 26.9.0

### DIFF
--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@trezor/suite",
-    "suiteVersion": "26.8.0",
+    "suiteVersion": "26.9.0",
     "version": "1.0.0",
     "private": true,
     "exports": {


### PR DESCRIPTION
## Description

Automatically generated PR to bump beta Suite version

## Notes for QA

Regular procedure of bumping the Suite version, just check it is updated accordingly in the app settings.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** package/suite/package.json is a broad configuration file with no static test coverage, so its changes most often risk build, startup, or dependency regressions. The recommended strategy is a tiny smoke-test trio covering app load, onboarding, and a simple route rather than running the full suite. If the actual diff shows a specific dependency bump (e.g., connect, analytics, or a coin library), the selection should be narrowed to tests exercising that feature directly.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/package.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/browser/firefox.test.ts` — A package.json change can alter runtime dependencies or browser compatibility polyfills; this smoke test verifies the Suite app actually loads in Firefox, which would fail quickly if a dependency broke the web build. (Inferred, not statically mapped.)
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — This test exercises the very first user-facing flow after app startup; a broken dependency or build artifact from a package.json change would typically surface here as a loading or onboarding failure. (Inferred, not statically mapped.)

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/suite/version-page.test.ts` — The version page is a lightweight route that still requires the app bundle to render correctly; it acts as a fast canary for build-time metadata and dependency issues introduced by package.json edits. (Inferred, not statically mapped.)

</details>

_Updated: 2026-08-05T14:43:56.587Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.9.0/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-suite-version-26.9.0/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-suite-version-26.9.0&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-suite-version-26.9.0&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:46:35.172Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:46:07.103Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->