### PR TITLE
fix(suite): getDiscoveryStatus check supported networks

### DIFF
--- a/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
+++ b/packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts
@@ -4,6 +4,7 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     isDiscoveryInProgress,
     selectAccountsByDeviceState,
+    selectDeviceSupportedNetworks,
     selectDiscoveryByDevicePath,
 } from '@suite-common/wallet-core';
 import { type Account, type DiscoveryStatus } from '@suite-common/wallet-types';
@@ -16,6 +17,7 @@ type GetDiscoveryStatusParams = {
     device: TrezorDevice | undefined;
     discovery: DiscoveryStatus | undefined;
     accounts: Account[] | undefined;
+    deviceSupportedNetworks: NetworkSymbol[];
     walletSettings: {
         enabledNetworks: NetworkSymbol[];
     };
@@ -25,6 +27,7 @@ const getDiscoveryStatus = ({
     device,
     discovery,
     accounts,
+    deviceSupportedNetworks,
     walletSettings,
 }: GetDiscoveryStatusParams): DiscoveryStatusType | undefined => {
     if (!device) {
@@ -34,7 +37,11 @@ const getDiscoveryStatus = ({
         };
     }
 
-    if (walletSettings.enabledNetworks.length === 0) {
+    const hasEnabledSupportedNetwork = walletSettings.enabledNetworks.some(networkSymbol =>
+        deviceSupportedNetworks.includes(networkSymbol),
+    );
+
+    if (!hasEnabledSupportedNetwork) {
         return {
             status: 'exception',
             type: 'discovery-empty',
@@ -83,9 +90,16 @@ const getDiscoveryStatus = ({
 // TODO move this selector somewhere more sensible
 export const selectDiscoveryOverallStatus = (state: AppState) => {
     const device = selectSelectedDevice(state);
+    const deviceSupportedNetworks = selectDeviceSupportedNetworks(state);
     const accounts = device?.state && selectAccountsByDeviceState(state, device.state);
     const discovery = selectDiscoveryByDevicePath(state, device?.path);
     const walletSettings = state.wallet.settings;
 
-    return getDiscoveryStatus({ device, discovery, accounts, walletSettings });
+    return getDiscoveryStatus({
+        device,
+        discovery,
+        accounts,
+        deviceSupportedNetworks,
+        walletSettings,
+    });
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When you connect bitcoin-only device to a suite which doesnt have enabled Bitcoin network the discovery is empty (no loaded networks) but the UI in dashboard display "success" view instead of "discovery-empty" view


## Notes for QA
- connect any universal FW
- enable only ETH network
- connect bitcoin-only FW and go to dashboard

Result: you should be able to add bitcoin network from the dashboard 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared discovery status selector with a very wide static fan-out. Most mapped tests only use discovery incidentally, so I concentrated on tests that directly observe discovery state/completion, including multi-coin discovery, custom backend discovery, and post-discovery UI transitions. If these targeted tests pass, the risk of a broad discovery regression is low.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/utils/wallet/selectDiscoveryOverallStatus.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Relies on discoveryShouldFinish after ejecting and re-adding a standard wallet; a regression in the discovery overall status selector would prevent the BTC balance from appearing.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Explicitly verifies that discovery completes and the portfolio graph appears when using custom Blockbook backends for BTC/LTC, directly exercising status aggregation with backend-specific discovery.
- `suite/e2e/tests/wallet/discovery.test.ts` — Directly asserts Redux wallet.discovery state transitions (starting, complete) across page reload and verifies balances appear only after discovery finishes.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Enabling a new network and seeing the asset appear depends on discovery completing; a status bug could leave the asset section empty.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — Activating multiple networks and hiding the empty discovery header relies on discovery completion, so it is affected by how overall discovery status is computed.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Tests both successful discovery and discovery errors with custom backends; the selector drives whether the UI shows a loaded account or a discovery error.
- `suite/e2e/tests/settings/coins.test.ts` — Covers activating mainnet/testnet assets and observing dashboard state changes that are gated by discovery completion.

</details>

_Updated: 2026-08-06T14:21:30.562Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/suite-dashboard-discovery-empty/web/](https://dev.suite.sldev.cz/suite-web/fix/suite-dashboard-discovery-empty/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/suite-dashboard-discovery-empty&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/suite-dashboard-discovery-empty&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-06T14:24:16.739Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T14:23:25.601Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->