### PR TITLE
chore(message-system): remove mev protection disabled

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-08-05T12:00:00+00:00",
-    "sequence": 153,
+    "timestamp": "2026-08-07T12:00:00+00:00",
+    "sequence": 154,
     "actions": [
         {
             "conditions": [
@@ -850,43 +850,6 @@
                     "domain": ["trading.exchange", "trading.buy", "trading.sell"]
                 }
             }
-        },
-        {
-            "message": {
-                "id": "5877b299-c8d7-46af-a339-a64c683c8cdd",
-                "priority": 94,
-                "dismissible": true,
-                "variant": "info",
-                "category": "banner",
-                "content": {
-                    "en": "MEV protection for Ethereum is temporarily disabled while we improve transaction reliability — even if it's enabled in your settings. Your funds are not at risk.",
-                    "es": "La protección MEV para Ethereum está temporalmente desactivada mientras mejoramos la fiabilidad de las transacciones, incluso si está activada en tu configuración. Tus fondos no están en riesgo.",
-                    "cs": "Ochrana MEV pro Ethereum je dočasně vypnutá, zatímco zlepšujeme spolehlivost transakcí – i když ji máte zapnutou v nastavení. Vaše prostředky nejsou v ohrožení.",
-                    "ru": "Защита от MEV для Ethereum временно отключена, пока мы улучшаем надёжность транзакций — даже если она включена в ваших настройках. Ваши средства в безопасности.",
-                    "ja": "イーサリアムのMEV保護は、取引の信頼性を向上させるため一時的に無効になっています（設定で有効になっている場合でも）。お客様の資金が危険にさらされることはありません。",
-                    "hu": "Az Ethereum MEV-védelme átmenetileg ki van kapcsolva, amíg javítjuk a tranzakciók megbízhatóságát – még akkor is, ha a beállításokban engedélyezve van. A pénzed nincs veszélyben.",
-                    "it": "La protezione MEV per Ethereum è temporaneamente disattivata mentre miglioriamo l'affidabilità delle transazioni, anche se è attivata nelle tue impostazioni. I tuoi fondi non sono a rischio.",
-                    "fr": "La protection MEV pour Ethereum est temporairement désactivée pendant que nous améliorons la fiabilité des transactions, même si elle est activée dans vos paramètres. Vos fonds ne sont pas en danger.",
-                    "de": "Der MEV-Schutz für Ethereum ist vorübergehend deaktiviert, während wir die Zuverlässigkeit der Transaktionen verbessern – auch wenn er in deinen Einstellungen aktiviert ist. Deine Gelder sind nicht in Gefahr.",
-                    "tr": "Ethereum için MEV koruması, işlem güvenilirliğini iyileştirdiğimiz sırada geçici olarak devre dışı bırakıldı — ayarlarınızda etkin olsa bile. Fonlarınız risk altında değil.",
-                    "pt": "A proteção MEV para Ethereum está temporariamente desativada enquanto melhoramos a fiabilidade das transações — mesmo que esteja ativada nas tuas definições. Os teus fundos não estão em risco.",
-                    "uk": "Захист від MEV для Ethereum тимчасово вимкнено, поки ми покращуємо надійність транзакцій — навіть якщо його ввімкнено у ваших налаштуваннях. Ваші кошти в безпеці."
-                }
-            },
-            "conditions": [
-                {
-                    "settings": [
-                        {
-                            "eth": true
-                        }
-                    ],
-                    "environment": {
-                        "desktop": "*",
-                        "mobile": "*",
-                        "web": "*"
-                    }
-                }
-            ]
         },
         {
             "conditions": [


### PR DESCRIPTION
## Description

Removing the message saying: "MEV protection for Ethereum is temporarily disabled while we improve transaction reliability — even if it's enabled in your settings. Your funds are not at risk.". The message was previously displayed as a dismissible global banner when ETH network is enabled.

## Notes for QA

Enable ETH in networks settings and check that the global message informing about disabled MEV protection is not displayed.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-remove-mev-protection/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-remove-mev-protection/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change is limited to a single message-system config JSON file. No test statically maps to it, and only one E2E test (Connect webextension popup) is inferred to interact with the message system via a mock. The overall risk is low; running the inferred test will catch regressions in message parsing/validation without requiring broad suite execution.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test's source hints explicitly list a 'Remote message system mock (mockRemoteMessageSystem)' as part of its setup. Changes to the message-system config schema could alter how Suite parses or validates remote message responses, so this provides a smoke check for the Connect webextension flow that initializes the message system. This is inferred coverage, not a static mapping.

</details>

_Updated: 2026-08-07T11:35:59.754Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-remove-mev-protection&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-remove-mev-protection&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-remove-mev-protection&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T11:36:57.756Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T11:36:26.450Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->