### PR TITLE
Chore: bump prettier 3.9

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,7 @@ build-electron
 build-renderer
 .build-storybook
 *.cpuprofile
+.next
 
 # Dependency directory
 node_modules

--- a/docs/misc/build.md
+++ b/docs/misc/build.md
@@ -11,15 +11,16 @@ The folder structure is as follows:
 These Webpack configurations are using TypeScript and use the `tsconfig.json` file at the root of the package. This is specified via the `TS_NODE_PROJECT` environment variable to avoid any issues regardless of the location where the command is run.
 
 The following commands are available in this package (using `yarn run` at the root of the package or `yarn workspace @trezor/suite-build run` at the root of the project):
-| Command | Description |
-| --- | --- |
-| dev:web | Runs a watch build of `suite-web` with development settings and serves it. |
-| build:web | Builds a production build of `suite-web`. |
-| dev:desktop | Runs a watch build of `suite-desktop` with development settings, serves it and runs the Electron wrapper. |
-| build:desktop | Builds a production build of `suite-desktop`. |
-| lint | Runs the linter on the package. |
-| type-check | Runs the TypeScript checker on the package. |
-| type-check:watch | Same as `type-check` but in watch mode. |
+
+| Command          | Description                                                                                               |
+| ---------------- | --------------------------------------------------------------------------------------------------------- |
+| dev:web          | Runs a watch build of `suite-web` with development settings and serves it.                                |
+| build:web        | Builds a production build of `suite-web`.                                                                 |
+| dev:desktop      | Runs a watch build of `suite-desktop` with development settings, serves it and runs the Electron wrapper. |
+| build:desktop    | Builds a production build of `suite-desktop`.                                                             |
+| lint             | Runs the linter on the package.                                                                           |
+| type-check       | Runs the TypeScript checker on the package.                                                               |
+| type-check:watch | Same as `type-check` but in watch mode.                                                                   |
 
 ## Aliases
 

