### PR TITLE
test(networks): normalize network symbol fixtures

### DIFF
--- a/packages/suite/src/actions/suite/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/protocolActions.test.ts
@@ -1,12 +1,13 @@
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
-import type { FindNetworkSymbolForProtocol } from '@suite-common/networks';
+import { type FindNetworkSymbolForProtocol } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import * as protocolConstants from './constants/protocolConstants';
 import * as protocolActions from './protocolActions';
 import { type HandleProtocolRequestDeps } from './protocolActions';
 
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol =>
-    protocol === 'bitcoin' ? 'btc' : null;
+    protocol === 'bitcoin' ? asNetworkSymbol('btc') : null;
 
 const createHandleProtocolRequestDeps = () => {
     const dispatch = jest.fn();

--- a/packages/suite/src/actions/suite/storageActions.test.ts
+++ b/packages/suite/src/actions/suite/storageActions.test.ts
@@ -19,6 +19,7 @@ import { setSuiteSyncOwner } from '@suite-common/suite-sync';
 import { type SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks, wireEnabledNetworksMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     changeCoinVisibility,
     prepareDiscoveryReducer,
@@ -43,6 +44,9 @@ import { preloadStore } from 'src/support/suite/preloadStore';
 import { type AcquiredDevice, type AppState } from 'src/types/suite';
 
 import * as storageActions from './storageActions';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 const { getWalletTransaction } = testMocks;
 
@@ -79,12 +83,12 @@ const dev2Instance1 = mockSuiteDevice({
 
 const acc1 = mockWalletAccount({
     deviceState: dev1.state?.staticSessionId,
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('desc1'),
 });
 const acc2 = mockWalletAccount({
     deviceState: dev2.state?.staticSessionId,
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('desc2'),
 });
 
@@ -92,13 +96,13 @@ const tx1 = getWalletTransaction({
     deviceState: dev1.state?.staticSessionId,
     txid: 'txid1',
     descriptor: asAccountDescriptor('desc1'),
-    symbol: 'btc',
+    symbol: btcSymbol,
 });
 const tx2 = getWalletTransaction({
     deviceState: dev2.state?.staticSessionId,
     txid: 'txid2',
     descriptor: asAccountDescriptor('desc2'),
-    symbol: 'btc',
+    symbol: btcSymbol,
 });
 
 type PartialState = Pick<
@@ -442,7 +446,7 @@ describe('Storage actions', () => {
     it('should store graph data with the device and remove it on ACCOUNT.REMOVE (triggered by disabling the coin)', async () => {
         const accLtc = mockWalletAccount({
             deviceState: dev1.state!.staticSessionId!,
-            symbol: 'ltc',
+            symbol: asNetworkSymbol('ltc'),
             descriptor: asAccountDescriptor('desc2'),
         });
 
@@ -488,8 +492,8 @@ describe('Storage actions', () => {
         // changeCoinVisibility awaits updateConnectSettings; mock it as a no-op success.
         wireEnabledNetworksMock();
         // disable btc network, enable ltc, triggering ACCOUNT.REMOVE
-        await store.dispatch(changeCoinVisibility({ symbol: 'ltc', shouldBeVisible: true }));
-        await store.dispatch(changeCoinVisibility({ symbol: 'btc', shouldBeVisible: false }));
+        await store.dispatch(changeCoinVisibility({ symbol: ltcSymbol, shouldBeVisible: true }));
+        await store.dispatch(changeCoinVisibility({ symbol: btcSymbol, shouldBeVisible: false }));
 
         // verify that graph data for acc1 were removed
         store.dispatch((await preloadStore())!);

--- a/packages/suite/src/actions/wallet/blockchainActions.test.ts
+++ b/packages/suite/src/actions/wallet/blockchainActions.test.ts
@@ -4,6 +4,7 @@ import {
     createNotificationsReducer,
     notificationsActions,
 } from '@suite-common/toast-notifications';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsState,
     type BlockchainState,
@@ -31,6 +32,7 @@ import {
 import * as fixtures from './__fixtures__/blockchainActions';
 
 const TrezorConnect = testMocks.getTrezorConnectMock();
+const btcSymbol = asNetworkSymbol('btc');
 
 const { reducer: notificationsReducer } = createNotificationsReducer<TranslationKey>();
 
@@ -212,7 +214,7 @@ describe('Blockchain Actions', () => {
     fixtures.customBackend.forEach(f => {
         it(`customBackend: ${f.description}`, async () => {
             const store = mockStore(getInitialState(f.initialState as any));
-            await store.dispatch(setCustomBackendThunk(f.symbol));
+            await store.dispatch(setCustomBackendThunk(asNetworkSymbol(f.symbol)));
             expect(TrezorConnect.blockchainSetCustomBackend).toHaveBeenCalledTimes(
                 f.blockchainSetCustomBackend,
             );
@@ -227,7 +229,7 @@ describe('Blockchain Actions', () => {
                     btc: { blockHeight: 109 },
                 },
                 fees: {
-                    btc: {
+                    [btcSymbol]: {
                         status: 'loaded',
                         data: {
                             minPriorityFee: 0,

--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.test.ts
@@ -2,6 +2,7 @@ import { type BuyTrade, type BuyTradeQuoteRequest, type CryptoId } from 'invity-
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
@@ -31,7 +32,7 @@ jest.mock('@suite-common/trading', () => ({
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor('0xAccount'),
 });
 

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.test.ts
@@ -2,6 +2,7 @@ import { type CryptoId, type ExchangeTrade, type ExchangeTradeQuoteRequest } fro
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
@@ -31,7 +32,7 @@ jest.mock('@suite-common/trading', () => ({
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor('0xAccount'),
 });
 

--- a/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.test.ts
@@ -2,6 +2,7 @@ import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
@@ -50,7 +51,7 @@ jest.mock('../tradingCommonActions', () => ({
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ACCOUNT: Account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
     descriptor: asAccountDescriptor('btcAccount'),
     balance: '100000000',
 });

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.test.ts
@@ -2,6 +2,7 @@ import { type CryptoId, type SellFiatTrade, type SellFiatTradeQuoteRequest } fro
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
@@ -32,7 +33,7 @@ jest.mock('./requestSellTradeThunk', () => ({
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor('0xAccount'),
 });
 

--- a/packages/suite/src/actions/wallet/transactionActions.test.ts
+++ b/packages/suite/src/actions/wallet/transactionActions.test.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import { getTxsPerPage } from '@suite-common/suite-utils';
 import { testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type TransactionsState,
     transactionsActions,
@@ -12,6 +13,8 @@ import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getAccountTransactions } from '@suite-common/wallet-utils';
 
 import { transactionsReducer } from 'src/reducers/wallet';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const { getWalletTransaction } = testMocks;
 
@@ -29,7 +32,7 @@ const initStore = (transactionsState?: TransactionsState) =>
 describe('Transaction Actions', () => {
     it('Add transaction for first page (used on account create)', () => {
         const store = initStore();
-        const account = mockWalletAccount({ symbol: 'btc' });
+        const account = mockWalletAccount({ symbol: btcSymbol });
         store.dispatch(
             transactionsActions.addTransaction({
                 transactions: [getWalletTransaction()],
@@ -45,11 +48,11 @@ describe('Transaction Actions', () => {
 
     it('Remove txs for a given account', () => {
         const account1 = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             descriptor: asAccountDescriptor('xpub1'),
         });
         const account2 = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             descriptor: asAccountDescriptor('xpub2'),
         });
         const store = initStore({

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -1,6 +1,6 @@
 import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type YieldFlowDisplayToken } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -27,10 +27,11 @@ jest.mock('./stablecoin-yield/signingHelpers', () => ({
     getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
-const account = mockWalletAccount({ symbol: 'eth' }) as Account;
+const ethSymbol = asNetworkSymbol('eth');
+const account = mockWalletAccount({ symbol: ethSymbol }) as Account;
 
 const token: YieldFlowDisplayToken & { contractAddress: string } = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -1,6 +1,6 @@
 import { events } from '@suite-common/analytics';
 import { configureMockStore } from '@suite-common/test-utils';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type YieldFlowDisplayToken,
     accountsActions,
@@ -12,6 +12,8 @@ import { mockAnalytics } from '@trezor/analytics-uploader/mocks';
 
 import { PUSH_TRANSACTION_FAILED_CAUSE } from './stablecoin-yield/signingHelpers';
 import { submitWrapNativeTokenThunk } from './wrapNativeTokenThunks';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const mockComposeYieldWrapTransactionThunk = jest.fn();
 const mockOpenDeferredModal = jest.fn();
@@ -33,10 +35,10 @@ jest.mock('./stablecoin-yield/signingHelpers', () => ({
     getYieldSubmitErrorAnalyticsMessage: jest.fn(() => 'submit-failed'),
 }));
 
-const account = mockWalletAccount({ symbol: 'eth' }) as Account;
+const account = mockWalletAccount({ symbol: ethSymbol }) as Account;
 
 const token: YieldFlowDisplayToken & { contractAddress: string } = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -179,7 +181,7 @@ describe('submitWrapNativeTokenThunk', () => {
     it('does not track the wrapped native token when it is already tracked', async () => {
         acceptModalAndSucceed();
         const accountWithTrackedToken = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [
                 {
                     standard: 'ERC20',

--- a/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/staking/hooks/useStakingAccountsVisibility.test.tsx
@@ -1,10 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { useStakingAccountsVisibility } from './useStakingAccountsVisibility';
 
 const mockGetAccountTotalStakingBalance = jest.fn<string | null, [Account]>();
+const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
+const adaSymbol = asNetworkSymbol('ada');
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),
@@ -16,7 +20,7 @@ const createMockAccount = (overrides: Partial<Account>): Account =>
     ({
         key: 'default-key',
         index: 0,
-        symbol: 'eth',
+        symbol: ethSymbol,
         networkType: 'ethereum',
         accountType: 'normal',
         formattedBalance: '0',
@@ -59,12 +63,12 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-0' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             formattedBalance: '0.005',
                         }),
                         createMockAccount({
                             key: 'sol-0' as Account['key'],
-                            symbol: 'sol',
+                            symbol: solSymbol,
                             networkType: 'solana',
                             formattedBalance: '0.001',
                         }),
@@ -84,12 +88,12 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-0' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             formattedBalance: '0.01',
                         }),
                         createMockAccount({
                             key: 'eth-1' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             formattedBalance: '1.0',
                         }),
                     ],
@@ -108,7 +112,7 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-0' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             formattedBalance: '0',
                         }),
                     ],
@@ -129,32 +133,32 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-2' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 2,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'eth-1' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 1,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'eth-0' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 0,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'sol-3' as Account['key'],
-                            symbol: 'sol',
+                            symbol: solSymbol,
                             networkType: 'solana',
                             index: 3,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'sol-0' as Account['key'],
-                            symbol: 'sol',
+                            symbol: solSymbol,
                             networkType: 'solana',
                             index: 0,
                             formattedBalance: '0',
@@ -183,14 +187,14 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'ada-5' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             index: 5,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'ada-1' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             index: 1,
                             formattedBalance: '0',
@@ -215,19 +219,19 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-2' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 2,
                             formattedBalance: '0.005',
                         }),
                         createMockAccount({
                             key: 'eth-1' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 1,
                             formattedBalance: '0.005',
                         }),
                         createMockAccount({
                             key: 'eth-0' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 0,
                             formattedBalance: '0.005',
                         }),
@@ -252,7 +256,7 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'ada-legacy-0' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'legacy',
                             index: 0,
@@ -260,7 +264,7 @@ describe('useStakingAccountsVisibility', () => {
                         }),
                         createMockAccount({
                             key: 'ada-normal-3' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'normal',
                             index: 3,
@@ -268,7 +272,7 @@ describe('useStakingAccountsVisibility', () => {
                         }),
                         createMockAccount({
                             key: 'ada-ledger-1' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'ledger',
                             index: 1,
@@ -294,32 +298,32 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'eth-8' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 8,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'eth-7' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 7,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'sol-1' as Account['key'],
-                            symbol: 'sol',
+                            symbol: solSymbol,
                             networkType: 'solana',
                             index: 1,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'eth-9' as Account['key'],
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             index: 9,
                             formattedBalance: '0',
                         }),
                         createMockAccount({
                             key: 'ada-0' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             index: 0,
                             formattedBalance: '0',
@@ -346,7 +350,7 @@ describe('useStakingAccountsVisibility', () => {
                     stakingAccounts: [
                         createMockAccount({
                             key: 'ada-ledger-0' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'ledger',
                             index: 0,
@@ -354,7 +358,7 @@ describe('useStakingAccountsVisibility', () => {
                         }),
                         createMockAccount({
                             key: 'ada-legacy-0' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'legacy',
                             index: 0,
@@ -362,7 +366,7 @@ describe('useStakingAccountsVisibility', () => {
                         }),
                         createMockAccount({
                             key: 'ada-normal-5' as Account['key'],
-                            symbol: 'ada',
+                            symbol: adaSymbol,
                             networkType: 'cardano',
                             accountType: 'normal',
                             index: 5,

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldAccountsVisibility.test.tsx
@@ -1,15 +1,19 @@
 import { renderHook } from '@testing-library/react';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import { useYieldAccountsVisibility } from './useYieldAccountsVisibility';
 import { type YieldAccountOpportunity } from '../types';
 
+const ethSymbol = asNetworkSymbol('eth');
+const baseSymbol = asNetworkSymbol('base');
+
 const createMockAccount = (overrides: Partial<Account>): Account =>
     ({
         key: 'default-key',
         index: 0,
-        symbol: 'eth',
+        symbol: ethSymbol,
         networkType: 'ethereum',
         accountType: 'normal',
         formattedBalance: '0',
@@ -142,14 +146,14 @@ describe('useYieldAccountsVisibility', () => {
         it('should prefer normal accountType over ledger when balances are equal but non-zero', () => {
             const baseLedger0 = createMockAccount({
                 key: 'base-ledger-0' as Account['key'],
-                symbol: 'base',
+                symbol: baseSymbol,
                 networkType: 'ethereum',
                 accountType: 'ledger',
                 index: 0,
             });
             const baseNormal3 = createMockAccount({
                 key: 'base-normal-3' as Account['key'],
-                symbol: 'base',
+                symbol: baseSymbol,
                 networkType: 'ethereum',
                 accountType: 'normal',
                 index: 3,
@@ -180,14 +184,14 @@ describe('useYieldAccountsVisibility', () => {
         it('should prefer normal accountType over ledger even when index is higher', () => {
             const baseLedger0 = createMockAccount({
                 key: 'base-ledger-0' as Account['key'],
-                symbol: 'base',
+                symbol: baseSymbol,
                 networkType: 'ethereum',
                 accountType: 'ledger',
                 index: 0,
             });
             const baseNormal5 = createMockAccount({
                 key: 'base-normal-5' as Account['key'],
-                symbol: 'base',
+                symbol: baseSymbol,
                 networkType: 'ethereum',
                 accountType: 'normal',
                 index: 5,

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldClaimRewardsData.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountWithNetworkType,
     asAccountDescriptor,
@@ -55,7 +56,7 @@ const createReward = ({ token, claimable, fiatClaimable }: CreateRewardProps): R
 
 const createAccount = (descriptor: string) =>
     mockWalletAccount({
-        symbol: 'eth',
+        symbol: asNetworkSymbol('eth'),
         descriptor: asAccountDescriptor(descriptor),
     }) as AccountWithNetworkType<'ethereum'>;
 

--- a/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
+++ b/packages/suite/src/components/earn/dashboard/yield/hooks/useYieldTableData.test.ts
@@ -1,11 +1,13 @@
 import { renderHook } from '@testing-library/react';
 
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getYieldOpportunityData, useYieldTableData } from './useYieldTableData';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 jest.mock('src/hooks/suite', () => ({
     useSelector: () => [],
@@ -65,7 +67,7 @@ describe(getYieldOpportunityData.name, () => {
     describe('wrapped-native (WETH) vault', () => {
         it('combines the token balance with the full native balance', () => {
             const account = mockWalletAccount({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -79,7 +81,7 @@ describe(getYieldOpportunityData.name, () => {
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: wethVault,
             });
 
@@ -87,11 +89,14 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('counts a native-only account (no WETH token) as depositable', () => {
-            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+            const account = mockWalletAccount({
+                symbol: ethSymbol,
+                formattedBalance: '1',
+            });
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: wethVault,
             });
 
@@ -101,11 +106,14 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {
-            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
+            const account = mockWalletAccount({
+                symbol: ethSymbol,
+                formattedBalance: '0.003',
+            });
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: wethVault,
             });
 
@@ -115,7 +123,7 @@ describe(getYieldOpportunityData.name, () => {
 
         it('denominates amounts in the native symbol without a token contract', () => {
             const account = mockWalletAccount({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -129,7 +137,7 @@ describe(getYieldOpportunityData.name, () => {
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: wethVault,
             });
 
@@ -141,7 +149,7 @@ describe(getYieldOpportunityData.name, () => {
     describe('non-wrapped-native vault', () => {
         it('uses only the matched token balance and keeps the token denomination', () => {
             const account = mockWalletAccount({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 formattedBalance: '1',
                 tokens: [
                     mockAccountToken({
@@ -155,7 +163,7 @@ describe(getYieldOpportunityData.name, () => {
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: usdcVault,
             });
 
@@ -165,11 +173,14 @@ describe(getYieldOpportunityData.name, () => {
         });
 
         it('is not depositable without the matched token, regardless of native balance', () => {
-            const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
+            const account = mockWalletAccount({
+                symbol: ethSymbol,
+                formattedBalance: '5',
+            });
 
             const data = getYieldOpportunityData({
                 account,
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
                 vault: usdcVault,
             });
 
@@ -182,12 +193,12 @@ describe(getYieldOpportunityData.name, () => {
 describe(useYieldTableData.name, () => {
     it('classifies a native-only account as depositable, ahead of empty accounts', () => {
         const emptyAccount = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             descriptor: asAccountDescriptor('0xbe1030e5e50e5e0'),
             formattedBalance: '0',
         });
         const nativeOnlyAccount = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             descriptor: asAccountDescriptor('0xde9051ab1e0e0e0'),
             formattedBalance: '1',
         });
@@ -196,7 +207,7 @@ describe(useYieldTableData.name, () => {
             useYieldTableData({
                 availableVaults: [wethVault],
                 visibleAccounts: [emptyAccount, nativeOnlyAccount],
-                visibleAccountSymbols: new Set<NetworkSymbol>(['eth']),
+                visibleAccountSymbols: new Set<NetworkSymbol>([ethSymbol]),
             }),
         );
 

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
@@ -3,11 +3,13 @@ import { useForm } from 'react-hook-form';
 import { act, renderHook } from '@testing-library/react';
 
 import { events } from '@suite-common/analytics';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type YieldFlowFormValues } from '@suite-common/wallet-core';
 
 import { useYieldFiatInput } from './useYieldFiatInput';
 
 const ETH_RATE = 3333.35;
+const ethSymbol = asNetworkSymbol('eth');
 
 const mockState = {
     wallet: {
@@ -39,7 +41,7 @@ const renderYieldFiatInput = (vaultId?: string) =>
 
         return {
             methods,
-            fiat: useYieldFiatInput({ methods, symbol: 'eth', decimals: 18, vaultId }),
+            fiat: useYieldFiatInput({ methods, symbol: ethSymbol, decimals: 18, vaultId }),
         };
     });
 

--- a/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/getYieldWithdrawCompletedValues.test.ts
@@ -1,11 +1,14 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type YieldFlowDisplayToken, type YieldFlowToken } from '@suite-common/wallet-core';
 
 import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
 
 type Params = Parameters<typeof getYieldWithdrawCompletedValues>[0];
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const token: YieldFlowToken = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     symbol: 'WETH',
     decimals: 18,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -13,7 +16,7 @@ const token: YieldFlowToken = {
 };
 
 const receiptToken: YieldFlowDisplayToken = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     symbol: 'trSHETHp',
     decimals: 18,
     contractAddress: '0x1111111111111111111111111111111111111111',
@@ -27,7 +30,7 @@ const pricePerShareState: Params['pricePerShareState'] = {
 };
 
 const base = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     token,
     receiptToken,
     pricePerShareState,

--- a/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
+++ b/packages/suite/src/components/earn/yield/yieldFlowUtils.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { getYieldFlowStepSequence } from '@suite-common/wallet-core';
 
 import {
@@ -13,7 +14,8 @@ import {
 // Checksummed WETH address; the helper lower-cases it for the (evm) rate key.
 const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const WETH_LOWER = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const ethToken = { networkSymbol: 'eth', contractAddress: WETH } as const;
+const ethSymbol = asNetworkSymbol('eth');
+const ethToken = { networkSymbol: ethSymbol, contractAddress: WETH } as const;
 
 const depositSequence = getYieldFlowStepSequence({ flowType: 'deposit' });
 const depositWithWrapSequence = getYieldFlowStepSequence({
@@ -52,14 +54,14 @@ const baseUnwrapParams: Parameters<typeof getYieldUnwrapDefaultAmount>[0] = {
     flowType: 'withdraw',
     withdrawnAmount: '0.5',
     token: {
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         symbol: 'WETH',
         decimals: 18,
         contractAddress: WETH_ADDRESS,
         balance: '5',
     },
     receiptToken: {
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         symbol: 'trSHETHp',
         decimals: 18,
         contractAddress: VAULT_ADDRESS,
@@ -207,7 +209,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'wrap',
                     flowType: 'deposit',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: ethToken,
                 }),
             ).toEqual({ symbol: 'eth' });
@@ -216,7 +218,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'unwrap',
                     flowType: 'withdraw',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: ethToken,
                 }),
             ).toEqual({ symbol: 'eth' });
@@ -227,7 +229,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'action',
                     flowType: 'deposit',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: ethToken,
                 }),
             ).toEqual({ symbol: 'eth', tokenAddress: WETH_LOWER });
@@ -238,7 +240,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'action',
                     flowType: 'withdraw',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: ethToken,
                 }),
             ).toBeNull();
@@ -247,7 +249,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'action',
                     flowType: 'redeem',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: ethToken,
                 }),
             ).toBeNull();
@@ -256,7 +258,7 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'action',
                     flowType: 'deposit',
-                    accountSymbol: 'eth',
+                    accountSymbol: ethSymbol,
                     token: null,
                 }),
             ).toBeNull();
@@ -265,8 +267,8 @@ describe('yieldFlowUtils', () => {
                 getYieldFiatRateToken({
                     step: 'action',
                     flowType: 'deposit',
-                    accountSymbol: 'eth',
-                    token: { networkSymbol: 'eth', contractAddress: null },
+                    accountSymbol: ethSymbol,
+                    token: { networkSymbol: ethSymbol, contractAddress: null },
                 }),
             ).toBeNull();
         });

--- a/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/hooks/useAccountsWithTokenDisplayNames.test.ts
@@ -6,7 +6,11 @@ import {
     type TradingAssetOption,
     type TradingAssetOptionWithContractAddress,
 } from '@suite-common/trading';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    asNetworkSymbol,
+    toNetworkSymbolNonTestnet,
+} from '@suite-common/wallet-config';
 import { BigNumber } from '@trezor/utils';
 
 import { type TokensWithRates } from 'src/utils/wallet/tokenUtils';
@@ -24,6 +28,9 @@ jest.mock('@suite-common/trading', () => ({
         buildAssetOptions: jest.fn(() => ({ assets: [] })),
     }),
 }));
+
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
+const polSymbol = asNetworkSymbol('pol');
 
 const createAccount = (symbol: NetworkSymbol): AccountWithSuiteSyncLabel =>
     ({
@@ -55,14 +62,14 @@ const createAsset = (
         displaySymbol: 'ASSET',
         contractAddress: '0x1',
         networkName: 'Ethereum',
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         ...assetOverrides,
     };
 };
 
 describe('useAccountsWithTokenDisplayNames', () => {
-    const ethereumAccount = createAccount('eth');
-    const polygonAccount = createAccount('pol');
+    const ethereumAccount = createAccount(ethSymbol);
+    const polygonAccount = createAccount(polSymbol);
 
     const accountOption: AccountWithTokensOption = {
         type: 'account',

--- a/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
+++ b/packages/suite/src/components/suite/asset-picker/utils/tokenDisplayNames.test.ts
@@ -4,12 +4,15 @@ import {
     type TradingAssetOption,
     type TradingAssetOptionWithContractAddress,
 } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 
 import {
     type TokenDisplayNameSource,
     getTokenDisplaySymbolName,
     getTokensDisplaySymbolNames,
 } from './tokenDisplayNames';
+
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
 
 const createAsset = (
     overrides: Partial<TradingAssetOptionWithContractAddress> &
@@ -26,7 +29,7 @@ const createAsset = (
         displaySymbol: 'ASSET',
         contractAddress: '0x1',
         networkName: 'Ethereum',
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         ...assetOverrides,
     };
 };
@@ -34,7 +37,7 @@ const createAsset = (
 describe('tokenDisplayNames', () => {
     it('returns canonical displaySymbolName for matching token crypto id', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: 'eth' },
+            account: { symbol: ethSymbol },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];
@@ -60,7 +63,7 @@ describe('tokenDisplayNames', () => {
 
     it('falls back to asset name when displaySymbolName is missing', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: 'eth' },
+            account: { symbol: ethSymbol },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];
@@ -86,7 +89,7 @@ describe('tokenDisplayNames', () => {
 
     it('falls back to discovered token name for unmatched tokens', () => {
         const tokenSource: TokenDisplayNameSource = {
-            account: { symbol: 'eth' },
+            account: { symbol: ethSymbol },
             token: { contract: '0x1', name: 'Discovered Name' },
         };
         const tokens = [tokenSource];

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/TransactionsGraph.test.tsx
@@ -1,4 +1,5 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { type AppState } from 'src/reducers/store';
@@ -15,7 +16,7 @@ global.ResizeObserver = class MockedResizeObserver {
     disconnect = jest.fn();
 };
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 
 // A single day interval (the '1d' range), which is empty for any account without a transaction today.
 const DAY_RANGE: GraphRange = {

--- a/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/hooks/useTransactionGraphUpdater.test.tsx
@@ -9,6 +9,7 @@ import {
     testMocks,
     waitFor,
 } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type WalletAccountTransaction,
     asAccountDescriptor,
@@ -19,7 +20,7 @@ import { useTransactionGraphUpdater } from './useTransactionGraphUpdater';
 
 const ACCOUNT_KEY = createAccountKey({
     accountDescriptor: asAccountDescriptor('descriptor'),
-    networkSymbol: 'btc',
+    networkSymbol: asNetworkSymbol('btc'),
     deviceStaticSessionId: 'wallet@device:0',
 });
 

--- a/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
+++ b/packages/suite/src/components/suite/notifications/NotificationRenderer/NotificationRenderer.test.tsx
@@ -4,6 +4,7 @@ import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { configureMockStore, fireEvent, screen } from '@suite-common/test-utils';
 import { type NotificationEntry } from '@suite-common/toast-notifications';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
 
@@ -14,6 +15,8 @@ import { type NotificationViewProps } from '../Notifications/NotificationGroup/N
 
 type TradingErrorNotification = Extract<NotificationEntry, { type: 'trading-error' }>;
 type WrapNotification = Extract<NotificationEntry, { type: 'tx-wrap' | 'tx-unwrap' }>;
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const mockReport = jest.fn();
 
@@ -63,15 +66,15 @@ const renderWrapToast = (payload: Omit<WrapNotification, 'context' | 'id'>) => {
 };
 
 const wrapMetadata = {
-    send: { symbol: 'eth', displaySymbol: 'ETH', amount: '1' },
-    receive: { symbol: 'eth', displaySymbol: 'WETH', amount: '1' },
+    send: { symbol: ethSymbol, displaySymbol: 'ETH', amount: '1' },
+    receive: { symbol: ethSymbol, displaySymbol: 'WETH', amount: '1' },
 } as const;
 
 const wrapToastPayload = {
     type: 'tx-wrap',
     metadata: wrapMetadata,
     descriptor: '0xdescriptor',
-    symbol: 'eth',
+    symbol: ethSymbol,
     txid: '0xwrap',
     formattedAmount: '1',
 } as const;

--- a/packages/suite/src/hooks/settings/useGapLimitForm.test.tsx
+++ b/packages/suite/src/hooks/settings/useGapLimitForm.test.tsx
@@ -1,11 +1,12 @@
 import { act } from '@testing-library/react';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { blockchainActions } from '@suite-common/wallet-core';
 
 import { useGapLimitForm } from './useGapLimitForm';
 
-const SYMBOL = 'btc';
+const SYMBOL = asNetworkSymbol('btc');
 
 const renderGapLimitForm = (savedGapLimit?: number) => {
     const store = configureMockStore({

--- a/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/buy/useBuyQuotes.test.tsx
@@ -11,10 +11,12 @@ import {
     buyInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 
 import { useBuyQuotes } from './useBuyQuotes';
 import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const QUOTES: BuyTrade[] = [
     {
@@ -59,7 +61,7 @@ const VALID_DEFAULTS: TradingBuyFormProps = {
     fiatInput: '100',
     cryptoInput: '',
     currencySelect: { value: 'eur', label: 'EUR' },
-    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: 'btc' } as TradingAssetOption,
+    cryptoSelect: { id: 'bitcoin' as CryptoId, networkSymbol: btcSymbol } as TradingAssetOption,
     countrySelect: { value: 'DE', label: 'Germany' } as TradingCountryOption,
     countrySubdivisionSelect: undefined,
     paymentMethod: undefined,
@@ -101,7 +103,7 @@ const renderBuyQuotes = (
                 defaultValues,
                 resolver,
             });
-            useBuyQuotes({ methods, network: getNetwork('btc'), shouldSendInSats: false });
+            useBuyQuotes({ methods, network: getNetwork(btcSymbol), shouldSendInSats: false });
 
             return methods;
         },

--- a/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useSelectedTradingAsset.test.tsx
@@ -1,23 +1,25 @@
 import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { useSelectedTradingAsset } from './useSelectedTradingAsset';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const ELIGIBLE_ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xEligible'),
     balance: '1000000000000000000',
     formattedBalance: '1',
 });
 const INELIGIBLE_ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xIneligible'),
     balance: '0',
     tokens: [],
@@ -65,11 +67,11 @@ describe('useSelectedTradingAsset', () => {
 
         expect(result.current).toEqual({
             symbol: 'eth',
-            decimals: getNetwork('eth').decimals,
+            decimals: getNetwork(ethSymbol).decimals,
             balance: ELIGIBLE_ACCOUNT.balance,
             formattedBalance: ELIGIBLE_ACCOUNT.formattedBalance,
             tokens: ELIGIBLE_ACCOUNT.tokens,
-            cryptoId: getNetwork('eth').tradeCryptoId,
+            cryptoId: getNetwork(ethSymbol).tradeCryptoId,
             isToken: false,
         });
     });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingComposeTransaction.test.tsx
@@ -4,7 +4,7 @@ import { act, waitFor } from '@testing-library/react';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingSellFormProps } from '@suite-common/trading';
-import { networks } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -43,8 +43,8 @@ jest.mock('src/utils/wallet/trading/tradingUtils', () => ({
 
 const mockGetComposeAddressPlaceholder = getComposeAddressPlaceholder as jest.Mock;
 
-const BTC_ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
-const SOL_ACCOUNT = mockWalletAccount({ symbol: 'sol', formattedBalance: '0.4' });
+const BTC_ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc'), formattedBalance: '2' });
+const SOL_ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('sol'), formattedBalance: '0.4' });
 
 const feeData = (blockTime: number) => ({
     blockHeight: 0,
@@ -101,7 +101,7 @@ const renderComposeTransaction = () => {
             const compose = useTradingComposeTransaction({
                 type: 'sell',
                 account,
-                network: networks[account.symbol],
+                network: getNetwork(account.symbol),
                 methods,
                 setShowReserveBanner: jest.fn(),
             });

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx
@@ -8,13 +8,16 @@ import {
     type TradingFiatRatesReturn,
     type TradingSellFormProps,
 } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useTradingCryptoAssetChange } from './useTradingCryptoAssetChange';
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
-const OTHER_ACCOUNT = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
+const ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '2' });
+const OTHER_ACCOUNT = mockWalletAccount({ symbol: ethSymbol, formattedBalance: '5' });
 
 const buildSelect = (accountKey: AccountKey): TradingAssetSellOption => ({
     id: 'bitcoin' as CryptoId,
@@ -22,10 +25,10 @@ const buildSelect = (accountKey: AccountKey): TradingAssetSellOption => ({
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
+    networkSymbol: btcSymbol,
     accountKey,
 });
 
@@ -72,7 +75,7 @@ const TRADING_FIAT_VALUES: TradingFiatRatesReturn = {
     fiatRate: undefined,
     accountBalance: '2',
     formattedBalance: '2',
-    symbol: 'btc',
+    symbol: btcSymbol,
     networkDecimals: 8,
     tokenAddress: undefined,
     fiatRatesUpdater: jest.fn(() => Promise.resolve(null)),

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingFiatCryptoAmount.test.tsx
@@ -8,10 +8,13 @@ import {
     type TradingFiatRatesReturn,
     type TradingSellFormProps,
 } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { type Timestamp } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useTradingFiatCryptoAmount } from './useTradingFiatCryptoAmount';
+
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
 
 const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     id: 'bitcoin' as CryptoId,
@@ -19,11 +22,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const DEFAULTS: TradingSellFormProps = {
@@ -72,11 +75,11 @@ const TRADING_FIAT_VALUES: TradingFiatRatesReturn = {
         lastSuccessfulFetchTimestamp: 0 as Timestamp,
         isLoading: false,
         error: null,
-        ticker: { symbol: 'btc' },
+        ticker: { symbol: btcSymbol },
     },
     accountBalance: '2',
     formattedBalance: '2',
-    symbol: 'btc',
+    symbol: btcSymbol,
     networkDecimals: 8,
     tokenAddress: undefined,
     fiatRatesUpdater: jest.fn(() => Promise.resolve(null)),

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingSendAssetBalance.test.tsx
@@ -2,6 +2,7 @@ import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingAssetSellOption } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { type BaseCurrencyOption } from '@suite-common/wallet-types';
 import {
     mockAccountKey,
@@ -11,6 +12,9 @@ import {
 
 import { useTradingSendAssetBalance } from './useTradingSendAssetBalance';
 
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
+
 jest.mock('src/hooks/wallet/trading/form/common/useTradingAssetDecimals', () => ({
     useTradingAssetDecimals: () => ({ getAssetDecimals: () => 8 }),
 }));
@@ -19,18 +23,18 @@ jest.mock('src/hooks/wallet/trading/form/common/useTradingFiatValues', () => ({
     useTradingFiatValues: () => ({ fiatRate: { rate: 50000 }, fiatRatesUpdater: jest.fn() }),
 }));
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
-const EMPTY_ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '0' });
+const ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '2' });
+const EMPTY_ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '0' });
 
 const TOKEN_CONTRACT = '0x' + 'a'.repeat(40);
 
 const FUNDED_TOKEN_ACCOUNT = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     formattedBalance: '0',
     tokens: [mockAccountToken({ contract: TOKEN_CONTRACT, balance: '100' })],
 });
 const EMPTY_TOKEN_ACCOUNT = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     formattedBalance: '2',
     tokens: [mockAccountToken({ contract: TOKEN_CONTRACT, balance: '0' })],
 });
@@ -41,11 +45,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const OUTPUT_CURRENCY: BaseCurrencyOption = { value: 'usd', label: 'USD' };

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeApproval.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeApproval.test.tsx
@@ -3,6 +3,7 @@ import { type ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { tradingExchangeActions } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeApproval } from './useExchangeApproval';
@@ -32,7 +33,7 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'eth', formattedBalance: '2' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth'), formattedBalance: '2' });
 
 const TRADE: ExchangeTrade = { exchange: 'provider-1', status: 'CONFIRM' };
 

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeDexQuote.test.tsx
@@ -10,6 +10,7 @@ import {
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
 } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { buildApprovalTransactionData } from '@suite-common/wallet-utils';
 
@@ -26,7 +27,8 @@ jest.mock('@suite-common/wallet-core', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '2' });
 
 const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     id: 'bitcoin' as CryptoId,
@@ -34,11 +36,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const DEX_QUOTE: ExchangeTrade = {

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFlow.test.tsx
@@ -2,9 +2,12 @@ import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingTransactionExchange, tradingExchangeActions } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeFlow } from './useExchangeFlow';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 jest.mock('@suite-common/trading', () => {
     const actual = jest.requireActual('@suite-common/trading');
@@ -22,7 +25,7 @@ const TRADE: TradingTransactionExchange = {
     date: '2024-01-01',
     tradeType: 'exchange',
     data: { exchange: 'provider-1', send: 'bitcoin' as CryptoId, receive: 'ethereum' as CryptoId },
-    sendAccountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    sendAccountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 type Props = {

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeFormInputs.test.tsx
@@ -10,6 +10,7 @@ import {
     type TradingExchangeFormProps,
     tradingExchangeActions,
 } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeFormInputs } from './useExchangeFormInputs';
@@ -39,7 +40,9 @@ jest.mock('@suite-common/wallet-core', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
+const ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '2' });
 
 const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     id: 'bitcoin' as CryptoId,
@@ -47,11 +50,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
@@ -60,10 +63,10 @@ const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
     name: 'Ethereum',
     coingeckoId: 'ethereum',
     contractAddress: null,
-    symbol: 'eth',
+    symbol: ethSymbol,
     displaySymbol: 'ETH',
     networkName: 'Ethereum',
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
 };
 
 const DEFAULTS: TradingExchangeFormProps = {

--- a/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/exchange/useExchangeQuotes.test.tsx
@@ -11,10 +11,18 @@ import {
     type TradingAssetSellOption,
     type TradingExchangeFormProps,
 } from '@suite-common/trading';
-import { type Network, type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
+import {
+    type Network,
+    type NetworkSymbol,
+    getNetwork,
+    toNetworkSymbolNonTestnet,
+} from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useExchangeQuotes } from './useExchangeQuotes';
+
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
 
 const QUOTES: ExchangeTrade[] = [
     { exchange: 'provider-1', send: 'bitcoin' as CryptoId, receive: 'ethereum' as CryptoId },
@@ -71,11 +79,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
@@ -84,10 +92,10 @@ const RECEIVE_CRYPTO_SELECT: TradingAssetOption = {
     name: 'Ethereum',
     coingeckoId: 'ethereum',
     contractAddress: null,
-    symbol: 'eth',
+    symbol: ethSymbol,
     displaySymbol: 'ETH',
     networkName: 'Ethereum',
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
 };
 
 const VALID_DEFAULTS: TradingExchangeFormProps = {
@@ -143,7 +151,7 @@ const renderExchangeQuotes = (
     } = {},
 ) => {
     const { receiveAddress, receiveAccountKey, receiveAccountSymbol, resolver } = options;
-    const network = 'network' in options ? options.network : getNetwork('btc');
+    const network = 'network' in options ? options.network : getNetwork(btcSymbol);
 
     const store = configureMockStore({
         preloadedState: {
@@ -245,8 +253,8 @@ describe('useExchangeQuotes', () => {
     it('does not dispatch a quotes request while the receive identity is incoherent (#28143/#30213)', async () => {
         const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
-            receiveAccountSymbol: 'eth',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
+            receiveAccountSymbol: ethSymbol,
         });
 
         await act(async () => {
@@ -282,8 +290,8 @@ describe('useExchangeQuotes', () => {
 
         const { result } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
-            receiveAccountSymbol: 'eth',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
+            receiveAccountSymbol: ethSymbol,
         });
 
         await act(async () => {
@@ -308,8 +316,8 @@ describe('useExchangeQuotes', () => {
     it('clears the selected quote and refetches when only the receive account changes', async () => {
         const { result, rerender } = renderExchangeQuotes(VALID_DEFAULTS, {
             receiveAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: 'eth' }),
-            receiveAccountSymbol: 'eth',
+            receiveAccountKey: mockAccountKey({ descriptor: 'receiveaccount1', symbol: ethSymbol }),
+            receiveAccountSymbol: ethSymbol,
         });
 
         await act(async () => {
@@ -321,10 +329,10 @@ describe('useExchangeQuotes', () => {
         mockSaveSelectedQuote.mockClear();
 
         rerender({
-            currentNetwork: getNetwork('btc'),
+            currentNetwork: getNetwork(btcSymbol),
             currentReceiveAccountKey: mockAccountKey({
                 descriptor: 'receiveaccount2',
-                symbol: 'eth',
+                symbol: ethSymbol,
             }),
         });
 
@@ -347,7 +355,7 @@ describe('useExchangeQuotes', () => {
         expect(mockHandleRequest).not.toHaveBeenCalled();
 
         rerender({
-            currentNetwork: getNetwork('btc'),
+            currentNetwork: getNetwork(btcSymbol),
             currentReceiveAccountKey: undefined,
         });
 

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellFlow.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellFlow.test.tsx
@@ -1,8 +1,11 @@
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingTransactionSell, tradingSellActions } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useSellFlow } from './useSellFlow';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 jest.mock('@suite-common/trading', () => {
     const actual = jest.requireActual('@suite-common/trading');
@@ -20,7 +23,7 @@ const TRADE: TradingTransactionSell = {
     date: '2024-01-01',
     tradeType: 'sell',
     data: { paymentMethod: 'bankTransfer', exchange: 'provider-1' },
-    sendAccountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    sendAccountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 type Props = {

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellFormInputs.test.tsx
@@ -5,6 +5,7 @@ import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { type TradingAssetSellOption, type TradingSellFormProps } from '@suite-common/trading';
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { useSellFormInputs } from './useSellFormInputs';
@@ -35,7 +36,8 @@ jest.mock('@suite-common/wallet-core', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc', formattedBalance: '2' });
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ACCOUNT = mockWalletAccount({ symbol: btcSymbol, formattedBalance: '2' });
 
 const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     id: 'bitcoin' as CryptoId,
@@ -43,11 +45,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const DEFAULTS: TradingSellFormProps = {

--- a/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/sell/useSellQuotes.test.tsx
@@ -10,11 +10,13 @@ import {
     sellInitialState,
     initialState as tradingInitialState,
 } from '@suite-common/trading';
-import { type Network, getNetwork } from '@suite-common/wallet-config';
+import { type Network, getNetwork, toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
 import { useSellQuotes } from './useSellQuotes';
 import { DEBOUNCE_DELAY_MS } from '../common/useTradingQuoteRequest';
+
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
 
 const QUOTES: SellFiatTrade[] = [
     {
@@ -70,11 +72,11 @@ const SEND_CRYPTO_SELECT: TradingAssetSellOption = {
     name: 'Bitcoin',
     coingeckoId: 'bitcoin',
     contractAddress: null,
-    symbol: 'btc',
+    symbol: btcSymbol,
     displaySymbol: 'BTC',
     networkName: 'Bitcoin',
-    networkSymbol: 'btc',
-    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+    networkSymbol: btcSymbol,
+    accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
 };
 
 const VALID_DEFAULTS: TradingSellFormProps = {
@@ -131,7 +133,7 @@ const renderSellQuotes = (
 ) => {
     const { resolver } = options;
     const initialProps: { currentNetwork: Network | undefined } = {
-        currentNetwork: getNetwork('btc'),
+        currentNetwork: getNetwork(btcSymbol),
     };
 
     const store = configureMockStore({

--- a/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/useTradingFormAccount.test.tsx
@@ -1,24 +1,27 @@
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
 
 import { useTradingFormAccount } from './useTradingFormAccount';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
 const FIRST_ELIGIBLE_ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xFirstEligible'),
     balance: '1000000000000000000',
 });
 const TRADE_ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xTradeAccount'),
     balance: '2000000000000000000',
 });
 const INELIGIBLE_TRADE_ACCOUNT: Account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xIneligibleTradeAccount'),
     balance: '0',
     tokens: [],

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
@@ -1,6 +1,7 @@
 import type { BuyTrade, CryptoId, FiatCurrencyCode } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -34,7 +35,7 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeConfirm.test.tsx
@@ -2,6 +2,7 @@ import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -30,7 +31,7 @@ jest.mock('@suite-common/trading', () => {
 
 const { tradingExchangeActions } = jest.requireActual('@suite-common/trading');
 
-const ACCOUNT = mockWalletAccount({ symbol: 'eth' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingExchangeTradeActions.test.tsx
@@ -2,6 +2,7 @@ import type { CryptoId, ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { exchangeInitialState, initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -79,7 +80,7 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'eth' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellConfirm.test.tsx
@@ -2,6 +2,7 @@ import type { CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
 import { sellInitialState, initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -32,7 +33,7 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
 

--- a/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingSellTradeActions.test.tsx
@@ -1,6 +1,7 @@
 import type { BankAccount, CryptoId, FiatCurrencyCode, SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, renderHookWithStoreProvider } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -87,7 +88,7 @@ jest.mock('@suite-common/trading', () => {
     };
 });
 
-const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
 

--- a/packages/suite/src/reducers/wallet/graphReducer.test.ts
+++ b/packages/suite/src/reducers/wallet/graphReducer.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 
@@ -9,7 +10,7 @@ import graphReducer from './graphReducer';
 const account: AccountIdentifier = {
     deviceState: 'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1' as StaticSessionId,
     descriptor: asAccountDescriptor('xpub123'),
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
 };
 
 const dataPoint: AccountHistoryWithBalance = {

--- a/packages/suite/src/storage/migrations/versions/26.6.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.6.0.1.test.ts
@@ -1,6 +1,7 @@
 import '@suite-common/test-utils/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -31,16 +32,16 @@ describe('migration 26.6.0.1', () => {
 
     test('delete sepolia and keep mainnet', async () => {
         const db = await openDB<SuiteDBSchema>(DB_NAME, INITIAL_VERSION, {
-            upgrade(db) {
-                const accountsStore = db.createObjectStore('accounts', {
+            upgrade(database) {
+                const accountsStore = database.createObjectStore('accounts', {
                     keyPath: ['descriptor', 'symbol', 'deviceState'],
                 });
                 accountsStore.createIndex('deviceState', 'deviceState', { unique: false });
             },
         });
 
-        const sep1 = mockWalletAccount({ symbol: 'tsep', accountType: 'normal' });
-        const eth1 = mockWalletAccount({ symbol: 'eth', accountType: 'normal' });
+        const sep1 = mockWalletAccount({ symbol: asNetworkSymbol('tsep'), accountType: 'normal' });
+        const eth1 = mockWalletAccount({ symbol: asNetworkSymbol('eth'), accountType: 'normal' });
 
         await db.put('accounts', sep1);
         await db.put('accounts', eth1);

--- a/packages/suite/src/storage/migrations/versions/26.8.0.1.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.1.test.ts
@@ -2,6 +2,7 @@ import '@suite-common/test-utils/globalOverrides';
 import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
@@ -10,6 +11,8 @@ import { type SuiteDBSchema } from 'src/storage/definitions';
 import { serializeDevice } from 'src/utils/suite/storage';
 
 import migration from './26.8.0.1';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const DB_NAME = 'suite-idb-test-26.8.0.1';
 const INITIAL_VERSION = 1;
@@ -51,17 +54,17 @@ describe('migration 26.8.0.1', () => {
 
         const rememberedAccount = mockWalletAccount({
             descriptor: asAccountDescriptor('rememberedAccount'),
-            symbol: 'btc',
+            symbol: btcSymbol,
             deviceState: REMEMBERED_DEVICE_STATE,
         });
         const unrememberedAccount = mockWalletAccount({
             descriptor: asAccountDescriptor('unrememberedAccount'),
-            symbol: 'btc',
+            symbol: btcSymbol,
             deviceState: UNREMEMBERED_DEVICE_STATE,
         });
         const orphanedAccount = mockWalletAccount({
             descriptor: asAccountDescriptor('orphanedAccount'),
-            symbol: 'btc',
+            symbol: btcSymbol,
             deviceState: ORPHANED_DEVICE_STATE,
         });
 

--- a/packages/suite/src/utils/wallet/accountUtils.test.ts
+++ b/packages/suite/src/utils/wallet/accountUtils.test.ts
@@ -1,7 +1,10 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import * as accountUtils from './accountUtils';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 describe('account utils', () => {
     it('getSelectedAccount null', () => {
@@ -18,25 +21,25 @@ describe('account utils', () => {
                         descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                         ),
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         index: 0,
                     }),
                     mockWalletAccount({
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
                 ],
                 {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     accountIndex: 1,
                     accountType: 'normal',
                 },
             ),
         ).toEqual(
             mockWalletAccount({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 descriptor: asAccountDescriptor('123'),
                 accountType: 'normal',
                 index: 1,
@@ -51,11 +54,11 @@ describe('account utils', () => {
                         descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                         ),
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         index: 0,
                     }),
                     mockWalletAccount({
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
@@ -73,18 +76,18 @@ describe('account utils', () => {
                         descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                         ),
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         index: 0,
                     }),
                     mockWalletAccount({
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
                 ],
                 {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     accountIndex: 1,
                     accountType: 'normal',
                 },
@@ -99,18 +102,18 @@ describe('account utils', () => {
                         descriptor: asAccountDescriptor(
                             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                         ),
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         index: 0,
                     }),
                     mockWalletAccount({
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         descriptor: asAccountDescriptor('123'),
                         accountType: 'normal',
                         index: 1,
                     }),
                 ],
                 {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     accountIndex: 3,
                     accountType: 'normal',
                 },

--- a/packages/suite/src/utils/wallet/tokenUtils.test.ts
+++ b/packages/suite/src/utils/wallet/tokenUtils.test.ts
@@ -1,3 +1,5 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import { getTokensFixtures, hasVisibleTokensFixtures } from './__fixtures__/tokenUtils';
 import { getTokens, hasVisibleTokens } from './tokenUtils';
 
@@ -5,10 +7,12 @@ describe('getTokens', () => {
     getTokensFixtures.forEach(
         ({ testName, tokens, symbol, coinDefinitions, searchQuery, result }) => {
             test(testName, () => {
+                const networkSymbol = asNetworkSymbol(symbol);
+
                 expect(
                     getTokens({
                         tokens,
-                        symbol,
+                        symbol: networkSymbol,
                         tokenDefinitions: coinDefinitions,
                         searchQuery,
                     }),
@@ -21,7 +25,9 @@ describe('getTokens', () => {
 describe('hasVisibleTokens', () => {
     hasVisibleTokensFixtures.forEach(({ testName, tokens, symbol, tokenDefinitions, result }) => {
         test(testName, () => {
-            expect(hasVisibleTokens(symbol, tokens, tokenDefinitions)).toStrictEqual(result);
+            const networkSymbol = asNetworkSymbol(symbol);
+
+            expect(hasVisibleTokens(networkSymbol, tokens, tokenDefinitions)).toStrictEqual(result);
         });
     });
 });

--- a/packages/suite/src/utils/wallet/trading/buildSellReturnUrl.test.ts
+++ b/packages/suite/src/utils/wallet/trading/buildSellReturnUrl.test.ts
@@ -1,6 +1,7 @@
 import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
 import { type TradingSellInfoSelector } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -13,7 +14,7 @@ jest.mock('src/utils/wallet/trading/sellUtils', () => ({
 }));
 
 const ACCOUNT: Account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
     descriptor: asAccountDescriptor('btcAccount'),
 });
 

--- a/packages/suite/src/utils/wallet/trading/tradingUtils.test.ts
+++ b/packages/suite/src/utils/wallet/trading/tradingUtils.test.ts
@@ -1,4 +1,4 @@
-import { type Network, networks } from '@suite-common/wallet-config';
+import { type Network, asNetworkSymbol, networks } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -143,7 +143,7 @@ describe('trading utils', () => {
 
         it('returns empty string for tron (fee uses compose context recipient)', async () => {
             const account = mockWalletAccount({
-                symbol: 'trx',
+                symbol: asNetworkSymbol('trx'),
                 descriptor: asAccountDescriptor('TTronAddress123'),
             });
 

--- a/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
+++ b/packages/suite/src/views/wallet/send/Options/EthereumOptions/EthereumNonceValidation.test.tsx
@@ -6,6 +6,7 @@ import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { SendContext } from 'src/hooks/wallet/useSendForm';
@@ -15,7 +16,7 @@ import { EthereumNonce } from './EthereumNonce';
 import { extraDependenciesDesktopMock } from '../../../../../../mocks/extraDependenciesDesktopMock';
 import { mockInitialAppState } from '../../../../../../mocks/mockInitialAppState';
 
-const ethAccount = mockWalletAccount({ symbol: 'eth' }) as any;
+const ethAccount = mockWalletAccount({ symbol: asNetworkSymbol('eth') }) as any;
 
 type Props = { displayNonce?: string; confirmedNonce?: string };
 

--- a/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingTransactions/TradingTransactionsList.test.tsx
@@ -5,6 +5,7 @@ import { screen } from '@testing-library/react';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     type SelectedAccountStatus,
@@ -46,6 +47,7 @@ jest.mock('src/views/wallet/trading/common/TradingTransactions/TradingTransactio
 }));
 
 const DEVICE_SSID = 'btcAddress@deviceId:0' as const;
+const btcSymbol = asNetworkSymbol('btc');
 const SELECTED_DEVICE = mockSuiteDevice({
     connected: true,
     available: true,
@@ -54,7 +56,7 @@ const SELECTED_DEVICE = mockSuiteDevice({
 
 const ACCOUNT_KEY = createAccountKey({
     accountDescriptor: asAccountDescriptor('btcDescriptor'),
-    networkSymbol: 'btc',
+    networkSymbol: btcSymbol,
     deviceStaticSessionId: DEVICE_SSID,
 });
 

--- a/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
+++ b/packages/suite/src/views/wallet/trading/sell/TradingFormOfferSellActions.test.tsx
@@ -4,6 +4,7 @@ import { screen } from '@testing-library/react';
 
 import { configureMockStore } from '@suite-common/test-utils';
 import { initialState as tradingInitialState } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
 
@@ -50,7 +51,10 @@ jest.mock(
 
 const DEVICE_STATE: StaticSessionId = '1stTestnetAddress@device_id:0';
 
-const account = mockWalletAccount({ symbol: 'eth', balance: '1000000000000000000' });
+const account = mockWalletAccount({
+    symbol: asNetworkSymbol('eth'),
+    balance: '1000000000000000000',
+});
 
 const renderWithNetworkFee = (composed: { fee: string } | undefined) => {
     const store = configureMockStore({

--- a/suite-common/address/src/autocorrectAddress.test.ts
+++ b/suite-common/address/src/autocorrectAddress.test.ts
@@ -2,9 +2,14 @@ import {
     createNetworkModuleRepository,
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { createAddressValidator } from './AddressValidator';
 import { autocorrectAddress } from './autocorrectAddress';
+
+const btcSymbol = asNetworkSymbol('btc');
+const bchSymbol = asNetworkSymbol('bch');
+const ethSymbol = asNetworkSymbol('eth');
 
 describe('autocorrectAddress', () => {
     const networkModules = createNetworksCompositionRoot();
@@ -18,7 +23,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'BC1QAFK4YHQVJ4WEP57M62DGRMUTLDUSQDE8ADH20D',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toEqual({
             corrected: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
@@ -31,7 +36,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'LTC1QKZYARPKHDECU5RZEUJ78PWPR5SFM798AFNY4N6',
-                symbol: 'ltc',
+                symbol: asNetworkSymbol('ltc'),
             }),
         ).toEqual({
             corrected: 'ltc1qkzyarpkhdecu5rzeuj78pwpr5sfm798afny4n6',
@@ -44,7 +49,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'BITCOINCASH:QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC',
-                symbol: 'bch',
+                symbol: bchSymbol,
             }),
         ).toEqual({
             corrected: 'bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
@@ -56,7 +61,7 @@ describe('autocorrectAddress', () => {
         const result = autocorrectAddress({
             addressValidator,
             address: 'qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
-            symbol: 'bch',
+            symbol: bchSymbol,
         });
         expect(result).toEqual({
             corrected: 'bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
@@ -68,7 +73,7 @@ describe('autocorrectAddress', () => {
         const result = autocorrectAddress({
             addressValidator,
             address: 'QZ8GJEXL9X7GAG53XL08MT7QSKVJG8X2WUEEJJMTTC',
-            symbol: 'bch',
+            symbol: bchSymbol,
         });
         expect(result).toEqual({
             corrected: 'bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
@@ -81,7 +86,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'bc1qafk4yhqvj4wep57m62dgrmutldusqde8adh20d',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toBeNull();
     });
@@ -91,7 +96,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'bitcoincash:qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
-                symbol: 'bch',
+                symbol: bchSymbol,
             }),
         ).toBeNull();
     });
@@ -101,7 +106,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: '0xE37c0D48d68da5c5b14E5c1a9f1CFE802776D9FF',
-                symbol: 'eth',
+                symbol: ethSymbol,
             }),
         ).toBeNull();
     });
@@ -111,7 +116,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'qz8gjexl9x7gag53xl08mt7qskvjg8x2wueejjmttc',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toBeNull();
     });
@@ -121,7 +126,7 @@ describe('autocorrectAddress', () => {
             autocorrectAddress({
                 addressValidator,
                 address: 'BC1SW50QA3JX3S',
-                symbol: 'eth',
+                symbol: ethSymbol,
             }),
         ).toBeNull();
     });

--- a/suite-common/address/src/getFirstFreshAddress.test.ts
+++ b/suite-common/address/src/getFirstFreshAddress.test.ts
@@ -1,12 +1,15 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getFirstFreshAddress, getFreshAddresses } from './getFirstFreshAddress';
 
+const testSymbol = asNetworkSymbol('test');
+
 describe(getFirstFreshAddress.name, () => {
     it('returns all unrevealed unused addresses for utxo-based accounts in order', () => {
         const account = mockWalletAccount({
-            symbol: 'test',
+            symbol: testSymbol,
             path: "m/84'/1'/0'",
             descriptor: asAccountDescriptor('descriptorTest'),
             history: { total: 13, tokens: 0, unconfirmed: 0 },
@@ -68,7 +71,7 @@ describe(getFirstFreshAddress.name, () => {
 
     it('returns the first unrevealed unused address for utxo-based accounts', () => {
         const account = mockWalletAccount({
-            symbol: 'test',
+            symbol: testSymbol,
             path: "m/84'/1'/0'",
             descriptor: asAccountDescriptor('descriptorTest'),
             history: { total: 13, tokens: 0, unconfirmed: 0 },
@@ -120,7 +123,7 @@ describe(getFirstFreshAddress.name, () => {
 
     it('returns the next address after a labeled unused address', () => {
         const account = mockWalletAccount({
-            symbol: 'test',
+            symbol: testSymbol,
             path: "m/84'/1'/0'",
             descriptor: asAccountDescriptor('descriptorTest'),
             history: { total: 13, tokens: 0, unconfirmed: 0 },
@@ -180,7 +183,7 @@ describe(getFirstFreshAddress.name, () => {
 
     it('returns the descriptor-based receive address for non-utxo accounts', () => {
         const account = mockWalletAccount({
-            symbol: 'xrp',
+            symbol: asNetworkSymbol('xrp'),
             path: "m/44'/144'/0'/0/0",
             descriptor: asAccountDescriptor('rXrpDescriptor'),
             history: { total: 7, tokens: 0, unconfirmed: 0 },
@@ -199,7 +202,7 @@ describe(getFirstFreshAddress.name, () => {
 
     it('returns the descriptor-based receive address for non-utxo accounts with empty addresses', () => {
         const account = mockWalletAccount({
-            symbol: 'trx',
+            symbol: asNetworkSymbol('trx'),
             path: "m/44'/195'/0'/0/0",
             descriptor: asAccountDescriptor('tTrxDescriptor'),
             history: { total: 3, tokens: 0, unconfirmed: 0 },
@@ -222,7 +225,7 @@ describe(getFirstFreshAddress.name, () => {
 
     it('returns undefined when all unused utxo addresses are already revealed or pending', () => {
         const account = mockWalletAccount({
-            symbol: 'test',
+            symbol: testSymbol,
             path: "m/84'/1'/0'",
             descriptor: asAccountDescriptor('descriptorTest'),
             history: { total: 13, tokens: 0, unconfirmed: 0 },

--- a/suite-common/address/src/getReceiveAddressHistory.test.ts
+++ b/suite-common/address/src/getReceiveAddressHistory.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
 import { type AccountAddress } from '@trezor/connect';
@@ -7,6 +8,8 @@ import {
     getReceiveAddressHistoryList,
     getReceiveAddressToAdd,
 } from './getReceiveAddressHistory';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const ACCOUNT_DESCRIPTOR = asAccountDescriptor(
     'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
@@ -35,7 +38,7 @@ const createAccount = (
     descriptor = asAccountDescriptor('descriptor'),
 ) =>
     mockWalletAccount({
-        symbol: 'btc',
+        symbol: btcSymbol,
         descriptor,
         addresses: {
             used: [],
@@ -101,7 +104,7 @@ describe(getReceiveAddressForFlowEntry.name, () => {
 
     it('returns the first unused address above a used address path', () => {
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             addresses: {
                 used: [createAddress(20, 1)],
                 unused: [createAddress(18), createAddress(21)],
@@ -122,7 +125,7 @@ describe(getReceiveAddressForFlowEntry.name, () => {
 
     it('does not return an unused address below a used address path', () => {
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             addresses: {
                 used: [createAddress(20, 1)],
                 unused: [createAddress(18)],
@@ -184,7 +187,7 @@ describe(getReceiveAddressToAdd.name, () => {
 describe(getReceiveAddressHistoryList.name, () => {
     it('keeps an unlabeled unused address when its path is lower than a used address path', () => {
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             addresses: {
                 used: [createAddress(20, 1)],
                 unused: [
@@ -208,7 +211,7 @@ describe(getReceiveAddressHistoryList.name, () => {
     it('keeps an unlabeled Cardano unused address when its path is lower than a used address path', () => {
         const account = mockWalletAccount(
             {
-                symbol: 'ada',
+                symbol: asNetworkSymbol('ada'),
                 addresses: {
                     used: [createCardanoAddress(20, 1)],
                     unused: [createCardanoAddress(18), createCardanoAddress(21)],
@@ -237,7 +240,7 @@ describe(getReceiveAddressHistoryList.name, () => {
             path: "m/84'/0'/0'/1/18",
         };
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             addresses: {
                 used: [createAddress(20, 1)],
                 unused: [changeAddress],
@@ -344,7 +347,7 @@ describe(getReceiveAddressHistoryList.name, () => {
     it('excludes the current receive address when requested', () => {
         const address = createAddress(18);
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             addresses: {
                 used: [createAddress(20, 1)],
                 unused: [address],

--- a/suite-common/address/src/isAddressDeprecated.test.ts
+++ b/suite-common/address/src/isAddressDeprecated.test.ts
@@ -2,9 +2,13 @@ import {
     createNetworkModuleRepository,
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { createAddressValidator } from './AddressValidator';
 import { isAddressDeprecated } from './isAddressDeprecated';
+
+const ltcSymbol = asNetworkSymbol('ltc');
+const bchSymbol = asNetworkSymbol('bch');
 
 // https://litecoin-project.github.io/p2sh-convert/
 // https://cashaddr.bitcoincash.org/
@@ -16,9 +20,13 @@ describe('isAddressDeprecated', () => {
     });
 
     it('returns undefined for non-deprecated LTC address', () => {
-        expect(isAddressDeprecated({ addressValidator, address: '3notValid', symbol: 'ltc' })).toBe(
-            undefined,
-        );
+        expect(
+            isAddressDeprecated({
+                addressValidator,
+                address: '3notValid',
+                symbol: ltcSymbol,
+            }),
+        ).toBe(undefined);
     });
 
     it('detects deprecated LTC address starting with "3"', () => {
@@ -26,15 +34,19 @@ describe('isAddressDeprecated', () => {
             isAddressDeprecated({
                 addressValidator,
                 address: '3NP9U8dbNzBcwhChpX8nk4F3Bf2oSucXj1',
-                symbol: 'ltc',
+                symbol: ltcSymbol,
             }),
         ).toBe('LTC_ADDRESS_INFO_URL');
     });
 
     it('returns undefined for non-deprecated BCH address', () => {
-        expect(isAddressDeprecated({ addressValidator, address: '1notValid', symbol: 'bch' })).toBe(
-            undefined,
-        );
+        expect(
+            isAddressDeprecated({
+                addressValidator,
+                address: '1notValid',
+                symbol: bchSymbol,
+            }),
+        ).toBe(undefined);
     });
 
     it('detects deprecated BCH address starting with "1"', () => {
@@ -42,7 +54,7 @@ describe('isAddressDeprecated', () => {
             isAddressDeprecated({
                 addressValidator,
                 address: '12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2y',
-                symbol: 'bch',
+                symbol: bchSymbol,
             }),
         ).toBe('HELP_CENTER_CASHADDR_URL');
     });

--- a/suite-common/address/src/isTaprootAddress.test.ts
+++ b/suite-common/address/src/isTaprootAddress.test.ts
@@ -2,9 +2,12 @@ import {
     createNetworkModuleRepository,
     createNetworksCompositionRoot,
 } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { createAddressValidator } from './AddressValidator';
 import { isTaprootAddress } from './isTaprootAddress';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 describe('isTaprootAddress', () => {
     const networkModules = createNetworksCompositionRoot();
@@ -14,7 +17,13 @@ describe('isTaprootAddress', () => {
     });
 
     it('returns false for empty string', () => {
-        expect(isTaprootAddress({ addressValidator, address: '', symbol: 'btc' })).toBe(false);
+        expect(
+            isTaprootAddress({
+                addressValidator,
+                address: '',
+                symbol: btcSymbol,
+            }),
+        ).toBe(false);
     });
 
     it('returns false for non-taproot addresses', () => {
@@ -22,14 +31,14 @@ describe('isTaprootAddress', () => {
             isTaprootAddress({
                 addressValidator,
                 address: 'bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toBe(false);
         expect(
             isTaprootAddress({
                 addressValidator,
                 address: 'bc1q6rgl33d3s9dugudw7n68yrryajkr3ha9q8q24j20zs62se4q9tsqdy0t2q',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toBe(false);
     });
@@ -39,14 +48,14 @@ describe('isTaprootAddress', () => {
             isTaprootAddress({
                 addressValidator,
                 address: 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
-                symbol: 'btc',
+                symbol: btcSymbol,
             }),
         ).toBe(true);
         expect(
             isTaprootAddress({
                 addressValidator,
                 address: 'tb1pn2d0yjeedavnkd8z8lhm566p0f2utm3lgvxrsdehnl94y34txmts5s7t4c',
-                symbol: 'test',
+                symbol: asNetworkSymbol('test'),
             }),
         ).toBe(true);
     });

--- a/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.test.ts
+++ b/suite-common/bip329/src/suiteSync/createBip329ToSuiteSync.test.ts
@@ -1,10 +1,11 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { err, ok } from '@trezor/type-utils';
 
 import { createBip329ToSuiteSync } from './createBip329ToSuiteSync';
 
 const account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
     deviceState: '1@2:3',
 });
 

--- a/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.test.ts
+++ b/suite-common/bip329/src/suiteSync/createSuiteSyncToBip329.test.ts
@@ -2,13 +2,16 @@ import {
     createSuiteSyncAddressId,
     createSuiteSyncOutputId,
 } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asTxTargetId } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { createSuiteSyncToBip329 } from './createSuiteSyncToBip329';
 
+const btcSymbol = asNetworkSymbol('btc');
+
 const account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     deviceState: 'walletDescriptor@deviceId:1',
 });
 const address = 'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs';
@@ -19,11 +22,11 @@ describe(createSuiteSyncToBip329.name, () => {
             accountLabel: 'Account Label',
             addressLabels: [
                 {
-                    id: createSuiteSyncAddressId(address, 'btc'),
+                    id: createSuiteSyncAddressId(address, btcSymbol),
                     address,
                     label: 'Address label',
                     accountDescriptor: account.descriptor,
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                 },
             ],
             outputLabels: [
@@ -33,7 +36,7 @@ describe(createSuiteSyncToBip329.name, () => {
                     txTargetId: asTxTargetId('1'),
                     label: 'Output label',
                     accountDescriptor: account.descriptor,
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                 },
             ],
         };

--- a/suite-common/bip329/src/suiteSync/suiteSyncToBip329.test.ts
+++ b/suite-common/bip329/src/suiteSync/suiteSyncToBip329.test.ts
@@ -4,9 +4,12 @@ import {
     createSuiteSyncAddressId,
     createSuiteSyncOutputId,
 } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 
 import { suiteSyncToBip329 } from './suiteSyncToBip329';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 describe(suiteSyncToBip329.name, () => {
     it('transforms suite sync labels to bip329 labels', () => {
@@ -20,7 +23,7 @@ describe(suiteSyncToBip329.name, () => {
                 txTargetId: asTxTargetId('0'),
                 label: 'this is expending transaction output or just tx',
                 accountDescriptor: asAccountDescriptor('xpub...'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
             },
             {
                 id: createSuiteSyncOutputId(
@@ -31,16 +34,19 @@ describe(suiteSyncToBip329.name, () => {
                 txTargetId: asTxTargetId('0'),
                 label: 'this is receive tx label',
                 accountDescriptor: asAccountDescriptor('xpub...'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
             },
         ];
         const addressLabels: SuiteSyncAddress[] = [
             {
-                id: createSuiteSyncAddressId('bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs', 'btc'),
+                id: createSuiteSyncAddressId(
+                    'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs',
+                    btcSymbol,
+                ),
                 address: 'bc1qq46pg2kafgjvsh7me3puv0jujdl77a5829xlrs',
                 label: 'This address is labeled',
                 accountDescriptor: asAccountDescriptor('xpub...'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
             },
         ];
 

--- a/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts
+++ b/suite-common/earn-stablecoin-api/src/hooks/merkl-rewards/useGetMerklRewardsQueryEntries.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import {
     mockWalletAccount,
@@ -8,7 +9,7 @@ import { getMerklRewardsQueryEntriesForAccounts } from './useGetMerklRewardsQuer
 
 const emptyEthereumAccount = mockWalletAccount(
     {
-        symbol: 'eth',
+        symbol: asNetworkSymbol('eth'),
         descriptor: asAccountDescriptor('0xff6845f200000000000000000000000013fb4863'),
     },
     {

--- a/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
+++ b/suite-common/formatters/src/formatters/prepareCryptoAmountFormatter.test.ts
@@ -1,8 +1,12 @@
 import { createIntl } from 'react-intl';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { PROTO } from '@trezor/connect';
 
 import { prepareCryptoAmountFormatter } from './prepareCryptoAmountFormatter';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 const intl = createIntl({ locale: 'en-US' });
 
@@ -27,7 +31,7 @@ describe('CryptoAmountFormatter', () => {
         it('BTC with symbol', () => {
             expect(
                 CryptoAmountFormatter.format('300', {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
             ).toBe('0.000003 BTC');
         });
@@ -35,7 +39,7 @@ describe('CryptoAmountFormatter', () => {
         it('BTC without symbol', () => {
             expect(
                 CryptoAmountFormatter.format('300', {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     withSymbol: false,
                 }),
             ).toBe('0.000003');
@@ -55,7 +59,7 @@ describe('CryptoAmountFormatter', () => {
         ])('BTC balance with symbol, case %#', (inputValue, expectedValue) => {
             expect(
                 CryptoAmountFormatter.format(inputValue, {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     isBalance: true,
                 }),
             ).toBe(expectedValue);
@@ -64,7 +68,7 @@ describe('CryptoAmountFormatter', () => {
         it('ETH balance with symbol + truncate decimals', () => {
             expect(
                 CryptoAmountFormatter.format('0.020638700284758254', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     isBalance: true,
                 }),
             ).toBe('0.0206387… ETH');
@@ -73,7 +77,7 @@ describe('CryptoAmountFormatter', () => {
         it('ETH balance with symbol + truncate decimals + hide ellipsis', () => {
             expect(
                 CryptoAmountFormatter.format('0.020638700284758254', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     isBalance: true,
                     isEllipsisAppended: false,
                 }),
@@ -83,7 +87,7 @@ describe('CryptoAmountFormatter', () => {
         it('ETH balance with units', () => {
             expect(
                 CryptoAmountFormatter.format('148985107694640', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     isBalance: false,
                 }),
             ).toBe('0.00014899… ETH');
@@ -92,7 +96,7 @@ describe('CryptoAmountFormatter', () => {
         it('ETH fee preserves all 18 decimals without Number precision loss', () => {
             expect(
                 CryptoAmountFormatter.format('1005309106970022', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     isBalance: false,
                     maxDisplayedDecimals: 18,
                 }),
@@ -103,7 +107,7 @@ describe('CryptoAmountFormatter', () => {
             it('BTC sats with symbol', () => {
                 expect(
                     CryptoAmountFormatterSats.format('300', {
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                     }),
                 ).toBe('300 sat');
             });
@@ -111,7 +115,7 @@ describe('CryptoAmountFormatter', () => {
             it('BTC sats without symbol', () => {
                 expect(
                     CryptoAmountFormatterSats.format('300', {
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         withSymbol: false,
                     }),
                 ).toBe('300');
@@ -120,7 +124,7 @@ describe('CryptoAmountFormatter', () => {
             it('BTC sats balance with symbol', () => {
                 expect(
                     CryptoAmountFormatterSats.format('0.3', {
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         isBalance: true,
                     }),
                 ).toBe('30,000,000 sat');
@@ -129,7 +133,7 @@ describe('CryptoAmountFormatter', () => {
             it('TEST sats with symbol', () => {
                 expect(
                     CryptoAmountFormatterSats.format('300', {
-                        symbol: 'test',
+                        symbol: asNetworkSymbol('test'),
                     }),
                 ).toBe('300 sat TEST');
             });

--- a/suite-common/formatters/src/utils/convert.test.ts
+++ b/suite-common/formatters/src/utils/convert.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { BigNumber } from '@trezor/utils';
 
 import { convertCryptoToFiatAmount } from './convert';
@@ -23,7 +24,7 @@ describe('convertCryptoToFiatAmount', () => {
         expect(
             convertCryptoToFiatAmount({
                 amount,
-                symbol: 'btc',
+                symbol: asNetworkSymbol('btc'),
                 isAmountInSats,
                 rate: 22666,
             }),

--- a/suite-common/graph/src/graphBalanceEvents.test.ts
+++ b/suite-common/graph/src/graphBalanceEvents.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { type AccountBalanceHistory } from '@trezor/blockchain-link';
 
@@ -7,6 +8,8 @@ import {
     mergeGroups,
 } from './graphBalanceEvents';
 import { type BalanceMovementEvent, type GroupedBalanceMovementEvent } from './types';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 describe('formatBalanceMovementEventsAmounts', () => {
     it('should calculate received and sent values for each balance movement', () => {
@@ -221,7 +224,7 @@ describe('mergeGroups', () => {
             ],
         ];
 
-        const symbol = 'btc';
+        const symbol = btcSymbol;
 
         const expectedMergedGroups: GroupedBalanceMovementEvent[] = [
             {
@@ -258,7 +261,7 @@ describe('mergeGroups', () => {
 
     it('should handle empty groups array', () => {
         const groups: BalanceMovementEvent[][] = [];
-        const symbol = 'btc';
+        const symbol = btcSymbol;
 
         const expectedMergedGroups: GroupedBalanceMovementEvent[] = [];
 

--- a/suite-common/graph/src/graphUtils.test.ts
+++ b/suite-common/graph/src/graphUtils.test.ts
@@ -1,5 +1,7 @@
 import { fromUnixTime } from 'date-fns';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import {
     findOldestBalanceMovementTimestamp,
     getDataStepInMinutes,
@@ -12,6 +14,9 @@ import type {
     FiatGraphPointWithCryptoBalance,
     FiatRatesItem,
 } from './types';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 describe(getDataStepInMinutes.name, () => {
     it('gets the 1m step size for 1 hour interval (60 points)', () => {
@@ -351,7 +356,7 @@ describe(findOldestBalanceMovementTimestamp.name, () => {
     it('finds the oldest balance movement', () => {
         const balanceHistory: AccountWithBalanceHistory[] = [
             {
-                symbol: 'btc',
+                symbol: btcSymbol,
                 descriptor: 'awdawd',
                 balanceHistory: [
                     {
@@ -365,7 +370,7 @@ describe(findOldestBalanceMovementTimestamp.name, () => {
                 ],
             },
             {
-                symbol: 'eth',
+                symbol: ethSymbol,
                 descriptor: 'awdawd',
                 balanceHistory: [
                     {
@@ -387,8 +392,8 @@ describe(findOldestBalanceMovementTimestamp.name, () => {
         // Math.min of an empty list is Infinity; callers must guard for it (fromUnixTime(Infinity)
         // is an Invalid Date) rather than assume a real timestamp is returned.
         const noMovements: AccountWithBalanceHistory[] = [
-            { symbol: 'btc', descriptor: 'awdawd', balanceHistory: [] },
-            { symbol: 'eth', descriptor: 'awdawd', balanceHistory: [] },
+            { symbol: btcSymbol, descriptor: 'awdawd', balanceHistory: [] },
+            { symbol: ethSymbol, descriptor: 'awdawd', balanceHistory: [] },
         ];
 
         expect(Number.isFinite(findOldestBalanceMovementTimestamp(noMovements))).toBe(false);

--- a/suite-common/logger/package.json
+++ b/suite-common/logger/package.json
@@ -30,5 +30,8 @@
         "@trezor/type-utils": "workspace:*",
         "react": "19.2.3",
         "react-redux": "9.3.0"
+    },
+    "devDependencies": {
+        "@suite-common/wallet-config": "workspace:^"
     }
 }

--- a/suite-common/logger/src/utils.test.ts
+++ b/suite-common/logger/src/utils.test.ts
@@ -1,4 +1,5 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { accountsActions } from '@suite-common/wallet-core';
 import {
     type Account,
@@ -22,7 +23,7 @@ describe('logsUtils', () => {
         descriptor: asAccountDescriptor(
             'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
         ),
-        symbol: 'btc',
+        symbol: asNetworkSymbol('btc'),
     });
     const device = mockSuiteDevice();
 

--- a/suite-common/logger/tsconfig.json
+++ b/suite-common/logger/tsconfig.json
@@ -15,6 +15,7 @@
         { "path": "../../packages/connect" },
         { "path": "../../packages/device-utils" },
         { "path": "../../packages/env-utils" },
-        { "path": "../../packages/type-utils" }
+        { "path": "../../packages/type-utils" },
+        { "path": "../wallet-config" }
     ]
 }

--- a/suite-common/message-system/src/messageSystemTypes.test.ts
+++ b/suite-common/message-system/src/messageSystemTypes.test.ts
@@ -3,9 +3,21 @@ import {
     type AccountType,
     type NetworkSymbol,
     type StakingNetworkSymbol,
+    asNetworkSymbol,
 } from '@suite-common/wallet-config';
 
 import { Context, type GeneralContextKey, type SettingsCategory } from './messageSystemTypes';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
+type StakingContextCase = readonly [StakingNetworkSymbol, string];
+
+const stakingContextCases: readonly StakingContextCase[] = [
+    ['eth', 'accounts.eth.staking'],
+    ['sol', 'accounts.sol.staking'],
+    ['trx', 'accounts.trx.staking'],
+];
 
 describe('Message system types', () => {
     describe('Context', () => {
@@ -20,11 +32,11 @@ describe('Message system types', () => {
 
         describe('getAccount', () => {
             it.each([
-                ['btc', undefined, 'accounts.btc'],
-                ['btc', 'legacy', 'accounts.btc.legacy'],
-                ['eth', undefined, 'accounts.eth'],
-                ['eth', 'ledger', 'accounts.eth.ledger'],
-                ['base', undefined, 'accounts.base'],
+                [btcSymbol, undefined, 'accounts.btc'],
+                [btcSymbol, 'legacy', 'accounts.btc.legacy'],
+                [ethSymbol, undefined, 'accounts.eth'],
+                [ethSymbol, 'ledger', 'accounts.eth.ledger'],
+                [asNetworkSymbol('base'), undefined, 'accounts.base'],
             ] as const satisfies [NetworkSymbol, AccountType | undefined, string][])(
                 'getAccount(%s, %s) → %s',
                 (symbol, type, expected) => {
@@ -34,16 +46,9 @@ describe('Message system types', () => {
         });
 
         describe('getStaking', () => {
-            it.each([
-                ['eth', 'accounts.eth.staking'],
-                ['sol', 'accounts.sol.staking'],
-                ['trx', 'accounts.trx.staking'],
-            ] as const satisfies [StakingNetworkSymbol, string][])(
-                'getStaking(%s) → %s',
-                (symbol, expected) => {
-                    expect(Context.getStaking(symbol)).toBe(expected);
-                },
-            );
+            it.each(stakingContextCases)('getStaking(%s) → %s', (symbol, expected) => {
+                expect(Context.getStaking(symbol)).toBe(expected);
+            });
         });
 
         describe('getTrading', () => {

--- a/suite-common/message-system/src/useMessageSystemStaking.test.ts
+++ b/suite-common/message-system/src/useMessageSystemStaking.test.ts
@@ -5,10 +5,14 @@ import {
     extraDependenciesCommonMock,
     renderHookWithStoreProvider,
 } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { messageSystemInitialState, prepareMessageSystemReducer } from './messageSystemReducer';
 import { type MessageSystemState } from './messageSystemTypes';
 import { useMessageSystemStaking } from './useMessageSystemStaking';
+
+const ethSymbol = asNetworkSymbol('eth');
+const adaSymbol = asNetworkSymbol('ada');
 
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 
@@ -80,7 +84,7 @@ const renderHook = (
 
 describe('useMessageSystemStaking', () => {
     it('returns disabled states and messages when features are disabled', () => {
-        const { result } = renderHook('eth');
+        const { result } = renderHook(ethSymbol);
 
         expect(result.current).toMatchObject({
             isStakingDisabled: true,
@@ -93,7 +97,7 @@ describe('useMessageSystemStaking', () => {
     });
 
     it('returns disabled state and message for ada change-delegate (vote) feature', () => {
-        const { result } = renderHook('ada');
+        const { result } = renderHook(adaSymbol);
 
         expect(result.current).toMatchObject({
             isVotingDisabled: true,
@@ -102,19 +106,19 @@ describe('useMessageSystemStaking', () => {
     });
 
     it('returns undefined voting state for networks without a vote feature key', () => {
-        const { result } = renderHook('eth');
+        const { result } = renderHook(ethSymbol);
 
         expect(result.current.isVotingDisabled).toBeUndefined();
         expect(result.current.votingMessageContent).toBeUndefined();
     });
 
     it('returns localized message content', () => {
-        const { result } = renderHook('eth', 'cs');
+        const { result } = renderHook(ethSymbol, 'cs');
 
         expect(result.current.stakingMessageContent).toBe('Staking vypnutý');
     });
 
-    it.each([undefined, null, 'btc' as const])(
+    it.each([undefined, null, asNetworkSymbol('btc')])(
         'returns undefined for unsupported networkSymbol: %s',
         networkSymbol => {
             const { result } = renderHook(networkSymbol);
@@ -128,7 +132,11 @@ describe('useMessageSystemStaking', () => {
     it('returns not disabled when no feature messages configured', () => {
         const store = createStore(messageSystemInitialState);
         const { result } = renderHookWithStoreProvider(
-            () => useMessageSystemStaking({ networkSymbol: 'eth', locale: 'en' }),
+            () =>
+                useMessageSystemStaking({
+                    networkSymbol: ethSymbol,
+                    locale: 'en',
+                }),
             { store },
         );
 

--- a/suite-common/receive/package.json
+++ b/suite-common/receive/package.json
@@ -18,6 +18,7 @@
         "@suite-common/wallet-types": "workspace:*"
     },
     "devDependencies": {
-        "@suite-common/test-utils": "workspace:*"
+        "@suite-common/test-utils": "workspace:*",
+        "@suite-common/wallet-config": "workspace:^"
     }
 }

--- a/suite-common/receive/src/receiveSlice.test.ts
+++ b/suite-common/receive/src/receiveSlice.test.ts
@@ -1,4 +1,5 @@
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { accountsActions } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import {
@@ -15,8 +16,11 @@ import {
     selectTouchedAddresses,
 } from './receiveSlice';
 
-const bitcoinAccount = mockWalletAccount({ symbol: 'btc' });
-const ethereumAccount = mockWalletAccount({ symbol: 'eth' }, networkSpecificDefaultEthereum);
+const bitcoinAccount = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
+const ethereumAccount = mockWalletAccount(
+    { symbol: asNetworkSymbol('eth') },
+    networkSpecificDefaultEthereum,
+);
 const extraDependencies = {
     ...extraDependenciesCommonMock,
     reducers: {

--- a/suite-common/receive/tsconfig.json
+++ b/suite-common/receive/tsconfig.json
@@ -5,6 +5,7 @@
         { "path": "../redux-utils" },
         { "path": "../wallet-core" },
         { "path": "../wallet-types" },
-        { "path": "../test-utils" }
+        { "path": "../test-utils" },
+        { "path": "../wallet-config" }
     ]
 }

--- a/suite-common/staking/src/ethereumStaking.test.ts
+++ b/suite-common/staking/src/ethereumStaking.test.ts
@@ -1,4 +1,5 @@
 import { type EthValidatorsQueue } from '@suite-common/earn-staking-api';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import TrezorConnect, {
     type AccountInfo,
@@ -58,6 +59,8 @@ import {
     type GetStakeTxGasLimitParams,
     type StakeTxBaseArgs,
 } from './types';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 describe('transformTx', () => {
     transformTxFixtures.forEach(test => {
@@ -235,7 +238,11 @@ describe('getAdjustedGasLimitConsumption', () => {
 describe('getEthNetworkForWalletSdk', () => {
     getEthNetworkForWalletSdkFixture.forEach(test => {
         it(test.description, () => {
-            const result = getEthNetworkForWalletSdk(test.args.symbol);
+            const result = getEthNetworkForWalletSdk(
+                test.args.symbol && test.args.symbol !== 'unknown'
+                    ? asNetworkSymbol(test.args.symbol)
+                    : test.args.symbol,
+            );
             expect(result).toEqual(test.result);
         });
     });
@@ -247,7 +254,7 @@ describe('getInstantStakeType', () => {
             const result = getInstantStakeType(
                 test.args.internalTransfer as InternalTransfer,
                 test.args.address,
-                test.args.symbol,
+                test.args.symbol && asNetworkSymbol(test.args.symbol),
             );
             expect(result).toEqual(test.result);
         });
@@ -261,7 +268,7 @@ describe('getChangedInternalTx', () => {
                 test.args.prevTxs as WalletAccountTransaction[],
                 test.args.currentTxs as WalletAccountTransaction[],
                 test.args.selectedAccountAddress,
-                test.args.symbol,
+                test.args.symbol && asNetworkSymbol(test.args.symbol),
             );
             expect(result).toEqual(test.result);
         });
@@ -277,7 +284,10 @@ describe('simulateUnstake', () => {
             jest.spyOn(TrezorConnect, 'blockchainEvmRpcCall').mockImplementation(() =>
                 Promise.resolve(test.blockchainEvmRpcCallResult as BlockchainEvmRpcCallResult),
             );
-            const result = await simulateUnstake(test.args as SimulateUnstakeArgs);
+            const result = await simulateUnstake({
+                ...test.args,
+                symbol: test.args.symbol ? asNetworkSymbol(test.args.symbol) : test.args.symbol,
+            } as unknown as SimulateUnstakeArgs);
             expect(result).toEqual(test.result);
         });
     });
@@ -376,7 +386,7 @@ describe('verifyEthereumStakingLiveState', () => {
         const result = await verifyEthereumStakingLiveState({
             stakeType: 'stake',
             from: '0xabc',
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(result).toEqual({ isValid: true });
@@ -396,7 +406,7 @@ describe('verifyEthereumStakingLiveState', () => {
         const result = await verifyEthereumStakingLiveState({
             stakeType: 'unstake',
             from: '0xabc',
-            symbol: 'eth',
+            symbol: ethSymbol,
             amount: '1.5',
         });
 
@@ -416,7 +426,7 @@ describe('verifyEthereumStakingLiveState', () => {
         const result = await verifyEthereumStakingLiveState({
             stakeType: 'unstake',
             from: '0xabc',
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(result).toEqual({
@@ -445,7 +455,7 @@ describe('verifyEthereumStakingLiveState', () => {
         const result = await verifyEthereumStakingLiveState({
             stakeType: 'claim',
             from: '0xabc',
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(result).toEqual({ isValid: true });
@@ -459,7 +469,7 @@ describe('verifyEthereumStakingLiveState', () => {
         const result = await verifyEthereumStakingLiveState({
             stakeType: 'claim',
             from: '0xabc',
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(result).toEqual({

--- a/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
+++ b/suite-common/suite-sync-evolu/src/evoluStorage.test.ts
@@ -10,6 +10,7 @@ import {
     asSuiteSyncOwnerId,
     asSuiteSyncOwnerSecretHex,
 } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { asWalletDescriptor } from '@trezor/device-utils';
 import { createDeferred } from '@trezor/utils';
@@ -17,6 +18,8 @@ import { createDeferred } from '@trezor/utils';
 import { createEvoluInstanceFactory } from './createEvoluInstance';
 import { createEvoluStorageFactory } from './evoluStorage';
 import { testCreateRunWithEvoluDeps } from '../mocks/testCreateRunWithEvoluDeps';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const suiteSyncOwner: SuiteSyncOwner = {
     ownerId: asSuiteSyncOwnerId('yg0UgROParTpm60ltI3hDw'),
@@ -82,7 +85,7 @@ describe(createEvoluStorageFactory.name, () => {
 
         const updateResult = storage.data.accounts.update({
             accountDescriptor: asAccountDescriptor('xpub123'),
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             label: 'My Bitcoin Account',
         });
         expect(updateResult.success).toBe(true);
@@ -125,7 +128,7 @@ describe(createEvoluStorageFactory.name, () => {
             address: 'bc1test123',
             label: 'My Receive Address',
             accountDescriptor: asAccountDescriptor('xpub123'),
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
         });
         expect(updateResult.success).toBe(true);
 
@@ -169,7 +172,7 @@ describe(createEvoluStorageFactory.name, () => {
             txTargetId: '0',
             label: 'Payment to Alice',
             accountDescriptor: asAccountDescriptor('xpub123'),
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
         });
         expect(updateResult.success).toBe(true);
 

--- a/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.test.ts
+++ b/suite-common/suite-sync/src/data/account/selectAccountsWithSuiteSyncLabel.test.ts
@@ -1,4 +1,5 @@
 import { type SuiteSyncAccount, createSuiteSyncAccountId } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId, asWalletDescriptor } from '@trezor/device-utils';
@@ -10,7 +11,7 @@ const WALLET_DESCRIPTOR = asWalletDescriptor('selectedWallet');
 const DEVICE_STATIC_SESSION_ID: StaticSessionId = 'selectedWallet@deviceId:0';
 
 const btcAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
     descriptor: asAccountDescriptor('btcdefault'),
     deviceState: DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',
@@ -18,7 +19,7 @@ const btcAccount = mockWalletAccount({
 });
 
 const ethAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor('ethdefault'),
     deviceState: DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',

--- a/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.test.ts
+++ b/suite-common/suite-sync/src/data/createEnsureSubscribedStorage.test.ts
@@ -10,6 +10,7 @@ import {
     createSuiteSyncOutputId,
 } from '@suite-common/suite-sync-storage';
 import { type SuiteSyncListener } from '@suite-common/suite-sync-types';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 import { asWalletDescriptor } from '@trezor/device-utils';
@@ -25,6 +26,7 @@ import { createStorageIdFromDeviceStaticSessionId } from '../storage/createStora
 import { createSubscriptionStorage } from '../storage/createSubscriptionStorage';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
+const btcSymbol = asNetworkSymbol('btc');
 
 const createListenerMock = (): SuiteSyncListener => ({
     onUnsubscribe: jest.fn(),
@@ -194,10 +196,10 @@ describe(createEnsureSubscribedStorage.name, () => {
         storageEmitters.accounts.forEach(it =>
             it.onChange([
                 {
-                    id: createSuiteSyncAccountId(asAccountDescriptor('account-1'), 'btc'),
+                    id: createSuiteSyncAccountId(asAccountDescriptor('account-1'), btcSymbol),
                     accountDescriptor: asAccountDescriptor('account-1'),
                     label: 'Account for Drugs',
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                 },
             ]),
         );
@@ -208,7 +210,7 @@ describe(createEnsureSubscribedStorage.name, () => {
                     id: 'account-1-btc',
                     accountDescriptor: 'account-1',
                     label: 'Account for Drugs',
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                 },
             ],
         );
@@ -216,8 +218,8 @@ describe(createEnsureSubscribedStorage.name, () => {
         storageEmitters.addresses.forEach(it =>
             it.onChange([
                 {
-                    id: createSuiteSyncAddressId('address', 'btc'),
-                    networkSymbol: 'btc',
+                    id: createSuiteSyncAddressId('address', btcSymbol),
+                    networkSymbol: btcSymbol,
                     accountDescriptor: asAccountDescriptor('account-1'),
                     address: 'address',
                     label: 'Address for drugs',
@@ -232,7 +234,7 @@ describe(createEnsureSubscribedStorage.name, () => {
                     accountDescriptor: 'account-1',
                     address: 'address',
                     label: 'Address for drugs',
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                 },
             ],
         );
@@ -241,7 +243,7 @@ describe(createEnsureSubscribedStorage.name, () => {
             it.onChange([
                 {
                     id: createSuiteSyncOutputId('transaction-id', '0'),
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                     accountDescriptor: asAccountDescriptor('account-1'),
                     txId: 'transaction-id',
                     txTargetId: '0',

--- a/suite-common/suite-sync/src/data/labeling/account/createUpdateAccountLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/account/createUpdateAccountLabel.test.ts
@@ -1,4 +1,5 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
@@ -8,9 +9,10 @@ import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyn
 import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
+const btcSymbol = asNetworkSymbol('btc');
 const accountKey = createAccountKey({
     accountDescriptor: asAccountDescriptor('accountDescriptor'),
-    networkSymbol: 'btc',
+    networkSymbol: btcSymbol,
     deviceStaticSessionId,
 });
 

--- a/suite-common/suite-sync/src/data/labeling/account/createWriteAccountLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/account/createWriteAccountLabel.test.ts
@@ -1,5 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import type { AccountTable } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/device-utils';
 import { ok } from '@trezor/type-utils';
@@ -9,6 +10,7 @@ import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyn
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3' as const;
 const accountDescriptor = asAccountDescriptor('accountDescriptor');
+const btcSymbol = asNetworkSymbol('btc');
 
 describe(createWriteAccountLabel.name, () => {
     it('writes account label to storage, reports analytics and propagates the result', () => {
@@ -30,7 +32,7 @@ describe(createWriteAccountLabel.name, () => {
                 deviceStaticSessionId,
                 accountKey: createAccountKey({
                     accountDescriptor,
-                    networkSymbol: 'btc',
+                    networkSymbol: btcSymbol,
                     deviceStaticSessionId,
                 }),
                 label: 'New Account Label',
@@ -39,7 +41,7 @@ describe(createWriteAccountLabel.name, () => {
 
         expect(storage.data.accounts.update).toHaveBeenCalledWith({
             accountDescriptor,
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             label: 'New Account Label',
         });
         expect(report).toHaveBeenCalledWith(

--- a/suite-common/suite-sync/src/data/labeling/address/createUpdateAddressLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/address/createUpdateAddressLabel.test.ts
@@ -1,6 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import { type UpdateAddressLabelParams } from '@suite-common/suite-sync-types';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
@@ -10,7 +10,7 @@ import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyn
 import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
-const networkSymbol: NetworkSymbol = 'btc';
+const networkSymbol = asNetworkSymbol('btc');
 const accountDescriptor = asAccountDescriptor('accountDescriptor');
 
 const params: UpdateAddressLabelParams = {

--- a/suite-common/suite-sync/src/data/labeling/address/createWriteAddressLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/address/createWriteAddressLabel.test.ts
@@ -1,6 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import type { AddressTable } from '@suite-common/suite-sync-storage';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { type StaticSessionId } from '@trezor/connect';
 import { ok } from '@trezor/type-utils';
@@ -9,7 +9,7 @@ import { type WriteAddressLabelDeps, createWriteAddressLabel } from './createWri
 import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyncStorage';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3' as const;
-const networkSymbol: NetworkSymbol = 'btc';
+const networkSymbol = asNetworkSymbol('btc');
 const accountDescriptor = asAccountDescriptor('accountDescriptor');
 
 describe(createWriteAddressLabel.name, () => {

--- a/suite-common/suite-sync/src/data/labeling/createDangerouslyWipeAllLabelsFromWallet.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/createDangerouslyWipeAllLabelsFromWallet.test.ts
@@ -10,6 +10,7 @@ import {
     type UpdateOutputLabelDep,
     type UpdateWalletLabelDep,
 } from '@suite-common/suite-sync-types';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId, asWalletDescriptor } from '@trezor/device-utils';
@@ -20,11 +21,13 @@ import {
     createDangerouslyWipeAllLabelsFromWallet,
 } from './createDangerouslyWipeAllLabelsFromWallet';
 
+const btcSymbol = asNetworkSymbol('btc');
+
 const walletDescriptor = asWalletDescriptor('wallet1');
 const deviceStaticSessionId: StaticSessionId = 'wallet1@device:0';
 
 const account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     deviceState: deviceStaticSessionId,
     descriptor: asAccountDescriptor('account1'),
 });
@@ -39,7 +42,7 @@ const createDeps = ({
     UpdateAddressLabelDep &
     UpdateOutputLabelDep): DangerouslyWipeAllLabelsFromWalletDeps => {
     const otherWalletAccount = mockWalletAccount({
-        symbol: 'btc',
+        symbol: btcSymbol,
         deviceState: 'wallet2@device:0',
         descriptor: asAccountDescriptor('account2'),
     });
@@ -54,18 +57,18 @@ const createDeps = ({
                 accountDescriptor === account.descriptor
                     ? [
                           {
-                              id: createSuiteSyncAddressId('bc1address', 'btc'),
+                              id: createSuiteSyncAddressId('bc1address', btcSymbol),
                               address: 'bc1address',
                               label: 'Address label',
                               accountDescriptor: account.descriptor,
-                              networkSymbol: 'btc',
+                              networkSymbol: btcSymbol,
                           },
                           {
-                              id: createSuiteSyncAddressId('bc1empty', 'btc'),
+                              id: createSuiteSyncAddressId('bc1empty', btcSymbol),
                               address: 'bc1empty',
                               label: null,
                               accountDescriptor: account.descriptor,
-                              networkSymbol: 'btc',
+                              networkSymbol: btcSymbol,
                           },
                       ]
                     : [],
@@ -78,7 +81,7 @@ const createDeps = ({
                               txTargetId: '0',
                               label: 'Output label',
                               accountDescriptor: account.descriptor,
-                              networkSymbol: 'btc',
+                              networkSymbol: btcSymbol,
                           },
                           {
                               id: createSuiteSyncOutputId('tx-id-2', '1'),
@@ -86,7 +89,7 @@ const createDeps = ({
                               txTargetId: '1',
                               label: null,
                               accountDescriptor: account.descriptor,
-                              networkSymbol: 'btc',
+                              networkSymbol: btcSymbol,
                           },
                       ]
                     : [],
@@ -130,7 +133,7 @@ describe(createDangerouslyWipeAllLabelsFromWallet.name, () => {
             address: 'bc1address',
             label: null,
             accountDescriptor: account.descriptor,
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
         });
         expect(updateOutputLabel).toHaveBeenCalledWith({
             deviceStaticSessionId,
@@ -138,7 +141,7 @@ describe(createDangerouslyWipeAllLabelsFromWallet.name, () => {
             txTargetId: '0',
             label: null,
             accountDescriptor: account.descriptor,
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
         });
         expect(updateAccountLabel).toHaveBeenCalledTimes(1);
         expect(updateAddressLabel).toHaveBeenCalledTimes(1);

--- a/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/fromSuiteSyncToSearchAccountLabels.test.ts
@@ -4,12 +4,15 @@ import {
     createSuiteSyncAddressId,
     createSuiteSyncOutputId,
 } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 
 import {
     fromSuiteSyncToSearchAccountLabels,
     fromSuiteSyncToSearchOutputLabels,
 } from './fromSuiteSyncToSearchAccountLabels';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const outputLabelsFixture: SuiteSyncOutput[] = [
     {
@@ -18,7 +21,7 @@ const outputLabelsFixture: SuiteSyncOutput[] = [
         txTargetId: '0',
         label: 'Label A',
         accountDescriptor: asAccountDescriptor('xpub...'),
-        networkSymbol: 'btc',
+        networkSymbol: btcSymbol,
     },
     {
         id: createSuiteSyncOutputId('txid1', '1'),
@@ -26,7 +29,7 @@ const outputLabelsFixture: SuiteSyncOutput[] = [
         txTargetId: '1',
         label: 'Label B',
         accountDescriptor: asAccountDescriptor('xpub...'),
-        networkSymbol: 'btc',
+        networkSymbol: btcSymbol,
     },
     {
         id: createSuiteSyncOutputId('txid2', '0'),
@@ -34,24 +37,24 @@ const outputLabelsFixture: SuiteSyncOutput[] = [
         txTargetId: '0',
         label: null,
         accountDescriptor: asAccountDescriptor('xpub...'),
-        networkSymbol: 'btc',
+        networkSymbol: btcSymbol,
     },
 ];
 
 const addressLabelsFixture: SuiteSyncAddress[] = [
     {
-        id: createSuiteSyncAddressId('tb1qaddress1', 'btc'),
+        id: createSuiteSyncAddressId('tb1qaddress1', btcSymbol),
         address: 'tb1qaddress1',
         label: 'Address label 1',
         accountDescriptor: asAccountDescriptor('xpub...'),
-        networkSymbol: 'btc',
+        networkSymbol: btcSymbol,
     },
     {
-        id: createSuiteSyncAddressId('tb1qaddress2', 'btc'),
+        id: createSuiteSyncAddressId('tb1qaddress2', btcSymbol),
         address: 'tb1qaddress2',
         label: null,
         accountDescriptor: asAccountDescriptor('xpub...'),
-        networkSymbol: 'btc',
+        networkSymbol: btcSymbol,
     },
 ];
 

--- a/suite-common/suite-sync/src/data/labeling/output/createUpdateOutputLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/output/createUpdateOutputLabel.test.ts
@@ -1,6 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import { type UpdateOutputLabelParams } from '@suite-common/suite-sync-types';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 import type { StaticSessionId } from '@trezor/connect';
 import { err, ok } from '@trezor/type-utils';
@@ -10,7 +10,7 @@ import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyn
 import { SuiteSyncUnavailableOnDeviceError } from '../../../createEnsureSuiteSyncKeys';
 
 const deviceStaticSessionId: StaticSessionId = '1@2:3';
-const networkSymbol: NetworkSymbol = 'btc';
+const networkSymbol = asNetworkSymbol('btc');
 const accountDescriptor = asAccountDescriptor('accountDescriptor');
 
 const params: UpdateOutputLabelParams = {

--- a/suite-common/suite-sync/src/data/labeling/output/createWriteOutputLabel.test.ts
+++ b/suite-common/suite-sync/src/data/labeling/output/createWriteOutputLabel.test.ts
@@ -1,6 +1,6 @@
 import { createMockDeps, mock } from '@suite-common/dependency-injection';
 import { type OutputTable, type SuiteSyncOutput } from '@suite-common/suite-sync-storage';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 import { ok } from '@trezor/type-utils';
 
@@ -8,7 +8,7 @@ import { type WriteOutputLabelDeps, createWriteOutputLabel } from './createWrite
 import { createSuiteSyncStorageMock } from '../../../../mocks/mockCreateSuiteSyncStorage';
 
 const deviceStaticSessionId = '1@2:3' as const;
-const networkSymbol: NetworkSymbol = 'btc';
+const networkSymbol = asNetworkSymbol('btc');
 const accountDescriptor = asAccountDescriptor('accountDescriptor');
 
 describe(createWriteOutputLabel.name, () => {

--- a/suite-common/toast-notifications/src/notificationsReducer.test.ts
+++ b/suite-common/toast-notifications/src/notificationsReducer.test.ts
@@ -1,10 +1,13 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { notificationsActions } from './notificationsActions';
 import { createNotificationsReducer } from './notificationsReducer';
 import { selectNotifications } from './notificationsSelectors';
 import { removeAccountEventsThunk } from './notificationsThunks';
 import { type NotificationsRootState, type NotificationsState } from './types';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 const { reducer: notificationsReducer } = createNotificationsReducer();
 
@@ -44,7 +47,7 @@ const mockedNotifications: NotificationsState = [
         type: 'tx-sent',
         formattedAmount: '0',
         descriptor: 'xpub',
-        symbol: 'btc',
+        symbol: btcSymbol,
         txid: 'abcd',
     },
 ];
@@ -57,7 +60,7 @@ describe('Notifications Actions', () => {
                 type: 'tx-sent',
                 formattedAmount: '0',
                 descriptor: 'xpub',
-                symbol: 'btc',
+                symbol: btcSymbol,
                 txid: 'abcd',
             }),
         );
@@ -146,7 +149,7 @@ describe('Notifications Actions', () => {
                         type: 'tx-sent',
                         formattedAmount: '0',
                         descriptor: 'xpub',
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         txid: '1',
                     },
                     {
@@ -155,7 +158,7 @@ describe('Notifications Actions', () => {
                         type: 'tx-confirmed',
                         formattedAmount: '0',
                         descriptor: 'xpub',
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         txid: '2',
                     },
                     {
@@ -164,7 +167,7 @@ describe('Notifications Actions', () => {
                         type: 'tx-received',
                         formattedAmount: '0',
                         descriptor: 'xpub',
-                        symbol: 'btc',
+                        symbol: btcSymbol,
                         txid: '3',
                     },
                     {

--- a/suite-common/token-definitions/src/tokenDefinitionsUtils.test.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsUtils.test.ts
@@ -1,3 +1,5 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import {
     buildTokenDefinitionsFromStorageFixtures,
     getSupportedDefinitionTypesFixtures,
@@ -13,9 +15,13 @@ describe('isTokenDefinitionKnown', () => {
     isTokenDefinitionKnownFixtures.forEach(
         ({ testName, tokenDefinitions, symbol, contractAddress, result }) => {
             test(testName, () => {
-                expect(isTokenDefinitionKnown(tokenDefinitions, symbol, contractAddress)).toBe(
-                    result,
-                );
+                expect(
+                    isTokenDefinitionKnown(
+                        tokenDefinitions,
+                        asNetworkSymbol(symbol),
+                        contractAddress,
+                    ),
+                ).toBe(result);
             });
         },
     );
@@ -24,7 +30,7 @@ describe('isTokenDefinitionKnown', () => {
 describe('getSupportedDefinitionTypes', () => {
     getSupportedDefinitionTypesFixtures.forEach(({ testName, symbol, result }) => {
         test(testName, () => {
-            expect(getSupportedDefinitionTypes(symbol)).toEqual(result);
+            expect(getSupportedDefinitionTypes(asNetworkSymbol(symbol))).toEqual(result);
         });
     });
 });

--- a/suite-common/trading/src/hooks/resolveAssetTokenOption.test.ts
+++ b/suite-common/trading/src/hooks/resolveAssetTokenOption.test.ts
@@ -1,11 +1,14 @@
 import { type Coins, type CryptoId } from 'invity-api';
 
+import { toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
+
 import { useTradingAssets } from './useTradingAssets';
 import coins from '../__fixtures__/coins.json';
 import { createTradingTestState, renderHookWithTradingStore } from '../test-utils/testUtils';
 
 const AUSDC_CONTRACT = '0x98c23e9d8f34fefb1b7bd6a91b7ff122f4e16f5c';
 const UNKNOWN_TOKEN_CONTRACT = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
 
 const renderHook = (preloadedCoins: Coins | null = coins as Coins) =>
     renderHookWithTradingStore(() => useTradingAssets(), {
@@ -21,7 +24,7 @@ describe('resolveAssetTokenOption', () => {
     it('uses invity symbol when token is known to invity', () => {
         const { result } = renderHook();
 
-        const option = result.current.resolveAssetTokenOption('eth', {
+        const option = result.current.resolveAssetTokenOption(ethSymbol, {
             contract: AUSDC_CONTRACT,
             symbol: 'aEthUSDC',
             name: 'Aave Ethereum USDC',
@@ -39,7 +42,7 @@ describe('resolveAssetTokenOption', () => {
     it('falls back to blockbook symbol when token is unknown to invity', () => {
         const { result } = renderHook();
 
-        const option = result.current.resolveAssetTokenOption('eth', {
+        const option = result.current.resolveAssetTokenOption(ethSymbol, {
             contract: UNKNOWN_TOKEN_CONTRACT,
             symbol: 'aEthUSDC',
             name: 'Aave Ethereum USDC',
@@ -56,7 +59,7 @@ describe('resolveAssetTokenOption', () => {
     it('falls back to blockbook symbol when invity coins are not loaded', () => {
         const { result } = renderHook(null);
 
-        const option = result.current.resolveAssetTokenOption('eth', {
+        const option = result.current.resolveAssetTokenOption(ethSymbol, {
             contract: AUSDC_CONTRACT,
             symbol: 'aEthUSDC',
             name: 'Aave Ethereum USDC',
@@ -71,7 +74,7 @@ describe('resolveAssetTokenOption', () => {
 
         const cryptoId = `ethereum--${AUSDC_CONTRACT}` as CryptoId;
 
-        const optionWithInvity = result.current.resolveAssetTokenOption('eth', {
+        const optionWithInvity = result.current.resolveAssetTokenOption(ethSymbol, {
             contract: AUSDC_CONTRACT,
             symbol: 'aEthUSDC',
             name: 'Aave Ethereum USDC',

--- a/suite-common/trading/src/hooks/useDexExchangeTxSimulation.test.ts
+++ b/suite-common/trading/src/hooks/useDexExchangeTxSimulation.test.ts
@@ -1,7 +1,7 @@
 import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { useTxSimulation } from '@suite-common/tx-simulation';
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type TxSimulationAction } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -22,7 +22,8 @@ const mockedUseTxSimulation = jest.mocked(useTxSimulation);
 const mockedComposeDexTxSimulationAction = jest.mocked(composeDexTxSimulationAction);
 
 const SOURCE_ORIGIN = 'https://example.com';
-const account = mockWalletAccount({ symbol: 'eth' });
+const ethSymbol = asNetworkSymbol('eth');
+const account = mockWalletAccount({ symbol: ethSymbol });
 const quote: ExchangeTrade = {
     send: 'ethereum' as CryptoId,
     sendStringAmount: '1',
@@ -89,7 +90,7 @@ describe('useDexExchangeTxSimulation', () => {
         mockedComposeDexTxSimulationAction.mockReturnValue(action);
         mockedUseTxSimulation.mockReturnValue({
             txSimulationQuery,
-            network: getNetwork('eth'),
+            network: getNetwork(ethSymbol),
             targetContract: account.descriptor,
         } as unknown as NonNullable<ReturnType<typeof useTxSimulation>>);
 

--- a/suite-common/trading/src/hooks/useExchangeFiatDeviation.test.ts
+++ b/suite-common/trading/src/hooks/useExchangeFiatDeviation.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type CryptoId } from 'invity-api';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 
 import { useExchangeFiatDeviation } from './useExchangeFiatDeviation';
@@ -14,6 +15,7 @@ const mockedUseTradingFiatValues = jest.mocked(useTradingFiatValues);
 
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+const btcSymbol = asNetworkSymbol('btc');
 
 const defaultProps = {
     sendCryptoId: BITCOIN_CRYPTO_ID,
@@ -28,7 +30,7 @@ const createTradingFiatValuesResult = (fiatValue: string | null): TradingFiatRat
     fiatRate: undefined,
     accountBalance: '1',
     formattedBalance: '1',
-    symbol: 'btc',
+    symbol: btcSymbol,
     networkDecimals: 8,
     tokenAddress: undefined,
     fiatRatesUpdater: () => Promise.resolve(null),

--- a/suite-common/trading/src/hooks/useTradingFiatValues.test.ts
+++ b/suite-common/trading/src/hooks/useTradingFiatValues.test.ts
@@ -1,6 +1,6 @@
 import { type CryptoId } from 'invity-api';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type Rate, type Timestamp } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
@@ -19,8 +19,10 @@ import {
 // Mock crypto IDs for testing
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const ETHEREUM_CRYPTO_ID = 'ethereum' as CryptoId;
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
-const createMockRate = (rate: number, symbol: NetworkSymbol = 'btc'): Rate => ({
+const createMockRate = (rate: number, symbol: NetworkSymbol = btcSymbol): Rate => ({
     rate,
     lastTickerTimestamp: 1000000 as Timestamp,
     lastSuccessfulFetchTimestamp: Date.now() as Timestamp,
@@ -33,7 +35,7 @@ const createMockRate = (rate: number, symbol: NetworkSymbol = 'btc'): Rate => ({
 
 const getPreloadedState = () => {
     const btcRate = createMockRate(50000);
-    const fiatRateKey = getFiatRateKey('btc', 'usd');
+    const fiatRateKey = getFiatRateKey(btcSymbol, 'usd');
 
     return createTestStateWithWalletSettings({
         fiat: {
@@ -111,8 +113,8 @@ describe('useTradingFiatValues', () => {
         });
 
         it('should calculate fiat value for Ethereum', () => {
-            const ethRate = createMockRate(3000, 'eth');
-            const fiatRateKey = getFiatRateKey('eth', 'eur');
+            const ethRate = createMockRate(3000, ethSymbol);
+            const fiatRateKey = getFiatRateKey(ethSymbol, 'eur');
 
             const preloadedState = createTestStateWithWalletSettings({
                 settings: {

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -9,7 +9,7 @@ import {
     type SellFiatTrade,
 } from 'invity-api';
 
-import { type NetworkSymbol } from '@suite-common/networks';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/connect';
@@ -120,7 +120,11 @@ import { type SellInfo, sellInitialState } from '../reducers/sellReducer';
 import { type TradingRootState, initialState } from '../reducers/tradingCommonReducer';
 import type { TradingTransactionExchange, TradingTransactionSell, TradingType } from '../types';
 
-const supportedCoins: readonly NetworkSymbol[] = ['btc', 'eth', 'base'];
+const supportedCoins: readonly NetworkSymbol[] = [
+    asNetworkSymbol('btc'),
+    asNetworkSymbol('eth'),
+    asNetworkSymbol('base'),
+];
 
 describe('tradingSelectors', () => {
     let state: TradingRootStateWithDeviceAndAccounts;

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { type CryptoId } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 
 import { ALTERNATIVE_QUOTES } from '../../__fixtures__/buyUtils';
 import {
@@ -22,6 +22,7 @@ import { MIN_MAX_QUOTES_OK } from '../../utils/buy/__fixtures__/buyUtils';
 
 import { buyThunks } from './index';
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
 const createMockQuotes = () =>
     [...MIN_MAX_QUOTES_OK, ...ALTERNATIVE_QUOTES].map(quote => ({ ...quote }));
 
@@ -86,13 +87,13 @@ describe('handleBuyRequestThunk', () => {
                 id: 'bitcoin' as CryptoId,
                 isNativeToken: true,
                 name: 'Bitcoin',
-                symbol: 'btc',
+                symbol: btcSymbol,
                 coingeckoId: 'bitcoin',
                 displaySymbol: 'BTC',
                 displaySymbolName: 'Bitcoin',
                 contractAddress: null,
                 networkName: 'Bitcoin',
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
             } satisfies TradingAssetOption,
             countrySelect: {
                 value: 'CZ',
@@ -111,7 +112,7 @@ describe('handleBuyRequestThunk', () => {
         };
         const input: HandleBuyRequestThunkProps = {
             formValues,
-            network: getNetwork('btc'),
+            network: getNetwork(btcSymbol),
             shouldSendInSats: false,
         };
 

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -5,6 +5,7 @@ import { createThunk } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
 import { type Account, type FeesState } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
@@ -26,6 +27,8 @@ jest.mock('@suite-common/wallet-core', () => {
 
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const trxSymbol = asNetworkSymbol('trx');
+const ethSymbol = asNetworkSymbol('eth');
 const btcFeeData = {
     blockHeight: 890366,
     blockTime: 10,
@@ -56,7 +59,7 @@ const fees: FeesState = {
         status: 'loaded',
         data: btcFeeData,
     },
-    trx: {
+    [trxSymbol]: {
         status: 'loaded',
         data: btcFeeData,
     },
@@ -198,8 +201,8 @@ describe('recomposeAndSignTxThunk', () => {
             tradingThunks.recomposeAndSignTxThunk({
                 account: {
                     ...account,
-                    symbol: undefined as unknown,
-                } as Account,
+                    symbol: ethSymbol,
+                },
                 address: 'address',
                 amount: '0.1',
                 tradingFormState,

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { type CryptoId, type ExchangeTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { prepareAccountsReducer } from '@suite-common/wallet-core';
 import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
@@ -25,6 +25,10 @@ import { exchangeThunks } from './index';
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
 const cloneExchangeQuotes = () => cloneObject(MIN_MAX_QUOTES_OK) as ExchangeTrade[];
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
+const ethSymbol = toNetworkSymbolNonTestnet('eth');
+const bscSymbol = toNetworkSymbolNonTestnet('bsc');
+const etcSymbol = toNetworkSymbolNonTestnet('etc');
 
 describe('handleExchangeRequestThunk', () => {
     afterEach(() => {
@@ -113,11 +117,11 @@ describe('handleExchangeRequestThunk', () => {
                 name: 'Bitcoin',
                 coingeckoId: 'bitcoin',
                 contractAddress: null,
-                symbol: 'btc',
+                symbol: btcSymbol,
                 displaySymbol: 'BTC',
                 networkName: 'Bitcoin',
-                networkSymbol: 'btc',
-                accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+                networkSymbol: btcSymbol,
+                accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
             } satisfies TradingAssetSellOption,
             receiveCryptoSelect: {
                 id: 'ethereum' as CryptoId,
@@ -125,11 +129,11 @@ describe('handleExchangeRequestThunk', () => {
                 name: 'Ethereum',
                 coingeckoId: 'ethereum',
                 contractAddress: null,
-                symbol: 'eth',
+                symbol: ethSymbol,
                 displaySymbol: 'ETH',
                 displaySymbolName: 'Ethereum',
                 networkName: 'Ethereum',
-                networkSymbol: 'eth',
+                networkSymbol: ethSymbol,
             } satisfies TradingAssetOption,
             rateType: 'fixed',
             exchangeType: 'CEX',
@@ -138,7 +142,7 @@ describe('handleExchangeRequestThunk', () => {
         };
         const input: HandleExchangeRequestThunkProps = {
             formValues,
-            network: getNetwork('btc'),
+            network: getNetwork(btcSymbol),
             shouldSendInSats: false,
             composeRequestCallback: mockComposeRequestCallback,
         };
@@ -249,10 +253,10 @@ describe('handleExchangeRequestThunk', () => {
                     name: 'BNB Smart Chain',
                     coingeckoId: 'binance-smart-chain',
                     contractAddress: null,
-                    symbol: 'bsc',
+                    symbol: bscSymbol,
                     displaySymbol: 'BNB',
                     networkName: 'BNB Smart Chain',
-                    networkSymbol: 'bsc',
+                    networkSymbol: bscSymbol,
                 } satisfies TradingAssetOption,
                 receiveAddress: ethAddress,
                 receiveAccountKey: ethAccountKey,
@@ -267,10 +271,10 @@ describe('handleExchangeRequestThunk', () => {
                     name: 'Ethereum Classic',
                     coingeckoId: 'ethereum-classic',
                     contractAddress: null,
-                    symbol: 'etc',
+                    symbol: etcSymbol,
                     displaySymbol: 'ETC',
                     networkName: 'Ethereum Classic',
-                    networkSymbol: 'etc',
+                    networkSymbol: etcSymbol,
                 } satisfies TradingAssetOption,
                 receiveAddress: ethAddress,
                 receiveAccountKey: ethAccountKey,

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.test.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.test.ts
@@ -2,7 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { type CryptoId, type SellFiatTrade } from 'invity-api';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, toNetworkSymbolNonTestnet } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { convertAmountUnitsToSubunits } from '@suite-common/wallet-utils';
 
@@ -24,6 +24,7 @@ import { sellUtilsFixtures } from '../../utils/sell/__fixtures__/sellUtils';
 import { sellThunks } from './index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
+const btcSymbol = toNetworkSymbolNonTestnet('btc');
 
 describe('handleSellRequestThunk', () => {
     afterEach(() => {
@@ -99,11 +100,11 @@ describe('handleSellRequestThunk', () => {
                 name: 'Bitcoin',
                 coingeckoId: 'bitcoin',
                 contractAddress: null,
-                symbol: 'btc',
+                symbol: btcSymbol,
                 displaySymbol: 'BTC',
                 networkName: 'Bitcoin',
-                networkSymbol: 'btc',
-                accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: 'btc' }),
+                networkSymbol: btcSymbol,
+                accountKey: mockAccountKey({ descriptor: 'descriptor123', symbol: btcSymbol }),
             } satisfies TradingAssetSellOption,
             amountInCrypto: true,
             feePerUnit: '',
@@ -122,7 +123,7 @@ describe('handleSellRequestThunk', () => {
 
         const input: HandleSellRequestThunkProps = {
             formValues,
-            network: getNetwork('btc'),
+            network: getNetwork(btcSymbol),
             shouldSendInSats: false,
             composeRequestCallback: mockComposeRequestCallback,
         };

--- a/suite-common/trading/src/utils.test.ts
+++ b/suite-common/trading/src/utils.test.ts
@@ -6,7 +6,7 @@ import {
     type SellFiatTrade,
 } from 'invity-api';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import type { Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
@@ -233,9 +233,9 @@ describe('isCrossChainTrade', () => {
 
 describe('toTokenCryptoId', () => {
     it('should return correct token cryptoId', () => {
-        expect(toTokenCryptoId('eth', '0x1234123412341234123412341234123412341234')).toBe(
-            'ethereum--0x1234123412341234123412341234123412341234',
-        );
+        expect(
+            toTokenCryptoId(asNetworkSymbol('eth'), '0x1234123412341234123412341234123412341234'),
+        ).toBe('ethereum--0x1234123412341234123412341234123412341234');
     });
 });
 

--- a/suite-common/trading/src/utils/exchange/receiveAddressCoherence.test.ts
+++ b/suite-common/trading/src/utils/exchange/receiveAddressCoherence.test.ts
@@ -1,6 +1,7 @@
 import { type CryptoId } from 'invity-api';
 
 import { type AddressValidator } from '@suite-common/address';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { isReceiveAddressCoherent, isReceiveAddressValid } from './receiveAddressCoherence';
 
@@ -9,6 +10,8 @@ const VALID_ETH_ADDRESS = '0xab5801a7d398351b8be11c439e05c5b3259aec9b';
 
 const ETH_CRYPTO_ID = 'ethereum' as CryptoId;
 const BTC_CRYPTO_ID = 'bitcoin' as CryptoId;
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
 
 const isAddressValid = jest.fn(
     (address: string, symbol: string) => address === VALID_ETH_ADDRESS && symbol === 'eth',
@@ -24,7 +27,7 @@ describe('isReceiveAddressValid', () => {
             throw new Error('validator blew up');
         });
 
-        expect(isReceiveAddressValid(addressValidator, VALID_ETH_ADDRESS, 'eth')).toBe(false);
+        expect(isReceiveAddressValid(addressValidator, VALID_ETH_ADDRESS, ethSymbol)).toBe(false);
     });
 });
 
@@ -36,7 +39,7 @@ describe('isReceiveAddressCoherent', () => {
                 receiveAddress: undefined,
                 receiveCryptoId: BTC_CRYPTO_ID,
                 receiveAccountKey: 'account-1',
-                receiveAccountSymbol: 'eth',
+                receiveAccountSymbol: ethSymbol,
             }),
         ).toBe(true);
     });
@@ -84,7 +87,7 @@ describe('isReceiveAddressCoherent', () => {
                 receiveAddress: VALID_ETH_ADDRESS,
                 receiveCryptoId: ETH_CRYPTO_ID,
                 receiveAccountKey: 'account-1',
-                receiveAccountSymbol: 'eth',
+                receiveAccountSymbol: ethSymbol,
             }),
         ).toBe(true);
     });
@@ -96,7 +99,7 @@ describe('isReceiveAddressCoherent', () => {
                 receiveAddress: VALID_ETH_ADDRESS,
                 receiveCryptoId: ETH_CRYPTO_ID,
                 receiveAccountKey: 'account-1',
-                receiveAccountSymbol: 'btc',
+                receiveAccountSymbol: btcSymbol,
             }),
         ).toBe(false);
     });

--- a/suite-common/trading/src/utils/receiveAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/receiveAccountUtils.test.ts
@@ -1,12 +1,16 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getReceiveAccountPreselection } from './receiveAccountUtils';
 
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
+
 const btcUnusedAddress = 'bc1qfcjv620stvtzjeelg26ncgww8ks49zy8lracjz';
 
 const btcAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('btcDescriptor'),
     addresses: {
         change: [],
@@ -25,26 +29,26 @@ const btcAccount = mockWalletAccount({
 });
 
 const ethAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0x0000000000000000000000000000000000000001'),
 });
 
 describe('getReceiveAccountPreselection', () => {
     it('returns null when there are no accounts', () => {
         expect(
-            getReceiveAccountPreselection({ receiveAssetNetworkSymbol: 'btc', accounts: [] }),
+            getReceiveAccountPreselection({ receiveAssetNetworkSymbol: btcSymbol, accounts: [] }),
         ).toBeNull();
     });
 
     it('returns the send account key when send account has the receive symbol', () => {
         const sendAccount = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             descriptor: asAccountDescriptor('ethSendDescriptor'),
         });
 
         expect(
             getReceiveAccountPreselection({
-                receiveAssetNetworkSymbol: 'eth',
+                receiveAssetNetworkSymbol: ethSymbol,
                 accounts: [ethAccount],
                 sendAccount,
             }),
@@ -57,7 +61,7 @@ describe('getReceiveAccountPreselection', () => {
     it('returns the first unused address for non-account-based networks', () => {
         expect(
             getReceiveAccountPreselection({
-                receiveAssetNetworkSymbol: 'btc',
+                receiveAssetNetworkSymbol: btcSymbol,
                 accounts: [btcAccount],
             }),
         ).toEqual({

--- a/suite-common/trading/src/utils/tradingAccountUtils.test.ts
+++ b/suite-common/trading/src/utils/tradingAccountUtils.test.ts
@@ -1,13 +1,19 @@
 import { type CryptoId } from 'invity-api';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { isAccountEligibleForTrade } from './tradingAccountUtils';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const TOKEN_CRYPTO_ID = 'ethereum--0xTokenContract' as CryptoId;
 
-const withBalance = mockWalletAccount({ symbol: 'eth', balance: '1000000000000000000' });
-const zeroBalance = mockWalletAccount({ symbol: 'eth', balance: '0', tokens: [] });
+const withBalance = mockWalletAccount({
+    symbol: ethSymbol,
+    balance: '1000000000000000000',
+});
+const zeroBalance = mockWalletAccount({ symbol: ethSymbol, balance: '0', tokens: [] });
 
 describe('isAccountEligibleForTrade', () => {
     it('is always eligible for buy regardless of balance', () => {

--- a/suite-common/transaction-search/package.json
+++ b/suite-common/transaction-search/package.json
@@ -19,5 +19,8 @@
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/utils": "workspace:*",
         "react": "19.2.3"
+    },
+    "devDependencies": {
+        "@suite-common/wallet-config": "workspace:^"
     }
 }

--- a/suite-common/transaction-search/src/simpleSearchTransactions.test.ts
+++ b/suite-common/transaction-search/src/simpleSearchTransactions.test.ts
@@ -1,9 +1,11 @@
 import { testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { type SearchAccountLabels } from './searchLabels';
 import { simpleSearchTransactions } from './simpleSearchTransactions';
 
 const { getWalletTransaction } = testMocks;
+const ethSymbol = asNetworkSymbol('eth');
 
 const emptyLabels: SearchAccountLabels = {
     outputLabels: new Map(),
@@ -22,7 +24,7 @@ describe(simpleSearchTransactions.name, () => {
 
     it('does not match token-only transactions by native display symbol', () => {
         const transaction = getWalletTransaction({
-            symbol: 'eth',
+            symbol: ethSymbol,
             txid: 'aaa2',
             amount: '0',
             tokens: [
@@ -45,7 +47,7 @@ describe(simpleSearchTransactions.name, () => {
 
     it('does not match token-only transactions by native display symbol even when token symbol or name contain it', () => {
         const transaction = getWalletTransaction({
-            symbol: 'eth',
+            symbol: ethSymbol,
             txid: 'aaa6',
             type: 'contract',
             amount: '0',
@@ -80,7 +82,7 @@ describe(simpleSearchTransactions.name, () => {
 
     it('matches contract transactions with native amount by native display symbol', () => {
         const transaction = getWalletTransaction({
-            symbol: 'eth',
+            symbol: ethSymbol,
             txid: 'aaa7',
             type: 'contract',
             amount: '1.5',
@@ -97,7 +99,7 @@ describe(simpleSearchTransactions.name, () => {
 
     it('matches transactions with native internal transfers by native display symbol', () => {
         const transaction = getWalletTransaction({
-            symbol: 'eth',
+            symbol: ethSymbol,
             txid: 'aaa4',
             amount: '0',
             internalTransfers: [{ type: 'recv', from: '0x1', to: '0x2', amount: '5' }],
@@ -110,7 +112,7 @@ describe(simpleSearchTransactions.name, () => {
 
     it('still finds token transactions by token symbol', () => {
         const transaction = getWalletTransaction({
-            symbol: 'eth',
+            symbol: ethSymbol,
             txid: 'aaa5',
             amount: '0',
             tokens: [

--- a/suite-common/transaction-search/tsconfig.json
+++ b/suite-common/transaction-search/tsconfig.json
@@ -12,6 +12,7 @@
         {
             "path": "../../packages/blockchain-link-types"
         },
-        { "path": "../../packages/utils" }
+        { "path": "../../packages/utils" },
+        { "path": "../wallet-config" }
     ]
 }

--- a/suite-common/transfer-uri/src/parseTransferUri.test.ts
+++ b/suite-common/transfer-uri/src/parseTransferUri.test.ts
@@ -1,11 +1,12 @@
-import type { FindNetworkSymbolForProtocol } from '@suite-common/networks';
+import { type FindNetworkSymbolForProtocol } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { err, ok } from '@trezor/type-utils';
 
 import { parseTransferUri } from './parseTransferUri';
 
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol => {
-    if (protocol === 'bitcoin') return 'btc';
-    if (protocol === 'ethereum') return 'eth';
+    if (protocol === 'bitcoin') return asNetworkSymbol('btc');
+    if (protocol === 'ethereum') return asNetworkSymbol('eth');
 
     return null;
 };

--- a/suite-common/wallet-config/src/earnRewardsProvider.test.ts
+++ b/suite-common/wallet-config/src/earnRewardsProvider.test.ts
@@ -1,5 +1,8 @@
 import { getEarnYieldClaimContractAddress, isEarnYieldClaimSupported } from './earnRewardsProvider';
+import { asNetworkSymbol } from './types';
 import { getNetworkFeatures, networkSymbolCollection } from './utils';
+
+const arbSymbol = asNetworkSymbol('arb');
 
 describe(isEarnYieldClaimSupported.name, () => {
     it('has a claim contract address for every network with the claim-rewards feature', () => {
@@ -16,16 +19,18 @@ describe(isEarnYieldClaimSupported.name, () => {
 
     it('does not support claim on a network without the claim-rewards feature', () => {
         // Arbitrum has a claim contract address but the feature flag is not enabled.
-        expect(getNetworkFeatures('arb')).not.toContain('claim-rewards');
-        expect(isEarnYieldClaimSupported('arb')).toBe(false);
+        expect(getNetworkFeatures(arbSymbol)).not.toContain('claim-rewards');
+        expect(isEarnYieldClaimSupported(arbSymbol)).toBe(false);
     });
 
     it('supports claim in debug mode on networks with a claim contract address', () => {
-        expect(isEarnYieldClaimSupported('arb', { isDebugMode: true })).toBe(true);
-        expect(isEarnYieldClaimSupported('btc', { isDebugMode: true })).toBe(false);
+        expect(isEarnYieldClaimSupported(arbSymbol, { isDebugMode: true })).toBe(true);
+        expect(isEarnYieldClaimSupported(asNetworkSymbol('btc'), { isDebugMode: true })).toBe(
+            false,
+        );
     });
 
     it('supports claim on networks with both the feature and a contract address', () => {
-        expect(isEarnYieldClaimSupported('eth')).toBe(true);
+        expect(isEarnYieldClaimSupported(asNetworkSymbol('eth'))).toBe(true);
     });
 });

--- a/suite-common/wallet-config/src/networksConfig.ts
+++ b/suite-common/wallet-config/src/networksConfig.ts
@@ -796,6 +796,9 @@ export type NetworkConfig = NetworksConfigs[keyof NetworksConfigs];
 
 export type NetworkConfigWithoutTestnets = Exclude<NetworkConfig, { testnet: true }>;
 
+export const toNetworkSymbolNonTestnet = (symbol: string): NetworkConfigWithoutTestnets['symbol'] =>
+    symbol as NetworkConfigWithoutTestnets['symbol'];
+
 export type NetworkDisplaySymbol = NetworkConfig['displaySymbol'];
 
 type NetworkWithFeature<TFeature extends NetworkFeature> = {

--- a/suite-common/wallet-config/src/types.ts
+++ b/suite-common/wallet-config/src/types.ts
@@ -5,6 +5,8 @@ import { type DeviceModelInternal } from '@trezor/device-utils';
 
 export type { NetworkSymbol };
 
+export const asNetworkSymbol = (symbol: string): NetworkSymbol => symbol as NetworkSymbol;
+
 /**
  * Used for some edge cases where extension of NetworkSymbol is necessary.
  * Autocomplete is working as expected but can be passed any string.

--- a/suite-common/wallet-config/src/utils.test.ts
+++ b/suite-common/wallet-config/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { networks } from './networksConfig';
-import { type NetworkSymbol } from './types';
+import { asNetworkSymbol } from './types';
 import {
     filterNetworksByName,
     getMainnets,
@@ -84,41 +84,30 @@ describe(isAccountOfNetwork.name, () => {
 });
 
 describe('isAccountBasedNetwork', () => {
-    it.each<NetworkSymbol>(['btc', 'ada'])('returns false for %s', symbol => {
-        expect(isAccountBasedNetwork(symbol)).toBe(false);
+    it.each(['btc', 'ada'])('returns false for %s', symbol => {
+        expect(isAccountBasedNetwork(asNetworkSymbol(symbol))).toBe(false);
     });
 
-    it.each<NetworkSymbol>(['eth', 'sol', 'hype'])('returns true for %s', symbol => {
-        expect(isAccountBasedNetwork(symbol)).toBe(true);
+    it.each(['eth', 'sol', 'hype'])('returns true for %s', symbol => {
+        expect(isAccountBasedNetwork(asNetworkSymbol(symbol))).toBe(true);
     });
 
     it('returns throw for unknown network type', () => {
-        expect(() => isAccountBasedNetwork('unknown' as NetworkSymbol)).toThrow();
+        expect(() => isAccountBasedNetwork(asNetworkSymbol('unknown'))).toThrow();
     });
 });
 
 describe(isNetworkUsingExternalBackend.name, () => {
-    it.each<NetworkSymbol>([
-        'bsc',
-        'pol',
-        'op',
-        'arb',
-        'base',
-        'rhc',
-        'hype',
-        'avax',
-        'sol',
-        'dsol',
-    ])('returns true for %s', symbol => {
-        expect(isNetworkUsingExternalBackend(symbol)).toBe(true);
-    });
-
-    it.each<NetworkSymbol>(['btc', 'eth', 'trx', 'xlm', 'xrp', 'ada'])(
-        'returns false for %s',
+    it.each(['bsc', 'pol', 'op', 'arb', 'base', 'rhc', 'hype', 'avax', 'sol', 'dsol'])(
+        'returns true for %s',
         symbol => {
-            expect(isNetworkUsingExternalBackend(symbol)).toBe(false);
+            expect(isNetworkUsingExternalBackend(asNetworkSymbol(symbol))).toBe(true);
         },
     );
+
+    it.each(['btc', 'eth', 'trx', 'xlm', 'xrp', 'ada'])('returns false for %s', symbol => {
+        expect(isNetworkUsingExternalBackend(asNetworkSymbol(symbol))).toBe(false);
+    });
 });
 
 describe(getNetworksWithMevProtection.name, () => {

--- a/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
@@ -2,6 +2,7 @@ import { combineReducers } from '@reduxjs/toolkit';
 
 import { type ExtraDependenciesPartial } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
@@ -9,6 +10,8 @@ import { accountsActions } from './accountsActions';
 import { type AccountsRootState, prepareAccountsReducer } from './accountsReducer';
 
 const accountsReducer = prepareAccountsReducer(extraDependenciesCommonMock);
+const btcSymbol = asNetworkSymbol('btc');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 interface InitStoreArgs {
     extra?: ExtraDependenciesPartial;
@@ -26,7 +29,7 @@ const initStore = ({ extra = {}, preloadedState }: InitStoreArgs = {}) => {
 };
 const getAccount = (a?: Partial<Account>) => ({
     descriptor: 'xpubDeFauLT1',
-    symbol: 'btc',
+    symbol: btcSymbol,
     history: {},
     ...a,
 });
@@ -44,7 +47,7 @@ describe('Account Reducer', () => {
                 index: 0,
                 path: testBip43Path,
                 accountType: 'normal',
-                symbol: 'btc',
+                symbol: btcSymbol,
                 accountInfo: {
                     descriptor: 'XPUB',
                     path: testBip43Path,
@@ -92,10 +95,10 @@ describe('Account Reducer', () => {
             visible: true,
         });
 
-        store.dispatch(accountsActions.createAccount(createAccountPayload('ltc', 'normal', 0)));
-        store.dispatch(accountsActions.createAccount(createAccountPayload('btc', 'legacy', 0)));
-        store.dispatch(accountsActions.createAccount(createAccountPayload('btc', 'normal', 1)));
-        store.dispatch(accountsActions.createAccount(createAccountPayload('btc', 'normal', 0)));
+        store.dispatch(accountsActions.createAccount(createAccountPayload(ltcSymbol, 'normal', 0)));
+        store.dispatch(accountsActions.createAccount(createAccountPayload(btcSymbol, 'legacy', 0)));
+        store.dispatch(accountsActions.createAccount(createAccountPayload(btcSymbol, 'normal', 1)));
+        store.dispatch(accountsActions.createAccount(createAccountPayload(btcSymbol, 'normal', 0)));
 
         expect(
             store.getState().wallet.accounts.map(a => `${a.symbol}/${a.accountType}/${a.index}`),
@@ -108,7 +111,7 @@ describe('Account Reducer', () => {
                 wallet: {
                     accounts: [
                         getAccount({
-                            symbol: 'ltc',
+                            symbol: ltcSymbol,
                             path: testBip43Path,
                             visible: false,
                         }) as Account,
@@ -120,14 +123,14 @@ describe('Account Reducer', () => {
         store.dispatch(
             accountsActions.changeAccountVisibility(
                 getAccount({
-                    symbol: 'ltc',
+                    symbol: ltcSymbol,
                     path: testBip43Path,
                     visible: false,
                 }) as Account,
             ),
         );
         expect(store.getState().wallet.accounts[0]).toEqual(
-            getAccount({ symbol: 'ltc', path: testBip43Path, visible: true }),
+            getAccount({ symbol: ltcSymbol, path: testBip43Path, visible: true }),
         );
     });
 
@@ -137,7 +140,7 @@ describe('Account Reducer', () => {
         store.dispatch(
             accountsActions.changeAccountVisibility(
                 getAccount({
-                    symbol: 'ltc',
+                    symbol: ltcSymbol,
                     path: testBip43Path,
                     visible: false,
                 }) as Account,

--- a/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsRefreshTimeReducer.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -9,13 +10,15 @@ import {
     selectAccountRefreshTime,
 } from './accountsRefreshTimeReducer';
 
+const btcSymbol = asNetworkSymbol('btc');
+
 const account = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     deviceState: '1@2:3',
     descriptor: asAccountDescriptor('accA'),
 });
 const otherAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     deviceState: '1@2:3',
     descriptor: asAccountDescriptor('accB'),
 });

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.test.ts
@@ -1,7 +1,7 @@
 import type { DeviceRootState } from '@suite-common/device';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { networks } from '@suite-common/wallet-config';
+import { asNetworkSymbol, networks } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
@@ -18,6 +18,9 @@ const BTC_DEVICE = mockSuiteDevice({ state: { staticSessionId: BTC_DEVICE_SSID }
 
 const ETH_DEVICE_SSID: `${string}@${string}:${number}` = '1stTestnetAddress@device_id:0';
 const ETH_DEVICE = mockSuiteDevice({ state: { staticSessionId: ETH_DEVICE_SSID } });
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
 
 const mockState: AccountsRootState & DeviceRootState = {
     wallet: {
@@ -31,7 +34,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 stellarCursor: undefined,
                 key: mockAccountKey({
                     descriptor: '1BitcoinAddress',
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     deviceStaticSessionId: BTC_DEVICE_SSID,
                 }),
                 accountType: 'normal',
@@ -41,7 +44,7 @@ const mockState: AccountsRootState & DeviceRootState = {
                 availableBalance: '0',
                 formattedBalance: '0',
                 tokens: [],
-                symbol: 'btc',
+                symbol: btcSymbol,
                 path: "m/84'/0'/0'",
                 descriptor: asAccountDescriptor('1BitcoinAddress'),
                 addresses: {
@@ -85,13 +88,13 @@ const mockState: AccountsRootState & DeviceRootState = {
                 page: { index: 1, size: 25, total: 1 },
             },
             {
-                symbol: 'eth',
+                symbol: ethSymbol,
                 networkType: 'ethereum',
                 descriptor: asAccountDescriptor('0xEthereumAddress'),
                 deviceState: ETH_DEVICE_SSID,
                 key: mockAccountKey({
                     descriptor: '0xEthereumAddress',
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     deviceStaticSessionId: ETH_DEVICE_SSID,
                 }),
                 accountType: 'normal',
@@ -234,14 +237,14 @@ describe('accountsSelectors', () => {
     describe('selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex', () => {
         const mockSolAccount = (override: Partial<Account>): Account =>
             ({
-                symbol: 'sol',
+                symbol: solSymbol,
                 accountType: 'normal',
                 index: 0,
                 deviceState: BTC_DEVICE_SSID,
                 visible: true,
                 key: mockAccountKey({
                     descriptor: `descriptor${override.index ?? 0}`,
-                    symbol: 'sol',
+                    symbol: solSymbol,
                     deviceStaticSessionId: BTC_DEVICE_SSID,
                 }),
                 ...override,
@@ -263,7 +266,7 @@ describe('accountsSelectors', () => {
             expect(
                 selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
                     state,
-                    'sol',
+                    solSymbol,
                     'normal',
                     2,
                 ),
@@ -274,7 +277,7 @@ describe('accountsSelectors', () => {
             const failedAccount = mockSolAccount({
                 key: mockAccountKey({
                     descriptor: 'failed:0:sol:normal',
-                    symbol: 'sol',
+                    symbol: solSymbol,
                     deviceStaticSessionId: BTC_DEVICE_SSID,
                 }),
                 failed: true,
@@ -284,7 +287,7 @@ describe('accountsSelectors', () => {
             expect(
                 selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
                     createState([failedAccount]),
-                    'sol',
+                    solSymbol,
                     'normal',
                     0,
                 ),
@@ -292,7 +295,7 @@ describe('accountsSelectors', () => {
             expect(
                 selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
                     createState([replacementAccount]),
-                    'sol',
+                    solSymbol,
                     'normal',
                     0,
                 ),
@@ -304,7 +307,7 @@ describe('accountsSelectors', () => {
                 deviceState: ETH_DEVICE_SSID,
                 key: mockAccountKey({
                     descriptor: 'descriptor0',
-                    symbol: 'sol',
+                    symbol: solSymbol,
                     deviceStaticSessionId: ETH_DEVICE_SSID,
                 }),
             });
@@ -312,7 +315,7 @@ describe('accountsSelectors', () => {
             expect(
                 selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
                     createState([otherDeviceAccount]),
-                    'sol',
+                    solSymbol,
                     'normal',
                     0,
                 ),
@@ -325,7 +328,7 @@ describe('accountsSelectors', () => {
             expect(
                 selectDeviceAccountKeyForNetworkSymbolAndAccountTypeWithIndex(
                     createState([legacyAccount]),
-                    'sol',
+                    solSymbol,
                     'normal',
                     0,
                 ),

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.test.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.test.ts
@@ -1,39 +1,41 @@
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type BackendSettings } from '@suite-common/wallet-types';
 
 import { type SetBackendPayload, blockchainActions } from './blockchainActions';
 import { blockchainInitialState, prepareBlockchainReducer } from './blockchainReducer';
 
 const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
+const btcSymbol = asNetworkSymbol('btc');
 
 const urls = ['http://a, http://b, http://c'];
 
 type BlockchainFixture = [string, BackendSettings, SetBackendPayload, BackendSettings];
 
 const fixtures: BlockchainFixture[] = [
-    ['try to set empty', {}, { symbol: 'btc', type: 'electrum', urls: [] }, {}],
+    ['try to set empty', {}, { symbol: btcSymbol, type: 'electrum', urls: [] }, {}],
     [
         'set custom',
         {},
-        { symbol: 'btc', type: 'electrum', urls },
+        { symbol: btcSymbol, type: 'electrum', urls },
         { selected: 'electrum', urls: { electrum: urls } },
     ],
     [
         'change custom',
         { selected: 'electrum', urls: { electrum: urls } },
-        { symbol: 'btc', type: 'blockbook', urls },
+        { symbol: btcSymbol, type: 'blockbook', urls },
         { selected: 'blockbook', urls: { electrum: urls, blockbook: urls } },
     ],
     [
         'reset with remembering',
         { selected: 'blockbook', urls: { electrum: urls, blockbook: urls } },
-        { symbol: 'btc', type: 'default' },
+        { symbol: btcSymbol, type: 'default' },
         { urls: { electrum: urls, blockbook: urls } },
     ],
     [
         'reset with forgetting',
         { selected: 'electrum', urls: { electrum: urls, blockbook: urls } },
-        { symbol: 'btc', type: 'electrum', urls: [] },
+        { symbol: btcSymbol, type: 'electrum', urls: [] },
         { urls: { blockbook: urls } },
     ],
 ];

--- a/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts
+++ b/suite-common/wallet-core/src/earn/earnDepositsFiatUtils.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type RatesByKey, type TokenAddress, toTokenAddress } from '@suite-common/wallet-types';
 import { getFiatRateKey } from '@suite-common/wallet-utils';
 
@@ -9,6 +10,7 @@ import {
 
 const USDC_CONTRACT_CHECKSUMMED = toTokenAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48');
 const USDC_CONTRACT_LOWERCASE = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
+const ethSymbol = asNetworkSymbol('eth');
 
 const createRates = (rates: Record<string, number>) =>
     Object.fromEntries(Object.entries(rates).map(([key, rate]) => [key, { rate }])) as RatesByKey;
@@ -17,7 +19,7 @@ const createYieldDeposit = (
     tokenContractAddress: TokenAddress,
 ): EarnStablecoinYieldDepositFiatInput => ({
     id: 'yield-1',
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     tokenContractAddress,
     balance: '4',
 });
@@ -28,8 +30,8 @@ describe(calculateEarnDepositsFiatData.name, () => {
             stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
             stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
             currentFiatRates: createRates({
-                [getFiatRateKey('eth', 'usd')]: 3_000,
-                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
+                [getFiatRateKey(ethSymbol, 'usd')]: 3_000,
+                [getFiatRateKey(ethSymbol, 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
             }),
             baseCurrencyCode: 'usd',
         });
@@ -45,7 +47,7 @@ describe(calculateEarnDepositsFiatData.name, () => {
             stakingDeposits: [],
             stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
             currentFiatRates: createRates({
-                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_CHECKSUMMED)]: 1,
+                [getFiatRateKey(ethSymbol, 'usd', USDC_CONTRACT_CHECKSUMMED)]: 1,
             }),
             baseCurrencyCode: 'usd',
         });
@@ -85,7 +87,7 @@ describe(calculateEarnDepositsFiatData.name, () => {
             stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
             stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
             currentFiatRates: createRates({
-                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
+                [getFiatRateKey(ethSymbol, 'usd', USDC_CONTRACT_LOWERCASE)]: 1,
             }),
             baseCurrencyCode: 'usd',
         });
@@ -100,8 +102,8 @@ describe(calculateEarnDepositsFiatData.name, () => {
             stakingDeposits: [{ id: 'staking-1', symbol: 'eth', balance: '2' }],
             stablecoinYieldDeposits: [createYieldDeposit(USDC_CONTRACT_LOWERCASE)],
             currentFiatRates: createRates({
-                [getFiatRateKey('eth', 'usd')]: 0,
-                [getFiatRateKey('eth', 'usd', USDC_CONTRACT_LOWERCASE)]: 0,
+                [getFiatRateKey(ethSymbol, 'usd')]: 0,
+                [getFiatRateKey(ethSymbol, 'usd', USDC_CONTRACT_LOWERCASE)]: 0,
             }),
             baseCurrencyCode: 'usd',
         });
@@ -152,7 +154,7 @@ describe(getEarnDepositsFiatStatus.name, () => {
 
     it('reports a lower-bound total when only one deposit type has a rate', () => {
         const result = getEarnDepositsFiatStatus({
-            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStakingRateTickers: [{ symbol: ethSymbol }],
             missingStablecoinYieldRateTickers: [],
             hasStakingFiatRate: false,
             hasStablecoinYieldFiatRate: true,
@@ -169,9 +171,9 @@ describe(getEarnDepositsFiatStatus.name, () => {
 
     it('reports an unavailable total when no deposit type has a rate', () => {
         const result = getEarnDepositsFiatStatus({
-            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStakingRateTickers: [{ symbol: ethSymbol }],
             missingStablecoinYieldRateTickers: [
-                { symbol: 'eth', tokenAddress: USDC_CONTRACT_LOWERCASE },
+                { symbol: ethSymbol, tokenAddress: USDC_CONTRACT_LOWERCASE },
             ],
             hasStakingFiatRate: false,
             hasStablecoinYieldFiatRate: false,
@@ -184,7 +186,7 @@ describe(getEarnDepositsFiatStatus.name, () => {
 
     it('does not report an incomplete total while missing rates are loading', () => {
         const result = getEarnDepositsFiatStatus({
-            missingStakingRateTickers: [{ symbol: 'eth' }],
+            missingStakingRateTickers: [{ symbol: ethSymbol }],
             missingStablecoinYieldRateTickers: [],
             hasStakingFiatRate: false,
             hasStablecoinYieldFiatRate: false,

--- a/suite-common/wallet-core/src/explorer/explorerActions.test.ts
+++ b/suite-common/wallet-core/src/explorer/explorerActions.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { explorerActions } from './explorerActions';
 import {
@@ -10,6 +11,7 @@ import {
 } from './explorerReducer';
 
 const explorerReducer = prepareExplorerReducer(extraDependenciesCommonMock);
+const btcSymbol = asNetworkSymbol('btc');
 
 const initStore = (state: Partial<ExplorerConfig> = {}) =>
     configureMockStore({
@@ -35,7 +37,7 @@ describe('setExplorer', () => {
 
         store.dispatch(
             explorerActions.setExplorer({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 explorer,
             }),
         );
@@ -45,13 +47,13 @@ describe('setExplorer', () => {
 
     test('removes stored custom explorer', () => {
         const store = initStore({
-            btc: {
+            [btcSymbol]: {
                 default: { base: 'https://mempool.space', tx: 'tx', address: 'address' },
                 custom: { base: 'https://mempool.space', tx: 'tx', address: 'address' },
             },
         });
 
-        store.dispatch(explorerActions.setExplorer({ symbol: 'btc' }));
+        store.dispatch(explorerActions.setExplorer({ symbol: btcSymbol }));
 
         expect(store.getState().wallet.explorer.btc.custom).toEqual(undefined);
     });
@@ -66,7 +68,7 @@ describe('setExplorer', () => {
 
         store.dispatch(
             explorerActions.setExplorer({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 explorer,
             }),
         );

--- a/suite-common/wallet-core/src/fees/feesThunks.test.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FeeInfo } from '@suite-common/wallet-types';
 
 import { DEFAULT_FEE_INFO } from './feesConstants';
@@ -9,6 +10,7 @@ import { updateFeeInfoThunk } from './feesThunks';
 import { blockchainInitialState, prepareBlockchainReducer } from '../blockchain/blockchainReducer';
 
 const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
+const trxSymbol = asNetworkSymbol('trx');
 
 const tronFeeInfo: FeeInfo = {
     blockHeight: 100,
@@ -38,16 +40,19 @@ const initStore = (feeInfo?: FeeInfo) =>
 describe(updateFeeInfoThunk.name, () => {
     it('fulfills with existing data for tron instead of fetching', async () => {
         const store = initStore(tronFeeInfo);
-        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: 'trx' }));
+        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: trxSymbol }));
 
         expect(response.meta.requestStatus).toBe('fulfilled');
         expect(response.payload).toEqual(tronFeeInfo);
-        expect(store.getState().wallet.fees.trx).toEqual({ status: 'loaded', data: tronFeeInfo });
+        expect(store.getState().wallet.fees[trxSymbol]).toEqual({
+            status: 'loaded',
+            data: tronFeeInfo,
+        });
     });
 
     it('fulfills with default fee info for tron when no data is stored', async () => {
         const store = initStore();
-        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: 'trx' }));
+        const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: trxSymbol }));
 
         expect(response.meta.requestStatus).toBe('fulfilled');
         expect(response.payload).toEqual({ ...DEFAULT_FEE_INFO, blockHeight: 0 });

--- a/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
+++ b/suite-common/wallet-core/src/fiat-rates/useMissingRateTickersQuery.test.ts
@@ -1,6 +1,7 @@
 import { useDispatch } from 'react-redux';
 
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type TickerId, toTokenAddress } from '@suite-common/wallet-types';
 
 import { updateFiatRatesThunk } from './fiatRatesThunks';
@@ -35,7 +36,7 @@ const mockUpdateFiatRatesThunk = jest.mocked(updateFiatRatesThunk);
 
 const missingRateTickers: TickerId[] = [
     {
-        symbol: 'eth',
+        symbol: asNetworkSymbol('eth'),
         tokenAddress: toTokenAddress('0x0000000000000000000000000000000000000001'),
     },
 ];

--- a/suite-common/wallet-core/src/selectors.test.ts
+++ b/suite-common/wallet-core/src/selectors.test.ts
@@ -1,6 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     type AccountFailureSpecific,
@@ -19,6 +19,7 @@ import { initialWalletSettingsState } from './settings/walletSettingsReducer';
 const STATIC_SESSION_ID: `${string}@${string}:${number}` =
     'mvbu1Gdy8SUjTenqerxUaZyYjmveZvt33q@ABC123:1';
 const DEVICE_PATH = 'device-path';
+const solSymbol = asNetworkSymbol('sol');
 
 const mockSolAccount = (
     account: Omit<Partial<Account>, 'failed' | 'error'>,
@@ -26,7 +27,7 @@ const mockSolAccount = (
 ) =>
     mockWalletAccount(
         {
-            symbol: 'sol',
+            symbol: solSymbol,
             deviceState: STATIC_SESSION_ID,
             ...account,
         },
@@ -53,7 +54,7 @@ const getState = ({
     accounts = [],
     device = mockDeviceWithPathAndState(),
     discovery,
-    enabledNetworks = ['sol'],
+    enabledNetworks = [solSymbol],
 }: GetStateOptions = {}): WalletCoreCompoundRootState => ({
     wallet: {
         accounts,

--- a/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
+++ b/suite-common/wallet-core/src/send/composeCancelTransaction/composeCancelTransactionThunk.test.ts
@@ -1,4 +1,5 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import type { WalletAccountTransaction } from '@suite-common/wallet-types';
 import TrezorConnect, { type PrecomposeResultFinal } from '@trezor/connect';
 
@@ -14,7 +15,7 @@ const FIRST_ACCOUNT_CHANGE_ADDRESS = 'bcrt1qte33uyyfzrdrm9nqk0uwlq9dqr6ezu2gurhr
 
 const account: ComposeCancelTransactionThunkParams['account'] = {
     path: "m/84'/1'/0'",
-    symbol: 'regtest',
+    symbol: asNetworkSymbol('regtest'),
     utxo: [],
     addresses: {
         change: [

--- a/suite-common/wallet-core/src/send/sendFormReducer.test.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.test.ts
@@ -1,5 +1,6 @@
 import { type ExtraDependencies } from '@suite-common/redux-utils';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     type AccountKey,
@@ -32,6 +33,7 @@ const extraDependencies: ExtraDependencies = {
 const formStateMock = 'FormStateMock' as unknown as FormState;
 const precomposedTxMock = 'precomposedTx' as unknown as PrecomposedTransactionFinal;
 const formSignedTxMock = 'formSignedTx' as unknown as SerializedTx;
+const btcSymbol = asNetworkSymbol('btc');
 
 describe('sendFormReducer', () => {
     it('STORAGE.LOAD', () => {
@@ -102,13 +104,13 @@ describe('sendFormReducer', () => {
     it('SEND.REQUEST_PUSH_TRANSACTION - save', () => {
         const action = sendFormActions.storeSignedTransaction({
             serializedTx: {
-                symbol: 'btc',
+                symbol: btcSymbol,
                 tx: 'test',
             },
         });
 
         const state = prepareSendFormReducer(extraDependencies)(initialState, action);
-        expect(state.serializedTx).toEqual({ symbol: 'btc', tx: 'test' });
+        expect(state.serializedTx).toEqual({ symbol: btcSymbol, tx: 'test' });
     });
 
     it('SEND.REQUEST_PUSH_TRANSACTION - delete', () => {

--- a/suite-common/wallet-core/src/send/sendFormSelectors.test.ts
+++ b/suite-common/wallet-core/src/send/sendFormSelectors.test.ts
@@ -1,6 +1,7 @@
 import { type DeviceRootState } from '@suite-common/device';
 import { type ButtonRequest } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { PAYMENT_REQUEST_BUTTON_NAMES } from './sendFormConstants';
 import {
@@ -21,13 +22,17 @@ const SLIP24_SEQUENCE: ButtonRequest[] = [
     { code: 'ButtonRequest_Other', name: 'confirm_trade' },
     { code: 'ButtonRequest_SignTx', name: 'confirm_total' },
 ];
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const xlmSymbol = asNetworkSymbol('xlm');
+const adaSymbol = asNetworkSymbol('ada');
 
 describe('selectSendFormButtonRequestCodes', () => {
     it('counts SLIP-24 payment request screens (ButtonRequest_Other by name) on bitcoin', () => {
         PAYMENT_REQUEST_BUTTON_NAMES.forEach(name => {
             const codes = selectSendFormButtonRequestCodes(
                 stateWith([{ code: 'ButtonRequest_Other', name }]),
-                'btc',
+                btcSymbol,
             );
             expect(codes).toEqual(['ButtonRequest_Other']);
         });
@@ -40,13 +45,13 @@ describe('selectSendFormButtonRequestCodes', () => {
                     { code: 'ButtonRequest_Other', name: 'confirm_something_else' },
                     { code: 'ButtonRequest_Other' },
                 ]),
-                'btc',
+                btcSymbol,
             ),
         ).toEqual([]);
     });
 
     it('maps the full bitcoin SLIP-24 sequence to its codes in order', () => {
-        expect(selectSendFormButtonRequestCodes(stateWith(SLIP24_SEQUENCE), 'btc')).toEqual([
+        expect(selectSendFormButtonRequestCodes(stateWith(SLIP24_SEQUENCE), btcSymbol)).toEqual([
             'ButtonRequest_Other',
             'ButtonRequest_Other',
             'ButtonRequest_SignTx',
@@ -58,7 +63,7 @@ describe('selectSendFormButtonRequestCodes', () => {
             { code: 'ButtonRequest_ConfirmOutput' },
             { code: 'ButtonRequest_SignTx' },
         ];
-        expect(selectSendFormButtonRequestCodes(stateWith(requests), 'btc')).toEqual([
+        expect(selectSendFormButtonRequestCodes(stateWith(requests), btcSymbol)).toEqual([
             'ButtonRequest_ConfirmOutput',
             'ButtonRequest_SignTx',
         ]);
@@ -66,7 +71,10 @@ describe('selectSendFormButtonRequestCodes', () => {
 
     it('counts any ButtonRequest_Other on ethereum (by network, not name)', () => {
         expect(
-            selectSendFormButtonRequestCodes(stateWith([{ code: 'ButtonRequest_Other' }]), 'eth'),
+            selectSendFormButtonRequestCodes(
+                stateWith([{ code: 'ButtonRequest_Other' }]),
+                ethSymbol,
+            ),
         ).toEqual(['ButtonRequest_Other']);
     });
 
@@ -74,7 +82,7 @@ describe('selectSendFormButtonRequestCodes', () => {
         expect(
             selectSendFormButtonRequestCodes(
                 stateWith([{ code: 'ButtonRequest_Other' }, { code: 'ButtonRequest_ProtectCall' }]),
-                'xlm',
+                xlmSymbol,
             ),
         ).toEqual(['ButtonRequest_Other', 'ButtonRequest_ProtectCall']);
     });
@@ -86,15 +94,15 @@ describe('selectSendFormButtonRequestCodes', () => {
                     { code: 'ButtonRequest_PinEntry' },
                     { code: 'ButtonRequest_ConfirmOutput' },
                 ]),
-                'ada',
+                adaSymbol,
             ),
         ).toEqual(['ButtonRequest_PinEntry', 'ButtonRequest_ConfirmOutput']);
     });
 
     it('returns a stable reference for unchanged inputs', () => {
         const state = stateWith(SLIP24_SEQUENCE);
-        expect(selectSendFormButtonRequestCodes(state, 'btc')).toBe(
-            selectSendFormButtonRequestCodes(state, 'btc'),
+        expect(selectSendFormButtonRequestCodes(state, btcSymbol)).toBe(
+            selectSendFormButtonRequestCodes(state, btcSymbol),
         );
     });
 });
@@ -105,7 +113,9 @@ describe('selectSendFormReviewButtonRequestsCount', () => {
     });
 
     it('counts the full bitcoin SLIP-24 sequence as 3 steps', () => {
-        expect(selectSendFormReviewButtonRequestsCount(stateWith(SLIP24_SEQUENCE), 'btc')).toBe(3);
+        expect(selectSendFormReviewButtonRequestsCount(stateWith(SLIP24_SEQUENCE), btcSymbol)).toBe(
+            3,
+        );
     });
 
     it('subtracts one on cardano', () => {
@@ -113,11 +123,11 @@ describe('selectSendFormReviewButtonRequestsCount', () => {
             { code: 'ButtonRequest_ConfirmOutput' },
             { code: 'ButtonRequest_SignTx' },
         ]);
-        expect(selectSendFormReviewButtonRequestsCount(state, 'ada')).toBe(1);
+        expect(selectSendFormReviewButtonRequestsCount(state, adaSymbol)).toBe(1);
     });
 
     it('does not return a negative count for cardano without button requests', () => {
-        expect(selectSendFormReviewButtonRequestsCount(stateWith([]), 'ada')).toBe(0);
+        expect(selectSendFormReviewButtonRequestsCount(stateWith([]), adaSymbol)).toBe(0);
     });
 
     it('drops one ConfirmOutput when decreasing an RBF output, without mutating the cached array', () => {
@@ -126,11 +136,11 @@ describe('selectSendFormReviewButtonRequestsCount', () => {
             { code: 'ButtonRequest_ConfirmOutput' },
         ]);
 
-        expect(selectSendFormReviewButtonRequestsCount(state, 'btc', 0)).toBe(1);
+        expect(selectSendFormReviewButtonRequestsCount(state, btcSymbol, 0)).toBe(1);
         // The memoized array must be untouched by the decrement above.
-        expect(selectSendFormButtonRequestCodes(state, 'btc')).toHaveLength(2);
+        expect(selectSendFormButtonRequestCodes(state, btcSymbol)).toHaveLength(2);
         // Without decreaseOutputId the full count is returned.
-        expect(selectSendFormReviewButtonRequestsCount(state, 'btc')).toBe(2);
+        expect(selectSendFormReviewButtonRequestsCount(state, btcSymbol)).toBe(2);
     });
 });
 
@@ -141,12 +151,15 @@ describe('selectSendFormReviewLastButtonCode', () => {
 
     it('returns null when there are no relevant button requests', () => {
         expect(
-            selectSendFormReviewLastButtonCode(stateWith([{ code: 'ButtonRequest_Other' }]), 'btc'),
+            selectSendFormReviewLastButtonCode(
+                stateWith([{ code: 'ButtonRequest_Other' }]),
+                btcSymbol,
+            ),
         ).toBeNull();
     });
 
     it('returns the last relevant code', () => {
-        expect(selectSendFormReviewLastButtonCode(stateWith(SLIP24_SEQUENCE), 'btc')).toBe(
+        expect(selectSendFormReviewLastButtonCode(stateWith(SLIP24_SEQUENCE), btcSymbol)).toBe(
             'ButtonRequest_SignTx',
         );
     });

--- a/suite-common/wallet-core/src/send/synchronizeSentTransactionThunk.test.ts
+++ b/suite-common/wallet-core/src/send/synchronizeSentTransactionThunk.test.ts
@@ -1,11 +1,12 @@
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import TrezorConnect from '@trezor/connect';
 
 import { synchronizeSentTransactionThunk } from './sendFormThunks';
 import { transactionsActions } from '../transactions/transactionsActions';
 
-const ethAccount = mockWalletAccount({ symbol: 'eth' });
+const ethAccount = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 
 const precomposed = (extra?: Record<string, unknown>) =>
     ({ type: 'final', totalSpent: '0', fee: '0', outputs: [], inputs: [], ...extra }) as any;

--- a/suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts
+++ b/suite-common/wallet-core/src/send/tron/deriveColdRecipient.test.ts
@@ -1,4 +1,4 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
@@ -11,14 +11,16 @@ jest.mock('@trezor/connect', () => ({
 
 const DEVICE_STATE = 'device-a' as Account['deviceState'];
 const DERIVED_ADDRESS = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
-const network = getNetwork('trx');
+const trxSymbol = asNetworkSymbol('trx');
+const ethSymbol = asNetworkSymbol('eth');
+const network = getNetwork(trxSymbol);
 const device = { state: DEVICE_STATE } as unknown as Parameters<
     typeof deriveTronColdRecipient
 >[0]['device'];
 
 const buildAccount = (overrides?: Partial<Account>): Account =>
     ({
-        symbol: 'trx',
+        symbol: trxSymbol,
         networkType: 'tron',
         accountType: 'normal',
         deviceState: DEVICE_STATE,
@@ -178,7 +180,7 @@ describe('deriveTronColdRecipient', () => {
     });
 
     it('returns undefined for a non-tron account without touching the device', async () => {
-        const account = buildAccount({ networkType: 'ethereum', symbol: 'eth' });
+        const account = buildAccount({ networkType: 'ethereum', symbol: ethSymbol });
 
         const result = await deriveTronColdRecipient({
             account,

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.test.ts
@@ -1,5 +1,5 @@
 import { configureMockStore } from '@suite-common/test-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import TrezorConnect from '@trezor/connect';
 
@@ -7,11 +7,12 @@ import { composeTronTransactionFeeLevelsThunk } from './sendFormTronThunks';
 
 const OWNER = 'TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9';
 const COLD_RECIPIENT = 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr';
+const trxSymbol = asNetworkSymbol('trx');
 
-const network = getNetwork('trx');
+const network = getNetwork(trxSymbol);
 
 const account = {
-    symbol: 'trx',
+    symbol: trxSymbol,
     networkType: 'tron',
     accountType: 'normal',
     index: 0,

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.test.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.test.ts
@@ -5,10 +5,14 @@ import {
     extraDependenciesCommonMock,
     wireEnabledNetworksMock,
 } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { walletSettingsFixtures } from './__fixtures__/walletSettingsActions.fixtures';
 import { prepareWalletSettingsReducer } from './walletSettingsReducer';
 import { changeCoinVisibility } from './walletSettingsThunks';
+
+const btcSymbol = asNetworkSymbol('btc');
+const adaSymbol = asNetworkSymbol('ada');
 
 const settingsReducer = prepareWalletSettingsReducer(extraDependenciesCommonMock);
 
@@ -35,11 +39,14 @@ describe('walletSettings Actions', () => {
 
     describe('changeCoinVisibility declares the enabled coin to Connect', () => {
         it('pushes the coin when enabling a not-yet-enabled network', async () => {
-            const store = initStore({ enabledNetworks: ['btc'] });
+            const store = initStore({ enabledNetworks: [btcSymbol] });
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({ symbol: 'ada', shouldBeVisible: true }) as any,
+                changeCoinVisibility({
+                    symbol: adaSymbol,
+                    shouldBeVisible: true,
+                }) as any,
             );
 
             expect(updateConnectSettings).toHaveBeenCalledTimes(1);
@@ -49,29 +56,35 @@ describe('walletSettings Actions', () => {
         });
 
         it('does not call Connect when disabling a coin (disable is one-way, not propagated)', async () => {
-            const store = initStore({ enabledNetworks: ['btc', 'ada'] });
+            const store = initStore({ enabledNetworks: [btcSymbol, adaSymbol] });
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({ symbol: 'ada', shouldBeVisible: false }) as any,
+                changeCoinVisibility({
+                    symbol: adaSymbol,
+                    shouldBeVisible: false,
+                }) as any,
             );
 
             expect(updateConnectSettings).not.toHaveBeenCalled();
         });
 
         it('does not call Connect when the coin is already enabled', async () => {
-            const store = initStore({ enabledNetworks: ['btc', 'ada'] });
+            const store = initStore({ enabledNetworks: [btcSymbol, adaSymbol] });
             const { updateConnectSettings } = wireEnabledNetworksMock();
 
             await store.dispatch(
-                changeCoinVisibility({ symbol: 'ada', shouldBeVisible: true }) as any,
+                changeCoinVisibility({
+                    symbol: adaSymbol,
+                    shouldBeVisible: true,
+                }) as any,
             );
 
             expect(updateConnectSettings).not.toHaveBeenCalled();
         });
 
         it('updates Redux immediately, without waiting for the Connect declaration', async () => {
-            const store = initStore({ enabledNetworks: ['btc'] });
+            const store = initStore({ enabledNetworks: [btcSymbol] });
             // Hold the Connect call open: the Redux/UI toggle must NOT block on it.
             const TrezorConnect = require('@trezor/connect').default;
             let resolveUpdate: (value: unknown) => void = () => {};
@@ -83,7 +96,10 @@ describe('walletSettings Actions', () => {
             );
 
             const dispatched = store.dispatch(
-                changeCoinVisibility({ symbol: 'ada', shouldBeVisible: true }) as any,
+                changeCoinVisibility({
+                    symbol: adaSymbol,
+                    shouldBeVisible: true,
+                }) as any,
             );
 
             // Redux already reflects the toggle even though Connect hasn't confirmed.

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
@@ -1,7 +1,7 @@
 import { deviceInitialState } from '@suite-common/device';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { FirmwareType } from '@trezor/device-utils';
 
 import * as walletSettingsActions from './walletSettingsActions';
@@ -13,6 +13,9 @@ import {
 } from './walletSettingsReducer';
 
 const initialState = initialWalletSettingsState;
+const opSymbol = asNetworkSymbol('op');
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
 
 const reducer = prepareWalletSettingsReducer(extraDependenciesCommonMock);
 
@@ -63,7 +66,7 @@ describe('settings reducer', () => {
     it('TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS toggles the setting only for the given network', () => {
         const toggledOn = reducer(
             undefined,
-            walletSettingsActions.toggleHideSuspiciousTransactions('op'),
+            walletSettingsActions.toggleHideSuspiciousTransactions(opSymbol),
         );
 
         expect(toggledOn).toEqual({
@@ -73,7 +76,7 @@ describe('settings reducer', () => {
 
         const toggledOff = reducer(
             toggledOn,
-            walletSettingsActions.toggleHideSuspiciousTransactions('op'),
+            walletSettingsActions.toggleHideSuspiciousTransactions(opSymbol),
         );
 
         expect(toggledOff).toEqual({
@@ -94,15 +97,17 @@ describe('selectIsHideSuspiciousTransactions', () => {
     });
 
     it('returns true only for networks with the setting enabled', () => {
-        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'op')).toBe(
-            true,
-        );
-        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'eth')).toBe(
-            false,
-        );
-        expect(selectIsHideSuspiciousTransactions(getState({ op: true, eth: false }), 'btc')).toBe(
-            false,
-        );
+        const hideSuspiciousTransactions = { [opSymbol]: true, [ethSymbol]: false };
+
+        expect(
+            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), opSymbol),
+        ).toBe(true);
+        expect(
+            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), ethSymbol),
+        ).toBe(false);
+        expect(
+            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), btcSymbol),
+        ).toBe(false);
     });
 });
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
@@ -25,7 +26,7 @@ const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const VAULT_ADDRESS = '0xd63070114470f685b75B74D60EEc7c1113d33a3D';
 
 const account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor(OWNER_ADDRESS),
     deviceState: 'mock@device:0',
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDepositThunks.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FeeInfo, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
@@ -34,7 +35,7 @@ const OWNER_ADDRESS = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326';
 const VAULT_ADDRESS = '0xd63070114470f685b75B74D60EEc7c1113d33a3D';
 
 const account = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     descriptor: asAccountDescriptor(OWNER_ADDRESS),
     deviceState: 'mock@device:0',
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldDeviceUtils.test.ts
@@ -1,5 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Features } from '@trezor/connect';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
@@ -16,13 +17,15 @@ const createDevice = (features: Partial<Features>): TrezorDevice =>
 const createDeviceWithFirmware = ([major, minor, patch]: [number, number, number]): TrezorDevice =>
     createDevice({ major_version: major, minor_version: minor, patch_version: patch });
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const wethVaultToken = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
 } as const;
 
 const usdcVaultToken = {
-    networkSymbol: 'eth',
+    networkSymbol: ethSymbol,
     contractAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
 } as const;
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldFeeEstimation.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import TrezorConnect from '@trezor/connect';
 
 import { estimateYieldFeeLevel } from './stablecoinYieldFeeEstimation';
@@ -8,7 +9,7 @@ jest.mock('@trezor/connect', () => ({
 }));
 
 const params = {
-    coin: 'eth',
+    coin: asNetworkSymbol('eth'),
     identity: 'mock-identity',
     from: '0xfrom',
     to: '0xto',

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import type { FormState, PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 
@@ -9,6 +10,8 @@ import {
     stablecoinYieldReducer,
 } from './stablecoinYieldReducer';
 import type { YieldFlowType, YieldPendingTransactionState } from './stablecoinYieldTypes';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const FLOW_KEY = 'account-key:yield-id:0xtoken';
 
@@ -379,13 +382,13 @@ describe('stablecoinYieldReducer', () => {
 
     describe('txReview', () => {
         const ACCOUNT_KEY = mockAccountKey({
-            symbol: 'eth',
+            symbol: ethSymbol,
             descriptor: '0xfffffffffffffffffffffffffffffffffffffffe',
             deviceStaticSessionId: '1stTestnetAddress@device_id:0',
         });
         const precomposedForm = { selectedFee: 'custom' } as unknown as FormState;
         const precomposedTx = { type: 'final', fee: '1' } as unknown as PrecomposedTransactionFinal;
-        const serializedTx = { tx: '0xsignedtx', symbol: 'eth' } as const;
+        const serializedTx = { tx: '0xsignedtx', symbol: ethSymbol } as const;
 
         const storePrecomposed = (state: StablecoinYieldState) =>
             stablecoinYieldReducer(

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldUtils.test.ts
@@ -1,5 +1,6 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import type { YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import type { YieldPendingTransactionState } from './stablecoinYieldTypes';
 import {
@@ -25,6 +26,7 @@ import {
 
 const ACCOUNT_DESCRIPTOR = asEvmAddress('0x9ea3721b5bf3b64b4418c38b603154d2d597fae3');
 const VAULT_ADDRESS = '0x58d97b57bb95320f9a05dc918aef65434969c2b2';
+const ethSymbol = asNetworkSymbol('eth');
 
 const account = {
     descriptor: ACCOUNT_DESCRIPTOR,
@@ -41,13 +43,13 @@ const flowData = {
         balance: '0',
         contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
         decimals: 6,
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         symbol: 'USDC',
     },
     receiptToken: {
         contractAddress: VAULT_ADDRESS,
         decimals: 18,
-        networkSymbol: 'eth',
+        networkSymbol: ethSymbol,
         symbol: 'trUSDC',
     },
 } as unknown as Parameters<typeof buildYieldWithdrawCalldata>[0]['flowData'];
@@ -357,7 +359,7 @@ describe('stablecoinYieldUtils', () => {
         it('returns only the matched token balance for a non-wrapped-native vault', () => {
             expect(
                 getYieldDepositableBalance({
-                    networkSymbol: 'eth',
+                    networkSymbol: ethSymbol,
                     nativeFormattedBalance: '5',
                     vaultTokenAddress: USDC_ADDRESS,
                     matchedTokenBalance: '100',
@@ -368,7 +370,7 @@ describe('stablecoinYieldUtils', () => {
         it('adds the full native balance for a wrapped-native vault', () => {
             expect(
                 getYieldDepositableBalance({
-                    networkSymbol: 'eth',
+                    networkSymbol: ethSymbol,
                     nativeFormattedBalance: '0.2',
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: '1.5',
@@ -379,7 +381,7 @@ describe('stablecoinYieldUtils', () => {
         it('counts the full native balance even below the gas reserve', () => {
             expect(
                 getYieldDepositableBalance({
-                    networkSymbol: 'eth',
+                    networkSymbol: ethSymbol,
                     nativeFormattedBalance: '0.003',
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: '1',
@@ -390,7 +392,7 @@ describe('stablecoinYieldUtils', () => {
         it('returns the full native balance when no token is matched', () => {
             expect(
                 getYieldDepositableBalance({
-                    networkSymbol: 'eth',
+                    networkSymbol: ethSymbol,
                     nativeFormattedBalance: '1',
                     vaultTokenAddress: WETH_ADDRESS,
                     matchedTokenBalance: undefined,
@@ -578,7 +580,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: [usdcVault, usdtVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toEqual([usdcVault]);
@@ -593,7 +595,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: [polygonVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toEqual([]);
@@ -612,7 +614,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: [maintainedVault, deprecatedVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toEqual([]);
@@ -627,7 +629,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: [closedVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toEqual([]);
@@ -639,7 +641,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: [addresslessVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: { address: USDC_ADDRESS, symbol: 'usdc', decimals: 6 },
                     }),
                 ).toEqual([addresslessVault]);
@@ -649,7 +651,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultsForInputToken({
                         vaults: undefined,
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toEqual([]);
@@ -672,7 +674,7 @@ describe('stablecoinYieldUtils', () => {
             it('reports a position when the receipt token is held with a balance', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '1.5')],
                     }),
@@ -682,7 +684,7 @@ describe('stablecoinYieldUtils', () => {
             it('matches the receipt token regardless of address case', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: [
                             createHeldReceiptToken(
@@ -697,7 +699,7 @@ describe('stablecoinYieldUtils', () => {
             it('reports no position when the receipt token balance is zero', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '0')],
                     }),
@@ -707,7 +709,7 @@ describe('stablecoinYieldUtils', () => {
             it('reports no position when the receipt token has no balance yet', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, undefined)],
                     }),
@@ -717,7 +719,7 @@ describe('stablecoinYieldUtils', () => {
             it('does not treat holding the deposit token as a position', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: [
                             {
@@ -734,7 +736,7 @@ describe('stablecoinYieldUtils', () => {
             it('reports no position for a vault without a receipt token', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: createVaultFixture({ tokenAddress: USDC_ADDRESS }),
                         accountTokens: [createHeldReceiptToken(RECEIPT_ADDRESS, '1')],
                     }),
@@ -744,7 +746,7 @@ describe('stablecoinYieldUtils', () => {
             it('reports no position when the account has no tokens', () => {
                 expect(
                     hasYieldVaultPosition({
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         vault: vaultWithReceiptToken,
                         accountTokens: undefined,
                     }),
@@ -764,7 +766,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultForOutputToken({
                         vaults: [vault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldReceiptToken,
                     }),
                 ).toBe(vault);
@@ -779,7 +781,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultForOutputToken({
                         vaults: [vault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldUsdc,
                     }),
                 ).toBeUndefined();
@@ -795,7 +797,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultForOutputToken({
                         vaults: [vault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldReceiptToken,
                     }),
                 ).toBeUndefined();
@@ -811,7 +813,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultForOutputToken({
                         vaults: [closedVault],
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldReceiptToken,
                     }),
                 ).toBe(closedVault);
@@ -821,7 +823,7 @@ describe('stablecoinYieldUtils', () => {
                 expect(
                     getYieldVaultForOutputToken({
                         vaults: undefined,
-                        networkSymbol: 'eth',
+                        networkSymbol: ethSymbol,
                         token: heldReceiptToken,
                     }),
                 ).toBeUndefined();

--- a/suite-common/wallet-core/src/stake/stakeThunks.test.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.test.ts
@@ -4,7 +4,7 @@ import {
     getStakingBatch,
 } from '@suite-common/earn-staking-api';
 import { configureMockStore } from '@suite-common/test-utils';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { stakeDataActions, stakeDataInitialState } from './stakeDataSlice';
 import { stakeInitialState } from './stakeReducer';
@@ -16,6 +16,11 @@ jest.mock('@suite-common/earn-staking-api', () => ({
 }));
 
 const getStakingBatchMock = jest.mocked(getStakingBatch);
+
+const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
+const adaSymbol = asNetworkSymbol('ada');
+const trxSymbol = asNetworkSymbol('trx');
 
 const ethSection = {
     symbol: 'eth',
@@ -49,7 +54,7 @@ const validationError = {
 } satisfies StakingBatchErrorsItem;
 
 const initStore = ({
-    enabledNetworks = ['eth', 'sol', 'ada', 'trx'],
+    enabledNetworks = [ethSymbol, solSymbol, adaSymbol, trxSymbol],
     stake = stakeInitialState,
 }: {
     enabledNetworks?: NetworkSymbol[];
@@ -172,7 +177,7 @@ describe('initStakeDataThunk', () => {
     });
 
     it('skips fetching when bitcoin is the only enabled network', async () => {
-        const store = initStore({ enabledNetworks: ['btc'] });
+        const store = initStore({ enabledNetworks: [asNetworkSymbol('btc')] });
 
         await store.dispatch(initStakeDataThunk());
 

--- a/suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts
+++ b/suite-common/wallet-core/src/stake/tron/tronStakeReducer.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey, type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
 
 import { initialTronStakeTxReview, tronStakeActions, tronStakeReducer } from './tronStakeReducer';
@@ -213,7 +214,7 @@ describe('tronStakeReducer', () => {
         const signed = tronStakeReducer(
             stored,
             tronStakeActions.storeSignedTransaction({
-                serializedTx: { tx: '0xdead', symbol: 'trx' },
+                serializedTx: { tx: '0xdead', symbol: asNetworkSymbol('trx') },
             }),
         );
 

--- a/suite-common/wallet-core/src/tokens/tokenUtils.test.ts
+++ b/suite-common/wallet-core/src/tokens/tokenUtils.test.ts
@@ -1,7 +1,10 @@
 import { type TokenDefinition } from '@suite-common/token-definitions';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getAccountAnalyticsTokenSymbols } from './tokenUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const legitContract = '0x' + 'a'.repeat(40);
 const spamContract = '0x' + 'b'.repeat(40);
@@ -18,14 +21,18 @@ const ethDefinitions: TokenDefinition = {
 
 describe('getAccountAnalyticsTokenSymbols', () => {
     it('lists the native token first when the account holds a native balance', () => {
-        const account = mockWalletAccount({ symbol: 'eth', balance: '1000', tokens: [] });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            balance: '1000',
+            tokens: [],
+        });
 
         expect(getAccountAnalyticsTokenSymbols(account, ethDefinitions)).toEqual(['ETH']);
     });
 
     it('omits the native token when the native balance is zero', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             balance: '0',
             tokens: [mockAccountToken({ symbol: 'USDC', contract: legitContract, balance: '100' })],
         });
@@ -35,7 +42,7 @@ describe('getAccountAnalyticsTokenSymbols', () => {
 
     it('includes only legit tokens with balance, native first', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             balance: '1000',
             tokens: [
                 mockAccountToken({ symbol: 'USDC', contract: legitContract, balance: '100' }),
@@ -58,7 +65,7 @@ describe('getAccountAnalyticsTokenSymbols', () => {
             show: [],
         };
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             balance: '0',
             tokens: [
                 mockAccountToken({ symbol: 'USDC', contract: legitContract, balance: '100' }),
@@ -71,7 +78,7 @@ describe('getAccountAnalyticsTokenSymbols', () => {
 
     it('omits definition-dependent tokens until token definitions are loaded', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             balance: '1000',
             tokens: [mockAccountToken({ symbol: 'USDC', contract: legitContract, balance: '100' })],
         });

--- a/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
+++ b/suite-common/wallet-core/src/transactions/target/createTargets.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import {
     type Target as BlockchainTarget,
@@ -38,7 +39,7 @@ const makeInternalTransfer = (overrides: Partial<InternalTransfer> = {}): Intern
 
 const account: Pick<Account, 'descriptor' | 'symbol'> = {
     descriptor: asAccountDescriptor('0xMyAddress'),
-    symbol: 'eth' as const,
+    symbol: asNetworkSymbol('eth'),
 };
 
 describe(createTargets.name, () => {

--- a/suite-common/wallet-utils/src/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/accountUtils.test.ts
@@ -1,5 +1,5 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type NetworkFeature } from '@suite-common/wallet-config';
+import { type NetworkFeature, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
@@ -26,6 +26,11 @@ import {
     formatNetworkAmount,
     networkAmountToSmallestUnit,
 } from './amountUtils';
+
+const btcSymbol = asNetworkSymbol('btc');
+const xrpSymbol = asNetworkSymbol('xrp');
+const ethSymbol = asNetworkSymbol('eth');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 describe('account utils', () => {
     fixtures.getUtxoFromSignedTransaction.forEach(f => {
@@ -64,23 +69,23 @@ describe('account utils', () => {
     });
 
     it('format network amount', () => {
-        expect(formatNetworkAmount('1', 'btc')).toEqual('0.00000001');
-        expect(formatNetworkAmount('1', 'xrp')).toEqual('0.000001');
-        expect(formatNetworkAmount('1', 'xrp', true)).toEqual('0.000001 XRP');
-        expect(formatNetworkAmount('1', 'eth')).toEqual('0.000000000000000001');
-        expect(formatNetworkAmount('1', 'btc', true)).toEqual('0.00000001 BTC');
-        expect(formatNetworkAmount('1', 'btc', true, true)).toEqual('1 sat BTC');
-        expect(formatNetworkAmount('', 'btc')).toEqual('0');
-        expect(formatNetworkAmount('', 'btc', true)).toEqual('0 BTC');
-        expect(formatNetworkAmount('', 'btc', true, true)).toEqual('0 sat BTC');
-        expect(() => formatNetworkAmount('aaa', 'eth')).toThrow();
+        expect(formatNetworkAmount('1', btcSymbol)).toEqual('0.00000001');
+        expect(formatNetworkAmount('1', xrpSymbol)).toEqual('0.000001');
+        expect(formatNetworkAmount('1', xrpSymbol, true)).toEqual('0.000001 XRP');
+        expect(formatNetworkAmount('1', ethSymbol)).toEqual('0.000000000000000001');
+        expect(formatNetworkAmount('1', btcSymbol, true)).toEqual('0.00000001 BTC');
+        expect(formatNetworkAmount('1', btcSymbol, true, true)).toEqual('1 sat BTC');
+        expect(formatNetworkAmount('', btcSymbol)).toEqual('0');
+        expect(formatNetworkAmount('', btcSymbol, true)).toEqual('0 BTC');
+        expect(formatNetworkAmount('', btcSymbol, true, true)).toEqual('0 sat BTC');
+        expect(() => formatNetworkAmount('aaa', ethSymbol)).toThrow();
     });
 
     it('format amount to satoshi', () => {
-        expect(networkAmountToSmallestUnit('0.00000001', 'btc')).toEqual('1');
-        expect(networkAmountToSmallestUnit('0.000001', 'xrp')).toEqual('1');
-        expect(networkAmountToSmallestUnit('0.000000000000000001', 'eth')).toEqual('1');
-        expect(networkAmountToSmallestUnit('aaa', 'eth')).toEqual('-1');
+        expect(networkAmountToSmallestUnit('0.00000001', btcSymbol)).toEqual('1');
+        expect(networkAmountToSmallestUnit('0.000001', xrpSymbol)).toEqual('1');
+        expect(networkAmountToSmallestUnit('0.000000000000000001', ethSymbol)).toEqual('1');
+        expect(networkAmountToSmallestUnit('aaa', ethSymbol)).toEqual('-1');
     });
 
     it('findAccountDevice', () => {
@@ -91,7 +96,7 @@ describe('account utils', () => {
                     descriptor: asAccountDescriptor(
                         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                     ),
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
                 [
                     mockSuiteDevice({
@@ -113,19 +118,19 @@ describe('account utils', () => {
         // Ethereum-style accounts have no `addresses` (used/unused/change) list,
         // so matching must fall back to comparing the address against the descriptor.
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             descriptor: asAccountDescriptor('0xAccountAddress'),
         });
 
-        expect(findAccountsByAddress('eth', '0xAccountAddress', [account])).toEqual([account]);
-        expect(findAccountsByAddress('eth', '0xOtherAddress', [account])).toEqual([]);
+        expect(findAccountsByAddress(ethSymbol, '0xAccountAddress', [account])).toEqual([account]);
+        expect(findAccountsByAddress(ethSymbol, '0xOtherAddress', [account])).toEqual([]);
     });
 
     it('getAccountKey', () => {
         expect(
             createAccountKey({
                 accountDescriptor: asAccountDescriptor('descriptor'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
                 deviceStaticSessionId: '1stTestnetAddress@device_id:0',
             }),
         ).toEqual('descriptor-btc-1stTestnetAddress@device_id:0');
@@ -135,7 +140,7 @@ describe('account utils', () => {
         expect(() =>
             createAccountKey({
                 accountDescriptor: asAccountDescriptor('btc-with-hyphen'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
                 deviceStaticSessionId: '1stTestnetAddress@device_id:0',
             }),
         ).toThrow(/accountDescriptor must not contain '-'/);
@@ -145,7 +150,7 @@ describe('account utils', () => {
         expect(() =>
             createAccountKey({
                 accountDescriptor: asAccountDescriptor('descriptor'),
-                networkSymbol: 'btc-bogus' as 'btc',
+                networkSymbol: asNetworkSymbol('btc-bogus'),
                 deviceStaticSessionId: '1stTestnetAddress@device_id:0',
             }),
         ).toThrow(/networkSymbol must not contain '-'/);
@@ -155,21 +160,21 @@ describe('account utils', () => {
         expect(() =>
             createAccountKey({
                 accountDescriptor: asAccountDescriptor('descriptor'),
-                networkSymbol: 'btc',
+                networkSymbol: btcSymbol,
                 deviceStaticSessionId: 'session-with-hyphen@device:0',
             }),
         ).toThrow(/deviceStaticSessionId must not contain '-'/);
     });
 
     it('isTestnet', () => {
-        expect(isTestnet('test')).toEqual(true);
-        expect(isTestnet('tsep')).toEqual(true);
-        expect(isTestnet('thod')).toEqual(true);
-        expect(isTestnet('txrp')).toEqual(true);
-        expect(isTestnet('txlm')).toEqual(true);
-        expect(isTestnet('btc')).toEqual(false);
-        expect(isTestnet('ltc')).toEqual(false);
-        expect(isTestnet('xlm')).toEqual(false);
+        expect(isTestnet(asNetworkSymbol('test'))).toEqual(true);
+        expect(isTestnet(asNetworkSymbol('tsep'))).toEqual(true);
+        expect(isTestnet(asNetworkSymbol('thod'))).toEqual(true);
+        expect(isTestnet(asNetworkSymbol('txrp'))).toEqual(true);
+        expect(isTestnet(asNetworkSymbol('txlm'))).toEqual(true);
+        expect(isTestnet(btcSymbol)).toEqual(false);
+        expect(isTestnet(ltcSymbol)).toEqual(false);
+        expect(isTestnet(asNetworkSymbol('xlm'))).toEqual(false);
     });
 
     it('getAccountIdentifier', () => {
@@ -180,7 +185,7 @@ describe('account utils', () => {
                     descriptor: asAccountDescriptor(
                         'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
                     ),
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
             ),
         ).toEqual({
@@ -197,7 +202,7 @@ describe('account utils', () => {
             descriptor: asAccountDescriptor(
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
             ),
-            symbol: 'btc',
+            symbol: btcSymbol,
             accountType: 'legacy',
             metadata: {
                 key: 'xpub-foo-bar',
@@ -209,15 +214,25 @@ describe('account utils', () => {
         });
 
         expect(accountSearchFn(btcAcc, 'btc', { accountLabel: '' })).toBe(true);
-        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'btc', accountLabel: '' })).toBe(true);
+        expect(
+            accountSearchFn(btcAcc, '', {
+                coinsFilter: btcSymbol,
+                accountLabel: '',
+            }),
+        ).toBe(true);
         expect(
             accountSearchFn(
                 btcAcc,
                 'zpub6rszzdAK6RuafeRwyN8z1cgWcXCuKbLmjjfnrW4fWKtcoXQ8787214pNJjnBG5UATyghuNzjn6Lfp5k5xymrLFJnCy46bMYJPyZsbpFGagT',
-                { coinsFilter: 'btc', accountLabel: '' },
+                { coinsFilter: btcSymbol, accountLabel: '' },
             ),
         ).toBe(true);
-        expect(accountSearchFn(btcAcc, '', { coinsFilter: 'ltc', accountLabel: '' })).toBe(false);
+        expect(
+            accountSearchFn(btcAcc, '', {
+                coinsFilter: ltcSymbol,
+                accountLabel: '',
+            }),
+        ).toBe(false);
         expect(accountSearchFn(btcAcc, 'bitcoin', { accountLabel: '' })).toBe(true);
         expect(accountSearchFn(btcAcc, 'legacy', { accountLabel: '' })).toBe(true);
         expect(accountSearchFn(btcAcc, 'bitco', { accountLabel: '' })).toBe(true);
@@ -245,7 +260,7 @@ describe('account utils', () => {
 
     it('accountSearchFn matches displayed account type name', () => {
         const segwitAcc = mockWalletAccount({
-            symbol: 'btc',
+            symbol: btcSymbol,
             accountType: 'segwit',
         });
 
@@ -279,7 +294,7 @@ describe('account utils', () => {
 
     it('accountSearchFn empty tokens', () => {
         const ethAcc = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [
                 mockAccountToken({ balance: '0.000069', name: 'test' }),
                 mockAccountToken({ balance: '0.0', name: 'test2' }),
@@ -292,7 +307,7 @@ describe('account utils', () => {
 
     it('accountSearchFn empty tokens pepe-like', () => {
         const ethAcc = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [
                 mockAccountToken({ balance: '0.000069', name: 'test' }),
                 mockAccountToken({ balance: '0.0', name: 'pepe' }),
@@ -307,7 +322,7 @@ describe('account utils', () => {
         const shownToken = mockAccountToken({ balance: '0.000069', name: 'shown' });
         const hiddenToken = mockAccountToken({ balance: '1.0', name: 'hidden-spam' });
         const ethAcc = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [shownToken, hiddenToken],
         });
 
@@ -327,11 +342,20 @@ describe('account utils', () => {
     });
 
     it('getNetworkAccountFeatures', () => {
-        const btcAcc = mockWalletAccount({ symbol: 'btc' });
-        const btcTaprootAcc = mockWalletAccount({ symbol: 'btc', accountType: 'taproot' });
-        const btcLegacy = mockWalletAccount({ symbol: 'btc', accountType: 'legacy' });
-        const ethAcc = mockWalletAccount({ symbol: 'eth' });
-        const coinjoinAcc = mockWalletAccount({ symbol: 'regtest', accountType: 'coinjoin' });
+        const btcAcc = mockWalletAccount({ symbol: btcSymbol });
+        const btcTaprootAcc = mockWalletAccount({
+            symbol: btcSymbol,
+            accountType: 'taproot',
+        });
+        const btcLegacy = mockWalletAccount({
+            symbol: btcSymbol,
+            accountType: 'legacy',
+        });
+        const ethAcc = mockWalletAccount({ symbol: ethSymbol });
+        const coinjoinAcc = mockWalletAccount({
+            symbol: asNetworkSymbol('regtest'),
+            accountType: 'coinjoin',
+        });
 
         expect(getNetworkAccountFeatures(btcAcc)).toEqual([
             'rbf',
@@ -359,9 +383,9 @@ describe('account utils', () => {
     });
 
     it('hasNetworkFeatures', () => {
-        const btcAcc = mockWalletAccount({ symbol: 'btc' });
+        const btcAcc = mockWalletAccount({ symbol: btcSymbol });
 
-        const ethAcc = mockWalletAccount({ symbol: 'eth' });
+        const ethAcc = mockWalletAccount({ symbol: ethSymbol });
 
         expect(hasNetworkFeatures(btcAcc, 'amount-unit')).toEqual(true);
         expect(hasNetworkFeatures(btcAcc, ['amount-unit', 'sign-verify'])).toEqual(true);

--- a/suite-common/wallet-utils/src/amountUtils.test.ts
+++ b/suite-common/wallet-utils/src/amountUtils.test.ts
@@ -1,14 +1,17 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { BigNumber } from '@trezor/utils';
 
 import { asAmountSubunit, asAmountUnit } from './AmountTypes';
 import { subunitsToUnits, unitsToSubunits } from './amountUtils';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 describe(subunitsToUnits.name, () => {
     it('converts Sats->BTC', () => {
         expect(
             subunitsToUnits({
                 value: asAmountSubunit(new BigNumber(1)),
-                symbol: 'btc',
+                symbol: btcSymbol,
             }).toString(),
         ).toEqual('0.00000001');
     });
@@ -18,7 +21,7 @@ describe(unitsToSubunits.name, () => {
     it('converts BTC->Sats', () => {
         const btcSymbolResult = unitsToSubunits({
             value: asAmountUnit(new BigNumber(1)),
-            symbol: 'btc',
+            symbol: btcSymbol,
         });
         expect(btcSymbolResult.toString()).toEqual(String(100_000_000));
 

--- a/suite-common/wallet-utils/src/backend.test.ts
+++ b/suite-common/wallet-utils/src/backend.test.ts
@@ -1,10 +1,12 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import { getDefaultBackendType, isTrezorConnectBackendType } from './backendUtils';
 
 describe('backend utils', () => {
     test('getDefaultBackendType', () => {
-        expect(getDefaultBackendType('btc')).toBe('blockbook');
-        expect(getDefaultBackendType('ltc')).toBe('blockbook');
-        expect(getDefaultBackendType('ada')).toBe('blockfrost');
+        expect(getDefaultBackendType(asNetworkSymbol('btc'))).toBe('blockbook');
+        expect(getDefaultBackendType(asNetworkSymbol('ltc'))).toBe('blockbook');
+        expect(getDefaultBackendType(asNetworkSymbol('ada'))).toBe('blockfrost');
     });
 
     test('isTrezorConnectBackendType', () => {

--- a/suite-common/wallet-utils/src/cardanoUtils.test.ts
+++ b/suite-common/wallet-utils/src/cardanoUtils.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { CARDANO, PROTO } from '@trezor/connect';
 
 import * as fixtures from './__fixtures__/cardanoUtils';
@@ -28,7 +29,7 @@ describe('cardano utils', () => {
     });
 
     it('basic test', () => {
-        expect(getProtocolMagic('ada')).toEqual(CARDANO.PROTOCOL_MAGICS.mainnet);
+        expect(getProtocolMagic(asNetworkSymbol('ada'))).toEqual(CARDANO.PROTOCOL_MAGICS.mainnet);
 
         expect(getDerivationType('normal')).toEqual(1);
         expect(getDerivationType('legacy')).toEqual(2);

--- a/suite-common/wallet-utils/src/earnSortUtils.test.ts
+++ b/suite-common/wallet-utils/src/earnSortUtils.test.ts
@@ -1,4 +1,4 @@
-import { type AccountType, type NetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountType, type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 
 import {
@@ -7,6 +7,9 @@ import {
     compareEarnByNetwork,
     compareEarnByNetworkTokenOrder,
 } from './earnSortUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
+const opSymbol = asNetworkSymbol('op');
 
 type Row = {
     id: string;
@@ -39,21 +42,21 @@ const getRowNetworkTokenKey = (r: Row) =>
 describe('compareEarnByNetwork', () => {
     it('groups rows by network in networkSymbolCollection order', () => {
         const sorted = [
-            row('op-0', 'op', 0),
-            row('eth-0', 'eth', 0),
-            row('op-1', 'op', 1),
-            row('eth-1', 'eth', 1),
+            row('op-0', opSymbol, 0),
+            row('eth-0', ethSymbol, 0),
+            row('op-1', opSymbol, 1),
+            row('eth-1', ethSymbol, 1),
         ].toSorted(compareEarnByNetwork(getRowSymbol));
 
         const symbols = sorted.map(r => r.account?.symbol);
-        expect(symbols.lastIndexOf('eth')).toBeLessThan(symbols.indexOf('op'));
+        expect(symbols.lastIndexOf(ethSymbol)).toBeLessThan(symbols.indexOf(opSymbol));
     });
 
     it('preserves input order within the same network (stable sort)', () => {
         const sorted = [
-            row('eth-3', 'eth', 3),
-            row('eth-0', 'eth', 0),
-            row('eth-2', 'eth', 2),
+            row('eth-3', ethSymbol, 3),
+            row('eth-0', ethSymbol, 0),
+            row('eth-2', ethSymbol, 2),
         ].toSorted(compareEarnByNetwork(getRowSymbol));
 
         expect(sorted.map(r => r.id)).toEqual(['eth-3', 'eth-0', 'eth-2']);
@@ -63,22 +66,38 @@ describe('compareEarnByNetwork', () => {
         const rows = [
             {
                 id: 'eth-0-50',
-                account: { symbol: 'eth' as const, accountType: 'normal' as const, index: 0 },
+                account: {
+                    symbol: ethSymbol,
+                    accountType: 'normal' as const,
+                    index: 0,
+                },
                 depositedAmount: '50',
             },
             {
                 id: 'op-0-75',
-                account: { symbol: 'op' as const, accountType: 'normal' as const, index: 0 },
+                account: {
+                    symbol: opSymbol,
+                    accountType: 'normal' as const,
+                    index: 0,
+                },
                 depositedAmount: '75',
             },
             {
                 id: 'eth-1-100',
-                account: { symbol: 'eth' as const, accountType: 'normal' as const, index: 1 },
+                account: {
+                    symbol: ethSymbol,
+                    accountType: 'normal' as const,
+                    index: 1,
+                },
                 depositedAmount: '100',
             },
             {
                 id: 'op-1-25',
-                account: { symbol: 'op' as const, accountType: 'normal' as const, index: 1 },
+                account: {
+                    symbol: opSymbol,
+                    accountType: 'normal' as const,
+                    index: 1,
+                },
                 depositedAmount: '25',
             },
         ];
@@ -93,9 +112,9 @@ describe('compareEarnByNetwork', () => {
     it('treats rows without an account as equal (no reordering)', () => {
         const rows: Row[] = [
             { id: 'a' },
-            row('eth-0', 'eth', 0),
+            row('eth-0', ethSymbol, 0),
             { id: 'b' },
-            row('eth-1', 'eth', 1),
+            row('eth-1', ethSymbol, 1),
         ];
 
         const sorted = rows.toSorted(compareEarnByNetwork(getRowSymbol));
@@ -107,12 +126,12 @@ describe('compareEarnByNetwork', () => {
 describe('compareEarnByNetworkTokenOrder', () => {
     it('groups by network → token → accountType → index so legacy/ledger rows stay with normal rows on the same token', () => {
         const sorted = [
-            row('eth-1-legacy-usdc', 'eth', 1, 'legacy', 'usdc'),
-            row('eth-9-normal-usdt', 'eth', 9, 'normal', 'usdt'),
-            row('eth-1-ledger-usdc', 'eth', 1, 'ledger', 'usdc'),
-            row('eth-1-normal-usdc', 'eth', 1, 'normal', 'usdc'),
-            row('eth-9-ledger-usdt', 'eth', 9, 'ledger', 'usdt'),
-            row('eth-1-normal-usdt', 'eth', 1, 'normal', 'usdt'),
+            row('eth-1-legacy-usdc', ethSymbol, 1, 'legacy', 'usdc'),
+            row('eth-9-normal-usdt', ethSymbol, 9, 'normal', 'usdt'),
+            row('eth-1-ledger-usdc', ethSymbol, 1, 'ledger', 'usdc'),
+            row('eth-1-normal-usdc', ethSymbol, 1, 'normal', 'usdc'),
+            row('eth-9-ledger-usdt', ethSymbol, 9, 'ledger', 'usdt'),
+            row('eth-1-normal-usdt', ethSymbol, 1, 'normal', 'usdt'),
         ].toSorted(compareEarnByNetworkTokenOrder(getRowNetworkTokenKey));
 
         // ETH accountTypes config: { ledger, legacy }. 'normal' indexOf returns -1 → sorts first.
@@ -131,8 +150,8 @@ describe('compareEarnByNetworkTokenOrder', () => {
 
     it('puts normal account #9 before legacy account #1 (accountType beats index)', () => {
         const sorted = [
-            row('eth-1-legacy-usdt', 'eth', 1, 'legacy', 'usdt'),
-            row('eth-9-normal-usdt', 'eth', 9, 'normal', 'usdt'),
+            row('eth-1-legacy-usdt', ethSymbol, 1, 'legacy', 'usdt'),
+            row('eth-9-normal-usdt', ethSymbol, 9, 'normal', 'usdt'),
         ].toSorted(compareEarnByNetworkTokenOrder(getRowNetworkTokenKey));
 
         expect(sorted.map(r => r.id)).toEqual(['eth-9-normal-usdt', 'eth-1-legacy-usdt']);
@@ -140,8 +159,8 @@ describe('compareEarnByNetworkTokenOrder', () => {
 
     it('puts ledger account #9 before legacy account #1 (accountType config order: ledger before legacy)', () => {
         const sorted = [
-            row('eth-1-legacy-usdt', 'eth', 1, 'legacy', 'usdt'),
-            row('eth-9-ledger-usdt', 'eth', 9, 'ledger', 'usdt'),
+            row('eth-1-legacy-usdt', ethSymbol, 1, 'legacy', 'usdt'),
+            row('eth-9-ledger-usdt', ethSymbol, 9, 'ledger', 'usdt'),
         ].toSorted(compareEarnByNetworkTokenOrder(getRowNetworkTokenKey));
 
         expect(sorted.map(r => r.id)).toEqual(['eth-9-ledger-usdt', 'eth-1-legacy-usdt']);
@@ -149,10 +168,10 @@ describe('compareEarnByNetworkTokenOrder', () => {
 
     it('groups all USDT together within an accountType block (token before index)', () => {
         const sorted = [
-            row('eth-3-normal-usdt', 'eth', 3, 'normal', 'usdt'),
-            row('eth-1-normal-usdc', 'eth', 1, 'normal', 'usdc'),
-            row('eth-1-normal-usdt', 'eth', 1, 'normal', 'usdt'),
-            row('eth-5-normal-usdc', 'eth', 5, 'normal', 'usdc'),
+            row('eth-3-normal-usdt', ethSymbol, 3, 'normal', 'usdt'),
+            row('eth-1-normal-usdc', ethSymbol, 1, 'normal', 'usdc'),
+            row('eth-1-normal-usdt', ethSymbol, 1, 'normal', 'usdt'),
+            row('eth-5-normal-usdc', ethSymbol, 5, 'normal', 'usdc'),
         ].toSorted(compareEarnByNetworkTokenOrder(getRowNetworkTokenKey));
 
         expect(sorted.map(r => r.id)).toEqual([
@@ -166,9 +185,9 @@ describe('compareEarnByNetworkTokenOrder', () => {
     it('treats rows without an account as equal (no reordering)', () => {
         const rows: Row[] = [
             { id: 'a' },
-            row('eth-0', 'eth', 0, 'normal', 'usdc'),
+            row('eth-0', ethSymbol, 0, 'normal', 'usdc'),
             { id: 'b' },
-            row('eth-1', 'eth', 1, 'normal', 'usdc'),
+            row('eth-1', ethSymbol, 1, 'normal', 'usdc'),
         ];
 
         const sorted = rows.toSorted(compareEarnByNetworkTokenOrder(getRowNetworkTokenKey));
@@ -209,7 +228,7 @@ describe('yield bucket ordering', () => {
             depositedAmount: string,
         ) => ({
             id,
-            account: { symbol, accountType: 'normal' as const, index },
+            account: { symbol: asNetworkSymbol(symbol), accountType: 'normal' as const, index },
             depositedAmount,
         });
 
@@ -222,7 +241,12 @@ describe('yield bucket ordering', () => {
             additionalDepositAmount: string,
         ) => ({
             id,
-            account: { symbol, accountType, index, formattedBalance: '0' },
+            account: {
+                symbol: asNetworkSymbol(symbol),
+                accountType,
+                index,
+                formattedBalance: '0',
+            },
             depositedSymbol,
             additionalDepositAmount,
             matchedInputToken: {},
@@ -260,12 +284,12 @@ describe('yield bucket ordering', () => {
             depositableBaseRow('op-0-depositable-normal-usdc', 'op', 'normal', 0, 'usdc', '75'),
         ];
         const noBalanceRows = [
-            row('eth-7-no-balance-normal-usdt', 'eth', 7, 'normal', 'usdt'),
-            row('eth-1-no-balance-normal-usdc', 'eth', 1, 'normal', 'usdc'),
-            row('eth-1-no-balance-legacy-usdc', 'eth', 1, 'legacy', 'usdc'),
-            row('op-2-no-balance-normal-usdc', 'op', 2, 'normal', 'usdc'),
-            row('eth-1-no-balance-ledger-usdt', 'eth', 1, 'ledger', 'usdt'),
-            row('eth-4-no-balance-normal-usdc', 'eth', 4, 'normal', 'usdc'),
+            row('eth-7-no-balance-normal-usdt', ethSymbol, 7, 'normal', 'usdt'),
+            row('eth-1-no-balance-normal-usdc', ethSymbol, 1, 'normal', 'usdc'),
+            row('eth-1-no-balance-legacy-usdc', ethSymbol, 1, 'legacy', 'usdc'),
+            row('op-2-no-balance-normal-usdc', opSymbol, 2, 'normal', 'usdc'),
+            row('eth-1-no-balance-ledger-usdt', ethSymbol, 1, 'ledger', 'usdt'),
+            row('eth-4-no-balance-normal-usdc', ethSymbol, 4, 'normal', 'usdc'),
         ];
 
         const ordered = [

--- a/suite-common/wallet-utils/src/ethUtils.test.ts
+++ b/suite-common/wallet-utils/src/ethUtils.test.ts
@@ -1,5 +1,6 @@
 import { Calldata, asEvmAddress } from '@suite-common/calldata';
 import { UINT256_MAX } from '@suite-common/suite-constants';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction } from '@suite-common/wallet-types';
 import { BigNumber } from '@trezor/utils';
 
@@ -17,6 +18,8 @@ import {
     sanitizeHex,
     strip,
 } from './ethUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const VALID_CLAIM_ADDRESS = asEvmAddress('0x1111111111111111111111111111111111111111');
 
@@ -199,16 +202,28 @@ describe('eth utils', () => {
 
         it('classifies WETH calldata as wrap/unwrap when the target is the wrapped-native contract', () => {
             expect(
-                getEvmTransactionPurpose({ networkSymbol: 'eth', to: WETH, data: WRAP_DATA }),
+                getEvmTransactionPurpose({
+                    networkSymbol: ethSymbol,
+                    to: WETH,
+                    data: WRAP_DATA,
+                }),
             ).toBe('wrap');
             expect(
-                getEvmTransactionPurpose({ networkSymbol: 'eth', to: WETH, data: UNWRAP_DATA }),
+                getEvmTransactionPurpose({
+                    networkSymbol: ethSymbol,
+                    to: WETH,
+                    data: UNWRAP_DATA,
+                }),
             ).toBe('unwrap');
         });
 
         it('keeps WETH calldata "unknown" for a non-wrapped-native target', () => {
             expect(
-                getEvmTransactionPurpose({ networkSymbol: 'eth', to: OTHER, data: WRAP_DATA }),
+                getEvmTransactionPurpose({
+                    networkSymbol: ethSymbol,
+                    to: OTHER,
+                    data: WRAP_DATA,
+                }),
             ).toBe('unknown');
         });
 
@@ -219,7 +234,11 @@ describe('eth utils', () => {
                 '0000000000000000000000000000000000000000000000000de0b6b3a7640000';
 
             expect(
-                getEvmTransactionPurpose({ networkSymbol: 'eth', to: OTHER, data: approveData }),
+                getEvmTransactionPurpose({
+                    networkSymbol: ethSymbol,
+                    to: OTHER,
+                    data: approveData,
+                }),
             ).toBe('approve');
         });
 
@@ -240,9 +259,9 @@ describe('eth utils', () => {
             '0000000000000000000000009ea3721b5bf3b64b4418c38b603154d2d597fae3';
 
         const wrap = (to: string | null, data: string | null) =>
-            isWrapNativeTx({ networkSymbol: 'eth', to, data });
+            isWrapNativeTx({ networkSymbol: ethSymbol, to, data });
         const unwrap = (to: string | null, data: string | null) =>
-            isUnwrapNativeTx({ networkSymbol: 'eth', to, data });
+            isUnwrapNativeTx({ networkSymbol: ethSymbol, to, data });
 
         it('isWrapNativeTx detects deposit() to the wrapped-native contract', () => {
             expect(wrap(WETH, DEPOSIT)).toBe(true);

--- a/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
+++ b/suite-common/wallet-utils/src/fiatRatesUtils.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
 
 import {
@@ -6,12 +7,14 @@ import {
     roundTimestampToNearestPastHour,
 } from './fiatRatesUtils';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 describe('fiat rates utils', () => {
     it('formats fiat rate key', () => {
-        expect(getFiatRateKey('eth', 'usd')).toMatch('eth-usd');
+        expect(getFiatRateKey(ethSymbol, 'usd')).toMatch('eth-usd');
 
         const result = getFiatRateKey(
-            'eth',
+            ethSymbol,
             'usd',
             '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
         );
@@ -19,11 +22,11 @@ describe('fiat rates utils', () => {
         expect(result).toMatch('eth-0x6b175474e89094c44da98b954eedeac495271d0f-usd');
     });
     it('formats fiat rate key from ticker', () => {
-        expect(getFiatRateKeyFromTicker({ symbol: 'eth' }, 'usd')).toMatch('eth-usd');
+        expect(getFiatRateKeyFromTicker({ symbol: ethSymbol }, 'usd')).toMatch('eth-usd');
 
         const result = getFiatRateKeyFromTicker(
             {
-                symbol: 'eth',
+                symbol: ethSymbol,
                 tokenAddress: '0x6b175474e89094c44da98b954eedeac495271d0f' as TokenAddress,
             },
             'usd',

--- a/suite-common/wallet-utils/src/filterReceiveAccounts.test.ts
+++ b/suite-common/wallet-utils/src/filterReceiveAccounts.test.ts
@@ -1,32 +1,43 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { filterReceiveAccounts, isDebugOnlyAccountType } from './filterReceiveAccounts';
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const polSymbol = asNetworkSymbol('pol');
+const solSymbol = asNetworkSymbol('sol');
+const tsepSymbol = asNetworkSymbol('tsep');
+
 const accountsList: Account[] = [
-    mockWalletAccount({ symbol: 'eth', accountType: 'legacy' }),
-    mockWalletAccount({ symbol: 'eth', accountType: 'normal' }),
-    mockWalletAccount({ symbol: 'eth', accountType: 'ledger' }),
-    mockWalletAccount({ symbol: 'btc', accountType: 'coinjoin' }),
-    mockWalletAccount({ symbol: 'btc', accountType: 'taproot' }),
-    mockWalletAccount({ symbol: 'btc', accountType: 'legacy' }),
-    mockWalletAccount({ symbol: 'btc', accountType: 'segwit' }),
-    mockWalletAccount({ symbol: 'btc', accountType: 'ledger' }),
-    mockWalletAccount({ symbol: 'pol', accountType: 'legacy' }),
-    mockWalletAccount({ symbol: 'pol', accountType: 'normal' }),
-    mockWalletAccount({ symbol: 'pol', accountType: 'ledger' }),
-    mockWalletAccount({ symbol: 'sol', accountType: 'normal', empty: true, visible: false }),
-    mockWalletAccount({ symbol: 'sol', accountType: 'ledger' }),
+    mockWalletAccount({ symbol: ethSymbol, accountType: 'legacy' }),
+    mockWalletAccount({ symbol: ethSymbol, accountType: 'normal' }),
+    mockWalletAccount({ symbol: ethSymbol, accountType: 'ledger' }),
+    mockWalletAccount({ symbol: btcSymbol, accountType: 'coinjoin' }),
+    mockWalletAccount({ symbol: btcSymbol, accountType: 'taproot' }),
+    mockWalletAccount({ symbol: btcSymbol, accountType: 'legacy' }),
+    mockWalletAccount({ symbol: btcSymbol, accountType: 'segwit' }),
+    mockWalletAccount({ symbol: btcSymbol, accountType: 'ledger' }),
+    mockWalletAccount({ symbol: polSymbol, accountType: 'legacy' }),
+    mockWalletAccount({ symbol: polSymbol, accountType: 'normal' }),
+    mockWalletAccount({ symbol: polSymbol, accountType: 'ledger' }),
     mockWalletAccount({
-        symbol: 'sol',
+        symbol: solSymbol,
+        accountType: 'normal',
+        empty: true,
+        visible: false,
+    }),
+    mockWalletAccount({ symbol: solSymbol, accountType: 'ledger' }),
+    mockWalletAccount({
+        symbol: solSymbol,
         accountType: 'ledger',
         empty: true,
         visible: false,
     }),
-    mockWalletAccount({ symbol: 'tsep', accountType: 'normal' }),
-    mockWalletAccount({ symbol: 'tsep', accountType: 'legacy' }),
+    mockWalletAccount({ symbol: tsepSymbol, accountType: 'normal' }),
+    mockWalletAccount({ symbol: tsepSymbol, accountType: 'legacy' }),
 ];
 
 type RunFilterReceiveAccountsTestParams = {
@@ -38,7 +49,7 @@ type RunFilterReceiveAccountsTestParams = {
 
 const runFilterReceiveAccouns = ({
     isDebug = true,
-    symbol = 'eth',
+    symbol = ethSymbol,
     deviceState = '1stTestnetAddress@device_id:0',
     accounts = accountsList,
 }: RunFilterReceiveAccountsTestParams) => {
@@ -59,17 +70,17 @@ const runFilterReceiveAccouns = ({
 
 describe('filter receive accounts', () => {
     it('checks if account is debug only type', () => {
-        expect(isDebugOnlyAccountType('legacy', 'btc')).toBe(false);
-        expect(isDebugOnlyAccountType('segwit', 'btc')).toBe(false);
-        expect(isDebugOnlyAccountType('coinjoin', 'btc')).toBe(false);
-        expect(isDebugOnlyAccountType('taproot', 'btc')).toBe(false);
-        expect(isDebugOnlyAccountType('ledger', 'btc')).toBe(false);
-        expect(isDebugOnlyAccountType('legacy', 'eth')).toBe(true);
-        expect(isDebugOnlyAccountType('ledger', 'eth')).toBe(true);
-        expect(isDebugOnlyAccountType('ledger', 'trx')).toBe(true);
-        expect(isDebugOnlyAccountType('normal', 'regtest')).toBe(false);
-        expect(isDebugOnlyAccountType('legacy', 'tsep')).toBe(true);
-        expect(isDebugOnlyAccountType('legacy', 'thod')).toBe(true);
+        expect(isDebugOnlyAccountType('legacy', btcSymbol)).toBe(false);
+        expect(isDebugOnlyAccountType('segwit', btcSymbol)).toBe(false);
+        expect(isDebugOnlyAccountType('coinjoin', btcSymbol)).toBe(false);
+        expect(isDebugOnlyAccountType('taproot', btcSymbol)).toBe(false);
+        expect(isDebugOnlyAccountType('ledger', btcSymbol)).toBe(false);
+        expect(isDebugOnlyAccountType('legacy', ethSymbol)).toBe(true);
+        expect(isDebugOnlyAccountType('ledger', ethSymbol)).toBe(true);
+        expect(isDebugOnlyAccountType('ledger', asNetworkSymbol('trx'))).toBe(true);
+        expect(isDebugOnlyAccountType('normal', asNetworkSymbol('regtest'))).toBe(false);
+        expect(isDebugOnlyAccountType('legacy', tsepSymbol)).toBe(true);
+        expect(isDebugOnlyAccountType('legacy', asNetworkSymbol('thod'))).toBe(true);
     });
 
     it('returns no results when given an empty accounts array', () => {
@@ -77,23 +88,23 @@ describe('filter receive accounts', () => {
     });
 
     it('returns no results when given a non-existing network in acccounts list', () => {
-        expect(runFilterReceiveAccouns({ symbol: 'bsc' })).toEqual([]);
+        expect(runFilterReceiveAccouns({ symbol: asNetworkSymbol('bsc') })).toEqual([]);
     });
 
     it('returns all accounts when debug mode is on', () => {
         const filteredAccounts = [
-            mockWalletAccount({ symbol: 'eth', accountType: 'normal' }),
-            mockWalletAccount({ symbol: 'eth', accountType: 'ledger' }),
-            mockWalletAccount({ symbol: 'eth', accountType: 'legacy' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'normal' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'ledger' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'legacy' }),
         ];
         expect(runFilterReceiveAccouns({})).toEqual(filteredAccounts);
     });
 
     it('returns non-debug + non-empty accounts when debug mode is off', () => {
         const filteredAccounts = [
-            mockWalletAccount({ symbol: 'eth', accountType: 'normal' }),
-            mockWalletAccount({ symbol: 'eth', accountType: 'ledger' }),
-            mockWalletAccount({ symbol: 'eth', accountType: 'legacy' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'normal' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'ledger' }),
+            mockWalletAccount({ symbol: ethSymbol, accountType: 'legacy' }),
         ];
 
         expect(runFilterReceiveAccouns({ isDebug: false })).toEqual(filteredAccounts);
@@ -107,42 +118,42 @@ describe('filter receive accounts', () => {
 
     it('excludes coinjoin accounts for BTC network (also tests isAnotherNetwork and isCoinjoinAccount methods)', () => {
         const filteredAccounts = [
-            mockWalletAccount({ symbol: 'btc', accountType: 'ledger' }),
-            mockWalletAccount({ symbol: 'btc', accountType: 'taproot' }),
-            mockWalletAccount({ symbol: 'btc', accountType: 'segwit' }),
-            mockWalletAccount({ symbol: 'btc', accountType: 'legacy' }),
+            mockWalletAccount({ symbol: btcSymbol, accountType: 'ledger' }),
+            mockWalletAccount({ symbol: btcSymbol, accountType: 'taproot' }),
+            mockWalletAccount({ symbol: btcSymbol, accountType: 'segwit' }),
+            mockWalletAccount({ symbol: btcSymbol, accountType: 'legacy' }),
         ];
 
-        expect(runFilterReceiveAccouns({ symbol: 'btc' })).toEqual(filteredAccounts);
+        expect(runFilterReceiveAccouns({ symbol: btcSymbol })).toEqual(filteredAccounts);
     });
 
     it('returns account when when its either first normal account (no matter is empty or not visible) or it is not empty and visible', () => {
         const filteredAccounts = [
             mockWalletAccount({
-                symbol: 'sol',
+                symbol: solSymbol,
                 accountType: 'normal',
                 empty: true,
                 visible: false,
             }),
-            mockWalletAccount({ symbol: 'sol', accountType: 'ledger' }),
+            mockWalletAccount({ symbol: solSymbol, accountType: 'ledger' }),
         ];
 
-        expect(runFilterReceiveAccouns({ symbol: 'sol' })).toEqual(filteredAccounts);
+        expect(runFilterReceiveAccouns({ symbol: solSymbol })).toEqual(filteredAccounts);
     });
 
     it('returns both normal and legacy for sepolia', () => {
         const filteredAccounts = [
-            mockWalletAccount({ symbol: 'tsep', accountType: 'normal' }),
-            mockWalletAccount({ symbol: 'tsep', accountType: 'legacy' }),
+            mockWalletAccount({ symbol: tsepSymbol, accountType: 'normal' }),
+            mockWalletAccount({ symbol: tsepSymbol, accountType: 'legacy' }),
         ];
 
-        expect(runFilterReceiveAccouns({ symbol: 'tsep' })).toEqual(filteredAccounts);
+        expect(runFilterReceiveAccouns({ symbol: tsepSymbol })).toEqual(filteredAccounts);
     });
 
     it('returns non-debug + excludes testnet accounts when debug mode is off', () => {
         const filteredAccounts = [
-            mockWalletAccount({ symbol: 'tsep', accountType: 'normal' }),
-            mockWalletAccount({ symbol: 'tsep', accountType: 'legacy' }),
+            mockWalletAccount({ symbol: tsepSymbol, accountType: 'normal' }),
+            mockWalletAccount({ symbol: tsepSymbol, accountType: 'legacy' }),
         ];
 
         expect(runFilterReceiveAccouns({ isDebug: false })).toEqual(

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -1,5 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     type FormState,
@@ -16,6 +17,9 @@ import {
     isClearSignedEvmTradingSwapTransaction,
     isClearSignedWrappedNativeTransaction,
 } from './reviewTransactionUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
+const bscSymbol = asNetworkSymbol('bsc');
 
 const buildPrecomposedTx = (to: string | undefined): GeneralPrecomposedTransactionFinal =>
     ({
@@ -59,13 +63,13 @@ const buildTrading = (overrides: Partial<FormStateTrading> = {}): FormStateTradi
     send: {
         cryptoId: undefined,
         accountKey: 'eth-account' as Account['key'],
-        symbol: 'eth',
+        symbol: ethSymbol,
         amount: '1',
     },
     receive: {
         cryptoId: undefined,
         accountKey: 'eth-account' as Account['key'],
-        symbol: 'eth',
+        symbol: ethSymbol,
         amount: '0.97',
     },
     receiveAddress: '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3',
@@ -87,7 +91,7 @@ const buildFormState = (overrides: Partial<FormState> = {}): FormState => ({
 
 const buildEthereumAccount = (overrides: Partial<Account> = {}): Account =>
     mockWalletAccount({
-        symbol: 'eth',
+        symbol: ethSymbol,
         accountType: 'normal',
         ...overrides,
     });
@@ -216,7 +220,7 @@ describe('isClearSignedWrappedNativeTransaction', () => {
 
     it('returns false for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {
         const result = isClearSignedWrappedNativeTransaction({
-            account: buildEthereumAccount({ symbol: 'bsc' }),
+            account: buildEthereumAccount({ symbol: bscSymbol }),
             device,
             precomposedTx: buildPrecomposedTransaction({ to: WBNB_BSC }),
             transactionData: WETH_DEPOSIT_DATA,
@@ -528,7 +532,7 @@ describe('constructTransactionReviewOutputs', () => {
 
     it('keeps the raw data row for a wrapped native the firmware does not clear-sign (WBNB on BSC)', () => {
         const outputs = constructTransactionReviewOutputs({
-            account: buildEthereumAccount({ symbol: 'bsc' }),
+            account: buildEthereumAccount({ symbol: bscSymbol }),
             device,
             decreaseOutputId: undefined,
             precomposedForm: buildFormState({ transactionData: WETH_DEPOSIT_DATA }),

--- a/suite-common/wallet-utils/src/sendFormUtils.test.ts
+++ b/suite-common/wallet-utils/src/sendFormUtils.test.ts
@@ -1,4 +1,4 @@
-import { networks, networksCollection } from '@suite-common/wallet-config';
+import { asNetworkSymbol, networks, networksCollection } from '@suite-common/wallet-config';
 import {
     mockWalletAccount,
     networkSpecificDefaultRipple,
@@ -23,6 +23,9 @@ import {
     prepareEthereumTransaction,
     restoreOrigOutputsOrder,
 } from './sendFormUtils';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 describe('sendForm utils', () => {
     fixtures.prepareEthereumTransaction.forEach(f => {
@@ -112,7 +115,7 @@ describe('sendForm utils', () => {
         // @ts-expect-error: invalid params
         expect(getBitcoinComposeOutputs('A', 'btc')).toEqual([]);
 
-        expect(getBitcoinComposeOutputs({ outputs: [] }, 'btc')).toEqual([]);
+        expect(getBitcoinComposeOutputs({ outputs: [] }, btcSymbol)).toEqual([]);
 
         let outputs: any[] = [
             null,
@@ -120,10 +123,10 @@ describe('sendForm utils', () => {
             { type: 'payment', amount: '' },
             { type: 'payment', amount: '1' },
         ];
-        expect(getBitcoinComposeOutputs({ outputs }, 'btc')).toEqual([
+        expect(getBitcoinComposeOutputs({ outputs }, btcSymbol)).toEqual([
             { type: 'payment-noaddress', amount: '100000000' },
         ]);
-        expect(getBitcoinComposeOutputs({ outputs }, 'btc', true)).toEqual([
+        expect(getBitcoinComposeOutputs({ outputs }, btcSymbol, true)).toEqual([
             { type: 'payment-noaddress', amount: '1' },
         ]);
 
@@ -143,7 +146,7 @@ describe('sendForm utils', () => {
                     setMaxOutputId: 2,
                     outputs,
                 },
-                'btc',
+                btcSymbol,
             ),
         ).toEqual([
             { type: 'payment', amount: '100000000', address: 'A' },
@@ -159,7 +162,7 @@ describe('sendForm utils', () => {
                     setMaxOutputId: 0,
                     outputs,
                 },
-                'btc',
+                btcSymbol,
             ),
         ).toEqual([{ type: 'send-max-noaddress' }]);
 
@@ -170,7 +173,7 @@ describe('sendForm utils', () => {
                     setMaxOutputId: 0,
                     outputs,
                 },
-                'btc',
+                btcSymbol,
             ),
         ).toEqual([{ type: 'send-max', address: 'A' }]);
 
@@ -179,7 +182,7 @@ describe('sendForm utils', () => {
             { type: 'payment', amount: '', address: 'A' },
             { type: 'payment', amount: '1', address: 'B' },
         ];
-        expect(getBitcoinComposeOutputs({ outputs }, 'btc')).toEqual([
+        expect(getBitcoinComposeOutputs({ outputs }, btcSymbol)).toEqual([
             { type: 'payment-noaddress', amount: '100000000', address: 'B' },
         ]);
 
@@ -194,7 +197,7 @@ describe('sendForm utils', () => {
                     setMaxOutputId: 1,
                     outputs,
                 },
-                'btc',
+                btcSymbol,
             ),
         ).toEqual([{ type: 'send-max-noaddress', address: 'B' }]);
 
@@ -202,7 +205,7 @@ describe('sendForm utils', () => {
             { type: 'payment', amount: '', address: 'A' },
             { type: 'payment', amount: '1' },
         ];
-        expect(getBitcoinComposeOutputs({ outputs }, 'btc')).toEqual([
+        expect(getBitcoinComposeOutputs({ outputs }, btcSymbol)).toEqual([
             { type: 'payment-noaddress', amount: '100000000' },
         ]);
     });
@@ -238,7 +241,7 @@ describe('sendForm utils', () => {
         };
 
         const EthAccount = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [
                 {
                     standard: 'ERC20',
@@ -374,7 +377,7 @@ describe('sendForm utils', () => {
     describe('getAmountValidationResult', () => {
         describe('should test bitcoin without tokens', () => {
             const btcAccount = mockWalletAccount({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 tokens: undefined,
                 balance: '1000000000', // 10 BTC
                 availableBalance: '10000000', // 0.1 BTC
@@ -400,7 +403,7 @@ describe('sendForm utils', () => {
         describe('should test ripple (with reserve)', () => {
             const rippleAccount = mockWalletAccount(
                 {
-                    symbol: 'xrp',
+                    symbol: asNetworkSymbol('xrp'),
                     tokens: undefined,
                     balance: '10000000', // 10 XRP
                     availableBalance: '9000000', // 9 XRP
@@ -427,7 +430,7 @@ describe('sendForm utils', () => {
         describe('should test stellar (with reserve)', () => {
             const stellarAccount = mockWalletAccount(
                 {
-                    symbol: 'xlm',
+                    symbol: asNetworkSymbol('xlm'),
                     balance: '100000000', // 10 XLM
                     availableBalance: '95000000', // 9.5 XLM
                 },
@@ -455,7 +458,7 @@ describe('sendForm utils', () => {
 
         describe('should test token balances', () => {
             const tokenAccount = mockWalletAccount({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 balance: '0',
                 availableBalance: '0',
                 tokens: [

--- a/suite-common/wallet-utils/src/stellarTokens.test.ts
+++ b/suite-common/wallet-utils/src/stellarTokens.test.ts
@@ -1,7 +1,10 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getTokenMetadata } from '@trezor/blockchain-link-utils/src/stellar';
 
 import { getStellarInactiveTokens } from './stellarTokens';
+
+const xlmSymbol = asNetworkSymbol('xlm');
 
 jest.mock('@trezor/blockchain-link-utils/src/stellar', () => ({
     STELLAR_DECIMALS: 7,
@@ -16,14 +19,14 @@ describe(getStellarInactiveTokens.name, () => {
     });
 
     it('returns empty array for non-Stellar accounts', async () => {
-        const account = mockWalletAccount({ symbol: 'btc' });
+        const account = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 
         await expect(getStellarInactiveTokens(account)).resolves.toEqual([]);
         expect(mockedGetTokenMetadata).not.toHaveBeenCalled();
     });
 
     it('returns all tokens when account has no active Stellar tokens', async () => {
-        const account = mockWalletAccount({ symbol: 'xlm', tokens: undefined });
+        const account = mockWalletAccount({ symbol: xlmSymbol, tokens: undefined });
 
         mockedGetTokenMetadata.mockResolvedValue({
             'USDC-GA123': { name: 'USD Coin', symbol: 'USDC', home_domain: 'centre.io', rating: 5 },
@@ -56,7 +59,7 @@ describe(getStellarInactiveTokens.name, () => {
 
     it('filters out active Stellar tokens', async () => {
         const account = mockWalletAccount({
-            symbol: 'xlm',
+            symbol: xlmSymbol,
             tokens: [{ contract: 'YBX-GC789' }] as never,
         });
 
@@ -73,7 +76,7 @@ describe(getStellarInactiveTokens.name, () => {
     });
 
     it('sorts tokens by rating in descending order and keeps unrated tokens last', async () => {
-        const account = mockWalletAccount({ symbol: 'xlm' });
+        const account = mockWalletAccount({ symbol: xlmSymbol });
 
         mockedGetTokenMetadata.mockResolvedValue({
             'LOW-GA111': { name: 'Low', symbol: 'LOW', home_domain: 'low.org', rating: 1 },

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -1,4 +1,5 @@
 import { testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
 
 import * as fixtures from './__fixtures__/transactionUtils';
@@ -27,6 +28,9 @@ import {
     parseTransactionMonthKey,
 } from './transactionUtils';
 
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
+
 const { getWalletTransaction } = testMocks;
 
 const ACCOUNT_DESCRIPTOR = '0x37567E60ab231b7D7f26B5b34FDD719098E4Ee1b';
@@ -49,7 +53,7 @@ const getEvmTransaction = (
 ) =>
     getWalletTransaction({
         descriptor: asAccountDescriptor(ACCOUNT_DESCRIPTOR),
-        symbol: 'eth',
+        symbol: ethSymbol,
         type,
         blockHeight,
         ...(txid ? { txid } : {}),
@@ -340,11 +344,11 @@ describe('transaction utils', () => {
     describe('groupTokensTransactionsByContractAddress', () => {
         it('groups tokens by contract address', () => {
             const groupedTokensTxs = groupTokensTransactionsByContractAddress([
-                getWalletTransaction({ symbol: 'eth' }),
-                getWalletTransaction({ symbol: 'eth' }),
-                getWalletTransaction({ symbol: 'eth' }),
+                getWalletTransaction({ symbol: ethSymbol }),
+                getWalletTransaction({ symbol: ethSymbol }),
+                getWalletTransaction({ symbol: ethSymbol }),
                 getWalletTransaction({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     tokens: [
                         {
                             ...fixtures.token,
@@ -353,7 +357,7 @@ describe('transaction utils', () => {
                     ],
                 }),
                 getWalletTransaction({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     tokens: [
                         {
                             ...fixtures.token,
@@ -362,7 +366,7 @@ describe('transaction utils', () => {
                     ],
                 }),
                 getWalletTransaction({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     tokens: [
                         {
                             ...fixtures.token,
@@ -374,7 +378,7 @@ describe('transaction utils', () => {
             expect(groupedTokensTxs).toEqual({
                 '0x01': [
                     getWalletTransaction({
-                        symbol: 'eth',
+                        symbol: ethSymbol,
                         tokens: [
                             {
                                 ...fixtures.token,
@@ -385,7 +389,7 @@ describe('transaction utils', () => {
                 ],
                 '0x02': [
                     getWalletTransaction({
-                        symbol: 'eth',
+                        symbol: ethSymbol,
                         tokens: [
                             {
                                 ...fixtures.token,
@@ -394,7 +398,7 @@ describe('transaction utils', () => {
                         ],
                     }),
                     getWalletTransaction({
-                        symbol: 'eth',
+                        symbol: ethSymbol,
                         tokens: [
                             {
                                 ...fixtures.token,
@@ -927,7 +931,10 @@ describe('transaction utils', () => {
         });
 
         it('returns the formatted transaction amount when there is no target', () => {
-            const transaction = getWalletTransaction({ symbol: 'btc', amount: '1000' });
+            const transaction = getWalletTransaction({
+                symbol: btcSymbol,
+                amount: '1000',
+            });
 
             expect(getTargetAmount(undefined, transaction)).toBe('0.00001');
         });
@@ -935,7 +942,7 @@ describe('transaction utils', () => {
         it('returns the formatted target amount for a non "sent to self" target', () => {
             const target = buildTarget({ amount: '2000', isAccountTarget: true });
             const transaction = getWalletTransaction({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 type: 'recv',
                 amount: '1000',
                 targets: [target],
@@ -947,7 +954,7 @@ describe('transaction utils', () => {
         it('returns the formatted amount of an external target in a sent transaction', () => {
             const externalTarget = buildTarget({ amount: '500', isAccountTarget: false });
             const transaction = getWalletTransaction({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 type: 'sent',
                 amount: '1000',
                 targets: [externalTarget],
@@ -959,7 +966,7 @@ describe('transaction utils', () => {
         it('returns the transaction amount for a "sent to self" target when there is no external target', () => {
             const selfTarget = buildTarget({ amount: '1000', isAccountTarget: true, n: 1 });
             const transaction = getWalletTransaction({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 type: 'sent',
                 amount: '1000',
                 targets: [selfTarget],
@@ -972,7 +979,7 @@ describe('transaction utils', () => {
             const selfTarget = buildTarget({ amount: '1000', isAccountTarget: true, n: 1 });
             const externalTarget = buildTarget({ amount: '500', isAccountTarget: false, n: 0 });
             const transaction = getWalletTransaction({
-                symbol: 'btc',
+                symbol: btcSymbol,
                 type: 'sent',
                 amount: '1000',
                 targets: [selfTarget, externalTarget],

--- a/suite-common/wallet-utils/src/tronStakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/tronStakingUtils.test.ts
@@ -1,5 +1,6 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import {
     type TronAccountExtraData,
@@ -94,14 +95,14 @@ const buildNonTronAccount = (): Account =>
 
 describe('isSupportedTronStakingNetworkSymbol', () => {
     it('returns true for trx', () => {
-        expect(isSupportedTronStakingNetworkSymbol('trx')).toBe(true);
+        expect(isSupportedTronStakingNetworkSymbol(asNetworkSymbol('trx'))).toBe(true);
     });
 
     it('returns false for non-Tron symbols', () => {
-        expect(isSupportedTronStakingNetworkSymbol('btc')).toBe(false);
-        expect(isSupportedTronStakingNetworkSymbol('eth')).toBe(false);
+        expect(isSupportedTronStakingNetworkSymbol(asNetworkSymbol('btc'))).toBe(false);
+        expect(isSupportedTronStakingNetworkSymbol(asNetworkSymbol('eth'))).toBe(false);
         // testnet Tron is not in the supported list
-        expect(isSupportedTronStakingNetworkSymbol('ttrx')).toBe(false);
+        expect(isSupportedTronStakingNetworkSymbol(asNetworkSymbol('ttrx'))).toBe(false);
     });
 });
 

--- a/suite-common/wallet-utils/src/tronUtils.test.ts
+++ b/suite-common/wallet-utils/src/tronUtils.test.ts
@@ -1,7 +1,10 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type TronAccountExtraData } from '@trezor/blockchain-link-types';
 
 import { calculateTronFeeBreakdown, computeBandwidthFeeLevel } from './tronUtils';
+
+const trxSymbol = asNetworkSymbol('trx');
 
 const makeTrc20Tx = (overrides: Record<string, unknown> = {}): GeneralPrecomposedTransaction =>
     ({
@@ -97,7 +100,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         // Tx: bandwidth: 300
         // Account: bandwidth: 300, energy: 0
         // Expected: trxBurned: 0 TRX, coveredBandwidth: 300
-        const result = calculateTronFeeBreakdown(makeNativeTrxTx(), makeTronResources(), 'trx');
+        const result = calculateTronFeeBreakdown(makeNativeTrxTx(), makeTronResources(), trxSymbol);
         expect(result?.trxBurned.toNumber()).toBe(0);
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
     });
@@ -109,7 +112,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeNativeTrxTx(),
             makeTronResources({ availableFreeBandwidth: 0 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toString()).toBe('0.3');
         expect(result?.coveredBandwidth.toNumber()).toBe(0);
@@ -122,7 +125,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeTrc20Tx(),
             makeTronResources({ availableEnergy: 1000 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toNumber()).toBe(0);
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
@@ -136,7 +139,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeTrc20Tx(),
             makeTronResources({ availableEnergy: 400 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toString()).toBe('0.06');
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
@@ -150,7 +153,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeTrc20Tx(),
             makeTronResources({ availableEnergy: 0 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toString()).toBe('0.1');
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
@@ -164,7 +167,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeTrc20Tx(),
             makeTronResources({ availableEnergy: 1000, availableFreeBandwidth: 0 }),
-            'trx',
+            trxSymbol,
             '100000',
         );
         expect(result?.trxBurned.toString()).toBe('0.3');
@@ -179,7 +182,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             makeTrc20Tx(),
             makeTronResources({ availableEnergy: 1000 }),
-            'trx',
+            trxSymbol,
             '110000',
         );
         expect(result?.trxBurned.toString()).toBe('0.01');
@@ -194,7 +197,7 @@ describe(calculateTronFeeBreakdown.name, () => {
             ...makeNativeTrxTx(),
             accountActivationFee: '1000000',
         } as GeneralPrecomposedTransaction;
-        const result = calculateTronFeeBreakdown(tx, makeTronResources(), 'trx');
+        const result = calculateTronFeeBreakdown(tx, makeTronResources(), trxSymbol);
         expect(result?.trxBurned.toString()).toBe('0.1');
         expect(result?.coveredBandwidth.toNumber()).toBe(0);
     });
@@ -210,7 +213,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             tx,
             makeTronResources({ availableFreeBandwidth: 0, availableStakedBandwidth: 300 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toNumber()).toBe(0);
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
@@ -221,7 +224,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         // Account: bandwidth: 300
         // Expected: trxBurned: 1 TRX (memo only, bandwidth covered)
         const tx = { ...makeNativeTrxTx(), memoFee: '1000000' } as GeneralPrecomposedTransaction;
-        const result = calculateTronFeeBreakdown(tx, makeTronResources(), 'trx');
+        const result = calculateTronFeeBreakdown(tx, makeTronResources(), trxSymbol);
         expect(result?.trxBurned.toString()).toBe('1');
         expect(result?.coveredBandwidth.toNumber()).toBe(300);
     });
@@ -234,7 +237,7 @@ describe(calculateTronFeeBreakdown.name, () => {
         const result = calculateTronFeeBreakdown(
             tx,
             makeTronResources({ availableEnergy: 1000 }),
-            'trx',
+            trxSymbol,
         );
         expect(result?.trxBurned.toString()).toBe('1');
         expect(result?.coveredBandwidth.toNumber()).toBe(300);

--- a/suite-native/accounts/src/components/AccountLabel.test.tsx
+++ b/suite-native/accounts/src/components/AccountLabel.test.tsx
@@ -3,6 +3,7 @@ import { type StateFromReducersMapObject, combineReducers } from '@reduxjs/toolk
 import { deviceInitialState } from '@suite-common/device';
 import { messageSystemInitialState } from '@suite-common/message-system';
 import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/suite-sync';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
@@ -17,11 +18,14 @@ import type { StaticSessionId } from '@trezor/connect';
 
 import { AccountLabel, type AccountLabelPropsWithAccount } from './AccountLabel';
 
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
+
 const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 
 describe('AccountLabel', () => {
     const ethAccount = mockWalletAccount({
-        symbol: 'eth',
+        symbol: ethSymbol,
         accountLabel: 'ETH Account #1',
         deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
 
@@ -31,7 +35,7 @@ describe('AccountLabel', () => {
     });
 
     const ethLedgerAccount = mockWalletAccount({
-        symbol: 'eth',
+        symbol: ethSymbol,
         accountLabel: 'ETH Ledger Account',
         deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
 
@@ -86,7 +90,7 @@ describe('AccountLabel', () => {
     it('should render nothing when accountLabel is not found', () => {
         const { toJSON } = renderAccountLabel({
             deviceStaticSessionId: ethAccount.deviceState,
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             accountDescriptor: ethAccount.descriptor,
         });
 

--- a/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
+++ b/suite-native/accounts/src/components/AccountTypeBadge.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
@@ -5,11 +6,13 @@ import type { StaticSessionId } from '@trezor/connect';
 
 import { AccountTypeBadge } from './AccountTypeBadge';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const MOCK_ACCOUNT_DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 
 describe('AccountTypeBadge', () => {
     const ethNormalAccount = mockWalletAccount({
-        symbol: 'eth',
+        symbol: ethSymbol,
         deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
         accountType: 'normal',
         descriptor: asAccountDescriptor('eth1normal'),
@@ -17,7 +20,7 @@ describe('AccountTypeBadge', () => {
     });
 
     const ethLedgerAccount = mockWalletAccount({
-        symbol: 'eth',
+        symbol: ethSymbol,
         deviceState: MOCK_ACCOUNT_DEVICE_SESSION_ID,
         accountType: 'ledger',
         descriptor: asAccountDescriptor('eth1ledger'),

--- a/suite-native/accounts/src/filteredDeviceAccountsSelectors.test.ts
+++ b/suite-native/accounts/src/filteredDeviceAccountsSelectors.test.ts
@@ -1,6 +1,7 @@
 import { type AccountWithSuiteSyncLabel } from '@suite-common/suite-sync';
 import { type SuiteSyncAccount, createSuiteSyncAccountId } from '@suite-common/suite-sync-storage';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount, networkSpecificDefaultCardano } from '@suite-common/wallet-types/mocks';
@@ -13,6 +14,11 @@ import {
     selectFilteredDeviceNetworkSymbols,
     selectNetworkFilterOptions,
 } from './selectors';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const adaSymbol = asNetworkSymbol('ada');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 const SELECTED_WALLET_DESCRIPTOR = asWalletDescriptor('selectedWallet');
 const SELECTED_DEVICE_STATIC_SESSION_ID: StaticSessionId = 'selectedWallet@deviceId:0';
@@ -28,7 +34,7 @@ const selectedDevice = mockSuiteDevice({
 });
 
 const btcDefaultAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('btcdefault'),
     deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',
@@ -37,7 +43,7 @@ const btcDefaultAccount = mockWalletAccount({
 });
 
 const btcTaprootAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('btctaproot'),
     deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
     accountType: 'taproot',
@@ -46,7 +52,7 @@ const btcTaprootAccount = mockWalletAccount({
 });
 
 const ethAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('ethdefault'),
     deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',
@@ -56,7 +62,7 @@ const ethAccount = mockWalletAccount({
 
 const adaAccount = mockWalletAccount(
     {
-        symbol: 'ada',
+        symbol: adaSymbol,
         descriptor: asAccountDescriptor('adadefault'),
         deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
         accountType: 'normal',
@@ -67,7 +73,7 @@ const adaAccount = mockWalletAccount(
 );
 
 const hiddenLtcAccount = mockWalletAccount({
-    symbol: 'ltc',
+    symbol: ltcSymbol,
     descriptor: asAccountDescriptor('ltchidden'),
     deviceState: SELECTED_DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',
@@ -77,7 +83,7 @@ const hiddenLtcAccount = mockWalletAccount({
 });
 
 const otherDeviceBtcAccount = mockWalletAccount({
-    symbol: 'btc',
+    symbol: btcSymbol,
     descriptor: asAccountDescriptor('btcotherdevice'),
     deviceState: OTHER_DEVICE_STATIC_SESSION_ID,
     accountType: 'normal',
@@ -114,7 +120,7 @@ const createState = (accounts: Account[]): NativeAccountsRootState => ({
         accounts,
         settings: {
             ...initialWalletSettingsState,
-            enabledNetworks: ['btc', 'eth', 'ada', 'ltc'],
+            enabledNetworks: [btcSymbol, ethSymbol, adaSymbol, ltcSymbol],
         },
         fiat: {
             current: {},
@@ -187,16 +193,17 @@ describe('selectFilteredDeviceNetworkSymbols', () => {
     });
 
     it('filters by network symbols', () => {
-        expect(selectFilteredDeviceNetworkSymbols(state, '', false, ['btc'])).toEqual(['btc']);
-        expect(selectFilteredDeviceNetworkSymbols(state, '', false, ['eth', 'ada'])).toEqual([
-            'eth',
-            'ada',
-        ]);
+        expect(selectFilteredDeviceNetworkSymbols(state, '', false, [btcSymbol])).toEqual(['btc']);
+        expect(
+            selectFilteredDeviceNetworkSymbols(state, '', false, [ethSymbol, adaSymbol]),
+        ).toEqual(['eth', 'ada']);
     });
 
     it('combines network symbol filter with text search', () => {
-        expect(selectFilteredDeviceNetworkSymbols(state, 'daily', false, ['btc'])).toEqual(['btc']);
-        expect(selectFilteredDeviceNetworkSymbols(state, 'daily', false, ['eth'])).toEqual([]);
+        expect(selectFilteredDeviceNetworkSymbols(state, 'daily', false, [btcSymbol])).toEqual([
+            'btc',
+        ]);
+        expect(selectFilteredDeviceNetworkSymbols(state, 'daily', false, [ethSymbol])).toEqual([]);
     });
 
     it('returns a referentially stable result when unrelated state changes', () => {
@@ -210,33 +217,32 @@ describe('selectFilteredDeviceNetworkSymbols', () => {
 
 describe('selectFilteredDeviceAccountTypesByNetworkSymbol', () => {
     it('returns account types of visible network accounts sorted by account type order', () => {
-        expect(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, 'btc')).toEqual([
-            'normal',
-            'taproot',
-        ]);
-        expect(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, 'eth')).toEqual([
-            'normal',
-        ]);
+        expect(
+            selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, btcSymbol),
+        ).toEqual(['normal', 'taproot']);
+        expect(
+            selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, ethSymbol),
+        ).toEqual(['normal']);
     });
 
     it('keeps only account types with send-available accounts when the send filter is enabled', () => {
-        expect(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', true, 'btc')).toEqual([
-            'taproot',
-        ]);
+        expect(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', true, btcSymbol)).toEqual(
+            ['taproot'],
+        );
     });
 
     it('returns an empty array for a network without visible accounts', () => {
-        expect(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, 'ltc')).toEqual(
-            [],
-        );
+        expect(
+            selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, ltcSymbol),
+        ).toEqual([]);
     });
 
     it('returns a referentially stable result when unrelated state changes', () => {
         const recreatedState = createState(stateAccounts);
 
         expect(
-            selectFilteredDeviceAccountTypesByNetworkSymbol(recreatedState, '', false, 'btc'),
-        ).toBe(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, 'btc'));
+            selectFilteredDeviceAccountTypesByNetworkSymbol(recreatedState, '', false, btcSymbol),
+        ).toBe(selectFilteredDeviceAccountTypesByNetworkSymbol(state, '', false, btcSymbol));
     });
 });
 
@@ -247,7 +253,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 '',
                 false,
-                'btc',
+                btcSymbol,
                 'normal',
             ),
         ).toEqual([withLabel(btcDefaultAccount, 'Daily spending')]);
@@ -257,7 +263,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 '',
                 false,
-                'btc',
+                btcSymbol,
                 'taproot',
             ),
         ).toEqual([withLabel(btcTaprootAccount, null)]);
@@ -269,7 +275,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 'daily',
                 false,
-                'btc',
+                btcSymbol,
                 'normal',
             ),
         ).toEqual([withLabel(btcDefaultAccount, 'Daily spending')]);
@@ -279,7 +285,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 'daily',
                 false,
-                'btc',
+                btcSymbol,
                 'taproot',
             ),
         ).toEqual([]);
@@ -291,7 +297,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 '',
                 false,
-                'ltc',
+                ltcSymbol,
                 'normal',
             ),
         ).toEqual([]);
@@ -305,7 +311,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 recreatedState,
                 '',
                 false,
-                'btc',
+                btcSymbol,
                 'normal',
             ),
         ).toBe(
@@ -313,7 +319,7 @@ describe('selectFilteredDeviceAccountsByNetworkSymbolAndAccountType', () => {
                 state,
                 '',
                 false,
-                'btc',
+                btcSymbol,
                 'normal',
             ),
         );

--- a/suite-native/accounts/src/selectors.test.ts
+++ b/suite-native/accounts/src/selectors.test.ts
@@ -1,4 +1,5 @@
 import { type AccountWithSuiteSyncLabel } from '@suite-common/suite-sync';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     type TokenInfoBranded,
@@ -13,6 +14,9 @@ import {
     selectIsAccountDiscoveryFailed,
 } from './selectors';
 import { isFilterValueMatchingAccount, sortAccountsByNetworksAndAccountTypes } from './utils';
+
+const btcSymbol = asNetworkSymbol('btc');
+const solSymbol = asNetworkSymbol('sol');
 
 let mockStakingBalance = '0';
 
@@ -102,8 +106,8 @@ describe('sortAccountsByNetworksAndAccountTypes', () => {
 
 describe('selectFreshAccountAddress', () => {
     const mockAccount = {
-        symbol: 'btc',
-        key: mockAccountKey({ symbol: 'btc', descriptor: 'btc1' }),
+        symbol: btcSymbol,
+        key: mockAccountKey({ symbol: btcSymbol, descriptor: 'btc1' }),
         addresses: {
             unused: [
                 {
@@ -409,20 +413,26 @@ describe('selectIsAccountDiscoveryFailed', () => {
             expect(
                 selectHasDeviceAnyFailedAccountForNetworkSymbol(
                     getState([normalAccount, failedAccount]),
-                    'sol',
+                    solSymbol,
                 ),
             ).toBe(true);
         });
 
         it('returns false when no account of the network failed', () => {
             expect(
-                selectHasDeviceAnyFailedAccountForNetworkSymbol(getState([normalAccount]), 'sol'),
+                selectHasDeviceAnyFailedAccountForNetworkSymbol(
+                    getState([normalAccount]),
+                    solSymbol,
+                ),
             ).toBe(false);
         });
 
         it('returns false for another network', () => {
             expect(
-                selectHasDeviceAnyFailedAccountForNetworkSymbol(getState([failedAccount]), 'btc'),
+                selectHasDeviceAnyFailedAccountForNetworkSymbol(
+                    getState([failedAccount]),
+                    btcSymbol,
+                ),
             ).toBe(false);
         });
     });

--- a/suite-native/discovery/src/pendingCoinVisibilitySlice.test.ts
+++ b/suite-native/discovery/src/pendingCoinVisibilitySlice.test.ts
@@ -1,11 +1,17 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import {
     addPendingCoinVisibility,
     clearPendingCoinVisibility,
     pendingCoinVisibilitySlice,
     selectPendingCoinVisibilitySymbols,
 } from './pendingCoinVisibilitySlice';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 describe('pendingCoinVisibilitySlice', () => {
     const createStore = () =>
@@ -18,7 +24,7 @@ describe('pendingCoinVisibilitySlice', () => {
     it('should add symbol to pending when not already present', () => {
         const store = createStore();
 
-        store.dispatch(addPendingCoinVisibility('btc'));
+        store.dispatch(addPendingCoinVisibility(btcSymbol));
 
         expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc']);
     });
@@ -26,8 +32,8 @@ describe('pendingCoinVisibilitySlice', () => {
     it('should not add duplicate symbols', () => {
         const store = createStore();
 
-        store.dispatch(addPendingCoinVisibility('btc'));
-        store.dispatch(addPendingCoinVisibility('btc'));
+        store.dispatch(addPendingCoinVisibility(btcSymbol));
+        store.dispatch(addPendingCoinVisibility(btcSymbol));
 
         expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc']);
     });
@@ -35,9 +41,9 @@ describe('pendingCoinVisibilitySlice', () => {
     it('should add multiple different symbols', () => {
         const store = createStore();
 
-        store.dispatch(addPendingCoinVisibility('btc'));
-        store.dispatch(addPendingCoinVisibility('eth'));
-        store.dispatch(addPendingCoinVisibility('ltc'));
+        store.dispatch(addPendingCoinVisibility(btcSymbol));
+        store.dispatch(addPendingCoinVisibility(ethSymbol));
+        store.dispatch(addPendingCoinVisibility(ltcSymbol));
 
         expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual(['btc', 'eth', 'ltc']);
     });
@@ -45,8 +51,8 @@ describe('pendingCoinVisibilitySlice', () => {
     it('should clear all pending symbols', () => {
         const store = createStore();
 
-        store.dispatch(addPendingCoinVisibility('btc'));
-        store.dispatch(addPendingCoinVisibility('eth'));
+        store.dispatch(addPendingCoinVisibility(btcSymbol));
+        store.dispatch(addPendingCoinVisibility(ethSymbol));
         store.dispatch(clearPendingCoinVisibility());
 
         expect(selectPendingCoinVisibilitySymbols(store.getState())).toEqual([]);

--- a/suite-native/graph/src/selectors.test.ts
+++ b/suite-native/graph/src/selectors.test.ts
@@ -1,6 +1,6 @@
 import type { DeviceRootState } from '@suite-common/device';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type DiscoveryRootState,
@@ -147,7 +147,7 @@ describe('selectPortfolioGraphAccountItemsIfDiscoveryIsNotRunning', () => {
 
     it('should return portfolio graph account items when discovery is not running', () => {
         const account = mockWalletAccount({
-            symbol: 'btc',
+            symbol: asNetworkSymbol('btc'),
             descriptor: asAccountDescriptor('descriptor1'),
         });
 

--- a/suite-native/helpers/src/hooks/useAmountInputTransformers.test.ts
+++ b/suite-native/helpers/src/hooks/useAmountInputTransformers.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type WalletSettingsRootState } from '@suite-common/wallet-core';
 import { PROTO } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
@@ -5,6 +6,9 @@ import { type DeepPartial } from '@trezor/type-utils';
 import { useAmountInputTransformers } from './useAmountInputTransformers';
 
 let mockState: DeepPartial<WalletSettingsRootState> | undefined;
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 jest.mock('react-redux', () => ({
     useSelector: (fn: (state: unknown) => unknown) => fn(mockState),
@@ -21,7 +25,7 @@ describe('useAmountInputTransformers', () => {
                 wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN } },
             };
 
-            const { cryptoAmountTransformer } = useAmountInputTransformers('btc');
+            const { cryptoAmountTransformer } = useAmountInputTransformers(btcSymbol);
 
             expect(cryptoAmountTransformer('123.456')).toBe('123.456');
         });
@@ -31,7 +35,7 @@ describe('useAmountInputTransformers', () => {
                 wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
             };
 
-            const { cryptoAmountTransformer } = useAmountInputTransformers('btc');
+            const { cryptoAmountTransformer } = useAmountInputTransformers(btcSymbol);
 
             expect(cryptoAmountTransformer('123.456')).toBe('123456');
         });
@@ -41,7 +45,7 @@ describe('useAmountInputTransformers', () => {
                 wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN } },
             };
 
-            const { cryptoAmountTransformer } = useAmountInputTransformers('eth');
+            const { cryptoAmountTransformer } = useAmountInputTransformers(ethSymbol);
 
             expect(cryptoAmountTransformer('123.456')).toBe('123.456');
         });
@@ -52,7 +56,7 @@ describe('useAmountInputTransformers', () => {
             wallet: { settings: { bitcoinAmountUnit: PROTO.AmountUnit.SATOSHI } },
         };
 
-        const { fiatAmountTransformer } = useAmountInputTransformers('btc');
+        const { fiatAmountTransformer } = useAmountInputTransformers(btcSymbol);
 
         expect(fiatAmountTransformer('123.456')).toBe('123.456');
     });
@@ -67,7 +71,7 @@ describe('useAmountInputTransformers', () => {
             },
         };
 
-        const { fiatAmountTransformer } = useAmountInputTransformers('btc');
+        const { fiatAmountTransformer } = useAmountInputTransformers(btcSymbol);
 
         expect(fiatAmountTransformer('123.456')).toBe('123456');
     });

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getCoingeckoId } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getCoingeckoId } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { getAssetLogoContractAddresses } from '@suite-common/wallet-utils';
 import { act, fireEvent, renderWithBasicProvider, waitFor } from '@suite-native/test-utils';
@@ -19,10 +19,13 @@ const networkIconHint = 'Network Icon';
 
 const contractA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const contractB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const opSymbol = asNetworkSymbol('op');
 
 const getTokenIconUrl = (contractAddress: string, size = 32) =>
     getAssetLogoUrl({
-        coingeckoId: getCoingeckoId('eth')!,
+        coingeckoId: getCoingeckoId(ethSymbol)!,
         contractAddress,
         density: 2,
         size,
@@ -33,16 +36,18 @@ describe('TokenIcon', () => {
         renderWithBasicProvider(<TokenIcon {...props} />);
 
     it('shows a placeholder immediately and the correct icon after resolving when a recycled instance receives new props', async () => {
-        const fresh = renderTokenIcon({ symbol: 'eth' });
+        const fresh = renderTokenIcon({ symbol: ethSymbol });
         await act(async () => {});
         const ethSource = fresh.getByHintText(tokenIconHint).props.source;
         fresh.unmount();
 
-        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({ symbol: 'btc' });
+        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
+            symbol: btcSymbol,
+        });
         await act(async () => {});
 
         // simulates FlashList cell recycling: same mounted instance, new asset props
-        rerender(<TokenIcon symbol="eth" />);
+        rerender(<TokenIcon symbol={ethSymbol} />);
 
         expect(queryByHintText(tokenIconHint)).toBeNull();
 
@@ -58,11 +63,11 @@ describe('TokenIcon', () => {
         );
 
         const { getByHintText, rerender } = renderTokenIcon({
-            symbol: 'eth',
+            symbol: ethSymbol,
             contractAddress: contractA,
         });
 
-        rerender(<TokenIcon symbol="eth" contractAddress={contractB} />);
+        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractB} />);
 
         await waitFor(() => {
             expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -81,7 +86,10 @@ describe('TokenIcon', () => {
     it('shows a text placeholder when the url resolution rejects', async () => {
         (getAssetLogoContractAddresses as jest.Mock).mockRejectedValue(new Error('failed'));
 
-        const { queryByHintText } = renderTokenIcon({ symbol: 'eth', contractAddress: contractA });
+        const { queryByHintText } = renderTokenIcon({
+            symbol: ethSymbol,
+            contractAddress: contractA,
+        });
 
         await act(async () => {});
 
@@ -94,7 +102,7 @@ describe('TokenIcon', () => {
         );
 
         const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
-            symbol: 'eth',
+            symbol: ethSymbol,
             contractAddress: contractA,
             size: 32,
         });
@@ -104,7 +112,7 @@ describe('TokenIcon', () => {
         fireEvent(getByHintText(tokenIconHint), 'error', { nativeEvent: {} });
         expect(queryByHintText(tokenIconHint)).toBeNull();
 
-        rerender(<TokenIcon symbol="eth" contractAddress={contractA} size={64} />);
+        rerender(<TokenIcon symbol={ethSymbol} contractAddress={contractA} size={64} />);
         await act(async () => {});
 
         expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
@@ -114,7 +122,7 @@ describe('TokenIcon', () => {
 
     it('should render without network icon for networks that are not l2 networks = op, arb, base', async () => {
         const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
-            symbol: 'btc',
+            symbol: btcSymbol,
             showNetworkIcon: true,
         });
 
@@ -129,7 +137,7 @@ describe('TokenIcon', () => {
 
     it('should render network with network icon for l2 networks = op, arb, base and ETH as icon', async () => {
         const { getByHintText, getByLabelText, queryByHintText } = renderTokenIcon({
-            symbol: 'op',
+            symbol: opSymbol,
             showNetworkIcon: true,
         });
 
@@ -144,7 +152,7 @@ describe('TokenIcon', () => {
     it('should render with network icon for contracts', async () => {
         const contract = '2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo' as TokenAddress;
         const { getByHintText, getByLabelText } = renderTokenIcon({
-            symbol: 'op',
+            symbol: opSymbol,
             contractAddress: contract,
             showNetworkIcon: true,
         });
@@ -162,7 +170,7 @@ describe('TokenIcon', () => {
 
         it('renders the native icon with a network badge for a wrapped-native token when set to network', async () => {
             const { getByHintText, getByLabelText } = renderTokenIcon({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 contractAddress: wethContract,
                 showNetworkIcon: true,
                 wrappedTokenIcon: 'network',
@@ -181,7 +189,7 @@ describe('TokenIcon', () => {
             );
 
             const { getByHintText, getByLabelText } = renderTokenIcon({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 contractAddress: wethContract,
                 showNetworkIcon: true,
             });
@@ -200,7 +208,7 @@ describe('TokenIcon', () => {
             );
 
             const { getByLabelText } = renderTokenIcon({
-                symbol: 'eth',
+                symbol: ethSymbol,
                 contractAddress: contractA,
                 showNetworkIcon: true,
                 wrappedTokenIcon: 'network',

--- a/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountSettingsScreen.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import {
@@ -20,8 +21,8 @@ const navigationMock = {} as StackProps<
     RootStackRoutes.AccountSettings
 >['navigation'];
 
-const btcAccount = mockWalletAccount({ symbol: 'btc' });
-const ethAccount = mockWalletAccount({ symbol: 'eth' });
+const btcAccount = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
+const ethAccount = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 
 const buildRoute = (accountKey: string) =>
     ({

--- a/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
+++ b/suite-native/module-earn/src/utils/chooseAccountBalanceUtils.test.ts
@@ -1,14 +1,20 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { toTokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { getChooseAccountBalanceData } from './chooseAccountBalanceUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const WETH_ADDRESS = toTokenAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
 const USDC_ADDRESS = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
 
 describe(getChooseAccountBalanceData.name, () => {
     it('returns the account balance when no token balance is requested', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1.5' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '1.5',
+        });
 
         expect(getChooseAccountBalanceData(account)).toEqual({
             type: 'account',
@@ -18,7 +24,7 @@ describe(getChooseAccountBalanceData.name, () => {
 
     it('combines the token balance with the full native balance for a wrapped-native vault, denominated as native', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             formattedBalance: '1',
             tokens: [mockAccountToken({ contract: WETH_ADDRESS, balance: '0.5' })],
         });
@@ -35,7 +41,10 @@ describe(getChooseAccountBalanceData.name, () => {
     });
 
     it('counts a native-only account (no WETH token) as depositable for a wrapped-native vault', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '1',
+        });
 
         expect(
             getChooseAccountBalanceData(account, {
@@ -50,7 +59,7 @@ describe(getChooseAccountBalanceData.name, () => {
 
     it('keeps the token denomination for a non-wrapped-native vault', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             formattedBalance: '1',
             tokens: [mockAccountToken({ contract: USDC_ADDRESS, balance: '100' })],
         });

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
@@ -1,9 +1,12 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { toTokenAddress } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { RootStackRoutes, YieldStackRoutes } from '@suite-native/navigation';
 
 import { type StablecoinYieldNavigationItem } from '../types';
 import { navigateByYieldAccountState } from './navigateByYieldAccountState';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 const WETH_ADDRESS = toTokenAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2');
 const USDC_ADDRESS = toTokenAddress('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48');
@@ -41,7 +44,7 @@ describe(navigateByYieldAccountState.name, () => {
 
     it('navigates to the account detail when the account holds the receipt token', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokens: [mockAccountToken({ contract: RECEIPT_ADDRESS, balance: '1' })],
         });
 
@@ -55,7 +58,7 @@ describe(navigateByYieldAccountState.name, () => {
 
     it('prefers the account detail over the deposit flow when the account holds both a receipt position and a depositable balance', () => {
         const account = mockWalletAccount({
-            symbol: 'eth',
+            symbol: ethSymbol,
             formattedBalance: '1',
             tokens: [mockAccountToken({ contract: RECEIPT_ADDRESS, balance: '1' })],
         });
@@ -64,7 +67,10 @@ describe(navigateByYieldAccountState.name, () => {
     });
 
     it('routes a native-only account into the deposit flow for a wrapped-native vault', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '1',
+        });
 
         expect(navigate(account)).toBe('deposit-in-a-nutshell-modal');
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.YieldNavigator, {
@@ -78,13 +84,19 @@ describe(navigateByYieldAccountState.name, () => {
     });
 
     it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0.003' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '0.003',
+        });
 
         expect(navigate(account)).toBe('deposit-in-a-nutshell-modal');
     });
 
     it('routes to the insufficient-balance screen when the account is empty', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '0' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '0',
+        });
 
         expect(navigate(account)).toBe('insufficient-balance-screen');
         expect(mockNavigate).toHaveBeenCalledWith(RootStackRoutes.YieldInsufficientBalance, {
@@ -95,14 +107,20 @@ describe(navigateByYieldAccountState.name, () => {
     });
 
     it('does not count the native balance for a non-wrapped-native vault', () => {
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '5' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '5',
+        });
 
         expect(navigate(account, createMockItem(USDC_ADDRESS))).toBe('insufficient-balance-screen');
     });
 
     it('shows the firmware update alert for a depositable account with unsupported firmware', () => {
         isFirmwareSupported.mockReturnValue(false);
-        const account = mockWalletAccount({ symbol: 'eth', formattedBalance: '1' });
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            formattedBalance: '1',
+        });
 
         expect(navigate(account)).toBe('firmware-update-alert');
         expect(showFirmwareUpdateAlert).toHaveBeenCalled();

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -1,4 +1,5 @@
 import { type ChainRewardsWithFiat } from '@suite-common/earn-stablecoin-api';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
     asAccountDescriptor,
@@ -15,10 +16,12 @@ import {
     getTotalFiatClaimableAmount,
 } from './stablecoinYieldClaimSummaryUtils';
 
+const ethSymbol = asNetworkSymbol('eth');
+
 const receiptTokenContract = toTokenAddress('0x0000000000000000000000000000000000000002');
 
 const ethereumAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xff6845f200000000000000000000000013fb4863'),
     accountLabel: 'Ethereum #1',
     tokens: [
@@ -32,7 +35,7 @@ const ethereumAccount = mockWalletAccount({
 });
 
 const anotherEthereumAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xaa6845f200000000000000000000000013fb4863'),
     accountLabel: 'Ethereum #2',
     tokens: [
@@ -46,7 +49,7 @@ const anotherEthereumAccount = mockWalletAccount({
 });
 
 const exitedEthereumAccount = mockWalletAccount({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: asAccountDescriptor('0xbb6845f200000000000000000000000013fb4863'),
     accountLabel: 'Ethereum #3',
     tokens: [],

--- a/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangeUsdcPresetButton.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { type TestStore, fireEvent, screen } from '@suite-native/test-utils-store';
@@ -17,7 +18,7 @@ jest.mock('../../hooks/exchange/useExchangeFormContext', () => ({
 }));
 
 const ethAccountWithUsdc = mockWalletAccount({
-    symbol: 'eth',
+    symbol: asNetworkSymbol('eth'),
     accountType: 'normal',
     descriptor: asAccountDescriptor('ethusdc'),
     tokens: [

--- a/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
+++ b/suite-native/module-trading/src/components/general/AccountList/AccountListItem.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
@@ -12,7 +13,7 @@ const DEVICE_SESSION_ID: StaticSessionId = '1@2:3';
 
 const btc10000000Account = mockWalletAccount({
     descriptor: asAccountDescriptor('abc'),
-    symbol: 'btc',
+    symbol: asNetworkSymbol('btc'),
     deviceState: '1@2:3',
     accountLabel: 'My BTC account',
     availableBalance: '10000000',

--- a/suite-native/staking/src/ethereumStakingSelectors.test.ts
+++ b/suite-native/staking/src/ethereumStakingSelectors.test.ts
@@ -1,4 +1,5 @@
 import { type TrezorDevice } from '@suite-common/suite-types';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { type StaticSessionId } from '@trezor/device-utils';
@@ -15,10 +16,11 @@ import {
 } from './ethereumStakingSelectors';
 
 const staticStateString: StaticSessionId = 'device@state:1';
+const ethSymbol = asNetworkSymbol('eth');
 
-const eth1Key = mockAccountKey({ symbol: 'eth', descriptor: 'eth1' });
-const eth2Key = mockAccountKey({ symbol: 'eth', descriptor: 'eth2' });
-const eth3Key = mockAccountKey({ symbol: 'eth', descriptor: 'eth3' });
+const eth1Key = mockAccountKey({ symbol: ethSymbol, descriptor: 'eth1' });
+const eth2Key = mockAccountKey({ symbol: ethSymbol, descriptor: 'eth2' });
+const eth3Key = mockAccountKey({ symbol: ethSymbol, descriptor: 'eth3' });
 const nonExistentKey = mockAccountKey({ descriptor: 'nonExistent' });
 
 const ethAccountWithStaking: Account = {

--- a/suite-native/staking/src/selectors.test.ts
+++ b/suite-native/staking/src/selectors.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type StakeDataState } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
@@ -8,10 +9,14 @@ import {
     selectClaimableAmountByAccountKey,
 } from './selectors';
 
-const eth1Key = mockAccountKey({ symbol: 'eth', descriptor: 'eth1' });
-const sol1Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol1' });
+const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
+const adaSymbol = asNetworkSymbol('ada');
+
+const eth1Key = mockAccountKey({ symbol: ethSymbol, descriptor: 'eth1' });
+const sol1Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol1' });
 const etc1Key = mockAccountKey({ descriptor: 'etc1' });
-const ada1Key = mockAccountKey({ symbol: 'ada', descriptor: 'ada1' });
+const ada1Key = mockAccountKey({ symbol: adaSymbol, descriptor: 'ada1' });
 const nonExistentKey = mockAccountKey({ descriptor: 'nonExistent' });
 
 const ethAccountWithClaimableStake: Account = {
@@ -204,7 +209,7 @@ describe('main staking selectors', () => {
         it('should return ETH APY by networkSymbol', () => {
             const testState = getTestState([]);
 
-            const result = selectApy(testState as any, { networkSymbol: 'eth' });
+            const result = selectApy(testState as any, { networkSymbol: ethSymbol });
 
             expect(result).toBe(3.08);
         });
@@ -220,7 +225,7 @@ describe('main staking selectors', () => {
         it('should return SOL APY by networkSymbol', () => {
             const testState = getTestState([]);
 
-            const result = selectApy(testState as any, { networkSymbol: 'sol' });
+            const result = selectApy(testState as any, { networkSymbol: solSymbol });
 
             expect(result).toBe(6.24);
         });
@@ -228,7 +233,7 @@ describe('main staking selectors', () => {
         it('should return best pool APY for ADA by networkSymbol', () => {
             const testState = getTestState([]);
 
-            const result = selectApy(testState as any, { networkSymbol: 'ada' });
+            const result = selectApy(testState as any, { networkSymbol: adaSymbol });
 
             expect(result).toBe(1.96);
         });

--- a/suite-native/staking/src/solanaStakingSelectors.test.ts
+++ b/suite-native/staking/src/solanaStakingSelectors.test.ts
@@ -1,5 +1,6 @@
 import { initialSuiteSyncDataState, initialSuiteSyncState } from '@suite-common/suite-sync';
 import { type TrezorDevice } from '@suite-common/suite-types';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type StakeState, stakeInitialState } from '@suite-common/wallet-core';
 import { type Account, type Timestamp } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
@@ -19,12 +20,13 @@ import {
 import { type NativeStakingRootState } from './types';
 
 const staticStateString: StaticSessionId = 'device@state:1';
+const solSymbol = asNetworkSymbol('sol');
 
-const sol1Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol1' });
-const sol2Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol2' });
-const sol3Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol3' });
-const sol4Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol4' });
-const sol5Key = mockAccountKey({ symbol: 'sol', descriptor: 'sol5' });
+const sol1Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol1' });
+const sol2Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol2' });
+const sol3Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol3' });
+const sol4Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol4' });
+const sol5Key = mockAccountKey({ symbol: solSymbol, descriptor: 'sol5' });
 const etc1Key = mockAccountKey({ descriptor: 'etc1' });
 const nonExistentKey = mockAccountKey({ descriptor: 'nonExistentKey' });
 const nonExistentKey2 = mockAccountKey({ descriptor: 'nonExistent' });
@@ -237,7 +239,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol',
+                    solSymbol,
                 ),
             ).toEqual([]);
         });
@@ -252,7 +254,7 @@ describe('selectors', () => {
                     {
                         ...testState,
                     },
-                    'sol',
+                    solSymbol,
                 ),
             ).toEqual([solAccountWithStaking]);
         });
@@ -264,11 +266,11 @@ describe('selectors', () => {
 
             const first = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
                 testState,
-                'sol',
+                solSymbol,
             );
             const second = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
                 testState,
-                'sol',
+                solSymbol,
             );
 
             expect(first).toEqual([]);
@@ -282,11 +284,11 @@ describe('selectors', () => {
 
             const first = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
                 testState,
-                'sol',
+                solSymbol,
             );
             const second = selectVisibleDeviceSolanaAccountsWithStakingByNetworkSymbol(
                 testState,
-                'sol',
+                solSymbol,
             );
 
             expect(first).toBe(second);

--- a/suite-native/staking/src/stakeNativeThunks.test.ts
+++ b/suite-native/staking/src/stakeNativeThunks.test.ts
@@ -4,6 +4,7 @@ import { messageSystemInitialState } from '@suite-common/message-system';
 import { buildStakeData } from '@suite-common/staking';
 import { type TrezorDevice } from '@suite-common/suite-types';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { WALLET_SDK_SOURCE_MOBILE } from '@suite-common/wallet-constants';
 import { prepareSendFormReducer } from '@suite-common/wallet-core';
 import {
@@ -92,13 +93,16 @@ jest.mock('@suite-native/device-mutex', () => ({
 }));
 
 const STATIC_SESSION_ID: StaticSessionId = '1stTestnetAddress@device_id:0';
+const ethSymbol = asNetworkSymbol('eth');
+const solSymbol = asNetworkSymbol('sol');
+const adaSymbol = asNetworkSymbol('ada');
 const ETH_ACCOUNT_KEY = mockAccountKey({
-    symbol: 'eth',
+    symbol: ethSymbol,
     descriptor: 'eth1',
     deviceStaticSessionId: STATIC_SESSION_ID,
 });
 const SOL_ACCOUNT_KEY = mockAccountKey({
-    symbol: 'sol',
+    symbol: solSymbol,
     descriptor: 'sol1',
     deviceStaticSessionId: STATIC_SESSION_ID,
 });
@@ -333,7 +337,7 @@ describe('signStakeTransactionNativeThunk', () => {
 
     it('rejects for unsupported networkType (cardano)', async () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-        const ada1Key = mockAccountKey({ symbol: 'ada', descriptor: 'ada1' });
+        const ada1Key = mockAccountKey({ symbol: adaSymbol, descriptor: 'ada1' });
         const cardanoAccount = {
             ...solAccount,
             symbol: 'ada',

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputItemList.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
@@ -5,6 +6,8 @@ import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { ReviewOutputItemList, type ReviewOutputItemListProps } from './ReviewOutputItemList';
 import { ETH_ACCOUNT_KEY, SOL_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 import { type ReviewSummaryOutput, type StatefulReviewOutput } from '../../types';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 let mockSelectTransactionReviewOutputsFromDraftReturnValue: StatefulReviewOutput[] | null;
 let mockSelectIsTransactionAlreadySignedValue: boolean;
@@ -52,7 +55,7 @@ describe('ReviewOutputItemList', () => {
 
     it('should render Error when account is not found', () => {
         const { getByText } = renderReviewOutputItemList({
-            accountKey: mockAccountKey({ symbol: 'btc', descriptor: 'btcAccount3' }),
+            accountKey: mockAccountKey({ symbol: btcSymbol, descriptor: 'btcAccount3' }),
         });
 
         expect(

--- a/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
+++ b/suite-native/transaction-management/src/components/ReviewOutputItemList/ReviewOutputSummaryItem.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress } from '@suite-common/wallet-types';
 import { Text as MockText } from '@suite-native/atoms';
 import { getTranslation } from '@suite-native/intl';
@@ -8,6 +9,9 @@ import {
     type ReviewOutputSummaryItemProps,
 } from './ReviewOutputSummaryItem';
 import { ETH_ACCOUNT_KEY } from '../../__fixtures__/walletState';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 const mockSelectIsClearSignedTradingSwap = jest.fn();
 jest.mock('../../selectors', () => ({
@@ -35,7 +39,7 @@ describe('ReviewOutputSummaryItem', () => {
         renderWithStoreProvider(
             <ReviewOutputSummaryItem
                 accountKey={ETH_ACCOUNT_KEY}
-                symbol="btc"
+                symbol={btcSymbol}
                 onLayout={jest.fn()}
                 prefix="trading-buy"
                 {...props}
@@ -86,7 +90,7 @@ describe('ReviewOutputSummaryItem', () => {
                 fee: '10',
                 state: 'active',
             },
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(
@@ -117,7 +121,7 @@ describe('ReviewOutputSummaryItem', () => {
                 fee: '10',
                 state: 'active',
             },
-            symbol: 'eth',
+            symbol: ethSymbol,
             flowType,
         });
 
@@ -140,7 +144,7 @@ describe('ReviewOutputSummaryItem', () => {
                 fee: '10',
                 state: 'active',
             },
-            symbol: 'eth',
+            symbol: ethSymbol,
             tokenContract: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as TokenAddress,
         });
 
@@ -170,7 +174,7 @@ describe('ReviewOutputSummaryItem', () => {
                 fee: '10',
                 state: 'active',
             },
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(

--- a/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/CustomFee/CustomFeeInputs.test.tsx
@@ -1,4 +1,4 @@
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
@@ -24,11 +24,14 @@ const mockSelectConvertedNetworkFeeInfo = jest.requireMock(
     '@suite-common/wallet-core',
 ).selectConvertedNetworkFeeInfo;
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
 describe('CustomFeeInputs', () => {
     let store: TestStore;
 
     const defaultProps = {
-        symbol: 'btc' as NetworkSymbol,
+        symbol: btcSymbol,
     };
     const defaultState = {
         wallet: getWalletState(),
@@ -95,7 +98,7 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'eth' },
+                props: { symbol: ethSymbol },
             });
 
             expect(
@@ -110,7 +113,7 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { getByText, getByTestId } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'eth' },
+                props: { symbol: ethSymbol },
             });
 
             expect(
@@ -125,7 +128,7 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { queryByText, queryByTestId } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'btc' },
+                props: { symbol: btcSymbol },
             });
             expect(
                 queryByText(
@@ -139,13 +142,13 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { getByText } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'btc' },
+                props: { symbol: btcSymbol },
             });
             expect(getByText('sat/vB')).toBeTruthy();
 
             const { getByText: getByText2 } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'eth' },
+                props: { symbol: ethSymbol },
             });
             expect(getByText2('Gwei')).toBeTruthy();
         });
@@ -154,7 +157,7 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { getByText } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'btc' },
+                props: { symbol: btcSymbol },
             });
             expect(
                 getByText(
@@ -169,7 +172,7 @@ describe('CustomFeeInputs', () => {
             const form = renderUseFeesForm();
             const { queryByText } = renderCustomFeeInputs({
                 form,
-                props: { symbol: 'eth' },
+                props: { symbol: ethSymbol },
             });
             expect(
                 queryByText(

--- a/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeOptionList/FeeOptionsList.test.tsx
@@ -1,6 +1,6 @@
 import { type StateFromReducersMapObject, combineReducers } from '@reduxjs/toolkit';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
 import { Form } from '@suite-native/forms';
@@ -33,6 +33,9 @@ const mockSelectConvertedNetworkFeeLevelFeePerUnit = jest.requireMock(
     '@suite-common/wallet-core',
 ).selectConvertedNetworkFeeLevelFeePerUnit;
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
 describe('FeeOptionsList', () => {
     const createMockFeeLevels = () =>
         createFeeLevels({
@@ -43,7 +46,7 @@ describe('FeeOptionsList', () => {
 
     const defaultProps = {
         feeLevels: createMockFeeLevels(),
-        symbol: 'eth' as NetworkSymbol,
+        symbol: ethSymbol,
         isLoading: false,
         onSelectedFeeLevel: jest.fn(),
     };
@@ -146,7 +149,7 @@ describe('FeeOptionsList', () => {
             };
 
             const { getByText, queryByText } = renderFeeOptionsList({
-                props: { feeLevels, symbol: 'btc' },
+                props: { feeLevels, symbol: btcSymbol },
             });
 
             expect(getByText(/Low/)).toBeTruthy();

--- a/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSelectorRow.test.tsx
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FormState } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
@@ -6,6 +7,7 @@ import { FeeSelectorRow } from './FeeSelectorRow';
 import { BTC_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 
 const noopThunk = jest.fn();
+const btcSymbol = asNetworkSymbol('btc');
 
 describe('FeeSelectorRow', () => {
     const getPreloadedState = () => ({
@@ -36,7 +38,10 @@ describe('FeeSelectorRow', () => {
     });
 
     it('should render nothing when the account is not in the store', () => {
-        const missingAccountKey = mockAccountKey({ symbol: 'btc', descriptor: 'unknownAccount' });
+        const missingAccountKey = mockAccountKey({
+            symbol: btcSymbol,
+            descriptor: 'unknownAccount',
+        });
 
         const { toJSON } = renderWithStoreProvider(
             <FeeSelectorRow

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryCard.test.tsx
@@ -1,12 +1,16 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { FeeSummaryCard, type FeeSummaryCardProps } from './FeeSummaryCard';
 import { getWalletState } from '../../__fixtures__/walletState';
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
 const defaultProps: FeeSummaryCardProps = {
     fee: '1000',
-    symbol: 'btc',
+    symbol: btcSymbol,
     networkType: 'bitcoin',
     areFeesLoading: false,
     onPress: jest.fn(),
@@ -32,7 +36,7 @@ describe('FeeSummaryCard', () => {
     });
 
     it('should render ethereum-specific label for ethereum network', () => {
-        const { getByText } = renderCard({ networkType: 'ethereum', symbol: 'eth' });
+        const { getByText } = renderCard({ networkType: 'ethereum', symbol: ethSymbol });
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),

--- a/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeeSummaryRow.test.tsx
@@ -1,12 +1,16 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { FeeSummaryRow, type FeeSummaryRowProps } from './FeeSummaryRow';
 import { getWalletState } from '../../__fixtures__/walletState';
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
 const defaultProps: FeeSummaryRowProps = {
     fee: '1000',
-    symbol: 'btc',
+    symbol: btcSymbol,
     networkType: 'bitcoin',
     areFeesLoading: false,
 };
@@ -30,7 +34,7 @@ describe('FeeSummaryRow', () => {
     });
 
     it('should render ethereum-specific label for ethereum network', () => {
-        const { getByText } = renderRow({ networkType: 'ethereum', symbol: 'eth' });
+        const { getByText } = renderRow({ networkType: 'ethereum', symbol: ethSymbol });
 
         expect(
             getByText(getTranslation('transactionManagement.fees.description.title.ethereum')),

--- a/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/FeesContent.test.tsx
@@ -1,4 +1,5 @@
 import { yup } from '@suite-common/validators';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FormState } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { Form, useForm } from '@suite-native/forms';
@@ -8,6 +9,9 @@ import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 import { FeesContent, type FeesContentProps } from './FeesContent';
 import { createFeeLevels } from '../../__fixtures__/feeLevels';
 import { getWalletState } from '../../__fixtures__/walletState';
+
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 // Create a simple validation schema for testing
 const testValidationSchema = yup.object({
@@ -31,7 +35,7 @@ const TestFormWrapper = ({ children }: { children: React.ReactNode }) => {
 };
 
 describe('FeesContent', () => {
-    const accountKey = mockAccountKey({ symbol: 'btc', descriptor: 'btc1' });
+    const accountKey = mockAccountKey({ symbol: btcSymbol, descriptor: 'btc1' });
     const mockOnSelectedFeeLevel = jest.fn();
     const mockOnCustomFeeSet = jest.fn();
 
@@ -45,7 +49,7 @@ describe('FeesContent', () => {
     const defaultProps: FeesContentProps = {
         selectedFeeLevel: 'normal',
         feeLevels: createMockFeeLevels(),
-        symbol: 'btc',
+        symbol: btcSymbol,
         networkType: 'bitcoin',
         accountKey,
         areFeesLoading: false,
@@ -126,7 +130,7 @@ describe('FeesContent', () => {
 
     it('should work with different network symbols', () => {
         const { getByText } = renderFeesContent({
-            symbol: 'eth',
+            symbol: ethSymbol,
         });
 
         expect(

--- a/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
+++ b/suite-native/transaction-management/src/components/fees/TronFeeSummaryCard/TronFeeSummaryRow.test.tsx
@@ -1,11 +1,14 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { renderWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { TronFeeSummaryRow, type TronFeeSummaryRowProps } from './TronFeeSummaryRow';
 import { getWalletState } from '../../../__fixtures__/walletState';
 
+const trxSymbol = asNetworkSymbol('trx');
+
 const defaultProps: TronFeeSummaryRowProps = {
-    symbol: 'trx',
+    symbol: trxSymbol,
     networkType: 'tron',
     supportsAdjustableFees: false,
     trxBurned: '1000000',

--- a/suite-native/transaction-management/src/feesFormSchema.test.ts
+++ b/suite-native/transaction-management/src/feesFormSchema.test.ts
@@ -1,10 +1,14 @@
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { type FeesFormContext, feesFormValidationSchema } from './feesFormSchema';
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+const adaSymbol = asNetworkSymbol('ada');
+
 describe('feesFormValidationSchema', () => {
     const createContext = (overrides: Partial<FeesFormContext> = {}): FeesFormContext => ({
-        symbol: 'eth' as NetworkSymbol,
+        symbol: ethSymbol,
         isEip1559Fee: false,
         networkFeeInfo: {
             minFee: 100,
@@ -38,7 +42,7 @@ describe('feesFormValidationSchema', () => {
                 customFeePerUnit: '100.50',
                 customFeeLimit: '1000',
             };
-            const context = createContext({ symbol: 'btc' });
+            const context = createContext({ symbol: btcSymbol });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -83,7 +87,7 @@ describe('feesFormValidationSchema', () => {
                 customFeePerUnit: '100.50', // Valid for Bitcoin (2 decimals)
                 customFeeLimit: '1000',
             };
-            const context = createContext({ symbol: 'btc', minimalFeeLimit: '21000' });
+            const context = createContext({ symbol: btcSymbol, minimalFeeLimit: '21000' });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -94,7 +98,7 @@ describe('feesFormValidationSchema', () => {
     describe('decimals validation', () => {
         it('should accept correct decimals for bitcoin', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.50' };
-            const context = createContext({ symbol: 'btc' });
+            const context = createContext({ symbol: btcSymbol });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,
@@ -103,7 +107,10 @@ describe('feesFormValidationSchema', () => {
 
         it('should reject too many decimals for bitcoin', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.123' };
-            const context = createContext({ symbol: 'btc', translate: () => 'Too many decimals.' });
+            const context = createContext({
+                symbol: btcSymbol,
+                translate: () => 'Too many decimals.',
+            });
 
             await expect(feesFormValidationSchema.validate(data, { context })).rejects.toThrow(
                 'Too many decimals.',
@@ -112,7 +119,7 @@ describe('feesFormValidationSchema', () => {
 
         it('should pass for non-bitcoin/ethereum networks', async () => {
             const data = { feeLevel: 'custom', customFeePerUnit: '100.123456789012345' };
-            const context = createContext({ symbol: 'ada' });
+            const context = createContext({ symbol: adaSymbol });
 
             await expect(feesFormValidationSchema.validate(data, { context })).resolves.toEqual(
                 data,

--- a/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesFetching.test.ts
@@ -1,4 +1,4 @@
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FeesStatus } from '@suite-common/wallet-types';
 import {
     type TestStore,
@@ -21,6 +21,7 @@ jest.mock('@suite-common/wallet-core', () => ({
 const mockUseFetchFeesOnce = jest.requireMock('@suite-common/wallet-core').useFetchFeesOnce;
 const mockUseRefetchFees = jest.requireMock('@suite-common/wallet-core').useRefetchFees;
 const mockSelectAreFeesLoading = jest.requireMock('@suite-common/wallet-core').selectAreFeesLoading;
+const btcSymbol = asNetworkSymbol('btc');
 
 // Add fees to the wallet state for testing
 const getWalletStateWithFees = () => ({
@@ -64,12 +65,12 @@ describe('useFeesFetching', () => {
 
     it('should select account by key from state', () => {
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({ store, networkSymbol: 'btc' });
+        const { result } = renderUseFeesFetching({ store, networkSymbol: btcSymbol });
 
         expect(result.current.areFeesLoading).toBe(false);
-        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
+        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: btcSymbol });
         expect(mockUseRefetchFees).toHaveBeenCalledWith({
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             isDisabled: false,
         });
     });
@@ -77,12 +78,12 @@ describe('useFeesFetching', () => {
     it('should handle loading state correctly', () => {
         mockSelectAreFeesLoading.mockReturnValue(true);
         const store = createStoreFromPreloadedState(createMockState());
-        const { result } = renderUseFeesFetching({ store, networkSymbol: 'btc' });
+        const { result } = renderUseFeesFetching({ store, networkSymbol: btcSymbol });
 
         expect(result.current.areFeesLoading).toBe(true);
-        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
+        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: btcSymbol });
         expect(mockUseRefetchFees).toHaveBeenCalledWith({
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             isDisabled: false,
         });
     });
@@ -91,14 +92,14 @@ describe('useFeesFetching', () => {
         const store = createStoreFromPreloadedState(createMockState());
         const { result } = renderUseFeesFetching({
             store,
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             isRefetchDisabled: true,
         });
 
         expect(result.current.areFeesLoading).toBe(false);
-        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: 'btc' });
+        expect(mockUseFetchFeesOnce).toHaveBeenCalledWith({ networkSymbol: btcSymbol });
         expect(mockUseRefetchFees).toHaveBeenCalledWith({
-            networkSymbol: 'btc',
+            networkSymbol: btcSymbol,
             isDisabled: true,
         });
     });

--- a/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useFeesForm.test.ts
@@ -1,9 +1,11 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
 import { type UseFeesFormProps, useFeesForm } from './useFeesForm';
 
-const ETH_ACCOUNT_KEY = mockAccountKey({ symbol: 'eth', descriptor: 'eth1' });
+const ethSymbol = asNetworkSymbol('eth');
+const ETH_ACCOUNT_KEY = mockAccountKey({ symbol: ethSymbol, descriptor: 'eth1' });
 
 describe('useFeesForm', () => {
     const mockProps: UseFeesFormProps = {
@@ -53,7 +55,7 @@ describe('useFeesForm', () => {
                     },
                     accounts: [
                         {
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             networkType: 'ethereum',
                             key: ETH_ACCOUNT_KEY,
                             path: "m/44'/60'/0'/0/0",
@@ -119,7 +121,7 @@ describe('useFeesForm', () => {
                     },
                     accounts: [
                         {
-                            symbol: 'eth',
+                            symbol: ethSymbol,
                             networkType: 'ethereum',
                             key: ETH_ACCOUNT_KEY,
                             path: "m/44'/60'/0'/0/0",

--- a/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
+++ b/suite-native/transaction-management/src/hooks/fees/useTronFeeBreakdown.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { renderHookWithStoreProvider } from '@suite-native/test-utils-store';
@@ -6,8 +7,10 @@ import { useTronFeeBreakdown } from './useTronFeeBreakdown';
 import { ETH_ACCOUNT_KEY, getWalletState } from '../../__fixtures__/walletState';
 
 const TRON_ACCOUNT_DESCRIPTOR = 'TRX1234567890abcdefghijklmnopqrstuvwxyz';
+const trxSymbol = asNetworkSymbol('trx');
+const btcSymbol = asNetworkSymbol('btc');
 const TRON_ACCOUNT_KEY = mockAccountKey({
-    symbol: 'trx',
+    symbol: trxSymbol,
     descriptor: TRON_ACCOUNT_DESCRIPTOR,
 });
 
@@ -17,7 +20,7 @@ const getTronAccount = () =>
         accountLabel: 'Tron #1',
         descriptor: TRON_ACCOUNT_DESCRIPTOR,
         accountType: 'normal',
-        symbol: 'trx',
+        symbol: trxSymbol,
         networkType: 'tron',
         balance: '5000000000',
         availableBalance: '5000000000',
@@ -57,7 +60,10 @@ describe('useTronFeeBreakdown', () => {
         const { result } = renderHookWithStoreProvider(
             () =>
                 useTronFeeBreakdown({
-                    accountKey: mockAccountKey({ symbol: 'btc', descriptor: 'nonExistent' }),
+                    accountKey: mockAccountKey({
+                        symbol: btcSymbol,
+                        descriptor: 'nonExistent',
+                    }),
                 }),
             { preloadedState: getPreloadedStateWith() },
         );

--- a/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
+++ b/suite-native/transaction-management/src/hooks/useIsNetworkReserveBannerVisible.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { localeReducer } from '@suite-native/intl';
 import {
@@ -10,6 +11,10 @@ import {
 } from '@suite-native/test-utils-store';
 
 import { useIsNetworkReserveBannerVisible } from './useIsNetworkReserveBannerVisible';
+
+const solSymbol = asNetworkSymbol('sol');
+const btcSymbol = asNetworkSymbol('btc');
+const baseSymbol = asNetworkSymbol('base');
 
 // SOL nativeTokenReserve: "0.003"; base: "0.0002"
 describe('useIsNetworkReserveBannerVisible', () => {
@@ -36,13 +41,13 @@ describe('useIsNetworkReserveBannerVisible', () => {
         expect(renderHook({ symbol: undefined, amount: '1', balance: '2' }).result.current).toBe(
             false,
         );
-        expect(renderHook({ symbol: 'sol', amount: null, balance: '1' }).result.current).toBe(
+        expect(renderHook({ symbol: solSymbol, amount: null, balance: '1' }).result.current).toBe(
             false,
         );
-        expect(renderHook({ symbol: 'sol', amount: '1', balance: null }).result.current).toBe(
+        expect(renderHook({ symbol: solSymbol, amount: '1', balance: null }).result.current).toBe(
             false,
         );
-        expect(renderHook({ symbol: 'btc', amount: '0.5', balance: '1' }).result.current).toBe(
+        expect(renderHook({ symbol: btcSymbol, amount: '0.5', balance: '1' }).result.current).toBe(
             false,
         );
     });
@@ -50,7 +55,7 @@ describe('useIsNetworkReserveBannerVisible', () => {
     it('returns false for tokens (contractAddress set)', () => {
         expect(
             renderHook({
-                symbol: 'sol',
+                symbol: solSymbol,
                 contractAddress: 'some-token-contract',
                 amount: '0.998',
                 balance: '1.0',
@@ -60,29 +65,29 @@ describe('useIsNetworkReserveBannerVisible', () => {
 
     it('shows banner when remainder is at or below static network reserve (no maxAmount)', () => {
         // remainder = 1.0 - 0.997 = 0.003 = SOL reserve
-        expect(renderHook({ symbol: 'sol', amount: '0.997', balance: '1.0' }).result.current).toBe(
-            true,
-        );
+        expect(
+            renderHook({ symbol: solSymbol, amount: '0.997', balance: '1.0' }).result.current,
+        ).toBe(true);
         // remainder = 1.0 - 0.998 = 0.002 < 0.003
-        expect(renderHook({ symbol: 'sol', amount: '0.998', balance: '1.0' }).result.current).toBe(
-            true,
-        );
+        expect(
+            renderHook({ symbol: solSymbol, amount: '0.998', balance: '1.0' }).result.current,
+        ).toBe(true);
     });
 
     it('hides banner when amount is below reserve zone', () => {
-        expect(renderHook({ symbol: 'sol', amount: '0.5', balance: '1.0' }).result.current).toBe(
-            false,
-        );
+        expect(
+            renderHook({ symbol: solSymbol, amount: '0.5', balance: '1.0' }).result.current,
+        ).toBe(false);
     });
 
     it('hides banner when amount exceeds balance', () => {
-        expect(renderHook({ symbol: 'sol', amount: '1.1', balance: '1.0' }).result.current).toBe(
-            false,
-        );
+        expect(
+            renderHook({ symbol: solSymbol, amount: '1.1', balance: '1.0' }).result.current,
+        ).toBe(false);
     });
 
     it('hides banner for zero amount', () => {
-        expect(renderHook({ symbol: 'sol', amount: '0', balance: '1.0' }).result.current).toBe(
+        expect(renderHook({ symbol: solSymbol, amount: '0', balance: '1.0' }).result.current).toBe(
             false,
         );
     });
@@ -91,7 +96,7 @@ describe('useIsNetworkReserveBannerVisible', () => {
         // feeWithReserve = balance - maxAmount = 0.01; remainder = 0.01
         expect(
             renderHook({
-                symbol: 'sol',
+                symbol: solSymbol,
                 amount: '0.99',
                 balance: '1.0',
                 maxAmount: '0.99',
@@ -102,7 +107,7 @@ describe('useIsNetworkReserveBannerVisible', () => {
     it('hides banner when below composed maxAmount threshold', () => {
         expect(
             renderHook({
-                symbol: 'sol',
+                symbol: solSymbol,
                 amount: '0.5',
                 balance: '1.0',
                 maxAmount: '0.99',
@@ -113,7 +118,7 @@ describe('useIsNetworkReserveBannerVisible', () => {
     it('shows banner on base network at reserve boundary', () => {
         // remainder = 0.1 - 0.0999 = 0.0001 <= base reserve 0.0002
         expect(
-            renderHook({ symbol: 'base', amount: '0.0999', balance: '0.1' }).result.current,
+            renderHook({ symbol: baseSymbol, amount: '0.0999', balance: '0.1' }).result.current,
         ).toBe(true);
     });
 });

--- a/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
+++ b/suite-native/transaction-management/src/hooks/useMaxSpendableAmount.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FormState, type TokenAddress } from '@suite-common/wallet-types';
 import { renderHookWithStoreProvider, waitFor } from '@suite-native/test-utils-store';
 
@@ -5,6 +6,8 @@ import { useMaxSpendableAmount } from './useMaxSpendableAmount';
 import { BTC_ACCOUNT_KEY, ETH_ACCOUNT_KEY, getWalletState } from '../__fixtures__/walletState';
 
 const mockCalculateFeeLevelsMaxAmountThunk = jest.fn();
+const btcSymbol = asNetworkSymbol('btc');
+const etcSymbol = asNetworkSymbol('etc');
 
 jest.mock('../thunks', () => ({
     ...jest.requireActual('../thunks'),
@@ -100,7 +103,7 @@ describe('useMaxSpendableAmount', () => {
         const { result } = renderUseMaxSpendableAmount({
             accountKey: ethAccountKey,
             tokenContract: usdcTokenContract,
-            symbol: 'etc',
+            symbol: etcSymbol,
         });
 
         await waitFor(() => {
@@ -114,7 +117,7 @@ describe('useMaxSpendableAmount', () => {
         mockMaxAmountThunkResult({ normal: '0.009', economy: '0.008' });
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
-            symbol: 'btc',
+            symbol: btcSymbol,
         });
 
         await waitFor(() => {
@@ -128,7 +131,7 @@ describe('useMaxSpendableAmount', () => {
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
             formState: customFormState,
-            symbol: 'btc',
+            symbol: btcSymbol,
         });
 
         await waitFor(() => {
@@ -148,7 +151,7 @@ describe('useMaxSpendableAmount', () => {
 
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
-            symbol: 'btc',
+            symbol: btcSymbol,
         });
 
         await waitFor(() => {
@@ -159,7 +162,7 @@ describe('useMaxSpendableAmount', () => {
     it('should skip native asset calculation when calculation is disabled', () => {
         const { result } = renderUseMaxSpendableAmount({
             accountKey: btcAccountKey,
-            symbol: 'btc',
+            symbol: btcSymbol,
             enabled: false,
         });
 

--- a/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
+++ b/suite-native/transaction-management/src/hooks/usePrecomposedTransactionError.test.tsx
@@ -1,6 +1,6 @@
 import { Text } from 'react-native';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { getTranslation } from '@suite-native/intl';
 import { renderHookWithBasicProvider, renderWithBasicProvider } from '@suite-native/test-utils';
 
@@ -9,6 +9,9 @@ import {
     usePrecomposedTransactionError,
 } from './usePrecomposedTransactionError';
 
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
+
 const ErrorText = (props: UsePrecomposedTransactionErrorProps) => {
     const msg = usePrecomposedTransactionError(props);
 
@@ -16,7 +19,7 @@ const ErrorText = (props: UsePrecomposedTransactionErrorProps) => {
 };
 
 describe('usePrecomposedTransactionError', () => {
-    const networkSymbol = 'btc' as NetworkSymbol;
+    const networkSymbol = btcSymbol;
     const networkDisplaySymbol = 'BTC';
 
     beforeEach(() => {
@@ -111,7 +114,7 @@ describe('usePrecomposedTransactionError', () => {
 
     it('should handle different network symbols', () => {
         const { getByText } = renderWithBasicProvider(
-            <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" networkSymbol="eth" />,
+            <ErrorText error="AMOUNT_NOT_ENOUGH_CURRENCY_FEE" networkSymbol={ethSymbol} />,
         );
 
         expect(

--- a/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
+++ b/suite-native/transaction-management/src/hooks/useTransactionDetails.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { explorerInitialState } from '@suite-common/wallet-core';
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { act } from '@suite-native/test-utils';
@@ -7,12 +8,14 @@ import { type WalletAccountTransaction, mockTransaction } from '@suite-native/to
 import { useTransactionDetails } from './useTransactionDetails';
 
 const mockOpenLink = jest.fn();
+const btcSymbol = asNetworkSymbol('btc');
+const ethSymbol = asNetworkSymbol('eth');
 
 jest.mock('@suite-native/link', () => ({
     useOpenLink: () => mockOpenLink,
 }));
 
-const ACCOUNT_KEY = mockAccountKey({ symbol: 'btc', descriptor: 'testDescriptor' });
+const ACCOUNT_KEY = mockAccountKey({ symbol: btcSymbol, descriptor: 'testDescriptor' });
 const TXID = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
 const TOKEN_CONTRACT = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 
@@ -25,7 +28,7 @@ const pendingTransaction: WalletAccountTransaction = {
 
 const transactionWithToken: WalletAccountTransaction = {
     ...confirmedTransaction,
-    symbol: 'eth',
+    symbol: ethSymbol,
     tokens: [
         {
             contract: TOKEN_CONTRACT,

--- a/suite-native/transaction-management/src/selectors.test.ts
+++ b/suite-native/transaction-management/src/selectors.test.ts
@@ -1,3 +1,4 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FeeLevelLabel, type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
 import { isClearSignedEvmTradingSwapTransaction } from '@suite-common/wallet-utils';
 
@@ -12,6 +13,8 @@ import {
     selectIsTransactionAlreadySigned,
 } from './selectors';
 import { type NativeSendRootState } from './sendFormSlice';
+
+const btcSymbol = asNetworkSymbol('btc');
 
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),
@@ -171,7 +174,9 @@ describe('transaction-management selectors', () => {
         });
 
         it('should be true when wallet.send.serializedTx is defined', () => {
-            const state = createMockState({ serializedTx: { tx: 'tx_data', symbol: 'btc' } });
+            const state = createMockState({
+                serializedTx: { tx: 'tx_data', symbol: btcSymbol },
+            });
 
             expect(selectIsTransactionAlreadySigned(state)).toBe(true);
         });

--- a/suite-native/transaction-management/src/utils.test.ts
+++ b/suite-native/transaction-management/src/utils.test.ts
@@ -1,35 +1,39 @@
-import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { getFeeDecimals, getFeeValue } from './utils';
+
+const btcSymbol = asNetworkSymbol('btc');
+const adaSymbol = asNetworkSymbol('ada');
+const solSymbol = asNetworkSymbol('sol');
 
 describe('utils', () => {
     describe('getFeeDecimals', () => {
         it.each(['eth', 'pol', 'bsc', 'arb', 'base', 'op', 'etc', 'tsep', 'thod'])(
             'should return 9 decimals for Ethereum network: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: symbol as NetworkSymbol })).toBe(9);
+                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBe(9);
             },
         );
 
         it.each(['btc', 'ltc', 'bch', 'doge', 'zec', 'test', 'regtest'])(
             'should return 2 decimals for Bitcoin network: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: symbol as NetworkSymbol })).toBe(2);
+                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBe(2);
             },
         );
 
         it.each(['ada', 'sol', 'xrp', 'xlm', 'dsol', 'txrp', 'txlm'])(
             'should return null for other network type: %s',
             symbol => {
-                expect(getFeeDecimals({ symbol: symbol as NetworkSymbol })).toBeNull();
+                expect(getFeeDecimals({ symbol: asNetworkSymbol(symbol) })).toBeNull();
             },
         );
     });
 
     describe('getFeeValue', () => {
         it('should return undefined when feeRate or symbol is missing', () => {
-            expect(getFeeValue({ feeRate: undefined, symbol: 'btc' })).toBeUndefined();
-            expect(getFeeValue({ feeRate: '', symbol: 'btc' })).toBeUndefined();
+            expect(getFeeValue({ feeRate: undefined, symbol: btcSymbol })).toBeUndefined();
+            expect(getFeeValue({ feeRate: '', symbol: btcSymbol })).toBeUndefined();
             expect(getFeeValue({ feeRate: '100', symbol: undefined })).toBeUndefined();
         });
 
@@ -40,7 +44,7 @@ describe('utils', () => {
         ])(
             'should round down Bitcoin fees to 2 decimals: %s -> %s (%s)',
             (feeRate, symbol, expected) => {
-                expect(getFeeValue({ feeRate, symbol: symbol as NetworkSymbol })).toBe(expected);
+                expect(getFeeValue({ feeRate, symbol: asNetworkSymbol(symbol) })).toBe(expected);
             },
         );
 
@@ -51,15 +55,15 @@ describe('utils', () => {
         ])(
             'should round down Ethereum fees to 9 decimals: %s -> %s (%s)',
             (feeRate, symbol, expected) => {
-                expect(getFeeValue({ feeRate, symbol: symbol as NetworkSymbol })).toBe(expected);
+                expect(getFeeValue({ feeRate, symbol: asNetworkSymbol(symbol) })).toBe(expected);
             },
         );
 
         it('should return original value for networks without decimal limits', () => {
-            expect(getFeeValue({ feeRate: '100.123456789012345', symbol: 'ada' })).toBe(
+            expect(getFeeValue({ feeRate: '100.123456789012345', symbol: adaSymbol })).toBe(
                 '100.123456789012345',
             );
-            expect(getFeeValue({ feeRate: '0.000000000000001', symbol: 'sol' })).toBe(
+            expect(getFeeValue({ feeRate: '0.000000000000001', symbol: solSymbol })).toBe(
                 '0.000000000000001',
             );
         });
@@ -67,7 +71,7 @@ describe('utils', () => {
         it.each(['btc', 'ltc', 'bch', 'doge', 'zec', 'test', 'regtest'])(
             'should work consistently for Bitcoin network variant: %s',
             symbol => {
-                expect(getFeeValue({ feeRate: '100.999', symbol: symbol as NetworkSymbol })).toBe(
+                expect(getFeeValue({ feeRate: '100.999', symbol: asNetworkSymbol(symbol) })).toBe(
                     '100.99',
                 );
             },
@@ -79,7 +83,7 @@ describe('utils', () => {
                 expect(
                     getFeeValue({
                         feeRate: '100.9999999999999',
-                        symbol: symbol as NetworkSymbol,
+                        symbol: asNetworkSymbol(symbol),
                     }),
                 ).toBe('100.999999999');
             },

--- a/suite/coinjoin/src/coinjoinClientActions.test.ts
+++ b/suite/coinjoin/src/coinjoinClientActions.test.ts
@@ -11,6 +11,7 @@ import {
     initPreloadedState,
     testMocks,
 } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { prepareAccountsReducer, prepareWalletSettingsReducer } from '@suite-common/wallet-core';
 import '@suite-common/test-utils/globalOverrides';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
@@ -42,6 +43,10 @@ jest.mock('./coinjoinService', () => {
 const messageSystemReducer = prepareMessageSystemReducer(extraDependenciesCommonMock);
 
 const walletSettingsReducer = prepareWalletSettingsReducer(extraDependenciesCommonMock);
+const btcSymbol = asNetworkSymbol('btc');
+const testSymbol = asNetworkSymbol('test');
+const regtestSymbol = asNetworkSymbol('regtest');
+const ltcSymbol = asNetworkSymbol('ltc');
 
 const rootReducer = combineReducers({
     suite: createReducer({}, () => ({})),
@@ -215,8 +220,8 @@ describe('coinjoinClientActions', () => {
         } as any); // partial required state
 
         const spy = jest.spyOn(CoinjoinService, 'createInstance');
-        const cli1 = await store.dispatch(initCoinjoinService('btc'));
-        const cli2 = await store.dispatch(initCoinjoinService('btc'));
+        const cli1 = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli2 = await store.dispatch(initCoinjoinService(btcSymbol));
         expect(cli1).toEqual(cli2);
         expect(spy.mock.calls[0]?.[0]).toMatchObject({
             symbol: 'btc',
@@ -239,16 +244,16 @@ describe('coinjoinClientActions', () => {
 
         // for coverage, init same instance multiple times without waiting
         // eslint-disable-next-line jest/valid-expect-in-promise
-        store.dispatch(initCoinjoinService('test')).then(cli3 => {
+        store.dispatch(initCoinjoinService(testSymbol)).then(cli3 => {
             expect(cli3?.client.settings.network).toEqual('test');
         });
-        const cli3a = await store.dispatch(initCoinjoinService('test'));
+        const cli3a = await store.dispatch(initCoinjoinService(testSymbol));
         expect(cli3a).toBe(undefined); // undefined because cli3 is not loaded yet
     });
 
     it('initCoinjoinService and throw error', async () => {
         const store = initStore();
-        const cli = await store.dispatch(initCoinjoinService('ltc')); // ltc not supported
+        const cli = await store.dispatch(initCoinjoinService(ltcSymbol)); // ltc not supported
         expect(cli).toBe(undefined);
     });
 
@@ -262,7 +267,7 @@ describe('coinjoinClientActions', () => {
                     },
                 }) as any,
         );
-        const cli = await store.dispatch(initCoinjoinService('btc'));
+        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
         expect(cli).toBe(undefined);
         spy.mockClear();
     });
@@ -271,7 +276,7 @@ describe('coinjoinClientActions', () => {
         it(`CoinjoinClient events: ${f.description}`, async () => {
             const store = initStore(f.state as Wallet);
 
-            const cli = await store.dispatch(initCoinjoinService('btc'));
+            const cli = await store.dispatch(initCoinjoinService(btcSymbol));
             cli?.client.emit(f.event as any, f.params);
 
             expect(store.getState().wallet.coinjoin).toMatchObject(f.result);
@@ -282,18 +287,22 @@ describe('coinjoinClientActions', () => {
         const store = initStore();
         expect(store.getState().wallet.coinjoin.debug).toBeUndefined();
 
-        store.dispatch(setDebugSettings({ coinjoinServerEnvironment: { test: 'public' } }));
+        store.dispatch(setDebugSettings({ coinjoinServerEnvironment: { [testSymbol]: 'public' } }));
 
         expect(store.getState().wallet.coinjoin.debug).toMatchObject({
             coinjoinServerEnvironment: { test: 'public' },
         });
 
-        store.dispatch(setDebugSettings({ coinjoinServerEnvironment: { regtest: 'localhost' } }));
+        store.dispatch(
+            setDebugSettings({ coinjoinServerEnvironment: { [regtestSymbol]: 'localhost' } }),
+        );
         expect(store.getState().wallet.coinjoin.debug).toMatchObject({
             coinjoinServerEnvironment: { test: 'public', regtest: 'localhost' },
         });
 
-        store.dispatch(setDebugSettings({ coinjoinServerEnvironment: { test: 'staging' } }));
+        store.dispatch(
+            setDebugSettings({ coinjoinServerEnvironment: { [testSymbol]: 'staging' } }),
+        );
         expect(store.getState().wallet.coinjoin.debug).toMatchObject({
             coinjoinServerEnvironment: { test: 'staging', regtest: 'localhost' },
         });
@@ -302,8 +311,8 @@ describe('coinjoinClientActions', () => {
     it('clientEmitException', async () => {
         const store = initStore();
 
-        const cli1 = await store.dispatch(initCoinjoinService('btc'));
-        const cli2 = await store.dispatch(initCoinjoinService('test'));
+        const cli1 = await store.dispatch(initCoinjoinService(btcSymbol));
+        const cli2 = await store.dispatch(initCoinjoinService(testSymbol));
 
         if (!cli1 || !cli2) throw new Error('Client not initialized');
 
@@ -316,7 +325,7 @@ describe('coinjoinClientActions', () => {
             payload: 'Some exception',
         });
 
-        store.dispatch(clientEmitException('Other exception', { symbol: 'btc' }));
+        store.dispatch(clientEmitException('Other exception', { symbol: btcSymbol }));
 
         expect(cli1.client.emit).toHaveBeenCalledTimes(2);
         expect(cli2.client.emit).toHaveBeenCalledTimes(1);
@@ -327,7 +336,7 @@ describe('coinjoinClientActions', () => {
             deviceState: '1stTestnetAddress@device_id:0',
             accountType: 'coinjoin',
             descriptor: asAccountDescriptor('account1'),
-            symbol: 'btc',
+            symbol: asNetworkSymbol('btc'),
         });
 
         const initializeStore = () =>
@@ -346,7 +355,7 @@ describe('coinjoinClientActions', () => {
 
         const store = initializeStore();
 
-        const cli = await store.dispatch(initCoinjoinService('btc'));
+        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
 
         if (!cli) throw new Error('Client not initialized');
 
@@ -398,7 +407,7 @@ describe('coinjoinClientActions', () => {
 
         testMocks.setTrezorConnectFixtures([{ success: false }]);
 
-        await store.dispatch(initCoinjoinService('btc'));
+        await store.dispatch(initCoinjoinService(btcSymbol));
 
         store.dispatch(stopCoinjoinSession(accountAKey));
     });
@@ -419,7 +428,7 @@ describe('coinjoinClientActions', () => {
             { success: false, error: { message: 'Firmware error' } },
         ]);
 
-        await store.dispatch(initCoinjoinService('btc'));
+        await store.dispatch(initCoinjoinService(btcSymbol));
 
         store.dispatch(stopCoinjoinSession(accountAKey));
 
@@ -462,7 +471,7 @@ describe('coinjoinClientActions', () => {
             },
         } as any);
 
-        await store.dispatch(initCoinjoinService('btc'));
+        await store.dispatch(initCoinjoinService(btcSymbol));
 
         store.dispatch(stopCoinjoinSession(accountAKey));
 
@@ -471,7 +480,7 @@ describe('coinjoinClientActions', () => {
 
     it('CoinjoinClient events', async () => {
         const store = initStore();
-        const cli = await store.dispatch(initCoinjoinService('btc'));
+        const cli = await store.dispatch(initCoinjoinService(btcSymbol));
 
         // other requests are covered by fixtures.getOwnershipProof and fixtures.signCoinjoinTx
         cli?.client.emit('request', [{ type: 'unknown' } as any]);

--- a/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
+++ b/suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts
@@ -6,6 +6,7 @@ import {
     mnemonic12Fixtures,
 } from '@suite-common/e2e-evolu-client';
 import { asSuiteSyncOwnerSecretHex } from '@suite-common/suite-sync-storage';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor } from '@suite-common/wallet-types';
 import { asWalletDescriptor } from '@trezor/device-utils';
 
@@ -51,7 +52,7 @@ const expectedAccountLabelWalletOne = {
         asAccountDescriptor(
             'zpub6r4imip23CwVmWTfqudEXK2PKZaw2bn8PEC1tju3d4oxQMfLK1QME9aN2o8t7potfCfz6f8T4jNafTyBVfEnqfXVUT8y4PWZ1JSc2HR8pRB',
         ),
-        'btc',
+        asNetworkSymbol('btc'),
     ),
     updatedAt: null,
     isDeleted: null,

--- a/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -51,7 +52,7 @@ test.describe(
                     },
                     buyAsset: {
                         searchFilter: 'Solana',
-                        assetCryptoId: getCryptoId('sol'),
+                        assetCryptoId: getCryptoId(asNetworkSymbol('sol')),
                     },
 
                     selectReceiveAddress: async () => {

--- a/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { expect, test } from '../../support/fixtures';
@@ -103,7 +104,7 @@ test.describe(
                     },
                     buyAsset: {
                         searchFilter: receiveAssetName,
-                        assetCryptoId: getCryptoId('sol'),
+                        assetCryptoId: getCryptoId(asNetworkSymbol('sol')),
                     },
                     selectReceiveAddress: async () => {
                         await tradingPage.receiveAccount.selectSuiteReceiveAccount(1, 'sol');

--- a/suite/e2e/tests/trading/buy-ethereum.test.ts
+++ b/suite/e2e/tests/trading/buy-ethereum.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { capitalizeFirstLetter } from '@trezor/utils';
 
@@ -32,7 +33,7 @@ test.describe('Trading - Buy Ethereum', { tag: ['@webOnly', '@T3W1', '@T3T1'] },
             await tradingPage.assetPicker.selectBuyAsset({
                 searchFilter: 'Ethereum',
                 networkFilter: 'eth',
-                assetCryptoId: getCryptoId('eth'),
+                assetCryptoId: getCryptoId(asNetworkSymbol('eth')),
             });
             await tradingPage.fillBuyForm({
                 amount: fiatAmount,

--- a/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
+++ b/suite/e2e/tests/trading/swap-fees-ethereum.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
@@ -48,7 +49,7 @@ test.describe('Trading - Swap fees', { tag: ['@webOnly', '@T3W1', '@T3T1'] }, ()
                 buyAsset: {
                     searchFilter: 'Bitcoin',
                     networkFilter: 'btc',
-                    assetCryptoId: getCryptoId('btc'),
+                    assetCryptoId: getCryptoId(asNetworkSymbol('btc')),
                 },
             });
             await tradingPage.fees.setEthereumCustomFees({

--- a/suite/e2e/tests/trading/swap-inputs.test.ts
+++ b/suite/e2e/tests/trading/swap-inputs.test.ts
@@ -1,5 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 
 import dump from '../../fixtures/remembered-wallet-db-lite.json';
 import { expect, test } from '../../support/fixtures';
@@ -23,7 +23,7 @@ const buyAssets: {
 }[] = [
     {
         label: 'ETH@ETH',
-        buy: { searchFilter: 'Ethereum', assetCryptoId: getCryptoId('eth') },
+        buy: { searchFilter: 'Ethereum', assetCryptoId: getCryptoId(asNetworkSymbol('eth')) },
         receiveNetwork: 'eth',
         accountIndex: 0,
     },
@@ -32,7 +32,10 @@ const buyAssets: {
         buy: {
             searchFilter: 'USDC',
             networkFilter: 'sol',
-            assetCryptoId: getCryptoId('sol', 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+            assetCryptoId: getCryptoId(
+                asNetworkSymbol('sol'),
+                'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            ),
         },
         receiveNetwork: 'sol',
         accountIndex: 1,
@@ -42,7 +45,10 @@ const buyAssets: {
         buy: {
             searchFilter: 'USDT',
             networkFilter: 'eth',
-            assetCryptoId: getCryptoId('eth', '0xdac17f958d2ee523a2206206994597c13d831ec7'),
+            assetCryptoId: getCryptoId(
+                asNetworkSymbol('eth'),
+                '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            ),
         },
         receiveNetwork: 'eth',
         accountIndex: 0,
@@ -52,7 +58,7 @@ const buyAssets: {
         buy: {
             searchFilter: 'ETH',
             networkFilter: 'eth',
-            assetCryptoId: getCryptoId('eth'),
+            assetCryptoId: getCryptoId(asNetworkSymbol('eth')),
         },
         receiveNetwork: 'eth',
         accountIndex: 0,

--- a/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { getCompanyNameFromList } from '../../fixtures/trading';
@@ -47,7 +48,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
                 },
                 buyAsset: {
                     searchFilter: 'Bitcoin',
-                    assetCryptoId: getCryptoId('btc'),
+                    assetCryptoId: getCryptoId(asNetworkSymbol('btc')),
                 },
                 selectReceiveAddress: async () => {
                     await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');

--- a/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import { getCompanyNameFromList } from '../../fixtures/trading';
@@ -48,7 +49,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
                 buyAsset: {
                     searchFilter: 'Ethereum',
                     networkFilter: 'eth',
-                    assetCryptoId: getCryptoId('eth'),
+                    assetCryptoId: getCryptoId(asNetworkSymbol('eth')),
                 },
                 selectReceiveAddress: async () => {
                     await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'eth');

--- a/suite/e2e/tests/trading/swap-token-to-coin.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-coin.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 
 import {
@@ -54,7 +55,7 @@ test.describe('Trading - Swap token to coin', { tag: ['@webOnly', '@T3W1', '@T3T
                 buyAsset: {
                     searchFilter: 'Bitcoin',
                     networkFilter: 'btc',
-                    assetCryptoId: getCryptoId('btc'),
+                    assetCryptoId: getCryptoId(asNetworkSymbol('btc')),
                 },
                 selectReceiveAddress: async () => {
                     await tradingPage.receiveAccount.selectSuiteReceiveAccount(0, 'btc');

--- a/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
+++ b/suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts
@@ -1,4 +1,5 @@
 import { getCryptoId } from '@suite-common/trading';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import { swapQuotesTetherStellar, tradeEndpoint } from '../../fixtures/trading';
 import { expect, test } from '../../support/fixtures';
@@ -42,7 +43,7 @@ test.describe(
                     buyAsset: {
                         searchFilter: 'XLM',
                         networkFilter: 'xlm',
-                        assetCryptoId: getCryptoId('xlm'),
+                        assetCryptoId: getCryptoId(asNetworkSymbol('xlm')),
                     },
                 });
             });

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -1,4 +1,4 @@
-import { getNetwork } from '@suite-common/wallet-config';
+import { asNetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { localizeNumber } from '@suite-common/wallet-utils';
 import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
 import { Model } from '@trezor/trezor-user-env-link';
@@ -12,7 +12,7 @@ import { transformAddress } from '../../support/testExtends/customMatchers';
 const RECIPIENT_ADDRESS = 'ENk2eeP4umP6cjAGRsVG4NEVKEVQmRn6JEpN8hubv2Hf';
 const FORMATTED_ADDRESS = formatAddressWithNewlines(RECIPIENT_ADDRESS);
 const TRANSFORMED_ADDRESS = transformAddress(RECIPIENT_ADDRESS, 'fourTetragrams');
-const SOL_DECIMALS = getNetwork('sol').decimals;
+const SOL_DECIMALS = getNetwork(asNetworkSymbol('sol')).decimals;
 
 test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
     test.use({

--- a/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.test.ts
+++ b/suite/metadata-migration/src/migrateLegacyLabelsToSuiteSync.test.ts
@@ -13,7 +13,7 @@ import type {
 } from '@suite-common/suite-sync-storage';
 import type { TrezorDeviceWithState } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
 import { asAccountDescriptor, asTxTargetId } from '@suite-common/wallet-types';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import type { StaticSessionId } from '@trezor/connect';
@@ -83,12 +83,13 @@ const createCurrentAccountLabels = (
 });
 
 const getCurrentAccountLabels: GetCurrentAccountLabels = () => createCurrentAccountLabels();
+const btcSymbol = asNetworkSymbol('btc');
 
 const createSuiteSyncAddressLabel = (
     address: string,
     label: string,
     accountDescriptor = asAccountDescriptor('descriptor1'),
-    networkSymbol: NetworkSymbol = 'btc',
+    networkSymbol: NetworkSymbol = btcSymbol,
 ): SuiteSyncAddress => ({
     id: createSuiteSyncAddressId(address, networkSymbol),
     address,
@@ -102,7 +103,7 @@ const createSuiteSyncOutputLabel = (
     txTargetId: string,
     label: string,
     accountDescriptor = asAccountDescriptor('descriptor1'),
-    networkSymbol: NetworkSymbol = 'btc',
+    networkSymbol: NetworkSymbol = btcSymbol,
 ): SuiteSyncOutput => {
     const targetId = asTxTargetId(txTargetId);
 
@@ -176,7 +177,7 @@ describe(createMigrateLegacyLabelsToSuiteSync.name, () => {
             getAccountsByDeviceState: () => [
                 createAccount({
                     descriptor: 'descriptor1',
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     deviceState: 'device@wallet:1',
                 }),
             ],
@@ -207,7 +208,7 @@ describe(createMigrateLegacyLabelsToSuiteSync.name, () => {
             getAccountsByDeviceState: () => [
                 createAccount({
                     descriptor: 'descriptor1',
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     deviceState: 'device@wallet:1',
                 }),
             ],

--- a/suite/router/src/anchor.test.ts
+++ b/suite/router/src/anchor.test.ts
@@ -1,5 +1,9 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import * as fixtures from './__fixtures__/anchor';
 import * as anchorUtils from './anchorUtils';
+
+const ethSymbol = asNetworkSymbol('eth');
 
 describe('anchor utils', () => {
     test('getDefaultBackendType', () => {
@@ -10,7 +14,7 @@ describe('anchor utils', () => {
         it('identifies the row by network, account type and index — never by account key', () => {
             expect(
                 anchorUtils.getEarnYieldRowAnchor({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountType: 'normal',
                     accountIndex: 0,
                     vaultId: 'ethereum:1:0x58d97b57bb95320f9a05dc918aef65434969c2b2',
@@ -25,14 +29,14 @@ describe('anchor utils', () => {
 
             expect(
                 anchorUtils.getEarnYieldRowAnchor({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountType: 'normal',
                     accountIndex: 0,
                     vaultId,
                 }),
             ).not.toBe(
                 anchorUtils.getEarnYieldRowAnchor({
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountType: 'normal',
                     accountIndex: 1,
                     vaultId,

--- a/suite/router/src/router.test.ts
+++ b/suite/router/src/router.test.ts
@@ -1,3 +1,5 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
 import { type Route } from './route';
 import {
     getAppWithParams,
@@ -7,6 +9,9 @@ import {
     stripPrefixedURL,
 } from './router';
 import type { RouteParams } from './routes';
+
+const ethSymbol = asNetworkSymbol('eth');
+const btcSymbol = asNetworkSymbol('btc');
 
 const OLD_ENV = { ...process.env };
 
@@ -45,7 +50,7 @@ describe('router', () => {
             expect(test('wallet-index')).toEqual('/accounts');
             expect(
                 test('earn-yield-deposit', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountIndex: 0,
                     accountType: 'normal',
                     vaultAddress: '0xvault',
@@ -53,7 +58,7 @@ describe('router', () => {
             ).toEqual('/earn/yield/deposit#/eth/0/normal/0xvault');
             expect(
                 test('earn-yield-withdraw', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountIndex: 0,
                     accountType: 'normal',
                     vaultAddress: '0xvault',
@@ -61,7 +66,7 @@ describe('router', () => {
             ).toEqual('/earn/yield/withdraw#/eth/0/normal/0xvault');
             expect(
                 test('earn-yield-claim', {
-                    symbol: 'eth',
+                    symbol: ethSymbol,
                     accountIndex: 0,
                     accountType: 'normal',
                 }),
@@ -69,7 +74,7 @@ describe('router', () => {
             // tests below with intentionally mixed # params
             expect(
                 test('wallet-index', {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     accountIndex: 0,
                     accountType: 'legacy',
                 }),
@@ -78,26 +83,26 @@ describe('router', () => {
                 test('wallet-index', {
                     accountIndex: 0,
                     accountType: 'segwit',
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
             ).toEqual('/accounts#/btc/0/segwit');
             expect(
                 test('wallet-index', {
                     accountType: 'normal',
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                     accountIndex: 0,
                 }),
             ).toEqual('/accounts#/btc/0/normal');
             expect(
                 test('wallet-index', {
                     accountIndex: 1,
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
             ).toEqual('/accounts#/btc/1');
             // route shouldn't have params
             expect(
                 test('onboarding-index', {
-                    symbol: 'btc',
+                    symbol: btcSymbol,
                 }),
             ).toEqual('/onboarding');
         });

--- a/suite/sign-verify/src/signVerifyActions.test.ts
+++ b/suite/sign-verify/src/signVerifyActions.test.ts
@@ -1,5 +1,6 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, testMocks } from '@suite-common/test-utils';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { showAddress, sign, verify } from './signVerifyActions';
@@ -8,7 +9,7 @@ const PATH = 'PATH';
 const ADDRESS = 'ADDRESS';
 const MESSAGE = 'MESSAGE';
 const SIGNATURE = 'SIGNATURE';
-const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
 
 describe('Sign/Verify actions', () => {
     let store: any;

--- a/suite/transfer-uri/package.json
+++ b/suite/transfer-uri/package.json
@@ -18,5 +18,8 @@
         "@suite-common/transfer-uri": "workspace:*",
         "@suite/analytics": "workspace:*",
         "@trezor/network-module-suite-common-types": "workspace:*"
+    },
+    "devDependencies": {
+        "@suite-common/wallet-config": "workspace:^"
     }
 }

--- a/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
@@ -1,5 +1,6 @@
 import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { type FindNetworkSymbolForProtocol } from '@suite-common/networks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
 
 import {
     type CoinProtocol,
@@ -8,8 +9,8 @@ import {
 } from './handleCoinProtocolUri';
 
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol => {
-    if (protocol === 'bitcoin') return 'btc';
-    if (protocol === 'ethereum') return 'eth';
+    if (protocol === 'bitcoin') return asNetworkSymbol('btc');
+    if (protocol === 'ethereum') return asNetworkSymbol('eth');
 
     return null;
 };

--- a/suite/transfer-uri/tsconfig.json
+++ b/suite/transfer-uri/tsconfig.json
@@ -12,6 +12,9 @@
         { "path": "../analytics" },
         {
             "path": "../../networks/network-module/network-module-suite-common-types"
+        },
+        {
+            "path": "../../suite-common/wallet-config"
         }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10633,6 +10633,7 @@ __metadata:
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
@@ -10748,6 +10749,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:2.12.0"
     "@suite-common/redux-utils": "workspace:*"
     "@suite-common/test-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:*"
   languageName: unknown
@@ -11152,6 +11154,7 @@ __metadata:
   resolution: "@suite-common/transaction-search@workspace:suite-common/transaction-search"
   dependencies:
     "@suite-common/test-utils": "workspace:*"
+    "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@trezor/blockchain-link": "workspace:*"
@@ -15459,6 +15462,7 @@ __metadata:
     "@suite-common/networks": "workspace:*"
     "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/transfer-uri": "workspace:*"
+    "@suite-common/wallet-config": "workspace:^"
     "@suite/analytics": "workspace:*"
     "@trezor/network-module-suite-common-types": "workspace:*"
   languageName: unknown


### PR DESCRIPTION
## Description

This extracts the repetitive NetworkSymbol test preparation from #30561 into a standalone change against develop. Existing tests now create network symbols through identity helpers and reuse local symbol constants, while the current literal-union NetworkSymbol and NetworkConfigWithoutTestnets types remain unchanged. The helpers are intentionally runtime identities, so this introduces no behavioral change and lets the later branded-symbol PR focus on production typing.\n\n- Extracted: **196 test files**\n- Test diff moved out of #30561: **2,775 changed lines**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/extract-network-symbol-tests/web/](https://dev.suite.sldev.cz/suite-web/extract-network-symbol-tests/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=extract-network-symbol-tests&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=extract-network-symbol-tests&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=extract-network-symbol-tests&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T10:11:19.275Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T10:11:22.051Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->