### PR TITLE
refactor(redux): narrow remaining common vanilla thunk state

### DIFF
--- a/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsThunks.ts
@@ -7,7 +7,11 @@ import { asCoinSymbol } from '@trezor/connect-common';
 
 import { changeNetworks, setBitcoinAmountUnits } from './walletSettingsActions';
 import { WALLET_SETTINGS } from './walletSettingsConstants';
-import { selectBitcoinAmountUnit, selectEnabledNetworks } from './walletSettingsReducer';
+import {
+    type WalletSettingsRootState,
+    selectBitcoinAmountUnit,
+    selectEnabledNetworks,
+} from './walletSettingsReducer';
 import { accountsActions } from '../accounts/accountsActions';
 import { type WalletCoreCompoundRootState, selectAccountsToBeForgotten } from '../selectors';
 
@@ -57,13 +61,16 @@ export const changeCoinVisibility = createThunk<
     },
 );
 
-export const toggleBitcoinAmountUnits = () => (dispatch: Dispatch, getState: () => any) => {
-    const currentUnits = selectBitcoinAmountUnit(getState());
+type ToggleBitcoinAmountUnitsThunkState = WalletSettingsRootState;
 
-    const nextUnits =
-        currentUnits === PROTO.AmountUnit.BITCOIN
-            ? PROTO.AmountUnit.SATOSHI
-            : PROTO.AmountUnit.BITCOIN;
+export const toggleBitcoinAmountUnits =
+    () => (dispatch: Dispatch, getState: () => ToggleBitcoinAmountUnitsThunkState) => {
+        const currentUnits = selectBitcoinAmountUnit(getState());
 
-    dispatch(setBitcoinAmountUnits(nextUnits));
-};
+        const nextUnits =
+            currentUnits === PROTO.AmountUnit.BITCOIN
+                ? PROTO.AmountUnit.SATOSHI
+                : PROTO.AmountUnit.BITCOIN;
+
+        dispatch(setBitcoinAmountUnits(nextUnits));
+    };


### PR DESCRIPTION
## Description

The final Suite Common or Suite Native vanilla thunk with a global state annotation was toggleBitcoinAmountUnits, whose getState returned any despite reading only wallet settings. It now declares a named WalletSettingsRootState-based contract. A syntax-level inventory confirmed that Suite Native has no remaining production vanilla thunks to migrate.

- Remaining Suite Common/Native vanilla thunks migrated: **1 → 0**
- Explicit any state annotations in vanilla thunks: **1 → 0**
- Suite Native vanilla migrations required: **0**
- Validation: wallet-core type-check, JavaScript lint, formatting, and diff checks

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-common-native-vanilla-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-common-native-vanilla-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-common-native-vanilla-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-common-native-vanilla-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-common-native-vanilla-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:26:25.977Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:23:32.271Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad wallet settings thunk module referenced by 135 tests, so we apply extra scrutiny and select only tests whose described behavior directly depends on changing or persisting wallet settings. The recommended set focuses on settings mutation, backend/network configuration, theme/locale autodetect, and settings migration, which are the most likely paths to regress if wallet settings thunk logic changed.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/wallet-core/src/settings/walletSettingsThunks.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/settings/autodetect.test.ts` — Directly exercises theme and locale autodetect settings that are dispatched through wallet settings thunks; a regression here would be immediately visible in onboarding UI appearance.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configures custom blockbook backends and network activation, which are core wallet settings persisted and applied via wallet settings thunks.
- `suite/e2e/tests/settings/coins.test.ts` — Enables/disables coin networks and configures custom backends through the Coins settings page, directly invoking the wallet settings thunks.
- `suite/e2e/tests/settings/general.test.ts` — Changes fiat currency, theme, language, and analytics toggle and verifies the resulting analytics events; these settings are precisely the domain of walletSettingsThunks.
- `suite/e2e/tests/suite/db-migration.test.ts` — Validates persistence and migration of a wallet setting (auto-eject) across Suite versions; this directly depends on wallet settings storage and thunk behavior.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Changes multiple application settings and asserts the resulting analytics payload; while the focus is analytics, it relies on wallet settings thunks applying the changes correctly.
- `suite/e2e/tests/settings/forget-device.test.ts` — Exercises the auto-eject wallet setting and device state transitions after discovery; relevant because auto-eject is managed by wallet settings thunks.

</details>

_Updated: 2026-08-07T16:25:55.688Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->