### PR TITLE
fix(dependency-injection): compare getter value shallowly

### DIFF
--- a/suite-common/dependency-injection/src/useGetter.test.tsx
+++ b/suite-common/dependency-injection/src/useGetter.test.tsx
@@ -35,8 +35,12 @@ const createTestStore = () => configureStore({ reducer: testSlice.reducer });
 type RelayUrlDep = { getRelayUrl: Getter<[], string> };
 type TorDep = { getIsTorEnabled: Getter<[], boolean> };
 type SelectedWalletDep = { getIsSelectedWallet: Getter<[walletDescriptor: string], boolean> };
+type ConnectionDep = { getConnection: Getter<[], { relayUrl: string; isTorEnabled: boolean }> };
 
 const selectRelayUrlDep = (services: any): RelayUrlDep => ({ getRelayUrl: services.getRelayUrl });
+const selectConnectionDep = (services: any): ConnectionDep => ({
+    getConnection: services.getConnection,
+});
 const selectSelectedWalletDep = (services: any): SelectedWalletDep => ({
     getIsSelectedWallet: services.getIsSelectedWallet,
 });
@@ -59,6 +63,12 @@ const renderUseGetter = <TResult, TProps>(
             (state: TestState, walletDescriptor: string) =>
                 state.selectedWalletDescriptor === walletDescriptor,
         ),
+        // Built on a plain, non-memoizing selector, so every call returns a new object reference
+        // holding the same values.
+        getConnection: toGetter(store.getState, (state: TestState) => ({
+            relayUrl: state.relayUrl,
+            isTorEnabled: state.isTorEnabled,
+        })),
     };
 
     const wrapper = ({ children }: PropsWithChildren) => (
@@ -105,6 +115,27 @@ describe(useGetter.name, () => {
         });
 
         expect(renderSpy.mock.calls.length).toBe(rendersBefore);
+    });
+
+    it('does not re-render when a getter returns a shallowly equal object', () => {
+        const { store, renderSpy } = renderUseGetter(() => useGetter(selectConnectionDep));
+        const rendersBefore = renderSpy.mock.calls.length;
+
+        act(() => {
+            store.dispatch(setTestState({ selectedWalletDescriptor: 'wallet-2' }));
+        });
+
+        expect(renderSpy.mock.calls.length).toBe(rendersBefore);
+    });
+
+    it('re-renders when a field of the returned object changes', () => {
+        const { store, result } = renderUseGetter(() => useGetter(selectConnectionDep));
+
+        act(() => {
+            store.dispatch(setTestState({ isTorEnabled: true }));
+        });
+
+        expect(result.current).toEqual({ relayUrl: 'wss://relay.example.com', isTorEnabled: true });
     });
 
     it('forwards params to the getter', () => {

--- a/suite-common/dependency-injection/src/useGetter.ts
+++ b/suite-common/dependency-injection/src/useGetter.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { shallowEqual, useSelector } from 'react-redux';
 
 import { type UnionToIntersection } from '@trezor/type-utils';
 import { typedObjectValues } from '@trezor/utils';
@@ -42,8 +42,9 @@ type GetterReturn<TSelected> =
  * const allowPrerelease = useGetter(selectGetAllowPrereleaseDep);
  * ```
  *
- * A getter returning a fresh object on every call re-renders on every action — such a getter has to
- * be built on a memoized selector.
+ * The value is compared shallowly, so a getter returning a fresh object holding the same values on
+ * every call does not re-render. Anything nested deeper still has to keep its identity stable, which
+ * usually means building the getter on a memoized selector.
  */
 export function useGetter<const TSelector extends ServiceSelector<any>>(
     selectGetterDep: TSelector,
@@ -67,5 +68,5 @@ export function useGetter(selectGetterDep: ServiceSelector<any>, ...params: unkn
         return onlyGetter;
     }, [services, selectGetterDep]);
 
-    return useSelector(() => getter(...params));
+    return useSelector(() => getter(...params), shallowEqual);
 }


### PR DESCRIPTION
## Description

`useGetter` subscribed through `useSelector` without an equality function, so the default reference equality re-rendered the component on **every dispatched action** whenever the getter returned a freshly created object — even when none of the values inside it had changed.

This passes `shallowEqual` to `useSelector`, so a getter returning a new object holding the same values no longer triggers a render. A getter built on a memoized selector behaves exactly as before.

The JSDoc on `useGetter` is updated accordingly: consumers no longer need a memoized selector just to avoid render churn on a flat object. Anything nested deeper than one level still has to keep its identity stable, so a memoized selector remains the right tool there.

Two tests cover the new behaviour, both using a getter built on a deliberately non-memoizing selector that returns a fresh `{ relayUrl, isTorEnabled }` object on every call:

- dispatching an unrelated state change does not re-render
- changing one field of the returned object does propagate the new value

## Notes for QA

No user-facing behaviour change and no UI change — this is a render-performance fix in a shared hook.

Covered by unit tests in `suite-common/dependency-injection`. The risk, if any, is the opposite of a regression: components consuming `useGetter` now re-render *less* often, so the thing worth watching is a component failing to update rather than updating too often.

Worth a quick smoke test on screens whose services are consumed through `useGetter` — that they still react to relevant state changes (e.g. Tor being toggled, wallet switching) and show current values rather than stale ones.

## Related Issue

<!--- link the issue here -->

## Screenshots:

No UI changes.

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/use-getter-shallow-equal&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/use-getter-shallow-equal&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/use-getter-shallow-equal&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T14:38:08.597Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T14:38:34.120Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/use-getter-shallow-equal/web/](https://dev.suite.sldev.cz/suite-web/fix/use-getter-shallow-equal/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are limited to an internal dependency-injection utility (useGetter.ts) and its unit test. No E2E test in the analysis directly exercises dependency injection or useGetter behavior; the 135 statically mapped tests only transitively import this broad utility. The most targeted validation is the existing unit test suite for useGetter. No E2E tests are recommended.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/dependency-injection/src/useGetter.test.tsx`
- `suite-common/dependency-injection/src/useGetter.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (1)**
- `suite-common/dependency-injection/src/useGetter.test.tsx`

_Updated: 2026-08-07T14:35:23.275Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->
