### PR TITLE
Hide token and staking badges in stake, unstake and claim flows

### DIFF
--- a/suite-native/accounts/src/components/AccountDetailsCard.tsx
+++ b/suite-native/accounts/src/components/AccountDetailsCard.tsx
@@ -1,4 +1,3 @@
-import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { G } from '@mobily/ts-belt';
@@ -9,7 +8,6 @@ import { isErc4626 } from '@suite-common/wallet-utils';
 import { Card, ErrorMessage, FullAlertBox, VStack } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { AccountsListItem } from './AccountsList/AccountsListItem';
 import { TokenReceiveCard } from './TokenReceiveCard';
@@ -17,34 +15,10 @@ import { TokenReceiveCard } from './TokenReceiveCard';
 type AccountDetailsCardProps = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
-    isStakeVariant?: boolean;
-    titleLabel?: ReactNode;
-    cryptoAmount?: string;
 };
 
-const stakeCardStyle = prepareNativeStyle<{ isStakeVariant: boolean }>(
-    (utils, { isStakeVariant }) => ({
-        extend: {
-            condition: isStakeVariant,
-            style: {
-                backgroundColor: utils.colors.surfaceFillSunken,
-                borderColor: utils.colors.surfaceBorderSunken,
-                borderWidth: utils.borders.widths.small,
-                pointerEvents: 'none',
-            },
-        },
-    }),
-);
-
-export const AccountDetailsCard = ({
-    accountKey,
-    tokenContract,
-    isStakeVariant = false,
-    titleLabel,
-    cryptoAmount,
-}: AccountDetailsCardProps) => {
+export const AccountDetailsCard = ({ accountKey, tokenContract }: AccountDetailsCardProps) => {
     const { translate } = useTranslate();
-    const { applyStyle } = useNativeStyles();
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -73,19 +47,11 @@ export const AccountDetailsCard = ({
                 />
             )}
 
-            <Card
-                noPadding={!tokenContract}
-                noShadow={isStakeVariant}
-                style={applyStyle(stakeCardStyle, { isStakeVariant })}
-            >
+            <Card noPadding={!tokenContract}>
                 {tokenContract ? (
                     <TokenReceiveCard contract={tokenContract} accountKey={accountKey} />
                 ) : (
-                    <AccountsListItem
-                        account={account}
-                        titleLabel={titleLabel}
-                        cryptoAmount={cryptoAmount}
-                    />
+                    <AccountsListItem account={account} />
                 )}
             </Card>
         </VStack>

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -35,8 +35,6 @@ type AccountListItemProps = {
     isFirst?: boolean;
     isLast?: boolean;
     showDivider?: boolean;
-    titleLabel?: React.ReactNode;
-    cryptoAmount?: string;
 };
 
 const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
@@ -61,8 +59,6 @@ const AccountsListItemComponent = ({
     isFirst = false,
     isLast = false,
     showDivider = false,
-    titleLabel,
-    cryptoAmount,
 }: AccountListItemProps) => {
     const formattedAccountType = useSelector((state: AccountsRootState) =>
         selectFormattedAccountType(state, account.key),
@@ -95,7 +91,6 @@ const AccountsListItemComponent = ({
     const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
     const shouldShowTokenBadge = accountHasKnownTokensWithBalance && !isNativeCoinOnly;
     const shouldShowStakingBadge = accountHasStaking && !isNativeCoinOnly;
-    const balanceValue = cryptoAmount ?? account.formattedBalance;
     const fiatBalanceValue =
         shouldShowTokenBadge && fiatBalance !== undefined ? (
             <BaseCurrencyAmountFormatter
@@ -105,14 +100,14 @@ const AccountsListItemComponent = ({
             />
         ) : (
             <CryptoToFiatAmountFormatter
-                value={balanceValue}
+                value={account.formattedBalance}
                 isBalance={true}
                 symbol={account.symbol}
             />
         );
     const cryptoBalanceValue = (
         <CryptoAmountFormatter
-            value={balanceValue}
+            value={account.formattedBalance}
             symbol={account.symbol}
             numberOfLines={1}
             adjustsFontSizeToFit
@@ -121,19 +116,11 @@ const AccountsListItemComponent = ({
 
     const isFailed = isAccountFailed(account);
 
-    const getTitle = () => {
-        if (titleLabel) {
-            return titleLabel;
-        }
-
-        if (shouldShowAccountLabel) {
-            return <AccountLabel account={account} />;
-        }
-
-        return <NetworkDisplaySymbolNameFormatter value={account.symbol} />;
-    };
-
-    const title = getTitle();
+    const title = shouldShowAccountLabel ? (
+        <AccountLabel account={account} />
+    ) : (
+        <NetworkDisplaySymbolNameFormatter value={account.symbol} />
+    );
 
     return (
         <AccountsListItemBase

--- a/suite-native/module-earn/src/components/EarnAmountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAmountCard.tsx
@@ -1,0 +1,72 @@
+import { type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { AccountLabel, AccountTypeBadge, AccountsListItemBase } from '@suite-native/accounts';
+import { Card, ErrorMessage } from '@suite-native/atoms';
+import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { TokenIcon } from '@suite-native/icons';
+import { useTranslate } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+type EarnAmountCardProps = {
+    accountKey: AccountKey;
+    label?: ReactNode;
+    cryptoAmount?: string;
+};
+
+const cardStyle = prepareNativeStyle(utils => ({
+    backgroundColor: utils.colors.surfaceFillSunken,
+    borderColor: utils.colors.surfaceBorderSunken,
+    borderWidth: utils.borders.widths.small,
+    pointerEvents: 'none',
+}));
+
+export const EarnAmountCard = ({ accountKey, label, cryptoAmount }: EarnAmountCardProps) => {
+    const { translate } = useTranslate();
+    const { applyStyle } = useNativeStyles();
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    if (!account) {
+        return (
+            <ErrorMessage
+                errorMessage={translate('moduleAccounts.accountNotFound', { accountKey })}
+            />
+        );
+    }
+
+    const amount = cryptoAmount ?? account.formattedBalance;
+
+    return (
+        <Card noPadding noShadow style={applyStyle(cardStyle)}>
+            <AccountsListItemBase
+                icon={<TokenIcon symbol={account.symbol} />}
+                title={label ?? <AccountLabel account={account} />}
+                titleBadge={<AccountTypeBadge accountKey={accountKey} />}
+                mainValue={
+                    <CryptoAmountFormatter
+                        value={amount}
+                        symbol={account.symbol}
+                        variant="body-md-strong"
+                        color="contentPrimary"
+                        numberOfLines={1}
+                        adjustsFontSizeToFit
+                    />
+                }
+                secondaryValue={
+                    <CryptoToFiatAmountFormatter
+                        value={amount}
+                        symbol={account.symbol}
+                        isBalance
+                        variant="body-sm"
+                        color="contentSecondary"
+                    />
+                }
+            />
+        </Card>
+    );
+};

--- a/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimReviewScreen.tsx
@@ -14,7 +14,6 @@ import {
     isSupportedSolStakingNetworkSymbol,
     subunitsToUnits,
 } from '@suite-common/wallet-utils';
-import { AccountDetailsCard } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, Button, FullAlertBox, InlineAlertBox, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -34,6 +33,7 @@ import { FeeSelector } from '@suite-native/transaction-management';
 import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT } from '@trezor/network-solana/constants';
 import { BigNumber } from '@trezor/utils';
 
+import { EarnAmountCard } from '../components/EarnAmountCard';
 import { useComposeEarnFees } from '../hooks/useComposeEarnFees';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useSolanaStakingLimit } from '../hooks/useSolanaStakingLimit';
@@ -152,10 +152,9 @@ export const ClaimReviewScreen = () => {
             }
         >
             <VStack spacing="sp16">
-                <AccountDetailsCard
+                <EarnAmountCard
                     accountKey={accountKey}
-                    isStakeVariant={true}
-                    titleLabel={<Translation id="earn.claimReviewScreen.amountLabel" />}
+                    label={<Translation id="earn.claimReviewScreen.amountLabel" />}
                     cryptoAmount={claimableAmount}
                 />
                 <FeeSelector

--- a/suite-native/module-earn/src/screens/EarnFormScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnFormScreen.tsx
@@ -5,7 +5,6 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { useServices } from '@suite-common/dependency-injection';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { AccountDetailsCard } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { type ActiveView, Box } from '@suite-native/atoms';
 import { Form } from '@suite-native/forms';
@@ -17,6 +16,7 @@ import {
 } from '@suite-native/navigation';
 import { FeeSelector } from '@suite-native/transaction-management';
 
+import { EarnAmountCard } from '../components/EarnAmountCard';
 import { EarnFormScreenFooter } from '../components/EarnFormScreenFooter';
 import { EarnFormScreenHeader } from '../components/EarnFormScreenHeader';
 import { EarnInsufficientBalanceBanner } from '../components/EarnInsufficientBalanceBanner';
@@ -97,7 +97,7 @@ export const EarnFormScreen = () => {
                 />
             }
         >
-            <AccountDetailsCard accountKey={accountKey} isStakeVariant />
+            <EarnAmountCard accountKey={accountKey} />
             <Box marginTop="sp16">
                 <Form form={form}>
                     <EarnOutputFields

--- a/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeFlowScreen.tsx
@@ -6,7 +6,6 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 import { useServices } from '@suite-common/dependency-injection';
 import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { AccountDetailsCard } from '@suite-native/accounts';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     type ActiveView,
@@ -26,6 +25,7 @@ import {
 import { FeeSelector } from '@suite-native/transaction-management';
 import { MAX_DEACTIVATE_ACCOUNTS_WITH_SPLIT } from '@trezor/network-solana/constants';
 
+import { EarnAmountCard } from '../components/EarnAmountCard';
 import { EarnOutputFields } from '../components/EarnOutputFields';
 import { SolanaUnstakeAmountBoundsAlert } from '../components/SolanaUnstakeAmountBoundsAlert';
 import { UnstakeCanClaimAlert } from '../components/UnstakeCanClaimAlert';
@@ -124,10 +124,9 @@ export const UnstakeFlowScreen = () => {
                 </>
             }
         >
-            <AccountDetailsCard
+            <EarnAmountCard
                 accountKey={accountKey}
-                isStakeVariant
-                titleLabel={<Translation id="earn.earnFormScreen.staked" />}
+                label={<Translation id="earn.earnFormScreen.staked" />}
                 cryptoAmount={stakedBalance ?? undefined}
             />
 


### PR DESCRIPTION
## Description

The stake, unstake, and claim screens reused the account list item, so they showed token and staking badges and a fiat total that included tokens. They now use a dedicated earn amount card with only the flow's amount - staked, claimable, or available - and its fiat value below.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29254

## Screenshots:
<img width="1290" height="1696" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-06 at 18 33 53" src="https://github.com/user-attachments/assets/00c44967-7271-43ca-b2a3-1467dd7bcec6" />