### PR TITLE
Poll signature status instead of kit's abort-based confirmation

### DIFF
--- a/networks/solana/network-solana/src/runtime/connect.test.ts
+++ b/networks/solana/network-solana/src/runtime/connect.test.ts
@@ -1,3 +1,6 @@
+import { SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, isSolanaError } from '@solana/kit';
+import type { Signature } from '@solana/kit';
+
 import { fixtures } from './__fixtures__/connect.fixture';
 import {
     buildCreateAssociatedTokenAccountInstruction,
@@ -6,7 +9,23 @@ import {
     buildTransferTransaction,
     getLamportsFromSol,
     getMinimumRequiredTokenAccountsForTransfer,
+    waitForSignatureConfirmation,
 } from './connect';
+import type { SolanaAPI } from '../types/common';
+
+const mockSignature = 'mock-signature' as Signature;
+
+const mockApi = (send: jest.Mock, epochInfoSend?: jest.Mock) =>
+    ({
+        rpc: {
+            getSignatureStatuses: jest.fn().mockReturnValue({ send }),
+            getEpochInfo: jest.fn().mockReturnValue({
+                send: epochInfoSend ?? jest.fn().mockResolvedValue({ blockHeight: 0n }),
+            }),
+        },
+    }) as unknown as SolanaAPI;
+
+const mockLastValidBlockHeight = 100n;
 
 describe('solana utils', () => {
     describe('getMinimumRequiredTokenAccountsForTransfer', () => {
@@ -110,5 +129,128 @@ describe('solana utils', () => {
     it('getLamportsFromSol', () => {
         expect(getLamportsFromSol('1')).toEqual(1000000000n);
         expect(getLamportsFromSol('0.000000001')).toEqual(1n);
+    });
+
+    describe('waitForSignatureConfirmation', () => {
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('resolves once the signature is confirmed', async () => {
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'confirmed', err: null }],
+            });
+
+            await expect(
+                waitForSignatureConfirmation(
+                    mockSignature,
+                    mockLastValidBlockHeight,
+                    mockApi(send),
+                ),
+            ).resolves.toBeUndefined();
+        });
+
+        it('throws a SolanaError when the transaction fails on-chain', async () => {
+            const send = jest.fn().mockResolvedValue({
+                value: [
+                    { confirmationStatus: null, err: { InstructionError: [0, 'GenericError'] } },
+                ],
+            });
+
+            const error = await waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send),
+            ).catch(caught => caught);
+
+            expect(isSolanaError(error)).toBe(true);
+        });
+
+        it('recovers from a transient RPC error and still confirms on the next poll', async () => {
+            jest.useFakeTimers();
+            const send = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('network blip'))
+                .mockResolvedValue({ value: [{ confirmationStatus: 'confirmed', err: null }] });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send),
+            );
+
+            await jest.advanceTimersByTimeAsync(2_000);
+
+            await expect(resultPromise).resolves.toBeUndefined();
+            expect(send).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects with a timeout once the deadline elapses without confirmation or block height exceedance', async () => {
+            jest.useFakeTimers();
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'processed', err: null }],
+            });
+            const epochInfoSend = jest.fn().mockResolvedValue({ blockHeight: 0n });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send, epochInfoSend),
+            );
+            resultPromise.catch(() => {
+                // Prevent an unhandled rejection warning before the assertion below attaches.
+            });
+
+            await jest.advanceTimersByTimeAsync(300_000);
+
+            await expect(resultPromise).rejects.toThrow(
+                'Timeout while waiting for the transaction to be confirmed.',
+            );
+        });
+
+        it('resolves when the transaction confirms between the block-height check and the final poll', async () => {
+            const send = jest
+                .fn()
+                .mockResolvedValueOnce({
+                    value: [{ confirmationStatus: 'processed', err: null }],
+                })
+                .mockResolvedValue({ value: [{ confirmationStatus: 'confirmed', err: null }] });
+            const epochInfoSend = jest
+                .fn()
+                .mockResolvedValue({ blockHeight: mockLastValidBlockHeight + 1n });
+
+            await expect(
+                waitForSignatureConfirmation(
+                    mockSignature,
+                    mockLastValidBlockHeight,
+                    mockApi(send, epochInfoSend),
+                ),
+            ).resolves.toBeUndefined();
+            expect(send).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects with a SolanaError once the block height is exceeded without confirmation', async () => {
+            jest.useFakeTimers();
+            const send = jest.fn().mockResolvedValue({
+                value: [{ confirmationStatus: 'processed', err: null }],
+            });
+            const epochInfoSend = jest
+                .fn()
+                .mockResolvedValue({ blockHeight: mockLastValidBlockHeight + 1n });
+
+            const resultPromise = waitForSignatureConfirmation(
+                mockSignature,
+                mockLastValidBlockHeight,
+                mockApi(send, epochInfoSend),
+            );
+            resultPromise.catch(() => {
+                // Prevent an unhandled rejection warning before the assertion below attaches.
+            });
+
+            await jest.advanceTimersByTimeAsync(60_000);
+
+            const error = await resultPromise.catch(caught => caught);
+            expect(isSolanaError(error, SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED)).toBe(true);
+        });
     });
 });

