### PR TITLE
refactor(redux): narrow slice dependencies

### DIFF
--- a/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
+++ b/packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts
@@ -1,6 +1,7 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
 import {
+    type BluetoothReducerDeps,
     type BluetoothState,
     prepareBluetoothReducerCreator,
     prepareInitialState,
@@ -69,7 +70,7 @@ const bluetoothSlice = createSliceWithExtraDeps({
             state.isManualPairingRequired = payload;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: BluetoothReducerDeps) => {
         const commonReducer = prepareBluetoothReducerCreator<DesktopBluetoothDevice>()(extra);
 
         builder

--- a/packages/suite/src/reducers/bioAuth/index.ts
+++ b/packages/suite/src/reducers/bioAuth/index.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 
 import { bioAuthActions } from 'src/actions/suite/bioAuthActions';
 export interface BioAuthState {
@@ -31,7 +35,9 @@ const initialState: BioAuthState = {
     cancelled: false,
 };
 
-export const prepareBioAuthReducer = createReducerWithExtraDeps<BioAuthState>(
+type BioAuthReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadBioAuth'>;
+
+export const prepareBioAuthReducer = createReducerWithExtraDeps<BioAuthState, BioAuthReducerDeps>(
     initialState,
     (builder, extra) => {
         builder.addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadBioAuth);

--- a/suite-common/analytics-redux/src/redux/analyticsReducer.ts
+++ b/suite-common/analytics-redux/src/redux/analyticsReducer.ts
@@ -1,6 +1,6 @@
 import { type AnyAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { analyticsActions } from './analyticsActions';
 
@@ -25,9 +25,11 @@ export const analyticsInitialState: AnalyticsState = {
     loggerEnabled: undefined,
 };
 
+type AnalyticsReducerDeps = ActionTypesDep<'storageLoad'>;
+
 export const prepareAnalyticsReducer = createReducerWithExtraDeps(
     analyticsInitialState,
-    (builder, extra) => {
+    (builder, extra: AnalyticsReducerDeps) => {
         builder
             .addCase(analyticsActions.initAnalytics, (state, { payload }) => {
                 const { enabled, confirmed, instanceId, sessionId } = payload;

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -1,7 +1,7 @@
 import { type AnyAction, type Draft } from '@reduxjs/toolkit';
 
 import { type DeviceConnectActionPayload, deviceActions } from '@suite-common/device';
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { type BluetoothDeviceId, TrezorPushNotificationType } from '@trezor/connect';
 
 import { bluetoothActions } from './bluetoothActions';
@@ -41,190 +41,193 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
 });
 
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
-    createReducerWithExtraDeps<BluetoothState<T>>(prepareInitialState<T>(), (builder, extra) =>
-        builder
-            .addCase(bluetoothActions.adapterEventAction, (state, { payload: { status } }) => {
-                state.adapterStatus = status;
-                if (status !== 'enabled') {
-                    state.nearbyDevices = [];
-                    state.scanStatus = 'idle';
-                }
-            })
-            .addCase(
-                bluetoothActions.nearbyDevicesUpdateAction,
-                (state, { payload: { nearbyDevices } }) => {
-                    state.nearbyDevices = filterOutOldDuplicates(
-                        nearbyDevices
-                            // Devices with 'pairing-error' status should NOT be displayed in the list, as it
-                            // won't be possible to connect to them ever again. User has to start pairing again,
-                            // which would produce a device with new id.
-                            .filter(
-                                nearbyDevice =>
-                                    nearbyDevice.connectionStatus?.type !== 'pairing-error' &&
-                                    !state.ignoredDeviceIds.includes(nearbyDevice.id),
-                            ) as Draft<T>[],
-                    );
-                },
-            )
-            .addCase(
-                bluetoothActions.updateDeviceConnectionStatus,
-                (state, { payload: { deviceId, connectionStatus } }) => {
-                    if (state.nearbyDevices !== null) {
-                        state.nearbyDevices = state.nearbyDevices.map(it =>
+    createReducerWithExtraDeps<BluetoothState<T>, ActionTypesDep<'storageLoad'>>(
+        prepareInitialState<T>(),
+        (builder, extra) =>
+            builder
+                .addCase(bluetoothActions.adapterEventAction, (state, { payload: { status } }) => {
+                    state.adapterStatus = status;
+                    if (status !== 'enabled') {
+                        state.nearbyDevices = [];
+                        state.scanStatus = 'idle';
+                    }
+                })
+                .addCase(
+                    bluetoothActions.nearbyDevicesUpdateAction,
+                    (state, { payload: { nearbyDevices } }) => {
+                        state.nearbyDevices = filterOutOldDuplicates(
+                            nearbyDevices
+                                // Devices with 'pairing-error' status should NOT be displayed in the list, as it
+                                // won't be possible to connect to them ever again. User has to start pairing again,
+                                // which would produce a device with new id.
+                                .filter(
+                                    nearbyDevice =>
+                                        nearbyDevice.connectionStatus?.type !== 'pairing-error' &&
+                                        !state.ignoredDeviceIds.includes(nearbyDevice.id),
+                                ) as Draft<T>[],
+                        );
+                    },
+                )
+                .addCase(
+                    bluetoothActions.updateDeviceConnectionStatus,
+                    (state, { payload: { deviceId, connectionStatus } }) => {
+                        if (state.nearbyDevices !== null) {
+                            state.nearbyDevices = state.nearbyDevices.map(it =>
+                                it.id === deviceId ? { ...it, connectionStatus } : it,
+                            );
+                        }
+
+                        state.knownDevices = state.knownDevices.map(it =>
                             it.id === deviceId ? { ...it, connectionStatus } : it,
                         );
+                    },
+                )
+                .addCase(bluetoothActions.deviceUpdateAction, (state, { payload: { device } }) => {
+                    if (state.nearbyDevices !== null) {
+                        state.nearbyDevices = state.nearbyDevices.map(it =>
+                            it.id === device.id ? device : it,
+                        ) as Draft<T>[];
+                    }
+
+                    // pairing error can be received from NAPI connectDevice
+                    // in that case the rust server doesnt know about it
+                    if (device.connectionStatus.type === 'pairing-error') {
+                        state.ignoredDeviceIds.push(device.id);
                     }
 
                     state.knownDevices = state.knownDevices.map(it =>
-                        it.id === deviceId ? { ...it, connectionStatus } : it,
-                    );
-                },
-            )
-            .addCase(bluetoothActions.deviceUpdateAction, (state, { payload: { device } }) => {
-                if (state.nearbyDevices !== null) {
-                    state.nearbyDevices = state.nearbyDevices.map(it =>
-                        it.id === device.id ? device : it,
+                        it.id === device.id ? { deviceId: it.deviceId, ...device } : it,
                     ) as Draft<T>[];
-                }
-
-                // pairing error can be received from NAPI connectDevice
-                // in that case the rust server doesnt know about it
-                if (device.connectionStatus.type === 'pairing-error') {
-                    state.ignoredDeviceIds.push(device.id);
-                }
-
-                state.knownDevices = state.knownDevices.map(it =>
-                    it.id === device.id ? { deviceId: it.deviceId, ...device } : it,
-                ) as Draft<T>[];
-            })
-            .addCase(
-                bluetoothActions.knownDevicesUpdateAction,
-                (state, { payload: { knownDevices } }) => {
-                    state.knownDevices = knownDevices as Draft<T>[];
-                },
-            )
-            .addCase(bluetoothActions.removeKnownDeviceAction, (state, { payload: { id } }) => {
-                state.knownDevices = state.knownDevices.filter(
-                    knownDevice => knownDevice.id !== id,
-                );
-            })
-            .addCase(bluetoothActions.scanStatusAction, (state, { payload: { status } }) => {
-                state.scanStatus = status;
-            })
-            .addCase(deviceActions.deviceDisconnect, (state, { payload: { descriptor } }) => {
-                if (descriptor.apiType === 'bluetooth' && descriptor.id !== undefined) {
-                    if (state.nearbyDevices !== null) {
-                        state.nearbyDevices = state.nearbyDevices.filter(
-                            it => it.id !== descriptor.id,
-                        );
+                })
+                .addCase(
+                    bluetoothActions.knownDevicesUpdateAction,
+                    (state, { payload: { knownDevices } }) => {
+                        state.knownDevices = knownDevices as Draft<T>[];
+                    },
+                )
+                .addCase(bluetoothActions.removeKnownDeviceAction, (state, { payload: { id } }) => {
+                    state.knownDevices = state.knownDevices.filter(
+                        knownDevice => knownDevice.id !== id,
+                    );
+                })
+                .addCase(bluetoothActions.scanStatusAction, (state, { payload: { status } }) => {
+                    state.scanStatus = status;
+                })
+                .addCase(deviceActions.deviceDisconnect, (state, { payload: { descriptor } }) => {
+                    if (descriptor.apiType === 'bluetooth' && descriptor.id !== undefined) {
+                        if (state.nearbyDevices !== null) {
+                            state.nearbyDevices = state.nearbyDevices.filter(
+                                it => it.id !== descriptor.id,
+                            );
+                        }
                     }
-                }
-            })
-            .addCase(bluetoothActions.enableAutoConnect, (state, { payload }) => {
-                if (payload) {
-                    delete state.autoConnectPolicy[payload.deviceId];
-                } else {
-                    state.autoConnectPolicy = {};
-                }
-            })
-            .addCase(bluetoothActions.setIsDeviceOsUnpairingRequired, (state, { payload }) => {
-                state.isDeviceOsUnpairingRequired = payload.isDeviceOsUnpairingRequired
-                    ? {
-                          isRequired: true,
-                          skipToggleModalConnection: payload.skipToggleModalConnection ?? false,
-                      }
-                    : null;
-            })
-            .addCase('REMOVE_KNOWN', state => {
-                state.knownDevices = [];
-            })
-
-            .addMatcher(
-                action =>
-                    action.type === deviceActions.connectDevice.type ||
-                    action.type === deviceActions.connectUnacquiredDevice.type,
-                (
-                    state,
-                    {
-                        payload: {
-                            device: { descriptor, id: deviceId },
-                        },
-                    }: { payload: DeviceConnectActionPayload },
-                ) => {
-                    if (descriptor.apiType !== 'bluetooth' || !descriptor.id) {
-                        return;
+                })
+                .addCase(bluetoothActions.enableAutoConnect, (state, { payload }) => {
+                    if (payload) {
+                        delete state.autoConnectPolicy[payload.deviceId];
+                    } else {
+                        state.autoConnectPolicy = {};
                     }
+                })
+                .addCase(bluetoothActions.setIsDeviceOsUnpairingRequired, (state, { payload }) => {
+                    state.isDeviceOsUnpairingRequired = payload.isDeviceOsUnpairingRequired
+                        ? {
+                              isRequired: true,
+                              skipToggleModalConnection: payload.skipToggleModalConnection ?? false,
+                          }
+                        : null;
+                })
+                .addCase('REMOVE_KNOWN', state => {
+                    state.knownDevices = [];
+                })
 
-                    const device = state.nearbyDevices?.find(it => it.id === descriptor.id);
+                .addMatcher(
+                    action =>
+                        action.type === deviceActions.connectDevice.type ||
+                        action.type === deviceActions.connectUnacquiredDevice.type,
+                    (
+                        state,
+                        {
+                            payload: {
+                                device: { descriptor, id: deviceId },
+                            },
+                        }: { payload: DeviceConnectActionPayload },
+                    ) => {
+                        if (descriptor.apiType !== 'bluetooth' || !descriptor.id) {
+                            return;
+                        }
 
-                    if (device !== undefined) {
-                        // Once the device is fully connected, we save it to the list of known devices,
-                        // so next time user opens suite, we can automatically connect to it.
-                        const foundKnownDevice = state.knownDevices.find(
-                            it => it.id === descriptor.id,
-                        );
-                        if (foundKnownDevice === undefined) {
-                            state.knownDevices.push({ ...device, deviceId });
-                        } else {
-                            delete state.autoConnectPolicy[descriptor.id as BluetoothDeviceId];
-                            // update deviceId in case it was missing
-                            if (deviceId && foundKnownDevice.deviceId !== deviceId) {
-                                foundKnownDevice.deviceId = deviceId;
+                        const device = state.nearbyDevices?.find(it => it.id === descriptor.id);
+
+                        if (device !== undefined) {
+                            // Once the device is fully connected, we save it to the list of known devices,
+                            // so next time user opens suite, we can automatically connect to it.
+                            const foundKnownDevice = state.knownDevices.find(
+                                it => it.id === descriptor.id,
+                            );
+                            if (foundKnownDevice === undefined) {
+                                state.knownDevices.push({ ...device, deviceId });
+                            } else {
+                                delete state.autoConnectPolicy[descriptor.id as BluetoothDeviceId];
+                                // update deviceId in case it was missing
+                                if (deviceId && foundKnownDevice.deviceId !== deviceId) {
+                                    foundKnownDevice.deviceId = deviceId;
+                                }
                             }
                         }
-                    }
-                },
-            )
-            .addMatcher(
-                action => action.type === deviceActions.deviceDisconnect.type,
-                (state, { payload }: ReturnType<typeof deviceActions.deviceDisconnect>) => {
-                    const id =
-                        payload.descriptor.apiType === 'bluetooth' && payload.descriptor.id
-                            ? (payload.descriptor.id as BluetoothDeviceId)
-                            : undefined;
-                    const affectedDevice = id && state.knownDevices.find(it => it.id === id);
-                    if (
-                        affectedDevice &&
-                        state.autoConnectPolicy[id]?.type !== 'autoconnect-disabled'
-                    ) {
-                        state.autoConnectPolicy[id] = {
-                            type: 'recently-disconnected',
-                            timestamp: Date.now(),
-                        };
-                    }
-                },
-            )
-            .addMatcher(
-                action => action.type === deviceActions.devicePushNotification.type,
-                (
-                    state,
-                    {
-                        payload: { device, type },
-                    }: ReturnType<typeof deviceActions.devicePushNotification>,
-                ) => {
-                    if (type === TrezorPushNotificationType.DISCONNECT) {
+                    },
+                )
+                .addMatcher(
+                    action => action.type === deviceActions.deviceDisconnect.type,
+                    (state, { payload }: ReturnType<typeof deviceActions.deviceDisconnect>) => {
                         const id =
-                            device.descriptor.apiType === 'bluetooth' && device.descriptor.id
-                                ? (device.descriptor.id as BluetoothDeviceId)
+                            payload.descriptor.apiType === 'bluetooth' && payload.descriptor.id
+                                ? (payload.descriptor.id as BluetoothDeviceId)
                                 : undefined;
                         const affectedDevice = id && state.knownDevices.find(it => it.id === id);
-                        if (affectedDevice) {
+                        if (
+                            affectedDevice &&
+                            state.autoConnectPolicy[id]?.type !== 'autoconnect-disabled'
+                        ) {
                             state.autoConnectPolicy[id] = {
-                                type: 'autoconnect-disabled',
+                                type: 'recently-disconnected',
+                                timestamp: Date.now(),
                             };
                         }
-                    }
-                },
-            )
-            .addMatcher(
-                action => action.type === extra.actionTypes.storageLoad,
-                (state, action: AnyAction) => {
-                    const loadedKnownDevices = (action.payload?.bluetooth?.knownDevices ??
-                        []) as T[];
+                    },
+                )
+                .addMatcher(
+                    action => action.type === deviceActions.devicePushNotification.type,
+                    (
+                        state,
+                        {
+                            payload: { device, type },
+                        }: ReturnType<typeof deviceActions.devicePushNotification>,
+                    ) => {
+                        if (type === TrezorPushNotificationType.DISCONNECT) {
+                            const id =
+                                device.descriptor.apiType === 'bluetooth' && device.descriptor.id
+                                    ? (device.descriptor.id as BluetoothDeviceId)
+                                    : undefined;
+                            const affectedDevice =
+                                id && state.knownDevices.find(it => it.id === id);
+                            if (affectedDevice) {
+                                state.autoConnectPolicy[id] = {
+                                    type: 'autoconnect-disabled',
+                                };
+                            }
+                        }
+                    },
+                )
+                .addMatcher(
+                    action => action.type === extra.actionTypes.storageLoad,
+                    (state, action: AnyAction) => {
+                        const loadedKnownDevices = (action.payload?.bluetooth?.knownDevices ??
+                            []) as T[];
 
-                    state.knownDevices = loadedKnownDevices.map(
-                        deserializeBluetoothDeviceSerialization,
-                    ) as Draft<T>[];
-                },
-            ),
+                        state.knownDevices = loadedKnownDevices.map(
+                            deserializeBluetoothDeviceSerialization,
+                        ) as Draft<T>[];
+                    },
+                ),
     );

--- a/suite-common/bluetooth/src/bluetoothReducer.ts
+++ b/suite-common/bluetooth/src/bluetoothReducer.ts
@@ -40,8 +40,10 @@ export const prepareInitialState = <T extends BluetoothDeviceCommon>(): Bluetoot
     isDeviceOsUnpairingRequired: null,
 });
 
+export type BluetoothReducerDeps = ActionTypesDep<'storageLoad'>;
+
 export const prepareBluetoothReducerCreator = <T extends BluetoothDeviceCommon>() =>
-    createReducerWithExtraDeps<BluetoothState<T>, ActionTypesDep<'storageLoad'>>(
+    createReducerWithExtraDeps<BluetoothState<T>, BluetoothReducerDeps>(
         prepareInitialState<T>(),
         (builder, extra) =>
             builder

--- a/suite-common/bluetooth/src/index.ts
+++ b/suite-common/bluetooth/src/index.ts
@@ -8,7 +8,7 @@ export type {
     ForgetBluetoothDeviceThunkParams,
     BluetoothDeviceCommon,
 } from './types';
-export type { BluetoothState } from './bluetoothReducer';
+export type { BluetoothReducerDeps, BluetoothState } from './bluetoothReducer';
 export type { WithBluetoothState } from './bluetoothSelectors';
 
 export { BLUETOOTH_PREFIX, bluetoothActions } from './bluetoothActions';

--- a/suite-common/connect-popup/src/connectPopupReducer.ts
+++ b/suite-common/connect-popup/src/connectPopupReducer.ts
@@ -1,6 +1,6 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { connectPopupActions } from './connectPopupActions';
 import { getPermissionDeferred } from './connectPopupPromiseManager';
@@ -38,9 +38,11 @@ const normalizeRememberedCoins = (app: AppRememberedPermission): AppRememberedPe
     allowedPermissions: canonicalizePermissionCoins(app.allowedPermissions),
 });
 
+type ConnectPopupReducerDeps = ActionTypesDep<'storageLoad'>;
+
 export const prepareConnectPopupReducer = createReducerWithExtraDeps(
     connectPopupInitialState,
-    (builder, extra) => {
+    (builder, extra: ConnectPopupReducerDeps) => {
         builder
             .addCase(
                 extra.actionTypes.storageLoad,

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -632,7 +632,7 @@ const updatePersistentDeviceData = (draft: DeviceReducerState, device: Device | 
     }
 };
 
-type DeviceReducerDeps = ActionTypesDep<
+export type DeviceReducerDeps = ActionTypesDep<
     'setDeviceMetadata' | 'setDeviceMetadataPasswords' | 'storageLoad'
 > &
     ReducersDep<

--- a/suite-common/device/src/deviceReducer.ts
+++ b/suite-common/device/src/deviceReducer.ts
@@ -1,6 +1,10 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import {
     type AcquiredDevice,
     type ButtonRequest,
@@ -628,9 +632,16 @@ const updatePersistentDeviceData = (draft: DeviceReducerState, device: Device | 
     }
 };
 
+type DeviceReducerDeps = ActionTypesDep<
+    'setDeviceMetadata' | 'setDeviceMetadataPasswords' | 'storageLoad'
+> &
+    ReducersDep<
+        'setDeviceMetadataPasswordsReducer' | 'setDeviceMetadataReducer' | 'storageLoadDevices'
+    >;
+
 export const prepareDeviceReducer = createReducerWithExtraDeps(
     deviceInitialState,
-    (builder, extra) => {
+    (builder, extra: DeviceReducerDeps) => {
         builder
             .addCase(deviceActions.deviceChanged, (state, { payload }) => {
                 changeDevice(state, payload, { connected: true, available: true });

--- a/suite-common/firmware/src/firmwareReducer.ts
+++ b/suite-common/firmware/src/firmwareReducer.ts
@@ -1,6 +1,6 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { type FirmwareStatus, type TrezorDevice } from '@suite-common/suite-types';
 import {
     DEVICE,
@@ -65,67 +65,72 @@ type StorageActionPayload = {
     };
 };
 
-export const prepareFirmwareReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
-    builder
-        .addCase(
-            extra.actionTypes.storageLoad,
-            (state, { payload }: PayloadAction<StorageActionPayload>) => {
-                if (payload.firmware) state.firmwareChannel = payload.firmware.firmwareChannel;
-            },
-        )
-        .addCase(firmwareActions.setStatus, (state, { payload }) => {
-            state.status = payload;
-        })
-        .addCase(firmwareActions.setSwitchFirmwareType, (state, { payload }) => {
-            state.switchFirmwareType = payload;
-        })
-        .addCase(firmwareActions.setFirmwareUpdateError, (state, { payload }) => {
-            state.error = payload;
-            if (payload) {
-                state.status = 'error';
-            }
-            state.uiEvent = undefined;
-        })
-        .addCase(firmwareActions.setTargetType, (state, { payload }) => {
-            state.targetType = payload;
-        })
-        .addCase(firmwareActions.resetReducer, state => ({
-            ...initialState,
-            firmwareChannel: state.firmwareChannel,
-            useDevkit: state.useDevkit,
-        }))
-        .addCase(firmwareActions.toggleUseDevkit, (state, { payload }) => {
-            state.useDevkit = payload;
-        })
-        .addCase(firmwareActions.cacheDevice, (state, { payload }) => {
-            state.cachedDevice = payload;
-        })
-        .addCase(firmwareActions.setFirmwareChannel, (state, { payload }) => {
-            state.firmwareChannel = payload;
-        })
-        .addMatcher<UiRequestConfirmation>(
-            action => action.type === UI_REQUEST.REQUEST_CONFIRMATION,
-            (state, action) => {
-                if (state.status === 'started' && action.payload.view === 'thp-pairing-start') {
-                    state.status = 'thp-pairing';
+type FirmwareReducerDeps = ActionTypesDep<'storageLoad'>;
+
+export const prepareFirmwareReducer = createReducerWithExtraDeps(
+    initialState,
+    (builder, extra: FirmwareReducerDeps) => {
+        builder
+            .addCase(
+                extra.actionTypes.storageLoad,
+                (state, { payload }: PayloadAction<StorageActionPayload>) => {
+                    if (payload.firmware) state.firmwareChannel = payload.firmware.firmwareChannel;
+                },
+            )
+            .addCase(firmwareActions.setStatus, (state, { payload }) => {
+                state.status = payload;
+            })
+            .addCase(firmwareActions.setSwitchFirmwareType, (state, { payload }) => {
+                state.switchFirmwareType = payload;
+            })
+            .addCase(firmwareActions.setFirmwareUpdateError, (state, { payload }) => {
+                state.error = payload;
+                if (payload) {
+                    state.status = 'error';
                 }
-            },
-        )
-        .addMatcher<FirmwareUpdateUiEvent>(
-            (action: FirmwareUpdateUiEvent) =>
-                action.type === UI_REQUEST.FIRMWARE_RECONNECT ||
-                action.type === UI_REQUEST.FIRMWARE_PROGRESS ||
-                action.type === UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY ||
-                action.type === DEVICE.BUTTON,
-            (state, action) => {
-                // DEVICE.BUTTON can be dispatched outside the firmware update flow and that should not change the uiEvent,
-                // otherwise it could result in confirmation pill being displayed unintentionally.
-                if (!(action.type === DEVICE.BUTTON && state.status === 'initial')) {
-                    state.uiEvent = action;
-                }
-            },
-        );
-});
+                state.uiEvent = undefined;
+            })
+            .addCase(firmwareActions.setTargetType, (state, { payload }) => {
+                state.targetType = payload;
+            })
+            .addCase(firmwareActions.resetReducer, state => ({
+                ...initialState,
+                firmwareChannel: state.firmwareChannel,
+                useDevkit: state.useDevkit,
+            }))
+            .addCase(firmwareActions.toggleUseDevkit, (state, { payload }) => {
+                state.useDevkit = payload;
+            })
+            .addCase(firmwareActions.cacheDevice, (state, { payload }) => {
+                state.cachedDevice = payload;
+            })
+            .addCase(firmwareActions.setFirmwareChannel, (state, { payload }) => {
+                state.firmwareChannel = payload;
+            })
+            .addMatcher<UiRequestConfirmation>(
+                action => action.type === UI_REQUEST.REQUEST_CONFIRMATION,
+                (state, action) => {
+                    if (state.status === 'started' && action.payload.view === 'thp-pairing-start') {
+                        state.status = 'thp-pairing';
+                    }
+                },
+            )
+            .addMatcher<FirmwareUpdateUiEvent>(
+                (action: FirmwareUpdateUiEvent) =>
+                    action.type === UI_REQUEST.FIRMWARE_RECONNECT ||
+                    action.type === UI_REQUEST.FIRMWARE_PROGRESS ||
+                    action.type === UI_REQUEST.FIRMWARE_PROGRESS_UNEXPECTED_DELAY ||
+                    action.type === DEVICE.BUTTON,
+                (state, action) => {
+                    // DEVICE.BUTTON can be dispatched outside the firmware update flow and that should not change the uiEvent,
+                    // otherwise it could result in confirmation pill being displayed unintentionally.
+                    if (!(action.type === DEVICE.BUTTON && state.status === 'initial')) {
+                        state.uiEvent = action;
+                    }
+                },
+            );
+    },
+);
 
 export const selectFirmware = (state: FirmwareRootState) => state.firmware;
 export const selectUseDevkit = (state: FirmwareRootState) => state.firmware.useDevkit;

--- a/suite-common/message-system/src/messageSystemReducer.ts
+++ b/suite-common/message-system/src/messageSystemReducer.ts
@@ -1,6 +1,6 @@
 import { type AnyAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { messageSystemActions } from './messageSystemActions';
 import { type MessageState, type MessageSystemState } from './messageSystemTypes';
@@ -49,9 +49,11 @@ const getMessageStateById = (draft: MessageSystemState, id: string): MessageStat
     return draft.dismissedMessages[id];
 };
 
+type MessageSystemReducerDeps = ActionTypesDep<'storageLoad'>;
+
 export const prepareMessageSystemReducer = createReducerWithExtraDeps(
     initialState,
-    (builder, extra) => {
+    (builder, extra: MessageSystemReducerDeps) => {
         builder
             .addCase(messageSystemActions.fetchSuccess, (state, { payload }) => {
                 const { timestamp } = payload;

--- a/suite-common/receive/src/receiveSlice.ts
+++ b/suite-common/receive/src/receiveSlice.ts
@@ -1,6 +1,11 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createSliceWithExtraDeps, createWeakMapSelector } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createSliceWithExtraDeps,
+    createWeakMapSelector,
+} from '@suite-common/redux-utils';
 import { accountsActions } from '@suite-common/wallet-core';
 import { type AccountKey, type ReceiveInfo } from '@suite-common/wallet-types';
 
@@ -32,6 +37,8 @@ type SetCurrentFreshAddressPayload = {
     accountKey: AccountKey;
     currentFreshAddress?: CurrentFreshAddress;
 };
+
+type ReceiveSliceDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadReceiveAccounts'>;
 
 export const receiveInitialState: ReceiveState = {
     accounts: {},
@@ -88,7 +95,7 @@ const receiveSlice = createSliceWithExtraDeps({
             accountState.currentFreshAddress = action.payload.currentFreshAddress;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: ReceiveSliceDeps) => {
         builder
             .addCase(accountsActions.removeAccount, (state, action) => {
                 action.payload.forEach((account: { key: AccountKey }) => {

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.ts
@@ -1,32 +1,34 @@
 import { type ActionReducerMapBuilder, type EnhancedStore, createReducer } from '@reduxjs/toolkit';
 import type { ThunkDispatch } from 'redux-thunk';
 
-// TODO: This dependency on the global ExtraDependencies type is bad, temporary, terrible, and
-// disastrous. Remove it in follow-ups tracked by https://github.com/trezor/trezor-suite/issues/30770.
-import { type ExtraDependenciesForReducer } from '@suite-common/redux-extra-dependencies';
-
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 type NotFunction<T> = T extends Function ? never : T;
+
+type InjectedReducer = (state: any, action: { type: any; payload: any }) => void;
+
+export type ActionTypesDep<TName extends string> = {
+    actionTypes: Record<TName, string>;
+};
+
+export type ReducersDep<TName extends string> = {
+    reducers: Record<TName, InjectedReducer>;
+};
+
+type ReducerExtra<TExtra> = [TExtra] extends [void] ? Record<never, never> : TExtra;
+type PrepareReducerExtra<TExtra> = [TExtra] extends [void] ? unknown : TExtra;
 
 type EnhancedStoreState<TStore extends EnhancedStore<any, any>> = ReturnType<TStore['getState']>;
 type EnhancedStoreAction<TStore extends EnhancedStore<any, any>> =
     TStore extends EnhancedStore<any, infer TAction> ? TAction : never;
 
 export const createReducerWithExtraDeps =
-    <S extends NotFunction<any>>(
+    <S extends NotFunction<any>, TExtra = void>(
         initialState: S | (() => S),
-        builderCallback: (
-            builder: ActionReducerMapBuilder<S>,
-            extra: ExtraDependenciesForReducer,
-        ) => void,
+        builderCallback: (builder: ActionReducerMapBuilder<S>, extra: ReducerExtra<TExtra>) => void,
     ) =>
-    (extraDeps: ExtraDependenciesForReducer) =>
+    (extraDeps: PrepareReducerExtra<TExtra>) =>
         createReducer(initialState, builder =>
-            builderCallback(builder, {
-                actionTypes: extraDeps.actionTypes,
-                actions: extraDeps.actions,
-                reducers: extraDeps.reducers,
-            }),
+            builderCallback(builder, extraDeps as ReducerExtra<TExtra>),
         );
 
 // Adds the thunk dispatch type that configureStore cannot infer through the extra middleware factory.

--- a/suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts
+++ b/suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts
@@ -1,0 +1,27 @@
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from './createReducerWithExtraDeps';
+
+type SelectedReducerDeps = ActionTypesDep<'selectedAction'> & ReducersDep<'selectedReducer'>;
+type TestState = { value: number };
+
+createReducerWithExtraDeps({ value: 0 }, (_builder, extra) => {
+    // @ts-expect-error Dependency-free reducers cannot access injected action types.
+    void extra.actionTypes;
+})(null);
+
+createReducerWithExtraDeps<TestState, SelectedReducerDeps>({ value: 0 }, (_builder, extra) => {
+    void extra.actionTypes.selectedAction;
+    void extra.reducers.selectedReducer;
+
+    // @ts-expect-error Reducers can access only explicitly declared action types.
+    void extra.actionTypes.unselectedAction;
+
+    // @ts-expect-error Reducers can access only explicitly declared child reducers.
+    void extra.reducers.unselectedReducer;
+})({
+    actionTypes: { selectedAction: 'test/selected-action' },
+    reducers: { selectedReducer: () => {} },
+});

--- a/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
+++ b/suite-common/redux-utils/src/createSliceWithExtraDeps.ts
@@ -6,24 +6,21 @@ import {
     createSlice,
 } from '@reduxjs/toolkit';
 
-// TODO: This dependency on the global ExtraDependencies type is bad, temporary, terrible, and
-// disastrous. Remove it in follow-ups tracked by https://github.com/trezor/trezor-suite/issues/30770.
-import { type ExtraDependenciesForReducer } from '@suite-common/redux-extra-dependencies';
-
 /*
 This is nearly same function as createSlice from redux-toolkit, but instead of generating reducer it will generate
 prepareReducer function that will be used to generate reducer. This functions accepts one argument - extra dependencies.
 */
+type SliceExtra<TExtra> = [TExtra] extends [void] ? Record<never, never> : TExtra;
+type PrepareSliceExtra<TExtra> = [TExtra] extends [void] ? unknown : TExtra;
+
 export const createSliceWithExtraDeps = <
     State,
     CaseReducers extends SliceCaseReducers<State>,
     Name extends string = string,
+    TExtra = void,
 >(
     options: Omit<CreateSliceOptions<State, CaseReducers, Name>, 'extraReducers'> & {
-        extraReducers: (
-            builder: ActionReducerMapBuilder<State>,
-            extra: ExtraDependenciesForReducer,
-        ) => void;
+        extraReducers: (builder: ActionReducerMapBuilder<State>, extra: SliceExtra<TExtra>) => void;
     },
 ) => {
     const emptyActionTypesProxy: any = new Proxy(
@@ -53,23 +50,21 @@ export const createSliceWithExtraDeps = <
     const { actions, name, getInitialState } = createSlice({
         ...options,
         extraReducers: builder => {
-            options.extraReducers(builder, {
+            const emptyExtra = {
                 actionTypes: emptyActionTypesProxy,
                 actions: emptyActionsProxy,
                 reducers: emptyReducersProxy,
-            });
+            } as SliceExtra<TExtra>;
+
+            options.extraReducers(builder, emptyExtra);
         },
     });
 
-    const prepareReducer = (extraDeps: ExtraDependenciesForReducer) =>
+    const prepareReducer = (extraDeps: PrepareSliceExtra<TExtra>) =>
         createSlice({
             ...options,
             extraReducers: builder => {
-                options.extraReducers(builder, {
-                    actionTypes: extraDeps.actionTypes,
-                    actions: extraDeps.actions,
-                    reducers: extraDeps.reducers,
-                });
+                options.extraReducers(builder, extraDeps as SliceExtra<TExtra>);
             },
         }).reducer;
 

--- a/suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts
+++ b/suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts
@@ -1,0 +1,33 @@
+import { type ActionTypesDep, type ReducersDep } from './createReducerWithExtraDeps';
+import { createSliceWithExtraDeps } from './createSliceWithExtraDeps';
+
+type SelectedSliceDeps = ActionTypesDep<'selectedAction'> & ReducersDep<'selectedReducer'>;
+
+createSliceWithExtraDeps({
+    name: 'dependency-free',
+    initialState: { value: 0 },
+    reducers: {},
+    extraReducers: (_builder, extra) => {
+        // @ts-expect-error Dependency-free slices cannot access injected action types.
+        void extra.actionTypes;
+    },
+}).prepareReducer(null);
+
+createSliceWithExtraDeps({
+    name: 'selected-dependencies',
+    initialState: { value: 0 },
+    reducers: {},
+    extraReducers: (_builder, extra: SelectedSliceDeps) => {
+        void extra.actionTypes.selectedAction;
+        void extra.reducers.selectedReducer;
+
+        // @ts-expect-error Slices can access only explicitly declared action types.
+        void extra.actionTypes.unselectedAction;
+
+        // @ts-expect-error Slices can access only explicitly declared child reducers.
+        void extra.reducers.unselectedReducer;
+    },
+}).prepareReducer({
+    actionTypes: { selectedAction: 'test/selected-action' },
+    reducers: { selectedReducer: () => {} },
+});

--- a/suite-common/thp/src/thpReducer.ts
+++ b/suite-common/thp/src/thpReducer.ts
@@ -1,6 +1,6 @@
 import { type AnyAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 import { type ThpSuiteCredentials } from '@suite-common/suite-types';
 import {
     DEVICE,
@@ -51,7 +51,9 @@ const addCredential = (credentials: ThpSuiteCredentials[], credential: ThpCreden
         .filter(c => c.trezor_static_public_key !== credential.trezor_static_public_key)
         .concat([{ ...credential, connectionCounter: 0 }]);
 
-export const prepareThpReducer = createReducerWithExtraDeps<ThpState>(
+type ThpReducerDeps = ActionTypesDep<'storageLoad'>;
+
+export const prepareThpReducer = createReducerWithExtraDeps<ThpState, ThpReducerDeps>(
     initialThpState,
     (builder, extra) =>
         builder

--- a/suite-common/token-definitions/src/tokenDefinitionsReducer.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsReducer.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 
 import { tokenDefinitionsActions } from './tokenDefinitionsActions';
 import { getTokenDefinitionThunk } from './tokenDefinitionsThunks';
@@ -6,9 +10,12 @@ import { type TokenDefinitionsState, TokenManagementAction } from './tokenDefini
 
 export const tokenDefinitionsInitialState: Partial<TokenDefinitionsState> = {};
 
+type TokenDefinitionsReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadTokenManagement'>;
+
 export const prepareTokenDefinitionsReducer = createReducerWithExtraDeps(
     tokenDefinitionsInitialState,
-    (builder, extra) => {
+    (builder, extra: TokenDefinitionsReducerDeps) => {
         builder
             .addCase(getTokenDefinitionThunk.pending, (state, action) => {
                 const { symbol } = action.meta.arg;

--- a/suite-common/trading/src/reducers/tradingReducer.ts
+++ b/suite-common/trading/src/reducers/tradingReducer.ts
@@ -1,6 +1,6 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 
 import {
     TRADING_BUY_PREFIX,
@@ -22,11 +22,13 @@ type StorageActionPayload = {
     tradingTrades?: TradingTransaction[];
 };
 
+export type TradingReducerDeps = ActionTypesDep<'storageLoad'>;
+
 const tradingSlice = createSliceWithExtraDeps({
     name: TRADING_EXTENDED_PREFIX,
     initialState,
     reducers: {},
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: TradingReducerDeps) => {
         builder
             .addCase(
                 extra.actionTypes.storageLoad,

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -1,7 +1,11 @@
-import { current, isAnyOf } from '@reduxjs/toolkit';
+import { type ActionCreatorWithPreparedPayload, current, isAnyOf } from '@reduxjs/toolkit';
 
 import { deviceActions } from '@suite-common/device';
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { networks } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { accountEqualTo, compareAccountsByCoin, enhanceHistory } from '@suite-common/wallet-utils';
@@ -92,9 +96,16 @@ const setMetadata = (state: Account[], account: Account) => {
     state[index].metadata = account.metadata;
 };
 
+type AccountsReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadAccounts'> & {
+        actions: {
+            setAccountAddMetadata: ActionCreatorWithPreparedPayload<[Account], Account>;
+        };
+    };
+
 export const prepareAccountsReducer = createReducerWithExtraDeps(
     accountsInitialState,
-    (builder, extra) => {
+    (builder, extra: AccountsReducerDeps) => {
         builder
             .addCase(accountsActions.removeAccount, (state, action) => {
                 remove(state, action.payload);

--- a/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainReducer.ts
@@ -1,6 +1,11 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps, createWeakMapSelector } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+    createWeakMapSelector,
+} from '@suite-common/redux-utils';
 import {
     type NetworkSymbol,
     getNetworkOptional,
@@ -139,9 +144,11 @@ const reconnecting = (draft: BlockchainState, payload: BlockchainReconnecting) =
     }
 };
 
+type BlockchainReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadBlockchain'>;
+
 export const prepareBlockchainReducer = createReducerWithExtraDeps(
     blockchainInitialState,
-    (builder, extra) => {
+    (builder, extra: BlockchainReducerDeps) => {
         builder
             .addCase(blockchainActions.synced, (state, action) => {
                 state[action.payload.symbol].syncTimeout = action.payload.timeout;

--- a/suite-common/wallet-core/src/explorer/explorerReducer.ts
+++ b/suite-common/wallet-core/src/explorer/explorerReducer.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import {
     type Explorer,
     type NetworkSymbol,
@@ -38,9 +42,11 @@ const normalizeExplorer = (explorer: Explorer) => {
     return explorer;
 };
 
+type ExplorerReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadExplorer'>;
+
 export const prepareExplorerReducer = createReducerWithExtraDeps(
     explorerInitialState,
-    (builder, extra) => {
+    (builder, extra: ExplorerReducerDeps) => {
         builder
             .addCase(explorerActions.setExplorer, (state, action) => {
                 const { symbol, explorer } = action.payload;

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { type Timestamp } from '@suite-common/wallet-types';
 import { getFiatRateKeyFromTicker, isTestnet } from '@suite-common/wallet-utils';
 
@@ -11,9 +15,11 @@ export const fiatRatesInitialState: FiatRatesState = {
     historic: {},
 };
 
+type FiatRatesReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadHistoricRates'>;
+
 export const prepareFiatRatesReducer = createReducerWithExtraDeps(
     fiatRatesInitialState,
-    (builder, extra) => {
+    (builder, extra: FiatRatesReducerDeps) => {
         builder
             .addCase(updateFiatRatesThunk.pending, (state, action) => {
                 const { tickers, baseCurrencyCode, rateType } = action.meta.arg;

--- a/suite-common/wallet-core/src/phishing/phishingReducer.ts
+++ b/suite-common/wallet-core/src/phishing/phishingReducer.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { DUST_PHISHING_THRESHOLD } from '@suite-common/token-definitions';
 
 import { phishingActions } from './phishingActions';
@@ -11,9 +15,12 @@ export const phishingInitialState: PhishingState = {
     },
 };
 
+type PhishingReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadPhishingMetadata'>;
+
 export const preparePhishingReducer = createReducerWithExtraDeps(
     phishingInitialState,
-    (builder, extra) => {
+    (builder, extra: PhishingReducerDeps) => {
         builder
             .addCase(phishingActions.setDustPhishing, (state, { payload }) => {
                 state.dustPhishing = payload;

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -47,7 +47,8 @@ export type SendRootState = {
     };
 };
 
-type SendFormReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadFormDrafts'>;
+export type SendFormReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadFormDrafts'>;
 
 export const prepareSendFormReducer = createReducerWithExtraDeps(
     initialState,

--- a/suite-common/wallet-core/src/send/sendFormReducer.ts
+++ b/suite-common/wallet-core/src/send/sendFormReducer.ts
@@ -1,4 +1,8 @@
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import {
     type AccountKey,
     type FormState,
@@ -43,81 +47,86 @@ export type SendRootState = {
     };
 };
 
-export const prepareSendFormReducer = createReducerWithExtraDeps(initialState, (builder, extra) => {
-    builder
-        .addCase(
-            sendFormActions.storeDraft,
-            (state, { payload: { accountKey, tokenContract, formState } }) => {
-                const draftKey = getSendFormDraftKey(accountKey, tokenContract);
+type SendFormReducerDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadFormDrafts'>;
 
-                // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
-                // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
-                // TypeError: Cannot assign to read only property of object '#<Object>'
-                // This might not be necessary in the future when the dependencies are upgraded.
-                state.drafts[draftKey] = cloneObject(formState);
-            },
-        )
-        .addCase(
-            sendFormActions.removeDraft,
-            (state, { payload: { accountKey, tokenContract } }) => {
-                const draftKey = getSendFormDraftKey(accountKey, tokenContract);
+export const prepareSendFormReducer = createReducerWithExtraDeps(
+    initialState,
+    (builder, extra: SendFormReducerDeps) => {
+        builder
+            .addCase(
+                sendFormActions.storeDraft,
+                (state, { payload: { accountKey, tokenContract, formState } }) => {
+                    const draftKey = getSendFormDraftKey(accountKey, tokenContract);
 
-                delete state.drafts[draftKey];
-            },
-        )
-        .addCase(
-            sendFormActions.storePrecomposedTransaction,
-            (state, { payload: { precomposedTransaction, formState, accountKey } }) => {
-                state.precomposedTx = precomposedTransaction;
-                // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
-                // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
-                // TypeError: Cannot assign to read only property of object '#<Object>'
-                // This might not be necessary in the future when the dependencies are upgraded.
-                state.precomposedForm = cloneObject(formState);
-                state.accountKey = accountKey;
-            },
-        )
-        .addCase(
-            sendFormActions.storeSignedTransaction,
-            (state, { payload: { serializedTx, signedTx } }) => {
-                state.serializedTx = serializedTx;
-                state.signedTx = signedTx;
-            },
-        )
-        .addCase(sendFormActions.storeResolvedEthereumNonce, (state, { payload: nonce }) => {
-            state.resolvedEthereumNonce = nonce;
-        })
-        .addCase(sendFormActions.discardTransaction, state => {
-            delete state.precomposedTx;
-            delete state.precomposedForm;
-            delete state.serializedTx;
-            delete state.signedTx;
-            delete state.accountKey;
-            delete state.resolvedEthereumNonce;
-        })
-        .addCase(sendFormActions.clearSignedTransactionData, state => {
-            delete state.serializedTx;
-            delete state.signedTx;
-            // Otherwise a retry after a failed push would briefly show the previous attempt's
-            // nonce in the review modal before signing resolves and stores a fresh one.
-            delete state.resolvedEthereumNonce;
-        })
-        .addCase(sendFormActions.sendRaw, (state, { payload: sendRaw }) => {
-            state.sendRaw = sendRaw;
-        })
-        .addCase(sendFormActions.dispose, state => {
-            delete state.sendRaw;
-            delete state.precomposedTx;
-            delete state.precomposedForm;
-            delete state.serializedTx;
-            delete state.signedTx;
-            delete state.accountKey;
-            delete state.resolvedEthereumNonce;
-        })
-        .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadFormDrafts)
-        .addCase(accountsActions.removeAccount, (state, { payload }) => {
-            payload.forEach(account => {
-                delete state.drafts[account.key];
+                    // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
+                    // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
+                    // TypeError: Cannot assign to read only property of object '#<Object>'
+                    // This might not be necessary in the future when the dependencies are upgraded.
+                    state.drafts[draftKey] = cloneObject(formState);
+                },
+            )
+            .addCase(
+                sendFormActions.removeDraft,
+                (state, { payload: { accountKey, tokenContract } }) => {
+                    const draftKey = getSendFormDraftKey(accountKey, tokenContract);
+
+                    delete state.drafts[draftKey];
+                },
+            )
+            .addCase(
+                sendFormActions.storePrecomposedTransaction,
+                (state, { payload: { precomposedTransaction, formState, accountKey } }) => {
+                    state.precomposedTx = precomposedTransaction;
+                    // Deep-cloning to prevent buggy interaction between react-hook-form and immer, see https://github.com/orgs/react-hook-form/discussions/3715#discussioncomment-2151458
+                    // Otherwise, whenever the outputs fieldArray is updated after the form draft or precomposedForm is saved, there is na error:
+                    // TypeError: Cannot assign to read only property of object '#<Object>'
+                    // This might not be necessary in the future when the dependencies are upgraded.
+                    state.precomposedForm = cloneObject(formState);
+                    state.accountKey = accountKey;
+                },
+            )
+            .addCase(
+                sendFormActions.storeSignedTransaction,
+                (state, { payload: { serializedTx, signedTx } }) => {
+                    state.serializedTx = serializedTx;
+                    state.signedTx = signedTx;
+                },
+            )
+            .addCase(sendFormActions.storeResolvedEthereumNonce, (state, { payload: nonce }) => {
+                state.resolvedEthereumNonce = nonce;
+            })
+            .addCase(sendFormActions.discardTransaction, state => {
+                delete state.precomposedTx;
+                delete state.precomposedForm;
+                delete state.serializedTx;
+                delete state.signedTx;
+                delete state.accountKey;
+                delete state.resolvedEthereumNonce;
+            })
+            .addCase(sendFormActions.clearSignedTransactionData, state => {
+                delete state.serializedTx;
+                delete state.signedTx;
+                // Otherwise a retry after a failed push would briefly show the previous attempt's
+                // nonce in the review modal before signing resolves and stores a fresh one.
+                delete state.resolvedEthereumNonce;
+            })
+            .addCase(sendFormActions.sendRaw, (state, { payload: sendRaw }) => {
+                state.sendRaw = sendRaw;
+            })
+            .addCase(sendFormActions.dispose, state => {
+                delete state.sendRaw;
+                delete state.precomposedTx;
+                delete state.precomposedForm;
+                delete state.serializedTx;
+                delete state.signedTx;
+                delete state.accountKey;
+                delete state.resolvedEthereumNonce;
+            })
+            .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadFormDrafts)
+            .addCase(accountsActions.removeAccount, (state, { payload }) => {
+                payload.forEach(account => {
+                    delete state.drafts[account.key];
+                });
             });
-        });
-});
+    },
+);

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -2,6 +2,8 @@ import { A } from '@mobily/ts-belt';
 
 import { type DeviceRootState, selectHasBitcoinOnlyFirmware } from '@suite-common/device';
 import {
+    type ActionTypesDep,
+    type ReducersDep,
     createReducerWithExtraDeps,
     createWeakMapSelector,
     returnStableArrayIfEmpty,
@@ -51,9 +53,12 @@ export const walletSettingsPersistedWhitelist: Array<keyof WalletSettingsState> 
     'addressDisplayType',
 ];
 
+type WalletSettingsReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadWalletSettings'>;
+
 export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
     initialState,
-    (builder, extra) => {
+    (builder, extra: WalletSettingsReducerDeps) => {
         builder.addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadWalletSettings);
         builder.addCase(
             walletSettingsActions.setBaseCurrency.type,

--- a/suite-common/wallet-core/src/transactions/transactionsReducer.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsReducer.ts
@@ -1,6 +1,10 @@
 import { isAnyOf } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createReducerWithExtraDeps,
+} from '@suite-common/redux-utils';
 import type { AccountKey } from '@suite-common/wallet-types';
 import { findTransaction } from '@suite-common/wallet-utils';
 
@@ -27,9 +31,12 @@ const initializeAccount = (state: TransactionsState, accountKey: AccountKey) => 
     return state.transactions[accountKey];
 };
 
+type TransactionsReducerDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadTransactions'>;
+
 export const prepareTransactionsReducer = createReducerWithExtraDeps(
     transactionsInitialState,
-    (builder, extra) => {
+    (builder, extra: TransactionsReducerDeps) => {
         builder
             .addCase(transactionsActions.resetTransaction, (state, { payload }) => {
                 const { account } = payload;

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -1,6 +1,6 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createReducerWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createReducerWithExtraDeps } from '@suite-common/redux-utils';
 
 import { walletConnectActions } from './walletConnectActions';
 import { type PendingConnectionProposal, type WalletConnectSession } from './walletConnectTypes';
@@ -25,9 +25,11 @@ export const walletConnectInitialState: WalletConnectState = {
     pendingProposal: undefined,
 };
 
+type WalletConnectReducerDeps = ActionTypesDep<'storageLoad'>;
+
 export const prepareWalletConnectReducer = createReducerWithExtraDeps(
     walletConnectInitialState,
-    (builder, extra) => {
+    (builder, extra: WalletConnectReducerDeps) => {
         builder
             .addCase(
                 extra.actionTypes.storageLoad,

--- a/suite-native/bluetooth/src/bluetoothSlice.ts
+++ b/suite-native/bluetooth/src/bluetoothSlice.ts
@@ -1,6 +1,7 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
 import {
+    type BluetoothReducerDeps,
     type BluetoothState,
     prepareBluetoothReducerCreator,
     prepareInitialState,
@@ -36,7 +37,7 @@ const bluetoothSlice = createSliceWithExtraDeps({
             }
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: BluetoothReducerDeps) => {
         const commonReducer = prepareBluetoothReducerCreator<BluetoothDevice>()(extra);
         builder
             .addCase(UI_REQUEST.FIRMWARE_DISCONNECT, (_, action: FirmwareDisconnect) => {

--- a/suite-native/trading-state/src/reducers/tradingSlice.ts
+++ b/suite-native/trading-state/src/reducers/tradingSlice.ts
@@ -3,6 +3,7 @@ import { type PayloadAction, isAnyOf } from '@reduxjs/toolkit';
 import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {
     type TradeServerEnvironment,
+    type TradingReducerDeps,
     type TradingTypeWithConcierge,
     prepareTradingReducer,
 } from '@suite-common/trading';
@@ -99,7 +100,7 @@ export const tradingSlice = createSliceWithExtraDeps({
             state.sell.tradingAccountKey = undefined;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: TradingReducerDeps) => {
         const commonTradingFormReducer = prepareTradingReducer(extra);
         builder
             .addMatcher(

--- a/suite-native/transaction-management/src/sendFormSlice.ts
+++ b/suite-native/transaction-management/src/sendFormSlice.ts
@@ -4,6 +4,7 @@ import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
 import {
     type SendState as CommonSendState,
     type SendFormError,
+    type SendFormReducerDeps,
     initialState as commonInitialState,
     composeSendFormTransactionFeeLevelsThunk,
     prepareSendFormReducer as prepareCommonSendFormReducer,
@@ -43,7 +44,7 @@ const sendFormSlice = createSliceWithExtraDeps({
             state.feeLevels = payload.feeLevels;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: SendFormReducerDeps) => {
         const commonSendFormReducer = prepareCommonSendFormReducer(extra);
         builder
             .addMatcher(

--- a/suite/debug/src/debugSlice.ts
+++ b/suite/debug/src/debugSlice.ts
@@ -1,6 +1,6 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import { type ActionTypesDep, createSliceWithExtraDeps } from '@suite-common/redux-utils';
 
 export interface DebugState {
     showDebugMenu: boolean;
@@ -14,6 +14,8 @@ type StorageActionPayload = {
     debug?: DebugState;
 };
 
+type DebugSliceDeps = ActionTypesDep<'storageLoad'>;
+
 export const debugInitialState: DebugState = {
     showDebugMenu: false,
 };
@@ -26,7 +28,7 @@ const debugSlice = createSliceWithExtraDeps({
             state.showDebugMenu = payload;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: DebugSliceDeps) => {
         builder.addCase(
             extra.actionTypes.storageLoad,
             (state, { payload }: PayloadAction<StorageActionPayload>) =>

--- a/suite/device/src/deviceSlice.ts
+++ b/suite/device/src/deviceSlice.ts
@@ -1,6 +1,7 @@
 import { type PayloadAction, isAnyOf } from '@reduxjs/toolkit';
 
 import {
+    type DeviceReducerDeps,
     type DeviceReducerState,
     deviceInitialState as commonInitialState,
     deviceActions,
@@ -42,7 +43,7 @@ const deviceSlice = createSliceWithExtraDeps({
             state.defaultConnectionMode = payload;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: DeviceReducerDeps) => {
         const commonReducer = prepareCommonDeviceReducer(extra);
 
         builder

--- a/suite/flags/src/flagsSlice.ts
+++ b/suite/flags/src/flagsSlice.ts
@@ -1,6 +1,10 @@
 import { type PayloadAction } from '@reduxjs/toolkit';
 
-import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createSliceWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { DEVICE } from '@trezor/connect';
 
 import { type NewContentIndicatorId } from './flagsConstants';
@@ -45,6 +49,8 @@ export type FlagsRootState = { flags: FlagsState };
 export type BooleanFlagKey = {
     [Key in keyof FlagsState]: FlagsState[Key] extends boolean ? Key : never;
 }[keyof FlagsState];
+
+type FlagsSliceDeps = ActionTypesDep<'storageLoad'> & ReducersDep<'storageLoadFlags'>;
 
 export const flagsInitialState: FlagsState = {
     initialRun: true,
@@ -108,7 +114,7 @@ const flagsSlice = createSliceWithExtraDeps({
             }
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: FlagsSliceDeps) => {
         builder
             .addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadFlags)
             .addCase(DEVICE.CONNECT, state => {

--- a/suite/settings/src/settingsSlice.ts
+++ b/suite/settings/src/settingsSlice.ts
@@ -3,7 +3,11 @@ import { type PayloadAction } from '@reduxjs/toolkit';
 import type { ExperimentalFeature } from '@suite/experimental';
 import { type EarnYieldWorkerBaseUrl } from '@suite-common/earn-stablecoin-defs';
 import { type OAuthServerEnvironment } from '@suite-common/metadata-types';
-import { createSliceWithExtraDeps } from '@suite-common/redux-utils';
+import {
+    type ActionTypesDep,
+    type ReducersDep,
+    createSliceWithExtraDeps,
+} from '@suite-common/redux-utils';
 import { type Locale } from '@suite-common/suite-types';
 import type { TradeServerEnvironment } from '@suite-common/trading';
 import type { DefinitionsChannel } from '@trezor/connect-common';
@@ -67,6 +71,9 @@ export interface SuiteSettingsState {
 export type SuiteSettingsRootState = {
     suiteSettings: SuiteSettingsState;
 };
+
+type SuiteSettingsSliceDeps = ActionTypesDep<'storageLoad'> &
+    ReducersDep<'storageLoadSuiteSettings'>;
 
 export const suiteSettingsInitialState: SuiteSettingsState = {
     theme: {
@@ -193,7 +200,7 @@ const suiteSettingsSlice = createSliceWithExtraDeps({
             state.enabledSecurityChecks.deviceMeta = payload;
         },
     },
-    extraReducers: (builder, extra) => {
+    extraReducers: (builder, extra: SuiteSettingsSliceDeps) => {
         builder.addCase(extra.actionTypes.storageLoad, extra.reducers.storageLoadSuiteSettings);
     },
 });


### PR DESCRIPTION
## Description

Makes `createSliceWithExtraDeps` generic over caller-owned reducer dependencies and removes its global `ExtraDependenciesForReducer` import. All 10 slices that consume or forward injected actions/reducers now declare selective contracts, while forwarding slices reuse their child reducer contracts and the remaining 2 production slices stay dependency-free. A type test rejects undeclared dependency access.

- Production slice consumers: **12 / 12 migrated**
- Selective contracts: **10**
- Dependency-free slices: **2**
- Redux-utils unit tests: **5 passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-slice-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-slice-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-slice-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-slice-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-slice-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:33:12.970Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:33:19.795Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set touches a wide range of Redux reducers and slice utilities across suite-common, suite, and suite-native. The highest risk is state-management regressions in analytics, device/settings, wallet discovery/send/receive, trading, Connect permissions, and THP onboarding. The recommended tests are a targeted smoke set across these areas rather than the full 135-test static mapping. Native-only slices and type-test files have no E2E coverage and should be validated separately.

<details><summary><b>Changed files (33)</b></summary>

- `packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts`
- `packages/suite/src/reducers/bioAuth/index.ts`
- `suite-common/analytics-redux/src/redux/analyticsReducer.ts`
- `suite-common/bluetooth/src/bluetoothReducer.ts`
- `suite-common/bluetooth/src/index.ts`
- `suite-common/connect-popup/src/connectPopupReducer.ts`
- `suite-common/device/src/deviceReducer.ts`
- `suite-common/firmware/src/firmwareReducer.ts`
- `suite-common/message-system/src/messageSystemReducer.ts`
- `suite-common/receive/src/receiveSlice.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts`
- `suite-common/thp/src/thpReducer.ts`
- `suite-common/token-definitions/src/tokenDefinitionsReducer.ts`
- `suite-common/trading/src/reducers/tradingReducer.ts`
- `suite-common/wallet-core/src/accounts/accountsReducer.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`
- `suite-common/wallet-core/src/explorer/explorerReducer.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts`
- `suite-common/wallet-core/src/phishing/phishingReducer.ts`
- `suite-common/wallet-core/src/send/sendFormReducer.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`
- `suite-common/wallet-core/src/transactions/transactionsReducer.ts`
- `suite-common/walletconnect/src/walletConnectReducer.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/trading-state/src/reducers/tradingSlice.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/device/src/deviceSlice.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/settings/src/settingsSlice.ts`

</details>

**Recommended tests (17)**

<details><summary>🔴 <b>High priority (14)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Directly exercises the analytics consent flow and the full lifecycle of analytics events, which depends on suite-common/analytics-redux/src/redux/analyticsReducer.ts that was changed.
- `suite/e2e/tests/analytics/toggle.test.ts` — Toggles analytics consent on/off and verifies settings/analytics state, directly covering analyticsReducer.ts and touching suite/settings/src/settingsSlice.ts.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Validates WalletConnect analytics events, exercising suite-common/walletconnect/src/walletConnectReducer.ts which changed.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Covers THP pairing during onboarding and device state, directly using suite-common/thp/src/thpReducer.ts, suite/device/src/deviceSlice.ts, and suite-common/firmware/src/firmwareReducer.ts.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgets TS7/TS5 devices and verifies Bluetooth history, hitting suite-common/bluetooth/src/bluetoothReducer.ts, suite-common/thp/src/thpReducer.ts, suite-common/device/src/deviceReducer.ts, and settingsSlice.
- `suite/e2e/tests/settings/general.test.ts` — Changes fiat, theme, language and analytics toggles; verifies dashboard state, covering suite/settings/src/settingsSlice.ts, suite-common/wallet-core/src/settings/walletSettingsReducer.ts, suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts, and analyticsReducer.
- `suite/e2e/tests/settings/safety-checks.test.ts` — Changes the device safety-checks level and verifies persistence, directly exercising suite-common/device/src/deviceReducer.ts and suite/device/src/deviceSlice.ts.
- `suite/e2e/tests/suite/db-migration.test.ts` — Verifies migration of the auto-eject wallet setting across Suite versions, directly depending on suite-common/wallet-core/src/settings/walletSettingsReducer.ts and suite/settings/src/settingsSlice.ts.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Tests Bridge session takeover and reclaim flows that rely on suite-common/device/src/deviceReducer.ts and suite-common/bluetooth/src/bluetoothReducer.ts state.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Swaps Solana SPL tokens and asserts trading state, covering suite-common/trading/src/reducers/tradingReducer.ts, suite-common/token-definitions/src/tokenDefinitionsReducer.ts, accountsReducer, and sendFormReducer.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Grants, remembers, and revokes Connect permissions, directly using suite-common/connect-popup/src/connectPopupReducer.ts and suite-common/device/src/deviceReducer.ts.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates many coin networks and verifies discovery state and dashboard balances, exercising accountsReducer, blockchainReducer, transactionsReducer, walletSettingsReducer, and deviceReducer.
- `suite/e2e/tests/wallet/receive.test.ts` — Generates and verifies receive addresses across coins, directly depending on suite-common/receive/src/receiveSlice.ts.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Fills the Ethereum send form with custom fees and signs a transaction, covering sendFormReducer, accountsReducer, transactionsReducer, and fiatRatesReducer.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/firmware/custom-firmware.test.ts` — Installs custom firmware and verifies device state, covering suite-common/firmware/src/firmwareReducer.ts and suite/device/src/deviceSlice.ts.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — End-to-end buy flow using mocked quotes and trade endpoints; exercises suite-common/trading/src/reducers/tradingReducer.ts and wallet account state not covered by the swap test.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Sends regtest transactions and asserts pending/confirmed grouping in the transaction list, directly using suite-common/wallet-core/src/transactions/transactionsReducer.ts.

</details>

⚠️ **Changes with no test coverage (9)**
- `packages/suite/src/reducers/bioAuth/index.ts`
- `suite-common/bluetooth/src/index.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/trading-state/src/reducers/tradingSlice.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/flags/src/flagsSlice.ts`

_Updated: 2026-08-07T15:32:01.303Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->