### PR TITLE
fix(e2e): update accountManagement test after change of the header

### DIFF
--- a/suite-native/app/e2e/tests/accountManagement.test.ts
+++ b/suite-native/app/e2e/tests/accountManagement.test.ts
@@ -32,7 +32,7 @@ describe('Account management [@noDevice]', () => {
 
         await onAccountDetailSettings.renameAccount({ newAccountName });
 
-        await detoxExpect(element(by.id('@screen/sub-header/title'))).toHaveText(newAccountName);
+        await detoxExpect(element(by.text(newAccountName))).toBeVisible();
     });
 
     it('Import account and remove it', async () => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the account management E2E test after the header changes introduced in #29455. The test now verifies that the renamed account label is visible instead of targeting the removed header title ID.

 
<img width="200" alt="testFnFailure" src="https://github.com/user-attachments/assets/a40a90ec-2a92-441e-9bd6-55fee01b6a68" />


CI run https://github.com/trezor/trezor-suite/actions/runs/31100120202

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=matejkriz/fix-account-management-test&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->