--- a/networks/solana/network-solana/src/runtime/connect.ts
+++ b/networks/solana/network-solana/src/runtime/connect.ts
@@ -5,6 +5,7 @@ import {
     SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_FAILED_TO_CONNECT,
     SOLANA_ERROR__RPC__TRANSPORT_HTTP_ERROR,
     SOLANA_ERROR__TRANSACTION_ERROR__BLOCKHASH_NOT_FOUND,
+    SolanaError,
     address,
     appendTransactionMessageInstruction,
     appendTransactionMessageInstructions,
@@ -16,12 +17,13 @@ import {
     getBase16Encoder,
     getCompiledTransactionMessageDecoder,
     getSignatureFromTransaction,
+    getSolanaErrorFromTransactionError,
     getTransactionDecoder,
     isSolanaError,
     isTransactionMessageWithDurableNonceLifetime,
     lamports,
     prependTransactionMessageInstructions,
-    sendAndConfirmTransactionFactory,
+    sendTransactionWithoutConfirmingFactory,
     setTransactionMessageFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/kit';
@@ -398,13 +400,88 @@ const getSendErrorMessage = (error: any) => {
     }
 };
 
+// Backstop only — confirmation normally ends with the blockhash expiry below.
+const SIGNATURE_CONFIRMATION_TIMEOUT_MS = 300_000;
+const SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS = 2_000;
+
+const isConfirmed = (status?: { confirmationStatus: string | null } | null) =>
+    status?.confirmationStatus === 'confirmed' || status?.confirmationStatus === 'finalized';
+
+// `@solana/kit`'s confirmation throws on React Native/Hermes, so poll instead.
+export const waitForSignatureConfirmation = async (
+    signature: ReturnType<typeof getSignatureFromTransaction>,
+    lastValidBlockHeight: bigint,
+    api: SolanaAPI,
+) => {
+    const deadline = Date.now() + SIGNATURE_CONFIRMATION_TIMEOUT_MS;
+
+    // A transient RPC error (timeout, 429, connection blip) is treated as "no status yet"
+    // rather than failing confirmation outright, since the tx may still land on-chain.
+    const getStatus = () =>
+        api.rpc
+            .getSignatureStatuses([signature])
+            .send()
+            .then(
+                ({ value }) => value[0],
+                () => undefined,
+            );
+
+    while (Date.now() < deadline) {
+        const status = await getStatus();
+
+        if (status?.err) {
+            throw getSolanaErrorFromTransactionError(status.err);
+        }
+        if (isConfirmed(status)) {
+            return;
+        }
+
+        // The transaction cannot land anymore once its blockhash expires — the same rule
+        // kit's confirmation applies. Reporting a timeout while the blockhash is still valid
+        // would read as a failure for a transaction that may yet confirm.
+        const currentBlockHeight = await api.rpc
+            .getEpochInfo({ commitment: 'confirmed' })
+            .send()
+            .then(
+                ({ blockHeight }) => blockHeight,
+                () => undefined,
+            );
+
+        if (currentBlockHeight !== undefined && currentBlockHeight > lastValidBlockHeight) {
+            // The tx could have confirmed between the two RPC calls above.
+            const finalStatus = await getStatus();
+
+            if (finalStatus?.err) {
+                throw getSolanaErrorFromTransactionError(finalStatus.err);
+            }
+            if (isConfirmed(finalStatus)) {
+                return;
+            }
+
+            throw new SolanaError(SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED, {
+                currentBlockHeight,
+                lastValidBlockHeight,
+            });
+        }
+
+        await new Promise(resolve => setTimeout(resolve, SIGNATURE_CONFIRMATION_POLL_INTERVAL_MS));
+    }
+
+    throw new Error('Timeout while waiting for the transaction to be confirmed.');
+};
+
 export const sendAndConfirmTransaction = async (rawTx: string, api: SolanaAPI) => {
     const transaction = await preparePushTransaction(rawTx, api);
 
     try {
         const signature = getSignatureFromTransaction(transaction);
-        const send = sendAndConfirmTransactionFactory(api);
+        const send = sendTransactionWithoutConfirmingFactory({ rpc: api.rpc });
         await send(transaction, { commitment: 'confirmed', skipPreflight: false });
+        await waitForSignatureConfirmation(
+            signature,
+            transaction.lifetimeConstraint.lastValidBlockHeight,
+            api,
+        );
 
         return signature;
     } catch (error) {


### PR DESCRIPTION
## Description

`@solana/kit`'s confirmation aborts a timeout strategy whose handler reads `e.target.reason`, which is `null` on React Native/Hermes - every confirmed transaction raised an unhandled `TypeError`. Now sends without confirming and polls `getSignatureStatuses` instead.

## Related Issue

