### PR TITLE
test(suite): remove deprecated promobanner test and fix passphrase test

### DIFF
--- a/suite/e2e/support/pageObjects/dashboardPage.ts
+++ b/suite/e2e/support/pageObjects/dashboardPage.ts
@@ -8,7 +8,7 @@ import { DeviceFixture } from '../device';
 import { expect } from '../testExtends/customMatchers';
 
 export type graphRangeOptions = 'day' | 'week' | 'month' | 'year' | 'all';
-export type PromoBannerType = 'tex' | 'ts7';
+export type PromoBannerType = 'ts7' | 'stablecoin-yield' | 'defi-yield' | 'eth-vault';
 
 export class DashboardPage {
     readonly suiteLayout: Locator;

--- a/suite/e2e/tests/analytics/promo-banner-events.test.ts
+++ b/suite/e2e/tests/analytics/promo-banner-events.test.ts
@@ -15,7 +15,7 @@ test.describe('Analytics Events - Promo Banner', { tag: ['@T3T1', '@nightlyOnly'
     });
 
     // --- Promo Banner Events ---
-    const bannerTypes: PromoBannerType[] = ['tex', 'ts7'];
+    const bannerTypes: PromoBannerType[] = ['ts7'];
 
     for (const bannerType of bannerTypes) {
         test(

--- a/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
+++ b/suite/e2e/tests/passphrase/passphrase-reconnection.test.ts
@@ -48,6 +48,7 @@ test.describe('Passphrase reconnection', { tag: ['@T3W1', '@T3T1'] }, () => {
             await device.powerOff();
             await expect(walletPage.deviceDisconnectedStatus).toBeVisible({ timeout: 30_000 });
             await device.powerOn();
+            await expect(walletPage.deviceConnectedStatus).toBeVisible({ timeout: 30_000 });
         });
 
         await test.step('Check passphrase wallet "abc" is still cached and connected', async () => {

--- a/suite/e2e/tests/wallet/send-base.test.ts
+++ b/suite/e2e/tests/wallet/send-base.test.ts
@@ -58,9 +58,6 @@ test.describe(
 
             await test.step('Fill in a Send form', async () => {
                 await walletPage.openSendFormButton.click();
-                // Race condition 1:5, if input is filled before form completely loads then
-                // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
-                await tradingPage.fees.expectEthereumFeeCalculated();
                 await tradingPage.sendAddressInput.fill(sendAddress);
                 await tradingPage.sendAmountInput.fill(sendAmount);
                 await tradingPage.fees.setEthereumCustomFees({
@@ -147,9 +144,6 @@ test.describe(
         }) => {
             await test.step('Fill in a Send form', async () => {
                 await walletPage.openSendFormButton.click();
-                // Race condition 1:5, if input is filled before form completely loads then
-                // input will be cleared and test will fail. As a workaround we wait for fees to be loaded.
-                await tradingPage.fees.expectEthereumFeeCalculated();
                 await tradingPage.sendAddressInput.fill(sendAddress);
                 await tradingPage.sendAmountInput.fill(sendAmount);
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

two test fixes:
- remove deprecated promo banner test - banner is gone
- update await for device reconnection in passphrase test

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-tests-8-6/web/](https://dev.suite.sldev.cz/suite-web/fix-tests-8-6/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-tests-8-6&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-tests-8-6&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T08:13:44.917Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T08:14:03.222Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->