### PR TITLE
test(suite): migrate remaining swap tests to the minimalistic mock

### DIFF
--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -7,10 +7,12 @@ import { TradingChainBackend, createTradingChainBackend } from './tradingChainBa
 import { tradeEndpoint } from '../../../fixtures/trading';
 import { step } from '../../common';
 
+// TODO: loose for DEX (no sendAddress, optional fields); revisit in the sell migration PR.
 export type CapturedLiveTrade = ExchangeTrade & {
     sendAddress: string;
     exchange: string;
     sendStringAmount: string;
+    receiveStringAmount: string;
 };
 
 type TradeFlow = 'buy' | 'sell' | 'swap';
@@ -137,9 +139,16 @@ export class TradingMockNew {
     async waitForLiveTrade() {
         const response = await this.page.waitForResponse(this.endpoints.trade);
         const trade = (await response.json()) as ExchangeTrade;
-        if (!trade.sendAddress || !trade.exchange || !trade.sendStringAmount) {
+        // A DEX trade sends to the provider's router contract (`dexTx`), so it has no sendAddress.
+        const hasDepositAddress = trade.isDex || trade.sendAddress;
+        if (
+            !trade.exchange ||
+            !trade.sendStringAmount ||
+            !trade.receiveStringAmount ||
+            !hasDepositAddress
+        ) {
             throw new Error(
-                'Live trade response is missing sendAddress, exchange or sendStringAmount',
+                'Live trade response is missing exchange, sendStringAmount, receiveStringAmount or sendAddress',
             );
         }
 

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -1,36 +1,22 @@
-import type { CryptoId } from 'invity-api';
-
 import { messages } from '@suite/intl';
-import { localizeNumber } from '@suite-common/wallet-utils';
+import { getCryptoId } from '@suite-common/trading';
+import { fromGwei, localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import {
-    getCompanyNameFromList,
-    swapQuotesEthDex,
-    swapTradeEthDex,
-    tradeEndpoint,
-} from '../../fixtures/trading';
+import { getCompanyNameFromList } from '../../fixtures/trading';
+import { swapStatusFlow } from '../../fixtures/trading/statusFlow';
 import { expect, test } from '../../support/fixtures';
 
-// Expected values derived from the captured LI.FI trade fixture.
-const sendAmount = swapTradeEthDex.sendStringAmount;
-const receiveAmount = localizeNumber(swapTradeEthDex.receiveStringAmount);
-const dexProvider = getCompanyNameFromList(swapTradeEthDex.exchange, 'swapList');
+const sendAmount = '0.03';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
-const formattedReceiveAmount = `${receiveAmount} USDC`;
-const usdcCryptoId = swapTradeEthDex.receive as CryptoId;
-const slippagePercent = `${swapTradeEthDex.swapSlippage}%`;
-const guaranteedShare = new BigNumber(100).minus(swapTradeEthDex.swapSlippage).div(100);
-const minimumReceived = new BigNumber(swapTradeEthDex.receiveStringAmount).times(guaranteedShare);
-const formattedMinimumReceived = `${localizeNumber(minimumReceived.toFixed(4))} USDC`;
-// Mocked feeLimit 21000 (eth-endpoints estimateFee) × the 1.25 DEX buffer (ETHEREUM_ADJUST_GAS_LIMIT).
-const dexGasLimit = '26250';
-// dexGasLimit × the mocked gas price.
-const dexMaximumFee = '0.00003161748342375 ETH';
-const gasLimitWithLabel = `${messages.TR_GAS_LIMIT.defaultMessage}: ${dexGasLimit}`;
 const accountLabel = 'Ethereum #1';
-// Provider name rendered by Suite in the confirm-on-device prompt.
-const suiteProviderName = 'LI.FI';
+const usdcCryptoId = getCryptoId('eth', '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+const dexProvider = getCompanyNameFromList('lifi', 'swapList');
+
+const gasLimitPattern = new RegExp(`^${messages.TR_GAS_LIMIT.defaultMessage}: (\\d+)$`);
+
+// A DEX swap broadcasts the swap itself, so there is no CONFIRMING deposit phase.
+const dexStatusFlow = swapStatusFlow.filter(phase => phase.status !== 'CONFIRMING');
 
 // Firmware strings on the DEX review pages.
 const deviceReview = {
@@ -49,70 +35,35 @@ const deviceReview = {
     signButton: 'Hold to sign',
 };
 
-test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
-    test.use({
-        deviceSetup: {
-            mnemonic: 'access juice claim special truth ugly swarm rabbit hair man error bar',
-        },
-    });
+test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
+    test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
 
     test.beforeEach(
-        async ({
-            page,
-            onboardingPage,
-            dashboardPage,
-            settingsPage,
-            walletPage,
-            tradingMock,
-            blockbookMock,
-        }) => {
-            await test.step('Mock the ETH backend', async () => {
-                await onboardingPage.completeOnboarding();
-                await settingsPage.navigateTo('coins');
-                await blockbookMock.start('eth');
-                blockbookMock.updateAccountState({
-                    balance: '1000000000000000000', // 1 ETH
-                    nonce: '0',
-                    txs: 0,
-                    nonTokenTxs: 0,
-                    internalTxs: 0,
-                    transactions: [],
-                });
-                //TODO: Switch to changeNetworks once mocks are refactored
-                await settingsPage.coinsTab.openNetworkAdvanceSettings('eth');
-                await settingsPage.coinsTab.changeBackend('blockbook', blockbookMock.url);
-            });
+        async ({ onboardingPage, dashboardPage, settingsPage, walletPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            const ethBackend = await tradingMockNew.startBackend('eth');
 
-            await test.step('Mock the trading API', async () => {
-                await tradingMock.routeTradeGeneralEndpoints();
-                await page.route(tradeEndpoint.swapQuotes, route => {
-                    route.fulfill({ json: swapQuotesEthDex });
-                });
-                await tradingMock.routeSwapTrade(swapTradeEthDex);
-                await page.route(tradeEndpoint.swapWatch, route => {
-                    route.fulfill({ json: { status: 'CONFIRM' } });
-                });
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'eth', backend: ethBackend }],
             });
-
-            await dashboardPage.navigateTo();
-            await page.discoveryShouldFinish();
+            await dashboardPage.deviceSwitchingOpenButton.click();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'eth' });
         },
     );
 
     test('User can swap ETH to USDC via LI.FI DEX', async ({
         page,
-        tradingPage,
-        tradingMock,
-        devicePrompt,
         device,
+        tradingPage,
+        devicePrompt,
+        tradingMockNew,
     }) => {
         await test.step('Fill in the Swap form (ETH -> USDC)', async () => {
             await tradingPage.fillSwapForm({
                 amount: sendAmount,
-                sellAsset: {
-                    networkSymbol: 'eth',
-                },
+                sellAsset: { networkSymbol: 'eth' },
                 buyAsset: {
                     searchFilter: 'USDC',
                     networkFilter: 'eth',
@@ -121,14 +72,43 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             });
         });
 
+        let maxFeePerGas: string;
+        let feeRate: string;
+        let priorityFeeRate: string;
+
         await test.step('Select the LI.FI DEX offer', async () => {
             await tradingPage.quotes.chooseDifferentOfferIfAvailable(dexProvider);
             await expect(tradingPage.quotes.selectedProviderName).toHaveText(dexProvider);
-            await expect(tradingPage.quotes.bestOfferAmount).toHaveText(formattedReceiveAmount);
+            await tradingPage.quotes.waitForSync();
+
+            let maxFeePerGasRounded: string;
+            let maxPriorityFeePerGasRounded: string;
+            ({ maxFeePerGas, maxFeePerGasRounded, maxPriorityFeePerGasRounded } =
+                await tradingPage.fees.getStandardFeeWorkaround());
+            feeRate = `${maxFeePerGasRounded} Gwei`;
+            priorityFeeRate = `${maxPriorityFeePerGasRounded} Gwei`;
+
+            const liveTradePromise = tradingMockNew.waitForLiveTrade();
             await tradingPage.swapBestOfferButton.click();
+            await liveTradePromise;
         });
 
+        // The DEX re-quotes on trade creation, so amounts come from the trade, not the offer.
+        let receiveAmount: string;
+        let formattedReceiveAmount: string;
+        let minimumReceived: BigNumber;
+        let formattedMinimumReceived: string;
+        let slippagePercent: string;
+
         await test.step('Verify DEX details on the Confirm & send screen', async () => {
+            const { receiveStringAmount, swapSlippage } = tradingMockNew.liveTrade;
+            receiveAmount = localizeNumber(receiveStringAmount);
+            formattedReceiveAmount = `${receiveAmount} USDC`;
+            slippagePercent = `${swapSlippage}%`;
+            const guaranteedShare = new BigNumber(100).minus(swapSlippage!).div(100);
+            minimumReceived = new BigNumber(receiveStringAmount).times(guaranteedShare);
+            formattedMinimumReceived = `${localizeNumber(minimumReceived.toFixed(4))} USDC`;
+
             await expect(tradingPage.confirmation.dexExchangeType).toHaveTranslation(
                 'TR_EXCHANGE_DEX',
             );
@@ -143,8 +123,10 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             await expect(tradingPage.confirmation.sendAccount).toHaveText(`from ${accountLabel}`);
             await expect(tradingPage.confirmation.receiveAccount).toHaveText(`to ${accountLabel}`);
             await expect(tradingPage.confirmation.sendCryptoAmount).toHaveText(formattedSendAmount);
+            // REWORK: The receiveCryptoAmount amount is now simulated and differs from trade offer
             await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
-                formattedReceiveAmount,
+                // positive amount, optional thousands separators, up to 6 decimals, then the symbol
+                /^(?=.*[1-9])\d{1,3}(,\d{3})*(\.\d{1,6})? USDC$/,
             );
         });
 
@@ -152,16 +134,16 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             await tradingPage.confirmation.openConfirmAndSendModal();
         });
 
+        let gasLimitWithLabel: string;
+
         await test.step('Confirm the DEX transaction on device', async () => {
             await devicePrompt.confirmOnDevicePromptIsShown();
 
-            await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(
-                suiteProviderName,
-            );
+            await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(dexProvider);
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.providerTitle },
-                    body: [[suiteProviderName]],
+                    body: [[dexProvider]],
                     actions: { right_button: deviceReview.confirmButton },
                 },
             });
@@ -187,7 +169,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             );
             // The recipient is the user's own receive address, not the LI.FI router (dexTx.to).
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
-                swapTradeEthDex.receiveAddress,
+                tradingMockNew.liveTrade.receiveAddress!,
             );
             await expect(device).toShowOnDisplay({
                 T3W1: {
@@ -203,13 +185,25 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             });
             await devicePrompt.waitForPromptAndConfirm();
 
-            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitWithLabel);
+            await expect(devicePrompt.ethereumFeeRate).toHaveText(feeRate);
+            await expect(devicePrompt.ethereumPriorityFeeRate).toHaveText(priorityFeeRate);
+
+            await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitPattern);
+            gasLimitWithLabel = await devicePrompt.ethereumGasLimit.innerText();
+            const reviewedGasLimit = gasLimitWithLabel.match(gasLimitPattern)?.[1];
+            if (!reviewedGasLimit) {
+                throw new Error(`Unexpected gas limit format: ${gasLimitWithLabel}`);
+            }
+
+            const maximumFeeInGwei = new BigNumber(maxFeePerGas).times(reviewedGasLimit).toFixed();
+            const maximumFee = `${localizeNumber(fromGwei(maximumFeeInGwei).toEther())} ETH`;
+            await expect(devicePrompt.cryptoAmountWithSymbolOf('fee')).toHaveText(maximumFee);
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.feeTitle },
                     body: [
                         [deviceReview.feeLabel],
-                        device.wrapText(dexMaximumFee, { isAmount: true }),
+                        device.wrapText(maximumFee, { isAmount: true }),
                     ],
                     actions: { right_button: deviceReview.signButton },
                 },
