### PR TITLE
refactor(suite): narrow remaining vanilla thunk dependencies

### DIFF
--- a/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts
@@ -1,11 +1,10 @@
 import {
+    type DesktopAnalyticsDep,
     type StakingCardanoPoolDelegationPayload,
-    asTypedDesktopAnalytics,
     events,
 } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
 import { type AdaPools } from '@suite-common/earn-staking-api';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import {
     calculate,
     composeStakingTransaction,
@@ -333,9 +332,11 @@ const getPoolDelegation = (
     };
 };
 
+type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
+
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: SignTransactionThunkDeps) => {
         const { selectedAccount, stake } = getState().wallet;
         const cardanoPools = selectCardanoPoolsInfo(getState());
         if (!selectedAccount?.account) return;
@@ -401,7 +402,7 @@ export const signTransaction =
         });
 
         if (!signedTx.success) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',

--- a/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts
@@ -1,6 +1,5 @@
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import {
     getStakeTxGasLimit,
     prepareClaimEthTx,
@@ -113,9 +112,11 @@ export const composeTransaction =
         );
     };
 
+type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
+
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: SignTransactionThunkDeps) => {
         const { selectedAccount } = getState().wallet;
         const device = selectSelectedDevice(getState());
         if (selectedAccount.status !== 'loaded' || !device || transactionInfo?.type !== 'final')
@@ -225,7 +226,7 @@ export const signTransaction =
         });
 
         if (!signedTx.success) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',

--- a/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
+++ b/packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts
@@ -1,6 +1,5 @@
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type DesktopAnalyticsDep, events } from '@suite/analytics';
 import { selectSelectedDevice } from '@suite-common/device';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { composeSolanaStakingTransaction, prepareSolanaStakeTxData } from '@suite-common/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { selectAddressDisplayType } from '@suite-common/wallet-core';
@@ -40,9 +39,11 @@ export const composeTransaction =
         });
     };
 
+type SignTransactionThunkDeps = { services: DesktopAnalyticsDep };
+
 export const signTransaction =
     (formValues: StakeFormState, transactionInfo: PrecomposedTransactionFinal) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: SignTransactionThunkDeps) => {
         const { selectedAccount, blockchain } = getState().wallet;
 
         const device = selectSelectedDevice(getState());
@@ -121,7 +122,7 @@ export const signTransaction =
         });
 
         if (!signedTx.success) {
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.transactionCancelEvent.name,
                 payload: {
                     txType: 'stake',

--- a/packages/suite/src/actions/wallet/stakeActions.ts
+++ b/packages/suite/src/actions/wallet/stakeActions.ts
@@ -1,12 +1,11 @@
 import {
+    type DesktopAnalyticsDep,
     type StakingCardanoPoolDelegationPayload,
-    asTypedDesktopAnalytics,
     events,
 } from '@suite/analytics';
 import { closeModal, openDeferredModal, openModal, preserveModal } from '@suite/modal';
 import { selectSelectedDevice } from '@suite-common/device';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
-import { type ExtraDependencies } from '@suite-common/redux-extra-dependencies';
 import { EarnFlow } from '@suite-common/suite-types/src/staking';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
@@ -92,10 +91,12 @@ export const cancelSignTx =
         }
     };
 
+type PushTransactionThunkDeps = { services: DesktopAnalyticsDep };
+
 // private, called from signTransaction only
 const pushTransaction =
     (stakeType: StakeType, cardanoPoolDelegation?: StakingCardanoPoolDelegationPayload) =>
-    async (dispatch: Dispatch, getState: GetState, extra: ExtraDependencies) => {
+    async (dispatch: Dispatch, getState: GetState, extra: PushTransactionThunkDeps) => {
         const { serializedTx, precomposedTx } = getState().wallet.stake;
         const { account } = getState().wallet.selectedAccount;
         const device = selectSelectedDevice(getState());
@@ -137,7 +138,7 @@ const pushTransaction =
             };
 
             if (cardanoPoolDelegation) {
-                asTypedDesktopAnalytics(extra.services.analytics).report({
+                extra.services.analytics.report({
                     type: events.stakingCardanoPoolDelegationEvent.name,
                     payload: cardanoPoolDelegation,
                 });
@@ -208,7 +209,7 @@ const pushTransaction =
                     }),
                 );
 
-                asTypedDesktopAnalytics(extra.services.analytics).report({
+                extra.services.analytics.report({
                     type: events.stakingConfirmEvent.name,
                     payload: { action: stakeType, networkSymbol: account.symbol },
                 });
@@ -229,7 +230,7 @@ const pushTransaction =
                 }),
             );
 
-            asTypedDesktopAnalytics(extra.services.analytics).report({
+            extra.services.analytics.report({
                 type: events.stakingConfirmEvent.name,
                 payload: { action: stakeType, networkSymbol: account.symbol, success: false },
             });


### PR DESCRIPTION
## Description

The remaining desktop Suite vanilla staking thunks accepted the complete global ExtraDependencies object even though they only report analytics. Each thunk now declares a named analytics-only dependency contract using DesktopAnalyticsDep, and the redundant runtime analytics casts are removed without changing behavior.

- Global dependency annotations in packages/suite/src/actions: **4 → 0**
- Global dependency imports in packages/suite/src/actions: **4 → 0**
- Vanilla staking thunks migrated: **4 across 4 files**
- Redundant analytics casts removed: **6**
- Validation: Suite type-check, Suite JavaScript lint, formatting, and diff checks

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are the core staking action creators for Cardano, Ethereum, and Solana, plus shared staking logic. The main risk is broken staking/unstaking/claim transactions. The static coverage mapping is extremely broad (135 tests per file), so it should be ignored in favor of the focused staking E2E suite. Run the high-priority chain-specific stake/unstake/claim tests for ADA, ETH, and SOL; add the ETH staking-form test as a medium-priority sanity check for form-level logic.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/actions/wallet/stake/stakeFormCardanoActions.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormEthereumActions.ts`
- `packages/suite/src/actions/wallet/stake/stakeFormSolanaActions.ts`
- `packages/suite/src/actions/wallet/stakeActions.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Directly exercises Cardano reward claiming, which is handled by stakeFormCardanoActions.ts. A regression would prevent users from claiming ADA staking rewards.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Covers the full Cardano staking transaction flow that stakeFormCardanoActions.ts prepares, including deposit, fees, and device confirmation.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Validates Cardano unstaking/withdrawal transaction preparation, a core path in stakeFormCardanoActions.ts.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Tests first-time Ethereum staking end-to-end, directly invoking stakeFormEthereumActions.ts for transaction composition and staking state updates.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Tests additional ETH staking from an already-staked account, a distinct path through stakeFormEthereumActions.ts.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Covers Ethereum unstaking and claim transaction flows prepared by stakeFormEthereumActions.ts.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Validates first-time Solana staking, which depends on stakeFormSolanaActions.ts for stake-account creation and transaction signing.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests staking more SOL from an existing staked account, exercising stakeFormSolanaActions.ts with multiple stake accounts.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Covers Solana unstake and claim transaction preparation via stakeFormSolanaActions.ts.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — Exercises ETH staking form validation and amount calculations that share state/composition logic with stakeFormEthereumActions.ts, though it stops before submitting a transaction.

</details>

_Updated: 2026-08-07T16:11:43.801Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-suite-vanilla-thunk-dependencies/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-suite-vanilla-thunk-dependencies/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-suite-vanilla-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-suite-vanilla-thunk-dependencies&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:13:53.715Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:13:40.547Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->