### PR TITLE
fix(suite): use Translation for passphrase confirm button label

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx
@@ -202,7 +202,7 @@ export const PassphraseInputCard = ({
                             isLoading={isLoading}
                             size="large"
                         >
-                            Confirm
+                            <Translation id="TR_CONFIRM" />
                         </Button>
                     </Tooltip>
                 </Column>


### PR DESCRIPTION
## Description

Passphrase entry confirm button text was hardcoded and thus not localized.

## Notes for QA

Use web/desktop Suite in NOT English and open passphrase wallet.

## Screenshots:

<img width="381" height="467" alt="image" src="https://github.com/user-attachments/assets/2eb72a2f-edf4-49f2-aa9f-40c71fad13f7" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is the PassphraseInputCard UI component used when entering or confirming a passphrase for hidden wallets. Although it is statically referenced by many tests, most references are transitive through shared fixtures. The highest-value tests are the dedicated passphrase suite, which directly exercise input entry, visibility toggling, mismatch handling, cancellation, and re-entry. Running these six tests provides focused coverage of the component's actual behavior without inflating the run with unrelated suites that merely add a hidden wallet as setup.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/DeviceContextModal/PassphraseInputCard.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test directly exercises the passphrase entry flow, filling in a passphrase and then cancelling it. A change to PassphraseInputCard could break the input field, submit button, or cancellation behavior.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — The test requires re-entering a passphrase after device restart to access a hidden Cardano wallet. This directly uses the passphrase input component for wallet unlock.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Tests adding hidden wallets with passphrases via the device switcher, which relies on the passphrase input card for entering the passphrase.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Adds multiple passphrase wallets through the device switcher, repeatedly exercising the passphrase input component. Regression here would affect hidden wallet creation.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — Explicitly verifies passphrase re-entry after device reconnection and tests passphrase caching behavior. This directly depends on the passphrase input UI working correctly.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This is the core passphrase test covering input visibility toggle, passphrase mismatch errors, confirmation retry, and hidden wallet creation. It is the most direct regression test for changes to PassphraseInputCard.

</details>

_Updated: 2026-08-07T08:22:45.838Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/passphrase-confirm-button-translation&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/passphrase-confirm-button-translation&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T08:24:55.900Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T08:24:02.984Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/passphrase-confirm-button-translation/web/](https://dev.suite.sldev.cz/suite-web/fix/passphrase-confirm-button-translation/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->