### PR TITLE
refactor(redux): narrow single-instance thunk dependencies

### DIFF
--- a/suite-common/redux-utils/src/createSingleInstanceThunk.test.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.test.ts
@@ -28,7 +28,7 @@ describe('createSingleInstanceThunk', () => {
         middleware: getDefaultMiddleware =>
             getDefaultMiddleware({
                 thunk: {
-                    extraArgument: {} as any,
+                    extraArgument: {},
                 },
                 serializableCheck: false,
                 immutableCheck: false,

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.ts
@@ -11,6 +11,35 @@ import {
 
 type CreateSingleInstanceThunkDispatch = ThunkDispatch<any, any, UnknownAction>;
 
+/**
+ * Turns the short permissions written by a thunk into the complete permissions Redux Toolkit
+ * needs. Think of `TThunkAPI` as a permission card: it says which Redux state and injected tools
+ * the thunk is allowed to use.
+ *
+ * `[TThunkAPI] extends [void]` asks whether the caller supplied no permission card at all. The
+ * square brackets are important. Without them, TypeScript may check pieces of a union separately
+ * and combine the answers into a surprising type. The brackets make TypeScript answer the question
+ * once for the whole type.
+ *
+ * When the caller supplies `void`, the thunk gets deliberately limited permissions:
+ *
+ * - The `state: unknown` field means that Redux has some state, but the thunk is not allowed to
+ *   assume its shape or pass it to a selector.
+ * - The `extra: Record<never, never>` field means that no injected dependency names exist, so
+ *   reading something such as `extra.services` is a type error.
+ * - The `dispatch` field stays broad because a parent thunk must be able to dispatch a child thunk
+ *   with its own, different permission card.
+ *
+ * When the caller supplies a Redux Toolkit config object, we keep its declared fields, including
+ * `state`, error payloads, and action metadata. We remove `dispatch` and `extra` first and then add
+ * safe versions back. A declared `extra` type is preserved; a missing one becomes the same empty
+ * dependency object used by the `void` branch. Replacing `dispatch` avoids making a parent thunk
+ * pretend that every child thunk has exactly the same state and dependencies.
+ *
+ * The final `never` means that any other input is impossible. The public generic is already limited
+ * to `AsyncThunkConfig | void`, but keeping this fallback prevents an unsupported value from quietly
+ * turning into a usable thunk API if that constraint changes later.
+ */
 type ResolveSingleInstanceThunkAPIRaw<TThunkAPI> = [TThunkAPI] extends [void]
     ? {
           state: unknown;
@@ -24,6 +53,13 @@ type ResolveSingleInstanceThunkAPIRaw<TThunkAPI> = [TThunkAPI] extends [void]
         }
       : never;
 
+/**
+ * Copies the fields from the raw result into a plain object type. The raw conditional above is like
+ * an unfinished formula in TypeScript's memory. Redux Toolkit's generic overloads struggle to
+ * compare that formula with `AsyncThunkConfig`. Copying every field makes TypeScript calculate the
+ * result now, while preserving exactly the same permissions. This changes types only and produces
+ * no JavaScript at runtime.
+ */
 type ResolveSingleInstanceThunkAPI<TThunkAPI> = {
     [TKey in keyof ResolveSingleInstanceThunkAPIRaw<TThunkAPI>]: ResolveSingleInstanceThunkAPIRaw<TThunkAPI>[TKey];
 };

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.ts
@@ -1,48 +1,73 @@
 import {
+    type AsyncThunk,
+    type AsyncThunkConfig,
     type AsyncThunkOptions,
     type AsyncThunkPayloadCreator,
+    type CreateAsyncThunkFunction,
+    type ThunkDispatch,
+    type UnknownAction,
     createAsyncThunk as createAsyncThunkReduxToolkit,
 } from '@reduxjs/toolkit';
 
-// TODO: This dependency on the global ExtraDependencies type is bad, temporary, terrible, and
-// disastrous. Remove it in follow-ups tracked by https://github.com/trezor/trezor-suite/issues/30770.
-import { type CustomThunkAPI } from '@suite-common/redux-extra-dependencies';
+type CreateSingleInstanceThunkDispatch = ThunkDispatch<any, any, UnknownAction>;
+
+type ResolveSingleInstanceThunkAPIRaw<TThunkAPI> = [TThunkAPI] extends [void]
+    ? {
+          state: unknown;
+          extra: Record<never, never>;
+          dispatch: CreateSingleInstanceThunkDispatch;
+      }
+    : TThunkAPI extends AsyncThunkConfig
+      ? Omit<TThunkAPI, 'dispatch' | 'extra'> & {
+            extra: TThunkAPI extends { extra: infer TExtra } ? TExtra : Record<never, never>;
+            dispatch: CreateSingleInstanceThunkDispatch;
+        }
+      : never;
+
+type ResolveSingleInstanceThunkAPI<TThunkAPI> = {
+    [TKey in keyof ResolveSingleInstanceThunkAPIRaw<TThunkAPI>]: ResolveSingleInstanceThunkAPIRaw<TThunkAPI>[TKey];
+};
 
 /**
  * @description This function will ensure that there is only one ongoing promise for a given function with given arguments.
  * If there is an ongoing promise, it will return the same promise.
  */
-function ensureSingleRunningInstance<T extends (...args: any[]) => Promise<any>>(func: T): T {
-    const ongoingPromises = new Map<string, Promise<any>>();
+function ensureSingleRunningInstance<TPayload, TParams, TThunkAPI extends AsyncThunkConfig>(
+    func: AsyncThunkPayloadCreator<TPayload, TParams, TThunkAPI>,
+): AsyncThunkPayloadCreator<TPayload, TParams, TThunkAPI> {
+    const ongoingPromises = new Map<string, Promise<unknown>>();
 
-    return function (this: any, ...args: Parameters<T>): ReturnType<T> {
-        // It's fine to hardcode first argument as key, because thunks has only one argument (second argument is thunkAPI which is not important for this case)
-        const key = JSON.stringify(args[0]);
+    return ((params, thunkAPI) => {
+        // The first argument is the key because an RTK thunk accepts exactly one params argument.
+        const key = JSON.stringify(params);
         if (!ongoingPromises.has(key)) {
-            const promise = func.apply(this, args).finally(() => {
+            const promise = Promise.resolve(func(params, thunkAPI)).finally(() => {
                 ongoingPromises.delete(key);
             });
             ongoingPromises.set(key, promise);
         }
 
-        return ongoingPromises.get(key) as ReturnType<T>;
-    } as unknown as T;
+        return ongoingPromises.get(key)!;
+    }) as AsyncThunkPayloadCreator<TPayload, TParams, TThunkAPI>;
 }
 
-export const createSingleInstanceThunk = <TParams = void, TPayload = void, TThunkAPI = void>(
+export const createSingleInstanceThunk = <
+    TParams = void,
+    TPayload = void,
+    TThunkAPI extends AsyncThunkConfig | void = void,
+>(
     typePrefix: string,
-    thunk: AsyncThunkPayloadCreator<TPayload, TParams, TThunkAPI & CustomThunkAPI>,
-    options?: AsyncThunkOptions<TParams, TThunkAPI & CustomThunkAPI>,
-) => {
-    const wrappedPayloadCreator: AsyncThunkPayloadCreator<
+    thunk: AsyncThunkPayloadCreator<TPayload, TParams, ResolveSingleInstanceThunkAPI<TThunkAPI>>,
+    options?: AsyncThunkOptions<TParams, ResolveSingleInstanceThunkAPI<TThunkAPI>>,
+): AsyncThunk<TPayload, TParams, ResolveSingleInstanceThunkAPI<TThunkAPI>> => {
+    const wrappedPayloadCreator = ensureSingleRunningInstance<
         TPayload,
         TParams,
-        TThunkAPI & CustomThunkAPI
-    > = ensureSingleRunningInstance(thunk as any);
+        ResolveSingleInstanceThunkAPI<TThunkAPI>
+    >(thunk);
 
-    return createAsyncThunkReduxToolkit<TPayload, TParams, TThunkAPI & CustomThunkAPI>(
-        typePrefix,
-        wrappedPayloadCreator,
-        options,
-    );
+    const createTypedThunk: CreateAsyncThunkFunction<ResolveSingleInstanceThunkAPI<TThunkAPI>> =
+        createAsyncThunkReduxToolkit;
+
+    return createTypedThunk<TPayload, TParams>(typePrefix, wrappedPayloadCreator, options);
 };

--- a/suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts
+++ b/suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts
@@ -1,0 +1,86 @@
+import { createSingleInstanceThunk } from './createSingleInstanceThunk';
+
+type SelectedExtraDependencies = {
+    services: {
+        selectedDependency: () => void;
+    };
+};
+
+type SelectedState = {
+    selected: {
+        value: string;
+    };
+};
+
+type UnselectedState = {
+    unselected: {
+        value: string;
+    };
+};
+
+const selectSelectedValue = (state: SelectedState) => state.selected.value;
+const selectUnselectedValue = (state: UnselectedState) => state.unselected.value;
+
+createSingleInstanceThunk<void, void, void>('test/noDependencies', (_, { extra, getState }) => {
+    // @ts-expect-error The thunk has no state dependencies.
+    selectSelectedValue(getState());
+
+    // @ts-expect-error The thunk has no extra dependencies.
+    void extra.services.analytics;
+});
+
+createSingleInstanceThunk('test/defaultNoDependencies', (_, { extra, getState }) => {
+    // @ts-expect-error The thunk has no state dependencies by default.
+    selectSelectedValue(getState());
+
+    // @ts-expect-error The thunk has no extra dependencies by default.
+    void extra.services.analytics;
+});
+
+createSingleInstanceThunk<void, void, { state: SelectedState }>(
+    'test/selectedStateWithoutExtraDependencies',
+    (_, { extra, getState }) => {
+        const selectedValue: string = selectSelectedValue(getState());
+
+        // @ts-expect-error The thunk has no extra dependencies.
+        void extra.services.analytics;
+
+        void selectedValue;
+    },
+);
+
+createSingleInstanceThunk<void, void, { extra: SelectedExtraDependencies }>(
+    'test/selectedExtraWithoutStateDependencies',
+    (_, { extra, getState }) => {
+        extra.services.selectedDependency();
+
+        // @ts-expect-error The thunk has no state dependencies.
+        selectSelectedValue(getState());
+    },
+);
+
+createSingleInstanceThunk<void, void, { state: SelectedState; extra: SelectedExtraDependencies }>(
+    'test/selectiveExtraDependencies',
+    (_, { extra, getState }) => {
+        const selectedValue: string = selectSelectedValue(getState());
+        extra.services.selectedDependency();
+
+        // @ts-expect-error The thunk only has access to its explicitly selected state.
+        const unselectedValue = selectUnselectedValue(getState());
+
+        // @ts-expect-error The thunk only has access to its explicitly selected dependencies.
+        const unselectedAnalytics = extra.services.analytics;
+
+        void selectedValue;
+        void unselectedValue;
+        void unselectedAnalytics;
+    },
+);
+
+const childThunk = createSingleInstanceThunk<string, string, void>('test/childThunk', value =>
+    Promise.resolve(value),
+);
+
+createSingleInstanceThunk<void, string, void>('test/parentThunk', (_, { dispatch }) =>
+    dispatch(childThunk('value')).unwrap(),
+);

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -652,8 +652,13 @@ export const fetchTransactionsPageThunk = createThunk<
 type FetchUtxoTransactionsForAccountThunkParams = {
     accountKey: AccountKey;
 };
+type FetchUtxoTransactionsForAccountThunkState = AccountsRootState & TransactionsRootState;
 
-export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk(
+export const fetchUtxoTransactionsForAccountThunk = createSingleInstanceThunk<
+    FetchUtxoTransactionsForAccountThunkParams,
+    WalletAccountTransaction[],
+    { state: FetchUtxoTransactionsForAccountThunkState }
+>(
     `${TRANSACTIONS_MODULE_PREFIX}/fetchUtxoTransactionsForAccountThunk`,
     async (
         { accountKey }: FetchUtxoTransactionsForAccountThunkParams,
@@ -700,7 +705,15 @@ type FetchAllTransactionsForAccountThunkParams = {
     accountKey: AccountKey;
     noLoading?: boolean;
 };
-export const fetchAllTransactionsForAccountThunk = createSingleInstanceThunk(
+type FetchAllTransactionsForAccountThunkState = AccountsRootState &
+    TransactionsRootState &
+    FetchTransactionsPageThunkState;
+
+export const fetchAllTransactionsForAccountThunk = createSingleInstanceThunk<
+    FetchAllTransactionsForAccountThunkParams,
+    WalletAccountTransaction[],
+    { state: FetchAllTransactionsForAccountThunkState }
+>(
     `${TRANSACTIONS_MODULE_PREFIX}/fetchAllTransactionsForAccount`,
     async (
         { accountKey }: FetchAllTransactionsForAccountThunkParams,
@@ -775,12 +788,22 @@ export const fetchAllTransactionsForAccountThunk = createSingleInstanceThunk(
     },
 );
 
-export const fetchTransactionsFromNowUntilTimestamp = createSingleInstanceThunk(
+type FetchTransactionsFromNowUntilTimestampParams = {
+    accountKey: AccountKey;
+    timestamp: Timestamp | null;
+};
+type FetchTransactionsFromNowUntilTimestampState = AccountsRootState &
+    TransactionsRootState &
+    FetchAllTransactionsForAccountThunkState &
+    FetchTransactionsPageThunkState;
+
+export const fetchTransactionsFromNowUntilTimestamp = createSingleInstanceThunk<
+    FetchTransactionsFromNowUntilTimestampParams,
+    WalletAccountTransaction[],
+    { state: FetchTransactionsFromNowUntilTimestampState }
+>(
     `${TRANSACTIONS_MODULE_PREFIX}/fetchTransactionsForAccount`,
-    async (
-        { accountKey, timestamp }: { accountKey: AccountKey; timestamp: Timestamp | null },
-        { dispatch, getState },
-    ) => {
+    async ({ accountKey, timestamp }, { dispatch, getState }) => {
         if (!timestamp) {
             return dispatch(fetchAllTransactionsForAccountThunk({ accountKey })).unwrap();
         }


### PR DESCRIPTION
## Description

createSingleInstanceThunk still intersected every caller contract with the global CustomThunkAPI, so its three production consumers could not declare the state they actually use. The helper now resolves caller-owned state and extra contracts, defaults omitted or explicit void config to dependency-free, and gives the wallet transaction thunks explicit composed state contracts. Compile-time tests cover dependency-free, state-only, extra-only, combined, and nested dispatch behavior; inline documentation explains the non-obvious conditional and mapped-type transformations.

- Global dependency imports in createSingleInstanceThunk: **1 -> 0**
- Production createSingleInstanceThunk consumers migrated: **0/3 -> 3/3**
- Focused runtime tests: **3 passing**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-single-instance-thunk-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-single-instance-thunk-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-single-instance-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-single-instance-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-single-instance-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T14:58:58.544Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T14:58:40.776Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set primarily touches transaction-related thunks and the createSingleInstanceThunk utility that underpins them. The highest risk is in send/broadcast flows across multiple networks. A focused set of wallet send tests (BTC regtest, ETH, Base, SOL, DOGE) provides broad coverage of the transaction thunk paths without running the entire suite. The unit/type-test files for createSingleInstanceThunk are not covered by E2E tests and should be verified by the existing unit test run.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/redux-utils/src/createSingleInstanceThunk.test.ts`
- `suite-common/redux-utils/src/createSingleInstanceThunk.ts`
- `suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multiple Bitcoin transactions on regtest and asserts pending/confirmed state transitions, which directly exercises the transaction signing/broadcasting thunks in transactionsThunks.ts. Any regression in single-instance thunk behavior or transaction dispatching would be visible here.
- `suite/e2e/tests/wallet/send-base.test.ts` — Performs a full EVM send on Base, including custom fee handling and device confirmation. It is a representative EVM transaction path that relies on transactionsThunks.ts for composing, signing, and broadcasting.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Tests the Dogecoin send flow and specifically the sign-transaction error path for amounts exceeding MAX_SAFE_INTEGER. This directly validates transaction thunk error handling and serialization logic.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Covers a complete Ethereum send with custom gas fees and device verification. It is a core transaction path that depends on the transaction thunks and their interaction with the device.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Exercises Bitcoin send form features such as multiple outputs, locktime, OP_RETURN, and unit switching, then broadcasts regtest transactions. This is a broad functional test of the Bitcoin transaction thunk path.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Validates a Solana send with send-max calculation, fee/reserve handling, and device signing. This covers a non-EVM transaction thunk path that is independent from Bitcoin/EVM code.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — Imports multiple outputs into the BTC send form via CSV. While it may not broadcast, it validates that the send-form/output state populated by transaction-related code remains correct after external input.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Tests an LTC send that spends a MimbleWimble peg-out output and confirms on device. It is a less common UTXO transaction path that still relies on the transaction thunks.
- `suite/e2e/tests/wallet/without-device.test.ts` — Verifies send-form behavior when the device is disconnected mid-flow. This exercises the transaction thunk/device interaction error path and the connection modal state.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/redux-utils/src/createSingleInstanceThunk.test.ts`
- `suite-common/redux-utils/src/createSingleInstanceThunk.type-test.ts`

_Updated: 2026-08-07T14:58:05.874Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->