### PR TITLE
feat(suite-native): skip approval step for vault deposits

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3012,6 +3012,7 @@ export const messages = {
             approvalLimit: 'Approval limit',
             increaseApprovalLimit: 'Increase approval limit',
             revokeApproval: 'Revoke approval',
+            skipApproval: 'Skip',
             perDeposit: 'Per deposit',
             estimatedRewardsLabel: 'Estimated yearly rewards',
             approvalLimitSheet: {

--- a/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
@@ -29,7 +29,9 @@ type YieldDepositFlowFooterProps = {
     approvalAction?: YieldApprovalAction;
     isDisabled: boolean;
     isLoading?: boolean;
+    isSkipDisabled?: boolean;
     onPress: () => void;
+    onSkipPress?: () => void;
     shouldKeepEstimatedRewardsVisible?: boolean;
     tokenSymbol: TokenSymbol;
 };
@@ -54,7 +56,9 @@ export const YieldDepositFlowFooter = ({
     approvalAction,
     isDisabled,
     isLoading = false,
+    isSkipDisabled = false,
     onPress,
+    onSkipPress,
     shouldKeepEstimatedRewardsVisible = false,
     tokenSymbol,
 }: YieldDepositFlowFooterProps) => {
@@ -86,27 +90,45 @@ export const YieldDepositFlowFooter = ({
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
-                <Box style={isEstimatedRewardsVisible ? applyStyle(rewardsBoxStyle) : undefined}>
-                    {isEstimatedRewardsVisible && (
-                        <VStack spacing="sp4" paddingVertical="sp12" alignItems="center">
-                            <Text variant="body-sm" color="contentPrimary">
-                                <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
-                            </Text>
-                            <Text variant="headline-sm" color="contentBrand">
-                                {estimatedRewards}
-                            </Text>
-                        </VStack>
-                    )}
-                    <Button
-                        accessibilityRole="button"
-                        accessibilityLabel={translate(buttonTranslationId)}
-                        onPress={onPress}
-                        isDisabled={isDisabled}
-                        isLoading={isLoading}
+                <VStack spacing="sp12">
+                    <Box
+                        style={isEstimatedRewardsVisible ? applyStyle(rewardsBoxStyle) : undefined}
                     >
-                        <Translation id={buttonTranslationId} />
-                    </Button>
-                </Box>
+                        {isEstimatedRewardsVisible && (
+                            <VStack spacing="sp4" paddingVertical="sp12" alignItems="center">
+                                <Text variant="body-sm" color="contentPrimary">
+                                    <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
+                                </Text>
+                                <Text variant="headline-sm" color="contentBrand">
+                                    {estimatedRewards}
+                                </Text>
+                            </VStack>
+                        )}
+                        <Button
+                            accessibilityRole="button"
+                            accessibilityLabel={translate(buttonTranslationId)}
+                            onPress={onPress}
+                            isDisabled={isDisabled}
+                            isLoading={isLoading}
+                        >
+                            <Translation id={buttonTranslationId} />
+                        </Button>
+                    </Box>
+                    {onSkipPress && (
+                        <Button
+                            accessibilityRole="button"
+                            accessibilityLabel={translate(
+                                'earn.yieldDepositFlowScreen.skipApproval',
+                            )}
+                            intent="neutral"
+                            priority="secondary"
+                            onPress={onSkipPress}
+                            isDisabled={isSkipDisabled}
+                        >
+                            <Translation id="earn.yieldDepositFlowScreen.skipApproval" />
+                        </Button>
+                    )}
+                </VStack>
             </Box>
         </Animated.View>
     );

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -167,6 +167,7 @@ export const YieldDepositApprovalScreen = () => {
         routeParams: route.params,
     });
     const isApprovalSessionReady = sessionStep === 'approve';
+    const canSkipApproval = isApprovalSessionReady && shouldShowApprovedAmountCard;
     const canSubmitApproval =
         isValid &&
         isAllowanceFeeReady &&
@@ -201,6 +202,42 @@ export const YieldDepositApprovalScreen = () => {
 
         dispatch(stablecoinYieldActions.disposeSession({ flowType: 'deposit', flowKey }));
     }, [dispatch, flowKey, isApprovalPending, navigateToInitialScreen, navigation]);
+
+    const handleSkipApproval = useCallback(() => {
+        if (!flowKey || isApprovalPending) {
+            return;
+        }
+
+        analytics.report({
+            type: events.yieldDepositEvent.name,
+            payload: {
+                action: 'cancel',
+                type: 'approve',
+                networkSymbol: account?.symbol,
+                vaultId: resolvedFlowData.vault?.id,
+            },
+        });
+
+        dispatch(
+            stablecoinYieldActions.skipApprovalStep({
+                flowType: 'deposit',
+                flowKey,
+                amount: amountValue || undefined,
+            }),
+        );
+
+        navigation.navigate(YieldStackRoutes.YieldDeposit, route.params);
+    }, [
+        account?.symbol,
+        amountValue,
+        analytics,
+        dispatch,
+        flowKey,
+        isApprovalPending,
+        navigation,
+        resolvedFlowData.vault?.id,
+        route.params,
+    ]);
 
     const handleNavigateToRevoke = useCallback(() => {
         if (!flowKey || isApprovalPending) {
@@ -326,7 +363,9 @@ export const YieldDepositApprovalScreen = () => {
                     apy={apy}
                     isDisabled={isSubmitDisabled}
                     isLoading={isCheckingApproval}
+                    isSkipDisabled={isApprovalPending || isCheckingApproval}
                     onPress={handleSubmit}
+                    onSkipPress={canSkipApproval ? handleSkipApproval : undefined}
                     tokenSymbol={tokenSymbol}
                 />
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds skipping of approval step if user already approved an amount

## Notes for QA

Also changes the flow for the stables deposit.

To be discussed if how it works screens need to be displayed for re-deposits 

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30989

## Screenshots:


https://github.com/user-attachments/assets/99c734e5-cbdb-48c5-a640-08e4ee71e949




<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/feat-skip-approve-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->