### PR TITLE
fix(ci): yarn install crashing in staging release pipeline

### DIFF
--- a/.github/workflows/release-suite-desktop-web-staging.yml
+++ b/.github/workflows/release-suite-desktop-web-staging.yml
@@ -65,7 +65,7 @@ jobs:
       # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Install deps and build libs
         run: |
-          yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-ui @trezor/suite-desktop-core @trezor/suite-build @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
+          yarn workspaces focus trezor-suite @trezor/suite-desktop @trezor/suite-desktop-ui @trezor/suite-desktop-core @trezor/suite-build @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib
@@ -189,7 +189,7 @@ jobs:
       - name: Install dependencies
         run: |
           echo -e "\nenableHardenedMode: false" >> .yarnrc.yml
-          yarn workspaces focus @trezor/suite-web @trezor/suite-data @suite-common/message-system
+          yarn workspaces focus trezor-suite @trezor/suite-web @trezor/suite-data @suite-common/message-system
 
       - name: Build suite-web
         env:
@@ -242,7 +242,7 @@ jobs:
       # safedep/pmg not available on macOS (that's ok, PMG must be run on PR workflows but here it's optional)
       - name: Install deps and build libs
         run: |
-          yarn workspaces focus @trezor/suite-desktop @trezor/suite-desktop-ui @trezor/suite-desktop-core @trezor/suite-build @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
+          yarn workspaces focus trezor-suite @trezor/suite-desktop @trezor/suite-desktop-ui @trezor/suite-desktop-core @trezor/suite-build @trezor/suite-data @trezor/transport-bridge @suite-common/message-system
           yarn message-system-sign-config
           yarn workspace @trezor/suite-data build:lib
           yarn workspace @trezor/transport-bridge build:lib


### PR DESCRIPTION
## Description

Add the root workspace to yarn focus, in order to fix crash in release staging pipeline – likely caused by https://github.com/trezor/trezor-suite/pull/28002

Anyway I did use the root repo in the [PR build desktop app workflow](https://github.com/trezor/trezor-suite/blob/f51ef3cc0cf141db7b59ec7c1c6be447c0ebd0d9/.github/workflows/build-desktop-apps.yml#L51), and I don't remember the details, but I probably had a reason to do it..
Because this workflow builds dekstop apps very analogically, let's include it too. 

~I'm puzzled. Yarn does not install `rimraf` so it fails, but it should install it, because rimraf is specified in devDependencies of both `suite-web` and `suite-desktop-core`~
EDIT: Explained. It does install rimraf, but it's only executable via `yarn workspace @trezor/suite-desktop-core`.
So it does not work in our case where we use `g:rimraf`, which tries to source it from root workspace, and it's not there :hear_no_evil: 