### PR TITLE
fix(e2e-utils): revert fix bot to Opus 4.8

### DIFF
--- a/packages/e2e-utils/src/fixBot/analyze.ts
+++ b/packages/e2e-utils/src/fixBot/analyze.ts
@@ -84,12 +84,12 @@ function main(): void {
         process.exit(1);
     }
 
-    if (agentResult.subtype === 'error_max_structured_output_retries') {
+    if (agentResult.subtype !== 'success') {
         // Persist the raw CLI envelope for troubleshooting
         const envelopePath = join(reportDir, 'analyze-envelope.json');
         writeFileSync(envelopePath, claudeOutput);
         error(
-            `Analysis agent could not produce schema-conformant output after retries. Raw envelope saved to ${envelopePath}.`,
+            `Analysis agent did not finish: ${agentResult.subtype ?? 'no subtype'}. No report produced; raw envelope saved to ${envelopePath}.`,
         );
         process.exit(1);
     }

--- a/packages/e2e-utils/src/fixBot/fix.ts
+++ b/packages/e2e-utils/src/fixBot/fix.ts
@@ -9,6 +9,7 @@ import { AnalysisReportSchema, FixResultJsonSchema, FixResultSchema } from './sc
 
 const MAX_BUDGET_USD = '10';
 const TIMEOUT_MS = 3 * 60 * 60 * 1000; // 3 hours
+const ENVELOPE_TAIL_CHARS = 20000;
 
 function main(): void {
     const reportPath = process.env.REPORT_PATH;
@@ -82,9 +83,9 @@ function main(): void {
         process.exit(1);
     }
 
-    if (agentResult.subtype === 'error_max_structured_output_retries') {
+    if (agentResult.subtype !== 'success') {
         error(
-            `Fix agent could not produce schema-conformant output after retries. Raw envelope:\n${output}`,
+            `Fix agent did not finish: ${agentResult.subtype ?? 'no subtype'}. No result produced. Last ${ENVELOPE_TAIL_CHARS} chars of the envelope:\n${output.slice(-ENVELOPE_TAIL_CHARS)}`,
         );
         process.exit(1);
     }

--- a/packages/e2e-utils/src/fixBot/settings.json
+++ b/packages/e2e-utils/src/fixBot/settings.json
@@ -1,5 +1,5 @@
 {
-    "model": "claude-opus-5",
+    "model": "claude-opus-4-8",
     "effortLevel": "high",
     "permissions": {
         "defaultMode": "auto"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Opus 5 blew the $10 budget cap on the last two nightly analysis runs, so the
model is pinned back to Opus 4.8. The kill also surfaced as a misleading schema
validation error; any non-`success` subtype now reports its subtype instead.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are part of a fixBot utility inside e2e-utils, which is test infrastructure/tooling for analyzing and fixing E2E tests rather than application functionality. None of the candidate E2E tests exercise this tooling, and the LLM analysis provides no evidence that any test path depends on fixBot behavior. Therefore, no E2E tests are recommended for this change set; coverage should be validated at the unit/integration level for the fixBot module itself.

<details><summary><b>Changed files (3)</b></summary>

- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/settings.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `packages/e2e-utils/src/fixBot/analyze.ts`
- `packages/e2e-utils/src/fixBot/fix.ts`
- `packages/e2e-utils/src/fixBot/settings.json`

_Updated: 2026-08-06T09:35:00.416Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/fixbot-budget-kill-handling/web/](https://dev.suite.sldev.cz/suite-web/fix/fixbot-budget-kill-handling/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/fixbot-budget-kill-handling&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/fixbot-budget-kill-handling&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T09:37:37.709Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T09:37:17.824Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->