### PR TITLE
fix(suite-native): ensure ScreenHeader scales based on OS config

### DIFF
--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -3,8 +3,8 @@ import { type ReactNode } from 'react';
 import { Box } from '@suite-native/atoms';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { GoBackIcon } from './GoBackIcon';
 import { type CloseActionType } from '../navigators';
+import { GoBackIcon } from './GoBackIcon';
 import { ScreenHeaderContent, type ScreenHeaderContentProps } from './ScreenHeaderContent';
 
 export type ScreenHeaderProps = ScreenHeaderContentProps &
@@ -22,8 +22,6 @@ export type ScreenHeaderProps = ScreenHeaderContentProps &
         rightIcon?: ReactNode;
     };
 
-const ICON_SIZE = 40;
-
 const headerStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -32,12 +30,7 @@ const headerStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
     paddingBottom: utils.spacings.sp16,
     backgroundColor: utils.colors.surfaceFillPage,
-    minHeight: ICON_SIZE,
-}));
-
-const iconWrapperStyle = prepareNativeStyle(() => ({
-    width: ICON_SIZE,
-    height: ICON_SIZE,
+    minHeight: 40, // i.e. medium IconButton size
 }));
 
 export const ScreenHeader = ({
@@ -52,7 +45,7 @@ export const ScreenHeader = ({
 
     return (
         <Box style={applyStyle(headerStyle)}>
-            <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-left">
+            <Box testID="@screen/sub-header/icon-left">
                 {leftIcon !== undefined ? (
                     leftIcon
                 ) : (
@@ -64,10 +57,7 @@ export const ScreenHeader = ({
                 )}
             </Box>
             <ScreenHeaderContent title={title} customContent={customContent} />
-
-            <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-right">
-                {rightIcon}
-            </Box>
+            <Box testID="@screen/sub-header/icon-right">{rightIcon}</Box>
         </Box>
     );
 };


### PR DESCRIPTION
## Description

On Android, increasing the font size in OS settings may lead to broken icons in `ScreenHeader`. Removing the hard-coded button constraints so that the UI may scale automagically.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1080" height="2340" alt="Screenshot_20260807_144510" src="https://github.com/user-attachments/assets/1339401f-c9de-409b-bd64-b2aded7a0230" /> | <img width="1080" height="2340" alt="Screenshot_20260807_144549" src="https://github.com/user-attachments/assets/499f54a0-9d84-4556-a2ad-22cf75f589ba" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/screen-header-scaling&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->