### PR TITLE
refactor(trading): type buy and shared thunks

### DIFF
--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -151,6 +151,7 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange' | 'sell
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
 const createMemoizedSelectorWithAccounts =
     createWeakMapSelector.withTypes<TradingRootStateWithAccounts>();
+const createMemoizedDeviceSelector = createWeakMapSelector.withTypes<DeviceRootState>();
 const createMemoizedSelectorWithDeviceAndAccounts =
     createWeakMapSelector.withTypes<TradingRootStateWithDeviceAndAccounts>();
 const createMemoizedFormAccountSelector =
@@ -786,18 +787,21 @@ export const selectIsTradingNetworkFeeMissing = (
 };
 
 export const selectTradingAccountAccordingActiveSection: (
-    state: TradingRootStateWithDeviceAndAccounts,
+    state: TradingRootStateWithAccounts,
     activeSection: TradingType,
     selectedAccount: SelectedAccountStatus,
-) => Account | undefined = createMemoizedSelectorWithDeviceAndAccounts(
+) => Account | undefined = createMemoizedSelectorWithAccounts(
     [
         selectTradingExchange,
         selectTradingSell,
         selectTradingBuy,
         ({ wallet }) => wallet.accounts,
-        (_: TradingRootState, activeSection: TradingType) => activeSection,
-        (_: TradingRootState, __: TradingType, selectedAccount: SelectedAccountStatus) =>
-            selectedAccount,
+        (_: TradingRootStateWithAccounts, activeSection: TradingType) => activeSection,
+        (
+            _: TradingRootStateWithAccounts,
+            __: TradingType,
+            selectedAccount: SelectedAccountStatus,
+        ) => selectedAccount,
     ],
     (tradingExchange, tradingSell, tradingBuy, accounts, activeSection, selectedAccount) => {
         const tradingSectionMap = {
@@ -1154,12 +1158,12 @@ export const selectTradingBuyTransactionId = (state: TradingRootState) =>
 export const selectTradingVerifiedAddress = (state: TradingRootState) =>
     state.wallet.trading.verifiedAddress;
 
-export const selectTradingIsSlip24Allowed = createMemoizedSelectorWithDeviceAndAccounts(
+export const selectTradingIsSlip24Allowed = createMemoizedDeviceSelector(
     [
         state => selectDeviceUnavailableCapabilities(state),
         state => selectDeviceFirmwareVersion(state),
-        (_: TradingRootState, account: Account | undefined | null) => account,
-        (_: TradingRootState, __: Account | undefined | null, isSlip24Active: boolean) =>
+        (_: DeviceRootState, account: Account | undefined | null) => account,
+        (_: DeviceRootState, __: Account | undefined | null, isSlip24Active: boolean) =>
             isSlip24Active,
     ],
     (unavailableCapabilities, firmwareVersion, account, isSlip24Active) => {

--- a/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
+++ b/suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts
@@ -5,7 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingBuyReceiveAccountKey,
     selectTradingBuySelectedQuote,
@@ -23,7 +23,13 @@ export type ConfirmTradeThunkProps = {
     processResponseData: (response: BuyTradeResponse) => void;
 };
 
-export const confirmBuyTradeThunk = createThunk(
+type ConfirmBuyTradeThunkState = TradingRootState;
+
+export const confirmBuyTradeThunk = createThunk<
+    BuyTrade | undefined,
+    ConfirmTradeThunkProps,
+    { state: ConfirmBuyTradeThunkState }
+>(
     `${TRADING_BUY_THUNK_PREFIX}/confirmTrade`,
     async (
         {
@@ -33,7 +39,7 @@ export const confirmBuyTradeThunk = createThunk(
             account,
             triggerAnalyticsTradeConfirmation,
             processResponseData,
-        }: ConfirmTradeThunkProps,
+        },
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingBuySelectedQuote(getState());

--- a/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
+++ b/suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts
@@ -6,7 +6,7 @@ import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingBuyQuotesRequest,
     selectTradingCoinSymbolByCryptoId,
@@ -87,16 +87,19 @@ const getQuoteRequestData = ({
     };
 };
 
+type HandleBuyRequestThunkState = TradingRootState;
+
 export const handleBuyRequestThunk = createThunk<
     BuyTrade[],
     HandleBuyRequestThunkProps,
     {
         rejectValue: string;
+        state: HandleBuyRequestThunkState;
     }
 >(
     `${TRADING_BUY_THUNK_PREFIX}/handleRequest`,
     async (
-        { formValues, network, shouldSendInSats }: HandleBuyRequestThunkProps,
+        { formValues, network, shouldSendInSats },
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal },
     ) => {
         const quotesRequest = selectTradingBuyQuotesRequest(getState());

--- a/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
+++ b/suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts
@@ -8,7 +8,7 @@ import { regional } from '../../regional';
 import { tradeApi } from '../../tradeApi';
 import { toTradingCountryCode } from '../../utils/countryUtils';
 
-export const loadBuyInfoThunk = createThunk<BuyInfo>(
+export const loadBuyInfoThunk = createThunk<BuyInfo, void, void>(
     `${TRADING_BUY_THUNK_PREFIX}/loadInfo`,
     async (_, { fulfillWithValue }) => {
         const buyInfo = await tradeApi.getBuyList();

--- a/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts
@@ -4,7 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 
 import { TRADING_BUY_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingBuyInfo,
     selectTradingBuyQuotesRequest,
@@ -20,12 +20,15 @@ export type SelectBuyQuoteThunkProps = {
     nextStep: () => void;
 };
 
-export const selectBuyQuoteThunk = createThunk(
+type SelectBuyQuoteThunkState = TradingRootState;
+
+export const selectBuyQuoteThunk = createThunk<
+    void,
+    SelectBuyQuoteThunkProps,
+    { state: SelectBuyQuoteThunkState }
+>(
     `${TRADING_BUY_THUNK_PREFIX}/selectQuote`,
-    async (
-        { quote, returnUrl, loginRequest, nextStep }: SelectBuyQuoteThunkProps,
-        { dispatch, getState },
-    ) => {
+    async ({ quote, returnUrl, loginRequest, nextStep }, { dispatch, getState }) => {
         const buyInfo = selectTradingBuyInfo(getState());
         const quotesRequest = selectTradingBuyQuotesRequest(getState());
 

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.test.ts
@@ -1,8 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 import { type CryptoId, type ExchangeTradeSigned } from 'invity-api';
 
+import { deviceInitialState } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { initialWalletSettingsState } from '@suite-common/wallet-core';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import TrezorConnect, { type Address, type PROTO } from '@trezor/connect';
 import { validatePath } from '@trezor/connect-common';
@@ -210,9 +212,11 @@ describe('createPaymentRequestsThunk', () => {
         configureMockStore({
             extra: extraDependenciesCommonMock,
             reducer: combineReducers({
+                device: () => deviceInitialState,
                 wallet: combineReducers({
-                    trading: tradingReducer,
                     accounts: () => [mockAccount],
+                    settings: () => initialWalletSettingsState,
+                    trading: tradingReducer,
                 }),
             }),
             preloadedState: {

--- a/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
+++ b/suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts
@@ -6,17 +6,18 @@ import {
 } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type Account, type GeneralPrecomposedTransaction } from '@suite-common/wallet-types';
 import { type PROTO } from '@trezor/connect';
 import { getSlip44ByPath, validatePath } from '@trezor/connect-common';
 import { exhaustive } from '@trezor/type-utils';
 
-import { getNonce } from './getNonce';
+import { type GetNonceThunkState, getNonce } from './getNonce';
 import { getPaymentRequestOutputs } from './getPaymentRequestOutputs';
-import { getPurchaseAddress } from './getPurchaseAddress';
-import { getRefundAddress } from './getRefundAddress';
+import { type GetPurchaseAddressThunkState, getPurchaseAddress } from './getPurchaseAddress';
+import { type GetRefundAddressThunkState, getRefundAddress } from './getRefundAddress';
 import { TRADING_THUNK_PREFIX } from '../../constants';
+import { type TradingRootState } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingCoinInfoByCryptoId,
     selectTradingCoinSymbolByCryptoId,
@@ -44,11 +45,18 @@ type CreateSignatureThunkProps = {
     destinationTag?: string;
 };
 
+export type CreatePaymentRequestsThunkState = AccountsRootState &
+    GetNonceThunkState &
+    GetPurchaseAddressThunkState &
+    GetRefundAddressThunkState &
+    TradingRootState;
+
 export const createPaymentRequestsThunk = createThunk<
     PROTO.PaymentRequest[],
     CreateSignatureThunkProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: CreatePaymentRequestsThunkState;
     }
 >(
     `${TRADING_THUNK_PREFIX}/createPaymentRequests`,

--- a/suite-common/trading/src/thunks/common/getNonce.test.ts
+++ b/suite-common/trading/src/thunks/common/getNonce.test.ts
@@ -1,14 +1,10 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { selectSelectedDevice } from '@suite-common/device';
-import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { deviceInitialState, selectSelectedDevice } from '@suite-common/device';
+import { configureMockStore } from '@suite-common/test-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { getNonce } from './getNonce';
-import { initialState } from '../../reducers/tradingCommonReducer';
-import { prepareTradingReducer } from '../../reducers/tradingReducer';
-
-const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 
 jest.mock('@suite-common/device', () => ({
     ...jest.requireActual('@suite-common/device'),
@@ -37,22 +33,12 @@ describe('getNonce thunk', () => {
         jest.clearAllMocks();
     });
 
-    const createMockStore = (preloadedState = {}) =>
+    const createMockStore = () =>
         configureMockStore({
-            extra: extraDependenciesCommonMock,
+            extra: {},
             reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                }),
+                device: () => deviceInitialState,
             }),
-            preloadedState: {
-                wallet: {
-                    trading: {
-                        ...initialState,
-                        ...preloadedState,
-                    },
-                },
-            },
         });
 
     describe('successful nonce retrieval', () => {

--- a/suite-common/trading/src/thunks/common/getNonce.ts
+++ b/suite-common/trading/src/thunks/common/getNonce.ts
@@ -1,11 +1,17 @@
-import { selectSelectedDevice } from '@suite-common/device';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import TrezorConnect from '@trezor/connect';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { type TradingSendRejectedProps } from '../../types';
 
-export const getNonce = createThunk<string, void, { rejectValue: TradingSendRejectedProps }>(
+export type GetNonceThunkState = DeviceRootState;
+
+export const getNonce = createThunk<
+    string,
+    void,
+    { rejectValue: TradingSendRejectedProps; state: GetNonceThunkState }
+>(
     `${TRADING_THUNK_PREFIX}/getNonce`,
     async (_, { getState, rejectWithValue, fulfillWithValue }) => {
         const device = selectSelectedDevice(getState());

--- a/suite-common/trading/src/thunks/common/getPurchaseAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/getPurchaseAddress.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { deviceInitialState } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import {
@@ -54,7 +55,9 @@ describe('getPurchaseAddress thunk', () => {
         configureMockStore({
             extra: extraDependenciesCommonMock,
             reducer: combineReducers({
+                device: () => deviceInitialState,
                 wallet: combineReducers({
+                    accounts: () => accounts,
                     settings: walletSettingsReducer,
                     trading: tradingReducer,
                 }),
@@ -117,7 +120,9 @@ describe('getPurchaseAddress thunk', () => {
             const storeWithNonChunked = configureMockStore({
                 extra: extraDependenciesCommonMock,
                 reducer: combineReducers({
+                    device: () => deviceInitialState,
                     wallet: combineReducers({
+                        accounts: () => accounts,
                         settings: walletSettingsReducer,
                         trading: tradingReducer,
                     }),

--- a/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
+++ b/suite-common/trading/src/thunks/common/getPurchaseAddress.ts
@@ -1,5 +1,10 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { confirmAddressOnDeviceThunk, selectAddressDisplayType } from '@suite-common/wallet-core';
+import {
+    type ConfirmAddressOnDeviceThunkState,
+    type WalletSettingsRootState,
+    confirmAddressOnDeviceThunk,
+    selectAddressDisplayType,
+} from '@suite-common/wallet-core';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
@@ -16,11 +21,15 @@ type GetPurchaseAddressFulfillValue = {
     path: string;
 };
 
+export type GetPurchaseAddressThunkState = ConfirmAddressOnDeviceThunkState &
+    WalletSettingsRootState;
+
 export const getPurchaseAddress = createThunk<
     GetPurchaseAddressFulfillValue,
     GetPurchaseAddressProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: GetPurchaseAddressThunkState;
     }
 >(
     `${TRADING_THUNK_PREFIX}/getPurchaseAddress`,

--- a/suite-common/trading/src/thunks/common/getRefundAddress.test.ts
+++ b/suite-common/trading/src/thunks/common/getRefundAddress.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { deviceInitialState } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import {
@@ -51,7 +52,9 @@ describe('getRefundAddress thunk', () => {
         configureMockStore({
             extra: extraDependenciesCommonMock,
             reducer: combineReducers({
+                device: () => deviceInitialState,
                 wallet: combineReducers({
+                    accounts: () => accounts,
                     settings: walletSettingsReducer,
                     trading: tradingReducer,
                 }),
@@ -112,7 +115,9 @@ describe('getRefundAddress thunk', () => {
             const storeWithNonChunked = configureMockStore({
                 extra: extraDependenciesCommonMock,
                 reducer: combineReducers({
+                    device: () => deviceInitialState,
                     wallet: combineReducers({
+                        accounts: () => accounts,
                         settings: walletSettingsReducer,
                         trading: tradingReducer,
                     }),

--- a/suite-common/trading/src/thunks/common/getRefundAddress.ts
+++ b/suite-common/trading/src/thunks/common/getRefundAddress.ts
@@ -1,5 +1,10 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { confirmAddressOnDeviceThunk, selectAddressDisplayType } from '@suite-common/wallet-core';
+import {
+    type ConfirmAddressOnDeviceThunkState,
+    type WalletSettingsRootState,
+    confirmAddressOnDeviceThunk,
+    selectAddressDisplayType,
+} from '@suite-common/wallet-core';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
@@ -16,11 +21,14 @@ type GetRefundAddressFulfillValue = {
     path: string;
 };
 
+export type GetRefundAddressThunkState = ConfirmAddressOnDeviceThunkState & WalletSettingsRootState;
+
 export const getRefundAddress = createThunk<
     GetRefundAddressFulfillValue,
     GetRefundAddressProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: GetRefundAddressThunkState;
     }
 >(
     `${TRADING_THUNK_PREFIX}/getRefundAddress`,

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts
@@ -1,8 +1,9 @@
-import { combineReducers, createReducer } from '@reduxjs/toolkit';
+import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
+import { getNetwork } from '@suite-common/wallet-config';
 import { prepareAccountsReducer } from '@suite-common/wallet-core';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import { loadInitialDataThunk } from './loadInitialDataThunk';
 import { accountBtc, accountEth } from '../../__fixtures__/utils';
@@ -26,50 +27,31 @@ jest.mock('../../tradeApi');
 tradeApi.setServersEnvironment = () => {};
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
-
-type SelectedAccountStatus = {
-    status: string;
-    account: Account | undefined;
-};
-type SelectedAccountState = SelectedAccountStatus;
-const mockedSelectedAccountReducer = createReducer<SelectedAccountState>(
-    {
-        status: 'none',
-        account: accountBtc as Account,
-    },
-    () => {},
-);
-
 const mockedAccountReducer = prepareAccountsReducer(extraDependenciesCommonMock);
-
-const mockedSuiteReducer = createReducer(
-    {
-        settings: {
-            debug: {
-                tradeServerEnvironment: 'localhost',
-            },
-        },
-    },
-    () => {},
-);
+const defaultAccount = accountBtc as Account;
+const defaultSelectedAccount: SelectedAccountStatus = {
+    status: 'loaded',
+    account: defaultAccount,
+    network: getNetwork(defaultAccount.symbol),
+    params: undefined,
+};
 
 const initStore = (
     localInitialState?: Partial<TradingState>,
-    selectedAccount: SelectedAccountStatus = { status: 'loaded', account: accountBtc as Account },
+    selectedAccount: SelectedAccountStatus = defaultSelectedAccount,
 ) =>
     configureMockStore({
         extra: {
             services: {
-                getSelectedAccount: () => selectedAccount as any,
+                getSelectedAccount: () => selectedAccount,
+                getTradingEnvironment: () => 'localhost' as const,
             },
         },
         reducer: combineReducers({
             wallet: combineReducers({
                 trading: tradingReducer,
-                selectedAccount: mockedSelectedAccountReducer,
                 accounts: mockedAccountReducer,
             }),
-            suite: mockedSuiteReducer,
         }),
         preloadedState: {
             wallet: {

--- a/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
+++ b/suite-common/trading/src/thunks/common/loadInitialDataThunk.ts
@@ -1,4 +1,5 @@
 import { createThunk } from '@suite-common/redux-utils';
+import { type SelectedAccountStatus } from '@suite-common/wallet-types';
 
 import {
     TRADE_API_RELOAD_DATA_AFTER_MS,
@@ -10,6 +11,7 @@ import { tradingExchangeActions } from '../../reducers/exchangeReducer';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { tradingActions } from '../../reducers/tradingCommonReducer';
 import {
+    type TradingRootStateWithAccounts,
     selectTradingAccountAccordingActiveSection,
     selectTradingBuyInfo,
     selectTradingExchangeInfo,
@@ -18,7 +20,7 @@ import {
     selectTradingSellInfo,
 } from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
-import { type TradingType } from '../../types';
+import { type TradeServerEnvironment, type TradingType } from '../../types';
 import { loadBuyInfoThunk } from '../buy/loadBuyInfoThunk';
 import { loadExchangeInfoThunk } from '../exchange/loadExchangeInfoThunk';
 import { loadSellInfoThunk } from '../sell/loadSellInfoThunk';
@@ -28,12 +30,21 @@ export interface LoadInitialDataThunkProps {
     forcedApiKey?: string;
 }
 
-export const loadInitialDataThunk = createThunk(
+type LoadInitialDataThunkState = TradingRootStateWithAccounts;
+type LoadInitialDataThunkDeps = {
+    services: {
+        getSelectedAccount: () => SelectedAccountStatus;
+        getTradingEnvironment: () => TradeServerEnvironment | undefined;
+    };
+};
+
+export const loadInitialDataThunk = createThunk<
+    void,
+    LoadInitialDataThunkProps,
+    { state: LoadInitialDataThunkState; extra: LoadInitialDataThunkDeps }
+>(
     `${TRADING_THUNK_PREFIX}/loadInitialData`,
-    async (
-        { activeSection, forcedApiKey }: LoadInitialDataThunkProps,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ activeSection, forcedApiKey }, { dispatch, getState, extra }) => {
         const selectedAccount = extra.services.getSelectedAccount();
         const account = selectTradingAccountAccordingActiveSection(
             getState(),

--- a/suite-common/trading/src/thunks/common/logErrorThunk.ts
+++ b/suite-common/trading/src/thunks/common/logErrorThunk.ts
@@ -15,9 +15,9 @@ export type LogErrorThunkProps = {
     tradingType: TradingType;
 };
 
-export const logErrorThunk = createThunk(
+export const logErrorThunk = createThunk<void, LogErrorThunkProps, void>(
     `${TRADING_THUNK_PREFIX}/logError`,
-    ({ errorMessage, tradingType, toastType = 'error' }: LogErrorThunkProps, { dispatch }) => {
+    ({ errorMessage, tradingType, toastType = 'error' }, { dispatch }) => {
         if (isResolvedTradeError(errorMessage)) {
             dispatch(
                 notificationsActions.addToast({

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -6,7 +6,11 @@ import { type TrezorDevice } from '@suite-common/suite-types';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { composeSendFormTransactionFeeLevelsThunk } from '@suite-common/wallet-core';
+import {
+    blockchainInitialState,
+    composeSendFormTransactionFeeLevelsThunk,
+    initialWalletSettingsState,
+} from '@suite-common/wallet-core';
 import { type Account, type FeesState } from '@suite-common/wallet-types';
 import { type TokenInfo } from '@trezor/connect';
 
@@ -133,8 +137,11 @@ describe('recomposeAndSignTxThunk', () => {
             extra: {},
             reducer: combineReducers({
                 wallet: combineReducers({
-                    trading: tradingReducer,
+                    accounts: () => [account],
+                    blockchain: () => blockchainInitialState,
                     fees: mockedSuiteReducer,
+                    settings: () => initialWalletSettingsState,
+                    trading: tradingReducer,
                 }),
                 device: deviceReducer,
             }),

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -1,10 +1,16 @@
 import { isRejected } from '@reduxjs/toolkit';
 
-import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
+import {
+    type DeviceRootState,
+    isApprovalFlowSupported,
+    selectSelectedDevice,
+} from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { getNetwork } from '@suite-common/wallet-config';
 import { DEFAULT_PAYMENT, DEFAULT_VALUES } from '@suite-common/wallet-constants';
 import {
+    type ComposeSendFormTransactionFeeLevelsThunkState,
+    type FeesRootState,
     composeSendFormTransactionFeeLevelsThunk,
     selectConvertedNetworkFeeInfo,
 } from '@suite-common/wallet-core';
@@ -22,8 +28,12 @@ import {
 } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
-import { createPaymentRequestsThunk } from './createPaymentRequestsThunk';
+import {
+    type CreatePaymentRequestsThunkState,
+    createPaymentRequestsThunk,
+} from './createPaymentRequestsThunk';
 import { TRADING_THUNK_PREFIX } from '../../constants';
+import { type TradingRootState } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingComposedTransactionInfo,
     selectTradingIsSlip24Allowed,
@@ -68,11 +78,18 @@ export type RecomposeAndSignTxThunkProps = {
  * 3. Signs the transaction and pushes it to the blockchain.
  * 4. Handles errors gracefully and provides detailed error messages.
  */
+export type RecomposeAndSignTxThunkState = ComposeSendFormTransactionFeeLevelsThunkState &
+    CreatePaymentRequestsThunkState &
+    DeviceRootState &
+    FeesRootState &
+    TradingRootState;
+
 export const recomposeAndSignTxThunk = createThunk<
     TradingFulfillValue,
     RecomposeAndSignTxThunkProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: RecomposeAndSignTxThunkState;
     }
 >(
     `${TRADING_THUNK_PREFIX}/recomposeAndSignTx`,
@@ -89,7 +106,7 @@ export const recomposeAndSignTxThunk = createThunk<
             isSlip24Active = false,
             tradingFormState,
             signAndPushSendFormTransaction,
-        }: RecomposeAndSignTxThunkProps,
+        },
         { dispatch, getState, rejectWithValue, fulfillWithValue },
     ) => {
         const { composed, selectedFee } = selectTradingComposedTransactionInfo(getState());

--- a/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
+++ b/suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts
@@ -12,9 +12,13 @@ export type SetLastErrorMessageByTradingTypeProps = {
     errorMessage: string | undefined;
 };
 
-export const setLastErrorMessageByTradingType = createThunk(
+export const setLastErrorMessageByTradingType = createThunk<
+    void,
+    SetLastErrorMessageByTradingTypeProps,
+    void
+>(
     `${TRADING_THUNK_PREFIX}/setLastErrorMessageByTradingType`,
-    ({ tradingType, errorMessage }: SetLastErrorMessageByTradingTypeProps, { dispatch }) => {
+    ({ tradingType, errorMessage }, { dispatch }) => {
         switch (tradingType) {
             case 'buy':
                 dispatch(tradingBuyActions.setLastErrorMessage(errorMessage));

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.test.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { deviceInitialState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import {
@@ -18,6 +18,29 @@ import { tradingThunks } from './index';
 
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const walletSettingsReducer = prepareWalletSettingsReducer(extraDependenciesCommonMock);
+const verifyAddressThunkDeps = {
+    actions: {
+        openModal: extraDependenciesCommonMock.actions.openModal,
+    },
+};
+
+const createMockStore = () =>
+    configureMockStore({
+        extra: verifyAddressThunkDeps,
+        reducer: combineReducers({
+            device: () => deviceInitialState,
+            wallet: combineReducers({
+                accounts: () => accounts,
+                settings: walletSettingsReducer,
+                trading: tradingReducer,
+            }),
+        }),
+        preloadedState: {
+            wallet: {
+                trading: initialState,
+            },
+        },
+    });
 
 jest.mock('@suite-common/device', () => ({
     ...jest.requireActual('@suite-common/device'),
@@ -42,20 +65,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should save verified address', async () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');
@@ -92,20 +102,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address device not found', async () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');
@@ -126,20 +123,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address when path or address are not defined', async () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = {
             ...accounts[0],
@@ -168,20 +152,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address, but trigger toast when device is not available', async () => {
-        const store = configureMockStore({
-            extra: extraDependenciesCommonMock,
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');
@@ -216,20 +187,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address, but trigger toast when device is not connected', async () => {
-        const store = configureMockStore({
-            extra: extraDependenciesCommonMock,
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');
@@ -264,20 +222,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address when a confirmation of address on device is not successful (no permission)', async () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');
@@ -310,20 +255,7 @@ describe('verifyAddressThunk', () => {
     });
 
     it('should not update verified address when a confirmation of address on device is not successful', async () => {
-        const store = configureMockStore({
-            extra: {},
-            reducer: combineReducers({
-                wallet: combineReducers({
-                    trading: tradingReducer,
-                    settings: walletSettingsReducer,
-                }),
-            }),
-            preloadedState: {
-                wallet: {
-                    trading: initialState,
-                },
-            },
-        });
+        const store = createMockStore();
 
         const account = accounts[0];
         if (!account) throw new Error('Missing test fixture');

--- a/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
+++ b/suite-common/trading/src/thunks/common/verifyAddressThunk.ts
@@ -1,13 +1,19 @@
 import { selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import { confirmAddressOnDeviceThunk, selectAddressDisplayType } from '@suite-common/wallet-core';
+import { type OpenModalDep } from '@suite-common/suite-types';
+import {
+    type ConfirmAddressOnDeviceThunkState,
+    type WalletSettingsRootState,
+    confirmAddressOnDeviceThunk,
+    selectAddressDisplayType,
+} from '@suite-common/wallet-core';
 import { type Account, AddressDisplayOptions } from '@suite-common/wallet-types';
 
 import { logErrorThunk } from './logErrorThunk';
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { tradingBuyActions } from '../../reducers/buyReducer';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingActiveSection } from '../../selectors/tradingSelectors';
 import { getUnusedAddressFromAccount } from '../../utils';
 
@@ -17,9 +23,20 @@ export interface VerifyAddressThunk {
     path: string | undefined;
 }
 
-export const verifyAddressThunk = createThunk(
+type VerifyAddressThunkState = ConfirmAddressOnDeviceThunkState &
+    TradingRootState &
+    WalletSettingsRootState;
+type VerifyAddressThunkDeps = {
+    actions: OpenModalDep;
+};
+
+export const verifyAddressThunk = createThunk<
+    void,
+    VerifyAddressThunk,
+    { state: VerifyAddressThunkState; extra: VerifyAddressThunkDeps }
+>(
     `${TRADING_THUNK_PREFIX}/verifyAddress`,
-    async ({ account, address, path }: VerifyAddressThunk, { dispatch, getState, extra }) => {
+    async ({ account, address, path }, { dispatch, getState, extra }) => {
         const device = selectSelectedDevice(getState());
         const activeSection = selectTradingActiveSection(getState());
 

--- a/suite-common/trading/src/thunks/common/watchTradeThunk.ts
+++ b/suite-common/trading/src/thunks/common/watchTradeThunk.ts
@@ -4,7 +4,7 @@ import { exhaustive } from '@trezor/type-utils';
 
 import { TRADING_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingSellSelectedQuote } from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
 import {
@@ -50,9 +50,11 @@ const watchTradeData = async <T extends TradingType>({
     };
 };
 
-export const watchTradeThunk = createThunk(
+type WatchTradeThunkState = TradingRootState;
+
+export const watchTradeThunk = createThunk<void, WatchTradeThunk, { state: WatchTradeThunkState }>(
     `${TRADING_THUNK_PREFIX}/watchTrade`,
-    async ({ account, trade, refreshCount }: WatchTradeThunk, { dispatch, getState }) => {
+    async ({ account, trade, refreshCount }, { dispatch, getState }) => {
         tradeApi.createApiKey(account.descriptor);
 
         const { tradeType } = trade;

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -9,7 +9,7 @@ import { regional } from '../../regional';
 import { tradeApi } from '../../tradeApi';
 import { toTradingCountryCode } from '../../utils/countryUtils';
 
-export const loadSellInfoThunk = createThunk<SellInfo>(
+export const loadSellInfoThunk = createThunk<SellInfo, void, void>(
     `${TRADING_SELL_THUNK_PREFIX}/loadInfo`,
     async (_, { fulfillWithValue }) => {
         const sellList = await tradeApi.getSellList();

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -292,7 +292,7 @@ type ConfirmAddressOnDeviceThunk = {
     chunkify: boolean;
     showOnTrezor?: boolean;
 };
-type ConfirmAddressOnDeviceThunkState = AccountsRootState & DeviceRootState;
+export type ConfirmAddressOnDeviceThunkState = AccountsRootState & DeviceRootState;
 
 export const confirmAddressOnDeviceThunk = createThunk<
     ConnectResponse<Address | CardanoAddress>,

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -181,7 +181,7 @@ type CoinSpecificComposeResponse = ActionsFromAsyncThunk<
     | typeof composeSolanaTransactionFeeLevelsThunk
     | typeof composeTronTransactionFeeLevelsThunk
 >;
-type ComposeSendFormTransactionFeeLevelsThunkState = BlockchainRootState &
+export type ComposeSendFormTransactionFeeLevelsThunkState = BlockchainRootState &
     DeviceRootState &
     WalletSettingsRootState;
 


### PR DESCRIPTION
## Description

Replaces the global thunk API inherited by trading buy and shared flows with explicit caller-owned state and dependency contracts. Parent thunks compose their child contracts, selector state is narrowed to what it actually reads, and related mock stores now provide only the required slices and modal action.

- Buy/shared chain: **10 global-default declarations -> 0; 17/17 declarations explicit**
- Validation: trading package type-check and targeted ESLint pass; **128/128 buy/shared thunk tests** and **246/246 selector/orchestration regression tests** pass.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set primarily modifies trading thunks (buy/sell/common) and wallet-core device/send thunks, affecting trade execution, payment requests, address verification, transaction signing, and device/send state. The recommended tests focus on representative buy, sell, swap, and send flows plus device management, providing strong regression coverage without running the full suite. Most changed files are broad utilities with transitive static coverage, so only tests with direct behavioral relevance are included.

<details><summary><b>Changed files (25)</b></summary>

- `suite-common/trading/src/selectors/tradingSelectors.ts`
- `suite-common/trading/src/thunks/buy/confirmBuyTradeThunk.ts`
- `suite-common/trading/src/thunks/buy/handleBuyRequestThunk.ts`
- `suite-common/trading/src/thunks/buy/loadBuyInfoThunk.ts`
- `suite-common/trading/src/thunks/buy/selectBuyQuoteThunk.ts`
- `suite-common/trading/src/thunks/common/createPaymentRequestsThunk.test.ts`
- `suite-common/trading/src/thunks/common/createPaymentRequestsThunk.ts`
- `suite-common/trading/src/thunks/common/getNonce.test.ts`
- `suite-common/trading/src/thunks/common/getNonce.ts`
- `suite-common/trading/src/thunks/common/getPurchaseAddress.test.ts`
- `suite-common/trading/src/thunks/common/getPurchaseAddress.ts`
- `suite-common/trading/src/thunks/common/getRefundAddress.test.ts`
- `suite-common/trading/src/thunks/common/getRefundAddress.ts`
- `suite-common/trading/src/thunks/common/loadInitialDataThunk.test.ts`
- `suite-common/trading/src/thunks/common/loadInitialDataThunk.ts`
- `suite-common/trading/src/thunks/common/logErrorThunk.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite-common/trading/src/thunks/common/setLastErrorMessageByTradingType.ts`
- `suite-common/trading/src/thunks/common/verifyAddressThunk.test.ts`
- `suite-common/trading/src/thunks/common/verifyAddressThunk.ts`
- `suite-common/trading/src/thunks/common/watchTradeThunk.ts`
- `suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the buy trade flow end-to-end, including quote selection, trade confirmation, and status watching. It covers confirmBuyTradeThunk, handleBuyRequestThunk, loadBuyInfoThunk, selectBuyQuoteThunk, and watchTradeThunk.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the sell flow, including payment request creation, address verification, trade confirmation, and watch polling. It covers loadSellInfoThunk, createPaymentRequestsThunk, verifyAddressThunk, and watchTradeThunk.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers the cross-chain swap flow, including transaction composition, signing, broadcasting, and status progression. It exercises recomposeAndSignTxThunk, verifyAddressThunk, and watchTradeThunk.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises the Ethereum send form and transaction signing flow, which is handled by sendFormThunks.ts. It validates custom gas fees, recipient address, amount, and device prompts.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This test exercises device management flows including disconnecting, forgetting, and unpairing devices. Changes to deviceThunks.ts could affect these device state transitions.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — This test provides additional coverage of the buy flow with a different asset and entry point (global trading button), helping catch regressions in buy thunk logic beyond the BTC path.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers an EVM sell flow variant with custom fees, exercising the same sell and common thunks as sell-bitcoin but with different network and fee handling.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — This test covers a cross-chain EVM-to-Solana swap variant, exercising swap transaction composition, address verification, and fee display paths that differ from BTC swaps.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test exercises the full send transaction lifecycle on regtest, including broadcast, pending state, confirmation, and toast notifications. It covers sendFormThunks and related send state management.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test exercises the Solana send form with Send Max calculation, transaction review, and device signing. It provides coverage of sendFormThunks for a non-EVM network.

</details>

_Updated: 2026-08-24T09:36:16.149Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-buy-shared-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-buy-shared-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-trading-buy-shared-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-trading-buy-shared-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-trading-buy-shared-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T09:34:45.926Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T09:35:00.221Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->