### PR TITLE
Use Solana-specific staking consent copy

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2685,10 +2685,18 @@ export const messages = {
             },
             delegatingCard: {
                 title: 'Delegate to Everstake',
-                firstItem:
-                    'Everstake maintains and protects your staked {displaySymbol} with their smart contracts, infrastructure, and technology.',
-                secondItem:
-                    "When you stake, the responsibility for your funds' security transitions from your Trezor to Everstake.",
+                eth: {
+                    firstItem:
+                        'Everstake maintains and protects your staked {displaySymbol} with their smart contracts, infrastructure, and technology.',
+                    secondItem:
+                        "When you stake, the responsibility for your funds' security transitions from your Trezor to Everstake.",
+                },
+                sol: {
+                    firstItem:
+                        "Stake your {displaySymbol} to receive rewards and help enhance the network's security and stability.",
+                    secondItem:
+                        'With Trezor Suite, easily and securely delegate your {displaySymbol} voting rights to the Everstake validator node. Enjoy competitive rewards, rely on a trusted validator, and retain full ownership of your assets.',
+                },
             },
         },
         earnTransactionDataReviewScreen: {

--- a/suite-native/module-earn/src/components/EarnConsentsDelegatingCard.tsx
+++ b/suite-native/module-earn/src/components/EarnConsentsDelegatingCard.tsx
@@ -7,7 +7,11 @@ import Animated, {
     withTiming,
 } from 'react-native-reanimated';
 
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
 import { Button, Card, Divider, HStack, Text, VStack } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
@@ -37,7 +41,7 @@ const confirmButtonStyle = prepareNativeStyle(() => ({ flex: 1 }));
 
 type EarnConsentsDelegatingCardProps = {
     isExpanded: boolean;
-    symbol?: NetworkSymbol;
+    symbol: NetworkSymbol;
     onConfirm: () => void;
 };
 
@@ -49,7 +53,17 @@ export const EarnConsentsDelegatingCard = ({
     const { applyStyle } = useNativeStyles();
     const measuredHeight = useSharedValue(-1);
     const expandableHeight = useSharedValue(0);
-    const displaySymbol = symbol ? getNetworkDisplaySymbol(symbol) : undefined;
+    const displaySymbol = getNetworkDisplaySymbol(symbol);
+    const isSolana = getNetwork(symbol).networkType === 'solana';
+    const firstItemTranslationId = isSolana
+        ? 'earn.earnConsentsScreen.delegatingCard.sol.firstItem'
+        : 'earn.earnConsentsScreen.delegatingCard.eth.firstItem';
+    const secondItemTranslationId = isSolana
+        ? 'earn.earnConsentsScreen.delegatingCard.sol.secondItem'
+        : 'earn.earnConsentsScreen.delegatingCard.eth.secondItem';
+    const translationValues = {
+        displaySymbol,
+    };
 
     const handleLayout = (event: LayoutChangeEvent) => {
         if (measuredHeight.value === -1) {
@@ -99,17 +113,10 @@ export const EarnConsentsDelegatingCard = ({
                 <Divider />
                 <VStack spacing="sp16" style={applyStyle(itemsSectionStyle)}>
                     <EarnConsentsItem iconName="everstakeLogo" color="contentPrimary">
-                        <Translation
-                            id="earn.earnConsentsScreen.delegatingCard.firstItem"
-                            values={{
-                                displaySymbol: displaySymbol ?? (
-                                    <Translation id="earn.notAvailableShort" />
-                                ),
-                            }}
-                        />
+                        <Translation id={firstItemTranslationId} values={translationValues} />
                     </EarnConsentsItem>
                     <EarnConsentsItem iconName="lock" color="contentPrimary">
-                        <Translation id="earn.earnConsentsScreen.delegatingCard.secondItem" />
+                        <Translation id={secondItemTranslationId} values={translationValues} />
                     </EarnConsentsItem>
                 </VStack>
                 <HStack style={applyStyle(buttonsRowStyle)}>


### PR DESCRIPTION
## Description

The mobile staking consent screen showed the Ethereum "smart contracts" copy for every network. Solana now uses its own string, matching desktop.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30977

## Screenshots:
<img width="1290" height="2376" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-10 at 16 43 33" src="https://github.com/user-attachments/assets/8e8eb043-eb3e-47d0-acbe-4280fd0493c6" />