### PR TITLE
fix(trading): keep selected fiat currency after trade redirect

### DIFF
--- a/suite-common/trading/src/utils/currencyUtils.test.ts
+++ b/suite-common/trading/src/utils/currencyUtils.test.ts
@@ -38,6 +38,11 @@ describe('currencyUtils', () => {
             expect(mapFiatCurrencyCodeToBaseCurrencyCode('xyz')).toBeUndefined();
             expect(mapFiatCurrencyCodeToBaseCurrencyCode('invalid')).toBeUndefined();
         });
+
+        it('should return lowercase code for uppercase API currency code', () => {
+            expect(mapFiatCurrencyCodeToBaseCurrencyCode('EUR')).toBe('eur');
+            expect(mapFiatCurrencyCodeToBaseCurrencyCode('Czk')).toBe('czk');
+        });
     });
 
     describe('buildTradingBaseCurrencyOptionFromFiat', () => {
@@ -61,6 +66,13 @@ describe('currencyUtils', () => {
                 label: 'USD',
             });
         });
+
+        it('should keep the currency for uppercase API currency code', () => {
+            expect(buildTradingBaseCurrencyOptionFromFiat('EUR')).toStrictEqual({
+                value: 'eur',
+                label: 'EUR',
+            });
+        });
     });
 
     describe('getCurrencyLabel', () => {
@@ -70,6 +82,10 @@ describe('currencyUtils', () => {
 
         it('should return uppercase code otherwise', () => {
             expect(getCurrencyLabel('xyz')).toBe('XYZ');
+        });
+
+        it('should return label for uppercase API currency code', () => {
+            expect(getCurrencyLabel('EUR')).toBe('Euro');
         });
     });
 
@@ -82,6 +98,10 @@ describe('currencyUtils', () => {
         it('should return usd for unsupported currency', () => {
             expect(getSupportedFiatCurrencyWithFallback('btc')).toBe('usd');
             expect(getSupportedFiatCurrencyWithFallback('xyz')).toBe('usd');
+        });
+
+        it('should return lowercase code for uppercase API currency code', () => {
+            expect(getSupportedFiatCurrencyWithFallback('EUR')).toBe('eur');
         });
     });
 });

--- a/suite-common/trading/src/utils/currencyUtils.ts
+++ b/suite-common/trading/src/utils/currencyUtils.ts
@@ -10,7 +10,6 @@ import {
 } from '../currency';
 import { type TradingFiatCurrencyOption } from '../types';
 
