### PR TITLE
fix(suite-native): preserve "All" graph timeframe

### DIFF
--- a/suite-native/graph/src/graphPersistTransform.ts
+++ b/suite-native/graph/src/graphPersistTransform.ts
@@ -8,7 +8,7 @@ import {
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
-import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphInstanceState, type GraphState } from './slice';
+import { type GraphInstanceState, type GraphState, getGraphTimeframeOrDefault } from './slice';
 import { type TimeframeHoursValue } from './types';
 
 type Graphs = GraphState['graphs'];
@@ -35,7 +35,7 @@ const rehydrateGraphState = (persistedState: PersistedGraphState | undefined): G
     Object.entries(persistedState?.graphs ?? {}).forEach(([instanceId, persistedGraph]) => {
         if (persistedGraph) {
             graphs[instanceId as GraphInstanceId] = {
-                timeframeHours: persistedGraph.timeframeHours ?? DEFAULT_GRAPH_TIMEFRAME_HOURS,
+                timeframeHours: getGraphTimeframeOrDefault(persistedGraph.timeframeHours),
             };
         }
     });

--- a/suite-native/graph/src/graphSelectors.ts
+++ b/suite-native/graph/src/graphSelectors.ts
@@ -5,14 +5,14 @@ import {
     getAccountGraphInstanceId,
     getPortfolioGraphInstanceId,
 } from './graphInstances';
-import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphSliceRootState } from './slice';
+import { type GraphSliceRootState, getGraphTimeframeOrDefault } from './slice';
 import { type TimeframeHoursValue } from './types';
 
 export const selectGraphTimeframe = (
     state: GraphSliceRootState,
     instanceId: GraphInstanceId,
 ): TimeframeHoursValue =>
-    state.graph.graphs[instanceId]?.timeframeHours ?? DEFAULT_GRAPH_TIMEFRAME_HOURS;
+    getGraphTimeframeOrDefault(state.graph.graphs[instanceId]?.timeframeHours);
 
 export const selectPortfolioGraphTimeframe = (state: GraphSliceRootState): TimeframeHoursValue =>
     selectGraphTimeframe(state, getPortfolioGraphInstanceId());

--- a/suite-native/graph/src/graphTimeframe.test.ts
+++ b/suite-native/graph/src/graphTimeframe.test.ts
@@ -1,0 +1,54 @@
+import { getPortfolioGraphInstanceId } from './graphInstances';
+import { graphPersistTransform } from './graphPersistTransform';
+import { selectGraphTimeframe } from './graphSelectors';
+import { DEFAULT_GRAPH_TIMEFRAME_HOURS, type GraphSliceRootState } from './slice';
+
+const instanceId = getPortfolioGraphInstanceId();
+
+const buildState = (timeframeHours: number | null): GraphSliceRootState => ({
+    graph: { graphs: { [instanceId]: { timeframeHours } } },
+});
+
+describe('graph "All" timeframe (null)', () => {
+    describe('selectGraphTimeframe', () => {
+        it('preserves null as the "All" timeframe', () => {
+            expect(selectGraphTimeframe(buildState(null), instanceId)).toBeNull();
+        });
+
+        it('returns the stored numeric timeframe unchanged', () => {
+            expect(selectGraphTimeframe(buildState(168), instanceId)).toBe(168);
+        });
+
+        it('falls back to the default only when no timeframe is stored', () => {
+            const emptyState: GraphSliceRootState = { graph: { graphs: {} } };
+
+            expect(selectGraphTimeframe(emptyState, instanceId)).toBe(
+                DEFAULT_GRAPH_TIMEFRAME_HOURS,
+            );
+        });
+    });
+
+    describe('graphPersistTransform rehydration', () => {
+        it('rehydrates a persisted null timeframe as "All"', () => {
+            const rehydrated = graphPersistTransform.out(
+                { graphs: { [instanceId]: { timeframeHours: null } } },
+                'graph',
+                {},
+            );
+
+            expect(rehydrated.graphs[instanceId]?.timeframeHours).toBeNull();
+        });
+
+        it('falls back to the default when a persisted timeframe is missing', () => {
+            const rehydrated = graphPersistTransform.out(
+                { graphs: { [instanceId]: {} as { timeframeHours: number | null } } },
+                'graph',
+                {},
+            );
+
+            expect(rehydrated.graphs[instanceId]?.timeframeHours).toBe(
+                DEFAULT_GRAPH_TIMEFRAME_HOURS,
+            );
+        });
+    });
+});

--- a/suite-native/graph/src/slice.ts
+++ b/suite-native/graph/src/slice.ts
@@ -16,6 +16,13 @@ import { type TimeframeHoursValue } from './types';
 // Default is 720 hours (1 month).
 export const DEFAULT_GRAPH_TIMEFRAME_HOURS = 720;
 
+// `null` is a valid timeframe meaning "All" (see the `all` option in TimeSwitch), so we must not
+// treat it as a missing value. Only fall back to the default when no timeframe has been stored yet.
+export const getGraphTimeframeOrDefault = (
+    timeframeHours: TimeframeHoursValue | undefined,
+): TimeframeHoursValue =>
+    timeframeHours === undefined ? DEFAULT_GRAPH_TIMEFRAME_HOURS : timeframeHours;
+
 export type GraphInstanceState = {
     timeframeHours: TimeframeHoursValue;
     isLoading?: boolean;


### PR DESCRIPTION
## Description

The mobile graph timeframe switcher stores the selected range as `timeframeHours` in Redux. The **"All"** option is represented by `null` (see the `all` entry in `TimeSwitch.tsx`), while every other option is a positive number of hours.

The bug: both the selector and the redux-persist rehydration read the stored value with `?? DEFAULT_GRAPH_TIMEFRAME_HOURS`. The `??` (nullish coalescing) operator treats `null` exactly like `undefined`, so a stored "All" (`null`) was silently coerced back to the default **720h (1 month)**.

Effect for the user: **"All" was the one broken option in the switcher.** Selecting it (on both the portfolio graph and the account-detail graph) showed 1 month of data instead of the full history, and the selection did not survive an app restart (rehydration re-applied the same coercion).

### Fix

Introduce `getGraphTimeframeOrDefault`, which distinguishes "never stored" (`undefined` → fall back to the default) from the legitimate "All" value (`null` → keep it). Both `selectGraphTimeframe` and `rehydrateGraphState` now use it.

Unit tests cover the selector and the persist rehydration for `null`, a numeric value, and the missing/`undefined` case.

Migration was considered, but when I weighed in the cost of migration code living there indefinitely and user just having month timeframe that he can reset, I don't think it's worth it.

## QA / Testing notes

Test on the **mobile app** (iOS or Android), on both the **portfolio graph** (home screen) and the **account-detail graph**:

1. Open a graph and tap the **All** option in the timeframe switcher.
   - ✅ Expected: the graph shows the full available history (from the first transaction / oldest data point), not just the last month.
   - ❌ Before this fix: it snapped back to the 1M (month) range.
2. With **All** selected, fully close and relaunch the app, then reopen the same graph.
   - ✅ Expected: **All** is still selected and the full history is shown.
   - ❌ Before this fix: it reverted to 1M after restart.
3. Regression check — the other options (1D / 1W / 1M / 1Y) still select and persist correctly, and a graph opened for the first time (no stored preference) still defaults to **1M**.
4. Verify both the portfolio (all-accounts) graph and a single account-detail graph, since they use the same selector/persistence path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/fix-native-graph-all-timeframe&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->