### PR TITLE
fix(suite): load bip321 label from protocol uri

### DIFF
--- a/packages/suite/src/actions/suite/protocolActions.test.ts
+++ b/packages/suite/src/actions/suite/protocolActions.test.ts
@@ -9,6 +9,10 @@ import * as protocolConstants from './constants/protocolConstants';
 import * as protocolActions from './protocolActions';
 import { type HandleProtocolRequestDeps } from './protocolActions';
 
+jest.mock('@suite-common/walletconnect', () => ({
+    walletConnectPairThunk: jest.fn(),
+}));
+
 const findNetworkSymbolForProtocol: FindNetworkSymbolForProtocol = protocol =>
     protocol === 'bitcoin' ? asNetworkSymbol('btc') : null;
 
@@ -32,10 +36,10 @@ const createHandleProtocolRequestDeps = () => {
 };
 
 describe('Protocol actions', () => {
-    it('saves address and amount from Bitcoin URI protocol', () => {
+    it('saves address, amount and label from Bitcoin URI protocol', () => {
         const { actions, dispatch, getState, extra } = createHandleProtocolRequestDeps();
 
-        protocolActions.handleProtocolRequest('bitcoin:12345abcde?amount=1.02')(
+        protocolActions.handleProtocolRequest('bitcoin:12345abcde?amount=1.02&label=Alice')(
             dispatch,
             getState,
             extra,
@@ -49,6 +53,7 @@ describe('Protocol actions', () => {
                     scheme: 'bitcoin',
                     address: '12345abcde',
                     amount: '1.02',
+                    label: 'Alice',
                 }),
             }),
         );

--- a/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts
@@ -31,6 +31,7 @@ import { PROTO } from '@trezor/connect';
 import { type DeepPartial } from '@trezor/type-utils';
 
 import { type AppState } from 'src/reducers/store';
+import protocolReducer from 'src/reducers/suite/protocolReducer';
 import { extraDependencies } from 'src/support/extraDependencies';
 
 const sendFormReducer = prepareSendFormReducer(extraDependencies);
@@ -416,7 +417,7 @@ export const getRootReducer: any = (selectedAccount = BTC_ACCOUNT, fees = DEFAUL
                 () => ({}),
             ),
         }),
-        protocol: createReducer({ sendForm: {} }, () => ({})),
+        protocol: protocolReducer,
         messageSystem: createReducer(
             {
                 validMessages: {

--- a/packages/suite/src/hooks/wallet/useSendForm.test.tsx
+++ b/packages/suite/src/hooks/wallet/useSendForm.test.tsx
@@ -20,6 +20,7 @@ import {
     type UserAction,
     actionSequence,
     findByTestId,
+    renderHookWithProviders,
     renderWithProviders,
     waitForLoader,
 } from 'src/support/test-utils/hooksHelper';
@@ -27,7 +28,7 @@ import { type SendContextValues } from 'src/types/wallet/sendForm';
 import SendIndex from 'src/views/wallet/send';
 
 import * as fixtures from './__fixtures__/useSendForm';
-import { useSendFormContext } from './useSendForm';
+import { useSendForm, useSendFormContext } from './useSendForm';
 import { extraDependenciesDesktopMock } from '../../../mocks/extraDependenciesDesktopMock';
 
 const TEST_TIMEOUT = 35000;
@@ -70,11 +71,19 @@ interface Args {
     selectedAccount?: any;
     coinjoin?: any;
     bitcoinAmountUnit?: PROTO.AmountUnit;
+    protocol?: Partial<RootReducerState['protocol']>;
 }
 
 const TrezorConnect = testMocks.getTrezorConnectMock();
 
-const initStore = ({ send, fees, selectedAccount, coinjoin, bitcoinAmountUnit }: Args = {}) => {
+const initStore = ({
+    send,
+    fees,
+    selectedAccount,
+    coinjoin,
+    bitcoinAmountUnit,
+    protocol,
+}: Args = {}) => {
     const rootReducer = fixtures.getRootReducer(selectedAccount, fees);
 
     const preloadedState = initPreloadedState({
@@ -88,6 +97,7 @@ const initStore = ({ send, fees, selectedAccount, coinjoin, bitcoinAmountUnit }:
             suiteSettings: { ...suiteSettingsInitialState, language: 'en' },
             debug: debugInitialState,
             router: { route: { name: 'wallet-send' } },
+            ...(protocol ? { protocol } : {}),
         },
     });
 
@@ -241,6 +251,54 @@ describe('useSendForm hook', () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
+
+    it(
+        'fills label from protocol uri into send output',
+        async () => {
+            const protocolAddress = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT';
+            const protocolAmount = '0.1';
+            const protocolLabel = 'Trezor donation';
+            const store = initStore({
+                protocol: {
+                    sendForm: {
+                        shouldFill: true,
+                        scheme: 'bitcoin',
+                        address: protocolAddress,
+                        amount: protocolAmount,
+                        label: protocolLabel,
+                    },
+                },
+            });
+            const state = store.getState();
+            const { result, unmount } = renderHookWithProviders(
+                store,
+                extraDependenciesDesktopMock.services,
+                () =>
+                    useSendForm({
+                        selectedAccount: state.wallet.selectedAccount,
+                        localCurrency: 'usd',
+                        fees: state.wallet.fees,
+                        online: true,
+                        metadataEnabled: false,
+                    }),
+            );
+
+            await waitFor(() => {
+                expect(result.current.getValues()).toMatchObject({
+                    outputs: [
+                        {
+                            address: protocolAddress,
+                            amount: protocolAmount,
+                            label: protocolLabel,
+                        },
+                    ],
+                });
+            });
+
+            unmount();
+        },
+        TEST_TIMEOUT,
+    );
 
     fixtures.addingOutputs.forEach(f => {
         it(

--- a/packages/suite/src/hooks/wallet/useSendForm.ts
+++ b/packages/suite/src/hooks/wallet/useSendForm.ts
@@ -346,6 +346,12 @@ export const useSendForm = (props: UseSendFormProps): SendContextValues => {
                 }, 0);
             }
 
+            if (protocol.sendForm.label) {
+                setValue(`outputs.${outputIndex}.label`, protocol.sendForm.label, {
+                    shouldDirty: true,
+                });
+            }
+
             dispatch(fillSendForm(false));
             dispatch(resetProtocol());
             composeRequest();

--- a/packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts
@@ -6,6 +6,7 @@ import { initialState } from 'src/reducers/suite/protocolReducer';
 const protocol = {
     address: 'bc1q00h58c5vzcyqavwpjvw8tl8r53t9d57e6smwqe',
     amount: 0.001,
+    label: 'Alice',
     scheme: asProtocol('bitcoin'),
 };
 

--- a/packages/suite/src/reducers/suite/protocolReducer.test.ts
+++ b/packages/suite/src/reducers/suite/protocolReducer.test.ts
@@ -1,6 +1,6 @@
 import { asProtocol } from '@trezor/network-module-suite-common-types';
 
-import { fillSendForm } from 'src/actions/suite/protocolActions';
+import { PROTOCOL } from 'src/actions/suite/constants';
 import type { Action } from 'src/types/suite';
 
 import fixtures from './__fixtures__/protocolReducer';
@@ -11,13 +11,19 @@ type FillSendFormCase = {
     sendForm: ProtocolState['sendForm'];
 };
 
+const fillSendForm = (shouldFill: boolean): Action => ({
+    type: PROTOCOL.FILL_SEND_FORM,
+    payload: shouldFill,
+});
+
 const fillSendFormCases: FillSendFormCase[] = [
     {
-        description: 'address and amount',
+        description: 'address, amount and label',
         sendForm: {
             scheme: asProtocol('bitcoin'),
             address: '12345abcde',
             amount: '1.02',
+            label: 'Alice',
             shouldFill: false,
         },
     },

--- a/packages/suite/src/reducers/suite/protocolReducer.ts
+++ b/packages/suite/src/reducers/suite/protocolReducer.ts
@@ -9,6 +9,7 @@ export interface SendFormState {
     scheme: Protocol;
     address: string;
     amount?: string;
+    label?: string;
     token?: string; // ERC-681: token contract address
     tokenAmount?: string; // ERC-681: amount in token's smallest unit (uint256)
 }
@@ -35,6 +36,7 @@ const protocolReducer = (state: ProtocolState = initialState, action: Action): P
                 draft.sendForm.address = action.payload.address;
                 draft.sendForm.scheme = action.payload.scheme;
                 draft.sendForm.amount = action.payload.amount;
+                draft.sendForm.label = action.payload.label;
                 draft.sendForm.token = action.payload.token;
                 draft.sendForm.tokenAmount = action.payload.tokenAmount;
                 draft.sendForm.shouldFill = false;

--- a/packages/suite/src/support/test-utils/hooksHelper.tsx
+++ b/packages/suite/src/support/test-utils/hooksHelper.tsx
@@ -4,9 +4,11 @@ import { Provider } from 'react-redux';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
+    type RenderHookOptions,
     type RenderResult,
     act,
     render,
+    renderHook,
     screen,
     waitForElementToBeRemoved,
 } from '@testing-library/react';
@@ -24,6 +26,30 @@ const testQueryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
 });
 
+const SuiteProviders = ({
+    store,
+    services,
+    children,
+}: {
+    store: any;
+    services: SuiteServices;
+    children: ReactNode;
+}) => (
+    <QueryClientProvider client={testQueryClient}>
+        <Provider store={store}>
+            <ServicesProvider services={services}>
+                <ConnectedThemeProvider>
+                    <ResponsiveContextProvider>
+                        <IntlProvider locale="en">
+                            <MockedFormatterProvider>{children}</MockedFormatterProvider>
+                        </IntlProvider>
+                    </ResponsiveContextProvider>
+                </ConnectedThemeProvider>
+            </ServicesProvider>
+        </Provider>
+    </QueryClientProvider>
+);
+
 // used in hooks tests
 export const renderWithProviders = (
     store: any,
@@ -31,20 +57,25 @@ export const renderWithProviders = (
     children: ReactNode,
 ): RenderResult =>
     render(
-        <QueryClientProvider client={testQueryClient}>
-            <Provider store={store}>
-                <ServicesProvider services={services}>
-                    <ConnectedThemeProvider>
-                        <ResponsiveContextProvider>
-                            <IntlProvider locale="en">
-                                <MockedFormatterProvider>{children}</MockedFormatterProvider>
-                            </IntlProvider>
-                        </ResponsiveContextProvider>
-                    </ConnectedThemeProvider>
-                </ServicesProvider>
-            </Provider>
-        </QueryClientProvider>,
+        <SuiteProviders store={store} services={services}>
+            {children}
+        </SuiteProviders>,
     );
+
+export const renderHookWithProviders = <Result, Props>(
+    store: any,
+    services: SuiteServices,
+    callback: (props: Props) => Result,
+    options?: Omit<RenderHookOptions<Props>, 'wrapper'>,
+) =>
+    renderHook(callback, {
+        wrapper: ({ children }) => (
+            <SuiteProviders store={store} services={services}>
+                {children}
+            </SuiteProviders>
+        ),
+        ...options,
+    });
 
 export const waitForLoader = (text = /Loading/i) => {
     try {

--- a/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.test.ts
@@ -40,7 +40,7 @@ describe('handleCoinProtocolUri', () => {
     it('reports the scheme, saves the protocol and toasts for a valid coin URI', () => {
         const { dispatch, report, saveCoinProtocol, run } = setup();
 
-        run('bitcoin:12345abcde?amount=1.02');
+        run('bitcoin:12345abcde?amount=1.02&label=Alice');
 
         expect(report).toHaveBeenCalledWith(
             expect.objectContaining({ payload: { scheme: 'bitcoin', isAmountPresent: true } }),
@@ -49,6 +49,7 @@ describe('handleCoinProtocolUri', () => {
             scheme: 'bitcoin',
             address: '12345abcde',
             amount: '1.02',
+            label: 'Alice',
             token: undefined,
             tokenAmount: undefined,
         });
@@ -70,6 +71,7 @@ describe('handleCoinProtocolUri', () => {
             scheme: 'ethereum',
             address: '0x8e23ee67d1332ad560396262c48ffbb01f93d052',
             amount: undefined,
+            label: undefined,
             token: '0x89205a3a3b2a69de6dbf7f01ed13b2108b2c43e7',
             tokenAmount: '1000000',
         });

--- a/suite/transfer-uri/src/handleCoinProtocolUri.ts
+++ b/suite/transfer-uri/src/handleCoinProtocolUri.ts
@@ -11,6 +11,7 @@ export type CoinProtocol = {
     scheme: Protocol;
     address: string;
     amount?: string;
+    label?: string;
     token?: string;
     tokenAmount?: string;
 };
@@ -51,6 +52,7 @@ export const handleCoinProtocolUri =
             scheme: info.scheme,
             address: info.address,
             amount: info.format === 'bip321' ? info.amount : undefined,
+            label: info.format === 'bip321' ? info.label : undefined,
             token: info.format === 'erc681' ? info.token : undefined,
             tokenAmount: info.format === 'erc681' ? info.tokenAmount : undefined,
         };


### PR DESCRIPTION
## Description

Preserve BIP-321 labels in the desktop protocol URI flow and fill the send form label when opening from a `bitcoin:` URI.

## Notes for QA

Open a desktop `bitcoin:<address>?amount=<amount>&label=<label>` URI and continue to the send form. The address, amount, and label should be filled.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28553

## Screenshots:

N/A

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/find-bip321-btc-parser/web/](https://dev.suite.sldev.cz/suite-web/find-bip321-btc-parser/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=find-bip321-btc-parser&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=find-bip321-btc-parser&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T14:40:02.004Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T14:40:17.184Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set mainly affects the wallet send-form hook (useSendForm.ts) and protocol URI handling code that has no matching E2E test in the candidate list. The highest regression risk is in send-form composition, validation, fees, and outputs across multiple networks. I recommend a focused set of send-form E2E tests covering BTC-like, EVM, Solana, Doge, LTC, and CSV import scenarios. Protocol URI and unit-test-only changes have no E2E coverage here, so confidence must come from the existing unit tests.

<details><summary><b>Changed files (10)</b></summary>

- `packages/suite/src/actions/suite/protocolActions.test.ts`
- `packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts`
- `packages/suite/src/hooks/wallet/useSendForm.test.tsx`
- `packages/suite/src/hooks/wallet/useSendForm.ts`
- `packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts`
- `packages/suite/src/reducers/suite/protocolReducer.test.ts`
- `packages/suite/src/reducers/suite/protocolReducer.ts`
- `packages/suite/src/support/test-utils/hooksHelper.tsx`
- `suite/transfer-uri/src/handleCoinProtocolUri.test.ts`
- `suite/transfer-uri/src/handleCoinProtocolUri.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/wallet/import-btc-csv.test.ts` — This test populates the wallet send form by importing a CSV and asserts that output address, amount, and metadata labels are rendered correctly. A change to useSendForm could break output parsing or form state initialization, so this directly exercises the changed hook.
- `suite/e2e/tests/wallet/send-base.test.ts` — Fills the EVM send form on Base, sets custom Ethereum fees, and verifies device prompt values. It relies on useSendForm for amount/fee validation and composition, making it a strong regression test for EVM send paths.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Exercises the send form with a Doge amount near MAX_SAFE_INTEGER and checks validation and device prompt output. This tests numeric handling and fee calculation in useSendForm for UTXO-like coins.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Uses the ETH send form with custom gas parameters (gas limit, max fee, priority fee) and verifies the composed transaction on the device prompt. It directly depends on useSendForm's fee and amount composition logic.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Opens the LTC send form, uses setMax, and broadcasts a transaction spending a MimbleWimble peg-out output. This tests form initialization, max amount calculation, and output handling in useSendForm.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Covers adding/removing outputs, locktime, OP_RETURN, and switching BTC/satoshi units in the send form. These are core useSendForm behaviors around outputs and amount formatting.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Tests the Solana send form including Send Max, balance minus fee/reserve calculation, and review modal. It relies on useSendForm for max amount and fee computation.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/without-device.test.ts` — Opens the send form and clicks review while the device is disconnected, verifying the connection modal appears. It touches send form review logic but is more about connection state than send form internals.

</details>

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/actions/suite/protocolActions.test.ts`
- `packages/suite/src/hooks/wallet/__fixtures__/useSendForm.ts`
- `packages/suite/src/hooks/wallet/useSendForm.test.tsx`
- `packages/suite/src/reducers/suite/__fixtures__/protocolReducer.ts`
- `packages/suite/src/reducers/suite/protocolReducer.test.ts`
- `packages/suite/src/support/test-utils/hooksHelper.tsx`
- `suite/transfer-uri/src/handleCoinProtocolUri.test.ts`
- `suite/transfer-uri/src/handleCoinProtocolUri.ts`

_Updated: 2026-08-10T14:40:36.956Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->