### PR TITLE
fix(connect-web): recover popup manager after a post-load open() failure

### DIFF
--- a/packages/connect-web/src/popup/abstract.test.ts
+++ b/packages/connect-web/src/popup/abstract.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { type CoreEventMessage } from '@trezor/connect-common/src/events';
+import { type AbstractMessageChannel } from '@trezor/connect-common/src/messageChannel/abstract';
+
+import { type Params, Popup } from './abstract';
+
+const createMockChannel = () => ({
+    on: jest.fn(),
+    postMessage: jest.fn(),
+    abortHandshake: jest.fn(),
+    disconnect: jest.fn(),
+    connect: jest.fn(),
+    clear: jest.fn(),
+    resolveMessagePromises: jest.fn(),
+    clearPendingSends: jest.fn(),
+    isConnected: false,
+});
+
+class TestPopup extends Popup {
+    protected createChannel(): AbstractMessageChannel<CoreEventMessage> {
+        return createMockChannel() as unknown as AbstractMessageChannel<CoreEventMessage>;
+    }
+    protected open(): Promise<void> {
+        return Promise.resolve();
+    }
+    protected closePopup(): void {}
+    protected isOpen(): Promise<boolean> {
+        return Promise.resolve(false);
+    }
+    protected onReset(): void {}
+
+    // Test helpers.
+    lock(): void {
+        (this as unknown as { locked: boolean }).locked = true;
+    }
+    failOpen(reason: string): void {
+        this.handleOpenFailure(reason);
+    }
+}
+
+const params = {
+    popupSrc: 'https://suite.trezor.io/connect-popup',
+    manifest: { appUrl: 'https://app.example', email: 'dev@example.com' },
+    version: '1.0.0',
+    logger: {
+        enabled: false,
+        error: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        log: jest.fn(),
+    },
+} as unknown as Params;
+
+const settlement = async (promise: Promise<unknown>) => {
+    let state = 'pending';
+    promise.then(
+        () => {
+            state = 'resolved';
+        },
+        () => {
+            state = 'rejected';
+        },
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    return state;
+};
+
+describe('Popup.handleOpenFailure', () => {
+    // Regression: a single failed open() can report the failure twice (iframe
+    // `channel-handshake-error` + the awaited channel handshake rejecting). The
+    // second report used to reject the handshakePromise that the first report's
+    // reset() had just recreated (reset() early-returns the second time because
+    // `locked` is already false), leaving it permanently rejected so every later
+    // call() failed until a page reload.
+    it('keeps a pending, usable handshakePromise after a double open-failure', async () => {
+        const popup = new TestPopup(params);
+        popup.lock();
+
+        popup.failOpen('channel-handshake-error');
+        popup.failOpen('handshake-timeout');
+
+        const { handshakePromise } = popup;
+        expect(handshakePromise).toBeDefined();
+        expect(await settlement(handshakePromise!.promise)).toBe('pending');
+
+        // The next call() resolves it via POPUP.CORE_LOADED.
+        handshakePromise!.resolve();
+        await expect(handshakePromise!.promise).resolves.toBeUndefined();
+    });
+
+    it('unlocks so the next open() can proceed', () => {
+        const popup = new TestPopup(params);
+        popup.lock();
+
+        popup.failOpen('handshake-timeout');
+
+        expect((popup as unknown as { locked: boolean }).locked).toBe(false);
+    });
+});

--- a/packages/connect-web/src/popup/abstract.test.ts
+++ b/packages/connect-web/src/popup/abstract.test.ts
@@ -1,104 +1,102 @@
-/**
- * @jest-environment jsdom
- */
-
 import { type CoreEventMessage } from '@trezor/connect-common/src/events';
-import { type AbstractMessageChannel } from '@trezor/connect-common/src/messageChannel/abstract';
+import { AbstractMessageChannel } from '@trezor/connect-common/src/messageChannel/abstract';
+import { initLog } from '@trezor/connect-common/src/utils/debug';
 
 import { type Params, Popup } from './abstract';
 
-const createMockChannel = () => ({
-    on: jest.fn(),
-    postMessage: jest.fn(),
-    abortHandshake: jest.fn(),
-    disconnect: jest.fn(),
-    connect: jest.fn(),
-    clear: jest.fn(),
-    resolveMessagePromises: jest.fn(),
-    clearPendingSends: jest.fn(),
-    isConnected: false,
-});
+// Channel without a peer: nothing is ever delivered, so a handshake only
+// settles through the manager's own abortHandshake()/reset() paths.
+class MockChannel extends AbstractMessageChannel<CoreEventMessage> {
+    constructor() {
+        super({
+            sendFn: () => {},
+            channel: { here: '@trezor/connect-web', peer: '@trezor/connect-popup' },
+        });
+    }
+
+    connect(): void {
+        this.isConnected = true;
+    }
+
+    disconnect(): void {
+        this.isConnected = false;
+    }
+}
 
 class TestPopup extends Popup {
+    openCount = 0;
+
     protected createChannel(): AbstractMessageChannel<CoreEventMessage> {
-        return createMockChannel() as unknown as AbstractMessageChannel<CoreEventMessage>;
+        return new MockChannel();
     }
+
     protected open(): Promise<void> {
+        this.openCount += 1;
+
         return Promise.resolve();
     }
+
     protected closePopup(): void {}
+
     protected isOpen(): Promise<boolean> {
         return Promise.resolve(false);
     }
+
     protected onReset(): void {}
 
-    // Test helpers.
-    lock(): void {
-        (this as unknown as { locked: boolean }).locked = true;
-    }
     failOpen(reason: string): void {
         this.handleOpenFailure(reason);
     }
 }
 
-const params = {
+const createParams = (): Params => ({
     popupSrc: 'https://suite.trezor.io/connect-popup',
-    manifest: { appUrl: 'https://app.example', email: 'dev@example.com' },
+    manifest: { appName: 'Test app', appUrl: 'https://app.example', email: 'dev@example.com' },
     version: '1.0.0',
-    logger: {
-        enabled: false,
-        error: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn(),
-        log: jest.fn(),
-    },
-} as unknown as Params;
+    logger: initLog('test'),
+});
 
-const settlement = async (promise: Promise<unknown>) => {
-    let state = 'pending';
-    promise.then(
-        () => {
-            state = 'resolved';
-        },
-        () => {
-            state = 'rejected';
-        },
-    );
-    await Promise.resolve();
-    await Promise.resolve();
+const getHandshakePromise = (popup: Popup) => {
+    const { handshakePromise } = popup;
+    if (!handshakePromise) throw new Error('handshakePromise is not set');
 
-    return state;
+    return handshakePromise;
 };
 
 describe('Popup.handleOpenFailure', () => {
+    it('rejects the pending handshake with the failure reason and unlocks the manager', async () => {
+        const popup = new TestPopup(createParams());
+        const abortHandshake = jest.spyOn(popup.channel, 'abortHandshake');
+        await popup.focusOrCreate();
+        const { promise: handshake } = getHandshakePromise(popup);
+
+        popup.failOpen('handshake-timeout');
+
+        await expect(handshake).rejects.toThrow('handshake-timeout');
+        expect(abortHandshake).toHaveBeenCalledWith('handshake-timeout');
+
+        // Unlocked: the next focusOrCreate() opens again instead of focusing.
+        await popup.focusOrCreate();
+        expect(popup.openCount).toBe(2);
+    });
+
     // Regression: a single failed open() can report the failure twice (iframe
     // `channel-handshake-error` + the awaited channel handshake rejecting). The
     // second report used to reject the handshakePromise that the first report's
     // reset() had just recreated (reset() early-returns the second time because
     // `locked` is already false), leaving it permanently rejected so every later
     // call() failed until a page reload.
-    it('keeps a pending, usable handshakePromise after a double open-failure', async () => {
-        const popup = new TestPopup(params);
-        popup.lock();
+    it('keeps a usable handshakePromise when the same open() failure is reported twice', async () => {
+        const popup = new TestPopup(createParams());
+        await popup.focusOrCreate();
 
         popup.failOpen('channel-handshake-error');
         popup.failOpen('handshake-timeout');
 
-        const { handshakePromise } = popup;
-        expect(handshakePromise).toBeDefined();
-        expect(await settlement(handshakePromise!.promise)).toBe('pending');
-
-        // The next call() resolves it via POPUP.CORE_LOADED.
-        handshakePromise!.resolve();
-        await expect(handshakePromise!.promise).resolves.toBeUndefined();
-    });
-
-    it('unlocks so the next open() can proceed', () => {
-        const popup = new TestPopup(params);
-        popup.lock();
-
-        popup.failOpen('handshake-timeout');
-
-        expect((popup as unknown as { locked: boolean }).locked).toBe(false);
+        // The next call() resolves it via POPUP.CORE_LOADED; a permanently
+        // rejected deferred would ignore resolve() and fail this.
+        const handshakePromise = getHandshakePromise(popup);
+        handshakePromise.resolve();
+        await expect(handshakePromise.promise).resolves.toBeUndefined();
     });
 });

--- a/packages/connect-web/src/popup/abstract.test.ts
+++ b/packages/connect-web/src/popup/abstract.test.ts
@@ -49,11 +49,11 @@ class TestPopup extends Popup {
     }
 }
 
-const createParams = (): Params => ({
+const createParams = (logger = initLog('test')): Params => ({
     popupSrc: 'https://suite.trezor.io/connect-popup',
     manifest: { appName: 'Test app', appUrl: 'https://app.example', email: 'dev@example.com' },
     version: '1.0.0',
-    logger: initLog('test'),
+    logger,
 });
 
 const getHandshakePromise = (popup: Popup) => {
@@ -80,18 +80,24 @@ describe('Popup.handleOpenFailure', () => {
         expect(popup.openCount).toBe(2);
     });
 
-    // Regression: a single failed open() can report the failure twice (iframe
-    // `channel-handshake-error` + the awaited channel handshake rejecting). The
-    // second report used to reject the handshakePromise that the first report's
-    // reset() had just recreated (reset() early-returns the second time because
-    // `locked` is already false), leaving it permanently rejected so every later
-    // call() failed until a page reload.
+    // Regression: a failure reported again after reset() (a duplicate report
+    // of the same open(), or a late webextension callback) used to reject the
+    // handshakePromise that reset() had just recreated (reset() early-returns
+    // the second time because `locked` is already false), leaving it
+    // permanently rejected so every later call() failed until a page reload.
     it('keeps a usable handshakePromise when the same open() failure is reported twice', async () => {
-        const popup = new TestPopup(createParams());
+        const logger = initLog('test');
+        const debug = jest.spyOn(logger, 'debug');
+        const popup = new TestPopup(createParams(logger));
         await popup.focusOrCreate();
 
         popup.failOpen('channel-handshake-error');
         popup.failOpen('handshake-timeout');
+
+        expect(debug).toHaveBeenCalledWith(
+            'Ignoring open failure after reset:',
+            'handshake-timeout',
+        );
 
         // The next call() resolves it via POPUP.CORE_LOADED; a permanently
         // rejected deferred would ignore resolve() and fail this.

--- a/packages/connect-web/src/popup/abstract.ts
+++ b/packages/connect-web/src/popup/abstract.ts
@@ -168,6 +168,15 @@ export abstract class Popup extends EventEmitter {
      * Rejects pending promises so callers get an error instead of hanging forever.
      */
     protected handleOpenFailure(reason: string): void {
+        // A single failed open() can report the failure twice (e.g. the iframe
+        // posts `channel-handshake-error` AND the awaited channel handshake then
+        // rejects). Only handle the first: the first call's reset() recreates a
+        // fresh handshakePromise, and a second call would reject that fresh one
+        // (reset() early-returns because `locked` is already false), leaving a
+        // permanently rejected handshakePromise that fails every later call()
+        // until the page is reloaded. `locked` is true for exactly one open().
+        if (!this.locked) return;
+
         this.logger.error('Failed to open popup:', reason);
         const error = new Error(reason);
         this.channel.abortHandshake(reason);

--- a/packages/connect-web/src/popup/abstract.ts
+++ b/packages/connect-web/src/popup/abstract.ts
@@ -168,14 +168,16 @@ export abstract class Popup extends EventEmitter {
      * Rejects pending promises so callers get an error instead of hanging forever.
      */
     protected handleOpenFailure(reason: string): void {
-        // A single failed open() can report the failure twice (e.g. the iframe
-        // posts `channel-handshake-error` AND the awaited channel handshake then
-        // rejects). Only handle the first: the first call's reset() recreates a
-        // fresh handshakePromise, and a second call would reject that fresh one
-        // (reset() early-returns because `locked` is already false), leaving a
-        // permanently rejected handshakePromise that fails every later call()
-        // until the page is reloaded. `locked` is true for exactly one open().
-        if (!this.locked) return;
+        // A failure can be reported after reset() already handled this open()
+        // (a duplicate report, or a late webextension callback). reset() has
+        // recreated a fresh handshakePromise for the next open(); rejecting it
+        // here would leave it permanently rejected and fail every later call()
+        // until the page is reloaded.
+        if (!this.locked) {
+            this.logger.debug('Ignoring open failure after reset:', reason);
+
+            return;
+        }
 
         this.logger.error('Failed to open popup:', reason);
         const error = new Error(reason);

--- a/packages/connect-web/src/popup/iframe.test.ts
+++ b/packages/connect-web/src/popup/iframe.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getIframeInstance } from './iframe';
+
+const IFRAME_ID = 'trezor-connect-bootstrap';
+const SRC = 'https://suite.trezor.io/connect-popup/bootstrap.html';
+
+jest.useFakeTimers();
+
+// Fully mock the DOM iframe handling so we never create a real jsdom browsing
+// context (whose teardown breaks on a stubbed contentWindow). `registry` mirrors
+// what the manager appends/removes, keyed by element id.
+let registry: Record<string, any> = {};
+let created: any[] = [];
+
+const makeFakeIframe = () => {
+    const el: any = {
+        id: '',
+        frameBorder: '',
+        width: '',
+        height: '',
+        style: {},
+        onload: null,
+        setAttribute: jest.fn((key: string, value: string) => {
+            el[key] = value;
+        }),
+        contentWindow: { location: { origin: 'https://suite.trezor.io' } },
+        parentNode: null,
+        remove: jest.fn(() => {
+            if (el.id) delete registry[el.id];
+            el.parentNode = null;
+        }),
+    };
+    created.push(el);
+
+    return el;
+};
+
+const origCreateElement = document.createElement.bind(document);
+
+beforeEach(() => {
+    registry = {};
+    created = [];
+    jest.clearAllTimers();
+
+    jest.spyOn(document, 'createElement').mockImplementation((tag: string) =>
+        tag === 'iframe' ? makeFakeIframe() : origCreateElement(tag),
+    );
+    jest.spyOn(document, 'getElementById').mockImplementation((id: string) => registry[id] ?? null);
+    jest.spyOn(document.body, 'appendChild').mockImplementation((el: any) => {
+        el.parentNode = {
+            removeChild: (child: any) => {
+                if (child.id) delete registry[child.id];
+                child.parentNode = null;
+            },
+        };
+        if (el.id) registry[el.id] = el;
+
+        return el;
+    });
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+const currentEl = () => registry[IFRAME_ID] ?? null;
+
+// Drive the appended iframe's onload; contentWindow reports a valid cross-origin
+// location, which is what makes handleIframeLoad resolve the init promise.
+const fireLoad = () => {
+    const el = currentEl();
+    if (!el) throw new Error('iframe element not appended');
+    el.onload?.(new Event('load'));
+};
+
+const createAndLoad = async (iframe: ReturnType<typeof getIframeInstance>) => {
+    const promise = iframe.create(SRC);
+    fireLoad();
+    await promise;
+};
+
+describe('getIframeInstance', () => {
+    it('resolves create() once the iframe finishes loading', async () => {
+        const iframe = getIframeInstance();
+        const promise = iframe.create(SRC);
+        expect(currentEl()).not.toBeNull();
+
+        fireLoad();
+        await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('reuses the existing iframe on a subsequent create()', async () => {
+        const iframe = getIframeInstance();
+        await createAndLoad(iframe);
+        expect(created).toHaveLength(1);
+
+        await iframe.create(SRC);
+        expect(created).toHaveLength(1);
+    });
+
+    // Regression: a failure that happens AFTER the iframe has loaded (e.g. the
+    // bootstrap handshake timing out) never rejects create(), so the manager
+    // keeps a resolved initPromise and a live iframe. destroy() must let the
+    // next create() rebuild a fresh iframe, mirroring a page reload.
+    it('destroy() tears the loaded iframe down so create() rebuilds a fresh one', async () => {
+        const iframe = getIframeInstance();
+        await createAndLoad(iframe);
+
+        const first = currentEl();
+        expect(first).not.toBeNull();
+
+        iframe.destroy();
+        expect(currentEl()).toBeNull();
+        expect(first.remove).toHaveBeenCalled();
+
+        const promise = iframe.create(SRC);
+        const second = currentEl();
+        expect(second).not.toBeNull();
+        expect(second).not.toBe(first);
+        expect(created).toHaveLength(2);
+
+        fireLoad();
+        await expect(promise).resolves.toBeUndefined();
+    });
+
+    // Guard for the original PR #29770 fix: a load timeout must clear the
+    // rejected initPromise so the next create() starts fresh.
+    it('clears the rejected init promise on load timeout (#29770)', async () => {
+        const iframe = getIframeInstance();
+        const settled = iframe.create(SRC).catch(error => error);
+        expect(currentEl()).not.toBeNull();
+
+        jest.advanceTimersByTime(10000);
+        const error = await settled;
+        expect(error).toBeDefined();
+        expect(currentEl()).toBeNull();
+
+        const promise = iframe.create(SRC);
+        expect(currentEl()).not.toBeNull();
+        expect(created).toHaveLength(2);
+
+        fireLoad();
+        await expect(promise).resolves.toBeUndefined();
+    });
+});

--- a/packages/connect-web/src/popup/iframe.test.ts
+++ b/packages/connect-web/src/popup/iframe.test.ts
@@ -4,81 +4,34 @@
 
 import { getIframeInstance } from './iframe';
 
-const IFRAME_ID = 'trezor-connect-bootstrap';
 const SRC = 'https://suite.trezor.io/connect-popup/bootstrap.html';
+
+type Iframe = ReturnType<typeof getIframeInstance>;
 
 jest.useFakeTimers();
 
-// Fully mock the DOM iframe handling so we never create a real jsdom browsing
-// context (whose teardown breaks on a stubbed contentWindow). `registry` mirrors
-// what the manager appends/removes, keyed by element id.
-let registry: Record<string, any> = {};
-let created: any[] = [];
-
-const makeFakeIframe = () => {
-    const el: any = {
-        id: '',
-        frameBorder: '',
-        width: '',
-        height: '',
-        style: {},
-        onload: null,
-        setAttribute: jest.fn((key: string, value: string) => {
-            el[key] = value;
-        }),
-        contentWindow: { location: { origin: 'https://suite.trezor.io' } },
-        parentNode: null,
-        remove: jest.fn(() => {
-            if (el.id) delete registry[el.id];
-            el.parentNode = null;
-        }),
-    };
-    created.push(el);
-
-    return el;
-};
-
-const origCreateElement = document.createElement.bind(document);
-
 beforeEach(() => {
-    registry = {};
-    created = [];
+    document.body.innerHTML = '';
     jest.clearAllTimers();
-
-    jest.spyOn(document, 'createElement').mockImplementation((tag: string) =>
-        tag === 'iframe' ? makeFakeIframe() : origCreateElement(tag),
-    );
-    jest.spyOn(document, 'getElementById').mockImplementation((id: string) => registry[id] ?? null);
-    jest.spyOn(document.body, 'appendChild').mockImplementation((el: any) => {
-        el.parentNode = {
-            removeChild: (child: any) => {
-                if (child.id) delete registry[child.id];
-                child.parentNode = null;
-            },
-        };
-        if (el.id) registry[el.id] = el;
-
-        return el;
-    });
 });
 
-afterEach(() => {
-    jest.restoreAllMocks();
-});
+const getElement = (iframe: Iframe) => {
+    const element = iframe.get();
+    if (!element) throw new Error('iframe element not appended');
 
-const currentEl = () => registry[IFRAME_ID] ?? null;
-
-// Drive the appended iframe's onload; contentWindow reports a valid cross-origin
-// location, which is what makes handleIframeLoad resolve the init promise.
-const fireLoad = () => {
-    const el = currentEl();
-    if (!el) throw new Error('iframe element not appended');
-    el.onload?.(new Event('load'));
+    return element;
 };
 
-const createAndLoad = async (iframe: ReturnType<typeof getIframeInstance>) => {
+// jsdom never fetches the iframe document, so the load event is dispatched by
+// hand. contentWindow still reports the origin of `src`, which is what
+// handleIframeLoad checks before resolving.
+const fireLoad = (iframe: Iframe) => {
+    getElement(iframe).dispatchEvent(new Event('load'));
+};
+
+const createAndLoad = async (iframe: Iframe) => {
     const promise = iframe.create(SRC);
-    fireLoad();
+    fireLoad(iframe);
     await promise;
 };
 
@@ -86,19 +39,19 @@ describe('getIframeInstance', () => {
     it('resolves create() once the iframe finishes loading', async () => {
         const iframe = getIframeInstance();
         const promise = iframe.create(SRC);
-        expect(currentEl()).not.toBeNull();
+        expect(iframe.get()).toBeDefined();
 
-        fireLoad();
+        fireLoad(iframe);
         await expect(promise).resolves.toBeUndefined();
     });
 
     it('reuses the existing iframe on a subsequent create()', async () => {
         const iframe = getIframeInstance();
         await createAndLoad(iframe);
-        expect(created).toHaveLength(1);
+        const first = getElement(iframe);
 
         await iframe.create(SRC);
-        expect(created).toHaveLength(1);
+        expect(iframe.get()).toBe(first);
     });
 
     // Regression: a failure that happens AFTER the iframe has loaded (e.g. the
@@ -108,21 +61,16 @@ describe('getIframeInstance', () => {
     it('destroy() tears the loaded iframe down so create() rebuilds a fresh one', async () => {
         const iframe = getIframeInstance();
         await createAndLoad(iframe);
-
-        const first = currentEl();
-        expect(first).not.toBeNull();
+        const first = getElement(iframe);
 
         iframe.destroy();
-        expect(currentEl()).toBeNull();
-        expect(first.remove).toHaveBeenCalled();
+        expect(iframe.get()).toBeUndefined();
+        expect(first.isConnected).toBe(false);
 
         const promise = iframe.create(SRC);
-        const second = currentEl();
-        expect(second).not.toBeNull();
-        expect(second).not.toBe(first);
-        expect(created).toHaveLength(2);
+        expect(getElement(iframe)).not.toBe(first);
 
-        fireLoad();
+        fireLoad(iframe);
         await expect(promise).resolves.toBeUndefined();
     });
 
@@ -131,18 +79,16 @@ describe('getIframeInstance', () => {
     it('clears the rejected init promise on load timeout (#29770)', async () => {
         const iframe = getIframeInstance();
         const settled = iframe.create(SRC).catch(error => error);
-        expect(currentEl()).not.toBeNull();
+        const first = getElement(iframe);
 
         jest.advanceTimersByTime(10000);
-        const error = await settled;
-        expect(error).toBeDefined();
-        expect(currentEl()).toBeNull();
+        await expect(settled).resolves.toMatchObject({ message: 'iframe-timeout' });
+        expect(iframe.get()).toBeUndefined();
 
         const promise = iframe.create(SRC);
-        expect(currentEl()).not.toBeNull();
-        expect(created).toHaveLength(2);
+        expect(getElement(iframe)).not.toBe(first);
 
-        fireLoad();
+        fireLoad(iframe);
         await expect(promise).resolves.toBeUndefined();
     });
 });

--- a/packages/connect-web/src/popup/iframe.test.ts
+++ b/packages/connect-web/src/popup/iframe.test.ts
@@ -91,4 +91,32 @@ describe('getIframeInstance', () => {
         fireLoad(iframe);
         await expect(promise).resolves.toBeUndefined();
     });
+
+    it('destroy() rejects a load still in flight so create() settles', async () => {
+        const iframe = getIframeInstance();
+        const settled = iframe.create(SRC).catch(error => error);
+        expect(iframe.get()).toBeDefined();
+
+        iframe.destroy();
+        await expect(settled).resolves.toMatchObject({ message: 'iframe-destroyed' });
+        expect(iframe.get()).toBeUndefined();
+
+        const promise = iframe.create(SRC);
+        fireLoad(iframe);
+        await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('destroy() leaves an iframe created by another instance alone', async () => {
+        const owner = getIframeInstance();
+        await createAndLoad(owner);
+        const element = getElement(owner);
+
+        // A second instance adopts the existing element instead of creating one.
+        const other = getIframeInstance();
+        await other.create(SRC);
+        other.destroy();
+
+        expect(element.isConnected).toBe(true);
+        expect(owner.get()).toBe(element);
+    });
 });

--- a/packages/connect-web/src/popup/iframe.test.ts
+++ b/packages/connect-web/src/popup/iframe.test.ts
@@ -123,17 +123,28 @@ describe('getIframeInstance', () => {
         expect(iframe.get()).toBeUndefined();
     });
 
-    it('destroy() leaves an iframe created by another instance alone', async () => {
-        const owner = getIframeInstance();
-        await createAndLoad(owner);
-        const element = getElement(owner);
+    it('gives each instance its own iframe', async () => {
+        const first = getIframeInstance();
+        const second = getIframeInstance();
+        await createAndLoad(first);
+        await createAndLoad(second);
+        expect(getElement(second)).not.toBe(getElement(first));
 
-        // A second instance adopts the existing element instead of creating one.
-        const other = getIframeInstance();
-        await other.create(SRC);
-        other.destroy();
+        second.destroy();
+        expect(second.get()).toBeUndefined();
+        expect(getElement(first).isConnected).toBe(true);
+    });
 
-        expect(element.isConnected).toBe(true);
-        expect(owner.get()).toBe(element);
+    it('does not adopt a foreign iframe left in the document', async () => {
+        const foreign = document.createElement('iframe');
+        foreign.id = 'trezor-connect-bootstrap';
+        document.body.appendChild(foreign);
+
+        const iframe = getIframeInstance();
+        await createAndLoad(iframe);
+        expect(getElement(iframe)).not.toBe(foreign);
+
+        iframe.destroy();
+        expect(foreign.isConnected).toBe(true);
     });
 });

--- a/packages/connect-web/src/popup/iframe.test.ts
+++ b/packages/connect-web/src/popup/iframe.test.ts
@@ -106,6 +106,23 @@ describe('getIframeInstance', () => {
         await expect(promise).resolves.toBeUndefined();
     });
 
+    // Regression: the first attempt's rejection reactions run as microtasks, so
+    // a create() issued synchronously after destroy() has already armed its own
+    // load timeout by the time they run. Clearing the shared timeout without
+    // checking whose it is left the second attempt without a timeout.
+    it('keeps the load timeout of a create() issued right after destroy()', async () => {
+        const iframe = getIframeInstance();
+        const first = iframe.create(SRC).catch(error => error);
+        iframe.destroy();
+        const second = iframe.create(SRC).catch(error => error);
+
+        await expect(first).resolves.toMatchObject({ message: 'iframe-destroyed' });
+
+        jest.advanceTimersByTime(10000);
+        await expect(second).resolves.toMatchObject({ message: 'iframe-timeout' });
+        expect(iframe.get()).toBeUndefined();
+    });
+
     it('destroy() leaves an iframe created by another instance alone', async () => {
         const owner = getIframeInstance();
         await createAndLoad(owner);

--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -96,8 +96,21 @@ export const getIframeInstance = () => {
             });
     };
 
+    // Tear the iframe down completely so the next create() rebuilds it from
+    // scratch. The `.catch` above only clears state when the iframe *load*
+    // rejects; a later failure (e.g. the bootstrap handshake) leaves a resolved
+    // `initPromise` and a live iframe whose bootstrap/storage-access state is
+    // reused. Recreating it mirrors what a page reload does (the only thing that
+    // currently recovers such a failure).
+    const destroy = () => {
+        clearInitTimeout();
+        getIframeElement()?.remove();
+        initPromise = undefined;
+    };
+
     return {
         create,
         get: getIframeElement,
+        destroy,
     };
 };

--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -102,7 +102,11 @@ export const getIframeInstance = () => {
 
         return init.promise
             .finally(() => {
-                clearInitTimeout();
+                // Skip once destroy() has moved on; the timeout then belongs
+                // to the next attempt.
+                if (initPromise === init) {
+                    clearInitTimeout();
+                }
             })
             .catch(error => {
                 // Reset state to allow initialization again, unless destroy()

--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -25,6 +25,10 @@ const createIframeElement = (): HTMLIFrameElement => {
 export const getIframeInstance = () => {
     let initPromise: Deferred<void> | undefined;
     let initTimeout: ReturnType<typeof setTimeout> | undefined;
+    // The element this instance appended, as opposed to one it merely adopted
+    // because it already carried IFRAME_ID (e.g. created by another copy of
+    // connect-web on the same page).
+    let ownedInstance: HTMLIFrameElement | undefined;
 
     const clearInitTimeout = () => {
         if (initTimeout) {
@@ -58,6 +62,21 @@ export const getIframeInstance = () => {
         initPromise?.resolve();
     };
 
+    // Tear down the iframe this instance created so the next create() rebuilds
+    // it from scratch, mirroring what a page reload does. A failure that happens
+    // after the iframe has loaded (e.g. the bootstrap handshake) leaves a resolved
+    // initPromise and a live iframe behind, which create() would otherwise reuse.
+    // A load still in flight is rejected so its awaiting create() settles instead
+    // of hanging. An adopted element is left alone.
+    const destroy = () => {
+        const pendingInit = initPromise;
+        clearInitTimeout();
+        initPromise = undefined;
+        ownedInstance?.remove();
+        ownedInstance = undefined;
+        pendingInit?.reject(ERRORS.TypedError('Handshake_Error', 'iframe-destroyed'));
+    };
+
     const create = (src: string) => {
         if (initPromise) {
             return initPromise.promise;
@@ -68,44 +87,32 @@ export const getIframeInstance = () => {
             return Promise.resolve();
         }
 
-        initPromise = createDeferred();
+        const init = createDeferred();
+        initPromise = init;
 
         const newInstance = createIframeElement();
+        ownedInstance = newInstance;
         initTimeout = setTimeout(() => {
-            initPromise?.reject(ERRORS.TypedError('Handshake_Error', 'iframe-timeout'));
+            init.reject(ERRORS.TypedError('Handshake_Error', 'iframe-timeout'));
         }, IFRAME_TIMEOUT);
 
         newInstance.onload = handleIframeLoad;
         newInstance.setAttribute('src', src);
         document.body.appendChild(newInstance);
 
-        return initPromise.promise
+        return init.promise
             .finally(() => {
                 clearInitTimeout();
             })
             .catch(error => {
-                // Reset state to allow initialization again.
-                if (newInstance.parentNode) {
-                    newInstance.parentNode.removeChild(newInstance);
+                // Reset state to allow initialization again, unless destroy()
+                // already did so (its rejection is what brought us here).
+                if (initPromise === init) {
+                    destroy();
                 }
-                // Clear the rejected deferred, otherwise the `if (initPromise)` guard above would
-                // keep returning this same rejected promise and the iframe would never be recreated.
-                initPromise = undefined;
                 // Propagate TypedError to caller.
                 throw error;
             });
-    };
-
-    // Tear the iframe down completely so the next create() rebuilds it from
-    // scratch. The `.catch` above only clears state when the iframe *load*
-    // rejects; a later failure (e.g. the bootstrap handshake) leaves a resolved
-    // `initPromise` and a live iframe whose bootstrap/storage-access state is
-    // reused. Recreating it mirrors what a page reload does (the only thing that
-    // currently recovers such a failure).
-    const destroy = () => {
-        clearInitTimeout();
-        getIframeElement()?.remove();
-        initPromise = undefined;
     };
 
     return {

--- a/packages/connect-web/src/popup/iframe.ts
+++ b/packages/connect-web/src/popup/iframe.ts
@@ -1,15 +1,12 @@
 import * as ERRORS from '@trezor/connect-common/src/constants/errors';
 import { type Deferred, createDeferred } from '@trezor/utils';
+import { getWeakRandomId } from '@trezor/utils/src/getWeakRandomId';
 
-const IFRAME_ID = 'trezor-connect-bootstrap';
 const IFRAME_TIMEOUT = 10000;
 
-const getIframeElement = (): HTMLIFrameElement | undefined =>
-    (document.getElementById(IFRAME_ID) as HTMLIFrameElement | null) ?? undefined;
-
-const createIframeElement = (): HTMLIFrameElement => {
+const createIframeElement = (id: string): HTMLIFrameElement => {
     const instance = document.createElement('iframe');
-    instance.id = IFRAME_ID;
+    instance.id = id;
     instance.frameBorder = '0';
     instance.width = '0px';
     instance.height = '0px';
@@ -23,12 +20,15 @@ const createIframeElement = (): HTMLIFrameElement => {
 };
 
 export const getIframeInstance = () => {
+    // Unique per manager, so two copies of connect-web on one page (or an
+    // iframe left behind by a previous bundle) never share, and never tear
+    // down, each other's iframe.
+    const iframeId = `trezor-connect-bootstrap-${getWeakRandomId(8)}`;
     let initPromise: Deferred<void> | undefined;
     let initTimeout: ReturnType<typeof setTimeout> | undefined;
-    // The element this instance appended, as opposed to one it merely adopted
-    // because it already carried IFRAME_ID (e.g. created by another copy of
-    // connect-web on the same page).
-    let ownedInstance: HTMLIFrameElement | undefined;
+
+    const getIframeElement = (): HTMLIFrameElement | undefined =>
+        (document.getElementById(iframeId) as HTMLIFrameElement | null) ?? undefined;
 
     const clearInitTimeout = () => {
         if (initTimeout) {
@@ -62,18 +62,17 @@ export const getIframeInstance = () => {
         initPromise?.resolve();
     };
 
-    // Tear down the iframe this instance created so the next create() rebuilds
-    // it from scratch, mirroring what a page reload does. A failure that happens
-    // after the iframe has loaded (e.g. the bootstrap handshake) leaves a resolved
-    // initPromise and a live iframe behind, which create() would otherwise reuse.
-    // A load still in flight is rejected so its awaiting create() settles instead
-    // of hanging. An adopted element is left alone.
+    // Tear the iframe down so the next create() rebuilds it from scratch,
+    // mirroring what a page reload does. A failure that happens after the
+    // iframe has loaded (e.g. the bootstrap handshake) leaves a resolved
+    // initPromise and a live iframe behind, which create() would otherwise
+    // reuse. A load still in flight is rejected so its awaiting create()
+    // settles instead of hanging.
     const destroy = () => {
         const pendingInit = initPromise;
         clearInitTimeout();
         initPromise = undefined;
-        ownedInstance?.remove();
-        ownedInstance = undefined;
+        getIframeElement()?.remove();
         pendingInit?.reject(ERRORS.TypedError('Handshake_Error', 'iframe-destroyed'));
     };
 
@@ -82,16 +81,10 @@ export const getIframeInstance = () => {
             return initPromise.promise;
         }
 
-        const instance = getIframeElement();
-        if (instance) {
-            return Promise.resolve();
-        }
-
         const init = createDeferred();
         initPromise = init;
 
-        const newInstance = createIframeElement();
-        ownedInstance = newInstance;
+        const newInstance = createIframeElement(iframeId);
         initTimeout = setTimeout(() => {
             init.reject(ERRORS.TypedError('Handshake_Error', 'iframe-timeout'));
         }, IFRAME_TIMEOUT);

--- a/packages/connect-web/src/popup/web.test.ts
+++ b/packages/connect-web/src/popup/web.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { POPUP } from '@trezor/connect-common/src/events';
+import { initLog } from '@trezor/connect-common/src/utils/debug';
+
+import { WebPopup } from './web';
+
+const ORIGIN = 'https://suite.trezor.io';
+const POPUP_SRC = `${ORIGIN}/connect-popup`;
+
+type FakePopupWindow = {
+    location: { href: string };
+    close: jest.Mock;
+    postMessage: jest.Mock;
+};
+
+jest.useFakeTimers();
+
+const openedWindows: FakePopupWindow[] = [];
+const popups: WebPopup[] = [];
+
+beforeAll(() => {
+    // jsdom has no crypto.randomUUID(), which the channel uses for message ids.
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        value: randomUUID,
+        configurable: true,
+    });
+});
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    openedWindows.length = 0;
+    jest.clearAllTimers();
+    jest.spyOn(window, 'open').mockImplementation(() => {
+        const popupWindow: FakePopupWindow = {
+            location: { href: 'about:blank' },
+            close: jest.fn(),
+            postMessage: jest.fn(),
+        };
+        openedWindows.push(popupWindow);
+
+        return popupWindow as unknown as Window;
+    });
+});
+
+afterEach(() => {
+    // Drop the window listeners so a popup from one test cannot consume
+    // the messages of the next one.
+    popups.splice(0).forEach(popup => popup.channel.disconnect());
+    jest.restoreAllMocks();
+});
+
+const createPopup = () => {
+    const popup = new WebPopup({
+        popupSrc: POPUP_SRC,
+        manifest: { appName: 'Test app', appUrl: 'https://app.example', email: 'dev@example.com' },
+        version: '1.0.0',
+        logger: initLog('test'),
+    });
+    popups.push(popup);
+
+    return popup;
+};
+
+const getOpenedWindow = (index: number) => {
+    const popupWindow = openedWindows[index];
+    if (!popupWindow) throw new Error(`popup window ${index} not opened`);
+
+    return popupWindow;
+};
+
+const getIframe = () => {
+    const element = document.querySelector('iframe');
+    if (!element) throw new Error('bootstrap iframe not appended');
+
+    return element;
+};
+
+const getChannelId = (url: string) => new URL(url).searchParams.get('connect-popup-req');
+
+// What the bootstrap iframe (or the popup, forwarded through it) posts to the
+// host window.
+const sendFromIframe = (
+    data: Record<string, unknown>,
+    here:
+        | '@trezor/connect-bootstrap-iframe'
+        | '@trezor/connect-popup' = '@trezor/connect-bootstrap-iframe',
+) => {
+    window.dispatchEvent(
+        new MessageEvent('message', {
+            origin: ORIGIN,
+            data: { ...data, channel: { here, peer: '@trezor/connect-web' } },
+        }),
+    );
+};
+
+// Drives open() up to the bootstrap handshake: the popup window is opened,
+// the hidden iframe appended and loaded.
+const openUntilBootstrapHandshake = async (popup: WebPopup) => {
+    const opened = popup.focusOrCreate();
+    // Suppress the unhandled rejection until the test attaches its own handler.
+    opened.catch(() => {});
+    await jest.advanceTimersByTimeAsync(0);
+    const iframe = getIframe();
+    iframe.dispatchEvent(new Event('load'));
+    await jest.advanceTimersByTimeAsync(0);
+
+    return { opened, iframe };
+};
+
+describe('WebPopup', () => {
+    // The Connect Explorer scenario: the bootstrap iframe <-> popup handshake
+    // fails after the iframe has loaded (`connect-popup-err=handshake-timeout`).
+    it('recovers from a bootstrap handshake failure with a fresh iframe and channel id', async () => {
+        const popup = createPopup();
+        const { opened, iframe } = await openUntilBootstrapHandshake(popup);
+        const failedWindow = getOpenedWindow(0);
+        const failedChannelId = getChannelId(failedWindow.location.href);
+        expect(failedChannelId).toBe(getChannelId(iframe.src));
+
+        sendFromIframe({ type: 'channel-handshake-error', error: 'handshake-timeout' });
+        await expect(opened).rejects.toMatchObject({
+            code: 'Handshake_Error',
+            message: 'handshake-timeout',
+        });
+
+        // The popup is told to show the error and stays open; the iframe is gone.
+        expect(failedWindow.postMessage).toHaveBeenCalledWith(
+            { type: 'channel-handshake-error', error: 'handshake-timeout' },
+            ORIGIN,
+        );
+        expect(failedWindow.close).not.toHaveBeenCalled();
+        expect(iframe.isConnected).toBe(false);
+        expect(document.querySelector('iframe')).toBeNull();
+
+        // The retry rebuilds the iframe and gives it and the popup a new channel id.
+        const retry = await openUntilBootstrapHandshake(popup);
+        expect(retry.iframe).not.toBe(iframe);
+        const retryChannelId = getChannelId(retry.iframe.src);
+        expect(retryChannelId).not.toBe(failedChannelId);
+        expect(getChannelId(getOpenedWindow(1).location.href)).toBe(retryChannelId);
+
+        sendFromIframe({ type: 'channel-handshake-confirm' });
+        await expect(retry.opened).resolves.toBeUndefined();
+
+        // The popup channel handshake and CORE_LOADED complete on the recovered manager.
+        const channelHandshake = popup.channel.init();
+        await jest.advanceTimersByTimeAsync(0);
+        sendFromIframe({ type: 'channel-handshake-confirm' }, '@trezor/connect-popup');
+        await expect(channelHandshake).resolves.toBeUndefined();
+
+        sendFromIframe({ type: POPUP.CORE_LOADED }, '@trezor/connect-popup');
+        await expect(popup.handshakePromise?.promise).resolves.toBeUndefined();
+    });
+
+    // The #29770 scenario: the iframe itself never loads.
+    it('closes the popup on an iframe load timeout and retries with a fresh iframe', async () => {
+        const popup = createPopup();
+        const opened = popup.focusOrCreate();
+        opened.catch(() => {});
+        await jest.advanceTimersByTimeAsync(0);
+        const iframe = getIframe();
+
+        await jest.advanceTimersByTimeAsync(10000);
+        await expect(opened).rejects.toMatchObject({ message: 'iframe-timeout' });
+        expect(getOpenedWindow(0).close).toHaveBeenCalled();
+        expect(iframe.isConnected).toBe(false);
+
+        const retry = await openUntilBootstrapHandshake(popup);
+        expect(retry.iframe).not.toBe(iframe);
+
+        sendFromIframe({ type: 'channel-handshake-confirm' });
+        await expect(retry.opened).resolves.toBeUndefined();
+    });
+});

--- a/packages/connect-web/src/popup/web.ts
+++ b/packages/connect-web/src/popup/web.ts
@@ -14,6 +14,22 @@ export class WebPopup extends Popup {
     private iframe = getIframeInstance();
     private channelId = getWeakRandomId(16);
 
+    /**
+     * Rebuild the reusable per-session state after a failed open() so the retry
+     * starts as clean as a fresh page load. A transient failure that happens
+     * *after* the hidden iframe has loaded (e.g. the bootstrap handshake times
+     * out — `connect-popup-err=handshake-timeout`) otherwise leaves the same
+     * iframe (with a resolved `initPromise` and stale bootstrap/storage-access
+     * state) and the same `channelId` in place, and every subsequent call reuses
+     * them and fails again until the page is reloaded. Reloading the page is the
+     * only thing that currently recovers, and it recreates exactly these two
+     * things, so we do the same here.
+     */
+    private resetForRetry(): void {
+        this.iframe.destroy();
+        this.channelId = getWeakRandomId(16);
+    }
+
     protected createChannel(): AbstractMessageChannel<CoreEventMessage> {
         return new WindowWindowChannel<CoreEventMessage>({
             windowHere: window,
@@ -47,6 +63,7 @@ export class WebPopup extends Popup {
         } catch (error) {
             windowResult.close();
             this.handleOpenFailure(error.message);
+            this.resetForRetry();
 
             return Promise.reject(error);
         }
@@ -94,6 +111,11 @@ export class WebPopup extends Popup {
         } catch (error) {
             this.handleOpenFailure(error.message);
             iframeWindowChannel.disconnect();
+            // Leave `windowResult` open: on this path the popup has navigated
+            // itself to the error page (`connect-popup-err=...`) to show the
+            // user the failure. But rebuild the iframe + channelId so the next
+            // call doesn't reuse the poisoned bootstrap state.
+            this.resetForRetry();
 
             const isBootstrapError = Object.values(BootstrapError).includes(error.message);
             if (isBootstrapError) {

--- a/packages/connect-web/src/popup/web.ts
+++ b/packages/connect-web/src/popup/web.ts
@@ -100,7 +100,7 @@ export class WebPopup extends Popup {
                     popupOrigin,
                 );
 
-                this.handleOpenFailure(message.error);
+                // Rejects the awaited init() below, which reports the failure once.
                 iframeWindowChannel.abortHandshake(message.error);
             }
         });

--- a/packages/connect-web/src/popup/web.ts
+++ b/packages/connect-web/src/popup/web.ts
@@ -14,17 +14,11 @@ export class WebPopup extends Popup {
     private iframe = getIframeInstance();
     private channelId = getWeakRandomId(16);
 
-    /**
-     * Rebuild the reusable per-session state after a failed open() so the retry
-     * starts as clean as a fresh page load. A transient failure that happens
-     * *after* the hidden iframe has loaded (e.g. the bootstrap handshake times
-     * out — `connect-popup-err=handshake-timeout`) otherwise leaves the same
-     * iframe (with a resolved `initPromise` and stale bootstrap/storage-access
-     * state) and the same `channelId` in place, and every subsequent call reuses
-     * them and fails again until the page is reloaded. Reloading the page is the
-     * only thing that currently recovers, and it recreates exactly these two
-     * things, so we do the same here.
-     */
+    // Rebuild the per-session state a failed open() leaves behind so the retry
+    // starts as clean as a page reload: the hidden iframe (a failure after it has
+    // loaded, e.g. `connect-popup-err=handshake-timeout`, keeps its `initPromise`
+    // resolved so create() would reuse it) and the channel id. The two must
+    // change together, because the iframe reads the id from its own `src`.
     private resetForRetry(): void {
         this.iframe.destroy();
         this.channelId = getWeakRandomId(16);
@@ -63,7 +57,6 @@ export class WebPopup extends Popup {
         } catch (error) {
             windowResult.close();
             this.handleOpenFailure(error.message);
-            this.resetForRetry();
 
             return Promise.reject(error);
         }
@@ -111,10 +104,8 @@ export class WebPopup extends Popup {
         } catch (error) {
             this.handleOpenFailure(error.message);
             iframeWindowChannel.disconnect();
-            // Leave `windowResult` open: on this path the popup has navigated
-            // itself to the error page (`connect-popup-err=...`) to show the
-            // user the failure. But rebuild the iframe + channelId so the next
-            // call doesn't reuse the poisoned bootstrap state.
+            // Leave `windowResult` open: the popup has navigated itself to the
+            // error page (`connect-popup-err=...`) to show the user the failure.
             this.resetForRetry();
 
             const isBootstrapError = Object.values(BootstrapError).includes(error.message);


### PR DESCRIPTION
## Description

Follow-up to #29770. That PR made the connect-web popup manager recover from a transient iframe **load** failure (`iframe-timeout`). QA still hit a permanent "The connection timed out. Try again." in **Connect Explorer** (embedded, cross-origin), where the failure surfaces as `connect-popup-err=handshake-timeout`: the bootstrap iframe ↔ popup handshake fails **after** the hidden iframe has loaded, so the `.catch` reset from #29770 never runs. Only a full page reload recovered.

This PR fixes that bug and hardens the code around it. One commit per bug; each is described below with a way to reproduce or verify it by hand.

The manual steps assume Connect Explorer (it initializes `TrezorConnect` with `debug: true`, so `@trezor/connect-web` logs are in the console) with DevTools open. The hidden iframe has the id `trezor-connect-bootstrap-<random>` in Elements (one per connect-web instance); its `src` and the popup URL both carry `connect-popup-req=<channel id>`.

### 1. A failed `open()` reported twice left `handshakePromise` permanently rejected (the reported bug)

**Symptom.** After one `handshake-timeout`, every later call failed with the same error until a page reload, even from another Connect Explorer method page (client-side navigation keeps the same `WebPopup` singleton).

**Root cause.** One failure was reported twice: the iframe posted `channel-handshake-error` (handled in `web.ts` → `handleOpenFailure`), and the awaited `iframeWindowChannel.init()` then rejected (→ `handleOpenFailure` again). The first call's `reset()` recreated a fresh `handshakePromise`; the second call rejected that fresh one, and `reset()` early-returned because `locked` was already `false`, so it was never recreated. Every `call()` awaits `handshakePromise` (`core-in-suite-web.ts`), so it threw the stale error each time.

**Fix.** `handleOpenFailure` is idempotent per `open()` (`if (!this.locked)` guard in `abstract.ts`), and the duplicate report is removed at its source: the `channel-handshake-error` listener now only aborts the iframe channel handshake, and the rejected `init()` is the single report (`web.ts`). The guard stays for late webextension callbacks that can arrive after `reset()`; a dropped report is logged at debug level (`Ignoring open failure after reset:`) instead of vanishing.

**Reproduce.**
1. Open a Connect Explorer method page, e.g. `…/methods/bitcoin/getPublicKey/`.
2. DevTools → Network → **Offline** (or heavy throttling).
3. Call **Get public key** → "The connection timed out. Try again." (the popup URL ends with `connect-popup-err=handshake-timeout`).
4. Go back online. **Do not reload.**
5. Call **Get public key** again.
   - Before: fails again with the same error.
   - After: the call proceeds. Also verify from another method page (e.g. `signMessage`).

Unit test: `abstract.test.ts` "keeps a usable handshakePromise when the same open() failure is reported twice" (fails without the guard).

### 2. Stale bootstrap iframe and channel id reused after a post-load failure

**Symptom.** After the bootstrap handshake failed, the hidden iframe stayed in the DOM with a resolved `initPromise`, so the next `create()` reused it, and the same channel id went to the next popup. Two things could bite a quick retry: (a) the failed attempt's popup keeps listening for the iframe handshake for 5 s while the iframe gives up after 2.5 s, so a retry on the same id could be answered by the stale popup; (b) `AbstractMessageChannel.handshakeWithPeer` fires one more `channel-handshake-request` after `abortHandshake()` (its retry loop is not cancelled), which restarted a bootstrap round in the old iframe whose late `channel-handshake-error` a retry could consume as its own failure.

**Fix.** `WebPopup.resetForRetry()` destroys the iframe and rotates the channel id together (the iframe reads the id from its own `src`, so the two must change together). It runs only on the post-load failure path. After an iframe **load** failure the `.catch` in `create()` has already torn everything down and the id was never handed to a bootstrap document, so the call there was a no-op and was dropped.

**Verify.**
1. Reproduce step 3 above and note the `connect-popup-req` value in the failed popup URL.
2. Elements: the `trezor-connect-bootstrap-…` iframe is gone after the failure (before: it stayed, with the old id in its `src`).
3. Retry: a new iframe appears and the new popup URL carries a **different** `connect-popup-req` value.

### 3. `destroy()` could strand a load in flight (latent)

**Bug.** `destroy()` cleared the load timeout, removed the element and dropped the pending deferred without settling it. A `create()` awaiting that load would never resolve, and because `focusOrCreate()` is serialized, every later call on the manager would queue behind it. Not reachable through `WebPopup` today (`resetForRetry()` runs after `create()` has settled), but `destroy()` is public and nothing enforced that.

**Fix.** A load in flight is rejected with `Handshake_Error: iframe-destroyed`, and the `.finally` cleanup of the aborted attempt only clears the shared timeout while that attempt is still the current one, so a `create()` issued synchronously after `destroy()` keeps its own 10 s timeout.

**Verify.** Not reachable from `TrezorConnect`; covered by `iframe.test.ts` "destroy() rejects a load still in flight so create() settles" and "keeps the load timeout of a create() issued right after destroy()" (both fail without the fix).

### 4. Every connect-web instance shared one iframe (`#trezor-connect-bootstrap`)

**Bug.** All iframe managers used the same fixed DOM id, and `create()` adopted any element that carried it. A second copy of `@trezor/connect-web` on the page (dApp + a wallet-adapter library bundling its own) or an iframe left behind by a previous bundle was adopted instead of rebuilt. An adopted iframe carries someone else's channel id in its `src`, so every bootstrap handshake through it times out. With the new `destroy()` this became a dilemma: removing the adopted element would tear the other copy's live iframe out from under it (hanging its in-flight call), while leaving it alone kept the retry stuck on the mismatched id (Copilot's remark).

**Fix.** Each manager appends its own `trezor-connect-bootstrap-<random>` iframe. There is nothing to adopt, so the "element already exists" fast path in `create()` is gone and `destroy()` always rebuilds. Nothing in the repository referenced the fixed id.

**Simulate.**
1. Before any call, inject a foreign iframe with the old id in the console:
   ```js
   document.body.appendChild(Object.assign(document.createElement('iframe'), { id: 'trezor-connect-bootstrap' }));
   ```
2. Call a method.
   - Before (`develop`): connect-web adopts the injected element, no bootstrap handshake can happen, the call fails after ~10 s (`handshake failed`) and keeps failing on every retry.
   - After: the injected element is ignored, connect-web appends its own `trezor-connect-bootstrap-…` iframe next to it and the call proceeds.

### Tests

- `abstract.test.ts` drives the manager through `focusOrCreate()` instead of poking the private `locked` field, uses a typed `AbstractMessageChannel` subclass and a real `Log` instead of cast mocks, and asserts the failure reason reaches both the handshake promise and `channel.abortHandshake()`.
- `iframe.test.ts` runs against the real jsdom DOM (no hand-rolled element fakes) and covers load, reuse, destroy-and-rebuild, load timeout (#29770), destroy during a pending load, destroy right before a new `create()`, per-instance iframes, and a foreign iframe left in the document.
- `web.test.ts` drives `WebPopup.open()` end to end in jsdom: the iframe posts `channel-handshake-error`, `init()` rejects, the popup stays open on its error page, the iframe is removed, and the retry rebuilds iframe + popup with a new channel id and completes the bootstrap handshake, the popup channel handshake and `POPUP.CORE_LOADED`. A second case covers the #29770 load-timeout path. With the original double report and no guard the first case fails exactly as QA observed.
- The full `@trezor/connect-web` unit suite passes locally; type-check and lint are verified by CI.

## Notes for QA

Run the **Reproduce** steps of bug 1 (the original QA scenario, now with self-recovery and no page reload) and the **Verify** steps of bug 2 (iframe gone after the failure, new channel id on retry). Bug 3 is covered by unit tests only; bug 4 has an optional console simulation above.

## Related Issue

Follow-up to #29770 (no separate issue).

## Screenshots:

N/A, no UI change.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** These changes touch the core connect-web popup machinery, so the main risk is regressions in popup opening/closing, foreground/focus behavior, and permissions/address modal rendering. The recommended high-priority tests cover the broad web and extension popup lifecycles plus silent-mode focus logic. Medium-priority tests add coverage for the desktop iframe popup path (error UI, address verification, and permissions persistence). No static coverage mapping was available, so these tests were inferred from the LLM analysis.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-web/src/popup/abstract.test.ts`
- `packages/connect-web/src/popup/abstract.ts`
- `packages/connect-web/src/popup/iframe.test.ts`
- `packages/connect-web/src/popup/iframe.ts`
- `packages/connect-web/src/popup/web.test.ts`
- `packages/connect-web/src/popup/web.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — This test exercises the full connect popup lifecycle in a web context—opening/closing, permission grants, address confirmation, cancellation, popup reuse, and popup-blocked detection—so it directly validates the abstract popup manager and the web popup implementation.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — It covers connect popup behavior when invoked from a web extension, including force-close recovery and focusing an existing popup, which exercises the web popup manager in a different host context and lifecycle path.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Silent mode controls whether connect calls bring Suite to the foreground, which depends on popup focus/visibility logic and the permissions modal; it runs in suite-desktop core mode, so it also exercises the iframe popup path.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/error.test.ts` — Verifies that popup error UI renders for invalid ethereumGetAddress paths; regressions in iframe popup initialization or rendering would surface here in the desktop core popup path.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Covers address confirmation UI states (single export, bundle, showOnTrezor, verify/error badges) in the desktop core popup, which helps catch iframe popup regressions in the address confirmation flow.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Tests the permissions modal’s remember checkbox and connected-apps persistence; since the modal is part of the connect popup flow, changes to popup management could affect whether it appears or stays dismissed.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/connect-web/src/popup/abstract.test.ts`
- `packages/connect-web/src/popup/iframe.test.ts`
- `packages/connect-web/src/popup/web.test.ts`

_Updated: 2026-09-07T06:35:05.459Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-timeout/web/](https://dev.suite.sldev.cz/suite-web/mroz22/connect-explorer-timeout/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=mroz22/connect-explorer-timeout&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=mroz22/connect-explorer-timeout&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-07T06:35:20.541Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-07T06:35:58.296Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