@@ -218,9 +212,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
         });
 
         await test.step('Re-verify the fully revealed review form', async () => {
-            await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(
-                suiteProviderName,
-            );
+            await expect(devicePrompt.outputValueOf('recipient_name')).toHaveText(dexProvider);
             await expect(devicePrompt.outputValueOf('swap_intent')).toHaveTranslation(
                 'TR_TRADING_INTENT_SWAP',
             );
@@ -231,40 +223,34 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
                 `+ ${minimumReceived.toFixed()} USDC`,
             );
             await expect(devicePrompt.assetsReceiveAddress).toHaveText(
-                swapTradeEthDex.receiveAddress,
+                tradingMockNew.liveTrade.receiveAddress!,
             );
             await expect(devicePrompt.ethereumGasLimit).toHaveText(gasLimitWithLabel);
         });
 
-        await test.step('Broadcast the signed DEX transaction', async () => {
+        await test.step('Send the DEX transaction (broadcast blocked by mock)', async () => {
+            await tradingMockNew.setStatus('SENDING');
             await page.clock.install();
             await devicePrompt.sendButton.click();
+
             await tradingPage.verifySwapToast({
                 sendAccount: accountLabel,
                 receiveAccount: accountLabel,
-                sendAmount,
+                // The toast echoes the provider's formatting of the amount, not the one we typed.
+                sendAmount: tradingMockNew.liveTrade.sendStringAmount,
                 receiveAmount,
             });
         });
 
-        await test.step('Wait 30s for watch refresh and status change to Processing', async () => {
-            await tradingMock.routeAndWaitForWatchResponse(tradeEndpoint.swapWatch, {
-                status: 'CONVERTING',
+        for (const step of dexStatusFlow) {
+            await test.step(`Wait for status change to ${step.status}`, async () => {
+                await tradingMockNew.advanceStatus(step.status);
+                await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
+                    step.translationKey,
+                    { values: step.translationValues?.(dexProvider) },
+                );
             });
-            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
-                'TR_TRADING_DETAIL_PROCESSING',
-                { values: { providerName: dexProvider, type: 'swap' } },
-            );
-        });
-
-        await test.step('Wait 30s for watch refresh and status change to Success', async () => {
-            await tradingMock.routeAndWaitForWatchResponse(tradeEndpoint.swapWatch, {
-                status: 'SUCCESS',
-            });
-            await expect(tradingPage.transactionDetailStatus).toHaveTranslation(
-                'TR_EXCHANGE_DETAIL_SUCCESS_TITLE',
-            );
-        });
+        }
 
         await test.step('Verify final transaction detail values', async () => {
             await expect(tradingPage.confirmation.sendCryptoAmount).toHaveText(formattedSendAmount);

--- a/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-bitcoin.test.ts
@@ -1,25 +1,23 @@
 import { BigNumber } from '@trezor/utils';
 
-import { swapQuotesBTCEthereum, swapTradeBTCEthereum, tradeEndpoint } from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 
-const sendAmount = '0.0004';
+const sendAmount = '0.0015';
 const customFee = '10';
 
-test.describe('Trading - Swap fees Bitcoin', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
+test.describe('Trading - Swap fees Bitcoin', { tag: ['@T3T1', '@T3W1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
 
     test.beforeEach(
-        async ({ onboardingPage, dashboardPage, walletPage, settingsPage, page, tradingMock }) => {
-            await test.step('Mocking responses', async () => {
-                await page.route(tradeEndpoint.swapQuotes, route => {
-                    route.fulfill({ json: swapQuotesBTCEthereum });
-                });
-                await tradingMock.routeSwapTrade(swapTradeBTCEthereum);
-            });
+        async ({ onboardingPage, dashboardPage, walletPage, settingsPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            // Backend is wired only as a broadcast guard; the test never gets past the device.
+            const btcBackend = await tradingMockNew.startBackend('btc');
 
             await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['btc', 'eth'] });
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'btc', backend: btcBackend }, 'eth'],
+            });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'btc' });
@@ -45,9 +43,7 @@ test.describe('Trading - Swap fees Bitcoin', { tag: ['@webOnly', '@T3T1', '@T3W1
             await tradingPage.fees.switchToCustom();
             await tradingPage.fees.customInput.fill(customFee);
             feeRate = await tradingPage.fees.getBitcoinFeeRate('custom');
-
-            // Wait for TX precomposition to avoid
-            await new Promise(resolve => setTimeout(resolve, 2500));
+            await tradingPage.fees.waitToBeCalculated();
         });
 
         await test.step('Continue Swap flow towards Send section', async () => {

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -3,10 +3,9 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { swapQuotesEthereumBTC, swapTradeEthereumBTC, tradeEndpoint } from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 
-const sendAmount = '0.008';
+const sendAmount = '0.03';
 const formattedSendAmount = `${localizeNumber(sendAmount)} ETH`;
 const gasLimit = '26000';
 const maxFeePerGas = '2.67674454';
@@ -17,22 +16,19 @@ const maxPriorityFeePerGasRounded = new BigNumber(maxPriorityFeePerGas).decimalP
     BigNumber.ROUND_UP,
 );
 
-test.describe('Trading - Swap fees', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, () => {
+test.describe('Trading - Swap fees', { tag: ['@T3W1', '@T3T1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true } });
 
     test.beforeEach(
-        async ({ page, onboardingPage, dashboardPage, walletPage, settingsPage, tradingMock }) => {
-            await test.step('Mocking responses', async () => {
-                await tradingMock.routeTradeGeneralEndpoints();
-                await page.route(tradeEndpoint.swapQuotes, route => {
-                    route.fulfill({ json: swapQuotesEthereumBTC });
-                });
-                await tradingMock.routeSwapTrade(swapTradeEthereumBTC);
-            });
+        async ({ onboardingPage, dashboardPage, walletPage, settingsPage, tradingMockNew }) => {
+            tradingMockNew.setTradeFlow('swap');
+            // Backend is wired only as a broadcast guard; the test never gets past the device.
+            const ethBackend = await tradingMockNew.startBackend('eth');
 
             await onboardingPage.completeOnboarding();
-            await settingsPage.changeNetworks({ enableNetworks: ['eth', 'btc'] });
-            await dashboardPage.navigateTo();
+            await settingsPage.changeNetworks({
+                enableNetworks: [{ symbol: 'eth', backend: ethBackend }, 'btc'],
+            });
             await dashboardPage.deviceSwitchingOpenButton.click();
             await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
             await walletPage.openSwapTrading({ symbol: 'eth' });
@@ -57,9 +53,7 @@ test.describe('Trading - Swap fees', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
                 maxFeePerGas,
                 maxPriorityFeePerGas,
             });
-
-            // Wait for TX precomposition to avoid
-            await new Promise(resolve => setTimeout(resolve, 2500));
+            await tradingPage.fees.waitToBeCalculated();
         });
 
         await test.step('Continue Swap flow towards Send section', async () => {

--- a/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
@@ -1,38 +1,32 @@
 import { getCryptoId } from '@suite-common/trading';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 
-import { swapQuotesTetherStellar, tradeEndpoint } from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
 
-const sendAmount = swapQuotesTetherStellar[0]?.sendStringAmount ?? '';
+const sendAmount = '9';
+const accountLabel = 'Stellar #1';
 
 test.describe(
     'Trading - Swap token to disabled network asset',
     {
-        tag: ['@webOnly', '@T3W1', '@T3T1'],
+        tag: ['@T3W1', '@T3T1'],
     },
     () => {
         test.use({
             deviceSetup: { mnemonic: 'mnemonic_academic', passphrase_protection: true },
         });
 
-        test.beforeEach(
-            async ({ page, onboardingPage, dashboardPage, walletPage, settingsPage }) => {
-                await test.step('Mocking responses', async () => {
-                    await page.route(tradeEndpoint.swapQuotes, async route => {
-                        await route.fulfill({ json: swapQuotesTetherStellar });
-                    });
-                });
+        test.beforeEach(async ({ onboardingPage, dashboardPage, walletPage, settingsPage }) => {
+            await onboardingPage.completeOnboarding();
+            await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
+            await dashboardPage.openDeviceSwitcher();
+            await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
+            await walletPage.openSwapTrading({ symbol: 'sol' });
+        });
 
-                await onboardingPage.completeOnboarding();
-                await settingsPage.changeNetworks({ enableNetworks: ['sol'] });
-                await dashboardPage.openDeviceSwitcher();
-                await dashboardPage.addHiddenWallet(process.env.PASSPHRASE!);
-                await walletPage.openSwapTrading({ symbol: 'sol' });
-            },
-        );
-
-        test('Show provider info for disabled network asset XLM', async ({ tradingPage }) => {
+        test('Show provider info for disabled network asset XLM and enable it', async ({
+            tradingPage,
+        }) => {
             await test.step('Fill in a Swap form with Stellar buy asset', async () => {
                 await tradingPage.fillSwapForm({
                     amount: sendAmount,
@@ -50,6 +44,13 @@ test.describe(
 
             await test.step('Verify provider info is visible in quotes', async () => {
                 await expect(tradingPage.quotes.selectedProvider).toBeVisible();
+            });
+
+            await test.step('Enable the Stellar network from the receive account picker', async () => {
+                await tradingPage.receiveAccount.selectAddSuiteReceiveAccount(0, 'xlm');
+                await expect(tradingPage.receiveAccount.selectedReceiveAccount).toContainText(
+                    accountLabel,
+                );
             });
         });
     },


### PR DESCRIPTION
swap-dex-lifi, swap-fees-ethereum, swap-fees-bitcoin and swap-token-to-disabled-network now run against live Invity and a passthru chain backend instead of captured JSON fixtures.

Adds DEX support to TradingMockNew: a DEX trade sends to the provider's router in dexTx, so it has no sendAddress.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Phase B2 of the trading mock migration — the last four swap files move off
captured JSON fixtures onto `TradingMockNew` (live Invity API + passthru chain
backend with the broadcast blocked, so no funds ever leave the account).

| File | Change |
| --- | --- |
| `swap-dex-lifi` | live DEX flow; the only one needing mock changes |
| `swap-fees-ethereum` | live Invity; typed custom fees keep every assertion exact |
| `swap-fees-bitcoin` | same, with `startBackend('btc')` |
| `swap-token-to-disabled-network` | live quotes; no trading mock needed |

`swap-inputs` and `swap-history` stay as they are — the first is already fully
live, the second seeds Redux via `window.store`, which only `suite-web` exposes.

**Mock change.** A DEX trade carries no `sendAddress` — it sends to the
provider's router contract (`dexTx`) — so `waitForLiveTrade` requires a deposit
address only when the trade is not a DEX one, and additionally requires
`receiveStringAmount`.

**Assertion rework** is the bulk of the diff. Against live data the DEX flow
differs from CEX in three ways worth knowing:
- the DEX re-quotes when the trade is created, so amounts must come from the
  trade response, never from `quotes.getBestOfferAmount()`;
- gas limit and max fee are estimated against live chain state, so they are read
  off the Suite prompt and crosschecked against the device rather than pinned;
- there is no `CONFIRMING` phase — the swap transaction *is* the on-chain event,
  so the trade goes straight to `CONVERTING` on broadcast.

Three tests also lose `@webOnly`, since their last `page.route` is gone.

**Base.** Contains the `tradingMockNew` change from #30867 as well, so it can go
in independently. Expect a conflict on those lines when #30867 merges.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=minimalist-mock-phase-B-3&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=minimalist-mock-phase-B-3&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/minimalist-mock-phase-B-3/web/](https://dev.suite.sldev.cz/suite-web/minimalist-mock-phase-B-3/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T09:58:24.052Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T08:33:40.653Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->