### PR TITLE
refactor(networks): modularize account sync intervals

### DIFF
--- a/networks/bitcoin/network-bitcoin-suite-common/src/BitcoinNetworkSuiteCommonNetworkModule.ts
+++ b/networks/bitcoin/network-bitcoin-suite-common/src/BitcoinNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 import type { SuiteCommonNetworkModule } from '@trezor/network-module-suite-common-types';
 
 import { bitcoinValidator } from './addressValidator/bitcoinAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type BitcoinNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<BitcoinNetworkSymbol>;
 
@@ -16,4 +16,5 @@ export const createBitcoinSuiteCommonNetworkModule =
         getSupportedNetworks: () => supportedBitcoinNetworks,
         isSupportedNetwork: isSupportedBitcoinNetwork,
         getNetworkConfig,
+        getAccountSyncInterval,
     });

--- a/networks/bitcoin/network-bitcoin-suite-common/src/networkConfig.ts
+++ b/networks/bitcoin/network-bitcoin-suite-common/src/networkConfig.ts
@@ -1,8 +1,19 @@
 import type { BitcoinNetworkSymbol } from '@trezor/network-bitcoin/constants';
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
+
+const syncIntervalBySymbol: Readonly<Record<BitcoinNetworkSymbol, number>> = {
+    btc: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    test: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    regtest: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    ltc: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    doge: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    zec: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    bch: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<BitcoinNetworkSymbol, SuiteCommonNetworkConfig>> = {
     btc: { color: '#f29937', protocols: [asProtocol('bitcoin'), asProtocol('btc')] },
@@ -16,3 +27,6 @@ const networkConfigBySymbol: Readonly<Record<BitcoinNetworkSymbol, SuiteCommonNe
 
 export const getNetworkConfig = (symbol: BitcoinNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: BitcoinNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/cardano/network-cardano-suite-common/src/CardanoNetworkSuiteCommonNetworkModule.ts
+++ b/networks/cardano/network-cardano-suite-common/src/CardanoNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 import type { SuiteCommonNetworkModule } from '@trezor/network-module-suite-common-types';
 
 import { adaValidator } from './addressValidator/cardanoAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type CardanoNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<CardanoNetworkSymbol>;
 
@@ -16,4 +16,5 @@ export const createCardanoSuiteCommonNetworkModule =
         getSupportedNetworks: () => supportedCardanoNetworks,
         isSupportedNetwork: isSupportedCardanoNetwork,
         getNetworkConfig,
+        getAccountSyncInterval,
     });

--- a/networks/cardano/network-cardano-suite-common/src/networkConfig.ts
+++ b/networks/cardano/network-cardano-suite-common/src/networkConfig.ts
@@ -1,8 +1,13 @@
 import type { CardanoNetworkSymbol } from '@trezor/network-cardano/constants';
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
+
+const syncIntervalBySymbol: Readonly<Record<CardanoNetworkSymbol, number>> = {
+    ada: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<CardanoNetworkSymbol, SuiteCommonNetworkConfig>> = {
     ada: { color: '#3468d1', protocols: [asProtocol('cardano'), asProtocol('ada')] },
@@ -10,3 +15,6 @@ const networkConfigBySymbol: Readonly<Record<CardanoNetworkSymbol, SuiteCommonNe
 
 export const getNetworkConfig = (symbol: CardanoNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: CardanoNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/ethereum/network-ethereum-suite-common/src/EthereumNetworkSuiteCommonNetworkModule.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/EthereumNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 import type { SuiteCommonNetworkModule } from '@trezor/network-module-suite-common-types';
 
 import { ethereumValidator } from './addressValidator/ethereumAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type EthereumNetworkSuiteCommonNetworkModule =
     SuiteCommonNetworkModule<EthereumNetworkSymbol>;
@@ -17,4 +17,5 @@ export const createEthereumSuiteCommonNetworkModule =
         getSupportedNetworks: () => supportedEthereumNetworks,
         isSupportedNetwork: isSupportedEthereumNetwork,
         getNetworkConfig,
+        getAccountSyncInterval,
     });

--- a/networks/ethereum/network-ethereum-suite-common/src/networkConfig.ts
+++ b/networks/ethereum/network-ethereum-suite-common/src/networkConfig.ts
@@ -1,8 +1,24 @@
 import type { EthereumNetworkSymbol } from '@trezor/network-ethereum/constants';
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
+
+const syncIntervalBySymbol: Readonly<Record<EthereumNetworkSymbol, number>> = {
+    eth: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    pol: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    bsc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    arb: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    base: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    op: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    rhc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    hype: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    avax: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    etc: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    tsep: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    thod: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<EthereumNetworkSymbol, SuiteCommonNetworkConfig>> = {
     eth: { color: '#454a75', protocols: [asProtocol('ethereum'), asProtocol('eth')] },
@@ -41,3 +57,6 @@ const networkConfigBySymbol: Readonly<Record<EthereumNetworkSymbol, SuiteCommonN
 
 export const getNetworkConfig = (symbol: EthereumNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: EthereumNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/network-module/network-module-suite-common-types/src/AccountSyncInterval.ts
+++ b/networks/network-module/network-module-suite-common-types/src/AccountSyncInterval.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ACCOUNT_SYNC_INTERVAL = 60 * 1000; // 1 minute

--- a/networks/network-module/network-module-suite-common-types/src/SuiteCommonNetworkModule.ts
+++ b/networks/network-module/network-module-suite-common-types/src/SuiteCommonNetworkModule.ts
@@ -16,4 +16,6 @@ export type SuiteCommonNetworkModule<TSymbol extends string> = {
     isSupportedNetwork: (symbol: string) => symbol is TSymbol;
 
     getNetworkConfig(symbol: TSymbol): SuiteCommonNetworkConfig;
+
+    getAccountSyncInterval(symbol: TSymbol): number;
 };

--- a/networks/network-module/network-module-suite-common-types/src/index.ts
+++ b/networks/network-module/network-module-suite-common-types/src/index.ts
@@ -1,5 +1,6 @@
 export { addressType } from './AddressValidator';
 export type { AddressType, AddressValidator } from './AddressValidator';
+export { DEFAULT_ACCOUNT_SYNC_INTERVAL } from './AccountSyncInterval';
 export { asProtocol } from './Protocol';
 export type { Protocol } from './Protocol';
 export type {

--- a/networks/ripple/network-ripple-suite-common/src/RippleNetworkSuiteCommonNetworkModule.ts
+++ b/networks/ripple/network-ripple-suite-common/src/RippleNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 } from '@trezor/network-ripple/constants';
 
 import { rippleValidator } from './addressValidator/rippleAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type RippleNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<RippleNetworkSymbol>;
 
@@ -15,4 +15,5 @@ export const createRippleSuiteCommonNetworkModule = (): RippleNetworkSuiteCommon
     getSupportedNetworks: () => supportedRippleNetworks,
     isSupportedNetwork: isSupportedRippleNetwork,
     getNetworkConfig,
+    getAccountSyncInterval,
 });

--- a/networks/ripple/network-ripple-suite-common/src/networkConfig.ts
+++ b/networks/ripple/network-ripple-suite-common/src/networkConfig.ts
@@ -1,8 +1,14 @@
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
 import type { RippleNetworkSymbol } from '@trezor/network-ripple/constants';
+
+const syncIntervalBySymbol: Readonly<Record<RippleNetworkSymbol, number>> = {
+    xrp: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    txrp: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<RippleNetworkSymbol, SuiteCommonNetworkConfig>> = {
     xrp: { color: '#24292e', protocols: [asProtocol('ripple'), asProtocol('xrp')] },
@@ -11,3 +17,6 @@ const networkConfigBySymbol: Readonly<Record<RippleNetworkSymbol, SuiteCommonNet
 
 export const getNetworkConfig = (symbol: RippleNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: RippleNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/solana/network-solana-suite-common/src/SolanaNetworkSuiteCommonNetworkModule.ts
+++ b/networks/solana/network-solana-suite-common/src/SolanaNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 } from '@trezor/network-solana/constants';
 
 import { solanaValidator } from './addressValidator/solanaAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type SolanaNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<SolanaNetworkSymbol>;
 
@@ -15,4 +15,5 @@ export const createSolanaSuiteCommonNetworkModule = (): SolanaNetworkSuiteCommon
     getSupportedNetworks: () => supportedSolanaNetworks,
     isSupportedNetwork: isSupportedSolanaNetwork,
     getNetworkConfig,
+    getAccountSyncInterval,
 });

--- a/networks/solana/network-solana-suite-common/src/networkConfig.ts
+++ b/networks/solana/network-solana-suite-common/src/networkConfig.ts
@@ -1,8 +1,14 @@
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
 import type { SolanaNetworkSymbol } from '@trezor/network-solana/constants';
+
+const syncIntervalBySymbol: Readonly<Record<SolanaNetworkSymbol, number>> = {
+    sol: DEFAULT_ACCOUNT_SYNC_INTERVAL * 5,
+    dsol: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<SolanaNetworkSymbol, SuiteCommonNetworkConfig>> = {
     sol: { color: '#9945ff', protocols: [asProtocol('solana'), asProtocol('sol')] },
@@ -11,3 +17,6 @@ const networkConfigBySymbol: Readonly<Record<SolanaNetworkSymbol, SuiteCommonNet
 
 export const getNetworkConfig = (symbol: SolanaNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: SolanaNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/stellar/network-stellar-suite-common/src/StellarNetworkSuiteCommonNetworkModule.ts
+++ b/networks/stellar/network-stellar-suite-common/src/StellarNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 } from '@trezor/network-stellar/constants';
 
 import { stellarValidator } from './addressValidator/stellarAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type StellarNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<StellarNetworkSymbol>;
 
@@ -16,4 +16,5 @@ export const createStellarSuiteCommonNetworkModule =
         getSupportedNetworks: () => supportedStellarNetworks,
         isSupportedNetwork: isSupportedStellarNetwork,
         getNetworkConfig,
+        getAccountSyncInterval,
     });

--- a/networks/stellar/network-stellar-suite-common/src/networkConfig.ts
+++ b/networks/stellar/network-stellar-suite-common/src/networkConfig.ts
@@ -1,8 +1,14 @@
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
 import type { StellarNetworkSymbol } from '@trezor/network-stellar/constants';
+
+const syncIntervalBySymbol: Readonly<Record<StellarNetworkSymbol, number>> = {
+    xlm: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+    txlm: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<StellarNetworkSymbol, SuiteCommonNetworkConfig>> = {
     xlm: { color: '#000000', protocols: [asProtocol('stellar'), asProtocol('xlm')] },
@@ -11,3 +17,6 @@ const networkConfigBySymbol: Readonly<Record<StellarNetworkSymbol, SuiteCommonNe
 
 export const getNetworkConfig = (symbol: StellarNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: StellarNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/networks/tron/network-tron-suite-common/src/TronNetworkSuiteCommonNetworkModule.ts
+++ b/networks/tron/network-tron-suite-common/src/TronNetworkSuiteCommonNetworkModule.ts
@@ -6,7 +6,7 @@ import {
 } from '@trezor/network-tron/constants';
 
 import { tronValidator } from './addressValidator/tronAddressValidator';
-import { getNetworkConfig } from './networkConfig';
+import { getAccountSyncInterval, getNetworkConfig } from './networkConfig';
 
 export type TronNetworkSuiteCommonNetworkModule = SuiteCommonNetworkModule<TronNetworkSymbol>;
 
@@ -15,4 +15,5 @@ export const createTronSuiteCommonNetworkModule = (): TronNetworkSuiteCommonNetw
     getSupportedNetworks: () => supportedTronNetworks,
     isSupportedNetwork: isSupportedTronNetwork,
     getNetworkConfig,
+    getAccountSyncInterval,
 });

--- a/networks/tron/network-tron-suite-common/src/networkConfig.ts
+++ b/networks/tron/network-tron-suite-common/src/networkConfig.ts
@@ -1,8 +1,14 @@
 import {
+    DEFAULT_ACCOUNT_SYNC_INTERVAL,
     type SuiteCommonNetworkConfig,
     asProtocol,
 } from '@trezor/network-module-suite-common-types';
 import type { TronNetworkSymbol } from '@trezor/network-tron/constants';
+
+const syncIntervalBySymbol: Readonly<Record<TronNetworkSymbol, number>> = {
+    trx: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
+    ttrx: DEFAULT_ACCOUNT_SYNC_INTERVAL,
+};
 
 const networkConfigBySymbol: Readonly<Record<TronNetworkSymbol, SuiteCommonNetworkConfig>> = {
     trx: { color: '#ec002a', protocols: [asProtocol('tron'), asProtocol('trx')] },
@@ -11,3 +17,6 @@ const networkConfigBySymbol: Readonly<Record<TronNetworkSymbol, SuiteCommonNetwo
 
 export const getNetworkConfig = (symbol: TronNetworkSymbol): SuiteCommonNetworkConfig =>
     networkConfigBySymbol[symbol];
+
+export const getAccountSyncInterval = (symbol: TronNetworkSymbol): number =>
+    syncIntervalBySymbol[symbol];

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -42,24 +42,6 @@ import { fetchAndUpdateAccountThunk, reportWalletBalanceThunk } from '../account
 import { preloadFeeInfoThunk } from '../fees/feesThunks';
 import { selectBitcoinAmountUnit } from '../settings/walletSettingsReducer';
 
-export const DEFAULT_ACCOUNT_SYNC_INTERVAL = 60 * 1000; // 1 minute
-
-const CUSTOM_ACCOUNT_SYNC_INTERVALS: Partial<Record<NetworkSymbol, number>> = {
-    bsc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    pol: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    op: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    base: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    arb: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    avax: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    trx: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    rhc: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    hype: DEFAULT_ACCOUNT_SYNC_INTERVAL / 1.5,
-    sol: DEFAULT_ACCOUNT_SYNC_INTERVAL * 5,
-};
-
-const getAccountSyncInterval = (symbol: NetworkSymbol) =>
-    CUSTOM_ACCOUNT_SYNC_INTERVALS[symbol] || DEFAULT_ACCOUNT_SYNC_INTERVAL;
-
 // call TrezorConnect.unsubscribe, it doesn't cost anything and should emit BLOCKCHAIN.CONNECT or BLOCKCHAIN.ERROR event
 export const reconnectBlockchainThunk = createThunk(
     `${BLOCKCHAIN_MODULE_PREFIX}/reconnectBlockchainThunk`,
@@ -236,7 +218,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
         const accounts = selectAccounts(getState());
         const blockchain = selectBlockchainState(getState());
         const {
-            services: { getIsWindowVisible },
+            services: { getIsWindowVisible, networkModuleRepository },
         } = extra;
         const isWindowVisible = getIsWindowVisible();
 
@@ -264,7 +246,7 @@ export const syncAccountsWithBlockchainThunk = createThunk(
 
         const timeout = setTimeout(
             () => dispatch(syncAccountsWithBlockchainThunk(symbol)),
-            getAccountSyncInterval(symbol),
+            networkModuleRepository.get(symbol).getAccountSyncInterval(symbol),
         );
 
         dispatch(blockchainActions.synced({ symbol, timeout }));


### PR DESCRIPTION
## Description

Account synchronization cadence is currently configured by a coin-specific map in wallet-core, so adding or tuning a network requires editing centralized application logic. This moves the unchanged interval values into each Suite Common network module through `getAccountSyncInterval`, with the shared one-minute default owned by `@trezor/network-module-suite-common-types`.\n\nRuntime behavior is unchanged: the nine fast networks remain at the default divided by 1.5, Solana remains at five times the default, and every other registered symbol keeps the one-minute interval. The central override map is replaced by seven exhaustive family-owned records.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/modularize-account-sync-intervals/web/](https://dev.suite.sldev.cz/suite-web/modularize-account-sync-intervals/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=modularize-account-sync-intervals&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=modularize-account-sync-intervals&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-06T15:08:42.715Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR refactors network configuration and account sync infrastructure across all supported coins. The highest-risk regressions are discovery failures, custom backend misconfiguration, and balance sync issues. Three high-priority tests target these directly. Three medium-priority tests provide inferred coverage for network modules (Cardano, Solana, Tron) that lack static test mappings, and for multi-network receive flows. This compact selection covers the changed functionality without running the full suite.

<details><summary><b>Changed files (18)</b></summary>

- `networks/bitcoin/network-bitcoin-suite-common/src/BitcoinNetworkSuiteCommonNetworkModule.ts`
- `networks/bitcoin/network-bitcoin-suite-common/src/networkConfig.ts`
- `networks/cardano/network-cardano-suite-common/src/CardanoNetworkSuiteCommonNetworkModule.ts`
- `networks/cardano/network-cardano-suite-common/src/networkConfig.ts`
- `networks/ethereum/network-ethereum-suite-common/src/EthereumNetworkSuiteCommonNetworkModule.ts`
- `networks/ethereum/network-ethereum-suite-common/src/networkConfig.ts`
- `networks/network-module/network-module-suite-common-types/src/AccountSyncInterval.ts`
- `networks/network-module/network-module-suite-common-types/src/SuiteCommonNetworkModule.ts`
- `networks/network-module/network-module-suite-common-types/src/index.ts`
- `networks/ripple/network-ripple-suite-common/src/RippleNetworkSuiteCommonNetworkModule.ts`
- `networks/ripple/network-ripple-suite-common/src/networkConfig.ts`
- `networks/solana/network-solana-suite-common/src/SolanaNetworkSuiteCommonNetworkModule.ts`
- `networks/solana/network-solana-suite-common/src/networkConfig.ts`
- `networks/stellar/network-stellar-suite-common/src/StellarNetworkSuiteCommonNetworkModule.ts`
- `networks/stellar/network-stellar-suite-common/src/networkConfig.ts`
- `networks/tron/network-tron-suite-common/src/TronNetworkSuiteCommonNetworkModule.ts`
- `networks/tron/network-tron-suite-common/src/networkConfig.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Directly exercises custom Blockbook backend configuration for BTC and ETH, including successful connection, discovery completion, and error handling when backend URLs are misconfigured. This is the most direct test for the networkConfig changes in Bitcoin and Ethereum modules.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Verifies that regtest account balances update correctly after receiving funds, which directly tests the account sync/polling mechanism affected by AccountSyncInterval.ts and blockchainThunks.ts changes.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates and discovers multiple networks (BTC, ETH, LTC, ETC, BCH, DOGE, XRP, ZEC) and validates discovery recovery after reload. This directly exercises network module integration, discovery orchestration via blockchainThunks.ts, and the shared network module interfaces for BTC, ETH, and XRP.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/cardano.test.ts` — No static coverage was found for the Cardano network module files, but this test exercises Cardano network enablement, account details, public key export, send form, and receive address verification—core paths that depend on Cardano networkConfig and the shared network module types.
- `suite/e2e/tests/wallet/receive.test.ts` — Covers receive address flows for BTC, ETH, SOL, and TRX in a single test. Since Bitcoin, Ethereum, Solana, and Tron network configs all changed, this efficiently verifies that address derivation and device verification still work correctly across those networks.
- `suite/e2e/tests/wallet/send-sol.test.ts` — No static coverage was found for the Solana network module files. This test exercises Solana account operations including fee/reserve calculation, max amount computation, and device signing—paths that rely on Solana networkConfig and shared network module interfaces.

</details>

_Updated: 2026-08-06T15:09:51.643Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->