### PR TITLE
fix(suite): show address labels in trading receive address modal

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressList.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressList.tsx
@@ -8,12 +8,14 @@ import { TradingUtxoReceiveAddressOption } from './TradingUtxoReceiveAddressOpti
 
 interface TradingUtxoReceiveAddressListProps {
     addresses: Address[];
+    addressLabels: Record<string, string | null>;
     title: ReactNode;
     account: Account;
 }
 
 export const TradingUtxoReceiveAddressList = ({
     addresses,
+    addressLabels,
     title,
     account,
 }: TradingUtxoReceiveAddressListProps) => {
@@ -31,6 +33,7 @@ export const TradingUtxoReceiveAddressList = ({
                         key={address.address}
                         account={account}
                         address={address}
+                        label={addressLabels[address.address] ?? undefined}
                     />
                 ))}
             </CardList>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.test.tsx
@@ -1,0 +1,221 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { fireEvent, screen } from '@testing-library/react';
+
+import { initialMetadataState } from '@suite/metadata';
+import { createSuiteSyncAddressId } from '@suite-common/suite-sync-storage';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
+import { type Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
+import { type Address } from '@trezor/blockchain-link-types';
+import { type WalletDescriptor } from '@trezor/device-utils';
+
+import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { TradingUtxoReceiveAddressModal } from './TradingUtxoReceiveAddressModal';
+import { extraDependenciesDesktopMock } from '../../../../../../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../../../../../../mocks/mockInitialAppState';
+import { useTradingReceiveAddressValues } from '../useTradingReceiveAddressValues';
+
+global.ResizeObserver = class MockedResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+};
+
+jest.mock('@suite/intl', () => ({
+    ...jest.requireActual('@suite/intl'),
+    Translation: ({ id }: { id: string }) => <span data-testid={id}>{id}</span>,
+}));
+
+jest.mock('../useTradingReceiveAddressValues', () => ({
+    useTradingReceiveAddressValues: jest.fn(),
+}));
+
+jest.mock(
+    'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls',
+    () => ({
+        useReceiveAddressModalControls: () => ({
+            activeModal: 'utxoAddressModal',
+            open: jest.fn(),
+            close: jest.fn(),
+        }),
+    }),
+);
+
+const OPTION = '@trading/bitcoin-receive-address-modal/option';
+const SEARCH_INPUT = '@asset-picker/search/input';
+
+const DEVICE_SSID = 'btcWallet@deviceId:0' as const;
+const WALLET_DESCRIPTOR = 'btcWallet' as WalletDescriptor;
+const ACCOUNT_DESCRIPTOR = asAccountDescriptor('btcDescriptor');
+
+const ACCOUNT_KEY = createAccountKey({
+    accountDescriptor: ACCOUNT_DESCRIPTOR,
+    networkSymbol: 'btc',
+    deviceStaticSessionId: DEVICE_SSID,
+});
+
+const mockAddress = (address: string, path: string, received: string): Address => ({
+    address,
+    path,
+    transfers: received === '0' ? 0 : 1,
+    balance: received,
+    sent: '0',
+    received,
+});
+
+const LABELED_USED = mockAddress('bc1qlabeledusedaddress', "m/84'/0'/0'/0/0", '100000');
+const UNLABELED_USED = mockAddress('bc1qunlabeledusedaddress', "m/84'/0'/0'/0/1", '200000');
+const LABELED_UNUSED = mockAddress('bc1qlabeledunusedaddress', "m/84'/0'/0'/0/2", '0');
+
+const USED_LABEL = 'Salary';
+const UNUSED_LABEL = 'Savings';
+
+const btcAccount = {
+    key: ACCOUNT_KEY,
+    descriptor: ACCOUNT_DESCRIPTOR,
+    deviceState: DEVICE_SSID,
+    accountType: 'normal',
+    visible: true,
+    empty: false,
+    symbol: 'btc',
+    networkType: 'bitcoin',
+    formattedBalance: '0.003',
+    addresses: {
+        used: [LABELED_USED, UNLABELED_USED],
+        unused: [LABELED_UNUSED],
+        change: [],
+    },
+} as unknown as Account;
+
+const mockSuiteSyncAddress = (address: string, label: string | null) => ({
+    id: createSuiteSyncAddressId(address, 'btc'),
+    address,
+    label,
+    accountDescriptor: ACCOUNT_DESCRIPTOR,
+    networkSymbol: 'btc' as const,
+});
+
+const buildState = () => ({
+    ...mockInitialAppState,
+    metadata: initialMetadataState,
+    device: {
+        ...mockInitialAppState.device,
+        selectedDevice: mockSuiteDevice({
+            connected: true,
+            available: true,
+            state: { staticSessionId: DEVICE_SSID },
+        }),
+    },
+    suiteSync: {
+        ...mockInitialAppState.suiteSync,
+        settings: { ...mockInitialAppState.suiteSync.settings, isSuiteSyncEnabled: true },
+    },
+    suiteSyncData: {
+        wallets: {
+            [WALLET_DESCRIPTOR]: {
+                wallet: { walletDescriptor: WALLET_DESCRIPTOR, label: null },
+                accounts: {},
+                addresses: {
+                    [LABELED_USED.address]: mockSuiteSyncAddress(LABELED_USED.address, USED_LABEL),
+                    [UNLABELED_USED.address]: mockSuiteSyncAddress(UNLABELED_USED.address, null),
+                    [LABELED_UNUSED.address]: mockSuiteSyncAddress(
+                        LABELED_UNUSED.address,
+                        UNUSED_LABEL,
+                    ),
+                },
+                outputs: {},
+            },
+        },
+    },
+    wallet: {
+        ...mockInitialAppState.wallet,
+        accounts: [btcAccount],
+        settings: initialWalletSettingsState,
+    } as any,
+});
+
+const renderModal = () => {
+    const store = configureMockStore({ preloadedState: buildState() });
+
+    return renderWithProviders(
+        store,
+        extraDependenciesDesktopMock.services,
+        <TradingUtxoReceiveAddressModal />,
+    );
+};
+
+const search = (value: string) => {
+    fireEvent.change(screen.getByTestId(SEARCH_INPUT), { target: { value } });
+};
+
+const optionOf = (container: HTMLElement, { address }: Address) =>
+    container.querySelector(`[id="${address}"]`)?.closest(`[data-testid="${OPTION}"]`) ?? null;
+
+describe('TradingUtxoReceiveAddressModal', () => {
+    beforeEach(() => {
+        jest.mocked(useTradingReceiveAddressValues).mockReturnValue({
+            cryptoId: 'btc',
+            extraFieldDescription: undefined,
+            tradingReceiveAddress: {
+                selectedAccount: btcAccount,
+                form: { setValue: jest.fn() },
+                onChangeAccount: jest.fn(),
+            },
+        } as unknown as ReturnType<typeof useTradingReceiveAddressValues>);
+    });
+
+    it('renders the label of a labeled address next to the address itself', () => {
+        const { container } = renderModal();
+
+        expect(screen.getAllByTestId(OPTION)).toHaveLength(3);
+
+        expect(optionOf(container, LABELED_USED)).toHaveTextContent(USED_LABEL);
+        expect(optionOf(container, LABELED_UNUSED)).toHaveTextContent(UNUSED_LABEL);
+    });
+
+    it('renders an unlabeled address without any label', () => {
+        const { container } = renderModal();
+
+        expect(screen.getAllByText(new RegExp(`^(${USED_LABEL}|${UNUSED_LABEL})$`))).toHaveLength(
+            2,
+        );
+        expect(optionOf(container, UNLABELED_USED)).not.toHaveTextContent(USED_LABEL);
+    });
+
+    it('filters addresses by label, case insensitively', () => {
+        const { container } = renderModal();
+
+        search('salary');
+
+        expect(screen.getAllByTestId(OPTION)).toHaveLength(1);
+        expect(optionOf(container, LABELED_USED)).toHaveTextContent(USED_LABEL);
+    });
+
+    it('still filters addresses by address and by path', () => {
+        const { container } = renderModal();
+
+        search(UNLABELED_USED.address);
+
+        expect(screen.getAllByTestId(OPTION)).toHaveLength(1);
+        expect(optionOf(container, UNLABELED_USED)).toBeInTheDocument();
+
+        search(LABELED_UNUSED.path);
+
+        expect(screen.getAllByTestId(OPTION)).toHaveLength(1);
+        expect(optionOf(container, LABELED_UNUSED)).toHaveTextContent(UNUSED_LABEL);
+    });
+
+    it('renders the empty state when nothing matches', () => {
+        renderModal();
+
+        search('no-such-address');
+
+        expect(screen.queryAllByTestId(OPTION)).toHaveLength(0);
+        expect(
+            screen.getByTestId('TR_TRADING_RECEIVE_ADDRESS_NOT_FOUND_TITLE'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from 'react';
 
+import { selectAddressLabelsForAccount } from '@suite/address';
 import { Translation, useTranslation } from '@suite/intl';
+import { normalizeForSearch } from '@suite-common/suite-utils';
 import { type Address } from '@trezor/blockchain-link-types';
 import { Column, Modal } from '@trezor/components';
 import { SearchAsset } from '@trezor/product-components';
 
+import { useSelector } from 'src/hooks/suite';
 import { TradingReceiveAddressEmpty } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingReceiveAddress';
 import { useReceiveAddressModalControls } from 'src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls';
 
@@ -12,6 +15,7 @@ import { TradingUtxoReceiveAddressList } from './TradingUtxoReceiveAddressList';
 import { useTradingReceiveAddressValues } from '../useTradingReceiveAddressValues';
 
 const MAX_UNUSED_ADDRESSES = 1;
+const EMPTY_ADDRESS_LABELS: Record<string, string | null> = {};
 
 export const TradingUtxoReceiveAddressModal = () => {
     const { tradingReceiveAddress } = useTradingReceiveAddressValues();
@@ -24,19 +28,36 @@ export const TradingUtxoReceiveAddressModal = () => {
 
     const addresses = account?.addresses;
 
-    const [usedAddresses, unusedAddresses] = useMemo(() => {
-        const used = addresses?.used ?? [];
-        const unused = addresses?.unused?.slice(0, MAX_UNUSED_ADDRESSES) ?? [];
-        const query = search.trim();
+    const accountAddresses = useMemo(
+        () =>
+            addresses
+                ? addresses.used
+                      .concat(addresses.unused.slice(0, MAX_UNUSED_ADDRESSES))
+                      .map(({ address }) => address)
+                : [],
+        [addresses],
+    );
 
-        const filterPredicate = (address: Address) =>
-            address.address.includes(query) || address.path.includes(query);
+    const addressLabels = useSelector(state =>
+        account
+            ? selectAddressLabelsForAccount(state, {
+                  addresses: accountAddresses,
+                  accountKey: account.key,
+                  deviceStaticId: account.deviceState,
+              })
+            : EMPTY_ADDRESS_LABELS,
+    );
 
-        const usedFiltered = used.filter(filterPredicate);
-        const unusedFiltered = unused.filter(filterPredicate);
+    const query = normalizeForSearch(search);
 
-        return [usedFiltered, unusedFiltered];
-    }, [addresses, search]);
+    const matchesQuery = ({ address, path }: Address) =>
+        normalizeForSearch(address).includes(query) ||
+        normalizeForSearch(path).includes(query) ||
+        normalizeForSearch(addressLabels[address] ?? '').includes(query);
+
+    const usedAddresses = addresses?.used.filter(matchesQuery) ?? [];
+    const unusedAddresses =
+        addresses?.unused.slice(0, MAX_UNUSED_ADDRESSES).filter(matchesQuery) ?? [];
 
     if (!account) return null;
 
@@ -76,12 +97,14 @@ export const TradingUtxoReceiveAddressModal = () => {
                         <TradingUtxoReceiveAddressList
                             account={account}
                             addresses={unusedAddresses}
+                            addressLabels={addressLabels}
                             title={<Translation id="TR_TRADING_RECEIVE_ADDRESS_NEW_ADDRESS" />}
                         />
 
                         <TradingUtxoReceiveAddressList
                             account={account}
                             addresses={usedAddresses}
+                            addressLabels={addressLabels}
                             title={<Translation id="TR_TRADING_RECEIVE_ADDRESS_USED_ADDRESSES" />}
                         />
                     </>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx
@@ -20,11 +20,13 @@ import { useTradingReceiveAddressValues } from '../useTradingReceiveAddressValue
 interface TradingUtxoReceiveAddressOptionProps {
     account: Account;
     address: BlockchainLinkAddress;
+    label?: string;
 }
 
 export const TradingUtxoReceiveAddressOption = ({
     account,
     address,
+    label,
 }: TradingUtxoReceiveAddressOptionProps) => {
     const { tradingReceiveAddress } = useTradingReceiveAddressValues();
     const modalControls = useReceiveAddressModalControls();
@@ -59,7 +61,27 @@ export const TradingUtxoReceiveAddressOption = ({
                 <Row gap={12}>
                     <TokenIcon size={24} symbol={account.symbol} />
                     <Column alignItems="flex-start">
-                        <Address isTruncated value={address.address} />
+                        {label ? (
+                            <>
+                                <Text
+                                    as="div"
+                                    typographyStyle="body-md"
+                                    ellipsisLineCount={1}
+                                    maxWidth={200}
+                                >
+                                    {label}
+                                </Text>
+                                <Address
+                                    value={address.address}
+                                    typographyStyle="body-sm"
+                                    intent="neutral"
+                                    priority="secondary"
+                                    isTruncated
+                                />
+                            </>
+                        ) : (
+                            <Address isTruncated value={address.address} />
+                        )}
                     </Column>
                 </Row>
 


### PR DESCRIPTION
## Description

The UTXO receive-address picker in trading rendered bare addresses, so labels created in the receive tab were invisible there. Labels are now read for the picked account (`selectAddressLabelsForAccount`) and shown as the row's primary line above the address; unlabeled rows are unchanged. Search matches labels too. Display only, no inline editing, because the whole row is the click target.

<img width="609" height="464" alt="Screenshot 2026-08-05 at 22 10 45" src="https://github.com/user-attachments/assets/45e6a799-ae66-4b79-9104-5db36377b142" />


## Notes for QA

- Label used addresses of a BTC account in receive, then pick that account in trading: the address modal should show the labels.
- Search the modal by label, address, derivation path.
- Check Suite sync and legacy metadata; no labels when labeling is off.
- Selecting a labeled address must still set that address on the offer.

## Related Issue

Resolve #29474

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are part of the UTXO receive-address selection modal used in trading when the receive asset is a UTXO coin (e.g., BTC). Although the static coverage map flags 23 tests, most reference the modal only transitively through shared trading components and do not render the UTXO path. The highest-confidence validation comes from tests that buy or swap into BTC and explicitly select a BTC receive address. The changed unit test has no E2E coverage and should be tracked as uncovered.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressList.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressOption.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test explicitly buys BTC and selects a BTC receive address, which renders the TradingUtxoReceiveAddressModal end-to-end. A regression in the modal's list, option rendering, or selection logic would be directly visible here.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Swaps SOL for BTC and explicitly selects a BTC receive address, so it traverses the UTXO receive-address modal. This covers the modal in a swap flow with a UTXO buy asset.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — This test swaps SOL to BTC and selects a Suite receive account for BTC, which exercises the UTXO receive address modal and its account/address selection path.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Swaps a Solana token to BTC and selects a receive address for BTC, directly hitting the UTXO receive-address modal during the swap confirmation flow.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — The test swaps ETH to BTC, so the BTC buy side must pass through the UTXO receive-address selection modal even though its primary assertions focus on custom Ethereum fees.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal.test.tsx`

_Updated: 2026-08-06T21:59:17.305Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/29474-address-labelling-not-working-in-trade/web/](https://dev.suite.sldev.cz/suite-web/29474-address-labelling-not-working-in-trade/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=29474-address-labelling-not-working-in-trade&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=29474-address-labelling-not-working-in-trade&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T22:00:14.744Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T22:00:28.125Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
