### PR TITLE
test(agent): pin nightly fix bot to opus 5 at high effort

### DIFF
--- a/packages/e2e-utils/src/fixBot/settings.json
+++ b/packages/e2e-utils/src/fixBot/settings.json
@@ -1,5 +1,6 @@
 {
-    "model": "claude-opus-4-8",
+    "model": "claude-opus-5",
+    "effortLevel": "high",
     "permissions": {
         "defaultMode": "auto"
     }


### PR DESCRIPTION
## Description

Moves the nightly fix bot from Claude Opus 4.8 (now legacy) to Claude Opus 5, and pins `effortLevel` so a future model bump can't silently change it. `settings.json` is shared by both stages via `--settings`, so analyze and fix move together.

Same pricing as 4.8 ($5/$25 per MTok), and both stages stay capped by `--max-budget-usd 10`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file, packages/e2e-utils/src/fixBot/settings.json, is an internal fix-bot configuration file with no references in the E2E test suite and no static coverage mapping. None of the 130 analyzed tests exercise fix-bot settings behavior, so the risk to user-facing functionality is negligible. No E2E tests need to be run for this change; coverage should be validated by any unit or integration tests for the fix-bot tool if they exist.

<details><summary><b>Changed files (1)</b></summary>

- `packages/e2e-utils/src/fixBot/settings.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `packages/e2e-utils/src/fixBot/settings.json`

_Updated: 2026-08-05T14:49:54.905Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/fix-bot-opus-5/web/](https://dev.suite.sldev.cz/suite-web/chore/fix-bot-opus-5/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/fix-bot-opus-5&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/fix-bot-opus-5&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:53:03.528Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T14:52:43.720Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->