### PR TITLE
feat(suite): auto-select a newly connected device when none is present

### DIFF
--- a/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
+++ b/packages/suite/src/actions/suite/__fixtures__/suiteActions.ts
@@ -1,4 +1,5 @@
 import { deviceActions } from '@suite-common/device';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockConnectDevice, mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectNewlyConnectedDeviceThunk } from '@suite-common/wallet-core';
@@ -14,6 +15,7 @@ const SUITE_DEVICE_UNACQUIRED = mockSuiteDevice({
     type: 'unacquired',
     path: '2',
 });
+const SUITE_DEVICE_CONNECTED = mockSuiteDevice({ path: '1', connected: true });
 const SUITE_DEVICE_REMEMBERED = mockSuiteDevice({ connected: false });
 const CONNECT_DEVICE = mockConnectDevice({ path: '1' });
 
@@ -212,7 +214,18 @@ const selectDevice = [
     },
 ];
 
-const selectNewlyConnectedDevice = [
+type SelectNewlyConnectedDeviceFixture = {
+    description: string;
+    state: {
+        device: Partial<AppState['device']>;
+        firmware?: Partial<AppState['firmware']>;
+        suite?: Partial<AppState['suite']>;
+    };
+    newlyConnectedDevice: Device | TrezorDevice;
+    expectedNextActionType: string;
+};
+
+const selectNewlyConnectedDevice: SelectNewlyConnectedDeviceFixture[] = [
     {
         description: `select a new device`,
         state: {
@@ -234,7 +247,29 @@ const selectNewlyConnectedDevice = [
     {
         description: `doesn't select a newly connected device if it is already selected`,
         state: {
-            device: { devices: [SUITE_DEVICE], selectedDevice: SUITE_DEVICE },
+            device: {
+                devices: [SUITE_DEVICE_CONNECTED],
+                selectedDevice: SUITE_DEVICE_CONNECTED,
+            },
+            suite: {},
+        },
+        newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.rejected.type,
+    },
+    {
+        description: `selects a newly connected device when the selected wallet has no device connected`,
+        state: {
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            suite: {},
+        },
+        newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,
+        expectedNextActionType: selectNewlyConnectedDeviceThunk.fulfilled.type,
+    },
+    {
+        description: `doesn't select a newly connected device during a firmware installation`,
+        state: {
+            device: { devices: [SUITE_DEVICE_REMEMBERED], selectedDevice: SUITE_DEVICE_REMEMBERED },
+            firmware: { status: 'started' },
             suite: {},
         },
         newlyConnectedDevice: SUITE_DEVICE_UNACQUIRED,

--- a/packages/suite/src/actions/suite/suiteActions.test.ts
+++ b/packages/suite/src/actions/suite/suiteActions.test.ts
@@ -115,7 +115,7 @@ describe('Suite Actions', () => {
 
     fixtures.selectNewlyConnectedDevice.forEach(f => {
         it(`selectNewlyConnectedDevice: ${f.description}`, async () => {
-            const state = getInitialState({}, f.state.device, undefined);
+            const state = getInitialState({}, f.state.device, undefined, f.state.firmware);
             const store = mockStore(state);
 
             const device = f.newlyConnectedDevice;

--- a/suite-common/device/src/deviceSelectors.ts
+++ b/suite-common/device/src/deviceSelectors.ts
@@ -23,7 +23,7 @@ import {
     getSortedDevicesWithoutInstances,
     getStatus,
 } from '@suite-common/suite-utils';
-import { type Device, type DeviceState, type StaticSessionId } from '@trezor/connect';
+import { type DeviceState, type StaticSessionId } from '@trezor/connect';
 import {
     DeviceModelInternal,
     getFirmwareRevision,
@@ -612,11 +612,6 @@ export const selectDeviceDefaultBackupType = createMemoizedSelector(
 
         return deviceModel ? defaultBackupTypeMap[deviceModel] : 'shamir-single';
     },
-);
-
-export const selectIsSameOrNewDevice = createMemoizedSelector(
-    [selectSelectedDevice, (_state, device: Device | TrezorDevice | undefined) => device],
-    (selectedDevice, device) => selectedDevice === undefined || device?.id === selectedDevice.id,
 );
 
 export const selectDeviceFirmwareRevision = createMemoizedSelector([selectSelectedDevice], device =>

--- a/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
@@ -1,0 +1,307 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+
+import { getShouldSelectConnectedDevice } from './getShouldSelectConnectedDevice';
+
+type Descriptor = TrezorDevice['descriptor'];
+
+// `descriptor.id` is what identifies a physical device across reconnects, so it is set explicitly
+// here - it is the only thing tying the bootloader instance below back to `DEVICE_A`.
+const descriptorA: Descriptor = { apiType: 'usb', id: 'descriptor-a' };
+const descriptorB: Descriptor = { apiType: 'usb', id: 'descriptor-b' };
+
+const withDescriptor = (device: TrezorDevice, descriptor: Descriptor): TrezorDevice => ({
+    ...device,
+    descriptor,
+});
+
+const DEVICE_A = withDescriptor(
+    mockSuiteDevice({ path: '1', connected: true }, { device_id: 'device-a' }),
+    descriptorA,
+);
+const DEVICE_A_REMEMBERED = withDescriptor(
+    mockSuiteDevice({ path: '', connected: false, remember: true }, { device_id: 'device-a' }),
+    descriptorA,
+);
+// Reconnecting in bootloader mode, so without an `id`, on a path assigned by the new connection.
+const DEVICE_A_BOOTLOADER = withDescriptor(
+    mockSuiteDevice({ path: '3', type: 'unacquired', connected: true }),
+    descriptorA,
+);
+const DEVICE_B = withDescriptor(
+    mockSuiteDevice({ path: '2', connected: true }, { device_id: 'device-b' }),
+    descriptorB,
+);
+const DEVICE_B_UNACQUIRED = withDescriptor(
+    mockSuiteDevice({ path: '2', type: 'unacquired', connected: true }),
+    descriptorB,
+);
+
+const NO_FIRMWARE_UPDATE = { status: 'initial' } as const;
+
+describe('getShouldSelectConnectedDevice', () => {
+    it('selects nothing when no device is connected', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: undefined,
+                selectedDevice: DEVICE_A,
+                physicalDeviceWallets: [DEVICE_A],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'no-connected-device' });
+    });
+
+    it('selects the first device when no wallet is selected yet', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_A,
+                selectedDevice: undefined,
+                physicalDeviceWallets: [DEVICE_A],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
+    });
+
+    it('selects the device of the selected remembered wallet when it connects', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_A,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'same-device' });
+    });
+
+    it('keeps the selection when the selected wallet already has its device connected', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B,
+                selectedDevice: DEVICE_A,
+                physicalDeviceWallets: [DEVICE_A, DEVICE_B],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'selected-device-connected' });
+    });
+
+    it('selects a connected device when the selected wallet has no device present', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+
+    it('selects an unacquired device, which is how a device pairing over THP shows up first', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+
+    it('keeps the selection when another device is connected too, as the intent is ambiguous', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A, DEVICE_B],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-connected' });
+    });
+
+    it('does not count two wallets of one connected device as two devices', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [
+                    DEVICE_A_REMEMBERED,
+                    DEVICE_B,
+                    { ...DEVICE_B, instance: 2 } as TrezorDevice,
+                ],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+
+    it('does not take two unacquired devices for one just because neither has an id', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_BOOTLOADER,
+                physicalDeviceWallets: [DEVICE_A_BOOTLOADER, DEVICE_B_UNACQUIRED],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'selected-device-connected' });
+    });
+
+    // A device in bootloader mode reports `id: null` rather than omitting it.
+    it('does not take two devices in bootloader mode for one just because both report a null id', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: { ...DEVICE_B, id: null } as TrezorDevice,
+                selectedDevice: { ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice,
+                physicalDeviceWallets: [{ ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice],
+                firmware: NO_FIRMWARE_UPDATE,
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+});
+
+// The device being updated disconnects and reconnects repeatedly, in bootloader mode and without
+// its `id`, so every state of the flow has to keep an unrelated device from being taken for it,
+// not only the installation itself.
+describe('getShouldSelectConnectedDevice during a firmware update', () => {
+    it('does not select an unrelated device while the installation is running', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'started', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('does not select an unrelated device while the updated device pairs over THP', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'thp-pairing', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('does not select an unrelated device while the seed backup is being confirmed', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'check-seed', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    // `done` is set the moment Connect resolves, while the device still reboots to normal mode.
+    it('does not select an unrelated device after the update is done', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'done', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    // A half-updated device is the one most likely to reconnect erratically.
+    it('does not select an unrelated device after the update failed', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'error', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('does not select an unrelated device when no device was cached', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
+                firmware: { status: 'started' },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('does not match two devices whose descriptor reports no id', () => {
+        const noDescriptorId: Descriptor = { apiType: 'usb', id: null };
+
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: withDescriptor(DEVICE_B_UNACQUIRED, noDescriptorId),
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED],
+                firmware: {
+                    status: 'started',
+                    cachedDevice: withDescriptor(DEVICE_A, noDescriptorId),
+                },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('selects the updated device when it reconnects in bootloader mode without its id', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_A_BOOTLOADER,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A_BOOTLOADER],
+                firmware: { status: 'started', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'only-connected-device' });
+    });
+
+    // The updated device is removed from the list while it reboots unless it is remembered, which
+    // leaves nothing selected - and an empty selection must not become a way in for another device.
+    it('does not select an unrelated device while nothing is selected', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_B_UNACQUIRED,
+                selectedDevice: undefined,
+                physicalDeviceWallets: [DEVICE_B_UNACQUIRED],
+                firmware: { status: 'done', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: false, reason: 'other-device-firmware-update' });
+    });
+
+    it('selects the updated device while nothing is selected', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_A,
+                selectedDevice: undefined,
+                physicalDeviceWallets: [DEVICE_A],
+                firmware: { status: 'done', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
+    });
+
+    // `descriptor.id` is scoped to the transport, so a device updated over USB and reconnecting
+    // over Bluetooth is recognised by its `id` instead.
+    it('selects the updated device when it comes back over another transport', () => {
+        const bluetoothDescriptor: Descriptor = { apiType: 'bluetooth', id: 'bluetooth-a' };
+
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: withDescriptor(DEVICE_A, bluetoothDescriptor),
+                selectedDevice: undefined,
+                physicalDeviceWallets: [withDescriptor(DEVICE_A, bluetoothDescriptor)],
+                firmware: { status: 'done', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'no-selected-device' });
+    });
+
+    it('selects the updated device when it comes back acquired with its id', () => {
+        expect(
+            getShouldSelectConnectedDevice({
+                connectedDevice: DEVICE_A,
+                selectedDevice: DEVICE_A_REMEMBERED,
+                physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A],
+                firmware: { status: 'done', cachedDevice: DEVICE_A },
+            }),
+        ).toEqual({ shouldSelect: true, reason: 'same-device' });
+    });
+});

--- a/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.test.ts
@@ -40,10 +40,10 @@ const DEVICE_B_UNACQUIRED = withDescriptor(
 const NO_FIRMWARE_UPDATE = { status: 'initial' } as const;
 
 describe('getShouldSelectConnectedDevice', () => {
-    it('selects nothing when no device is connected', () => {
+    it('selects nothing when no device is being connected', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: undefined,
+                incomingDevice: undefined,
                 selectedDevice: DEVICE_A,
                 physicalDeviceWallets: [DEVICE_A],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -54,7 +54,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('selects the first device when no wallet is selected yet', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_A,
+                incomingDevice: DEVICE_A,
                 selectedDevice: undefined,
                 physicalDeviceWallets: [DEVICE_A],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -65,7 +65,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('selects the device of the selected remembered wallet when it connects', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_A,
+                incomingDevice: DEVICE_A,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -76,7 +76,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('keeps the selection when the selected wallet already has its device connected', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B,
+                incomingDevice: DEVICE_B,
                 selectedDevice: DEVICE_A,
                 physicalDeviceWallets: [DEVICE_A, DEVICE_B],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -87,7 +87,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('selects a connected device when the selected wallet has no device present', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B,
+                incomingDevice: DEVICE_B,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -98,7 +98,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('selects an unacquired device, which is how a device pairing over THP shows up first', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -109,7 +109,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('keeps the selection when another device is connected too, as the intent is ambiguous', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B,
+                incomingDevice: DEVICE_B,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A, DEVICE_B],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -120,7 +120,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('does not count two wallets of one connected device as two devices', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B,
+                incomingDevice: DEVICE_B,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [
                     DEVICE_A_REMEMBERED,
@@ -135,7 +135,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('does not take two unacquired devices for one just because neither has an id', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_BOOTLOADER,
                 physicalDeviceWallets: [DEVICE_A_BOOTLOADER, DEVICE_B_UNACQUIRED],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -147,7 +147,7 @@ describe('getShouldSelectConnectedDevice', () => {
     it('does not take two devices in bootloader mode for one just because both report a null id', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: { ...DEVICE_B, id: null } as TrezorDevice,
+                incomingDevice: { ...DEVICE_B, id: null } as TrezorDevice,
                 selectedDevice: { ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice,
                 physicalDeviceWallets: [{ ...DEVICE_A_REMEMBERED, id: null } as TrezorDevice],
                 firmware: NO_FIRMWARE_UPDATE,
@@ -163,7 +163,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device while the installation is running', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'started', cachedDevice: DEVICE_A },
@@ -174,7 +174,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device while the updated device pairs over THP', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'thp-pairing', cachedDevice: DEVICE_A },
@@ -185,7 +185,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device while the seed backup is being confirmed', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'check-seed', cachedDevice: DEVICE_A },
@@ -197,7 +197,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device after the update is done', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'done', cachedDevice: DEVICE_A },
@@ -209,7 +209,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device after the update failed', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'error', cachedDevice: DEVICE_A },
@@ -220,7 +220,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device when no device was cached', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_B_UNACQUIRED],
                 firmware: { status: 'started' },
@@ -233,7 +233,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
 
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: withDescriptor(DEVICE_B_UNACQUIRED, noDescriptorId),
+                incomingDevice: withDescriptor(DEVICE_B_UNACQUIRED, noDescriptorId),
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED],
                 firmware: {
@@ -247,7 +247,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('selects the updated device when it reconnects in bootloader mode without its id', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_A_BOOTLOADER,
+                incomingDevice: DEVICE_A_BOOTLOADER,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A_BOOTLOADER],
                 firmware: { status: 'started', cachedDevice: DEVICE_A },
@@ -260,7 +260,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('does not select an unrelated device while nothing is selected', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_B_UNACQUIRED,
+                incomingDevice: DEVICE_B_UNACQUIRED,
                 selectedDevice: undefined,
                 physicalDeviceWallets: [DEVICE_B_UNACQUIRED],
                 firmware: { status: 'done', cachedDevice: DEVICE_A },
@@ -271,7 +271,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('selects the updated device while nothing is selected', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_A,
+                incomingDevice: DEVICE_A,
                 selectedDevice: undefined,
                 physicalDeviceWallets: [DEVICE_A],
                 firmware: { status: 'done', cachedDevice: DEVICE_A },
@@ -286,7 +286,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
 
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: withDescriptor(DEVICE_A, bluetoothDescriptor),
+                incomingDevice: withDescriptor(DEVICE_A, bluetoothDescriptor),
                 selectedDevice: undefined,
                 physicalDeviceWallets: [withDescriptor(DEVICE_A, bluetoothDescriptor)],
                 firmware: { status: 'done', cachedDevice: DEVICE_A },
@@ -297,7 +297,7 @@ describe('getShouldSelectConnectedDevice during a firmware update', () => {
     it('selects the updated device when it comes back acquired with its id', () => {
         expect(
             getShouldSelectConnectedDevice({
-                connectedDevice: DEVICE_A,
+                incomingDevice: DEVICE_A,
                 selectedDevice: DEVICE_A_REMEMBERED,
                 physicalDeviceWallets: [DEVICE_A_REMEMBERED, DEVICE_A],
                 firmware: { status: 'done', cachedDevice: DEVICE_A },

--- a/suite-common/device/src/getShouldSelectConnectedDevice.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.ts
@@ -34,7 +34,7 @@ type FirmwareState = {
 
 type GetShouldSelectConnectedDeviceParams = {
     /** The device that has just connected. */
-    connectedDevice: Device | TrezorDevice | undefined;
+    incomingDevice: Device | TrezorDevice | undefined;
     /** The wallet selected so far, whose device may or may not be present. */
     selectedDevice: TrezorDevice | undefined;
     /** All wallets of all physical devices, i.e. `selectPhysicalDeviceWallets`. */
@@ -43,8 +43,16 @@ type GetShouldSelectConnectedDeviceParams = {
 };
 
 /**
- * `descriptor.id` identifies the physical device across reconnects, unlike `path`, which is
- * assigned per connection, and unlike `id`, which a device in bootloader mode does not report.
+ * Neither identifier alone recognises a device that comes back, so both are compared:
+ *
+ * - `descriptor.id` is stable across reconnects, unlike `path`, which is assigned per connection,
+ *   and it is reported in bootloader mode, unlike `id`. It is scoped to the transport that reports
+ *   it, though - a device reached over USB and over Bluetooth has a different one of each.
+ * - `id` is the same on every transport, but a device in bootloader mode does not report it.
+ *
+ * What is left uncovered is a device in bootloader mode arriving on another transport than it left
+ * on, which has nothing in common with the device it was. It is then taken for an unrelated device,
+ * which is the safe way to be wrong here: nothing is selected, rather than the wrong wallet.
  */
 const isSamePhysicalDevice = (
     a: Device | TrezorDevice | undefined,
@@ -58,8 +66,7 @@ const isSamePhysicalDevice = (
         return true;
     }
 
-    // `descriptor.id` is scoped to the transport, so the same device reached over another one does
-    // not match by it. `id` is reported whenever the device is not in bootloader mode.
+    // Same as above: a device that reports no `id` must not match another one that reports none.
     return a?.id != null && a.id === b?.id;
 };
 
@@ -69,24 +76,25 @@ const isSamePhysicalDevice = (
  * the state it needs.
  */
 export const getShouldSelectConnectedDevice = ({
-    connectedDevice,
+    incomingDevice,
     selectedDevice,
     physicalDeviceWallets,
     firmware,
 }: GetShouldSelectConnectedDeviceParams): DeviceSelectionDecision => {
-    if (connectedDevice === undefined) {
+    // This function should be called when there is an incoming device being connected, but just to cover all cases:
+    if (incomingDevice === undefined) {
         return { shouldSelect: false, reason: 'no-connected-device' };
     }
 
-    // Checked before anything else: the device being updated disconnects and reconnects, and while
-    // it is away the selection can end up empty, which would otherwise let any device take it.
-    // While an update is running, only the device it started on may take the selection.
+    // Checked before anything else: while an update runs, no device may take the selection - except
+    // the device being updated, which is what the comparison is for. It disconnects and reconnects
+    // in bootloader mode, and while it is away the selection can end up empty, which would
+    // otherwise let any device take it. Its reconnect is also the only chance to select it again.
     // `status` covers the whole flow, not just the installation: the device also reconnects while
     // pairing over THP, after the update is `done` and after it failed.
-    if (
-        firmware.status !== 'initial' &&
-        !isSamePhysicalDevice(firmware.cachedDevice, connectedDevice)
-    ) {
+    const isDeviceBeingUpdated = isSamePhysicalDevice(firmware.cachedDevice, incomingDevice);
+
+    if (firmware.status !== 'initial' && !isDeviceBeingUpdated) {
         return { shouldSelect: false, reason: 'other-device-firmware-update' };
     }
 
@@ -94,10 +102,10 @@ export const getShouldSelectConnectedDevice = ({
         return { shouldSelect: true, reason: 'no-selected-device' };
     }
 
-    // Compared only when the connected device reports an `id`, otherwise two devices that both
+    // Compared only when the incoming device reports an `id`, otherwise two devices that both
     // lack one - an unacquired device has none and a device in bootloader mode reports `null` -
     // would look like a match.
-    if (connectedDevice.id != null && connectedDevice.id === selectedDevice.id) {
+    if (incomingDevice.id != null && incomingDevice.id === selectedDevice.id) {
         return { shouldSelect: true, reason: 'same-device' };
     }
 
@@ -108,7 +116,7 @@ export const getShouldSelectConnectedDevice = ({
     // Wallets are matched by path, because an unacquired device has no `id` yet and a device
     // reconnecting in bootloader mode reports none either.
     const isOnlyConnectedDevice = physicalDeviceWallets.every(
-        wallet => !wallet.connected || wallet.path === connectedDevice.path,
+        wallet => !wallet.connected || wallet.path === incomingDevice.path,
     );
 
     return isOnlyConnectedDevice

--- a/suite-common/device/src/getShouldSelectConnectedDevice.ts
+++ b/suite-common/device/src/getShouldSelectConnectedDevice.ts
@@ -1,0 +1,117 @@
+import { type FirmwareStatus, type TrezorDevice } from '@suite-common/suite-types';
+import { type Device } from '@trezor/connect';
+
+/** Why the connected device takes the selection over. */
+export type SelectDeviceReason =
+    /** No wallet is selected yet, the first device that shows up takes the selection. */
+    | 'no-selected-device'
+    /** The physical device of the selected wallet, remembered or freshly reconnected. */
+    | 'same-device'
+    /** The selected wallet has no device present and nothing else competes for the selection. */
+    | 'only-connected-device';
+
+/** Why the currently selected wallet keeps the selection. */
+export type KeepSelectionReason =
+    /** Nothing connected, so there is nothing to select. */
+    | 'no-connected-device'
+    /** The selected wallet already has its device present. */
+    | 'selected-device-connected'
+    /** Another device is present, so it is not clear which one the user means. */
+    | 'other-device-connected'
+    /** A firmware update is running and this is not the device being updated. */
+    | 'other-device-firmware-update';
+
+/** Paired with its reason, so that a reason cannot end up on the verdict it does not belong to. */
+export type DeviceSelectionDecision =
+    | { shouldSelect: true; reason: SelectDeviceReason }
+    | { shouldSelect: false; reason: KeepSelectionReason };
+
+/** Only the firmware state this decision needs, so that the caller may pass the whole reducer. */
+type FirmwareState = {
+    status: FirmwareStatus | 'error';
+    cachedDevice?: TrezorDevice;
+};
+
+type GetShouldSelectConnectedDeviceParams = {
+    /** The device that has just connected. */
+    connectedDevice: Device | TrezorDevice | undefined;
+    /** The wallet selected so far, whose device may or may not be present. */
+    selectedDevice: TrezorDevice | undefined;
+    /** All wallets of all physical devices, i.e. `selectPhysicalDeviceWallets`. */
+    physicalDeviceWallets: readonly TrezorDevice[];
+    firmware: FirmwareState;
+};
+
+/**
+ * `descriptor.id` identifies the physical device across reconnects, unlike `path`, which is
+ * assigned per connection, and unlike `id`, which a device in bootloader mode does not report.
+ */
+const isSamePhysicalDevice = (
+    a: Device | TrezorDevice | undefined,
+    b: Device | TrezorDevice | undefined,
+) => {
+    const descriptorId = a?.descriptor?.id;
+
+    // A nullish `descriptor.id` means "unknown", not "no id": it is optional in the transport
+    // layer and old bridge does not report it at all. Two unknowns must never look like a match.
+    if (descriptorId != null && descriptorId === b?.descriptor?.id) {
+        return true;
+    }
+
+    // `descriptor.id` is scoped to the transport, so the same device reached over another one does
+    // not match by it. `id` is reported whenever the device is not in bootloader mode.
+    return a?.id != null && a.id === b?.id;
+};
+
+/**
+ * Decides whether a newly connected device takes over the selection from the currently selected
+ * wallet. Pure, so that the rules can be read and tested in one place - the caller only feeds it
+ * the state it needs.
+ */
+export const getShouldSelectConnectedDevice = ({
+    connectedDevice,
+    selectedDevice,
+    physicalDeviceWallets,
+    firmware,
+}: GetShouldSelectConnectedDeviceParams): DeviceSelectionDecision => {
+    if (connectedDevice === undefined) {
+        return { shouldSelect: false, reason: 'no-connected-device' };
+    }
+
+    // Checked before anything else: the device being updated disconnects and reconnects, and while
+    // it is away the selection can end up empty, which would otherwise let any device take it.
+    // While an update is running, only the device it started on may take the selection.
+    // `status` covers the whole flow, not just the installation: the device also reconnects while
+    // pairing over THP, after the update is `done` and after it failed.
+    if (
+        firmware.status !== 'initial' &&
+        !isSamePhysicalDevice(firmware.cachedDevice, connectedDevice)
+    ) {
+        return { shouldSelect: false, reason: 'other-device-firmware-update' };
+    }
+
+    if (selectedDevice === undefined) {
+        return { shouldSelect: true, reason: 'no-selected-device' };
+    }
+
+    // Compared only when the connected device reports an `id`, otherwise two devices that both
+    // lack one - an unacquired device has none and a device in bootloader mode reports `null` -
+    // would look like a match.
+    if (connectedDevice.id != null && connectedDevice.id === selectedDevice.id) {
+        return { shouldSelect: true, reason: 'same-device' };
+    }
+
+    if (selectedDevice.connected) {
+        return { shouldSelect: false, reason: 'selected-device-connected' };
+    }
+
+    // Wallets are matched by path, because an unacquired device has no `id` yet and a device
+    // reconnecting in bootloader mode reports none either.
+    const isOnlyConnectedDevice = physicalDeviceWallets.every(
+        wallet => !wallet.connected || wallet.path === connectedDevice.path,
+    );
+
+    return isOnlyConnectedDevice
+        ? { shouldSelect: true, reason: 'only-connected-device' }
+        : { shouldSelect: false, reason: 'other-device-connected' };
+};

--- a/suite-common/device/src/index.ts
+++ b/suite-common/device/src/index.ts
@@ -4,6 +4,7 @@ export type * from './deviceDeps';
 export * from './deviceReducer';
 export * from './deviceSelectors';
 export * from './deviceUtils';
+export * from './getShouldSelectConnectedDevice';
 export * from './sortDevices';
 export * from './usePinHook';
 export { getIsIgnoredEntropyCheckError } from './services/getIsIgnoredEntropyCheckError';

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -1,10 +1,14 @@
 import {
     DEVICE_MODULE_PREFIX,
     type DeviceRootState,
+    type KeepSelectionReason,
     deviceActions,
+    getShouldSelectConnectedDevice,
     selectDevices,
-    selectIsSameOrNewDevice,
+    selectPhysicalDeviceWallets,
+    selectSelectedDevice,
 } from '@suite-common/device';
+import { type FirmwareRootState, selectFirmware } from '@suite-common/firmware';
 import { createThunk } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { getSelectedDevice, sortByTimestamp } from '@suite-common/suite-utils';
@@ -51,19 +55,26 @@ export const selectDeviceThunk = createThunk<
     },
 );
 
-type SelectNewlyConnectedDeviceThunkState = DeviceRootState;
+type SelectNewlyConnectedDeviceThunkState = DeviceRootState & FirmwareRootState;
 
 export const selectNewlyConnectedDeviceThunk = createThunk<
     void,
     SelectDeviceThunkParams,
-    { state: SelectNewlyConnectedDeviceThunkState }
+    { state: SelectNewlyConnectedDeviceThunkState; rejectValue: KeepSelectionReason }
 >(
     `${DEVICE_MODULE_PREFIX}/selectNewlyConnectedDevice`,
     ({ device }, { dispatch, getState, rejectWithValue }) => {
-        if (!isNative() && !selectIsSameOrNewDevice(getState(), device)) {
-            // Select automatically when it is the first known device (none selected),
-            // or when we connected physical device corresponding to a selected remembered wallet.
-            return rejectWithValue('no-need-to-select');
+        const { shouldSelect, reason } = getShouldSelectConnectedDevice({
+            connectedDevice: device,
+            selectedDevice: selectSelectedDevice(getState()),
+            physicalDeviceWallets: selectPhysicalDeviceWallets(getState()),
+            firmware: selectFirmware(getState()),
+        });
+
+        // Mobile has a single device at a time, so it always follows the one that connected.
+        if (!isNative() && !shouldSelect) {
+            // Rejected with the reason, so that it is visible in the action and in the logs.
+            return rejectWithValue(reason);
         }
 
         dispatch(selectDeviceThunk({ device }));

--- a/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
+++ b/suite-common/wallet-core/src/discovery/selectDeviceThunk.ts
@@ -64,15 +64,21 @@ export const selectNewlyConnectedDeviceThunk = createThunk<
 >(
     `${DEVICE_MODULE_PREFIX}/selectNewlyConnectedDevice`,
     ({ device }, { dispatch, getState, rejectWithValue }) => {
+        // Mobile has a single device at a time, so it always follows the one that connected.
+        if (isNative()) {
+            dispatch(selectDeviceThunk({ device }));
+
+            return;
+        }
+
         const { shouldSelect, reason } = getShouldSelectConnectedDevice({
-            connectedDevice: device,
+            incomingDevice: device,
             selectedDevice: selectSelectedDevice(getState()),
             physicalDeviceWallets: selectPhysicalDeviceWallets(getState()),
             firmware: selectFirmware(getState()),
         });
 
-        // Mobile has a single device at a time, so it always follows the one that connected.
-        if (!isNative() && !shouldSelect) {
+        if (!shouldSelect) {
             // Rejected with the reason, so that it is visible in the action and in the logs.
             return rejectWithValue(reason);
         }


### PR DESCRIPTION
Switch to a newly connected device when the selected wallet has no device connected (e.g. a remembered one) and nothing else competes for the selection.

Skipped during a firmware installation, because the updated device disconnects and reconnects in bootloader mode without its `id`, and must not be taken for an unrelated newly connected device.

Closes #30929

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Notes for QA

To test out:
- have TS7 already paried
- pair another wired device
- turn off BT on TS7 
- select the wired device
- disconnect the Wired device
- turn ON BT on TS7
- observe that TS7 wallet is selected

**Please test that this process doesn't break the update FW process of some wired device** (do onboarding on a wirde device, and during that flow, connect the TS7 via BT as described above)

**Also please test that auto-selecting still works after a firmware update is over** — both after a successful one and after a cancelled/failed one:
- do a FW update on a wired device, then close the firmware modal
- disconnect the wired device
- turn ON BT on TS7 and observe that the TS7 wallet is selected
- repeat the same, but cancel the FW update instead of finishing it

Auto-selecting is deliberately suspended while a firmware update is in progress (the updated device reconnects in bootloader mode without its id and must not be taken for an unrelated device), and it is resumed when the firmware flow is closed. If the flow ever ends without being closed properly, auto-selecting would stay off until the app is restarted, which is what this scenario checks.

## Related Issue

Resolve #30929

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/30929-bt-device-auto-connect/web/](https://dev.suite.sldev.cz/suite-web/30929-bt-device-auto-connect/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on device selection logic (getShouldSelectConnectedDevice) and its use in selectors and the discovery thunk. Risk is concentrated in flows that switch, reconnect, eject, or discover wallets. The recommended high-priority tests target discovery, multi-session device acquisition, and wallet rediscovery. Medium-priority tests extend coverage to passphrase reconnection, remembered devices, device forgetting, and disconnected-state handling. The remaining changed files are test fixtures, unit tests, or an export index with no e2e coverage needed.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `suite-common/device/src/deviceSelectors.ts`
- `suite-common/device/src/getShouldSelectConnectedDevice.test.ts`
- `suite-common/device/src/getShouldSelectConnectedDevice.ts`
- `suite-common/device/src/index.ts`
- `suite-common/wallet-core/src/discovery/selectDeviceThunk.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Directly exercises device ejection, adding a standard wallet, and discovery — all flows that depend on selecting the correct connected device via the changed device selection logic and discovery thunk.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session stealing/reclaiming across tabs and the 'Use Here' vs 'Connected' device status, which directly relies on device selection and acquisition logic touched by the changed selectors and thunk.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates many coins, triggers discovery, and verifies recovery after a page reload mid-discovery — a scenario where selectDeviceThunk and device selection decisions are heavily exercised.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — Forgetting devices removes them from the device pool; regressions in device selection could cause stale selection state or incorrect onboarding redirects after a device is forgotten.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — Covers remembered devices while the emulator is powered off and after reconnection; device selection must correctly fall back to and resume from a remembered wallet state.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Adds a hidden wallet, disconnects/reconnects the device, and verifies cached passphrase wallets remain selectable — directly tests device selection after reconnect.
- `suite/e2e/tests/wallet/without-device.test.ts` — Powers off the device mid-send flow and checks disconnected state handling; the changed selection logic controls how Suite behaves when the previously selected device disappears.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/suite/src/actions/suite/__fixtures__/suiteActions.ts`
- `packages/suite/src/actions/suite/suiteActions.test.ts`
- `suite-common/device/src/getShouldSelectConnectedDevice.test.ts`
- `suite-common/device/src/index.ts`

_Updated: 2026-08-17T12:58:56.363Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=30929-bt-device-auto-connect&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=30929-bt-device-auto-connect&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=30929-bt-device-auto-connect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-17T13:01:41.668Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-17T13:00:39.786Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
