### PR TITLE
Show 0% APY badge for accounts staked with FiveBinaries

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -13,11 +13,16 @@ import {
 } from '@suite-native/formatters';
 import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { type NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
+import {
+    type NativeStakingRootState,
+    selectAccountHasStaking,
+    selectIsCardanoStakedWithFiveBinaries,
+} from '@suite-native/staking';
 import { isNetworkWithTokens } from '@suite-native/tokens';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
 import { StakingBadge } from './StakingBadge';
+import { ZeroApyBadge } from './ZeroApyBadge';
 import {
     type NativeAccountsRootState,
     selectAccountFiatBalance,
@@ -73,6 +78,10 @@ const AccountsListItemComponent = ({
         selectAccountHasStaking(state, account.key),
     );
 
+    const isStakedWithFiveBinaries = useSelector((state: AccountsRootState) =>
+        selectIsCardanoStakedWithFiveBinaries(state, account.key),
+    );
+
     const fiatBalance = useSelector((state: NativeAccountsRootState) =>
         selectAccountFiatBalance(state, account.key, accountHasStaking),
     );
@@ -88,6 +97,7 @@ const AccountsListItemComponent = ({
     const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
     const shouldShowTokenBadge = accountHasKnownTokensWithBalance && !isNativeCoinOnly;
     const shouldShowStakingBadge = accountHasStaking && !isNativeCoinOnly;
+    const shouldShowZeroApyBadge = isStakedWithFiveBinaries && !isNativeCoinOnly;
     const fiatBalanceValue =
         shouldShowTokenBadge && fiatBalance !== undefined ? (
             <BaseCurrencyAmountFormatter
@@ -127,8 +137,12 @@ const AccountsListItemComponent = ({
             }
             badges={
                 <>
-                    {shouldShowStakingBadge && (
-                        <StakingBadge networkSymbol={account.symbol} account={account} />
+                    {shouldShowZeroApyBadge ? (
+                        <ZeroApyBadge />
+                    ) : (
+                        shouldShowStakingBadge && (
+                            <StakingBadge networkSymbol={account.symbol} account={account} />
+                        )
                     )}
                     {shouldShowTokenBadge && <TokenBadge accountKey={account.key} />}
                     {badges}

--- a/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItemBase.tsx
@@ -8,7 +8,6 @@ type AccountListItemBaseProps = {
     icon: React.ReactNode;
     title: React.ReactNode;
     titleBadge?: React.ReactNode;
-    secondaryTitle?: React.ReactNode;
     mainValue: React.ReactNode;
     secondaryValue: React.ReactNode;
     badges?: React.ReactNode;
@@ -95,7 +94,6 @@ export const AccountsListItemBase = ({
     icon,
     title,
     titleBadge,
-    secondaryTitle,
     badges,
     mainValue,
     secondaryValue,
@@ -135,7 +133,6 @@ export const AccountsListItemBase = ({
                         </Text>
                         {titleBadge}
                     </HStack>
-                    {secondaryTitle}
                     <HStack spacing="sp4" alignItems="center">
                         {badges}
                     </HStack>

--- a/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AdaAccountsListStakingItem.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { type AccountsRootState } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { RoundedIcon, Text } from '@suite-native/atoms';
+import { RoundedIcon } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import {
@@ -13,6 +13,7 @@ import {
 } from '@suite-native/staking';
 
 import { AccountsListItemBase } from './AccountsListItemBase';
+import { ZeroApyBadge } from './ZeroApyBadge';
 
 type AdaAccountsListStakingItemProps = {
     account: Account;
@@ -37,15 +38,16 @@ export const AdaAccountsListStakingItem = ({
         selectIsCardanoStakedWithFiveBinaries(state, account.key),
     );
 
-    const icon = useMemo(
-        () =>
-            isStakedOutsideEverstake ? (
-                <Icon name="warning" color="contentWarning" />
-            ) : (
-                <Icon name="check" color="contentBrand" />
-            ),
-        [isStakedOutsideEverstake],
-    );
+    const mainValue = useMemo(() => {
+        if (isStakedWithFiveBinaries) {
+            return <ZeroApyBadge />;
+        }
+        if (isStakedOutsideEverstake) {
+            return <Icon name="warning" color="contentWarning" />;
+        }
+
+        return <Icon name="check" color="contentBrand" />;
+    }, [isStakedOutsideEverstake, isStakedWithFiveBinaries]);
 
     return (
         <AccountsListItemBase
@@ -54,14 +56,7 @@ export const AdaAccountsListStakingItem = ({
             showDivider={!isLast}
             icon={<RoundedIcon name="piggyBankFilled" intent="neutral" size={32} />}
             title={<Translation id="accountList.staking" />}
-            secondaryTitle={
-                isStakedWithFiveBinaries && (
-                    <Text variant="body-sm" color="contentWarning">
-                        <Translation id="accountList.rewardsReduced" />
-                    </Text>
-                )
-            }
-            mainValue={icon}
+            mainValue={mainValue}
             secondaryValue={undefined}
         />
     );

--- a/suite-native/accounts/src/components/AccountsList/ZeroApyBadge.tsx
+++ b/suite-native/accounts/src/components/AccountsList/ZeroApyBadge.tsx
@@ -1,0 +1,11 @@
+import { Badge } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
+
+export const ZeroApyBadge = () => (
+    <Badge
+        intent="warning"
+        icon="warning"
+        size="small"
+        label={<Translation id="earn.zeroApyBadge" />}
+    />
+);

--- a/suite-native/accounts/src/index.ts
+++ b/suite-native/accounts/src/index.ts
@@ -6,6 +6,7 @@ export * from './components/AccountsList/AccountsListItem';
 export * from './components/AccountsList/AccountsListItemBase';
 export * from './components/AccountsList/AccountsListStakingItem';
 export * from './components/AccountsList/StakingBadge';
+export * from './components/AccountsList/ZeroApyBadge';
 export * from './components/SearchableAccountsListHeader';
 export * from './components/SelectableNetworkItem';
 export * from './components/AccountsList/AccountsListTokenItem';

--- a/suite-native/assets/src/components/AssetItem.tsx
+++ b/suite-native/assets/src/components/AssetItem.tsx
@@ -57,6 +57,10 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
         selectHasDeviceAnyFailedAccountForNetworkSymbol(state, cryptoCurrencySymbol),
     );
 
+    const secondaryValue = hasAnyFailedAccount ? undefined : (
+        <CryptoAmount symbol={cryptoCurrencySymbol} />
+    );
+
     const handleAssetPress = useCallback(() => {
         // A single tokenless account opens its detail directly; anything else opens the list.
         if (singleAccountKey && !hasAnyTokens && !hasAnyAccountsWithStaking) {
@@ -93,9 +97,7 @@ export const AssetItem = memo(({ cryptoCurrencySymbol }: AssetItemProps) => {
                     <FiatAmount symbol={cryptoCurrencySymbol} />
                 )
             }
-            secondaryValue={
-                hasAnyFailedAccount ? undefined : <CryptoAmount symbol={cryptoCurrencySymbol} />
-            }
+            secondaryValue={secondaryValue}
         />
     );
 });

--- a/suite-native/assets/src/components/AssetItemStakingBadge.tsx
+++ b/suite-native/assets/src/components/AssetItemStakingBadge.tsx
@@ -1,10 +1,11 @@
 import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { StakingBadge } from '@suite-native/accounts';
+import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
+import { StakingBadge, ZeroApyBadge } from '@suite-native/accounts';
 import {
     type NativeStakingRootState,
+    selectFirstCardanoAccountStakedWithFiveBinaries,
     selectHasAnyDeviceAccountsWithStaking,
 } from '@suite-native/staking';
 
@@ -16,9 +17,16 @@ export const AssetItemStakingBadge = memo(({ symbol }: AssetItemStakingBadgeProp
     const hasAnyAccountsWithStaking = useSelector((state: NativeStakingRootState) =>
         selectHasAnyDeviceAccountsWithStaking(state, symbol),
     );
+    const stakedWithFiveBinariesAccount = useSelector((state: NativeStakingRootState) =>
+        selectFirstCardanoAccountStakedWithFiveBinaries(state),
+    );
 
     if (!hasAnyAccountsWithStaking) {
         return null;
+    }
+
+    if (getNetworkType(symbol) === 'cardano' && stakedWithFiveBinariesAccount) {
+        return <ZeroApyBadge />;
     }
 
     return <StakingBadge networkSymbol={symbol} />;

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3542,6 +3542,7 @@ export const messages = {
         apy: 'Annual Percentage Yield',
         apr: 'Annual Percentage Return',
         apyAbbr: 'APY',
+        apyValueWithLabel: '{value} APY',
         aprAbbr: 'APR',
         tron: {
             votes: 'Votes',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -204,7 +204,6 @@ export const messages = {
     accountList: {
         numberOfTokens: '+{numberOfTokens, plural, one{1 Token} other{# Tokens}}',
         staking: 'Staking',
-        rewardsReduced: 'Rewards reduced',
         stakingDisabled: 'Staking is currently unavailable.',
     },
     assets: {
@@ -3560,9 +3559,6 @@ export const messages = {
         },
         stakingCanBeManaged: 'Manage your staking accounts in the',
         trezorDesktop: 'Trezor Suite desktop app.',
-        infoBanner: {
-            rewardsReduced: 'Cardano staking rewards reduced',
-        },
         notAvailable: 'Not available',
         apyNotAvailable: 'APY not available',
         apyPercentage: '~{apy}% APY',
@@ -3585,6 +3581,7 @@ export const messages = {
             upToApr: 'up to {value}% APR',
             upToRate: 'up to {value}% Rate',
         },
+        zeroApyBadge: '0% APY',
         messageSystem: {
             depositDisabled: 'Deposits currently disabled.',
             withdrawDisabled: 'Withdrawals currently disabled.',

--- a/suite-native/module-earn/src/components/ApyValue.tsx
+++ b/suite-native/module-earn/src/components/ApyValue.tsx
@@ -3,12 +3,28 @@ import { Translation } from '@suite-native/intl';
 
 type ApyValueProps = {
     apy: number | null | undefined;
+    isNotEarning?: boolean;
+    withLabel?: boolean;
 };
 
-export const ApyValue = ({ apy }: ApyValueProps) => {
+const getApyValue = ({ apy, isNotEarning }: Pick<ApyValueProps, 'apy' | 'isNotEarning'>) => {
+    if (isNotEarning) {
+        return <>0%</>;
+    }
+
     if (!isApyAvailable(apy)) {
         return <Translation id="earn.notAvailableShort" />;
     }
 
     return <>{`~${apy}%`}</>;
+};
+
+export const ApyValue = ({ apy, isNotEarning = false, withLabel = false }: ApyValueProps) => {
+    const value = getApyValue({ apy, isNotEarning });
+
+    if (!withLabel) {
+        return value;
+    }
+
+    return <Translation id="earn.apyValueWithLabel" values={{ value }} />;
 };

--- a/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
+++ b/suite-native/module-earn/src/components/CardanoStakingInfoBanner.tsx
@@ -30,7 +30,7 @@ export const CardanoStakingInfoBanner = ({ accountKey }: CardanoStakingInfoBanne
         return (
             <BannerFull
                 testID="@staking/cardano-not-earning-banner"
-                intent="info"
+                intent="warning"
                 title={
                     <Translation id="earn.stakingManagementScreen.cardanoNotEarningBanner.title" />
                 }

--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -8,6 +8,7 @@ import {
 } from '@suite-common/earn-staking-api';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { isApyAvailable, isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import { ZeroApyBadge } from '@suite-native/accounts';
 import { Text } from '@suite-native/atoms';
 import { TokenIcon } from '@suite-native/icons';
 import { Translation, selectSupportedLanguageLocale } from '@suite-native/intl';
@@ -16,11 +17,13 @@ import {
     selectCanClaimByAccountKey,
     selectClaimableAmountByAccountKey,
     selectIsCardanoStakedOutsideEverstake,
+    selectIsCardanoStakedWithFiveBinaries,
     selectTronAvailableVotingPowerByAccountKey,
     selectTronVotesByAccountKey,
     useSelector as useStakingSelector,
 } from '@suite-native/staking';
 
+import { ApyValue } from './ApyValue';
 import { EarnAccountCardLayout } from './EarnAccountCardLayout';
 import { EarnClaimAlert } from './EarnClaimAlert';
 import { EarnTronVotingAlert } from './EarnTronVotingAlert';
@@ -75,6 +78,10 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
         selectIsCardanoStakedOutsideEverstake(state, item.accountKey),
     );
 
+    const isStakedWithFiveBinaries = useStakingSelector(state =>
+        selectIsCardanoStakedWithFiveBinaries(state, item.accountKey),
+    );
+
     const canClaim = useStakingSelector(state =>
         isSupportedStaking ? selectCanClaimByAccountKey(state, item.accountKey) : false,
     );
@@ -92,6 +99,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
         isStakingItem && item.symbol === 'trx' && availableTronVotingPower !== '0';
 
     const contractAddress = isDefiYieldItem ? item.tokenContractAddress : undefined;
+
     const secondaryDescription = isDefiYieldItem
         ? item.accountLabel || getNetworkDisplaySymbolName(item.networkSymbol)
         : null;
@@ -118,10 +126,13 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
             }
             value={<Text variant="body-md">{formatEarnActiveItemBalance({ item, locale })}</Text>}
             valueDescription={
-                (isAdaStakedOutsideEverstake || apyValue != null) && (
+                (isAdaStakedOutsideEverstake || apyValue != null) &&
+                (isStakedWithFiveBinaries ? (
+                    <ZeroApyBadge />
+                ) : (
                     <Text variant="body-sm" color="contentSecondary">
                         {isAdaStakedOutsideEverstake || !isApyAvailable(apyValue) ? (
-                            <Translation id="earn.notAvailableShort" />
+                            <ApyValue apy={null} withLabel />
                         ) : (
                             <>
                                 {item.type === 'staking' ? (
@@ -142,7 +153,7 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
                             </>
                         )}
                     </Text>
-                )
+                ))
             }
             alerts={
                 <>

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useMemo } from 'react';
+import { useStore } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type BaseCurrencyAmount } from '@suite-common/wallet-types';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
@@ -32,6 +34,8 @@ import { StablecoinYieldClaimRewardsBottomSheet } from './StablecoinYieldClaimRe
 import { StablecoinYieldClaimRewardsCardSection } from './StablecoinYieldClaimRewardsCardSection';
 import { useEarnDepositsCardData } from '../hooks/useEarnDepositsCardData';
 import { useStablecoinYieldFirmwareUpdateAlert } from '../hooks/useStablecoinYieldFirmwareUpdateAlert';
+import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
+import { useStakingNavigateAnalytics } from '../hooks/useStakingNavigateAnalytics';
 import {
     type StablecoinYieldClaimSummary,
     type StablecoinYieldEarnItem,
@@ -79,6 +83,9 @@ export const EarnDepositsCard = ({
         stakingActiveItems,
         stablecoinYieldActiveItems,
     });
+    const reportStakingNavigate = useStakingNavigateAnalytics();
+    const store = useStore<AccountsRootState>();
+    const { navigateToStakingDetail } = useStakingDetailNavigation();
     const { isFirmwareSupported, showFirmwareUpdateAlert } =
         useStablecoinYieldFirmwareUpdateAlert();
     const {
@@ -131,6 +138,29 @@ export const EarnDepositsCard = ({
         },
         [analytics, navigation],
     );
+
+    const handleStakingRowPress = useCallback(() => {
+        const activeItems = stakingRow?.activeItems ?? [];
+
+        if (activeItems.length === 1) {
+            const onlyItem = activeItems[0];
+
+            if (onlyItem?.type === 'staking') {
+                const account = selectAccountByKey(store.getState(), onlyItem.accountKey);
+                if (account) {
+                    reportStakingNavigate(account);
+                }
+                navigateToStakingDetail({
+                    accountKey: onlyItem.accountKey,
+                    symbol: onlyItem.symbol,
+                });
+            }
+
+            return;
+        }
+
+        openStakingSheet();
+    }, [navigateToStakingDetail, openStakingSheet, reportStakingNavigate, stakingRow, store]);
 
     const handleStablecoinYieldClaimRewardsPress = useCallback(() => {
         if (!isFirmwareSupported('claim')) {
@@ -213,7 +243,7 @@ export const EarnDepositsCard = ({
                         <EarnDepositsCardRow
                             key={stakingRow.type}
                             row={stakingRow}
-                            onPress={openStakingSheet}
+                            onPress={handleStakingRowPress}
                         />
                     )}
 

--- a/suite-native/module-earn/src/components/FiveBinariesHomeBanner.tsx
+++ b/suite-native/module-earn/src/components/FiveBinariesHomeBanner.tsx
@@ -2,31 +2,24 @@ import { useSelector } from 'react-redux';
 
 import type { DeviceRootState } from '@suite-common/device';
 import { type AccountsRootState } from '@suite-common/wallet-core';
-import { BannerInline } from '@suite-native/atoms';
+import { BannerFull } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { useOpenLink } from '@suite-native/link';
 import { selectFirstCardanoAccountStakedWithFiveBinaries } from '@suite-native/staking';
-import { HELP_CENTER_ADA_STAKING } from '@trezor/urls';
 
 export const FiveBinariesHomeBanner = () => {
-    const openLink = useOpenLink();
-
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>
         selectFirstCardanoAccountStakedWithFiveBinaries(state),
     );
 
     if (!account) return null;
 
-    const handleButtonPress = () => {
-        openLink(`${HELP_CENTER_ADA_STAKING}#migrating-staking-pools`);
-    };
-
     return (
-        <BannerInline
+        <BannerFull
             intent="warning"
-            title={<Translation id="earn.infoBanner.rewardsReduced" />}
-            buttonLabel={<Translation id="generic.buttons.learnMore" />}
-            onButtonPress={handleButtonPress}
+            title={<Translation id="earn.stakingManagementScreen.cardanoNotEarningBanner.title" />}
+            description={
+                <Translation id="earn.stakingManagementScreen.cardanoNotEarningBanner.description" />
+            }
         />
     );
 };

--- a/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
+++ b/suite-native/module-earn/src/components/StakingManagementStakedCard.tsx
@@ -238,8 +238,11 @@ export const StakingManagementStakedCard = ({
                     })}
                 >
                     <Text variant="body-sm">
-                        {(isCardanoStaking || apy != null) && 'APY '}
-                        {isNotEarning ? '0%' : <ApyValue apy={apy} />}
+                        <ApyValue
+                            apy={apy}
+                            isNotEarning={isNotEarning}
+                            withLabel={isCardanoStaking || apy != null}
+                        />
                     </Text>
                     {rewardsFrequencyInDays !== null ? (
                         <Text variant="body-sm">


### PR DESCRIPTION
## Description

Adds a 0% APY badge for Cardano accounts staked with FiveBinaries, since the pool currently pays no rewards. Also extracts a shared `useNavigateToStakingDetailWithAnalytics` hook to avoid duplicating staking-navigation logic.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30638

## Screenshots:
<img width="369" height="287" alt="Screenshot 2026-08-09 at 11 11 20" src="https://github.com/user-attachments/assets/f543cbd7-3b2c-44e5-83e3-a530c8f51e8a" />
<img width="367" height="269" alt="Screenshot 2026-08-10 at 08 41 13" src="https://github.com/user-attachments/assets/6a5f1668-b7df-4efb-9a94-ec53fd77fdf0" />
<img width="367" height="546" alt="Screenshot 2026-08-07 at 15 10 43" src="https://github.com/user-attachments/assets/9a3c850a-efcc-468b-8236-b7fea19627db" />
<img width="371" height="611" alt="Screenshot 2026-08-07 at 15 11 09" src="https://github.com/user-attachments/assets/8183e0e7-c4de-4482-ab00-d07372eb1296" />
<img width="1290" height="1183" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-07 at 15 19 09" src="https://github.com/user-attachments/assets/091a2381-3ccf-4be1-8da6-310066021522" />
