### PR TITLE
refactor(redux): finish wallet-core foundation thunk contracts

### DIFF
--- a/suite-common/wallet-core/src/device/entropyCheckThunks.ts
+++ b/suite-common/wallet-core/src/device/entropyCheckThunks.ts
@@ -44,8 +44,13 @@ type ProcessEntropyCheckResultThunkParams = {
     device: AcquiredDevice;
     result: Awaited<ReturnType<typeof TrezorConnect.resetDevice>>;
 };
+type ProcessEntropyCheckResultThunkDeps = FailEntropyCheckThunkDeps;
 
-export const processEntropyCheckResultThunk = createThunk(
+export const processEntropyCheckResultThunk = createThunk<
+    void,
+    ProcessEntropyCheckResultThunkParams,
+    { extra: ProcessEntropyCheckResultThunkDeps }
+>(
     `${DEVICE_MODULE_PREFIX}/processEntropyCheckResultThunk`,
     ({ device, result }: ProcessEntropyCheckResultThunkParams, { dispatch }) => {
         if (result.success) {

--- a/suite-common/wallet-core/src/discovery/discoveryThunks.ts
+++ b/suite-common/wallet-core/src/discovery/discoveryThunks.ts
@@ -618,8 +618,8 @@ type StartDiscoveryThunkParams = {
     isAddingExistingWallet?: boolean;
     useScopedCallIds?: boolean;
 };
-type StartDiscoveryThunkState = RunDiscoveryThunkState;
-type StartDiscoveryThunkDeps = {
+export type StartDiscoveryThunkState = RunDiscoveryThunkState;
+export type StartDiscoveryThunkDeps = {
     services: AnalyticsDep & GetTradedAccountKeysDep;
     thunks: FetchAndSaveMetadataDep;
 };

--- a/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
+++ b/suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts
@@ -10,6 +10,8 @@ import { DISCOVERY_MODULE_PREFIX, discoveryActions } from './discoveryActions';
 import { isDiscoveryInProgress, selectDiscoveryByDevicePath } from './discoverySelectors';
 import {
     type RunDiscoveryThunkState,
+    type StartDiscoveryThunkDeps,
+    type StartDiscoveryThunkState,
     runDiscoveryThunk,
     startDiscoveryThunk,
 } from './discoveryThunks';
@@ -112,18 +114,31 @@ const startDiscoveryOfExistingPassphraseWalletThunk = createThunk<
 // AddWalletButton and the retry paths (PassphraseDuplicate / Mismatch / IsNotExist
 // modals), which restart the flow. New hidden wallet: only sets state (PassphraseModal
 // runs it later); existing hidden / standard wallet: starts the discovery right away.
-export const startAddWalletDiscoveryThunk = createThunk(
+type StartAddWalletDiscoveryThunkParams = {
+    device: TrezorDevice;
+    isAddingHiddenWallet?: boolean;
+    isAddingExistingWallet?: boolean;
+};
+type StartAddWalletDiscoveryThunkState = StartDiscoveryOfExistingPassphraseWalletThunkState &
+    StartDiscoveryThunkState;
+type StartAddWalletDiscoveryThunkDeps = StartDiscoveryOfExistingPassphraseWalletThunkDeps &
+    StartDiscoveryThunkDeps;
+
+export const startAddWalletDiscoveryThunk = createThunk<
+    void,
+    StartAddWalletDiscoveryThunkParams,
+    {
+        state: StartAddWalletDiscoveryThunkState;
+        extra: StartAddWalletDiscoveryThunkDeps;
+    }
+>(
     `${DISCOVERY_MODULE_PREFIX}/startAddWalletDiscovery`,
     (
         {
             device,
             isAddingHiddenWallet,
             isAddingExistingWallet,
-        }: {
-            device: TrezorDevice;
-            isAddingHiddenWallet?: boolean;
-            isAddingExistingWallet?: boolean;
-        },
+        }: StartAddWalletDiscoveryThunkParams,
         { dispatch },
     ): void => {
         if (isAddingHiddenWallet && isAddingExistingWallet) {


### PR DESCRIPTION
## Description

The wallet-core foundation domains had two remaining createThunk declarations that still inherited the global state and dependency defaults. processEntropyCheckResultThunk now composes the report-security child dependency, while startAddWalletDiscoveryThunk composes the state and dependencies of both discovery paths it may dispatch. The child discovery contracts are exported for direct reuse instead of repeating their structure.

- Foundation createThunk declarations with explicit contracts: **52/54 → 54/54**
- Global-default foundation declarations: **2 → 0**
- Foundation domains completed: **accounts, blockchain, device, discovery, explorer, fiat rates, settings, token management, and UI events**
- Out-of-scope non-explicit declarations remaining: **8**, all in the later earn/staking batch
- Validation: wallet-core type-check, JavaScript lint, formatting, post-rebase inventory, and diff checks

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch three core wallet-core thunks: entropy check, discovery, and passphrase wallet management. The highest-risk paths are entropy-check failure handling during T2T1 onboarding, multi-coin discovery completion/reload recovery, and passphrase wallet add/eject/switch flows. Run the focused high tests for these behaviors plus a small set of medium tests covering backend discovery and passphrase wallet edge cases.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/wallet-core/src/device/entropyCheckThunks.ts`
- `suite-common/wallet-core/src/discovery/discoveryThunks.ts`
- `suite-common/wallet-core/src/discovery/passphraseWalletThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t2t1/t2t1-entropy-check-failure.test.ts` — This test directly simulates entropy-check failures during T2T1 wallet creation and asserts the resulting device-compromised modal and error-toast behavior. Any change to entropyCheckThunks is highly likely to affect these outcomes.
- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — The duplicate-passphrase warning is produced by the passphrase wallet creation flow. Changes to passphraseWalletThunks could alter when duplicate detection fires or how wallet state is stored.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Adding, ejecting, and re-adding hidden wallets exercises the passphrase wallet lifecycle and ID numbering logic implemented in passphraseWalletThunks.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This test covers adding hidden wallets, switching between them, and address discovery for passphrase wallets, which directly depends on passphraseWalletThunks.
- `suite/e2e/tests/wallet/discovery.test.ts` — The test asserts discovery state transitions, multi-coin discovery, and recovery after a page reload, which are the core responsibilities of discoveryThunks.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/general/wallet-discovery.test.ts` — Ejecting a wallet and discovering a standard wallet after ejection uses the discovery flow; a regression in discoveryThunks could prevent the new wallet from being discovered.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This test adds and switches between standard and multiple passphrase wallets, relying on passphrase wallet state management; it also verifies sync behavior across wallets.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — Hidden wallet creation plus Cardano account discovery and address verification share the passphrase wallet thunk infrastructure, so a regression could surface here.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — After device reconnect, passphrase wallet caching and re-verification depend on stable passphrase wallet state managed by passphraseWalletThunks.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — Discovery against a custom Blockbook backend is a variant of the discovery flow; changes to discoveryThunks could affect whether discovery completes with custom backends.

</details>

_Updated: 2026-08-07T16:26:58.719Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-wallet-core-foundation-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-wallet-core-foundation-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-wallet-core-foundation-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-wallet-core-foundation-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-wallet-core-foundation-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:28:57.555Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T16:28:05.397Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->