### PR TITLE
chore(message-system): add a warning about ES256 deviation

### DIFF
--- a/packages/env-utils/src/jws.ts
+++ b/packages/env-utils/src/jws.ts
@@ -1,3 +1,9 @@
+// Public keys for message-system JWS verification
+//
+// Warning: Keys are secp256k1 instead of P-256, which is a deviation from the ES256 specification (RFC 7518). This issue is known and it has been accepted,
+// as it has no security implications.
+// Impact: It is not possible to easily replace `jws` library, as most alternatives verify that the used keys are P-256.
+
 export const publicKey = {
     dev: `-----BEGIN PUBLIC KEY-----
 MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbSUHJlr17+NywPS/w+xMkp3dSD8eWXSuAfFKwonZPe5fL63kISipJC+eJP7Mad0WxgyJoiMsZCV6BZPK2jIFdg==

--- a/suite-common/message-system/scripts/sign-config.ts
+++ b/suite-common/message-system/scripts/sign-config.ts
@@ -19,6 +19,11 @@ MHQCAQEEINi7lfZE3Y5U9srS58A+AN7Ul7HeBXsHEfzVzijColOkoAcGBSuBBAAKoUQDQgAEbSUHJlr1
 const getPrivateKey = () => {
     // Only CI jobs flagged with "codesign", sign message system config by production private key. All other branches use development key.
     // The isCodesignBuild() util cannot be used here because the lib is not built at this point. Building libs would make the release script slower.
+    //
+    // Warning: Keys are secp256k1 instead of P-256, which is a deviation from the ES256 specification (RFC 7518). This issue is known and it has been accepted,
+    // as it has no security implications.
+    // Impact: It is not possible to easily replace `jws` library, as most alternatives verify that the used keys are P-256.
+
     if (process.env.IS_CODESIGN_BUILD !== 'true') {
         console.log('Signing config using develop private key!');
 


### PR DESCRIPTION
## Description

In the signing of message-system JWS, `secp256k1` keys are used instead of `P-256`. This is a deviation from the ES256 specification. Using `secp256k1` keys has no security implications. However, it prevents replacing `jws` lib by e.g. `jose`, as `jose` does not allow `secp256k1` keys in ES256.

## Notes for QA

Nothing to be tested.

## Related Issue

None.

## Screenshots:

None.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed runtime file with a plausible E2E impact is packages/env-utils/src/jws.ts, a broad utility likely used by the message-system for remote config validation. The only test with concrete evidence of touching that path is the Connect webextension popup test via its Remote message system mock. suite-common/message-system/scripts/sign-config.ts is a build-time signing script with no known E2E coverage. Running the Connect webextension test provides a targeted smoke check that JWS/message-system changes have not broken app initialization or Connect flows.

<details><summary><b>Changed files (2)</b></summary>

- `packages/env-utils/src/jws.ts`
- `suite-common/message-system/scripts/sign-config.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test explicitly references the Remote message system mock (mockRemoteMessageSystem), which relies on message-system config validation. Changes to packages/env-utils/src/jws.ts could break JWS verification of remote config/messages, directly impacting this Connect webextension flow.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/scripts/sign-config.ts`

_Updated: 2026-08-06T15:46:14.191Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/m1nd3r/es256-secp256k1/web/](https://dev.suite.sldev.cz/suite-web/m1nd3r/es256-secp256k1/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=m1nd3r/es256-secp256k1&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=m1nd3r/es256-secp256k1&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=m1nd3r/es256-secp256k1&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T10:49:36.356Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T10:47:37.092Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->