### PR TITLE
fix(suite-native): do not uppercase vault token symbol

### DIFF
--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -208,7 +208,7 @@ export const StablecoinYieldTokenOverview = ({
                   }),
                   contractAddress: toTokenAddress(vault.token.address),
                   symbol: account.symbol,
-                  tokenSymbol: toTokenSymbol(vault.token.symbol.toUpperCase()),
+                  tokenSymbol: toTokenSymbol(vault.token.symbol),
               }
             : null;
     const hasApyBreakdown = vault.rewardRate.components.length > 0;

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -144,7 +144,7 @@ export const resolveYieldFlowData = ({
         apy,
         bonusRewardTokenSymbol: protocolIncentiveRewardToken?.symbol ?? null,
         providerName,
-        tokenSymbol: toTokenSymbol(vault.token.symbol.toUpperCase()),
+        tokenSymbol: toTokenSymbol(vault.token.symbol),
         vault,
         vaultTokenName,
         vaultTokenSymbol,

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldListData.ts
@@ -96,7 +96,7 @@ export const useStablecoinYieldListData = () => {
                 continue;
             }
 
-            const stablecoinSymbol = toTokenSymbol(vault.token.symbol.toUpperCase());
+            const stablecoinSymbol = toTokenSymbol(vault.token.symbol);
 
             const apy = vault.rewardRate.total
                 ? Number((vault.rewardRate.total * 100).toFixed(2))

--- a/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
@@ -95,8 +95,8 @@ export const YieldWithdrawCompleteScreen = () => {
         }
 
         const { completedAmount } = session.result;
-        const underlyingSymbol = toTokenSymbol(vault.token.symbol.toUpperCase());
-        const vaultTokenSymbol = toTokenSymbol(vault.outputToken.symbol.toUpperCase());
+        const underlyingSymbol = toTokenSymbol(vault.token.symbol);
+        const vaultTokenSymbol = toTokenSymbol(vault.outputToken.symbol);
         const receivedUnderlyingAmount = isSharesInput
             ? getConvertedOutputTokenBalanceToInputTokenAmount({
                   networkSymbol: account.symbol,

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -495,10 +495,10 @@ export const YieldWithdrawScreen = () => {
         return null;
     }
 
-    const underlyingTokenSymbol = toTokenSymbol(flowData.token.symbol.toUpperCase());
-    const vaultTokenSymbol = toTokenSymbol(flowData.receiptToken.symbol.toUpperCase());
+    const underlyingTokenSymbol = toTokenSymbol(flowData.token.symbol);
+    const vaultTokenSymbol = toTokenSymbol(flowData.receiptToken.symbol);
 
-    const activeUnitSymbol = toTokenSymbol(activeInputToken.symbol.toUpperCase());
+    const activeUnitSymbol = toTokenSymbol(activeInputToken.symbol);
     const activeUnitTokenContract = activeInputToken.contractAddress
         ? toTokenAddress(activeInputToken.contractAddress)
         : undefined;


### PR DESCRIPTION
## Description

Do not uppercase vault token symbol.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30231

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-06 at 11 22 13" src="https://github.com/user-attachments/assets/47adea58-37ff-4b04-9e9c-f989d95a86d3" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-06 at 11 24 58" src="https://github.com/user-attachments/assets/681c3923-42bd-4cf9-9de3-e93af555c249" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-06 at 11 25 44" src="https://github.com/user-attachments/assets/faa647a6-6ca9-4a43-96fb-f4173ba6d57a" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/token-symbol-uppercase&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->