### PR TITLE
fix(connect): scope popup cancellation by callId

### DIFF
--- a/suite-common/connect-popup/src/connectPopupActions.ts
+++ b/suite-common/connect-popup/src/connectPopupActions.ts
@@ -13,7 +13,7 @@ const ACTION_PREFIX = '@suite-common/connect-popup';
 
 type InitiateCallPayload = Pick<
     ConnectPopupCall & { state: 'ongoing' },
-    'method' | 'methodInfo' | 'source' | 'payload'
+    'method' | 'methodInfo' | 'source' | 'payload' | 'callId'
 >;
 
 const initiateCall = createAction(

--- a/suite-common/connect-popup/src/connectPopupCancelThunk.test.ts
+++ b/suite-common/connect-popup/src/connectPopupCancelThunk.test.ts
@@ -1,0 +1,84 @@
+import { deviceActions } from '@suite-common/device';
+import { configureMockStore } from '@suite-common/test-utils';
+import TrezorConnect from '@trezor/connect';
+
+import { connectPopupActions } from './connectPopupActions';
+import { connectPopupCancelThunk } from './connectPopupThunks';
+import { CALL_SOURCE_WEB, type ConnectPopupCall } from './connectPopupTypes';
+
+type ActiveCallFixture = ConnectPopupCall & { callId?: string };
+
+const createActiveCall = (callId?: string): ActiveCallFixture => ({
+    state: 'ongoing',
+    method: 'getAddress',
+    payload: {},
+    methodInfo: { methodTitle: '', permissionTypes: [], useUi: true },
+    source: {
+        type: CALL_SOURCE_WEB,
+        origin: 'https://example.com',
+        manifest: { appName: 'Test app' },
+    },
+    callId,
+});
+
+const createStore = (activeCall: ActiveCallFixture) =>
+    configureMockStore({
+        preloadedState: { connectPopup: { activeCall, permissions: [] } },
+    });
+
+describe('connectPopupCancelThunk', () => {
+    let cancelSpy: jest.SpiedFunction<typeof TrezorConnect.cancel>;
+
+    beforeEach(() => {
+        cancelSpy = jest.spyOn(TrezorConnect, 'cancel').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('forwards a cancel for another call without tearing down the active popup', () => {
+        const store = createStore(createActiveCall('active-id'));
+
+        store.dispatch(connectPopupCancelThunk({ callId: 'other-id' }));
+
+        expect(cancelSpy).toHaveBeenCalledWith({ reason: undefined, callId: 'other-id' });
+        const actions = store.getActions();
+        expect(actions.some(action => action.type === connectPopupActions.setError.type)).toBe(false);
+        expect(
+            actions.some(action => action.type === deviceActions.removeButtonRequests.type),
+        ).toBe(false);
+    });
+
+    it('tears down the active popup when callId matches', () => {
+        const store = createStore(createActiveCall('active-id'));
+
+        store.dispatch(connectPopupCancelThunk({ callId: 'active-id' }));
+
+        expect(cancelSpy).toHaveBeenCalledWith({ reason: undefined, callId: 'active-id' });
+        expect(
+            store
+                .getActions()
+                .some(action => action.type === connectPopupActions.setError.type),
+        ).toBe(true);
+    });
+
+    it('scopes a plain cancel to the active call', () => {
+        const store = createStore(createActiveCall('active-id'));
+
+        store.dispatch(connectPopupCancelThunk({}));
+
+        expect(cancelSpy).toHaveBeenCalledWith({ reason: undefined, callId: 'active-id' });
+    });
+
+    it('preserves full teardown for an active call without callId', () => {
+        const store = createStore(createActiveCall());
+
+        store.dispatch(connectPopupCancelThunk({ callId: 'caller-id' }));
+
+        expect(cancelSpy).toHaveBeenCalledWith({ reason: undefined, callId: 'caller-id' });
+        expect(
+            store
+                .getActions()
+                .some(action => action.type === connectPopupActions.setError.type),
+        ).toBe(true);
+    });
+});

--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -85,6 +85,9 @@ export const connectPopupCallThunkInner = createThunk<
     async ({ source, ...params }, { dispatch, getState, extra }) => {
         try {
             const { method, payload } = compatibilityHooks(params);
+            // Store the caller's token before permissions or device selection so a cancel can be
+            // matched throughout the entire popup flow.
+            const { callId } = payload as { callId?: string };
 
             if (!connectCallableMethods.includes(method)) throw TypedError('Method_Unsupported');
 
@@ -131,6 +134,7 @@ export const connectPopupCallThunkInner = createThunk<
                     },
                     payload,
                     source,
+                    callId,
                 }),
             );
 
@@ -1089,9 +1093,24 @@ export const connectPopupResolveSelectAccountThunk = createThunk<
 
 export const connectPopupCancelThunk = createThunk<void, { error?: string; callId?: string }, void>(
     `${CONNECT_POPUP_MODULE}/cancelThunk`,
-    ({ error, callId }, { dispatch }) => {
+    ({ error, callId }, { dispatch, getState }) => {
+        const activeCall = selectConnectPopupCall(getState());
+
+        // A scoped cancel for another call still needs to reach Core, but must not tear down the
+        // active popup.
+        if (
+            activeCall?.callId !== undefined &&
+            callId !== undefined &&
+            callId !== activeCall.callId
+        ) {
+            TrezorConnect.cancel({ reason: error, callId });
+
+            return;
+        }
+
         getPermissionDeferred().reject(TypedError('Method_Cancel'));
-        TrezorConnect.cancel({ reason: error, callId });
+        // Without a token Core keeps its legacy behavior of aborting every in-flight call.
+        TrezorConnect.cancel({ reason: error, callId: callId ?? activeCall?.callId });
         // todo: probably not needed to call explicitly anymore
         dispatch(deviceActions.removeButtonRequests({}));
 

--- a/suite-common/connect-popup/src/connectPopupTypes.ts
+++ b/suite-common/connect-popup/src/connectPopupTypes.ts
@@ -241,7 +241,13 @@ type ConnectPopupCallError = {
     state: 'error';
     error: ConnectSerializedError;
 };
-export type ConnectPopupCall = ConnectPopupCallLoaded | ConnectPopupCallError;
+
+type ConnectPopupCallMeta = {
+    callId?: string;
+};
+
+export type ConnectPopupCall = (ConnectPopupCallLoaded | ConnectPopupCallError) &
+    ConnectPopupCallMeta;
 
 export type ConnectPopupCallWithState<
     CallState extends ConnectPopupCall['state'],


### PR DESCRIPTION
## Description

Scope connect-popup cancellation to the call that owns the active popup.

The popup receives both window-close events and scoped `CORE_CALL_CANCEL` events. Previously every cancel tore down the active popup, even when its `callId` targeted another in-flight call. A plain cancel also reached Core without a `callId`, invoking the legacy cancel-all behavior.

This change:

- stores the caller-provided `callId` on the active popup call before permissions and device selection;
- forwards cancels for other calls to Core without tearing down the active popup;
- scopes a plain popup cancel to the active call when possible;
- preserves the existing full teardown behavior for calls that do not have a `callId`.

This PR intentionally contains no button-request or device-path changes.

## Notes for QA

Automated tests cover foreign, matching, plain, and unscoped cancel behavior. No UI copy or visual changes.

Checks run:

- `yarn workspace @suite-common/connect-popup test:unit --coverage=0` (42 tests passed)
- `yarn workspace @suite-common/connect-popup lint:js`
- `git diff --check`

## Related Issue

N/A

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the Connect popup permission/cancellation layer. Most mapped tests only transitively import these files, so the minimal high-confidence set is the trezor-connect tests that actually exercise permission grants, cancellation, and remembered permissions. Run those first; add the silent-mode and upfront-permissions tests if broader Connect-popup regression coverage is needed.

<details><summary><b>Changed files (4)</b></summary>

- `suite-common/connect-popup/src/connectPopupActions.ts`
- `suite-common/connect-popup/src/connectPopupCancelThunk.test.ts`
- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/connectPopupTypes.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises Connect popup permission grants, address confirmation, and multiple cancellation paths (user-cancel, TrezorConnect.cancel, popup close). These flows are implemented by connectPopupActions/connectPopupThunks and shaped by connectPopupTypes.
- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Covers the same permission, address export, and cancellation flows as the web test but through a webextension context, exercising the shared connect-popup thunks and cancellation behavior in a different host environment.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Specifically tests granting, remembering, listing, and forgetting Connect app permissions, which is the core state managed by connectPopupActions/connectPopupThunks and defined by connectPopupTypes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Verifies the silent-mode permission option and connectPopup.permissions state behavior; changes to permission thunks or types could affect whether silent mode is stored and honored.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Tests TrezorConnect.init with requestedPermissions and the resulting batched consent modal, which depends on how connectPopupTypes model permissions and how thunks present/approve them.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/connect-popup/src/connectPopupCancelThunk.test.ts`

_Updated: 2026-08-07T16:22:36.782Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/agent/scope-connect-popup-cancel-by-call-id/web/](https://dev.suite.sldev.cz/suite-web/agent/scope-connect-popup-cancel-by-call-id/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=agent/scope-connect-popup-cancel-by-call-id&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=agent/scope-connect-popup-cancel-by-call-id&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=agent/scope-connect-popup-cancel-by-call-id&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:25:09.518Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:24:58.189Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->