### PR TITLE
test(redux-utils): await dispatched actions in mock dispatch

### DIFF
--- a/suite-common/connect-init/src/connectInitThunks.test.ts
+++ b/suite-common/connect-init/src/connectInitThunks.test.ts
@@ -4,7 +4,7 @@ import { asGetter } from '@suite-common/dependency-injection';
 import { deviceInitialState } from '@suite-common/device';
 import { firmwareInitialState } from '@suite-common/firmware';
 import { messageSystemInitialState } from '@suite-common/message-system';
-import { createMockDispatch } from '@suite-common/redux-utils/mocks';
+import { type MockDispatch, createMockDispatch } from '@suite-common/redux-utils/mocks';
 import { testMocks } from '@suite-common/test-utils';
 import {
     defaultTrezorUIEventHandlerThunk,
@@ -30,7 +30,7 @@ import {
 
 type ConnectInitThunkTestDeps = {
     actions: unknown[];
-    waitForThunks: () => Promise<void>;
+    onDispatch: MockDispatch<ConnectInitThunkState, ConnectInitThunkDeps>['onDispatch'];
     dispatch: ConnectInitThunkDispatch;
     getState: () => ConnectInitThunkState;
     extra: ConnectInitThunkDeps;
@@ -74,11 +74,11 @@ const createThunkDeps = (
         },
     };
 
-    const { actions, dispatch, waitForThunks } = createMockDispatch({ getState, extra });
+    const { actions, dispatch, onDispatch } = createMockDispatch({ getState, extra });
 
     return {
         actions,
-        waitForThunks,
+        onDispatch,
         dispatch,
         getState,
         extra,
@@ -247,11 +247,26 @@ describe('TrezorConnect Actions', () => {
     });
 
     it('only scoped callId-bearing UI events are swallowed by the global listener', async () => {
-        const { actions, waitForThunks, dispatch, getState, extra } = createThunkDeps();
+        const { actions, onDispatch, dispatch, getState, extra } = createThunkDeps();
         await connectInitThunk()(dispatch, getState, extra);
         actions.length = 0;
         const { emitTestEvent } = testMocks.getTrezorConnectMock();
         const scopedCallId = 'scoped-call-id';
+
+        // Only the scoped event is swallowed, so the single handler thunk that runs is the one for
+        // the unscoped event. Asserting when that thunk reports itself finished is what makes the
+        // assertions deterministic, without waiting for anything unrelated.
+        const handlerFinished = onDispatch((action, resolve) => {
+            if (!defaultTrezorUIEventHandlerThunk.fulfilled.match(action)) return;
+
+            expect(actions).toEqual([
+                expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.pending.type }),
+                expect.objectContaining({ type: UI_REQUEST.REQUEST_BUTTON }),
+                expect.objectContaining({ type: '@suite/device/addButtonRequest' }),
+                expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.fulfilled.type }),
+            ]);
+            resolve();
+        });
 
         emitTestEvent(UI_EVENT, {
             type: UI_REQUEST.REQUEST_BUTTON,
@@ -267,18 +282,12 @@ describe('TrezorConnect Actions', () => {
                 callId: scopedCallId,
             });
 
-            await waitForThunks();
+            await handlerFinished;
         } finally {
             unregisterScopedCallId(scopedCallId);
         }
-
-        expect(actions).toEqual([
-            expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.pending.type }),
-            expect.objectContaining({ type: UI_REQUEST.REQUEST_BUTTON }),
-            expect.objectContaining({ type: '@suite/device/addButtonRequest' }),
-            expect.objectContaining({ type: defaultTrezorUIEventHandlerThunk.fulfilled.type }),
-        ]);
     });