-// Invity API works with uppercase currency codes, internally we keep them lowercase.
 const normalizeCurrencyCode = (currencyCode: string) => currencyCode.toLowerCase();
 
 export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string => {

--- a/suite-common/trading/src/utils/currencyUtils.ts
+++ b/suite-common/trading/src/utils/currencyUtils.ts
@@ -10,10 +10,16 @@ import {
 } from '../currency';
 import { type TradingFiatCurrencyOption } from '../types';
 
-export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string =>
-    isSupportedFiatCurrency(currencyCode)
-        ? supportedFiatCurrenciesMap[currencyCode]
+// Invity API works with uppercase currency codes, internally we keep them lowercase.
+const normalizeCurrencyCode = (currencyCode: string) => currencyCode.toLowerCase();
+
+export const getCurrencyLabel = (currencyCode: FiatCurrencyCode | string): string => {
+    const normalizedCode = normalizeCurrencyCode(currencyCode);
+
+    return isSupportedFiatCurrency(normalizedCode)
+        ? supportedFiatCurrenciesMap[normalizedCode]
         : currencyCode.toUpperCase();
+};
 
 export const buildTradingFiatOption = (currency: FiatCurrencyCode): TradingFiatCurrencyOption => ({
     value: currency,
@@ -27,7 +33,9 @@ export const mapFiatCurrencyCodeToBaseCurrencyCode = (
         return undefined;
     }
 
-    return isBaseCurrencyCode(fiatCurrencyCode) ? fiatCurrencyCode : undefined;
+    const normalizedCode = normalizeCurrencyCode(fiatCurrencyCode);
+
+    return isBaseCurrencyCode(normalizedCode) ? normalizedCode : undefined;
 };
 
 export const buildTradingBaseCurrencyOptionFromFiat = (
@@ -43,8 +51,10 @@ export const buildTradingBaseCurrencyOptionFromFiat = (
 };
 
 export const getSupportedFiatCurrencyWithFallback = (currencyCode: string): FiatCurrencyCode => {
-    if (isSupportedFiatCurrency(currencyCode)) {
-        return currencyCode;
+    const normalizedCode = normalizeCurrencyCode(currencyCode);
+
+    if (isSupportedFiatCurrency(normalizedCode)) {
+        return normalizedCode;
     }
 
     return DEFAULT_FIAT_CURRENCY_FALLBACK;


### PR DESCRIPTION
## Description

Invity API returns uppercase fiat currency codes (`EUR`), internally we use lowercase (`eur`). The currency helpers matched case-sensitively, so an uppercase code silently fell back to `usd`.

Hit whenever a provider redirects back into the app (e.g. BTC Direct `v1/register-identifier`): the return URL carries `EUR`, so the restored form switched to USD and providers without USD support vanished from the offers.

Helpers now normalize the code before the lookup — fixes the sell redirect, buy redirect and quote-derived fiat values at once. Fallback for genuinely unsupported codes unchanged.

## Notes for QA

- Sell -> EUR -> BTC Direct -> link identifier -> after redirect back, currency stays EUR and BTC Direct is still offered.
- Same for the buy redirect.
- Unsupported currency still falls back to USD.

## Related Issue

Resolve #29566

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=29566-sell-currency-reset-after-redirect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=29566-sell-currency-reset-after-redirect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=29566-sell-currency-reset-after-redirect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/29566-sell-currency-reset-after-redirect/web/](https://dev.suite.sldev.cz/suite-web/29566-sell-currency-reset-after-redirect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-05T20:29:46.264Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-05T20:30:28.498Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** currencyUtils.ts is a broad trading utility, so only tests whose key assertions directly involve fiat/crypto formatting, quote amounts, fee calculation, or currency conversion are recommended. The chosen set covers buy, sell, and swap flows plus fee and input handling, providing strong regression signal without running every trading test. The unit test file currencyUtils.test.ts has no E2E coverage.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/utils/currencyUtils.test.ts`
- `suite-common/trading/src/utils/currencyUtils.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test verifies exact buy-quote crypto/fiat amounts and formatted confirmation values (CZK fiat, BTC crypto), which are produced or converted by currencyUtils.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Asserts the best-offer amount in ETH and localized fiat/crypto values on the confirmation screen, directly exercising currency formatting and conversion.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Checks mocked-quote fiat amount display and confirmation preview fiat/crypto formatting for a token buy flow, making it sensitive to currencyUtils changes.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Validates fraction/Max amount calculations, fiat currency switching, and fee display in the sell form; these depend on currency/fee utilities in currencyUtils.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Verifies sell-quote fiat amounts, max fee/fiat display, and confirmation fiat/crypto values, all of which are computed via currencyUtils.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Checks DEX quote receive amounts, slippage-adjusted minimum received, and network-fee formatting (≈ $X.XX), which rely on currency conversion/formatting.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Tests custom Ethereum fee parameters and verifies calculated maximum fee in ETH and Gwei formatting, a direct use case for currencyUtils.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Covers crypto/fiat input switching, fraction/Max amount calculation, balance validation, and exchange-rate conversion for swap inputs.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Validation messages use fiat-denominated min/max thresholds; changes to currency parsing or formatting could affect how those limits are displayed.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Verifies custom fee rate application and total-amount calculation in BTC swaps, which share fee/amount formatting code with currencyUtils.
- `suite/e2e/tests/trading/swap-history.test.ts` — Displays historical send/receive amounts with symbols and formatted dates; amount rendering may be influenced by currency formatting utilities.
- `suite/e2e/tests/dashboard/assets.test.ts` — Asset grid/table view renders fiat amounts for enabled coins; currency formatting changes could affect how those balances are displayed.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/utils/currencyUtils.test.ts`

_Updated: 2026-08-05T20:27:23.884Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->