### PR TITLE
refactor(walletconnect): narrow thunk dependencies

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -70,8 +70,10 @@ type ConnectPopupCallThunkParams<M extends CallMethodKeys> = {
     source: ConnectCallSource;
 };
 
-type ConnectPopupCallThunkState = DeviceRootState & ConnectPopupStateRootState & AccountsRootState;
-type ConnectPopupCallThunkDeps = {
+export type ConnectPopupCallThunkState = DeviceRootState &
+    ConnectPopupStateRootState &
+    AccountsRootState;
+export type ConnectPopupCallThunkDeps = {
     actions: LockDeviceDep;
     services: AnalyticsDep;
 };

--- a/suite-common/mev/src/index.ts
+++ b/suite-common/mev/src/index.ts
@@ -1,4 +1,5 @@
 export {
+    type MevProtectionRootState,
     selectIsMevProtectionFeatureEnabled,
     selectIsMevProtectionSettingsVisible,
 } from './mevProtectionSettings';

--- a/suite-common/mev/src/mevProtectionSettings.ts
+++ b/suite-common/mev/src/mevProtectionSettings.ts
@@ -10,7 +10,9 @@ const createMemoizedSelector = createWeakMapSelector.withTypes<
     DeviceRootState & MessageSystemRootState
 >();
 
-export const selectIsMevProtectionFeatureEnabled = (state: MessageSystemRootState) =>
+export type MevProtectionRootState = MessageSystemRootState;
+
+export const selectIsMevProtectionFeatureEnabled = (state: MevProtectionRootState) =>
     selectIsFeatureEnabled(state, Feature.mevProtection, true);
 
 export const selectIsMevProtectionSettingsVisible = createMemoizedSelector(

--- a/suite-common/walletconnect/src/adapters/bitcoin.ts
+++ b/suite-common/walletconnect/src/adapters/bitcoin.ts
@@ -13,7 +13,7 @@ import { asCoinSymbol } from '@trezor/connect-common';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
-import { selectSessionByTopic } from '../walletConnectReducer';
+import { type WalletConnectStateRootState, selectSessionByTopic } from '../walletConnectReducer';
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
@@ -35,6 +35,10 @@ const findAccount = (accounts: Account[], firstAddress: string) =>
         return usedAddresses.includes(firstAddress) || unusedAddresses.includes(firstAddress);
     });
 
+export type BitcoinRequestThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
+    WalletConnectStateRootState;
+export type BitcoinRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
+
 const bitcoinRequestThunk = createThunk<
     | { address: string; publicKey: string; path: Bip43Path }[]
     | { address: string; signature: string }
@@ -42,7 +46,8 @@ const bitcoinRequestThunk = createThunk<
     | undefined,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: BitcoinRequestThunkState; extra: BitcoinRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/bitcoinRequest`, async ({ event }, { dispatch, getState }) => {
     const device = selectSelectedDevice(getState());
     const session = selectSessionByTopic(getState(), event.topic);

--- a/suite-common/walletconnect/src/adapters/ethereum.ts
+++ b/suite-common/walletconnect/src/adapters/ethereum.ts
@@ -3,11 +3,16 @@ import type { ProposalTypes } from '@walletconnect/types';
 
 import * as trezorConnectPopupActions from '@suite-common/connect-popup';
 import { selectSelectedDevice } from '@suite-common/device';
-import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
+import {
+    type MevProtectionRootState,
+    selectIsMevProtectionFeatureEnabled,
+} from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network, getNetwork, networksCollection } from '@suite-common/wallet-config';
 import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
 import {
+    type TransactionsRootState,
+    type WalletSettingsRootState,
     ethereumGetCurrentNonceThunk,
     selectAccounts,
     selectIsMevProtectionEnabled,
@@ -23,7 +28,7 @@ import { asCoinSymbol } from '@trezor/connect-common';
 import { isAscii, isHex, throwError } from '@trezor/utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
-import { selectSessionByTopic } from '../walletConnectReducer';
+import { type WalletConnectStateRootState, selectSessionByTopic } from '../walletConnectReducer';
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
@@ -37,11 +42,19 @@ const methods = [
     'wallet_switchEthereumChain',
 ];
 
+export type EthereumRequestThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
+    WalletConnectStateRootState &
+    MevProtectionRootState &
+    WalletSettingsRootState &
+    TransactionsRootState;
+export type EthereumRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
+
 const ethereumRequestThunk = createThunk<
     string | undefined,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: EthereumRequestThunkState; extra: EthereumRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/ethereumRequest`, async ({ event }, { dispatch, getState }) => {
     const device = selectSelectedDevice(getState());
     const isMevProtectionEnabled = selectIsMevProtectionEnabled(getState());

--- a/suite-common/walletconnect/src/adapters/index.ts
+++ b/suite-common/walletconnect/src/adapters/index.ts
@@ -2,15 +2,38 @@ import type { ProposalTypes } from '@walletconnect/types';
 
 import { type Account } from '@suite-common/wallet-types';
 
-import { bitcoinAdapter } from './bitcoin';
-import { ethereumAdapter } from './ethereum';
-import { solanaAdapter } from './solana';
-import { stellarAdapter } from './stellar';
-import { tronAdapter } from './tron';
+import {
+    type BitcoinRequestThunkDeps,
+    type BitcoinRequestThunkState,
+    bitcoinAdapter,
+} from './bitcoin';
+import {
+    type EthereumRequestThunkDeps,
+    type EthereumRequestThunkState,
+    ethereumAdapter,
+} from './ethereum';
+import { type SolanaRequestThunkDeps, type SolanaRequestThunkState, solanaAdapter } from './solana';
+import {
+    type StellarRequestThunkDeps,
+    type StellarRequestThunkState,
+    stellarAdapter,
+} from './stellar';
+import { type TronRequestThunkDeps, type TronRequestThunkState, tronAdapter } from './tron';
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
 } from '../walletConnectTypes';