+
     it('connectInitHooks.deviceEvent is called for DEVICE.CONNECT / DEVICE.CONNECT_UNACQUIRED', async () => {
         const onConnect = jest.fn();
         const onConnectUnacquired = jest.fn();

--- a/suite-common/redux-utils/mocks/createMockDispatch.test.ts
+++ b/suite-common/redux-utils/mocks/createMockDispatch.test.ts
@@ -1,10 +1,13 @@
 import { type ThunkAction, type UnknownAction } from '@reduxjs/toolkit';
 
-import { createMockDispatch } from './createMockDispatch';
+import { createMockDispatch, failOnUnobservedSubscriptions } from './createMockDispatch';
 
 type State = { value: number };
 type Extra = { value: string };
 type TestThunk = ThunkAction<Promise<void>, State, Extra, UnknownAction>;
+
+const createTestMockDispatch = () =>
+    createMockDispatch({ getState: () => ({ value: 1 }), extra: { value: 'extra' } });
 
 describe(createMockDispatch.name, () => {
     it('stores plain actions', () => {
@@ -20,10 +23,10 @@ describe(createMockDispatch.name, () => {
         expect(actions).toEqual([action]);
     });
 
-    it('recursively runs thunks and waits for their actions', async () => {
+    it('recursively runs thunks with the same dispatch, state and extra dependencies', async () => {
         const state = { value: 1 };
         const extra = { value: 'extra' };
-        const { actions, dispatch, waitForThunks } = createMockDispatch({
+        const { actions, dispatch, onDispatch } = createMockDispatch({
             getState: () => state,
             extra,
         });
@@ -37,12 +40,212 @@ describe(createMockDispatch.name, () => {
             parentDispatch({ type: 'test/parent' });
         };
 
+        const childDispatched = onDispatch((action, resolve) => {
+            if (action.type === 'test/child') {
+                resolve();
+            }
+        });
+
         dispatch(parentThunk);
-        await waitForThunks();
+        await childDispatched;
 
         expect(actions).toEqual([
             { type: 'test/parent' },
             { type: 'test/child', payload: { state, injectedExtra: extra } },
         ]);
+    });
+
+    describe('onDispatch', () => {
+        it('notifies a listener about every dispatched action', () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const listener = jest.fn();
+
+            const subscription = onDispatch(listener);
+            dispatch({ type: 'test/first' });
+            dispatch({ type: 'test/second' });
+            subscription.unsubscribe();
+
+            expect(listener.mock.calls.map(([action]) => action)).toEqual([
+                { type: 'test/first' },
+                { type: 'test/second' },
+            ]);
+        });
+
+        it('resolves the returned subscription when the listener resolves', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const thunk: TestThunk = async thunkDispatch => {
+                await Promise.resolve();
+                thunkDispatch({ type: 'test/awaited', payload: { id: 'expected-id' } });
+            };
+
+            const dispatched = onDispatch((action, resolve) => {
+                if (action.type !== 'test/awaited') return;
+
+                expect(action.payload).toEqual({ id: 'expected-id' });
+                resolve();
+            });
+
+            dispatch(thunk);
+
+            await dispatched;
+        });
+
+        it('stops notifying the listener once it resolved', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const listener = jest.fn((_action, resolve: () => void) => resolve());
+
+            const dispatched = onDispatch(listener);
+            dispatch({ type: 'test/first' });
+            await dispatched;
+            dispatch({ type: 'test/second' });
+
+            expect(listener).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects an awaited subscription that the listener never resolves', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+
+            const dispatched = onDispatch(() => {}, { timeout: 10 });
+            dispatch({ type: 'test/unrelated' });
+
+            await expect(dispatched).rejects.toThrow(
+                'onDispatch timed out after 10 ms, dispatched actions: test/unrelated',
+            );
+        });
+
+        it('rejects an awaited subscription with an error handed to its resolve', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const thunk: TestThunk = async thunkDispatch => {
+                await Promise.resolve();
+                thunkDispatch({ type: 'test/awaited' });
+            };
+
+            const dispatched = onDispatch((action, resolve) => {
+                if (action.type !== 'test/awaited') return;
+
+                resolve(new Error('the action arrived in a state the test rejects'));
+            });
+            dispatch(thunk);
+
+            await expect(dispatched).rejects.toThrow(
+                'the action arrived in a state the test rejects',
+            );
+        });
+
+        // Assertions belong in the listener, so a failing one has to surface as the failure of the
+        // awaited subscription. Left to propagate, it would instead break the code that dispatched
+        // the action and the test would fail on a timeout, hiding the assertion.
+        it('rejects an awaited subscription with what the listener threw', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const thunk: TestThunk = async thunkDispatch => {
+                await Promise.resolve();
+                thunkDispatch({ type: 'test/awaited' });
+            };
+
+            const dispatched = onDispatch(action => {
+                if (action.type !== 'test/awaited') return;
+
+                expect(action.payload).toBe('never dispatched with a payload');
+            });
+            dispatch(thunk);
+
+            await expect(dispatched).rejects.toThrow('never dispatched with a payload');
+        });
+
+        it('does not break the dispatching code when the listener throws', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            let thunkFinished = false;
+            const thunk: TestThunk = async thunkDispatch => {
+                await Promise.resolve();
+                thunkDispatch({ type: 'test/awaited' });
+                thunkFinished = true;
+            };
+
+            const dispatched = onDispatch(() => {
+                throw new Error('listener failed');
+            });
+            dispatch(thunk);
+            await expect(dispatched).rejects.toThrow('listener failed');
+
+            expect(thunkFinished).toBe(true);
+        });
+
+        // A subscription used as a plain listener must not schedule a rejection nobody awaits,
+        // which would surface as an unhandled promise rejection.
+        it('does not start the timeout of a subscription before it is awaited', () => {
+            const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+            const { onDispatch } = createTestMockDispatch();
+
+            onDispatch(() => {}).unsubscribe();
+
+            expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+            setTimeoutSpy.mockRestore();
+        });
+    });
+
+    describe('failOnUnobservedSubscriptions', () => {
+        it('reports a subscription that was neither awaited nor unsubscribed', () => {
+            const { onDispatch } = createTestMockDispatch();
+
+            onDispatch(() => {});
+
+            expect(() => failOnUnobservedSubscriptions()).toThrow(
+                'onDispatch subscription was never awaited or unsubscribed',
+            );
+        });
+
+        it('points at the line the forgotten subscription was created on', () => {
+            const { onDispatch } = createTestMockDispatch();
+
+            onDispatch(() => {});
+
+            expect(() => failOnUnobservedSubscriptions()).toThrow('createMockDispatch.test.ts');
+        });
+
+        it('accepts an awaited subscription', async () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const thunk: TestThunk = async thunkDispatch => {
+                await Promise.resolve();
+                thunkDispatch({ type: 'test/awaited' });
+            };
+
+            const dispatched = onDispatch((_action, resolve) => resolve());
+            dispatch(thunk);
+            await dispatched;
+
+            expect(() => failOnUnobservedSubscriptions()).not.toThrow();
+        });
+
+        it('accepts an unsubscribed subscription', () => {
+            const { onDispatch } = createTestMockDispatch();
+
+            onDispatch(() => {}).unsubscribe();
+
+            expect(() => failOnUnobservedSubscriptions()).not.toThrow();
+        });
+
+        it('reports each forgotten subscription only once', () => {
+            const { onDispatch } = createTestMockDispatch();
+
+            onDispatch(() => {});
+
+            expect(() => failOnUnobservedSubscriptions()).toThrow();
+            expect(() => failOnUnobservedSubscriptions()).not.toThrow();
+        });
+
+        it('stops notifying an unsubscribed listener', () => {
+            const { dispatch, onDispatch } = createTestMockDispatch();
+            const listener = jest.fn();
+
+            const subscription = onDispatch(listener);
+            dispatch({ type: 'test/before' });
+            subscription.unsubscribe();
+            dispatch({ type: 'test/after' });
+
+            expect(listener.mock.calls.map(([action]) => action)).toEqual([
+                { type: 'test/before' },
+            ]);
+        });
     });
 });

--- a/suite-common/redux-utils/mocks/createMockDispatch.ts
+++ b/suite-common/redux-utils/mocks/createMockDispatch.ts
@@ -5,18 +5,76 @@ type CreateMockDispatchParams<TState, TExtra> = {
     extra: TExtra;
 };
 
-type MockDispatch<TState, TExtra, TAction extends Action> = {
+/**
+ * Receives every dispatched action, together with the `resolve` of the subscription it belongs to.
+ * Calling `resolve` is what tells the test that what it waited for has happened, so a listener can
+ * assert on the action first and only then let the test continue. Handing `resolve` an error fails
+ * the subscription with it instead, the way jest's own `done(error)` used to.
+ */
+type DispatchListener = (action: UnknownAction, resolve: (error?: Error) => void) => void;
+
+/** A listener with its subscription's `resolve` already bound to it. */
+type SubscribedListener = (action: UnknownAction) => void;
+
+/**
+ * An awaitable subscription. Awaiting it waits until the listener calls its `resolve` and rejects if
+ * that does not happen in time. The timeout starts only once the subscription is awaited, so a
+ * subscription used as a plain listener never rejects behind the test's back.
+ */
+type DispatchSubscription = PromiseLike<void> & {
+    catch: (onRejected: (reason: unknown) => void) => PromiseLike<void>;
+    finally: (onFinally: () => void) => PromiseLike<void>;
+    unsubscribe: () => void;
+};
+
+type OnDispatchOptions = {
+    /** How long to wait once the subscription is awaited. Defaults to `DEFAULT_WAIT_TIMEOUT`. */
+    timeout?: number;
+};
+
+export type MockDispatch<TState, TExtra, TAction extends Action = UnknownAction> = {
     actions: unknown[];
     dispatch: ThunkDispatch<TState, TExtra, TAction>;
-    waitForThunks: () => Promise<void>;
+    onDispatch: (listener: DispatchListener, options?: OnDispatchOptions) => DispatchSubscription;
 };
+
+const DEFAULT_WAIT_TIMEOUT = 1000;
+
+/**
+ * Subscriptions that were created but so far neither awaited nor unsubscribed. A test that forgets
+ * to await one asserts nothing in its listener while still passing, so they are reported.
+ */
+const unobservedSubscriptions = new Set<{ creationStack: string }>();
+
+/**
+ * Throws if a subscription is still unobserved, and forgets it so that it is reported once only.
+ * Registered as an `afterEach` below; exported for its own test.
+ */
+export const failOnUnobservedSubscriptions = () => {
+    if (unobservedSubscriptions.size === 0) return;
+
+    const forgotten = [...unobservedSubscriptions]
+        .map(({ creationStack }) => creationStack)
+        .join('\n\n');
+    unobservedSubscriptions.clear();
+
+    throw new Error(
+        `onDispatch subscription was never awaited or unsubscribed, so its listener asserted nothing:\n\n${forgotten}`,
+    );
+};
+
+// `afterEach` is registered when a test file imports this module, so a forgotten `await` fails the
+// test it belongs to. Read off the global to keep this module free of a dependency on jest types.
+const registerAfterEach = (globalThis as { afterEach?: (hook: () => void) => void }).afterEach;
+
+registerAfterEach?.(failOnUnobservedSubscriptions);
 
 export const createMockDispatch = <TState, TExtra, TAction extends Action = UnknownAction>({
     getState,
     extra,
 }: CreateMockDispatchParams<TState, TExtra>): MockDispatch<TState, TExtra, TAction> => {
     const actions: unknown[] = [];
-    const thunkPromises: Promise<unknown>[] = [];
+    const listeners = new Set<SubscribedListener>();
 
     // Calling a thunk directly in a test bypasses the Redux store and its thunk middleware. This
     // small replacement does the two middleware jobs these tests need: it stores plain actions for
@@ -24,28 +82,113 @@ export const createMockDispatch = <TState, TExtra, TAction extends Action = Unkn
     // dependencies.
     const dispatch: ThunkDispatch<TState, TExtra, TAction> = (action: unknown) => {
         if (typeof action === 'function') {
-            // We cannot simply await here. Making dispatch async would only make dispatch return a
-            // promise; it would not force its caller to await that promise. Production callbacks
-            // such as event listeners often intentionally ignore the value returned by dispatch.
-            // Keep the promise so the test can explicitly wait until the thunk is really finished.
-            const thunkPromise = Promise.resolve(action(dispatch, getState, extra));
-            thunkPromises.push(thunkPromise);
-
-            return thunkPromise;
+            // Returned rather than awaited: making dispatch async would only make dispatch return a
+            // promise, it would not force its caller to await it, and production callbacks such as
+            // event listeners intentionally ignore what dispatch returns. A test waits for what a
+            // thunk does through `onDispatch` instead.
+            return Promise.resolve(action(dispatch, getState, extra));
         }
 
         actions.push(action);
+        listeners.forEach(listener => listener(action as UnknownAction));
 
         return action;
     };
 
-    // A running thunk may dispatch another asynchronous thunk. Keep draining the list until every
-    // recursively dispatched thunk has completed, including thunks added while we were waiting.
-    const waitForThunks = async () => {
-        while (thunkPromises.length > 0) {
-            await Promise.all(thunkPromises.splice(0));
-        }
+    /**
+     * Subscribes to every dispatched action. The listener decides when the test may continue by
+     * calling its `resolve`, so a test waits for the action it actually cares about instead of
+     * hoping that everything relevant settles within an unspecific await.
+     *
+     * Subscribe before triggering the code under test: only actions dispatched afterwards reach the
+     * listener.
+     */
+    const onDispatch = (
+        listener: DispatchListener,
+        { timeout = DEFAULT_WAIT_TIMEOUT }: OnDispatchOptions = {},
+    ): DispatchSubscription => {
+        let resolveSubscription = () => {};
+        let rejectSubscription = (_reason: Error) => {};
+        const resolved = new Promise<void>((resolve, reject) => {
+            resolveSubscription = resolve;
+            rejectSubscription = reject;
+        });
+
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let isAwaited = false;
+        let stopListening = () => {};
+
+        // Where this subscription was created, so that a report about it can point at the test. Held
+        // per subscription rather than by its stack, so two created on one line count separately.
+        const subscription = { creationStack: new Error('onDispatch').stack ?? 'onDispatch' };
+
+        unobservedSubscriptions.add(subscription);
+        const markObserved = () => unobservedSubscriptions.delete(subscription);
+
+        const subscribedListener = (action: UnknownAction) => {
+            try {
+                listener(action, error => {
+                    // Thrown rather than rejected here, so that an error handed to `resolve` takes
+                    // the same path as one thrown by a failed assertion in the listener.
+                    if (error) throw error;
+
+                    stopListening();
+                    resolveSubscription();
+                });
+            } catch (error) {
+                // A listener asserting on the action is the point of this API, so a failed assertion
+                // has to fail the awaited subscription. Letting it propagate would instead break
+                // whatever dispatched the action, and the test would time out with the assertion
+                // lost. With nobody awaiting there is no such place to report it, so it is rethrown.
+                stopListening();
+                // Reported here, one way or the other, so the afterEach hook stays quiet about it.
+                markObserved();
+
+                if (!isAwaited) throw error;
+
+                rejectSubscription(error as Error);
+            }
+        };
+
+        listeners.add(subscribedListener);
+
+        stopListening = () => {
+            clearTimeout(timeoutId);
+            listeners.delete(subscribedListener);
+        };
+
+        // Awaiting is what arms the timeout: a listener that nobody awaits must not reject.
+        const startWaiting = () => {
+            isAwaited = true;
+            markObserved();
+            timeoutId ??= setTimeout(() => {
+                stopListening();
+                rejectSubscription(
+                    new Error(
+                        `onDispatch timed out after ${timeout} ms, dispatched actions: ${(
+                            actions as UnknownAction[]
+                        )
+                            .map(action => action.type)
+                            .join(', ')}`,
+                    ),
+                );
+            }, timeout);
+
+            return resolved;
+        };
+
+        return {
+            then: (onFulfilled, onRejected) => startWaiting().then(onFulfilled, onRejected),
+            catch: onRejected => startWaiting().catch(onRejected),
+            finally: onFinally => startWaiting().finally(onFinally),
+            unsubscribe: () => {
+                // Unsubscribing is a deliberate way of being done with a subscription, the same as
+                // awaiting it, so it is not reported as forgotten either.
+                markObserved();
+                stopListening();
+            },
+        };
     };
 
-    return { actions, dispatch, waitForThunks };
+    return { actions, dispatch, onDispatch };
 };


### PR DESCRIPTION
## Description

Test-only change to `createMockDispatch` in `@suite-common/redux-utils`.

It offered `waitForThunks`, which awaited whatever happened to be pending and told a reader nothing about what the test was actually waiting for. It is replaced by `onDispatch(listener)`, which turns the mock dispatch into an emitter: the listener receives each dispatched action together with the `resolve` of an awaitable subscription, so a test asserts on the action it cares about inside the listener and only then lets itself continue.

- A failed assertion in the listener, or an error handed to `resolve`, rejects the subscription instead of propagating into the code that dispatched the action — where it would otherwise be swallowed and surface as a timeout.
- A subscription that is not resolved in time rejects **listing the actions that were dispatched**, instead of an unspecific jest timeout.
- The timeout starts only once the subscription is awaited, so a subscription used as a plain listener never rejects behind the test's back.
- A subscription that is neither awaited nor unsubscribed fails its test from an `afterEach` hook, pointing at the line it was created on — otherwise a listener that is never reached would let a test pass while asserting nothing.

`waitForThunks` is removed; awaiting the action a test cares about covers what it was used for, and it had no other callers. `connectInitThunks.test.ts` is migrated to the new API.

## Notes for QA

**Nothing to test — no production code is touched.** The change is limited to a test utility and its consumers:

- `suite-common/redux-utils/mocks/createMockDispatch.ts` (test helper)
- `suite-common/redux-utils/mocks/createMockDispatch.test.ts`
- `suite-common/connect-init/src/connectInitThunks.test.ts`

There is no runtime, UI or behaviour change in the app, so no manual testing is needed. Coverage is the unit test suites themselves:

```bash
yarn workspace @suite-common/redux-utils test:unit
yarn workspace @suite-common/connect-init test:unit
```

## Related Issue

<!--- link the issue here -->

## Screenshots:

No UI changes.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/mock-dispatch-await-actions/web/](https://dev.suite.sldev.cz/suite-web/test/mock-dispatch-await-actions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/mock-dispatch-await-actions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/mock-dispatch-await-actions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/mock-dispatch-await-actions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T09:44:54.775Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T09:47:57.350Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all unit-test/mock utilities (a connect-init thunk test, a mock dispatch utility, and its test). They do not modify production application code or any E2E page objects/fixtures, so there is no direct or inferable Playwright E2E coverage needed. The risk to end-to-end behavior is negligible; no targeted E2E runs are recommended.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/connect-init/src/connectInitThunks.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (3)**
- `suite-common/connect-init/src/connectInitThunks.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.test.ts`
- `suite-common/redux-utils/mocks/createMockDispatch.ts`

_Updated: 2026-08-13T09:41:33.844Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->
