### PR TITLE
refactor(e2e): deduplicate page object locator definitions

### DIFF
--- a/suite/e2e/support/pageObjects/assetsSection.ts
+++ b/suite/e2e/support/pageObjects/assetsSection.ts
@@ -56,15 +56,9 @@ export class AssetsSection {
 
     @step()
     async verifyAssetContents() {
-        await expect(
-            this.page.getByTestId('@dashboard/asset-item/btc').getByTestId('@dashboard/asset/name'),
-        ).toHaveText('Bitcoin');
-        await expect(
-            this.page.getByTestId('@dashboard/asset-item/eth').getByTestId('@dashboard/asset/name'),
-        ).toHaveText('Ethereum');
-        await expect(this.page.getByTestId('@dashboard/asset/btc/fiat-amount')).toHaveText('$0.00');
-        await expect(this.page.getByTestId('@dashboard/asset/eth/fiat-amount')).toContainText(
-            '$0.00',
-        );
+        await expect(this.assetName('btc')).toHaveText('Bitcoin');
+        await expect(this.assetName('eth')).toHaveText('Ethereum');
+        await expect(this.assetFiatAmount('btc')).toHaveText('$0.00');
+        await expect(this.assetFiatAmount('eth')).toContainText('$0.00');
     }
 }

--- a/suite/e2e/support/pageObjects/devicePrompt.ts
+++ b/suite/e2e/support/pageObjects/devicePrompt.ts
@@ -50,7 +50,7 @@ export class DevicePrompt {
         this.confirmOnDevicePrompt = page.getByTestId('@prompts/confirm-on-device');
         this.confirmOnDevicePromptSuccess = page.getByTestId('@prompts/confirm-on-device/success');
         this.connectDevicePrompt = page.getByTestId('@connect-device-prompt');
-        this.modalCloseButton = page.getByTestId('@modal/close-button');
+        this.modalCloseButton = page.modalCloseButton;
         this.modal = page.modal;
         this.paginatedText = page.locator("[data-testid-alt='@device-display/paginated-text']");
         this.paginatedTextSeparator = page.getByTestId('@device-display/paginated-text/separator');

--- a/suite/e2e/support/pageObjects/onboarding/backupSection.ts
+++ b/suite/e2e/support/pageObjects/onboarding/backupSection.ts
@@ -20,6 +20,8 @@ export class BackupSection {
     readonly backupFailedSettingLink: Locator;
     readonly backupFailedSettingButton: Locator;
     readonly skipBackupButton: Locator;
+    readonly createBackupButton: Locator;
+    readonly continueButton: Locator;
 
     constructor(
         private readonly page: Page,
@@ -51,6 +53,8 @@ export class BackupSection {
             '@device-settings/backup-failed/disabled-button',
         );
         this.skipBackupButton = this.page.getByTestId('@onboarding/skip-backup');
+        this.createBackupButton = this.page.getByTestId('@onboarding/create-backup-button');
+        this.continueButton = this.page.getByTestId('@onboarding/continue-button');
     }
 
     @step()
@@ -63,16 +67,13 @@ export class BackupSection {
         threshold?: number;
         deviceConfirmations: number;
     }) {
-        const backupButton = this.page.getByTestId('@onboarding/create-backup-button');
-        const closeButton = this.page.getByTestId('@onboarding/continue-button');
-
-        await expect(backupButton).toBeDisabled();
+        await expect(this.createBackupButton).toBeDisabled();
 
         await this.wroteSeedProperlyCheckbox.click();
         await this.madeNoDigitalCopyCheckbox.click();
         await this.willHideSeedCheckbox.click();
 
-        await backupButton.click();
+        await this.createBackupButton.click();
 
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         for (let i = 0; i < deviceConfirmations; i++) {
@@ -88,21 +89,18 @@ export class BackupSection {
             await this.device.readAndConfirmSingleShamirMnemonic();
         }
 
-        await closeButton.click();
+        await this.continueButton.click();
     }
 
     @step()
     async passThroughBip39Backup({ deviceConfirmations }: { deviceConfirmations: number }) {
-        const backupButton = this.page.getByTestId('@onboarding/create-backup-button');
-        const closeButton = this.page.getByTestId('@onboarding/continue-button');
-
-        await expect(backupButton).toBeDisabled();
+        await expect(this.createBackupButton).toBeDisabled();
 
         await this.wroteSeedProperlyCheckbox.click();
         await this.madeNoDigitalCopyCheckbox.click();
         await this.willHideSeedCheckbox.click();
 
-        await backupButton.click();
+        await this.createBackupButton.click();
 
         await this.devicePrompt.confirmOnDevicePromptIsShown();
         for (let i = 0; i < deviceConfirmations; i++) {
@@ -116,6 +114,6 @@ export class BackupSection {
             await this.device.pressYes();
         }
 
-        await closeButton.click();
+        await this.continueButton.click();
     }
 }

--- a/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
+++ b/suite/e2e/support/pageObjects/onboarding/onboardingPage.ts
@@ -25,7 +25,6 @@ export class OnboardingPage {
 
     readonly welcomeBody: Locator;
     readonly completeOnboardingButton: Locator;
-    readonly connectDevicePrompt: Locator;
     readonly authenticityStartButton: Locator;
     readonly authenticityContinueButton: Locator;
     readonly createBackupButton: Locator;
@@ -63,12 +62,11 @@ export class OnboardingPage {
 
         this.welcomeBody = this.page.getByTestId('@welcome-layout/body');
         this.completeOnboardingButton = this.page.getByTestId('@onboarding/complete-onboarding');
-        this.connectDevicePrompt = this.page.getByTestId('@connect-device-prompt');
         this.authenticityStartButton = this.page.getByTestId('@authenticity-check/start-button');
         this.authenticityContinueButton = this.page.getByTestId(
             '@authenticity-check/continue-button',
         );
-        this.createBackupButton = this.page.getByTestId('@onboarding/create-backup-button');
+        this.createBackupButton = this.backup.createBackupButton;
         this.recoverWalletButton = this.page.getByTestId('@onboarding/path-recovery-button');
         this.startRecoveryButton = this.page.getByTestId('@onboarding/recovery/start-button');
         this.continueRecoveryButton = this.page.getByTestId('@onboarding/recovery/continue-button');

--- a/suite/e2e/support/pageObjects/onboarding/pinSection.ts
+++ b/suite/e2e/support/pageObjects/onboarding/pinSection.ts
@@ -8,7 +8,6 @@ export class PinSection {
     readonly skipConfirmButton: Locator;
     readonly pinButton = (pinNumber: number): Locator =>
         this.page.getByTestId(`@pin/input/${pinNumber}`);
-    readonly submitButton: Locator;
     readonly tryAgainButton: Locator;
     readonly pinMismatch: Locator;
 
@@ -16,7 +15,6 @@ export class PinSection {
         this.skipButton = this.page.getByTestId('@onboarding/skip-button');
         this.setPinButton = this.page.getByTestId('@onboarding/set-pin-button');
         this.skipConfirmButton = this.page.getByTestId('@onboarding/skip-button-confirm');
-        this.submitButton = this.page.getByTestId('@pin/submit-button');
         this.tryAgainButton = this.page.getByTestId('@pin-mismatch/try-again-button');
         this.pinMismatch = this.page.getByTestId('@pin-mismatch');
     }

--- a/suite/e2e/support/pageObjects/recoveryModal.ts
+++ b/suite/e2e/support/pageObjects/recoveryModal.ts
@@ -8,6 +8,7 @@ export class RecoveryModal {
         this.page.getByTestId(`@recovery/select-type/${type}`);
     readonly userUnderstandsCheckbox: Locator;
     readonly startButton: Locator;
+    readonly continueButton: Locator;
     readonly successTitle: Locator;
     readonly header: Locator;
     readonly prompt: Locator;
@@ -17,9 +18,10 @@ export class RecoveryModal {
     constructor(private page: Page) {
         this.userUnderstandsCheckbox = page.getByTestId('@recovery/user-understands-checkbox');
         this.startButton = page.getByTestId('@recovery/start-button');
+        this.continueButton = page.getByTestId('@recovery/continue-button');
         this.successTitle = page.getByTestId('@recovery/success-title');
-        this.header = page.getByTestId('@modal/header');
-        this.prompt = page.getByTestId('@modal').getByTestId('@recovery/paragraph');
+        this.header = page.modalHeader;
+        this.prompt = page.modal.getByTestId('@recovery/paragraph');
     }
 
     @step()
@@ -32,9 +34,9 @@ export class RecoveryModal {
         await this.userUnderstandsCheckbox.click();
         await this.startButton.click();
         await this.selectWordCount(numberOfWords);
-        await this.page.getByTestId('@recovery/continue-button').click();
+        await this.continueButton.click();
         await this.selectRecoveryButton(type).click();
-        await this.page.getByTestId('@recovery/continue-button').click();
+        await this.continueButton.click();
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/settings/debugTab.ts
+++ b/suite/e2e/support/pageObjects/settings/debugTab.ts
@@ -21,8 +21,8 @@ export class DebugTab {
     constructor(private readonly page: Page) {
         this.suiteSyncUrlInput = page.getByTestId('@settings/debug/suite-sync/relay-url-input');
         this.suiteSyncUrlSaveButton = page.getByTestId('@settings/debug/suite-sync/save-button');
-        this.modal = page.getByTestId('@modal');
-        this.modalCloseButton = page.getByTestId('@modal/close-button');
+        this.modal = page.modal;
+        this.modalCloseButton = page.modalCloseButton;
         this.messageManagerButton = page.getByTestId(
             '@settings/debug/message-system/message-manager-button',
         );

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -128,7 +128,7 @@ export class SettingsPage {
         this.earlyAccessSkipButton = this.page.getByTestId('@settings/early-access-skip-button');
         this.settingsCloseButton = this.page.getByTestId('@suite/menu/suite-start');
         this.modal = this.page.modal;
-        this.modalCloseButton = this.page.getByTestId('@modal/close-button');
+        this.modalCloseButton = this.page.modalCloseButton;
         this.deviceLabelInput = this.page.getByTestId('@settings/device/label-input');
         this.deviceLabelSubmit = this.page.getByTestId('@settings/device/label-submit');
         this.confirmOnDevicePrompt = this.page.getByTestId('@prompts/confirm-on-device');
@@ -139,9 +139,7 @@ export class SettingsPage {
         this.checkSeedButton = this.page.getByTestId('@settings/device/check-seed-button');
         this.metadataSelectInput = this.page.getByTestId('@settings/labeling-select/input');
         this.analyticsSwitch = this.page.getByTestId('@analytics/toggle-switch');
-        this.analyticsSwitchInput = this.page
-            .getByTestId('@analytics/toggle-switch')
-            .locator('input');
+        this.analyticsSwitchInput = this.analyticsSwitch.locator('input');
         this.showLogButton = this.page.getByTestId('@settings/show-log-button');
         this.fiatCurrencyInput = this.page.getByTestId('@settings/fiat-select/input');
         this.btcUnitsInput = this.page.getByTestId('@settings/btc-units-select/input');

--- a/suite/e2e/support/pageObjects/settings/walletConnectTab.ts
+++ b/suite/e2e/support/pageObjects/settings/walletConnectTab.ts
@@ -20,7 +20,7 @@ export class WalletConnectTab {
         this.connectButton = page.getByTestId('@walletconnect/connect-button');
         this.confirmProposalButton = page.getByTestId('@walletconnect-proposal/confirm-button');
         this.cancelProposalButton = page.getByTestId('@walletconnect-proposal/cancel-button');
-        this.modal = page.getByTestId('@modal');
+        this.modal = page.modal;
         this.modalHeader = this.modal.getByTestId('@modal/header');
     }
 

--- a/suite/e2e/support/pageObjects/staking/rewardList.ts
+++ b/suite/e2e/support/pageObjects/staking/rewardList.ts
@@ -8,18 +8,10 @@ import { expect } from '../../testExtends/customMatchers';
 
 export class RewardsList {
     readonly rewardItems: Locator;
-    readonly itemDate: Locator;
-    readonly itemEpoch: Locator;
-    readonly itemCryptoAmount: Locator;
-    readonly itemFiatAmount: Locator;
     readonly itemsPerPage = 10;
 
     constructor(private readonly page: Page) {
         this.rewardItems = this.page.getByTestId('@staking/rewards-item');
-        this.itemDate = this.page.getByTestId('@staking/rewards-item/date');
-        this.itemEpoch = this.page.getByTestId('@staking/rewards-item/epoch');
-        this.itemCryptoAmount = this.page.getByTestId('@staking/rewards-item/crypto-amount');
-        this.itemFiatAmount = this.page.getByTestId('@staking/rewards-item/fiat-amount');
     }
 
     getRewardsFromPage = async () => await this.rewardItems.all();

--- a/suite/e2e/support/pageObjects/trading/approvalModal.ts
+++ b/suite/e2e/support/pageObjects/trading/approvalModal.ts
@@ -19,7 +19,7 @@ export class TradingApprovalModal {
     readonly feeAmountWithSymbol: Locator;
 
     constructor(private readonly page: Page) {
-        this.modal = this.page.getByTestId('@modal');
+        this.modal = this.page.modal;
         this.heading = this.modal.getByTestId('@modal/header');
         this.continueButton = this.modal.getByTestId('@modal/approve/continue-button');
         this.accountValue = this.modal.getByTestId('@modal/approve/account-value');

--- a/suite/e2e/support/pageObjects/trading/formInputs.ts
+++ b/suite/e2e/support/pageObjects/trading/formInputs.ts
@@ -73,9 +73,7 @@ export class TradingFormInputs {
             return;
         }
         await this.countrySelect.click();
-        await expect(this.page.getByTestId('@modal/header')).toHaveTranslation(
-            'TR_TRADING_COUNTRY',
-        );
+        await expect(this.page.modalHeader).toHaveTranslation('TR_TRADING_COUNTRY');
         await this.countryOption(countryCode).click();
         await expect(this.countryValue).toContainText(countryCode);
     }
@@ -83,9 +81,7 @@ export class TradingFormInputs {
     @step()
     async selectCountrySubdivision(subdivisionCode: string) {
         await this.countrySubdivisionSelect.click();
-        await expect(this.page.getByTestId('@modal/header')).toHaveTranslation(
-            'TR_TRADING_COUNTRY_SUBDIVISION',
-        );
+        await expect(this.page.modalHeader).toHaveTranslation('TR_TRADING_COUNTRY_SUBDIVISION');
         await this.countrySubdivisionOption(subdivisionCode).click();
         const subdivision = getCountrySubdivisionByCode(subdivisionCode);
         if (!subdivision) {
@@ -102,7 +98,7 @@ export class TradingFormInputs {
             return;
         }
         await this.currencySelect.click();
-        await expect(this.page.getByTestId('@modal/header')).toHaveTranslation('TR_CURRENCY');
+        await expect(this.page.modalHeader).toHaveTranslation('TR_CURRENCY');
         await this.currencyOption(currencyCode).click();
         await expect(this.currencySelect).toHaveValue(currencyCode.toUpperCase());
     }
@@ -114,9 +110,7 @@ export class TradingFormInputs {
             return;
         }
         await this.paymentMethodSelect.click();
-        await expect(this.page.getByTestId('@modal/header')).toHaveTranslation(
-            'TR_TRADING_PAYMENT_METHOD',
-        );
+        await expect(this.page.modalHeader).toHaveTranslation('TR_TRADING_PAYMENT_METHOD');
         await this.paymentMethodOption(method).click();
     }
 

--- a/suite/e2e/support/pageObjects/trading/quotesSection.ts
+++ b/suite/e2e/support/pageObjects/trading/quotesSection.ts
@@ -8,6 +8,7 @@ export class TradingQuotesSection {
     readonly provider: Locator;
     readonly providerOfQuote = (provider: string) =>
         this.page.getByTestId(`@trading/offers/quote-${provider}`);
+    readonly providerInList: Locator;
     readonly selectedProvider: Locator;
     readonly selectedProviderName: Locator;
     readonly loadingSpinner: Locator;
@@ -16,6 +17,7 @@ export class TradingQuotesSection {
     constructor(private readonly page: Page) {
         this.list = this.page.getByTestId('@trading/offers/quote');
         this.provider = this.page.getByTestId('@trading/offers/quote/provider');
+        this.providerInList = this.list.getByTestId('@trading/offers/quote/provider');
         this.selectedProvider = this.page.getByTestId('@trading/selected-offer-provider');
         this.selectedProviderName = this.selectedProvider.getByTestId(
             '@trading/offers/quote/provider',
@@ -60,9 +62,9 @@ export class TradingQuotesSection {
         await this.selectedProvider.click();
         await expect(this.list.first()).toBeVisible();
 
-        const offerProviderNames = (
-            await this.list.getByTestId('@trading/offers/quote/provider').allInnerTexts()
-        ).map(name => name.trim());
+        const offerProviderNames = (await this.providerInList.allInnerTexts()).map(name =>
+            name.trim(),
+        );
 
         let differentProvider: string | undefined;
         if (provider) {

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -17,7 +17,6 @@ type WalletParams = {
 export class WalletPage {
     readonly transactionSearch: Locator;
     readonly accountSearch: Locator;
-    readonly walletStakingButton: Locator;
     readonly stakeAddress: Locator;
     readonly walletExtraDropDown: Locator;
     readonly openTradingGlobalButton: Locator;
@@ -81,7 +80,6 @@ export class WalletPage {
     readonly retryLoadingAccount: Locator;
     readonly emptyAccount: Locator;
     readonly buyButton: Locator;
-    readonly sellButton: Locator;
     readonly swapButton: Locator;
     readonly overviewTabButton: Locator;
     readonly deviceConnectedStatus: Locator;
@@ -97,7 +95,6 @@ export class WalletPage {
     constructor(private readonly page: Page) {
         this.transactionSearch = this.page.getByTestId('@wallet/accounts/search-icon');
         this.accountSearch = this.page.getByTestId('@account-menu/search-input');
-        this.walletStakingButton = this.page.getByTestId('@wallet/menu/staking');
         this.stakeAddress = this.page.getByTestId('@cardano/staking/address');
         this.walletExtraDropDown = this.page.getByTestId('@wallet/menu/extra-dropdown');
         this.openTradingGlobalButton = this.page.getByTestId('@wallet/menu/wallet-trading-buy');
@@ -159,7 +156,6 @@ export class WalletPage {
         );
         this.emptyAccount = this.page.getByTestId('@accounts/empty-account');
         this.buyButton = this.page.getByTestId('@accounts/empty-account/buy');
-        this.sellButton = this.page.getByTestId('@trading/menu/wallet-trading-sell');
         this.swapButton = this.page.getByTestId('@trading/menu/wallet-trading-exchange');
         this.overviewTabButton = this.page.getByTestId('@wallet/menu/wallet-overview');
         this.deviceConnectedStatus = this.page
@@ -220,7 +216,7 @@ export class WalletPage {
         ] as WalletParams[];
         for (const account of cardanoAccounts) {
             await this.openAccount(account);
-            await this.walletStakingButton.click();
+            await this.stakingButton.click();
             await expect(this.stakeAddress).toBeVisible();
         }
     }

--- a/suite/e2e/tests/settings/t3b1-device-settings.test.ts
+++ b/suite/e2e/tests/settings/t3b1-device-settings.test.ts
@@ -28,7 +28,7 @@ test.describe('T3B1 - Device settings', { tag: ['@T3B1'] }, () => {
         async ({ settingsPage, page }) => {
             await test.step('Verify firmware modal', async () => {
                 await page.getByTestId('@settings/device/update-button').click();
-                await page.getByTestId('@modal/close-button').click();
+                await page.modalCloseButton.click();
             });
 
             await test.step("Change and verify device's name", async () => {

--- a/suite/e2e/tests/trading/navigation.test.ts
+++ b/suite/e2e/tests/trading/navigation.test.ts
@@ -61,7 +61,7 @@ test.describe('Trading - Navigation', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await test.step('Sell from account trade section', async () => {
                 await walletPage.openAccount({ symbol: 'btc' });
-                await walletPage.sellButton.click();
+                await tradingPage.sellTabButton.click();
                 await tradingPage.verifySellFormOpened(/Bitcoin/);
             });
 

--- a/suite/e2e/tests/trading/sell-inputs.test.ts
+++ b/suite/e2e/tests/trading/sell-inputs.test.ts
@@ -104,7 +104,7 @@ test.describe('Trading - Sell inputs', { tag: ['@T3W1', '@T3T1'] }, () => {
 
         await test.step('Try all % inputs on Solana', async () => {
             await walletPage.openAccount({ symbol: 'sol', atIndex: 0 });
-            await walletPage.sellButton.click();
+            await tradingPage.sellTabButton.click();
             await expect(tradingPage.inputs.swapAmountCurrencyTicker).toHaveText('SOL');
             await tradingPage.inputs.selectFiatCurrency('eur');
 

--- a/suite/e2e/tests/wallet/without-device.test.ts
+++ b/suite/e2e/tests/wallet/without-device.test.ts
@@ -53,7 +53,7 @@ test.describe('Without device', { tag: ['@T3W1', '@T3T1'] }, () => {
 
             await page.getByTestId('@send/review-button').click();
             await expect(page.getByTestId('@suite/connection-modal')).toBeVisible();
-            await page.getByTestId('@modal/close-button').click();
+            await page.modalCloseButton.click();
         });
 
         await test.step('Go to settings and verify Trezor disconnected warning', async () => {


### PR DESCRIPTION
## Description

Collapses duplicated testid literals in the e2e page objects onto a single definition, preferring an already-existing chained or composed locator over a new one. No new imports between page objects, so the import graph is unchanged.

- `@modal`, `@modal/header` and `@modal/close-button` were re-declared in eight page objects (and inlined in two tests) despite `enhancePage` exposing `page.modal`, `page.modalHeader` and `page.modalCloseButton` — the first two testids now have a single definition, `@modal/header` keeps only the variants that are legitimately chained to their own modal container
- Hoisted repeatedly inlined locators to properties in `backupSection`, `quotesSection` and `recoveryModal`; `onboardingPage.createBackupButton` now delegates to the `BackupSection` it already constructs
- `assetsSection.verifyAssetContents()` reuses the parameterized `assetName()` / `assetFiatAmount()` locators instead of rebuilding the chains
- Deleted never-referenced locators in `rewardList` (4), `pinSection` and `onboardingPage`
- Removed the `walletPage` duplicates of `stakingButton` and the trading sell tab; the two affected tests use `tradingPage.sellTabButton`

A number of cross-page-object duplicates are deliberately left in place — deduplicating them would mean importing a whole page object for one locator, or introducing a shared owner for a component reached from two features. Those are for a follow-up.

## Notes for QA

Test-infrastructure only; no product code is touched. Every change is a like-for-like locator substitution, so the affected specs should behave identically.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/locator-dedupe/web/](https://dev.suite.sldev.cz/suite-web/locator-dedupe/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=locator-dedupe&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=locator-dedupe&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-28T10:37:24.808Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Trading - DEX swap (LI.FI),User can swap ETH to USDC via LI.FI DEX" | 🙋 manual |
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-28T10:36:49.417Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->