### PR TITLE
fix(transfer-uri): normalize uppercase Bitcoin Bech32

### DIFF
--- a/suite-common/transfer-uri/src/parseBip321Uri.test.ts
+++ b/suite-common/transfer-uri/src/parseBip321Uri.test.ts
@@ -16,6 +16,30 @@ const cases: { description: string; uri: string; expected: Result<unknown, unkno
         }),
     },
     {
+        description: 'normalizes an uppercase Bitcoin Bech32 address',
+        uri: 'BITCOIN:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4?amount=0.1&message=hello',
+        expected: ok({
+            format: 'bip321',
+            scheme: 'bitcoin',
+            address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+            amount: '0.1',
+            label: undefined,
+            message: 'hello',
+        }),
+    },
+    {
+        description: 'preserves case-sensitive Bitcoin Base58 addresses',
+        uri: 'bitcoin:1BoatSLRHtKNngkdXEeobR76b53LETtpyT',
+        expected: ok({
+            format: 'bip321',
+            scheme: 'bitcoin',
+            address: '1BoatSLRHtKNngkdXEeobR76b53LETtpyT',
+            amount: undefined,
+            label: undefined,
+            message: undefined,
+        }),
+    },
+    {
         description: 'parses amount, label and message (BIP-321 params)',
         uri: 'bitcoin:bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq?amount=0.0123&label=Alice&message=Donation%20for%20project',
         expected: ok({

--- a/suite-common/transfer-uri/src/parseBip321Uri.ts
+++ b/suite-common/transfer-uri/src/parseBip321Uri.ts
@@ -7,6 +7,9 @@ const SINGLE_VALUE_PARAMS = ['amount', 'label', 'message'] as const;
 
 const removeLeadingTrailingSlashes = (text: string) => text.replace(/^\/{0,2}|\/$/g, '');
 
+const isBitcoinBech32AddressUppercase = (address: string) =>
+    /^(bc1|tb1)/.test(address.toLowerCase()) && /[A-Z]/.test(address);
+
 /**
  * Extracts BIP-321 / BIP-21 fields from an already-parsed, scheme-validated URL.
  * The URI/scheme validation is done upstream by `parseTransferUri`.
@@ -17,8 +20,13 @@ export const parseBip321Uri = (uri: URL): Result<BipTransferUriInfo, TransferUri
     const { protocol, pathname, host, searchParams } = uri;
     const scheme = asProtocol(protocol.slice(0, -1));
 
-    const address = removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host);
-    if (!address) return err({ type: 'MISSING_ADDRESS' });
+    const rawAddress = removeLeadingTrailingSlashes(pathname) || removeLeadingTrailingSlashes(host);
+    if (!rawAddress) return err({ type: 'MISSING_ADDRESS' });
+
+    const address =
+        scheme === 'bitcoin' && isBitcoinBech32AddressUppercase(rawAddress)
+            ? rawAddress.toLowerCase()
+            : rawAddress;
 
     // BIP-321: a recognized parameter must not appear more than once — treat it as a malformed URI.
     const hasDuplicateParam = SINGLE_VALUE_PARAMS.some(


### PR DESCRIPTION
## Description

- normalize uppercase Bitcoin Bech32 recipients while parsing BIP-321/BIP-21 URIs
- preserve case-sensitive Base58 recipients unchanged
- port the fix to the current `@suite-common/transfer-uri` parser after the legacy Suite parser was removed

## Notes for QA

Scan or open an uppercase Bitcoin URI such as `BITCOIN:BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4?amount=0.1&message=hello`. The recipient should be lowercased while amount and message are preserved. Base58 recipients must retain their original case.

## Related Issue

Replaces #26566, which conflicts because the parser it changed no longer exists on `develop`.

## Testing

- `node .yarn/releases/yarn-4.14.1.cjs workspace @suite-common/transfer-uri test:unit --coverage=0` (32 passed)
- `node .yarn/releases/yarn-4.14.1.cjs workspace @suite-common/transfer-uri lint:js`
- `node .yarn/releases/yarn-4.14.1.cjs workspace @suite-common/transfer-uri type-check`
- Prettier check and `git diff --check`

## Screenshots:

Not applicable; parser-only change.