--- a/networks/solana/network-solana/src/runtime/fees.ts
+++ b/networks/solana/network-solana/src/runtime/fees.ts
@@ -42,8 +42,7 @@ import type {
 const DEFAULT_COMPUTE_UNIT_PRICE_MICROLAMPORTS = BigInt(300_000); // micro-lamports, value taken from other wallets
 
 type CompiledTransactionMessageV0OrLegacy =
-    | LegacyCompiledTransactionMessage
-    | V0CompiledTransactionMessage;
+    LegacyCompiledTransactionMessage | V0CompiledTransactionMessage;
 
 const stripComputeBudgetInstructions = (message: CompiledTransactionMessageV0OrLegacy) => ({
     ...message,

--- a/networks/solana/network-solana/src/runtime/stakingUtils.ts
+++ b/networks/solana/network-solana/src/runtime/stakingUtils.ts
@@ -170,8 +170,7 @@ export const getFeeSummary = (
         TransactionMessageWithBlockhashLifetime,
 ) => {
     const compiledMessage = compileTransactionMessage(transactionMessage) as
-        | LegacyCompiledTransactionMessage
-        | V0CompiledTransactionMessage;
+        LegacyCompiledTransactionMessage | V0CompiledTransactionMessage;
 
     const baseFeeLamports = SOL_BASE_FEE * BigInt(compiledMessage.header.numSignerAccounts);
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "resolutions": {
         "typescript": "6.0.3",
         "@types/jest": "30.0.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "react-native": "0.85.3",
         "type-fest": "5.5.0",
         "bcrypto": "5.4.0",
@@ -159,7 +159,7 @@
         "nx": "23.0.0",
         "postcss-styled-syntax": "^0.7.1",
         "postcss-value-parser": "^4.2.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "rimraf": "^6.1.2",
         "stylelint": "^17.1.1",
         "ts-node": "^10.9.2",

--- a/packages/analytics-docs/src/utils/normalizeChangelog.ts
+++ b/packages/analytics-docs/src/utils/normalizeChangelog.ts
@@ -57,8 +57,7 @@ export const normalizeChangelog = (
 
     const firstNumeric = sortedNumericVersions[0] as AppVersion | undefined;
     const lastNumeric = sortedNumericVersions[sortedNumericVersions.length - 1] as
-        | AppVersion
-        | undefined;
+        AppVersion | undefined;
     const onlyUnknown = !firstNumeric && unknownVersions.length > 0 ? UNKNOWN_VERSION : undefined;
 
     const first = firstNumeric ?? onlyUnknown;

--- a/packages/analytics-docs/src/utils/normalizeEvents.ts
+++ b/packages/analytics-docs/src/utils/normalizeEvents.ts
@@ -17,8 +17,7 @@ const toAttributeDoc = ([name, attribute]: [string, AttributeDef<unknown>]): [
 ];
 
 type NormalizableEvent = (
-    | EventDef<Record<string, AttributeDef<unknown>>, string>
-    | EventDef<unknown, string>
+    EventDef<Record<string, AttributeDef<unknown>>, string> | EventDef<unknown, string>
 ) & { platform?: string; attributes?: Record<string, AttributeDef<unknown>> };
 
 const toEventDoc = (event: NormalizableEvent): [string, EventDoc] => {

--- a/packages/coinjoin/src/types/coordinator.ts
+++ b/packages/coinjoin/src/types/coordinator.ts
@@ -130,9 +130,7 @@ export interface CoinjoinOutputAddedEvent {
 }
 
 export type CoinjoinStateEvent =
-    | CoinjoinRoundCreatedEvent
-    | CoinjoinInputAddedEvent
-    | CoinjoinOutputAddedEvent;
+    CoinjoinRoundCreatedEvent | CoinjoinInputAddedEvent | CoinjoinOutputAddedEvent;
 
 export interface AllowedRange {
     Min: number;

--- a/packages/components/src/components/Card/utils.tsx
+++ b/packages/components/src/components/Card/utils.tsx
@@ -50,22 +50,26 @@ export const mapCardTypeToCSS = ({
             background: ${theme.surfaceFillRaised};
             outline: 1px solid ${theme.surfaceBorderRaised};
 
-            ${$isClickable &&
-            css`
-                background: ${theme.surfaceFillAction};
-                outline-color: ${theme.surfaceBorderAction};
-
-                ${$isSelected &&
+            ${
+                $isClickable &&
                 css`
-                    outline: 2px solid ${theme.borderBrand};
-                `}
+                    background: ${theme.surfaceFillAction};
+                    outline-color: ${theme.surfaceBorderAction};
 
-                box-shadow: ${theme.surfaceShadowAction};
+                    ${
+                        $isSelected &&
+                        css`
+                            outline: 2px solid ${theme.borderBrand};
+                        `
+                    }
 
-                &:hover {
-                    box-shadow: ${theme.surfaceShadowActionHovered};
-                }
-            `}
+                    box-shadow: ${theme.surfaceShadowAction};
+
+                    &:hover {
+                        box-shadow: ${theme.surfaceShadowActionHovered};
+                    }
+                `
+            }
         `,
         sunken: css`
             background: ${theme.surfaceFillSunken};
@@ -80,19 +84,23 @@ export const mapCardTypeToCSS = ({
             outline: 1px solid ${theme.elementBorderNeutralSofterAlt};
             outline-offset: -1px;
 
-            ${$isClickable &&
-            css`
-                ${$isSelected &&
+            ${
+                $isClickable &&
                 css`
-                    outline: 2px solid ${theme.borderBrand};
-                `}
+                    ${
+                        $isSelected &&
+                        css`
+                            outline: 2px solid ${theme.borderBrand};
+                        `
+                    }
 
-                box-shadow: ${theme.surfaceShadowAction};
+                    box-shadow: ${theme.surfaceShadowAction};
 
-                &:hover {
-                    box-shadow: ${theme.surfaceShadowActionHovered};
-                }
-            `}
+                    &:hover {
+                        box-shadow: ${theme.surfaceShadowActionHovered};
+                    }
+                `
+            }
         `,
     };
 

--- a/packages/components/src/components/Flex/Flex.tsx
+++ b/packages/components/src/components/Flex/Flex.tsx
@@ -61,20 +61,24 @@ export const withDivider = ({
         display: block;
         position: absolute;
 
-        ${$direction === 'column' &&
-        `
+        ${
+            $direction === 'column' &&
+            `
         top: -${$rowGap / 2}px;
         height: 1px;
         width: 100%;
         left: 0;
-        border-top: 1px solid ${$dividerColor ? theme[$dividerColor] : theme.borderNeutral};`}
-        ${$direction === 'row' &&
-        `
+        border-top: 1px solid ${$dividerColor ? theme[$dividerColor] : theme.borderNeutral};`
+        }
+        ${
+            $direction === 'row' &&
+            `
         top: 0;
         height: 100%;
         width: 1px;
         left: -${$columnGap / 2}px;
-        border-left: 1px solid ${$dividerColor ? theme[$dividerColor] : theme.borderNeutral};`}
+        border-left: 1px solid ${$dividerColor ? theme[$dividerColor] : theme.borderNeutral};`
+        }
     }
 `;
 

--- a/packages/components/src/components/Table/TableRow.tsx
+++ b/packages/components/src/components/Table/TableRow.tsx
@@ -56,12 +56,12 @@ export const Row = styled.tr<{
         `}
 
         ${({ onClick }) =>
-        onClick &&
-        css`
-            &:hover {
-                cursor: pointer;
-            }
-        `}
+            onClick &&
+            css`
+                &:hover {
+                    cursor: pointer;
+                }
+            `}
 `;
 
 export interface TableRowProps {

--- a/packages/components/src/components/form/Switch/Switch.tsx
+++ b/packages/components/src/components/form/Switch/Switch.tsx
@@ -38,20 +38,24 @@ const Container = styled.div<{
     ${({ $isDisabled, theme, $isChecked }) =>
         $isDisabled
             ? css`
-                  background: ${$isChecked
-                      ? theme.elementFillFieldSelectedDisabled
-                      : theme.elementFillBoldDisabled};
+                  background: ${
+                      $isChecked
+                          ? theme.elementFillFieldSelectedDisabled
+                          : theme.elementFillBoldDisabled
+                  };
               `
             : css`
-                  background: ${$isChecked
-                      ? theme.elementFillFieldSelected
-                      : theme.elementFillNeutralBold};
+                  background: ${
+                      $isChecked ? theme.elementFillFieldSelected : theme.elementFillNeutralBold
+                  };
 
                   :focus-within:has(:focus-visible),
                   &:hover {
-                      background: ${$isChecked
-                          ? theme.elementFillFieldSelectedHovered
-                          : theme.elementFillNeutralBoldHovered};
+                      background: ${
+                          $isChecked
+                              ? theme.elementFillFieldSelectedHovered
+                              : theme.elementFillNeutralBoldHovered
+                      };
                   }
 
                   &:focus-within:has(:focus-visible) {

--- a/packages/components/src/components/typography/Text/Text.tsx
+++ b/packages/components/src/components/typography/Text/Text.tsx
@@ -131,14 +131,14 @@ const StyledText = styled.span<StyledTextProps>`
             letter-spacing: 0 !important;
         `}
         ${({ $isHighlighted }) =>
-        $isHighlighted &&
-        css`
-            display: inline;
-            padding: 0 4px;
-            border-radius: 4px;
-            background-color: ${({ theme }) => theme.elementFillNeutralSoft};
-            box-decoration-break: clone;
-        `}
+            $isHighlighted &&
+            css`
+                display: inline;
+                padding: 0 4px;
+                border-radius: 4px;
+                background-color: ${({ theme }) => theme.elementFillNeutralSoft};
+                box-decoration-break: clone;
+            `}
     
     ${withTextProps};
     ${withFrameProps};

--- a/packages/components/src/components/typography/utils.tsx
+++ b/packages/components/src/components/typography/utils.tsx
@@ -48,51 +48,67 @@ export const withTextProps = ({
     $wordBreak,
     $overflowWrap,
 }: TransientTextProps) => css`
-    ${$textWrap &&
-    css`
-        text-wrap: ${$textWrap};
-    `}
-    ${$wordBreak &&
-    css`
-        word-break: ${$wordBreak};
-    `}
-    ${$overflowWrap &&
-    css`
-        overflow-wrap: ${$overflowWrap};
-    `}
-    ${$typographyStyle
-        ? css`
-              ${typography[$typographyStyle]}
-          `
-        : ''}
-    ${$align &&
-    css`
-        text-align: ${$align};
-    `}
-    ${$ellipsisLineCount > 0 &&
-    css`
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-    `}
-    ${$ellipsisLineCount > 1 &&
-    css`
-        white-space: initial;
-        -webkit-line-clamp: ${$ellipsisLineCount};
-        display: -webkit-box;
-        -webkit-box-orient: vertical;
-    `}
-    ${$case && $case === 'titlecase'
-        ? css`
-              text-transform: lowercase;
+    ${
+        $textWrap &&
+        css`
+            text-wrap: ${$textWrap};
+        `
+    }
+    ${
+        $wordBreak &&
+        css`
+            word-break: ${$wordBreak};
+        `
+    }
+    ${
+        $overflowWrap &&
+        css`
+            overflow-wrap: ${$overflowWrap};
+        `
+    }
+    ${
+        $typographyStyle
+            ? css`
+                  ${typography[$typographyStyle]}
+              `
+            : ''
+    }
+    ${
+        $align &&
+        css`
+            text-align: ${$align};
+        `
+    }
+    ${
+        $ellipsisLineCount > 0 &&
+        css`
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        `
+    }
+    ${
+        $ellipsisLineCount > 1 &&
+        css`
+            white-space: initial;
+            -webkit-line-clamp: ${$ellipsisLineCount};
+            display: -webkit-box;
+            -webkit-box-orient: vertical;
+        `
+    }
+    ${
+        $case && $case === 'titlecase'
+            ? css`
+                  text-transform: lowercase;
 
-              &::first-letter {
-                  text-transform: uppercase;
-              }
-          `
-        : css`
-              text-transform: ${$case};
-          `}
+                  &::first-letter {
+                      text-transform: uppercase;
+                  }
+              `
+            : css`
+                  text-transform: ${$case};
+              `
+    }
 `;
 
 const getStorybookType = (key: TextPropsKeys) => {

--- a/packages/components/src/utils/frameProps.tsx
+++ b/packages/components/src/utils/frameProps.tsx
@@ -150,110 +150,154 @@ export const withFrameProps = ({
     $objectPosition,
     $display,
 }: TransientFrameProps) => css`
-    ${$margin &&
-    (typeof $margin === 'object'
-        ? css`
-              margin: ${getValueWithUnit($margin?.top ?? $margin.vertical ?? 0)}
-                  ${getValueWithUnit($margin?.right ?? $margin.horizontal ?? 0)}
-                  ${getValueWithUnit($margin?.bottom ?? $margin.vertical ?? 0)}
-                  ${getValueWithUnit($margin?.left ?? $margin.horizontal ?? 0)};
-          `
-        : css`
-              margin: ${getValueWithUnit($margin)};
-          `)}
-    ${$padding &&
-    (typeof $padding === 'object'
-        ? css`
-              padding: ${getValueWithUnit($padding?.top ?? $padding.vertical ?? 0)}
-                  ${getValueWithUnit($padding?.right ?? $padding.horizontal ?? 0)}
-                  ${getValueWithUnit($padding?.bottom ?? $padding.vertical ?? 0)}
-                  ${getValueWithUnit($padding?.left ?? $padding.horizontal ?? 0)};
-          `
-        : css`
-              padding: ${getValueWithUnit($padding)};
-          `)}
-    ${typeof $minWidth !== 'undefined' &&
-    css`
-        min-width: ${getValueWithUnit($minWidth)};
-    `};
-    ${typeof $maxWidth !== 'undefined' &&
-    css`
-        max-width: ${getValueWithUnit($maxWidth)};
-    `};
-    ${typeof $minHeight !== 'undefined' &&
-    css`
-        min-height: ${getValueWithUnit($minHeight)};
-    `};
-    ${typeof $maxHeight !== 'undefined' &&
-    css`
-        max-height: ${getValueWithUnit($maxHeight)};
-    `};
-    ${typeof $width !== 'undefined' &&
-    css`
-        width: ${getValueWithUnit($width)};
-    `};
-    ${typeof $height !== 'undefined' &&
-    css`
-        height: ${getValueWithUnit($height)};
-    `};
-    ${$overflow &&
-    css`
-        overflow: ${$overflow};
-    `};
-    ${typeof $borderRadius !== 'undefined' &&
-    css`
-        border-radius: ${getBorderRadiusCssValue($borderRadius)};
-    `};
-    ${$pointerEvents &&
-    css`
-        pointer-events: ${$pointerEvents};
-    `};
-    ${$flex &&
-    css`
-        flex: ${$flex};
-    `};
-    ${$position &&
-    css`
-        position: ${$position.type};
-        ${typeof $position.inset !== 'undefined' && `inset: ${getValueWithUnit($position.inset)};`}
-        ${typeof $position.top !== 'undefined' && `top: ${getValueWithUnit($position.top)};`}
+    ${
+        $margin &&
+        (typeof $margin === 'object'
+            ? css`
+                  margin: ${getValueWithUnit($margin?.top ?? $margin.vertical ?? 0)}
+                      ${getValueWithUnit($margin?.right ?? $margin.horizontal ?? 0)}
+                      ${getValueWithUnit($margin?.bottom ?? $margin.vertical ?? 0)}
+                      ${getValueWithUnit($margin?.left ?? $margin.horizontal ?? 0)};
+              `
+            : css`
+                  margin: ${getValueWithUnit($margin)};
+              `)
+    }
+    ${
+        $padding &&
+        (typeof $padding === 'object'
+            ? css`
+                  padding: ${getValueWithUnit($padding?.top ?? $padding.vertical ?? 0)}
+                      ${getValueWithUnit($padding?.right ?? $padding.horizontal ?? 0)}
+                      ${getValueWithUnit($padding?.bottom ?? $padding.vertical ?? 0)}
+                      ${getValueWithUnit($padding?.left ?? $padding.horizontal ?? 0)};
+              `
+            : css`
+                  padding: ${getValueWithUnit($padding)};
+              `)
+    }
+    ${
+        typeof $minWidth !== 'undefined' &&
+        css`
+            min-width: ${getValueWithUnit($minWidth)};
+        `
+    };
+    ${
+        typeof $maxWidth !== 'undefined' &&
+        css`
+            max-width: ${getValueWithUnit($maxWidth)};
+        `
+    };
+    ${
+        typeof $minHeight !== 'undefined' &&
+        css`
+            min-height: ${getValueWithUnit($minHeight)};
+        `
+    };
+    ${
+        typeof $maxHeight !== 'undefined' &&
+        css`
+            max-height: ${getValueWithUnit($maxHeight)};
+        `
+    };
+    ${
+        typeof $width !== 'undefined' &&
+        css`
+            width: ${getValueWithUnit($width)};
+        `
+    };
+    ${
+        typeof $height !== 'undefined' &&
+        css`
+            height: ${getValueWithUnit($height)};
+        `
+    };
+    ${
+        $overflow &&
+        css`
+            overflow: ${$overflow};
+        `
+    };
+    ${
+        typeof $borderRadius !== 'undefined' &&
+        css`
+            border-radius: ${getBorderRadiusCssValue($borderRadius)};
+        `
+    };
+    ${
+        $pointerEvents &&
+        css`
+            pointer-events: ${$pointerEvents};
+        `
+    };
+    ${
+        $flex &&
+        css`
+            flex: ${$flex};
+        `
+    };
+    ${
+        $position &&
+        css`
+            position: ${$position.type};
+            ${typeof $position.inset !== 'undefined' && `inset: ${getValueWithUnit($position.inset)};`}
+            ${typeof $position.top !== 'undefined' && `top: ${getValueWithUnit($position.top)};`}
         ${typeof $position.right !== 'undefined' && `right: ${getValueWithUnit($position.right)};`}
-            ${typeof $position.bottom !== 'undefined' &&
-        `bottom: ${getValueWithUnit($position.bottom)};`}
+            ${
+                typeof $position.bottom !== 'undefined' &&
+                `bottom: ${getValueWithUnit($position.bottom)};`
+            }
             ${typeof $position.left !== 'undefined' && `left: ${getValueWithUnit($position.left)};`}
-    `};
-    ${$cursor &&
-    css`
-        cursor: ${$cursor};
-    `};
-    ${typeof $zIndex !== 'undefined' &&
-    css`
-        z-index: ${$zIndex};
-    `};
-    ${typeof $aspectRatio !== 'undefined' &&
-    css`
-        aspect-ratio: ${$aspectRatio};
-    `};
-    ${typeof $opacity !== 'undefined' &&
-    css`
-        opacity: ${$opacity};
-    `};
-    ${$userSelect &&
-    css`
-        user-select: ${$userSelect};
-    `};
-    ${$objectFit &&
-    css`
-        object-fit: ${$objectFit};
-    `};
-    ${$objectPosition &&
-    css`
-        object-position: ${$objectPosition};
-    `};
-    ${$display &&
-    css`
-        display: ${$display};
-    `};
+        `
+    };
+    ${
+        $cursor &&
+        css`
+            cursor: ${$cursor};
+        `
+    };
+    ${
+        typeof $zIndex !== 'undefined' &&
+        css`
+            z-index: ${$zIndex};
+        `
+    };
+    ${
+        typeof $aspectRatio !== 'undefined' &&
+        css`
+            aspect-ratio: ${$aspectRatio};
+        `
+    };
+    ${
+        typeof $opacity !== 'undefined' &&
+        css`
+            opacity: ${$opacity};
+        `
+    };
+    ${
+        $userSelect &&
+        css`
+            user-select: ${$userSelect};
+        `
+    };
+    ${
+        $objectFit &&
+        css`
+            object-fit: ${$objectFit};
+        `
+    };
+    ${
+        $objectPosition &&
+        css`
+            object-position: ${$objectPosition};
+        `
+    };
+    ${
+        $display &&
+        css`
+            display: ${$display};
+        `
+    };
 `;
 
 const getStorybookType = (key: FramePropsKeys) => {

--- a/packages/connect-common/src/events/call.ts
+++ b/packages/connect-common/src/events/call.ts
@@ -79,8 +79,7 @@ export const createResponseMessage = (
     success: boolean,
     payload: any,
     deviceIdentity:
-        | { path: DeviceUniquePath; state?: DeviceState; instance: number }
-        | undefined = undefined,
+        { path: DeviceUniquePath; state?: DeviceState; instance: number } | undefined = undefined,
 ): MethodResponseMessage => {
     if (success)
         return {

--- a/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
+++ b/packages/connect-common/src/types/api/bitcoin/composeTransaction.ts
@@ -60,9 +60,7 @@ export type PrecomposeResultFinal = Omit<ComposeResultFinal, 'inputs' | 'outputs
 };
 
 export type PrecomposedResult =
-    | PrecomposeResultError
-    | PrecomposeResultNonFinal
-    | PrecomposeResultFinal;
+    PrecomposeResultError | PrecomposeResultNonFinal | PrecomposeResultFinal;
 
 export declare function composeTransaction(
     params: Params<PrecomposeParams>,

--- a/packages/connect-common/src/types/device.ts
+++ b/packages/connect-common/src/types/device.ts
@@ -15,12 +15,7 @@ import type { FirmwareCapability, FirmwareReleaseConfigInfo } from './firmware';
  * - `thp-locked`         device is waiting for THP pairing
  */
 export type DeviceBusyStatus =
-    | 'busy'
-    | 'rebooting'
-    | 'bootloader-locked'
-    | 'hard-locked'
-    | 'pin-locked'
-    | 'thp-locked';
+    'busy' | 'rebooting' | 'bootloader-locked' | 'hard-locked' | 'pin-locked' | 'thp-locked';
 
 /**
  * - `available`  no other application has an active session
@@ -47,12 +42,7 @@ export type DeviceMode =
     | 'seedless';
 
 export type DeviceFirmwareStatus =
-    | 'valid'
-    | 'outdated'
-    | 'required'
-    | 'unknown'
-    | 'custom'
-    | 'none';
+    'valid' | 'outdated' | 'required' | 'unknown' | 'custom' | 'none';
 
 export type UnavailableCapability =
     | 'no-capability' // flag missing, could mean it's outdated or BTC only

--- a/packages/connect-common/src/types/firmware.ts
+++ b/packages/connect-common/src/types/firmware.ts
@@ -90,10 +90,7 @@ export type FirmwareReleaseConfigInfo = {
  *      Case: fresh device with no FW (most usual case).
  */
 export type FirmwareUpdateFlowType =
-    | 'reboot_and_wait'
-    | 'reboot_and_upgrade'
-    | 'manual'
-    | 'unknown_flow';
+    'reboot_and_wait' | 'reboot_and_upgrade' | 'manual' | 'unknown_flow';
 
 export type FirmwareChannel =
     | 'production'

--- a/packages/connect-common/src/types/params.ts
+++ b/packages/connect-common/src/types/params.ts
@@ -76,8 +76,7 @@ type ProtoWithoutAddressN<T, A> = Exclude<T, { address_n: A }>;
 
 // replace address_n: number[] with address_n: DerivationPath
 export type ProtoWithDerivationPath<T> =
-    | ProtoWithoutAddressN<T, number[]>
-    | ProtoWithExtendedAddressN<T, number[], DerivationPath>;
+    ProtoWithoutAddressN<T, number[]> | ProtoWithExtendedAddressN<T, number[], DerivationPath>;
 
 // Common fields for all *.getAddress methods
 export type GetAddress = Static<typeof GetAddress>;

--- a/packages/connect/src/core/AbstractMethod.ts
+++ b/packages/connect/src/core/AbstractMethod.ts
@@ -31,9 +31,7 @@ export type Payload<M> = Extract<CallMethodPayload, { method: M }> & { override?
 export type MethodReturnType<M extends CallMethodPayload['method']> = CallMethodResponse<M>;
 
 export type DeviceMode =
-    | typeof UI_REQUEST.SEEDLESS
-    | typeof UI_REQUEST.BOOTLOADER
-    | typeof UI_REQUEST.INITIALIZE;
+    typeof UI_REQUEST.SEEDLESS | typeof UI_REQUEST.BOOTLOADER | typeof UI_REQUEST.INITIALIZE;
 
 export type MethodContext = {
     sendCoreMessage: (message: CoreEventMessage) => void;

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,6 +18,6 @@
     "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "@trezor/eslint": "workspace:*",
-        "prettier": "^3.8.4"
+        "prettier": "^3.9.6"
     }
 }

--- a/packages/product-components/src/components/IconSet/IconSetBase.tsx
+++ b/packages/product-components/src/components/IconSet/IconSetBase.tsx
@@ -53,9 +53,11 @@ const Container = styled.div<{
         css`
             display: grid;
             grid-template-columns: repeat(
-                ${$length > $maxVisibleIcons
-                    ? $maxVisibleIcons + Number($isCountVisible)
-                    : $length},
+                ${
+                    $length > $maxVisibleIcons
+                        ? $maxVisibleIcons + Number($isCountVisible)
+                        : $length
+                },
                 ${$gap}px
             );
             justify-items: center;

--- a/packages/protobuf/scripts/protobuf-patches/ThpCreateNewSession.ts
+++ b/packages/protobuf/scripts/protobuf-patches/ThpCreateNewSession.ts
@@ -1,6 +1,5 @@
 // ThpCreateNewSession replacement
 // either passphrase or on_device needs to be present
 export type ThpCreateNewSession = { derive_cardano?: boolean } & (
-    | { passphrase: string; on_device?: undefined }
-    | { passphrase?: undefined; on_device: boolean }
+    { passphrase: string; on_device?: undefined } | { passphrase?: undefined; on_device: boolean }
 );

--- a/packages/protocol/src/protocol-thp/messages/protobufTypes.ts
+++ b/packages/protocol/src/protocol-thp/messages/protobufTypes.ts
@@ -33,8 +33,7 @@ export type ThpCodeEntrySecret = {
 // ThpCreateNewSession replacement
 // either passphrase or on_device needs to be present
 export type ThpCreateNewSession = { derive_cardano?: boolean } & (
-    | { passphrase: string; on_device?: undefined }
-    | { passphrase?: undefined; on_device: boolean }
+    { passphrase: string; on_device?: undefined } | { passphrase?: undefined; on_device: boolean }
 );
 
 export type ThpCredentialRequest = {

--- a/packages/styles-native/src/types.ts
+++ b/packages/styles-native/src/types.ts
@@ -30,5 +30,4 @@ export type NativeStyle<TProps extends object = object> = (
 ) => NativeStyleObject;
 export type NativeStyles<TProps extends object> = Array<NativeStyle<TProps> | null | undefined>;
 export type NativeStyleOrStylesParam<TProps extends object> =
-    | NativeStyle<TProps>
-    | NativeStyles<TProps>;
+    NativeStyle<TProps> | NativeStyles<TProps>;

--- a/packages/suite-desktop-native/src/types.ts
+++ b/packages/suite-desktop-native/src/types.ts
@@ -29,9 +29,7 @@ export interface IPCErrorResponse {
 }
 
 export type IPCResponse =
-    | IPCISHelloAvailableSuccessResponse
-    | IPCRequestHelloSuccessResponse
-    | IPCErrorResponse;
+    IPCISHelloAvailableSuccessResponse | IPCRequestHelloSuccessResponse | IPCErrorResponse;
 
 export interface IPCReadyMessage {
     ready: true;

--- a/packages/suite-desktop/README.md
+++ b/packages/suite-desktop/README.md
@@ -69,18 +69,19 @@ yarn workspace @trezor/suite-desktop build:linux
 appimage-run ./packages/suite-desktop/build-electron/Trezor-Suite[version].AppImage
 ```
 
-_Note: If build fails on a missing cache file _(.cache/\*\*/mksquashfsthis)_ additionally run `./nixos-fix-binaries.sh` script and repeat build step._
+_Note: If build fails on a missing cache file *(.cache/\*\*/mksquashfsthis)* additionally run `./nixos-fix-binaries.sh` script and repeat build step._
 
 ---
 
 ## User data dir
 
 Location of data directory depends on platform:
-| Platform | User data dir path |
-| --------------------- | ------------------------------------------------------------------- |
-| linux | `/home/<user>/.config/` |
-| macOS | `~/Library/Application Support/` |
-| Windows | `C:\Users\<user>\AppData\Roaming\` |
+
+| Platform | User data dir path                 |
+| -------- | ---------------------------------- |
+| linux    | `/home/<user>/.config/`            |
+| macOS    | `~/Library/Application Support/`   |
+| Windows  | `C:\Users\<user>\AppData\Roaming\` |
 
 Name of data directory [depends on environment](../../docs/packages/suite-desktop/index.md/#app-id-and-name-by-environment) and it's `@trezor/suite-desktop`, `@trezor/suite-desktop-dev` or `@trezor/suite-desktop-local`.
 

--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -164,21 +164,19 @@ export const saveKnownDevices = createThunk<void, void, { state: SaveKnownDevice
         await db.addItem(
             'bluetooth',
             {
-                knownDevices: knownDevices.map(
-                    (it): DesktopBluetoothDevice => ({
-                        id: it.id,
-                        name: it.name,
-                        macAddress: it.macAddress,
-                        manufacturerData: it.manufacturerData,
-                        lastUpdatedTimestamp: it.lastUpdatedTimestamp,
-                        paired: it.paired,
-                        rssi: it.rssi,
-                        deviceId: it.deviceId,
+                knownDevices: knownDevices.map((it): DesktopBluetoothDevice => ({
+                    id: it.id,
+                    name: it.name,
+                    macAddress: it.macAddress,
+                    manufacturerData: it.manufacturerData,
+                    lastUpdatedTimestamp: it.lastUpdatedTimestamp,
+                    paired: it.paired,
+                    rssi: it.rssi,
+                    deviceId: it.deviceId,
 
-                        // Those fields are reset to prevent some state-inconsistency and UI flickering
-                        connectionStatus: { type: 'disconnected' },
-                    }),
-                ),
+                    // Those fields are reset to prevent some state-inconsistency and UI flickering
+                    connectionStatus: { type: 'disconnected' },
+                })),
             },
             'value',
             true,
@@ -512,11 +510,7 @@ export const saveAnalytics = () => (_dispatch: Dispatch, getState: GetState) => 
 };
 
 type MetadataPersistentKeys =
-    | 'providers'
-    | 'enabled'
-    | 'selectedProvider'
-    | 'error'
-    | 'hasLegacyLabelsMigrated';
+    'providers' | 'enabled' | 'selectedProvider' | 'error' | 'hasLegacyLabelsMigrated';
 
 const saveMetadata = async (metadata: Partial<Pick<MetadataState, MetadataPersistentKeys>>) => {
     if (!db.isAccessible()) return;

--- a/packages/suite/src/actions/suite/windowActions.ts
+++ b/packages/suite/src/actions/suite/windowActions.ts
@@ -19,5 +19,4 @@ export const updateBreakpoints = createAction(
 );
 
 export type WindowAction =
-    | ReturnType<typeof updateWindowVisibility>
-    | ReturnType<typeof updateBreakpoints>;
+    ReturnType<typeof updateWindowVisibility> | ReturnType<typeof updateBreakpoints>;

--- a/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.ts
+++ b/packages/suite/src/components/earn/yield/hooks/ensureDeviceSession.ts
@@ -5,8 +5,7 @@ import TrezorConnect from '@trezor/connect';
 import { getYieldErrorTranslationKey } from 'src/actions/wallet/stablecoin-yield/signingHelpers';
 
 export type EnsureDeviceSessionResult =
-    | { success: true }
-    | { success: false; error?: StablecoinYieldTranslationKey };
+    { success: true } | { success: false; error?: StablecoinYieldTranslationKey };
 
 export const ensureDeviceSession = async (
     device: TrezorDevice | undefined,

--- a/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
+++ b/packages/suite/src/components/suite/DeviceMatrixExplanation.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div<{ $isGuideOpen?: boolean }>`
     border-radius: 4px;
 
     @media only screen and (max-width: ${props =>
-            props.$isGuideOpen ? variables.SCREEN_SIZE.XL : variables.SCREEN_SIZE.MD}) {
+        props.$isGuideOpen ? variables.SCREEN_SIZE.XL : variables.SCREEN_SIZE.MD}) {
         display: none;
     }
 `;

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/utils.ts
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/utils.ts
@@ -7,10 +7,7 @@ import {
 import { type FormState } from '@suite-common/wallet-types';
 
 export type TxInfoState =
-    | SendState
-    | StakeState
-    | StablecoinYieldTxReviewState
-    | TronStakeTxReviewState;
+    SendState | StakeState | StablecoinYieldTxReviewState | TronStakeTxReviewState;
 
 export const isStakeState = (state: TxInfoState): state is StakeState => 'data' in state;
 

--- a/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
+++ b/packages/suite/src/hooks/suite/useOpenSuiteDesktop.ts
@@ -14,9 +14,9 @@ export const useOpenSuiteDesktop = () => {
     const isWebUsbTransport = useSelector(selectHasTransportOfType('WebUsbTransport'));
     const activeTransports = useSelector(selectActiveTransports);
     const windowFocused = useWindowFocus();
-    const { createTransports } = useServices(
-        (services): TransportsDep => ({ createTransports: services.createTransports }),
-    );
+    const { createTransports } = useServices((services): TransportsDep => ({
+        createTransports: services.createTransports,
+    }));
 
     const handleOpenSuite = () => {
         const iframe = document.createElement('iframe');

--- a/packages/suite/src/storage/migrations/versions/26.4.0.2.ts
+++ b/packages/suite/src/storage/migrations/versions/26.4.0.2.ts
@@ -15,8 +15,7 @@ export default createMigration<SuiteDBSchema>('26.4.0.2', async (db, tx) => {
             'experimentalFeedback',
         );
         const oldData = (await oldStore.get('experimentalFeedback')) as
-            | FeatureFeedbackState
-            | undefined;
+            FeatureFeedbackState | undefined;
 
         if (oldData) {
             tx.objectStore('featureFeedback').put(oldData, 'featureFeedback');

--- a/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
+++ b/packages/suite/src/support/suite/useConnectPopupDesktop.tsx
@@ -119,8 +119,7 @@ export const useConnectPopupDesktop = () => {
                                   manifest: params.manifest,
                                   // Cast across the IPC boundary, same as `params.method` above.
                                   requestedPermissions: params.requestedPermissions as
-                                      | PermissionRequest[]
-                                      | undefined,
+                                      PermissionRequest[] | undefined,
                               },
                     }),
                 );

--- a/packages/suite/src/types/trading/tradingForm.ts
+++ b/packages/suite/src/types/trading/tradingForm.ts
@@ -66,9 +66,7 @@ export interface TradingBuyFormDefaultValuesProps {
 export type TradingBuySellFormProps = TradingBuyFormProps | TradingSellFormProps;
 export type TradingSellExchangeFormProps = TradingSellFormProps | TradingExchangeFormProps;
 export type TradingAllFormProps =
-    | TradingBuyFormProps
-    | TradingSellFormProps
-    | TradingExchangeFormProps;
+    TradingBuyFormProps | TradingSellFormProps | TradingExchangeFormProps;
 
 export interface TradingSellFormDefaultValuesProps {
     defaultValues: TradingSellFormProps;

--- a/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
+++ b/packages/suite/src/views/settings/SettingsDebug/Transport.tsx
@@ -56,9 +56,9 @@ export const Transport = () => {
     const dispatch = useDispatch();
     const transports = isDesktop() ? TRANSPORTS_DESKTOP : TRANSPORTS_WEB;
     const items = useTransportItems(transports);
-    const { createTransports } = useServices(
-        (services): TransportsDep => ({ createTransports: services.createTransports }),
-    );
+    const { createTransports } = useServices((services): TransportsDep => ({
+        createTransports: services.createTransports,
+    }));
 
     return (
         <>

--- a/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
+++ b/packages/suite/src/views/settings/SettingsGeneral/BitcoinAmountUnit.tsx
@@ -26,8 +26,7 @@ export const BitcoinAmountUnit = () => {
                             value={{
                                 label: UNIT_LABELS[
                                     bitcoinAmountUnit as
-                                        | PROTO.AmountUnit.BITCOIN
-                                        | PROTO.AmountUnit.SATOSHI
+                                        PROTO.AmountUnit.BITCOIN | PROTO.AmountUnit.SATOSHI
                                 ],
                                 value: bitcoinAmountUnit,
                             }}

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputFiatCrypto/TradingFormInputFiat.tsx
@@ -89,8 +89,7 @@ const TradingFormInputFiatContent = ({
         : undefined;
 
     const tokenAddress = (sendCryptoSelect?.contractAddress ?? undefined) as
-        | TokenAddress
-        | undefined;
+        TokenAddress | undefined;
     const balance = tokenAddress
         ? findToken(asset.tokens, tokenAddress)?.balance
         : asset.formattedBalance;

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputPaymentMethod/TradingFormInputPaymentMethod.tsx
@@ -72,8 +72,7 @@ export const TradingFormInputPaymentMethod = ({
     const options = useSelector(state => selectTradingPaymentMethodsByType(state, type));
 
     const paymentMethod = useWatch({ name: TRADING_FORM_PAYMENT_METHOD_SELECT }) as
-        | TradingPaymentMethodListProps
-        | undefined;
+        TradingPaymentMethodListProps | undefined;
     const hasPaymentMethods = options.length > 0;
 
     const selectedOption = useSelector(state =>

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingReceiveAddress/useReceiveAddressModalControls.tsx
@@ -8,10 +8,7 @@ import { TradingReceiveAddressModal } from './TradingReceiveAddressModal';
 import { TradingUtxoReceiveAddressModal } from './TradingUtxoReceiveAddressModal/TradingUtxoReceiveAddressModal';
 
 type ReceiveAddressModal =
-    | 'accountModal'
-    | 'customAddressModal'
-    | 'utxoAddressModal'
-    | 'extraFieldModal';
+    'accountModal' | 'customAddressModal' | 'utxoAddressModal' | 'extraFieldModal';
 
 const useReceiveAddressModal = () => {
     const [activeModal, setActiveModal] = useState<ReceiveAddressModal>();

--- a/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProviderKyc.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingUtils/TradingUtilsProviderKyc.tsx
@@ -19,8 +19,7 @@ const getKycType = ({
     isDex,
     isBuySell,
 }: Pick<TradingUtilsProviderKycProps, 'exchange' | 'providers' | 'isDex' | 'isBuySell'>):
-    | ExchangeKYCType
-    | undefined => {
+    ExchangeKYCType | undefined => {
     // Buy and sell providers always require KYC and do not expose a kyc policy.
     if (isBuySell) {
         return KYC_REQUIRED;

--- a/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
+++ b/packages/suite/src/views/wallet/trading/redirect/TradingRedirect.tsx
@@ -47,11 +47,7 @@ export const TradingRedirect = () => {
         const indexParam: string = params[3];
         const redirectCommonParams = {
             routeType: params[0] as
-                | 'detail'
-                | 'offers'
-                | 'sell-detail'
-                | 'sell-offers'
-                | 'exchange-offers',
+                'detail' | 'offers' | 'sell-detail' | 'sell-offers' | 'exchange-offers',
             symbol: params[1] as Account['symbol'],
             accountType: params[2] as Account['accountType'],
             index: parseInt(indexParam, 10),

--- a/packages/theme/src/breakpoints.ts
+++ b/packages/theme/src/breakpoints.ts
@@ -8,8 +8,7 @@ export const breakpoints = {
 export type Breakpoint = keyof typeof breakpoints;
 export type BreakpointValue = (typeof breakpoints)[Breakpoint];
 export type BreakpointFlagName =
-    | `isBelow${Capitalize<Breakpoint>}`
-    | `isAbove${Capitalize<Breakpoint>}`;
+    `isBelow${Capitalize<Breakpoint>}` | `isAbove${Capitalize<Breakpoint>}`;
 
 export type BreakpointFlags = {
     [K in BreakpointFlagName]: boolean;

--- a/packages/theme/src/spacings.ts
+++ b/packages/theme/src/spacings.ts
@@ -27,25 +27,7 @@ export type NegativeSpacingValue =
 export type SignedSpacingValue = SpacingValue | NegativeSpacingValue;
 
 type NativeSpacingValue =
-    | 1
-    | 2
-    | 4
-    | 6
-    | 8
-    | 10
-    | 12
-    | 16
-    | 18
-    | 20
-    | 24
-    | 32
-    | 36
-    | 40
-    | 48
-    | 44
-    | 52
-    | 56
-    | 64;
+    1 | 2 | 4 | 6 | 8 | 10 | 12 | 16 | 18 | 20 | 24 | 32 | 36 | 40 | 48 | 44 | 52 | 56 | 64;
 
 export const nativeSpacings = {
     sp1: 1,

--- a/packages/transport-common/src/types/apiCall.ts
+++ b/packages/transport-common/src/types/apiCall.ts
@@ -17,8 +17,6 @@ export type AsyncResultWithTypedError<T, E extends string> = Promise<Result<T, T
 export type AbortableParam = { signal?: AbortSignal; timeout?: number };
 
 export type BridgeCommonErrors =
-    | typeof ERRORS.HTTP_ERROR
-    | typeof ERRORS.WRONG_RESULT_TYPE
-    | typeof ERRORS.UNEXPECTED_ERROR;
+    typeof ERRORS.HTTP_ERROR | typeof ERRORS.WRONG_RESULT_TYPE | typeof ERRORS.UNEXPECTED_ERROR;
 
 export type MessageResponse = MessagesSchema.MessageResponse | protocolThp.ThpMessageResponse;

--- a/packages/transport-common/src/utils/bridgeApiResult.ts
+++ b/packages/transport-common/src/utils/bridgeApiResult.ts
@@ -43,21 +43,19 @@ export function devices(res: UnknownPayload) {
     }
 
     return success(
-        res.map(
-            (o: any): Descriptor => ({
-                path: o.path,
-                session: o.session,
-                sessionOwner: o.sessionOwner,
-                product: o.product,
-                type: o.type,
-                vendor: o.vendor,
-                debug: o.debug,
-                debugSession: o.debugSession,
-                id: o.id,
-                apiType: o.apiType || 'usb', // no other option is implemented at this moment
-                model: o.model,
-            }),
-        ),
+        res.map((o: any): Descriptor => ({
+            path: o.path,
+            session: o.session,
+            sessionOwner: o.sessionOwner,
+            product: o.product,
+            type: o.type,
+            vendor: o.vendor,
+            debug: o.debug,
+            debugSession: o.debugSession,
+            id: o.id,
+            apiType: o.apiType || 'usb', // no other option is implemented at this moment
+            model: o.model,
+        })),
     );
 }
 

--- a/packages/type-utils/src/utils.ts
+++ b/packages/type-utils/src/utils.ts
@@ -93,10 +93,7 @@ export type ConstWithOptionalFields<
 > = {
     [Key in keyof Const]: {
         [FieldKey in Fields]: Const[Key][FieldKey] extends
-            | string
-            | number
-            | { [key: string]: any }
-            | boolean
+            string | number | { [key: string]: any } | boolean
             ? Const[Key][FieldKey]
             : undefined;
     };

--- a/packages/utxo-lib/src/types/compose.ts
+++ b/packages/utxo-lib/src/types/compose.ts
@@ -56,9 +56,7 @@ export interface ComposeOutputChange {
 }
 
 export type ComposeFinalOutput =
-    | ComposeOutputPayment
-    | ComposeOutputSendMax
-    | ComposeOutputOpreturn;
+    ComposeOutputPayment | ComposeOutputSendMax | ComposeOutputOpreturn;
 
 export type ComposeNotFinalOutput = ComposeOutputPaymentNoAddress | ComposeOutputSendMaxNoAddress;
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,7 @@
         "cross-fetch": "^4.1.0",
         "fs-extra": "^11.3.1",
         "minimatch": "^10.2.4",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "rollup": "^4.60.1",
         "rollup-plugin-dts": "^6.4.1",
         "semver": "^7.7.1",

--- a/suite-common/bluetooth/src/types.ts
+++ b/suite-common/bluetooth/src/types.ts
@@ -20,8 +20,7 @@ export type BluetoothFilterPolicy = {
 };
 
 export type BluetoothAutoConnectPolicy =
-    | { type: 'recently-disconnected'; timestamp: number }
-    | { type: 'autoconnect-disabled' };
+    { type: 'recently-disconnected'; timestamp: number } | { type: 'autoconnect-disabled' };
 
 export type BluetoothManufacturerData = {
     deviceModel: DeviceModelInternal;

--- a/suite-common/calldata/src/types/decoder.ts
+++ b/suite-common/calldata/src/types/decoder.ts
@@ -5,10 +5,9 @@ import { type ExtractAbiFunction, type NamedAbiParameter } from './abi';
 export type DecodedAbiInputs<T extends Abi> =
     ExtractAbiFunction<T>['inputs'][number] extends infer P
         ? {
-              [Param in Extract<
-                  P,
-                  NamedAbiParameter
-              > as Param['name']]: AbiParameterToPrimitiveType<Param>;
+              [
+                  Param in Extract<P, NamedAbiParameter> as Param['name']
+              ]: AbiParameterToPrimitiveType<Param>;
           }
         : never;
 

--- a/suite-common/earn-stablecoin-defs/package.json
+++ b/suite-common/earn-stablecoin-defs/package.json
@@ -16,7 +16,7 @@
     },
     "devDependencies": {
         "orval": "8.19.0",
-        "prettier": "^3.8.4"
+        "prettier": "^3.9.6"
     },
     "dependencies": {
         "zod": "4.3.6"

--- a/suite-common/earn-staking-api/package.json
+++ b/suite-common/earn-staking-api/package.json
@@ -24,6 +24,6 @@
     },
     "devDependencies": {
         "orval": "8.19.0",
-        "prettier": "^3.8.4"
+        "prettier": "^3.9.6"
     }
 }

--- a/suite-common/feedback/src/feedback.ts
+++ b/suite-common/feedback/src/feedback.ts
@@ -31,5 +31,4 @@ interface SuggestionPayload extends BasePayload {
 }
 
 export type Feedback =
-    | { type: 'BUG'; payload: BugPayload }
-    | { type: 'SUGGESTION'; payload: SuggestionPayload };
+    { type: 'BUG'; payload: BugPayload } | { type: 'SUGGESTION'; payload: SuggestionPayload };

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -17,10 +17,7 @@ import {
 import { firmwareActions } from './firmwareActions';
 
 type FirmwareUpdateUiEvent =
-    | DeviceButtonRequest
-    | FirmwareProgress
-    | FirmwareReconnect
-    | FirmwareProgressUnexpectedDelay;
+    DeviceButtonRequest | FirmwareProgress | FirmwareReconnect | FirmwareProgressUnexpectedDelay;
 
 type FirmwareUpdateCommon = {
     // Device before installation begun. Used to display the original firmware type and version during the installation.

--- a/suite-common/http-client/src/httpClient.ts
+++ b/suite-common/http-client/src/httpClient.ts
@@ -51,11 +51,11 @@ export function createHttpClient({ baseUrl, ...defaultFetcherOptions }: HttpClie
             T,
             any
         >,
-        Schema extends EndpointFetcherOptions['schema'] extends infer S
+        Schema extends (EndpointFetcherOptions['schema'] extends infer S
             ? S extends StandardSchemaV1<infer I, infer O>
                 ? Required<StandardSchemaV1<I, O>>
                 : never
-            : never,
+            : never),
         Endpoint extends string,
     >(endpoint: Endpoint, options: EndpointFetcherOptions) {
         return <
@@ -66,8 +66,7 @@ export function createHttpClient({ baseUrl, ...defaultFetcherOptions }: HttpClie
                 ([RouteParams] extends [never] ? unknown : { routeParams: RouteParams }),
         ) => {
             const opts = fetcherOptions as
-                | (Options & { routeParams?: Record<string, string> })
-                | undefined;
+                (Options & { routeParams?: Record<string, string> }) | undefined;
 
             const pathname = opts?.routeParams
                 ? composePathnameFromRoute(endpoint, opts.routeParams)

--- a/suite-common/icons/package.json
+++ b/suite-common/icons/package.json
@@ -18,7 +18,7 @@
         "@suite-common/wallet-config": "workspace:^",
         "chalk": "^5.6.2",
         "fantasticon": "4.1.0",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "sharp": "^0.34.2",
         "svgo": "^4.0.1"
     },

--- a/suite-common/illustrations/package.json
+++ b/suite-common/illustrations/package.json
@@ -13,7 +13,7 @@
     },
     "devDependencies": {
         "chalk": "^5.6.2",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "svgo": "^4.0.1"
     }
 }

--- a/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
+++ b/suite-common/redux-extra-dependencies/src/extraDependenciesType.ts
@@ -60,8 +60,7 @@ type OriginalReduxThunk<TPayload, TReturn = void> = (
 // TODO: Replace with a generic shared `Thunk` type from @suite-common/redux-utils after
 // https://github.com/trezor/trezor-suite/issues/30770 is completed.
 type SuiteCompatibleThunk<TPayload, TReturn = void> =
-    | AsyncThunk<TReturn, TPayload, Record<never, never>>
-    | OriginalReduxThunk<TPayload, TReturn>;
+    AsyncThunk<TReturn, TPayload, Record<never, never>> | OriginalReduxThunk<TPayload, TReturn>;
 
 type BaseReducer = (state: any, action: { type: any; payload: any }) => void;
 type StorageLoadReducer = (state: any, action: { type: any; payload: any }) => void;

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.ts
@@ -61,7 +61,9 @@ type ResolveSingleInstanceThunkAPIRaw<TThunkAPI> = [TThunkAPI] extends [void]
  * no JavaScript at runtime.
  */
 type ResolveSingleInstanceThunkAPI<TThunkAPI> = {
-    [TKey in keyof ResolveSingleInstanceThunkAPIRaw<TThunkAPI>]: ResolveSingleInstanceThunkAPIRaw<TThunkAPI>[TKey];
+    [
+        TKey in keyof ResolveSingleInstanceThunkAPIRaw<TThunkAPI>
+    ]: ResolveSingleInstanceThunkAPIRaw<TThunkAPI>[TKey];
 };
 
 /**

--- a/suite-common/redux-utils/src/types.ts
+++ b/suite-common/redux-utils/src/types.ts
@@ -14,8 +14,7 @@ export type OriginalReduxThunk<TPayload, TReturn = void> = (
 // for both redux-toolkit and legacy redux stuff like it is in externalDependencies.
 // Primary you should use types like ActionCreatorWithPayload from redux-toolkit!
 export type SuiteCompatibleThunk<TPayload, TReturn = void> =
-    | AsyncThunk<TReturn, TPayload, Record<never, never>>
-    | OriginalReduxThunk<TPayload, TReturn>;
+    AsyncThunk<TReturn, TPayload, Record<never, never>> | OriginalReduxThunk<TPayload, TReturn>;
 
 export type ActionType = string;
 

--- a/suite-common/staking/src/ethereumStaking.ts
+++ b/suite-common/staking/src/ethereumStaking.ts
@@ -161,8 +161,7 @@ export type EthereumStakingLiveStateReason =
     | { code: 'UNSUPPORTED_STAKE_TYPE'; stakeType: string };
 
 export type EthereumStakingLiveStateValidation =
-    | { isValid: true }
-    | { isValid: false; reason: EthereumStakingLiveStateReason };
+    { isValid: true } | { isValid: false; reason: EthereumStakingLiveStateReason };
 
 const VALID_LIVE_STATE: EthereumStakingLiveStateValidation = { isValid: true };
 

--- a/suite-common/suite-sync/src/suiteSyncTypes.ts
+++ b/suite-common/suite-sync/src/suiteSyncTypes.ts
@@ -1,5 +1,2 @@
 export type SuiteSyncInteraction =
-    | 'suite-sync-off'
-    | 'firmware-upgrade-needed'
-    | 'unsupported'
-    | 'keys-needed';
+    'suite-sync-off' | 'firmware-upgrade-needed' | 'unsupported' | 'keys-needed';

--- a/suite-common/suite-sync/src/suiteSyncUncontrolledErrorHandler.ts
+++ b/suite-common/suite-sync/src/suiteSyncUncontrolledErrorHandler.ts
@@ -10,9 +10,7 @@ import { type TrezorDeviceWithState } from '@suite-common/suite-types';
  * a user-controlled flow (e.g. asynchronously in response to some websocket message).
  */
 export type SuiteSyncUncontrolledError =
-    | AllocateOwnerQuotaErr
-    | EnsureWalletSuiteSyncOnErrors
-    | SuiteSyncOtherError;
+    AllocateOwnerQuotaErr | EnsureWalletSuiteSyncOnErrors | SuiteSyncOtherError;
 
 /**
  * This is External error handler. The caller of the SuiteSync (Desktop, Web, Native, ...)

--- a/suite-common/suite-types/src/connectInit.ts
+++ b/suite-common/suite-types/src/connectInit.ts
@@ -33,10 +33,7 @@ export type ConnectInitSettingsDep = {
 };
 
 export type TransportName =
-    | 'BridgeTransport'
-    | 'NodeUsbTransport'
-    | 'UdpTransport'
-    | 'WebUsbTransport';
+    'BridgeTransport' | 'NodeUsbTransport' | 'UdpTransport' | 'WebUsbTransport';
 
 export type CreateTransports = (transports: TransportName[]) => ConnectSettings['transports'];
 

--- a/suite-common/suite-types/src/device.ts
+++ b/suite-common/suite-types/src/device.ts
@@ -126,8 +126,7 @@ type ConnectAuthenticateDeviceResultPayload = AuthenticateDeviceResult | { error
  *    (e.g. optiga & tropic) and it is up to Suite to decide which results to use.
  */
 export type StoredAuthenticateDeviceResult =
-    | (ConnectAuthenticateDeviceResultPayload & { valid: boolean })
-    | undefined;
+    (ConnectAuthenticateDeviceResultPayload & { valid: boolean }) | undefined;
 
 /**
  * This whole file is intended as a helper for wrapping connect errors to abstract them for use

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -281,8 +281,7 @@ type EventNotification = { context: 'event' } & CommonNotificationPayload &
     NotificationEventPayload;
 
 export type NotificationEntry<TranslationKey extends string = UnknownTranslationKey> =
-    | ToastNotification<TranslationKey>
-    | EventNotification;
+    ToastNotification<TranslationKey> | EventNotification;
 
 export type AddNotificationAction<TranslationKey extends string = UnknownTranslationKey> = {
     payload: NotificationEntry<TranslationKey>;
@@ -296,8 +295,7 @@ export type NotificationsRootState<TranslationKey extends string = UnknownTransl
 };
 
 export type TransactionNotification = (
-    | SentTransactionNotification
-    | ReceivedTransactionNotification
+    SentTransactionNotification | ReceivedTransactionNotification
 ) &
     CommonNotificationPayload;
 

--- a/suite-common/token-definitions/src/phishing/types.ts
+++ b/suite-common/token-definitions/src/phishing/types.ts
@@ -31,11 +31,7 @@ export interface PhishingDetectorResult {
 export type PhishingDetectorFn = (props: PhishingDetectorFnProps) => PhishingDetectorResult;
 
 export type PhishingDetectorId =
-    | 'FAKE_TOKEN'
-    | 'UNKNOWN_TX'
-    | 'DUST_AMOUNT'
-    | 'ZERO_AMOUNT'
-    | 'TRC10_TRANSFER';
+    'FAKE_TOKEN' | 'UNKNOWN_TX' | 'DUST_AMOUNT' | 'ZERO_AMOUNT' | 'TRC10_TRANSFER';
 
 export type PhishingDetector = {
     id: PhishingDetectorId;

--- a/suite-common/trading/src/types.ts
+++ b/suite-common/trading/src/types.ts
@@ -86,8 +86,7 @@ export type TradingAssetOptionWithContractAddress = TradingAssetOptionBase & {
 };
 
 export type TradingAssetOption =
-    | TradingAssetOptionNativeToken
-    | TradingAssetOptionWithContractAddress;
+    TradingAssetOptionNativeToken | TradingAssetOptionWithContractAddress;
 
 // information about created trade
 export type TradingTradeType = BuyTrade | SellFiatTrade | ExchangeTrade;
@@ -150,9 +149,7 @@ export type TradingTransactionExchange = TradingCommonTransaction & {
     sendAccountKey: Account['key'] | undefined;
 };
 export type TradingTransaction =
-    | TradingTransactionBuy
-    | TradingTransactionSell
-    | TradingTransactionExchange;
+    TradingTransactionBuy | TradingTransactionSell | TradingTransactionExchange;
 
 export type TradingTransactionStatus = TradingTransaction['data']['status'];
 
@@ -230,12 +227,10 @@ export type TradingExchangeAmountLimitProps = Pick<
 >;
 
 export type TradingExchangeRateType =
-    | typeof constants.TRADING_EXCHANGE_RATE_FIXED
-    | typeof constants.TRADING_EXCHANGE_RATE_FLOATING;
+    typeof constants.TRADING_EXCHANGE_RATE_FIXED | typeof constants.TRADING_EXCHANGE_RATE_FLOATING;
 
 export type TradingExchangeFormType =
-    | typeof constants.TRADING_EXCHANGE_FORM_CEX
-    | typeof constants.TRADING_EXCHANGE_FORM_DEX;
+    typeof constants.TRADING_EXCHANGE_FORM_CEX | typeof constants.TRADING_EXCHANGE_FORM_DEX;
 
 export type TradingExchangeKycFilter =
     | typeof constants.TRADING_EXCHANGE_COMPARATOR_KYC_FILTER_ALL

--- a/suite-common/trading/src/utils/exchange/exchangeUtils.ts
+++ b/suite-common/trading/src/utils/exchange/exchangeUtils.ts
@@ -110,12 +110,7 @@ export const getStatusMessage = (status: ExchangeTradeStatus) => {
 };
 
 export type ApprovalStatus =
-    | 'approved'
-    | 'needs_approval'
-    | 'needs_increase'
-    | 'needs_revoke'
-    | 'not_needed'
-    | null;
+    'approved' | 'needs_approval' | 'needs_increase' | 'needs_revoke' | 'not_needed' | null;
 
 export const hasEip712SignDataType = (quote?: ExchangeTrade): boolean =>
     quote?.signData?.type === 'eip712-typed-data';

--- a/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
+++ b/suite-common/trading/src/utils/exchange/resolveExchangeTradeError.ts
@@ -39,8 +39,7 @@ export const isResolvedTradeError = (value: unknown): value is ResolvedTradeErro
     typeof value.code === 'string';
 
 export type TradingErrorDisplay =
-    | { kind: 'detailed'; values: TradingErrorValuesRecord }
-    | { kind: 'base'; message?: string };
+    { kind: 'detailed'; values: TradingErrorValuesRecord } | { kind: 'base'; message?: string };
 
 // This helper is prepared for using in desktop and native mobile apps,
 // where we can use rich text formatting for structured error messages.

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -14,13 +14,7 @@ export const asNetworkSymbol = (symbol: string): NetworkSymbol => symbol as Netw
 export type NetworkSymbolExtended = NetworkSymbol | (string & {});
 
 export type NetworkType =
-    | 'bitcoin'
-    | 'ethereum'
-    | 'ripple'
-    | 'cardano'
-    | 'solana'
-    | 'stellar'
-    | 'tron';
+    'bitcoin' | 'ethereum' | 'ripple' | 'cardano' | 'solana' | 'stellar' | 'tron';
 
 type UtilityAccountType = 'normal' | 'imported' | 'placeholder'; // reserved accountTypes to stand in for a real accountType
 type RealAccountType = 'legacy' | 'segwit' | 'coinjoin' | 'taproot' | 'ledger';

--- a/suite-common/wallet-core/src/blockchain/blockchainActions.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainActions.ts
@@ -21,8 +21,7 @@ const synced = createAction(
 );
 
 export type SetBackendPayload =
-    | CustomBackend
-    | { symbol: NetworkSymbol; type: 'default'; urls?: unknown };
+    CustomBackend | { symbol: NetworkSymbol; type: 'default'; urls?: unknown };
 const setBackend = createAction(
     `${BLOCKCHAIN_MODULE_PREFIX}/setBackend`,
     (payload: SetBackendPayload) => ({

--- a/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
@@ -70,8 +70,7 @@ describe('useMissingRateTickersQuery', () => {
         });
 
         const queryParams = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1]?.[0] as
-            | { queryFn: () => Promise<unknown> }
-            | undefined;
+            { queryFn: () => Promise<unknown> } | undefined;
 
         expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
         await queryParams?.queryFn();

--- a/suite-common/wallet-core/src/selectors.ts
+++ b/suite-common/wallet-core/src/selectors.ts
@@ -110,9 +110,10 @@ const getAccountChainsPerAccountType = (accounts: Account[]) =>
             // accounts when a known-accounts refresh fails for some of them (e.g. flaky backend)
             firstFailedAccount: accs
                 .filter(isAccountFailed)
-                .reduce<
-                    Account | undefined
-                >((first, current) => (!first || current.index < first.index ? current : first), undefined),
+                .reduce<Account | undefined>(
+                    (first, current) => (!first || current.index < first.index ? current : first),
+                    undefined,
+                ),
         }),
     );
 

--- a/suite-common/wallet-core/src/stake/stakeActions.ts
+++ b/suite-common/wallet-core/src/stake/stakeActions.ts
@@ -16,8 +16,7 @@ type RequestPushTransactionPayload = {
 };
 
 export type VotingDelegationOption =
-    | { type: 'everstake' }
-    | { type: 'another_drep'; drepId: string };
+    { type: 'everstake' } | { type: 'another_drep'; drepId: string };
 
 const setVotingDelegationOption = createAction(
     `${STAKE_MODULE_PREFIX}/setVotingDelegationOption`,

--- a/suite-common/wallet-types/src/account.ts
+++ b/suite-common/wallet-types/src/account.ts
@@ -123,8 +123,7 @@ export type AccountBackendSpecific =
       };
 
 export type AccountFailureSpecific =
-    | { failed: true; error: string }
-    | { failed?: false; error?: undefined };
+    { failed: true; error: string } | { failed?: false; error?: undefined };
 
 /**
  * This is synthetic (combined) key, it may be useful for some data-structures.

--- a/suite-common/wallet-types/src/cardanoStaking.ts
+++ b/suite-common/wallet-types/src/cardanoStaking.ts
@@ -1,9 +1,5 @@
 export type CardanoAction =
-    | 'delegate'
-    | 'withdrawal'
-    | 'voteDelegate'
-    | 'voteAbstain'
-    | 'deregister';
+    'delegate' | 'withdrawal' | 'voteDelegate' | 'voteAbstain' | 'deregister';
 
 export type ActionAvailability =
     | { status: true; reason?: undefined }

--- a/suite-common/wallet-types/src/selectedAccount.ts
+++ b/suite-common/wallet-types/src/selectedAccount.ts
@@ -66,7 +66,4 @@ type SelectedAccountNone = {
 };
 
 export type SelectedAccountStatus =
-    | SelectedAccountLoaded
-    | SelectedAccountLoading
-    | SelectedAccountException
-    | SelectedAccountNone;
+    SelectedAccountLoaded | SelectedAccountLoading | SelectedAccountException | SelectedAccountNone;

--- a/suite-common/wallet-types/src/send.ts
+++ b/suite-common/wallet-types/src/send.ts
@@ -3,5 +3,4 @@ import { type Branded } from '@trezor/type-utils';
 import { type AccountKey, type TokenAddress } from './account';
 
 export type SendFormDraftKey =
-    | AccountKey
-    | (`${AccountKey}-${TokenAddress}` & Branded<'SendFormDraftKey'>);
+    AccountKey | (`${AccountKey}-${TokenAddress}` & Branded<'SendFormDraftKey'>);

--- a/suite-common/wallet-types/src/sendForm.ts
+++ b/suite-common/wallet-types/src/sendForm.ts
@@ -58,9 +58,7 @@ export type FormStateTradingExchange = {
 } & FormStateTradingCommon;
 
 export type FormStateTrading =
-    | FormStateTradingSell
-    | FormStateTradingExchange
-    | FormStateTradingDefault;
+    FormStateTradingSell | FormStateTradingExchange | FormStateTradingDefault;
 
 export interface FormState {
     outputs: Output[]; // output arrays, each element is corresponding with single Output item

--- a/suite-common/wallet-types/src/transaction.ts
+++ b/suite-common/wallet-types/src/transaction.ts
@@ -210,9 +210,7 @@ export type PrecomposedTransactionFinal =
     | PrecomposedTransactionFinalCancelRbf;
 
 export type PrecomposedTransaction =
-    | PrecomposedTransactionError
-    | PrecomposedTransactionNonFinal
-    | PrecomposedTransactionFinal;
+    PrecomposedTransactionError | PrecomposedTransactionNonFinal | PrecomposedTransactionFinal;
 
 export type PrecomposedTransactionCardano =
     | PrecomposedTransactionCardanoError

--- a/suite-common/wallet-utils/src/sendFormUtils.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.ts
@@ -601,9 +601,7 @@ export const getSendFormDraftKey = (
     tokenAddress ? (`${accountKey}-${tokenAddress}` as SendFormDraftKey) : accountKey;
 
 type AmountValidationResult =
-    | { type: 'ok' }
-    | { type: 'not_enough' }
-    | { type: 'reserve'; reserve: string };
+    { type: 'ok' } | { type: 'not_enough' } | { type: 'reserve'; reserve: string };
 
 interface GetAmountValidationResultParams {
     amount: string | undefined;

--- a/suite-native/alerts/src/alertsAtoms.ts
+++ b/suite-native/alerts/src/alertsAtoms.ts
@@ -7,11 +7,7 @@ import { type IconName } from '@suite-native/icons';
 import { type NativeSpacing } from '@trezor/theme';
 
 export type AlertType =
-    | 'autoEject'
-    | 'bluetoothAdapter'
-    | 'bluetoothPairing'
-    | 'connectDevice'
-    | 'deviceError';
+    'autoEject' | 'bluetoothAdapter' | 'bluetoothPairing' | 'connectDevice' | 'deviceError';
 
 export type Alert = {
     title?: ReactNode;

--- a/suite-native/analytics/src/definitions.ts
+++ b/suite-native/analytics/src/definitions.ts
@@ -12,8 +12,7 @@ export type AnalyticsSendFlowStep =
 
 export type CountryChangeContextCheck = 'settings' | 'onboarding';
 export type CountryChangeContext =
-    | Exclude<TradingTypeWithConcierge, 'exchange'>
-    | CountryChangeContextCheck;
+    Exclude<TradingTypeWithConcierge, 'exchange'> | CountryChangeContextCheck;
 export type CountryChangeAction = 'submitDefault' | 'submitCustom' | 'cancel';
 
 export type DeviceAuthenticityCheckResult = 'successful' | 'compromised' | 'cancelled' | 'failed';
@@ -62,12 +61,7 @@ export type TradingNavigateFrom =
     | 'trade/exchange'
     | 'trade/concierge';
 export type TradingExchangeAction =
-    | 'continue'
-    | 'cancel'
-    | 'retry'
-    | 'visit'
-    | 'revoke'
-    | 'value_change';
+    'continue' | 'cancel' | 'retry' | 'visit' | 'revoke' | 'value_change';
 export type TradingExchangeStep =
     | 'exchange-form'
     | 'account-selection'
@@ -88,8 +82,4 @@ export type TradingBuyStep = 'buy-form' | 'account-selection' | 'buy-preview';
 
 export type TradingSellAction = 'continue' | 'cancel' | 'retry' | 'visit';
 export type TradingSellStep =
-    | 'sell-form'
-    | 'transaction-preview'
-    | 'fee-selection'
-    | 'sign-and-send'
-    | 'webview';
+    'sell-form' | 'transaction-preview' | 'fee-selection' | 'sign-and-send' | 'webview';

--- a/suite-native/analytics/src/events/demoAccountQuestionnaireLinksEvent.ts
+++ b/suite-native/analytics/src/events/demoAccountQuestionnaireLinksEvent.ts
@@ -3,10 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 export type DemoAccountQuestionnaireLinkKey =
-    | 'hardwareWallet'
-    | 'trezorSecurity'
-    | 'TS7'
-    | 'dashboard';
+    'hardwareWallet' | 'trezorSecurity' | 'TS7' | 'dashboard';
 
 type Attributes = {
     option: AttributeDef<DemoAccountQuestionnaireLinkKey>;

--- a/suite-native/analytics/src/events/demoAccountQuestionnaireQuestionEvent.ts
+++ b/suite-native/analytics/src/events/demoAccountQuestionnaireQuestionEvent.ts
@@ -5,13 +5,7 @@ import { EventType } from '../constants';
 export type DemoAccountQuestionnaireQuestion = 'reason' | 'suiteAction';
 
 export type DemoAccountQuestionnaireQuestionOption =
-    | 'considering'
-    | 'ad'
-    | 'friend'
-    | 'none'
-    | 'explore'
-    | 'transaction'
-    | 'hardwareWallet';
+    'considering' | 'ad' | 'friend' | 'none' | 'explore' | 'transaction' | 'hardwareWallet';
 
 type Attributes = {
     option: AttributeDef<DemoAccountQuestionnaireQuestionOption>;

--- a/suite-native/analytics/src/events/switcherEvent.ts
+++ b/suite-native/analytics/src/events/switcherEvent.ts
@@ -3,10 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 type DeviceManagerAction =
-    | 'deviceItem'
-    | 'portfolioTracker'
-    | 'connectDeviceButton'
-    | 'deviceSettings';
+    'deviceItem' | 'portfolioTracker' | 'connectDeviceButton' | 'deviceSettings';
 
 type Attributes = {
     action: AttributeDef<DeviceManagerAction>;

--- a/suite-native/analytics/src/events/tradingParameterChangedEvent.ts
+++ b/suite-native/analytics/src/events/tradingParameterChangedEvent.ts
@@ -5,12 +5,7 @@ import { EventType } from '../constants';
 import { type CountryChangeContext } from '../definitions';
 
 type TradingParameter =
-    | 'fiat'
-    | 'cryptoFrom'
-    | 'cryptoTo'
-    | 'paymentMethod'
-    | 'provider'
-    | 'country';
+    'fiat' | 'cryptoFrom' | 'cryptoTo' | 'paymentMethod' | 'provider' | 'country';
 
 type Attributes = {
     type: AttributeDef<TradingType | CountryChangeContext>;

--- a/suite-native/analytics/src/events/tradingStatusEvent.ts
+++ b/suite-native/analytics/src/events/tradingStatusEvent.ts
@@ -4,14 +4,7 @@ import { type TradingType } from '@suite-common/trading';
 import { EventType } from '../constants';
 
 type TradingStatusValue =
-    | 'waiting'
-    | 'processing'
-    | 'pending'
-    | 'converting'
-    | 'sending'
-    | 'kyc'
-    | 'success'
-    | 'error';
+    'waiting' | 'processing' | 'pending' | 'converting' | 'sending' | 'kyc' | 'success' | 'error';
 
 type Attributes = {
     type: AttributeDef<TradingType>;

--- a/suite-native/analytics/src/events/unsupportedDeviceEvent.ts
+++ b/suite-native/analytics/src/events/unsupportedDeviceEvent.ts
@@ -3,10 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 type UnsupportedDeviceState =
-    | 'unsupportedFirmware'
-    | 'noSeed'
-    | 'bootloaderMode'
-    | 'noSeedWithFirmware';
+    'unsupportedFirmware' | 'noSeed' | 'bootloaderMode' | 'noSeedWithFirmware';
 
 type Attributes = {
     deviceState: AttributeDef<UnsupportedDeviceState>;

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -29,8 +29,7 @@ export type BiometricsToggleFulfilledResult = Extract<
 >;
 
 type BiometricsToggleRejectReason =
-    | BiometricsToggleResult.BiometricsNotAvailable
-    | AuthenticateError;
+    BiometricsToggleResult.BiometricsNotAvailable | AuthenticateError;
 
 export type BiometricsAppStateChangePayload = {
     isUserAuthenticated?: boolean;

--- a/suite-native/bluetooth/src/types.ts
+++ b/suite-native/bluetooth/src/types.ts
@@ -3,12 +3,7 @@ import { type BluetoothDeviceId } from '@trezor/connect';
 import { type BluetoothDevice as TransportBluetoothDevice } from '@trezor/transport-native-bluetooth';
 
 export type BluetoothPermissionStatus =
-    | 'unavailable'
-    | 'requested'
-    | 'denied'
-    | 'blocked'
-    | 'granted'
-    | 'limited';
+    'unavailable' | 'requested' | 'denied' | 'blocked' | 'granted' | 'limited';
 
 export type BluetoothDevice = Omit<TransportBluetoothDevice, 'manufacturerData' | 'id'> & {
     id: BluetoothDeviceId;

--- a/suite-native/graph/src/graphInstances.ts
+++ b/suite-native/graph/src/graphInstances.ts
@@ -4,8 +4,7 @@ export const PORTFOLIO_GRAPH_INSTANCE_ID = 'portfolio';
 
 export type PortfolioGraphInstanceId = typeof PORTFOLIO_GRAPH_INSTANCE_ID;
 export type AccountGraphInstanceId =
-    | `account:${AccountKey}`
-    | `account:${AccountKey}:token:${TokenAddress}`;
+    `account:${AccountKey}` | `account:${AccountKey}:token:${TokenAddress}`;
 export type GraphInstanceId = PortfolioGraphInstanceId | AccountGraphInstanceId;
 
 type GetAccountGraphInstanceIdParams = {

--- a/suite-native/module-earn/src/components/StakingPromoRingIcon.tsx
+++ b/suite-native/module-earn/src/components/StakingPromoRingIcon.tsx
@@ -10,8 +10,7 @@ import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { hexToRgba } from '@trezor/utils';
 
 type StakingPromoRingIconProps = { networkColor?: NetworkColor } & (
-    | { iconName: IconName; children?: never }
-    | { iconName?: never; children: ReactNode }
+    { iconName: IconName; children?: never } | { iconName?: never; children: ReactNode }
 );
 
 const iconInnerContainerStyle = prepareNativeStyle(

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
@@ -40,8 +40,7 @@ export type ComposedTxBase = {
 };
 
 export type ComposeTxResult<TComposed extends ComposedTxBase> =
-    | { type: 'ready'; transaction: TComposed }
-    | { type: 'error'; isFeeEstimationError: boolean };
+    { type: 'ready'; transaction: TComposed } | { type: 'error'; isFeeEstimationError: boolean };
 
 export type PreparedTx<TComposed extends ComposedTxBase> = {
     amount: string;

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -27,11 +27,7 @@ import { capitalizeFirstLetter } from '@trezor/utils';
 import { getAccountTokenByContract } from '../utils/contractTokenBalanceUtils';
 
 export type YieldFlowResolutionStatus =
-    | 'resolved'
-    | 'missing-vault'
-    | 'missing-network'
-    | 'missing-account'
-    | 'missing-token';
+    'resolved' | 'missing-vault' | 'missing-network' | 'missing-account' | 'missing-token';
 
 type UnresolvedYieldFlowData = {
     account: Account | null;

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -24,11 +24,7 @@ export type YieldReviewStatus = YieldReviewActionStatus | 'signed';
 export type YieldDepositReviewStatus = YieldReviewStatus;
 
 export type YieldReviewSigningResult =
-    | 'signed'
-    | 'cancelled'
-    | 'failed'
-    | 'not-ready'
-    | 'already-running';
+    'signed' | 'cancelled' | 'failed' | 'not-ready' | 'already-running';
 
 export type YieldBroadcastTransaction = {
     txid: string;

--- a/suite-native/module-earn/src/utils.ts
+++ b/suite-native/module-earn/src/utils.ts
@@ -42,16 +42,10 @@ export const isUserCancelledSignError = (
     (!!payload?.errorCode && USER_CANCELLED_ERROR_CODES.some(code => code === payload.errorCode));
 
 export type EarnReviewErrorPayload =
-    | { error?: string; errorCode?: string; message?: string }
-    | undefined;
+    { error?: string; errorCode?: string; message?: string } | undefined;
 
 export type EarnReviewErrorReaction =
-    | 'none'
-    | 'popScreen'
-    | 'pendingConflict'
-    | 'pushFailed'
-    | 'signFailed'
-    | 'deviceDisconnected';
+    'none' | 'popScreen' | 'pendingConflict' | 'pushFailed' | 'signFailed' | 'deviceDisconnected';
 
 export const getEarnReviewErrorReaction = (
     payload: EarnReviewErrorPayload,

--- a/suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts
+++ b/suite-native/module-earn/src/utils/yieldReviewOutputUtils.ts
@@ -59,8 +59,7 @@ type YieldTransactionReviewValueOutput = Extract<ReviewOutput, { value: string }
 type YieldTransactionReviewRewardsOutput = Extract<ReviewOutput, { type: 'rewards' }>;
 
 export type YieldTransactionReviewOutput =
-    | YieldTransactionReviewRewardsOutput
-    | YieldTransactionReviewValueOutput;
+    YieldTransactionReviewRewardsOutput | YieldTransactionReviewValueOutput;
 
 type BuildYieldReviewPreviewBaseParams = {
     account: Account;

--- a/suite-native/module-earn/src/yieldApprovalThunks.ts
+++ b/suite-native/module-earn/src/yieldApprovalThunks.ts
@@ -109,8 +109,7 @@ export const prepareYieldAllowanceReviewTransactionThunk = createThunk(
 
         const formDraftKey = getYieldAllowanceFormDraftKey(flowKey, transactionType);
         const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as
-            | FormState
-            | undefined;
+            FormState | undefined;
         const { approval } = selectStablecoinYieldSession(getState(), 'deposit', flowKey);
 
         const { modalState } = approval;
@@ -179,8 +178,7 @@ export const updateYieldAllowanceSelectedFeeLevelThunk = createThunk(
         if (!formDraftKey) return;
 
         const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as
-            | FormState
-            | undefined;
+            FormState | undefined;
 
         if (!formDraft) return;
 

--- a/suite-native/module-earn/src/yieldClaimThunks.ts
+++ b/suite-native/module-earn/src/yieldClaimThunks.ts
@@ -50,8 +50,7 @@ export const updateYieldClaimSelectedFeeLevelThunk = createThunk(
         if (!formDraftKey) return;
 
         const formDraft = selectDeepCopyOfFormDraft(getState(), formDraftKey) as
-            | FormState
-            | undefined;
+            FormState | undefined;
 
         if (!formDraft) return;
 

--- a/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
+++ b/suite-native/module-trading/src/hooks/general/form/useTradeableAssetChange.ts
@@ -97,8 +97,7 @@ export const useTradeableAssetChange = <TFieldValues extends FieldValues>({
 
             const counterpartAsset = collision
                 ? (getValues(collision.counterpartAssetField as Path<TFieldValues>) as
-                      | TradeableAsset
-                      | undefined)
+                      TradeableAsset | undefined)
                 : undefined;
 
             if (collision && asset.cryptoId === counterpartAsset?.cryptoId) {

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -391,12 +391,10 @@ export type DeviceSettingsStackParamList = {
     [DeviceSettingsStackRoutes.DevicePassphraseStack]: undefined;
     [DeviceSettingsStackRoutes.DeviceAuthenticity]: undefined;
     [DeviceSettingsStackRoutes.DeviceAuthenticityStack]:
-        | NavigatorScreenParams<DeviceAuthenticityStackParamList>
-        | undefined;
+        NavigatorScreenParams<DeviceAuthenticityStackParamList> | undefined;
     [DeviceSettingsStackRoutes.WipeDevice]: undefined;
     [DeviceSettingsStackRoutes.WipeDeviceStack]:
-        | NavigatorScreenParams<WipeDeviceStackParamList>
-        | undefined;
+        NavigatorScreenParams<WipeDeviceStackParamList> | undefined;
 };
 
 export type DeviceNameStackParamList = {
@@ -470,8 +468,7 @@ export type DeviceAuthenticityStackParamList = {
 
 export type AuthorizeDeviceStackParamList = {
     [AuthorizeDeviceStackRoutes.DeviceConnectionGuard]:
-        | { onCancelNavigationTarget: NavigateParameters<RootStackParamList> }
-        | undefined;
+        { onCancelNavigationTarget: NavigateParameters<RootStackParamList> } | undefined;
     [AuthorizeDeviceStackRoutes.ConnectDeviceCrossroads]: undefined;
     [AuthorizeDeviceStackRoutes.ConnectAndUnlockDevice]: undefined;
     [AuthorizeDeviceStackRoutes.TurnOnAndUnlockDevice]: undefined;

--- a/suite-native/react-native-graph/src/LineGraphProps.ts
+++ b/suite-native/react-native-graph/src/LineGraphProps.ts
@@ -90,9 +90,7 @@ interface BaseLineGraphProps extends ViewProps {
     enableFadeInMask?: boolean;
 }
 
-export type StaticLineGraphProps = BaseLineGraphProps & {
-    /* any static-only line graph props? */
-};
+export type StaticLineGraphProps = BaseLineGraphProps & {/* any static-only line graph props? */};
 
 export type AnimatedLineGraphProps<TEventPayload extends object> = BaseLineGraphProps & {
     /**

--- a/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.ts
+++ b/suite-native/trading-analytics/src/hooks/useExchangeAnalyticReportCallback.ts
@@ -37,8 +37,7 @@ const useExchangeFormAnalyticsPayload = (quote: ExchangeTrade | undefined) => {
         (state: TradingRootState) =>
             (
                 selectTradingProviderByNameAndTradeType(state, exchange, 'exchange') as
-                    | ExchangeProviderInfo
-                    | undefined
+                    ExchangeProviderInfo | undefined
             )?.isFixedRate,
     );
 

--- a/suite-native/trading-atoms/src/hooks/useSectionList.tsx
+++ b/suite-native/trading-atoms/src/hooks/useSectionList.tsx
@@ -73,8 +73,7 @@ type RenderInternalItemProps<T, U> = {
         sheetControls: BottomSheetFlashListControls,
     ) => ReactElement;
     renderSectionHeader:
-        | ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement)
-        | undefined;
+        ((label: ReactNode, config: SectionHeaderRenderConfig<U>) => ReactElement) | undefined;
     SectionEmptyComponent: ReactElement | undefined;
     applyStyle: ReturnType<typeof useNativeStyles>['applyStyle'];
     itemStyle?: ReturnType<typeof prepareNativeStyle<ItemRenderConfig<unknown>>>;
@@ -118,18 +117,16 @@ const transformToInternalFlatListData = <T, U = undefined>({
 }: TransformToInternalFlatListDataProps<T, U>): ListInternalItemShape<T, U>[] =>
     inputData.reduce(
         (acc, { key, label, data, sectionData }) => {
-            const itemsData = data.map(
-                (item, index): ListInternalItemShape<T, U> => ({
-                    type: 'item',
-                    item,
-                    config: {
-                        isFirst: index === 0,
-                        isLast: index === data.length - 1 && isLastItemRounded,
-                        sectionData,
-                        isEnabled: item.isEnabled !== undefined ? item.isEnabled : true,
-                    },
-                }),
-            );
+            const itemsData = data.map((item, index): ListInternalItemShape<T, U> => ({
+                type: 'item',
+                item,
+                config: {
+                    isFirst: index === 0,
+                    isLast: index === data.length - 1 && isLastItemRounded,
+                    sectionData,
+                    isEnabled: item.isEnabled !== undefined ? item.isEnabled : true,
+                },
+            }));
 
             if (!noSingletonSectionHeader || inputData.length > 1) {
                 acc.push({

--- a/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.ts
+++ b/suite-native/trading-debug/src/hooks/useTransactionStatusOverride.ts
@@ -5,11 +5,7 @@ import type { TransactionStatus } from '@suite-common/trading';
 import { useTradingDebugModeFlag } from './useTradingDebugModeFlag';
 
 type TransactionStatusOverrideType =
-    | 'none'
-    | 'isConfirmed'
-    | 'isFailed'
-    | 'isPending'
-    | 'no-override';
+    'none' | 'isConfirmed' | 'isFailed' | 'isPending' | 'no-override';
 
 export type TransactionStatusWithOverride = {
     status: TransactionStatus;

--- a/suite-native/trading-residence/src/utils/getPreferredCountryOption.ts
+++ b/suite-native/trading-residence/src/utils/getPreferredCountryOption.ts
@@ -8,8 +8,7 @@ export const getPreferredCountryOption = () => {
     const preferredCountryCode = getLocales()
         .map(({ regionCode }) => regionCode)
         .find(regionCode => countriesOptionsMap.has(regionCode as TradingCountryCode)) as
-        | TradingCountryCode
-        | undefined;
+        TradingCountryCode | undefined;
 
     return countriesOptionsMap.get(preferredCountryCode ?? 'unknown')!;
 };

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.ts
@@ -28,8 +28,7 @@ export const useTransactionDetails = ({
     const transaction = useSelector((state: TransactionsRootState) =>
         accountKey && txid
             ? (selectTransactionByAccountKeyAndTxid(state, accountKey, txid) as
-                  | WalletAccountTransaction
-                  | undefined)
+                  WalletAccountTransaction | undefined)
             : undefined,
     );
 

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -65,8 +65,7 @@ type TypedTokenTransferWithTx = TypedTokenTransfer & {
 };
 
 type TransactionListItem =
-    | (TypedTokenTransferWithTx | MonthKey)
-    | (WalletAccountTransaction | MonthKey);
+    (TypedTokenTransferWithTx | MonthKey) | (WalletAccountTransaction | MonthKey);
 
 const sectionListContainerStyle = prepareNativeStyle(utils => ({
     paddingTop: utils.spacings.sp8,

--- a/suite-native/transactions/src/utils.ts
+++ b/suite-native/transactions/src/utils.ts
@@ -31,14 +31,12 @@ export const mapTransactionInputsOutputsToAddresses = ({
                     (target.isAccountOwned || target.isAccountTarget)) ??
                 false;
 
-            return target.addresses?.map(
-                (address): VinVoutAddress => ({
-                    address,
-                    isChangeAddress,
-                    outputIndex: target.n,
-                    txTargetId: createSimpleTargetId(target),
-                }),
-            );
+            return target.addresses?.map((address): VinVoutAddress => ({
+                address,
+                isChangeAddress,
+                outputIndex: target.n,
+                txTargetId: createSimpleTargetId(target),
+            }));
         }),
         A.filter(isNotNullOrUndefined),
         A.concatMany,

--- a/suite-native/tx-simulation/src/components/EvmInsufficientGasWarning.tsx
+++ b/suite-native/tx-simulation/src/components/EvmInsufficientGasWarning.tsx
@@ -9,8 +9,7 @@ export type EvmInsufficientGasWarningProps = {
     gasLimit: string;
     networkSymbol: NetworkSymbol;
     transaction:
-        | TxSimulationMethod<'ethereumSignTransaction'>['payload']['transaction']
-        | undefined;
+        TxSimulationMethod<'ethereumSignTransaction'>['payload']['transaction'] | undefined;
 };
 
 export function EvmInsufficientGasWarning({

--- a/suite-native/video-assets/package.json
+++ b/suite-native/video-assets/package.json
@@ -16,7 +16,7 @@
         "@trezor/styles-native": "workspace:*",
         "expo": "~56.0.6",
         "expo-video": "~56.1.2",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.6",
         "react": "19.2.3",
         "react-native": "0.85.3",
         "react-native-reanimated": "4.3.1"

--- a/suite/analytics/src/events/settingsDeviceChangeThpAutoconnectEvent.ts
+++ b/suite/analytics/src/events/settingsDeviceChangeThpAutoconnectEvent.ts
@@ -3,8 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 export type SettingsDeviceChangeThpAutoConnectEventAction =
-    | 'disable-autoconnect'
-    | 'enable-autoconnect';
+    'disable-autoconnect' | 'enable-autoconnect';
 
 type Attributes = {
     action: AttributeDef<SettingsDeviceChangeThpAutoConnectEventAction>;

--- a/suite/analytics/src/events/transactionCreatedEvent.ts
+++ b/suite/analytics/src/events/transactionCreatedEvent.ts
@@ -3,11 +3,7 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 import { EventType } from '../constants';
 
 export type TransactionCreatedEventAction =
-    | 'sent'
-    | 'copied'
-    | 'downloaded'
-    | 'replaced'
-    | 'canceled';
+    'sent' | 'copied' | 'downloaded' | 'replaced' | 'canceled';
 
 type Attributes = {
     action: AttributeDef<TransactionCreatedEventAction>;

--- a/suite/e2e/docs/indexeddb-dumps.md
+++ b/suite/e2e/docs/indexeddb-dumps.md
@@ -16,9 +16,7 @@ The dump is a JSON file with the following shape (v1):
         "<storeName>": [
             {
                 "key": "...",
-                "value": {
-                    /* ... */
-                }
+                "value": {/* ... */}
             }
         ]
     }

--- a/suite/e2e/support/indexedDb.ts
+++ b/suite/e2e/support/indexedDb.ts
@@ -22,12 +22,7 @@ type GetIndexedDbValueParams = {
 type IndexedDbValuePath = string | Array<string | number>;
 
 type ExpectedIndexedDbValue =
-    | string
-    | number
-    | boolean
-    | Record<string, unknown>
-    | unknown[]
-    | null;
+    string | number | boolean | Record<string, unknown> | unknown[] | null;
 
 type ExpectIndexedDbValueParams = GetIndexedDbValueParams & {
     valuePath?: IndexedDbValuePath;

--- a/suite/e2e/support/pageObjects/settings/settingsPage.ts
+++ b/suite/e2e/support/pageObjects/settings/settingsPage.ts
@@ -38,8 +38,7 @@ const backgroundImageButton = {
 };
 
 export type NetworkToEnable =
-    | NetworkSymbol
-    | { symbol: NetworkSymbol; backend: { type: BackendType; url: string } };
+    NetworkSymbol | { symbol: NetworkSymbol; backend: { type: BackendType; url: string } };
 
 export class SettingsPage {
     private readonly TIMES_CLICK_TO_SET_DEBUG_MODE = 5;

--- a/suite/e2e/support/types/index.ts
+++ b/suite/e2e/support/types/index.ts
@@ -24,12 +24,7 @@ export type EventPayload<T extends SuiteDesktopAnalyticsEventsForE2e> = T extend
     : undefined;
 
 export type PaymentMethods =
-    | 'googlePay'
-    | 'applePay'
-    | 'creditCard'
-    | 'paypal'
-    | 'bankTransfer'
-    | 'revolutPay';
+    'googlePay' | 'applePay' | 'creditCard' | 'paypal' | 'bankTransfer' | 'revolutPay';
 
 export type PercentageOfBalanceParams = {
     percentage: number;

--- a/suite/firmware-upgrade/src/firmwareUtils.ts
+++ b/suite/firmware-upgrade/src/firmwareUtils.ts
@@ -17,10 +17,10 @@ export const getFormattedFingerprint = (fingerprint: string) =>
 
 // naming is based on fw version and chip, not model
 enum FirmwareFormat {
-    'T1' = 1,
-    'T1_EMBEDDED_V2',
-    'T1_V2',
-    'T2',
+    T1 = 1,
+    T1_EMBEDDED_V2,
+    T1_V2,
+    T2,
 }
 
 const FORMAT_MAP: { [format in FirmwareFormat]: DeviceModelInternal[] } = {

--- a/suite/locks/src/locksSlice.ts
+++ b/suite/locks/src/locksSlice.ts
@@ -41,9 +41,7 @@ export const locksSlice = createSlice({
 export const { lockUI, lockDevice, lockRouter } = locksSlice.actions;
 
 export type LockAction =
-    | ReturnType<typeof lockUI>
-    | ReturnType<typeof lockDevice>
-    | ReturnType<typeof lockRouter>;
+    ReturnType<typeof lockUI> | ReturnType<typeof lockDevice> | ReturnType<typeof lockRouter>;
 
 export const locksReducer = locksSlice.reducer;
 

--- a/suite/metadata/src/metadataProviderThunks.ts
+++ b/suite/metadata/src/metadataProviderThunks.ts
@@ -28,10 +28,7 @@ import { GoogleProvider } from './providers/GoogleProvider';
 import { InMemoryTestProvider } from './providers/InMemoryTestProvider';
 
 type ProviderInstance =
-    | DropboxProvider
-    | GoogleProvider
-    | FileSystemProvider
-    | InMemoryTestProvider;
+    DropboxProvider | GoogleProvider | FileSystemProvider | InMemoryTestProvider;
 
 // needs to be declared here in top level context because it's not recommended to keep classes instances in redux state (serialization)
 export const providerInstance: Record<DataType, ProviderInstance | undefined> = {

--- a/suite/router/src/anchors.ts
+++ b/suite/router/src/anchors.ts
@@ -1,10 +1,7 @@
 import { type Route } from './route';
 
 export type AnchorSettingSection =
-    | 'general-settings'
-    | 'device-settings'
-    | 'coin-settings'
-    | 'earn';
+    'general-settings' | 'device-settings' | 'coin-settings' | 'earn';
 
 type Anchor = `@${AnchorSettingSection}/${string}`;
 

--- a/suite/router/src/routes.ts
+++ b/suite/router/src/routes.ts
@@ -28,10 +28,9 @@ export type ModalAppParams = {
 };
 
 export type RouteParams = {
-    [K in keyof (CommonWalletParams &
-        EarnParams &
-        ModalAppParams &
-        DashboardParams)]?: (CommonWalletParams & EarnParams & ModalAppParams & DashboardParams)[K];
+    [
+        K in keyof (CommonWalletParams & EarnParams & ModalAppParams & DashboardParams)
+    ]?: (CommonWalletParams & EarnParams & ModalAppParams & DashboardParams)[K];
 };
 
 type AppWithParams<T extends { [key: string]: any }> = {

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -16,10 +16,7 @@ import { SIDEBAR_WIDTH_NUMERIC } from './suiteConstants';
  * String identifiers used by the debug transport switcher UI.
  */
 export type DebugTransport =
-    | 'BridgeTransport'
-    | 'NodeUsbTransport'
-    | 'UdpTransport'
-    | 'WebUsbTransport';
+    'BridgeTransport' | 'NodeUsbTransport' | 'UdpTransport' | 'WebUsbTransport';
 
 export interface DebugModeOptions {
     tradeServerEnvironment?: TradeServerEnvironment;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10422,7 +10422,7 @@ __metadata:
   resolution: "@suite-common/earn-stablecoin-defs@workspace:suite-common/earn-stablecoin-defs"
   dependencies:
     orval: "npm:8.19.0"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
@@ -10454,7 +10454,7 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@trezor/env-utils": "workspace:*"
     orval: "npm:8.19.0"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     zod: "npm:4.3.6"
   languageName: unknown
   linkType: soft
@@ -10604,7 +10604,7 @@ __metadata:
     "@suite-common/wallet-config": "workspace:^"
     chalk: "npm:^5.6.2"
     fantasticon: "npm:4.1.0"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     sharp: "npm:^0.34.2"
     svgo: "npm:^4.0.1"
     zod: "npm:4.3.6"
@@ -10616,7 +10616,7 @@ __metadata:
   resolution: "@suite-common/illustrations@workspace:suite-common/illustrations"
   dependencies:
     chalk: "npm:^5.6.2"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     svgo: "npm:^4.0.1"
   languageName: unknown
   linkType: soft
@@ -14667,7 +14667,7 @@ __metadata:
     "@trezor/styles-native": "workspace:*"
     expo: "npm:~56.0.6"
     expo-video: "npm:~56.1.2"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-reanimated: "npm:4.3.1"
@@ -16802,7 +16802,7 @@ __metadata:
   dependencies:
     "@svgr/cli": "npm:^8.1.0"
     "@trezor/eslint": "workspace:*"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     react: "npm:19.2.3"
   languageName: unknown
   linkType: soft
@@ -17138,7 +17138,7 @@ __metadata:
     cross-fetch: "npm:^4.1.0"
     fs-extra: "npm:^11.3.1"
     minimatch: "npm:^10.2.4"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     rollup: "npm:^4.60.1"
     rollup-plugin-dts: "npm:^6.4.1"
     semver: "npm:^7.7.1"
@@ -39659,12 +39659,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.8.4":
-  version: 3.8.4
-  resolution: "prettier@npm:3.8.4"
+"prettier@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "prettier@npm:3.9.6"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10/54684a3cc6689238692b29fab541c01934af7677be94c02293ba49981a1ac121c8bebe2a865f0c3b963e99d208f847c53aed354cc0ce8750e2d45791d64506c5
+  checksum: 10/1dd1a1e0e40ec3b91cda9d294c4a95022aef61880ca3f441aad99b1252279f58a766c4cece81132c01550dcff1fd445efbd8812ea4a2374313e7fc6c8136f11f
   languageName: node
   linkType: hard
 
@@ -45140,7 +45140,7 @@ __metadata:
     nx: "npm:23.0.0"
     postcss-styled-syntax: "npm:^0.7.1"
     postcss-value-parser: "npm:^4.2.0"
-    prettier: "npm:^3.8.4"
+    prettier: "npm:^3.9.6"
     rimraf: "npm:^6.1.2"
     stylelint: "npm:^17.1.1"
     ts-node: "npm:^10.9.2"


### PR DESCRIPTION
## Description

Bump prettier to 3.9, which brings for us mainly:
- less newlines
- nicer formatting of MD tables

## Related issues

Part of https://github.com/trezor/trezor-suite/issues/30667

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bump-prettier-3.9/web/](https://dev.suite.sldev.cz/suite-web/chore/bump-prettier-3.9/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bump-prettier-3.9&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bump-prettier-3.9&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/bump-prettier-3.9&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T20:02:06.907Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T20:01:19.000Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->