+
+export type WalletConnectRequestThunkState = BitcoinRequestThunkState &
+    EthereumRequestThunkState &
+    SolanaRequestThunkState &
+    StellarRequestThunkState &
+    TronRequestThunkState;
+export type WalletConnectRequestThunkDeps = BitcoinRequestThunkDeps &
+    EthereumRequestThunkDeps &
+    SolanaRequestThunkDeps &
+    StellarRequestThunkDeps &
+    TronRequestThunkDeps;
 
 export const adapters: WalletConnectAdapter[] = [
     ethereumAdapter,

--- a/suite-common/walletconnect/src/adapters/solana.ts
+++ b/suite-common/walletconnect/src/adapters/solana.ts
@@ -12,7 +12,7 @@ import TrezorConnect, { type CallMethodResponse } from '@trezor/connect';
 import { type Result } from '@trezor/type-utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
-import { selectSessionByTopic } from '../walletConnectReducer';
+import { type WalletConnectStateRootState, selectSessionByTopic } from '../walletConnectReducer';
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
@@ -28,6 +28,9 @@ const methods = [
     'solana_signMessage',
 ];
 
+type SolanaSignTransactionThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState;
+type SolanaSignTransactionThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
+
 const solanaSignTransaction = createThunk<
     { signature: string; transaction: string },
     {
@@ -36,7 +39,8 @@ const solanaSignTransaction = createThunk<
         feePayer?: string;
         origin: string;
         isDevnet: boolean;
-    }
+    },
+    { state: SolanaSignTransactionThunkState; extra: SolanaSignTransactionThunkDeps }
 >(
     `${WALLETCONNECT_MODULE}/solanaSignTransaction`,
     async ({ session, transaction, feePayer, origin, isDevnet }, { dispatch, getState }) => {
@@ -105,11 +109,15 @@ const solanaSignTransaction = createThunk<
     },
 );
 
