### PR TITLE
feat(suite-native): add fiat input to wrap/unwrap

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2681,6 +2681,9 @@ export const messages = {
             subtitle: 'Get more {tokenSymbol} in this account to start earning yield.',
             getButton: 'Get more {tokenSymbol}',
         },
+        wrappedNativeToken: {
+            maxButton: 'Max',
+        },
         wrapNativeToken: {
             entryButton: 'Wrap',
             title: 'Wrap {nativeSymbol} to {wrappedSymbol}',

--- a/suite-native/module-earn/src/components/EarnCryptoAmountInput.tsx
+++ b/suite-native/module-earn/src/components/EarnCryptoAmountInput.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
+import { type TokenAddress } from '@suite-common/wallet-types';
 import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
 import { Input, type InputType, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
@@ -17,6 +18,9 @@ import { type EarnFormValues } from '../earnFormSchema';
 
 type EarnCryptoAmountInputProps = {
     symbol: NetworkSymbol;
+    tokenContract?: TokenAddress;
+    displaySymbol?: string;
+    accessibilityLabel?: string;
     inputRef?: RefObject<InputType | null>;
     isDisabled?: boolean;
     onPress?: TextInputProps['onPress'];
@@ -24,6 +28,9 @@ type EarnCryptoAmountInputProps = {
 
 export const EarnCryptoAmountInput = ({
     symbol,
+    tokenContract,
+    displaySymbol,
+    accessibilityLabel = 'amount to stake input',
     inputRef,
     isDisabled = false,
     onPress,
@@ -38,7 +45,7 @@ export const EarnCryptoAmountInput = ({
         code: baseCurrencyCode,
         isInSats: isBaseCurrencyInSats,
     });
-    const converters = useCryptoFiatConverters({ symbol });
+    const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
     const { onChange, onBlur, value, hasError } = useField({
         name: 'amount',
@@ -66,7 +73,7 @@ export const EarnCryptoAmountInput = ({
             value={value}
             placeholder="0"
             keyboardType="numeric"
-            accessibilityLabel="amount to stake input"
+            accessibilityLabel={accessibilityLabel}
             editable={!isDisabled}
             onChangeText={handleChangeValue}
             onBlur={() => {
@@ -76,7 +83,7 @@ export const EarnCryptoAmountInput = ({
             hasError={!isDisabled && hasError}
             rightIcon={
                 <Text color={isDisabled ? 'contentSecondary' : 'contentPrimary'}>
-                    {formatter.format(symbol)}
+                    {displaySymbol ?? formatter.format(symbol)}
                 </Text>
             }
         />

--- a/suite-native/module-earn/src/components/EarnFiatAmountInput.tsx
+++ b/suite-native/module-earn/src/components/EarnFiatAmountInput.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol, getNetwork } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
-import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { type TokenAddress, asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { Input, type InputType, Text } from '@suite-native/atoms';
 import { useCryptoFiatConverters } from '@suite-native/formatters';
 import { useField, useFormContext } from '@suite-native/forms';
@@ -15,6 +15,9 @@ import { type EarnFormValues } from '../earnFormSchema';
 
 type EarnFiatAmountInputProps = {
     symbol: NetworkSymbol;
+    tokenContract?: TokenAddress;
+    tokenDecimals?: number;
+    accessibilityLabel?: string;
     inputRef?: RefObject<InputType | null>;
     isDisabled?: boolean;
     onPress?: TextInputProps['onPress'];
@@ -22,16 +25,19 @@ type EarnFiatAmountInputProps = {
 
 export const EarnFiatAmountInput = ({
     symbol,
+    tokenContract,
+    tokenDecimals,
+    accessibilityLabel = 'fiat amount to stake input',
     inputRef,
     isDisabled = false,
     onPress,
 }: EarnFiatAmountInputProps) => {
     const { setValue } = useFormContext<EarnFormValues>();
     const { fiatAmountTransformer } = useAmountInputTransformers(symbol);
-    const { decimals } = getNetwork(symbol);
+    const decimals = tokenDecimals ?? getNetwork(symbol).decimals;
     const baseCurrencyCode = useSelector(selectBaseCurrency);
     const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
-    const converters = useCryptoFiatConverters({ symbol });
+    const converters = useCryptoFiatConverters({ symbol, tokenContract });
 
     const { onChange, onBlur, value } = useField({
         name: 'fiat',
@@ -58,7 +64,7 @@ export const EarnFiatAmountInput = ({
             value={value}
             placeholder="0"
             keyboardType="numeric"
-            accessibilityLabel="fiat amount to stake input"
+            accessibilityLabel={accessibilityLabel}
             editable={!isDisabled}
             onChangeText={handleChangeValue}
             onBlur={onBlur}

--- a/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
+import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
+import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
+import { BaseAmountInputs, Button, Card, HStack, Text, VStack } from '@suite-native/atoms';
+import { TokenAmountFormatter, useCryptoFiatConverters } from '@suite-native/formatters';
+import { useFormContext } from '@suite-native/forms';
+import { Translation } from '@suite-native/intl';
+import { BigNumber } from '@trezor/utils';
+
+import { AMOUNT_INPUT_UNFOCUSED_OFFSET, AMOUNT_INPUT_WRAPPER_HEIGHT } from '../constants';
+import { type YieldDepositFormValues } from '../yieldDepositFormSchema';
+import { EarnAmountErrorMessage } from './EarnAmountErrorMessage';
+import { EarnCryptoAmountInput } from './EarnCryptoAmountInput';
+import { EarnFiatAmountInput } from './EarnFiatAmountInput';
+
+type WrappedNativeTokenAmountInputCardProps = {
+    amountLabel: ReactNode;
+    balance: string;
+    maxAmount?: string;
+    symbol: NetworkSymbol;
+    tokenContract?: TokenAddress;
+    tokenDecimals?: number;
+    tokenSymbol: TokenSymbol;
+};
+
+export const WrappedNativeTokenAmountInputCard = ({
+    amountLabel,
+    balance,
+    maxAmount,
+    symbol,
+    tokenContract,
+    tokenDecimals,
+    tokenSymbol,
+}: WrappedNativeTokenAmountInputCardProps) => {
+    const { setValue } = useFormContext<YieldDepositFormValues>();
+    const baseCurrencyCode = useSelector(selectBaseCurrency);
+    const isBaseCurrencyInSats = useSelector(selectIsBaseCurrencyInSats);
+    const converters = useCryptoFiatConverters({ symbol, tokenContract });
+
+    const handleMaxPress = () => {
+        const value = maxAmount ?? balance;
+        setValue('amount', value, { shouldValidate: true });
+
+        const fiatValue = converters?.convertCryptoToFiat?.(new BigNumber(value));
+        if (fiatValue && !fiatValue.isNaN()) {
+            setValue(
+                'fiat',
+                fiatValue.toFixed(
+                    getDecimalsForBaseCurrency({
+                        code: baseCurrencyCode,
+                        isInSats: isBaseCurrencyInSats,
+                    }),
+                ),
+            );
+        }
+    };
+
+    return (
+        <Card>
+            <VStack spacing="sp12">
+                <BaseAmountInputs
+                    symbol={symbol}
+                    unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
+                    wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
+                    renderTopRow={() => <Text variant="body-sm">{amountLabel}</Text>}
+                    renderCryptoInput={({ onPress, isDisabled, inputRef }) => (
+                        <EarnCryptoAmountInput
+                            symbol={symbol}
+                            tokenContract={tokenContract}
+                            displaySymbol={tokenSymbol}
+                            accessibilityLabel="amount input"
+                            inputRef={inputRef}
+                            isDisabled={isDisabled}
+                            onPress={onPress}
+                        />
+                    )}
+                    renderFiatInput={({ onPress, isDisabled, inputRef }) => (
+                        <EarnFiatAmountInput
+                            symbol={symbol}
+                            tokenContract={tokenContract}
+                            tokenDecimals={tokenDecimals}
+                            accessibilityLabel="fiat amount input"
+                            inputRef={inputRef}
+                            isDisabled={isDisabled}
+                            onPress={onPress}
+                        />
+                    )}
+                    renderErrorMessage={isFiatDisplayed => (
+                        <EarnAmountErrorMessage isFiatDisplayed={isFiatDisplayed} />
+                    )}
+                />
+                <HStack spacing="sp8" alignItems="center">
+                    <HStack spacing="sp4" alignItems="center">
+                        <Text variant="body-sm" color="contentSecondary">
+                            <Translation id="earn.yieldDepositFlowScreen.balance" />
+                        </Text>
+                        <TokenAmountFormatter
+                            value={balance}
+                            tokenSymbol={tokenSymbol}
+                            variant="body-sm"
+                            color="contentSecondary"
+                        />
+                    </HStack>
+                    <Button
+                        size="medium"
+                        intent="neutral"
+                        priority="secondary"
+                        onPress={handleMaxPress}
+                        testID="@wrapped-native-token/max-button"
+                    >
+                        <Translation id="earn.wrappedNativeToken.maxButton" />
+                    </Button>
+                </HStack>
+            </VStack>
+        </Card>
+    );
+};

--- a/suite-native/module-earn/src/components/YieldDepositAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositAmountInputCard.tsx
@@ -19,7 +19,6 @@ import { Translation } from '@suite-native/intl';
 import { YieldDepositAmountInput } from './YieldDepositAmountInput';
 
 type YieldDepositAmountInputCardProps = {
-    amountLabel?: ReactNode;
     isApprovalLimitDisabled?: boolean;
     approvalLimitTitle?: ReactNode;
     balance?: string;
@@ -31,7 +30,6 @@ type YieldDepositAmountInputCardProps = {
 };
 
 export const YieldDepositAmountInputCard = ({
-    amountLabel,
     approvalLimitTitle,
     balance,
     isApprovalLimitDisabled = false,
@@ -68,9 +66,7 @@ export const YieldDepositAmountInputCard = ({
             <VStack spacing="sp12" padding="sp16">
                 <HStack justifyContent="space-between" alignItems="center">
                     <Text variant="body-sm">
-                        {amountLabel ?? (
-                            <Translation id="earn.yieldDepositFlowScreen.amountToDeposit" />
-                        )}
+                        <Translation id="earn.yieldDepositFlowScreen.amountToDeposit" />
                     </Text>
                     <HStack spacing="sp8" alignItems="center">
                         <Text variant="body-sm">

--- a/suite-native/module-earn/src/hooks/useWrappedNativeTokenForm.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeTokenForm.ts
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { useForm, useWatch } from '@suite-native/forms';
 import { useTranslate } from '@suite-native/intl';
 
@@ -11,18 +9,15 @@ import {
 type UseWrappedNativeTokenFormParams = {
     availableBalance: string;
     decimals: number;
-    maxAmount?: string;
     tokenSymbol: string;
 };
 
 export const useWrappedNativeTokenForm = ({
     availableBalance,
     decimals,
-    maxAmount,
     tokenSymbol,
 }: UseWrappedNativeTokenFormParams) => {
     const { translate } = useTranslate();
-    const [isMaxSelected, setIsMaxSelected] = useState(false);
 
     const form = useForm<YieldDepositFormValues>({
         validation: yieldDepositFormValidationSchema,
@@ -33,29 +28,13 @@ export const useWrappedNativeTokenForm = ({
             tokenSymbol,
             translate,
         },
-        defaultValues: { amount: '' },
+        defaultValues: { amount: '', fiat: '' },
     });
 
     const amountValue = useWatch({ control: form.control, name: 'amount' });
 
-    const handleMaxChange = (value: boolean) => {
-        setIsMaxSelected(value);
-        form.setValue('amount', value ? (maxAmount ?? availableBalance) : '', {
-            shouldValidate: true,
-        });
-    };
-
-    const handleAmountChange = () => {
-        if (isMaxSelected) {
-            setIsMaxSelected(false);
-        }
-    };
-
     return {
         amountValue,
         form,
-        isMaxSelected,
-        handleAmountChange,
-        handleMaxChange,
     };
 };

--- a/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
@@ -15,8 +15,8 @@ import {
 } from '@suite-native/navigation';
 import { FeeSelector } from '@suite-native/transaction-management';
 
+import { WrappedNativeTokenAmountInputCard } from '../components/WrappedNativeTokenAmountInputCard';
 import { WrappedNativeTokenScreenHeader } from '../components/WrappedNativeTokenScreenHeader';
-import { YieldDepositAmountInputCard } from '../components/YieldDepositAmountInputCard';
 import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
@@ -57,7 +57,7 @@ export const UnwrapNativeTokenScreen = () => {
         decimals: wrappedNative?.decimals ?? 0,
         tokenSymbol: wrappedNative?.symbol ?? '',
     });
-    const { amountValue, handleAmountChange, handleMaxChange, isMaxSelected } = form;
+    const { amountValue } = form;
     const {
         formState: { isValid },
     } = form.form;
@@ -110,12 +110,12 @@ export const UnwrapNativeTokenScreen = () => {
                         />
                     )}
                     <Form form={form.form}>
-                        <YieldDepositAmountInputCard
+                        <WrappedNativeTokenAmountInputCard
                             amountLabel={<Translation id="earn.unwrapNativeToken.amountToUnwrap" />}
                             balance={wrappedBalance}
-                            isMaxSelected={isMaxSelected}
-                            onAmountChange={handleAmountChange}
-                            onMaxChange={handleMaxChange}
+                            symbol={account.symbol}
+                            tokenContract={toTokenAddress(wrappedNative.address)}
+                            tokenDecimals={wrappedNative.decimals}
                             tokenSymbol={wrappedTokenSymbol}
                         />
                     </Form>

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -21,8 +21,8 @@ import {
 } from '@suite-native/navigation';
 import { FeeSelector } from '@suite-native/transaction-management';
 
+import { WrappedNativeTokenAmountInputCard } from '../components/WrappedNativeTokenAmountInputCard';
 import { WrappedNativeTokenScreenHeader } from '../components/WrappedNativeTokenScreenHeader';
-import { YieldDepositAmountInputCard } from '../components/YieldDepositAmountInputCard';
 import { YieldDisabledAlert } from '../components/YieldDisabledAlert';
 import { YieldFeeEstimationErrorAlert } from '../components/YieldFeeEstimationErrorAlert';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
@@ -57,10 +57,9 @@ export const WrapNativeTokenScreen = () => {
     const form = useWrappedNativeTokenForm({
         availableBalance: account?.formattedBalance ?? '0',
         decimals: account ? getNetwork(account.symbol).decimals : 0,
-        maxAmount: getMaxWrapAmount(account?.formattedBalance ?? '0'),
         tokenSymbol: nativeSymbol,
     });
-    const { amountValue, handleAmountChange, handleMaxChange, isMaxSelected } = form;
+    const { amountValue } = form;
     const {
         formState: { isValid },
     } = form.form;
@@ -121,12 +120,11 @@ export const WrapNativeTokenScreen = () => {
                         />
                     )}
                     <Form form={form.form}>
-                        <YieldDepositAmountInputCard
+                        <WrappedNativeTokenAmountInputCard
                             amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                             balance={account.formattedBalance}
-                            isMaxSelected={isMaxSelected}
-                            onAmountChange={handleAmountChange}
-                            onMaxChange={handleMaxChange}
+                            maxAmount={getMaxWrapAmount(account.formattedBalance)}
+                            symbol={account.symbol}
                             tokenSymbol={nativeSymbol}
                         />
                     </Form>

--- a/suite-native/module-earn/src/yieldDepositFormSchema.ts
+++ b/suite-native/module-earn/src/yieldDepositFormSchema.ts
@@ -60,6 +60,7 @@ export const yieldDepositFormValidationSchema = yup.object({
 
             return true;
         }),
+    fiat: yup.string(),
 });
 
 export type YieldDepositFormValues = yup.InferType<typeof yieldDepositFormValidationSchema>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes wrapping/unwrapping consistent with other flows with fiat input

## Notes for QA

eth -> detail cog -> wrap
weth -> asset page -> detail cog -> unwrap

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30988





## Screenshots:

| Unwrap | Wrap |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-07 at 11 07 43" src="https://github.com/user-attachments/assets/52887c37-0f10-4fd7-bc15-42a27a23a2dc" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-07 at 11 06 25" src="https://github.com/user-attachments/assets/114d348c-f088-4f65-bb30-41830e889ada" />| 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/fiat-native-weth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->