### PR TITLE
fix(suite-native): use plain staking and defi yield labels in your deposits card

### DIFF
--- a/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
+++ b/suite-native/module-earn/src/hooks/useEarnDepositsCardData.ts
@@ -161,46 +161,22 @@ export const useEarnDepositsCardData = ({
         isFiatRatesLoading,
     });
 
-    const stakingTitle = useMemo(() => {
-        const firstStakingSymbol = stakingRows[0]?.symbol;
-        const hasMultipleStakingSymbols = stakingRows.some(
-            item => item.symbol !== firstStakingSymbol,
-        );
-
-        return firstStakingSymbol && !hasMultipleStakingSymbols
-            ? translate('earn.earnScreen.depositsCard.networkStaking', {
-                  networkName: getNetworkDisplaySymbolName(firstStakingSymbol),
-              })
-            : translate('earn.staking');
-    }, [stakingRows, translate]);
-
-    const stablecoinTitle = useMemo(() => {
-        const firstStablecoinVaultName = stablecoinRows[0]?.title;
-        const hasMultipleStablecoinVaults = stablecoinRows.some(
-            item => item.title !== firstStablecoinVaultName,
-        );
-
-        return firstStablecoinVaultName && !hasMultipleStablecoinVaults
-            ? firstStablecoinVaultName
-            : translate('earn.defiYield');
-    }, [stablecoinRows, translate]);
-
     const stakingRow = useMemo(
         () =>
             createSummaryRow({
                 activeItems: stakingRows,
-                title: stakingTitle,
+                title: translate('earn.staking'),
             }),
-        [stakingRows, stakingTitle],
+        [stakingRows, translate],
     );
 
     const stablecoinYieldRow = useMemo(
         () =>
             createSummaryRow({
                 activeItems: stablecoinRows,
-                title: stablecoinTitle,
+                title: translate('earn.defiYield'),
             }),
-        [stablecoinRows, stablecoinTitle],
+        [stablecoinRows, translate],
     );
 
     return {


### PR DESCRIPTION
## Description

When only one account is in the `Your deposits` staking/yield row, use the plain `Staking` and `DeFi Yield` labels anyway.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30122

## Screenshots:

<img width="1206" height="2622" alt="simulator_screenshot_FCFC39CD-0F9B-453E-B416-FCBB9B551436" src="https://github.com/user-attachments/assets/4c683386-de41-4be2-a878-f06bff6bb4d1" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/earn-deposits-label-update&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->