### PR TITLE
refactor(wallet-core): type earn thunk contracts

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts
@@ -219,9 +219,9 @@ export const handleYieldApproveSuccessTxidThunk = createThunk<
     },
 );
 
-export const handleYieldApproveCancelThunk = createThunk(
+export const handleYieldApproveCancelThunk = createThunk<void, YieldSessionPayload, void>(
     `${YIELD_THUNK_PREFIX}/handleApproveCancel`,
-    ({ flowKey, flowType }: YieldSessionPayload, { dispatch }) => {
+    ({ flowKey, flowType }, { dispatch }) => {
         dispatch(stablecoinYieldActions.closeApprovalModal({ flowType, flowKey }));
     },
 );
@@ -330,9 +330,9 @@ export const submitYieldRevokeThunk = createThunk<
     },
 );
 
-export const submitYieldApproveThunk = createThunk(
+export const submitYieldApproveThunk = createThunk<void, SubmitYieldApprovePayload, void>(
     `${YIELD_THUNK_PREFIX}/submitApprove`,
-    async ({ flowKey, flowType, flowData, amount }: SubmitYieldApprovePayload, { dispatch }) => {
+    async ({ flowKey, flowType, flowData, amount }, { dispatch }) => {
         const requestAmount = getApprovalRequestAmount({
             flowType,
             amount,

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -80,17 +80,20 @@ export const initStakeDataThunk = createThunk<void, void, { state: InitStakeData
 
 let stakeDataTimeout: TimerId | null = null;
 
-export const periodicCheckStakeDataThunk = createThunk(
-    `${STAKE_MODULE}/periodicCheckStakeDataThunk`,
-    (_, { dispatch }) => {
-        if (stakeDataTimeout) {
-            clearTimeout(stakeDataTimeout);
-        }
+type PeriodicCheckStakeDataThunkState = InitStakeDataThunkState;
 
-        stakeDataTimeout = setTimeout(() => {
-            dispatch(periodicCheckStakeDataThunk());
-        }, 60_000);
+export const periodicCheckStakeDataThunk = createThunk<
+    unknown,
+    void,
+    { state: PeriodicCheckStakeDataThunkState }
+>(`${STAKE_MODULE}/periodicCheckStakeDataThunk`, (_, { dispatch }) => {
+    if (stakeDataTimeout) {
+        clearTimeout(stakeDataTimeout);
+    }
 
-        return dispatch(initStakeDataThunk());
-    },
-);
+    stakeDataTimeout = setTimeout(() => {
+        dispatch(periodicCheckStakeDataThunk());
+    }, 60_000);
+
+    return dispatch(initStakeDataThunk());
+});

--- a/suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts
@@ -12,7 +12,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { buildClaimContract, buildClaimReviewForm } from './claimContract';
 import { type ClaimThunkArguments, composeTronClaimFeeLevelsThunk } from './composeClaim';
-import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import {
+    type AddFakePendingTronTxThunkState,
+    addFakePendingTronTxThunk,
+} from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
 import { signTronContract } from '../../shared/signTronContract';
 import { tronStakeActions } from '../../tronStakeReducer';
@@ -25,7 +28,13 @@ interface SubmitClaimThunkArguments extends ClaimThunkArguments {
     onSettled?: () => void;
 }
 
-export const submitTronClaimThunk = createThunk<void, SubmitClaimThunkArguments>(
+type SubmitTronClaimThunkState = AddFakePendingTronTxThunkState;
+
+export const submitTronClaimThunk = createThunk<
+    void,
+    SubmitClaimThunkArguments,
+    { state: SubmitTronClaimThunkState }
+>(
     `${TRON_STAKE_MODULE}/submitTronClaimThunk`,
     async ({ account, device, requestPushApproval, onSigningStart, onSettled }, { dispatch }) => {
         const { key: accountKey } = account;

--- a/suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts
@@ -8,7 +8,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { type FreezeThunkArguments, composeTronFreezeFeeLevelsThunk } from './composeFreeze';
 import { buildFreezeContract, buildFreezeReviewForm } from './freezeContract';
-import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import {
+    type AddFakePendingTronTxThunkState,
+    addFakePendingTronTxThunk,
+} from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
 import { signTronContract } from '../../shared/signTronContract';
 import { tronStakeActions } from '../../tronStakeReducer';
@@ -21,7 +24,13 @@ interface SubmitFreezeThunkArguments extends FreezeThunkArguments {
     onSettled?: () => void;
 }
 
-export const submitTronFreezeThunk = createThunk<void, SubmitFreezeThunkArguments>(
+type SubmitTronFreezeThunkState = AddFakePendingTronTxThunkState;
+
+export const submitTronFreezeThunk = createThunk<
+    void,
+    SubmitFreezeThunkArguments,
+    { state: SubmitTronFreezeThunkState }
+>(
     `${TRON_STAKE_MODULE}/submitTronFreezeThunk`,
     async (
         { account, device, amount, resourceType, requestPushApproval, onSigningStart, onSettled },

--- a/suite-common/wallet-core/src/stake/tron/actions/unstake/submitUnstake.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/unstake/submitUnstake.ts
@@ -8,7 +8,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { type UnstakeThunkArguments, composeTronUnstakeFeeLevelsThunk } from './composeUnstake';
 import { buildUnstakeContract, buildUnstakeReviewForm } from './unstakeContract';
-import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import {
+    type AddFakePendingTronTxThunkState,
+    addFakePendingTronTxThunk,
+} from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
 import { signTronContract } from '../../shared/signTronContract';
 import { tronStakeActions } from '../../tronStakeReducer';
@@ -21,7 +24,13 @@ interface SubmitUnstakeThunkArguments extends UnstakeThunkArguments {
     onSettled?: () => void;
 }
 
-export const submitTronUnstakeThunk = createThunk<void, SubmitUnstakeThunkArguments>(
+type SubmitTronUnstakeThunkState = AddFakePendingTronTxThunkState;
+
+export const submitTronUnstakeThunk = createThunk<
+    void,
+    SubmitUnstakeThunkArguments,
+    { state: SubmitTronUnstakeThunkState }
+>(
     `${TRON_STAKE_MODULE}/submitTronUnstakeThunk`,
     async (
         { account, device, amount, resourceType, requestPushApproval, onSigningStart, onSettled },

--- a/suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts
@@ -6,7 +6,10 @@ import { asCoinSymbol } from '@trezor/connect-common';
 
 import { type VoteThunkArguments, composeTronVoteFeeLevelsThunk } from './composeVote';
 import { buildVoteContract, buildVoteReviewForm, getTotalVotes } from './voteContract';
-import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import {
+    type AddFakePendingTronTxThunkState,
+    addFakePendingTronTxThunk,
+} from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
 import { reportTronStakeTxId } from '../../shared/reportTronStakeTxId';
 import { signTronContract } from '../../shared/signTronContract';
@@ -22,7 +25,13 @@ interface SubmitVoteThunkArguments extends VoteThunkArguments {
     onSettled?: () => void;
 }
 
-export const submitTronVoteThunk = createThunk<void, SubmitVoteThunkArguments>(
+type SubmitTronVoteThunkState = AddFakePendingTronTxThunkState;
+
+export const submitTronVoteThunk = createThunk<
+    void,
+    SubmitVoteThunkArguments,
+    { state: SubmitTronVoteThunkState }
+>(
     `${TRON_STAKE_MODULE}/submitTronVoteThunk`,
     async (
         {

--- a/suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts
+++ b/suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts
@@ -12,7 +12,10 @@ import { BigNumber } from '@trezor/utils';
 
 import { type WithdrawThunkArguments, composeTronWithdrawFeeLevelsThunk } from './composeWithdraw';
 import { buildWithdrawContract, buildWithdrawReviewForm } from './withdrawContract';
-import { addFakePendingTronTxThunk } from '../../../../transactions/transactionsThunks';
+import {
+    type AddFakePendingTronTxThunkState,
+    addFakePendingTronTxThunk,
+} from '../../../../transactions/transactionsThunks';
 import { TRON_STAKE_MODULE } from '../../shared/constants';
 import { signTronContract } from '../../shared/signTronContract';
 import { tronStakeActions } from '../../tronStakeReducer';
@@ -25,7 +28,13 @@ interface SubmitWithdrawThunkArguments extends WithdrawThunkArguments {
     onSettled?: () => void;
 }
 
-export const submitTronWithdrawThunk = createThunk<void, SubmitWithdrawThunkArguments>(
+type SubmitTronWithdrawThunkState = AddFakePendingTronTxThunkState;
+
+export const submitTronWithdrawThunk = createThunk<
+    void,
+    SubmitWithdrawThunkArguments,
+    { state: SubmitTronWithdrawThunkState }
+>(
     `${TRON_STAKE_MODULE}/submitTronWithdrawThunk`,
     async ({ account, device, requestPushApproval, onSigningStart, onSettled }, { dispatch }) => {
         const { key: accountKey } = account;

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -498,7 +498,7 @@ interface AddFakePendingTronTxThunkParams {
     target?: { addresses: string[]; amount: string };
     tronSpecific?: WalletAccountTransaction['tronSpecific'];
 }
-type AddFakePendingTronTxThunkState = BlockchainRootState & FeesRootState;
+export type AddFakePendingTronTxThunkState = BlockchainRootState & FeesRootState;
 
 export const addFakePendingTronTxThunk = createThunk<
     void,


### PR DESCRIPTION
## Description

Gives every wallet-core earn-flow RTK thunk an explicit state/dependency contract. Dependency-free stablecoin approval handlers use `void`, while periodic staking and Tron submit thunks compose the minimal state required by their child thunks. All 23 production earn-flow `createThunk` declarations now have an explicit third generic.

Validation: wallet-core type-check passed; targeted ESLint passed for all 8 changed files; 14 focused staking and stablecoin-yield tests passed.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect staking flows, stablecoin-yield token approvals, general transaction thunks, and Tron staking actions. The highest user-visible risk lies in ETH/ADA/SOL staking and DEX token approvals, so run the core per-chain staking tests plus the LI.FI approval test. The Tron staking action files have no dedicated E2E coverage in the analyzed test suite and should be validated separately.

<details><summary><b>Changed files (8)</b></summary>

- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldApprovalThunks.ts`
- `suite-common/wallet-core/src/stake/stakeThunks.ts`
- `suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts`
- `suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts`
- `suite-common/wallet-core/src/stake/tron/actions/unstake/submitUnstake.ts`
- `suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts`
- `suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — Completes the full Cardano staking flow including transaction submission and device confirmation, directly exercising stakeThunks and transactionsThunks.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — First-time Ethereum staking test submits a staking transaction and verifies pending/confirmed/activated states, directly exercising stakeThunks and transaction handling.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — First-time Solana staking test submits a staking transaction and verifies pending/epoch-advancement states, directly exercising stakeThunks.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — Directly exercises the token approval spending flow (USDC approval) which is the core behavior implemented by stablecoinYieldApprovalThunks, including approval limits and device confirmation.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/staking/ada/unstake.test.ts` — Cardano unstaking and reward claiming shares the same staking infrastructure and transaction submission paths as staking; a regression in stakeThunks could affect this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Ethereum unstaking and claiming involves transaction submission through the same staking thunks infrastructure used by initial staking.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Solana unstaking and claiming exercises the same staking thunk layer as initial staking and submits transactions through transactionsThunks.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Submits a standard Ethereum transaction with custom fees, providing coverage of transactionsThunks outside of staking and swap contexts.

</details>

⚠️ **Changes with no test coverage (5)**
- `suite-common/wallet-core/src/stake/tron/actions/claim/submitClaim.ts`
- `suite-common/wallet-core/src/stake/tron/actions/freeze/submitFreeze.ts`
- `suite-common/wallet-core/src/stake/tron/actions/unstake/submitUnstake.ts`
- `suite-common/wallet-core/src/stake/tron/actions/vote/submitVote.ts`
- `suite-common/wallet-core/src/stake/tron/actions/withdraw/submitWithdraw.ts`

_Updated: 2026-08-07T17:00:23.211Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-wallet-core-earn-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-wallet-core-earn-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-wallet-core-earn-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-wallet-core-earn-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-wallet-core-earn-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T17:02:52.554Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Send Base > User can perform ethereum sending on base network | 🤖 auto |
| Send Base > User can set custom fees | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T17:02:32.478Z • 7 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->