+export type SolanaRequestThunkState = SolanaSignTransactionThunkState & WalletConnectStateRootState;
+export type SolanaRequestThunkDeps = SolanaSignTransactionThunkDeps;
+
 const solanaRequestThunk = createThunk<
     { pubkey: string }[] | { signature: string } | undefined,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: SolanaRequestThunkState; extra: SolanaRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/solanaRequest`, async ({ event }, { dispatch, getState }) => {
     const session = selectSessionByTopic(getState(), event.topic);
     if (!session) {

--- a/suite-common/walletconnect/src/adapters/stellar.ts
+++ b/suite-common/walletconnect/src/adapters/stellar.ts
@@ -12,7 +12,7 @@ import { asCoinSymbol } from '@trezor/connect-common';
 import loadStellar from '@trezor/network-stellar/runtime';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
-import { selectSessionByTopic } from '../walletConnectReducer';
+import { type WalletConnectStateRootState, selectSessionByTopic } from '../walletConnectReducer';
 import {
     type PendingConnectionProposalNetwork,
     type WalletConnectAdapter,
@@ -58,6 +58,9 @@ const resolveStellarRequestContext = (event: WalletKitTypes.SessionRequest) => {
     };
 };
 
+type StellarSignXDRThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState;
+type StellarSignXDRThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
+
 const stellarSignXDR = createThunk<
     { signedXDR: string },
     {
@@ -65,7 +68,8 @@ const stellarSignXDR = createThunk<
         xdrBase64: string;
         origin: string;
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: StellarSignXDRThunkState; extra: StellarSignXDRThunkDeps }
 >(
     `${WALLETCONNECT_MODULE}/stellarSignXDR`,
     async ({ session, xdrBase64, origin, event }, { dispatch, getState }) => {
@@ -127,11 +131,15 @@ const stellarSignXDR = createThunk<
     },
 );
 
+export type StellarRequestThunkState = StellarSignXDRThunkState & WalletConnectStateRootState;
+export type StellarRequestThunkDeps = StellarSignXDRThunkDeps;
+
 const stellarRequestThunk = createThunk<
     { signedXDR: string } | { status: string } | undefined,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: StellarRequestThunkState; extra: StellarRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/stellarRequest`, async ({ event }, { dispatch, getState }) => {
     const session = selectSessionByTopic(getState(), event.topic);
     if (!session) {

--- a/suite-common/walletconnect/src/adapters/tron.ts
+++ b/suite-common/walletconnect/src/adapters/tron.ts
@@ -12,7 +12,7 @@ import type { TronContractInput } from '@trezor/connect-common';
 import { type Result } from '@trezor/type-utils';
 
 import { WALLETCONNECT_MODULE } from '../walletConnectConstants';
-import { selectSessionByTopic } from '../walletConnectReducer';
+import { type WalletConnectStateRootState, selectSessionByTopic } from '../walletConnectReducer';
 import type {
     PendingConnectionProposalNetwork,
     WalletConnectAdapter,
@@ -105,11 +105,16 @@ const processNamespaces = (
         },
     );
 
+export type TronRequestThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
+    WalletConnectStateRootState;
+export type TronRequestThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
+
 const tronRequestThunk = createThunk<
     Record<string, unknown> | undefined,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: TronRequestThunkState; extra: TronRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/tronRequest`, async ({ event }, { dispatch, getState }) => {
     const session = selectSessionByTopic(getState(), event.topic);
     if (!session) {

--- a/suite-common/walletconnect/src/walletConnectReducer.ts
+++ b/suite-common/walletconnect/src/walletConnectReducer.ts
@@ -10,7 +10,7 @@ export type WalletConnectState = {
     pendingProposal: PendingConnectionProposal | undefined;
 };
 
-type WalletConnectStateRootState = {
+export type WalletConnectStateRootState = {
     walletConnect: WalletConnectState;
 };
 

--- a/suite-common/walletconnect/src/walletConnectThunks.ts
+++ b/suite-common/walletconnect/src/walletConnectThunks.ts
@@ -7,17 +7,24 @@ import {
     populateAuthPayload,
 } from '@walletconnect/utils';
 
-import { events } from '@suite-common/analytics';
+import { type AnalyticsDep, events } from '@suite-common/analytics';
 import * as trezorConnectPopupActions from '@suite-common/connect-popup';
+import { type DeviceRootState } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { isDevEnv } from '@suite-common/suite-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getNetwork } from '@suite-common/wallet-config';
-import { selectAllSuccessfulAccountsToList } from '@suite-common/wallet-core';
+import {
+    type AccountsRootState,
+    type WalletSettingsRootState,
+    selectAllSuccessfulAccountsToList,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { type CallMethodResponse } from '@trezor/connect';
 
 import {
+    type WalletConnectRequestThunkDeps,
+    type WalletConnectRequestThunkState,
     getAdapterByMethod,
     getAdapterByNetwork,
     getNamespaces,
@@ -25,16 +32,23 @@ import {
 } from './adapters';
 import { walletConnectActions } from './walletConnectActions';
 import { PROJECT_ID, WALLETCONNECT_METADATA, WALLETCONNECT_MODULE } from './walletConnectConstants';
-import { selectPendingProposal } from './walletConnectReducer';
+import { type WalletConnectStateRootState, selectPendingProposal } from './walletConnectReducer';
 import { type PendingConnectionProposalNetwork } from './walletConnectTypes';
 
 let walletKit: IWalletKit;
+
+type SuccessfulAccountsThunkState = AccountsRootState & DeviceRootState & WalletSettingsRootState;
+
+type SessionAuthenticateThunkState = trezorConnectPopupActions.ConnectPopupCallThunkState &
+    SuccessfulAccountsThunkState;
+type SessionAuthenticateThunkDeps = trezorConnectPopupActions.ConnectPopupCallThunkDeps;
 
 const sessionAuthenticateThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionAuthenticate;
-    }
+    },
+    { state: SessionAuthenticateThunkState; extra: SessionAuthenticateThunkDeps }
 >(`${WALLETCONNECT_MODULE}/sessionAuthenticateThunk`, async ({ event }, { getState, dispatch }) => {
     // Support for Sign-In with Ethereum (SIWE) message, enhanced by ReCaps (ReCap Capabilities)
     try {
@@ -116,11 +130,17 @@ const sessionAuthenticateThunk = createThunk<
     }
 });
 
+type SessionProposalThunkState = SuccessfulAccountsThunkState;
+type SessionProposalThunkDeps = {
+    services: AnalyticsDep;
+};
+
 const sessionProposalThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionProposal;
-    }
+    },
+    { state: SessionProposalThunkState; extra: SessionProposalThunkDeps }
 >(`${WALLETCONNECT_MODULE}/sessionProposalThunk`, ({ event }, { dispatch, getState, extra }) => {
     // Check supported networks
     const accounts = selectAllSuccessfulAccountsToList(getState());
@@ -147,11 +167,15 @@ const sessionProposalThunk = createThunk<
     });
 });
 
+type SessionRequestThunkState = WalletConnectRequestThunkState;
+type SessionRequestThunkDeps = WalletConnectRequestThunkDeps;
+
 const sessionRequestThunk = createThunk<
     void,
     {
         event: WalletKitTypes.SessionRequest;
-    }
+    },
+    { state: SessionRequestThunkState; extra: SessionRequestThunkDeps }
 >(`${WALLETCONNECT_MODULE}/sessionRequestThunk`, async ({ event }, { dispatch, extra }) => {
     try {
         const adapter = getAdapterByMethod(event.params.request.method);
@@ -196,9 +220,12 @@ const sessionRequestThunk = createThunk<
 });
 
 // Selected Account was switched in Suite
+type SwitchSelectedAccountThunkState = SuccessfulAccountsThunkState;
+
 export const switchSelectedAccountThunk = createThunk<
     void,
-    { account: Account; sessionTopic: string }
+    { account: Account; sessionTopic: string },
+    { state: SwitchSelectedAccountThunkState }
 >(
     `${WALLETCONNECT_MODULE}/switchSelectedAccountThunk`,
     async ({ account, sessionTopic }, { getState }) => {
@@ -267,12 +294,18 @@ export const switchSelectedAccountThunk = createThunk<
     },
 );
 
+type SessionProposalApproveThunkState = SuccessfulAccountsThunkState & WalletConnectStateRootState;
+type SessionProposalApproveThunkDeps = {
+    services: AnalyticsDep;
+};
+
 export const sessionProposalApproveThunk = createThunk<
     void,
     {
         eventId: number;
         selectedDefaultAccount?: Account | null;
-    }
+    },
+    { state: SessionProposalApproveThunkState; extra: SessionProposalApproveThunkDeps }
 >(
     `${WALLETCONNECT_MODULE}/sessionProposalApproveThunk`,
     async ({ eventId, selectedDefaultAccount }, { dispatch, getState, extra }) => {
@@ -345,11 +378,17 @@ export const sessionProposalApproveThunk = createThunk<
     },
 );
 
+type SessionProposalRejectThunkState = WalletConnectStateRootState;
+type SessionProposalRejectThunkDeps = {
+    services: AnalyticsDep;
+};
+
 export const sessionProposalRejectThunk = createThunk<
     void,
     {
         eventId: number;
-    }
+    },
+    { state: SessionProposalRejectThunkState; extra: SessionProposalRejectThunkDeps }
 >(
     `${WALLETCONNECT_MODULE}/sessionProposalRejectThunk`,
     async ({ eventId }, { getState, dispatch, extra }) => {
@@ -368,84 +407,98 @@ export const sessionProposalRejectThunk = createThunk<
     },
 );
 
-export const walletConnectInitThunk = createThunk(
-    `${WALLETCONNECT_MODULE}/walletConnectInitThunk`,
-    async (_, { dispatch, extra }) => {
-        if (walletKit) return;
+export type WalletConnectInitThunkState = SessionAuthenticateThunkState &
+    SessionProposalThunkState &
+    SessionRequestThunkState &
+    SessionProposalRejectThunkState;
+export type WalletConnectInitThunkDeps = SessionAuthenticateThunkDeps &
+    SessionProposalThunkDeps &
+    SessionRequestThunkDeps &
+    SessionProposalRejectThunkDeps;
 
-        const core = new Core({
-            projectId: PROJECT_ID,
-            telemetryEnabled: false,
-            logger: isDevEnv ? 'warn' : 'silent',
-        });
+export const walletConnectInitThunk = createThunk<
+    void,
+    void,
+    { state: WalletConnectInitThunkState; extra: WalletConnectInitThunkDeps }
+>(`${WALLETCONNECT_MODULE}/walletConnectInitThunk`, async (_, { dispatch, extra }) => {
+    if (walletKit) return;
 
-        walletKit = await WalletKit.init({
-            core,
-            metadata: WALLETCONNECT_METADATA,
-        });
+    const core = new Core({
+        projectId: PROJECT_ID,
+        telemetryEnabled: false,
+        logger: isDevEnv ? 'warn' : 'silent',
+    });
 
-        walletKit.on('session_proposal', event => {
-            dispatch(sessionProposalThunk({ event }));
-        });
+    walletKit = await WalletKit.init({
+        core,
+        metadata: WALLETCONNECT_METADATA,
+    });
 
-        walletKit.on('proposal_expire', () => {
-            dispatch(walletConnectActions.expireSessionProposal());
-        });
+    walletKit.on('session_proposal', event => {
+        dispatch(sessionProposalThunk({ event }));
+    });
 
-        walletKit.on('session_request', event => {
-            dispatch(sessionRequestThunk({ event }));
-        });
+    walletKit.on('proposal_expire', () => {
+        dispatch(walletConnectActions.expireSessionProposal());
+    });
 
-        walletKit.on('session_authenticate', event => {
-            dispatch(sessionAuthenticateThunk({ event }));
-        });
+    walletKit.on('session_request', event => {
+        dispatch(sessionRequestThunk({ event }));
+    });
 
-        walletKit.on('session_delete', event => {
-            dispatch(walletConnectActions.removeSession({ topic: event.topic }));
-        });
+    walletKit.on('session_authenticate', event => {
+        dispatch(sessionAuthenticateThunk({ event }));
+    });
 
-        // Populate active sessions
-        const sessions = walletKit.getActiveSessions();
-        for (const topic in sessions) {
-            // @ts-expect-error: indexing with noUncheckedIndexedAccess
-            const session: (typeof sessions)[string] = sessions[topic];
-            dispatch(
-                walletConnectActions.saveSession({
-                    ...session,
-                }),
-            );
-        }
-        // Reject stale proposals
-        const proposals = walletKit.getPendingSessionProposals();
-        for (const proposal of Object.values(proposals)) {
-            dispatch(sessionProposalRejectThunk({ eventId: proposal.id }));
-        }
+    walletKit.on('session_delete', event => {
+        dispatch(walletConnectActions.removeSession({ topic: event.topic }));
+    });
+
+    // Populate active sessions
+    const sessions = walletKit.getActiveSessions();
+    for (const topic in sessions) {
+        // @ts-expect-error: indexing with noUncheckedIndexedAccess
+        const session: (typeof sessions)[string] = sessions[topic];
+        dispatch(
+            walletConnectActions.saveSession({
+                ...session,
+            }),
+        );
+    }
+    // Reject stale proposals
+    const proposals = walletKit.getPendingSessionProposals();
+    for (const proposal of Object.values(proposals)) {
+        dispatch(sessionProposalRejectThunk({ eventId: proposal.id }));
+    }
+    extra.services.analytics.report({
+        type: events.walletConnectInitEvent.name,
+    });
+});
+
+type WalletConnectPairThunkState = WalletConnectInitThunkState;
+type WalletConnectPairThunkDeps = WalletConnectInitThunkDeps;
+
+export const walletConnectPairThunk = createThunk<
+    void,
+    { uri: string },
+    { state: WalletConnectPairThunkState; extra: WalletConnectPairThunkDeps }
+>(`${WALLETCONNECT_MODULE}/walletConnectPairThunk`, async ({ uri }, { dispatch, extra }) => {
+    if (!walletKit) {
+        // May happen when Suite cold-starts from deeplink
+        await dispatch(walletConnectInitThunk());
+    }
+
+    try {
+        await walletKit.pair({ uri });
         extra.services.analytics.report({
-            type: events.walletConnectInitEvent.name,
+            type: events.walletConnectPairedEvent.name,
         });
-    },
-);
+    } catch {
+        throw new Error('Invalid WalletConnect URI');
+    }
+});
 
-export const walletConnectPairThunk = createThunk<void, { uri: string }>(
-    `${WALLETCONNECT_MODULE}/walletConnectPairThunk`,
-    async ({ uri }, { dispatch, extra }) => {
-        if (!walletKit) {
-            // May happen when Suite cold-starts from deeplink
-            await dispatch(walletConnectInitThunk());
-        }
-
-        try {
-            await walletKit.pair({ uri });
-            extra.services.analytics.report({
-                type: events.walletConnectPairedEvent.name,
-            });
-        } catch {
-            throw new Error('Invalid WalletConnect URI');
-        }
-    },
-);
-
-export const walletConnectDisconnectThunk = createThunk<void, { topic: string }>(
+export const walletConnectDisconnectThunk = createThunk<void, { topic: string }, void>(
     `${WALLETCONNECT_MODULE}/walletConnectDisconnectThunk`,
     async ({ topic }, { dispatch }) => {
         await dispatch(walletConnectActions.removeSession({ topic }));


### PR DESCRIPTION
## Description

Converts all WalletConnect session and adapter thunks from the global default to named selective state/dependency contracts. Adapter contracts reuse the popup-call child contract, the dynamic request handler composes all adapter requirements, and the exported init contract is ready for app-level parent migration.

- WalletConnect `createThunk` declarations: **16**
- Global-default declarations: **16 -> 0**
- Connect-popup tests: **38 passed**
- Package depcheck: **3 passed**

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-walletconnect-thunk-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-walletconnect-thunk-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-walletconnect-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-walletconnect-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-walletconnect-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:54:31.863Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T15:54:49.412Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR changes a large number of Redux reducers/slices/thunks across suite-common, suite-native, and packages/suite, including foundational utilities createReducerWithExtraDeps and createSliceWithExtraDeps. The risk is broad but shallow: a bug in a utility or reducer shape could break many features. The recommended strategy is to run a focused smoke set covering onboarding, device/session management, wallet discovery, send/receive, trading, WalletConnect, and Connect popup flows, rather than the entire suite. Several changed files (native-specific slices, type tests, and some suite-specific slices) have no known web E2E coverage.

<details><summary><b>Changed files (46)</b></summary>

- `packages/suite/src/actions/bluetooth/desktopBluetoothReducer.ts`
- `packages/suite/src/reducers/bioAuth/index.ts`
- `suite-common/analytics-redux/src/redux/analyticsReducer.ts`
- `suite-common/bluetooth/src/bluetoothReducer.ts`
- `suite-common/bluetooth/src/index.ts`
- `suite-common/connect-popup/src/connectPopupReducer.ts`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/device/src/deviceReducer.ts`
- `suite-common/feedback/src/sendFeedbackAction.ts`
- `suite-common/firmware/src/firmwareReducer.ts`
- `suite-common/message-system/src/messageSystemReducer.ts`
- `suite-common/message-system/src/messageSystemThunks.ts`
- `suite-common/mev/src/index.ts`
- `suite-common/mev/src/mevProtectionSettings.ts`
- `suite-common/receive/src/receiveSlice.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts`
- `suite-common/thp/src/thpReducer.ts`
- `suite-common/token-definitions/src/tokenDefinitionsReducer.ts`
- `suite-common/token-definitions/src/tokenDefinitionsThunks.ts`
- `suite-common/trading/src/reducers/tradingReducer.ts`
- `suite-common/wallet-core/src/accounts/accountsReducer.ts`
- `suite-common/wallet-core/src/blockchain/blockchainReducer.ts`
- `suite-common/wallet-core/src/explorer/explorerReducer.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesReducer.ts`
- `suite-common/wallet-core/src/phishing/phishingReducer.ts`
- `suite-common/wallet-core/src/send/sendFormReducer.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`
- `suite-common/wallet-core/src/transactions/transactionsReducer.ts`
- `suite-common/walletconnect/src/adapters/bitcoin.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`
- `suite-common/walletconnect/src/adapters/index.ts`
- `suite-common/walletconnect/src/adapters/solana.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`
- `suite-common/walletconnect/src/adapters/tron.ts`
- `suite-common/walletconnect/src/walletConnectReducer.ts`
- `suite-common/walletconnect/src/walletConnectThunks.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/trading-state/src/reducers/tradingSlice.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/device/src/deviceSlice.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/settings/src/settingsSlice.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (15)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Directly exercises the analytics consent flow and onboarding state, which depend on analyticsReducer, deviceReducer, and the flags/settings/debug slices that were changed.
- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — Covers device onboarding, firmware revision/hash handling, and message system state — all touched by changed reducers.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — T3W1 onboarding uses THP pairing and Bluetooth-aware device flow; validates thpReducer, desktopBluetoothReducer, and device/firmware reducers.
- `suite/e2e/tests/settings/forget-device.test.ts` — Exercises device removal, Bluetooth history/pairing state, and discovery — directly covering deviceReducer, walletSettingsReducer, and desktopBluetoothReducer.
- `suite/e2e/tests/general/wallet-discovery.test.ts` — Smoke test for wallet discovery and device switching, exercising accountsReducer, blockchainReducer, fiatRatesReducer, and wallet settings.
- `suite/e2e/tests/wallet/discovery.test.ts` — Multi-coin discovery with page reload resilience; validates accounts, blockchain, transactions, and wallet settings reducers.
- `suite/e2e/tests/analytics/events.test.ts` — Directly verifies analytics event emission and the analytics reducer behavior after settings changes.
- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Directly exercises WalletConnect reducer, thunks, and adapters that were modified.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — End-to-end validation of the Connect popup reducer and thunks, including permissions and cancellation flows.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Exercises the trading reducer, accounts, wallet settings, and send form state for the buy flow.
- `suite/e2e/tests/trading/swap-coins.test.ts` — Full swap flow using BTC/SOL, covering trading reducer, send form state, accounts, and device/session handling.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly tests the send form reducer, accounts, device state, and fee calculations for EVM sends.
- `suite/e2e/tests/wallet/receive.test.ts` — Directly exercises the receive slice and account state for BTC, ETH, SOL, and TRX.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Validates device session management and device reducer behavior under bridge session takeover.
- `suite/e2e/tests/suite/initial-run.test.ts` — Covers onboarding persistence, analytics consent, THP pairing, and flags/settings/debug slice state across reloads.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/general.test.ts` — Tests settings changes (fiat, theme, language, analytics toggle) that rely on analyticsReducer and suite settings slices.
- `suite/e2e/tests/settings/coins.test.ts` — Exercises wallet settings, network enablement, and discovery infrastructure touched by multiple changed reducers.
- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet mode toggle uses settings and analytics reducers, and verifies balance display state across the dashboard.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Device confirmation flow for message signing depends on deviceReducer and accounts state.
- `suite/e2e/tests/suite/bug-report-form.test.ts` — Directly exercises the sendFeedbackAction that was changed, plus guide/support state.

</details>

⚠️ **Changes with no test coverage (11)**
- `suite-common/bluetooth/src/index.ts`
- `suite-common/mev/src/index.ts`
- `suite-common/redux-utils/src/createReducerWithExtraDeps.type-test.ts`
- `suite-common/redux-utils/src/createSliceWithExtraDeps.type-test.ts`
- `suite-native/bluetooth/src/bluetoothSlice.ts`
- `suite-native/trading-state/src/reducers/tradingSlice.ts`
- `suite-native/transaction-management/src/sendFormSlice.ts`
- `suite/debug/src/debugSlice.ts`
- `suite/device/src/deviceSlice.ts`
- `suite/flags/src/flagsSlice.ts`
- `suite/settings/src/settingsSlice.ts`

_Updated: 2026-08-07T15:32:54.114Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->