### PR TITLE
refactor(redux): narrow small common thunk dependencies

### DIFF
--- a/suite-common/feedback/src/sendFeedbackAction.ts
+++ b/suite-common/feedback/src/sendFeedbackAction.ts
@@ -6,7 +6,7 @@ import { getFeedbackUrl } from './getFeedbackUrl';
 
 const FEEDBACK_MODULE_PREFIX = '@suite/feedback';
 
-export const sendFeedbackAction = createThunk<void, Feedback>(
+export const sendFeedbackAction = createThunk<void, Feedback, void>(
     `${FEEDBACK_MODULE_PREFIX}/sendFeedback`,
     async ({ type, payload }, { dispatch, rejectWithValue }) => {
         const url = getFeedbackUrl(type);

--- a/suite-common/message-system/src/messageSystemThunks.ts
+++ b/suite-common/message-system/src/messageSystemThunks.ts
@@ -131,16 +131,17 @@ export const fetchConfigThunk = createThunk<void, void, { state: FetchConfigThun
     },
 );
 
-export const initMessageSystemThunk = createThunk(
-    `${ACTION_PREFIX}/init`,
-    async (_, { dispatch }) => {
-        const run = async () => {
-            await dispatch(fetchConfigThunk()).unwrap();
-        };
-        const interval = isNative()
-            ? FETCH_CHECK_INTERVAL_IN_MS_MOBILE
-            : FETCH_CHECK_INTERVAL_IN_MS;
+type InitMessageSystemThunkState = FetchConfigThunkState;
 
-        await messageSystemPolling.restart(run, interval);
-    },
-);
+export const initMessageSystemThunk = createThunk<
+    void,
+    void,
+    { state: InitMessageSystemThunkState }
+>(`${ACTION_PREFIX}/init`, async (_, { dispatch }) => {
+    const run = async () => {
+        await dispatch(fetchConfigThunk()).unwrap();
+    };
+    const interval = isNative() ? FETCH_CHECK_INTERVAL_IN_MS_MOBILE : FETCH_CHECK_INTERVAL_IN_MS;
+
+    await messageSystemPolling.restart(run, interval);
+});

--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -84,17 +84,24 @@ export const initTokenDefinitionsThunk = createThunk<
 
 let tokenDefinitionsTimeout: TimerId | null = null;
 
-export const periodicCheckTokenDefinitionsThunk = createThunk(
-    `${TOKEN_DEFINITIONS_MODULE}/periodicCheckTokenDefinitionsThunk`,
-    (_, { dispatch }) => {
-        if (tokenDefinitionsTimeout) {
-            clearTimeout(tokenDefinitionsTimeout);
-        }
+type PeriodicCheckTokenDefinitionsThunkDeps = InitTokenDefinitionsThunkDeps;
+type PeriodicCheckTokenDefinitionsThunkState = InitTokenDefinitionsThunkState;
 
-        tokenDefinitionsTimeout = setTimeout(() => {
-            dispatch(periodicCheckTokenDefinitionsThunk());
-        }, 60_000);
+export const periodicCheckTokenDefinitionsThunk = createThunk<
+    void,
+    void,
+    {
+        state: PeriodicCheckTokenDefinitionsThunkState;
+        extra: PeriodicCheckTokenDefinitionsThunkDeps;
+    }
+>(`${TOKEN_DEFINITIONS_MODULE}/periodicCheckTokenDefinitionsThunk`, async (_, { dispatch }) => {
+    if (tokenDefinitionsTimeout) {
+        clearTimeout(tokenDefinitionsTimeout);
+    }
 
-        return dispatch(initTokenDefinitionsThunk());
-    },
-);
+    tokenDefinitionsTimeout = setTimeout(() => {
+        dispatch(periodicCheckTokenDefinitionsThunk());
+    }, 60_000);
+
+    await dispatch(initTokenDefinitionsThunk());
+});


### PR DESCRIPTION
## Description

Converts the last global-default `createThunk` declarations in the issue's remaining small Suite Common package group. The message-system initializer and periodic token-definition checker reuse their child state/service contracts, while the dependency-free feedback sender now opts into `void` explicitly. The periodic checker preserves its wait-for-child lifecycle.

- Global-default thunks in the listed small packages: **3 -> 0**
- Changed package type-checks: **3 passed**
- Unit tests: **299 passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-small-common-thunk-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-small-common-thunk-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-small-common-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-small-common-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-small-common-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:49:04.168Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:48:29.553Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All three changed files are broad shared utilities mapped to the entire test suite. sendFeedbackAction.ts has clear, targeted coverage via the Suite Guide and bug report form tests, which should be run unconditionally. tokenDefinitionsThunks.ts affects token trading flows, so a couple of token-centric trading tests are recommended as a sanity check. messageSystemThunks.ts has no clearly targeted end-to-end test in the provided analysis; its changes are best validated through broader regression runs or unit tests rather than a specific E2E pick.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/feedback/src/sendFeedbackAction.ts`
- `suite-common/message-system/src/messageSystemThunks.ts`
- `suite-common/token-definitions/src/tokenDefinitionsThunks.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/general/suite-guide.test.ts` — This test explicitly sends bug reports and feedback through the Suite Guide panel, directly exercising the sendFeedbackAction.ts code path. A regression in feedback submission would be immediately visible here.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — This test fills out and submits the bug report form, which is the primary user-facing entry point for sendFeedbackAction.ts. It is the most targeted end-to-end coverage for the changed feedback action.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-tokens.test.ts` — This test swaps SPL tokens (USDT to USDC) and relies on token definitions being loaded and resolved correctly. It provides a concrete check that tokenDefinitionsThunks.ts changes do not break token recognition in trading flows.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test buys a specific Solana token (Jupiter/JUP) and uses token definitions for asset picker selection and quote display. It helps catch regressions in token definition loading for non-native assets.

</details>

_Updated: 2026-08-07T15:47:35.191Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->