### PR TITLE
feat(suite-native): show vault association in yield claim entry flow

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2824,9 +2824,6 @@ export const messages = {
                 stakingTitle: 'Your stakes',
                 stablecoinYieldTitle: 'Your yields',
             },
-            claimRewards: {
-                title: 'Claim rewards from an account',
-            },
             stablecoinYieldLoadError: {
                 title: 'Unable to load yield opportunities',
                 description:

--- a/suite-native/module-earn/package.json
+++ b/suite-native/module-earn/package.json
@@ -55,6 +55,7 @@
         "@suite-native/helpers": "workspace:*",
         "@suite-native/icons": "workspace:*",
         "@suite-native/intl": "workspace:*",
+        "@suite-native/labeling": "workspace:*",
         "@suite-native/link": "workspace:*",
         "@suite-native/message-system": "workspace:*",
         "@suite-native/navigation": "workspace:*",

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useNavigation } from '@react-navigation/native';
 
@@ -26,6 +26,10 @@ import {
 } from '@suite-native/navigation';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { EarnActiveItemsBottomSheet } from './EarnActiveItemsBottomSheet';
+import { EarnDepositsCardRow } from './EarnDepositsCardRow';
+import { StablecoinYieldClaimRewardsBottomSheet } from './StablecoinYieldClaimRewardsBottomSheet';
+import { StablecoinYieldClaimRewardsCardSection } from './StablecoinYieldClaimRewardsCardSection';
 import { useEarnDepositsCardData } from '../hooks/useEarnDepositsCardData';
 import { useStablecoinYieldFirmwareUpdateAlert } from '../hooks/useStablecoinYieldFirmwareUpdateAlert';
 import { useStakingDetailNavigation } from '../hooks/useStakingDetailNavigation';
@@ -34,10 +38,10 @@ import {
     type StablecoinYieldEarnItem,
     type StakingEarnItem,
 } from '../types';
-import { EarnActiveItemsBottomSheet } from './EarnActiveItemsBottomSheet';
-import { EarnDepositsCardRow } from './EarnDepositsCardRow';
-import { StablecoinYieldClaimRewardsBottomSheet } from './StablecoinYieldClaimRewardsBottomSheet';
-import { StablecoinYieldClaimRewardsCardSection } from './StablecoinYieldClaimRewardsCardSection';
+import {
+    type StablecoinYieldClaimItem,
+    buildStablecoinYieldClaimItems,
+} from '../utils/stablecoinYieldClaimSummaryUtils';
 
 const cardHeaderStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp16,
@@ -99,20 +103,29 @@ export const EarnDepositsCard = ({
 
     const { analytics } = useServices(selectNativeAnalyticsDep);
 
+    const stablecoinYieldClaimItems = useMemo(
+        () =>
+            buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries,
+                stablecoinYieldActiveItems,
+            }),
+        [stablecoinYieldActiveItems, stablecoinYieldClaimSummaries],
+    );
+
     const handleStablecoinYieldClaimRewardPress = useCallback(
-        ({ accountKey, networkSymbol }: StablecoinYieldClaimSummary) => {
+        ({ summary, vault }: StablecoinYieldClaimItem) => {
             analytics.report({
                 type: events.yieldNavigateEvent.name,
                 payload: {
                     action: 'continue',
                     from: 'earn-dashboard',
                     to: 'claim-form',
-                    networkSymbol,
+                    networkSymbol: summary.networkSymbol,
                 },
             });
             navigation.navigate(RootStackRoutes.YieldNavigator, {
                 screen: YieldStackRoutes.YieldClaim,
-                params: { accountKey },
+                params: { accountKey: summary.accountKey, vault: vault ?? undefined },
             });
         },
         [analytics, navigation],
@@ -125,11 +138,11 @@ export const EarnDepositsCard = ({
             return;
         }
 
-        if (stablecoinYieldClaimSummaries.length === 1) {
-            const claimReward = stablecoinYieldClaimSummaries[0];
+        if (stablecoinYieldClaimItems.length === 1) {
+            const claimItem = stablecoinYieldClaimItems[0];
 
-            if (claimReward) {
-                handleStablecoinYieldClaimRewardPress(claimReward);
+            if (claimItem) {
+                handleStablecoinYieldClaimRewardPress(claimItem);
             }
 
             return;
@@ -141,7 +154,7 @@ export const EarnDepositsCard = ({
         isFirmwareSupported,
         openStablecoinYieldClaimRewardsSheet,
         showFirmwareUpdateAlert,
-        stablecoinYieldClaimSummaries,
+        stablecoinYieldClaimItems,
     ]);
 
     return (
@@ -231,7 +244,7 @@ export const EarnDepositsCard = ({
 
             <StablecoinYieldClaimRewardsBottomSheet
                 ref={stablecoinYieldClaimRewardsSheetRef}
-                claimRewards={stablecoinYieldClaimSummaries}
+                claimItems={stablecoinYieldClaimItems}
                 onClaimRewardPress={handleStablecoinYieldClaimRewardPress}
                 onClose={closeStablecoinYieldClaimRewardsSheet}
             />

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -113,7 +113,7 @@ export const EarnDepositsCard = ({
     );
 
     const handleStablecoinYieldClaimRewardPress = useCallback(
-        ({ summary, vault }: StablecoinYieldClaimItem) => {
+        ({ summary, vaults }: StablecoinYieldClaimItem) => {
             analytics.report({
                 type: events.yieldNavigateEvent.name,
                 payload: {
@@ -125,7 +125,10 @@ export const EarnDepositsCard = ({
             });
             navigation.navigate(RootStackRoutes.YieldNavigator, {
                 screen: YieldStackRoutes.YieldClaim,
-                params: { accountKey: summary.accountKey, vault: vault ?? undefined },
+                params: {
+                    accountKey: summary.accountKey,
+                    vault: vaults.length === 1 ? vaults[0] : undefined,
+                },
             });
         },
         [analytics, navigation],

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
@@ -1,7 +1,9 @@
 import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { AccountTypeBadge } from '@suite-native/accounts';
+import { parseAccountKey } from '@suite-common/wallet-utils';
+import { AccountTypeBadge, selectAccountLabel } from '@suite-native/accounts';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -15,6 +17,7 @@ import {
 import { AddressFormatter, BaseCurrencyAmountFormatter } from '@suite-native/formatters';
 import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { type CombinedLabelingState } from '@suite-native/labeling';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { type StablecoinYieldClaimItem } from '../utils/stablecoinYieldClaimSummaryUtils';
@@ -54,36 +57,40 @@ const StablecoinYieldClaimRewardsItem = ({
     onPress,
 }: StablecoinYieldClaimRewardsItemProps) => {
     const { applyStyle } = useNativeStyles();
-    const { summary, vault } = claimItem;
+    const { summary, vaults } = claimItem;
+
+    const { accountDescriptor, deviceStaticSessionId } = parseAccountKey(summary.accountKey);
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        selectAccountLabel(state, deviceStaticSessionId, accountDescriptor, summary.networkSymbol),
+    );
 
     const handlePress = useCallback(() => {
         onPress(claimItem);
     }, [claimItem, onPress]);
 
-    const accountTitle = summary.accountLabel ?? getNetworkDisplaySymbolName(summary.networkSymbol);
+    const accountTitle = customAccountLabel ?? getNetworkDisplaySymbolName(summary.networkSymbol);
+    const hasVaults = vaults.length > 0;
+    const singleVault = vaults.length === 1 ? vaults[0] : undefined;
+    const vaultsTitle = vaults.map(vault => vault.name).join(', ');
 
     return (
         <Card borderColor="borderNeutral" noPadding style={applyStyle(itemCardStyle)}>
             <PressableOpacity onPress={handlePress} style={applyStyle(itemRowStyle)}>
                 <Box marginRight="sp12">
-                    {vault ? (
-                        <TokenIcon
-                            symbol={summary.networkSymbol}
-                            contractAddress={vault.tokenContract}
-                            size="small"
-                            showNetworkIcon
-                            wrappedTokenIcon="network"
-                        />
-                    ) : (
-                        <TokenIcon symbol={summary.networkSymbol} size="small" />
-                    )}
+                    <TokenIcon
+                        symbol={summary.networkSymbol}
+                        contractAddress={singleVault?.tokenContract}
+                        size="small"
+                        showNetworkIcon={!!singleVault}
+                        wrappedTokenIcon="network"
+                    />
                 </Box>
 
                 <VStack spacing="sp2" style={applyStyle(itemContentStyle)}>
                     <Text numberOfLines={1} ellipsizeMode="tail">
-                        {vault?.name ?? accountTitle}
+                        {hasVaults ? vaultsTitle : accountTitle}
                     </Text>
-                    {vault ? (
+                    {hasVaults ? (
                         <Text
                             variant="body-sm"
                             color="contentSecondary"
@@ -94,7 +101,7 @@ const StablecoinYieldClaimRewardsItem = ({
                         </Text>
                     ) : (
                         <AddressFormatter
-                            value={summary.accountDescriptor}
+                            value={accountDescriptor}
                             format="short"
                             variant="body-sm"
                             color="contentSecondary"

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
@@ -17,7 +17,7 @@ import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { type StablecoinYieldClaimSummary } from '../types';
+import { type StablecoinYieldClaimItem } from '../utils/stablecoinYieldClaimSummaryUtils';
 
 const itemCardStyle = prepareNativeStyle(utils => ({
     marginBottom: utils.spacings.sp16,
@@ -45,47 +45,68 @@ const itemValueStyle = prepareNativeStyle(utils => ({
 }));
 
 type StablecoinYieldClaimRewardsItemProps = {
-    claimReward: StablecoinYieldClaimSummary;
-    onPress: (claimReward: StablecoinYieldClaimSummary) => void;
+    claimItem: StablecoinYieldClaimItem;
+    onPress: (claimItem: StablecoinYieldClaimItem) => void;
 };
 
 const StablecoinYieldClaimRewardsItem = ({
-    claimReward,
+    claimItem,
     onPress,
 }: StablecoinYieldClaimRewardsItemProps) => {
     const { applyStyle } = useNativeStyles();
+    const { summary, vault } = claimItem;
 
     const handlePress = useCallback(() => {
-        onPress(claimReward);
-    }, [claimReward, onPress]);
+        onPress(claimItem);
+    }, [claimItem, onPress]);
 
-    const title =
-        claimReward.accountLabel ?? getNetworkDisplaySymbolName(claimReward.networkSymbol);
+    const accountTitle = summary.accountLabel ?? getNetworkDisplaySymbolName(summary.networkSymbol);
 
     return (
         <Card borderColor="borderNeutral" noPadding style={applyStyle(itemCardStyle)}>
             <PressableOpacity onPress={handlePress} style={applyStyle(itemRowStyle)}>
                 <Box marginRight="sp12">
-                    <TokenIcon symbol={claimReward.networkSymbol} size="small" />
+                    {vault ? (
+                        <TokenIcon
+                            symbol={summary.networkSymbol}
+                            contractAddress={vault.tokenContract}
+                            size="small"
+                            showNetworkIcon
+                            wrappedTokenIcon="network"
+                        />
+                    ) : (
+                        <TokenIcon symbol={summary.networkSymbol} size="small" />
+                    )}
                 </Box>
 
                 <VStack spacing="sp2" style={applyStyle(itemContentStyle)}>
                     <Text numberOfLines={1} ellipsizeMode="tail">
-                        {title}
+                        {vault?.name ?? accountTitle}
                     </Text>
-                    <AddressFormatter
-                        value={claimReward.accountDescriptor}
-                        format="short"
-                        variant="body-sm"
-                        color="contentSecondary"
-                        numberOfLines={1}
-                    />
-                    <AccountTypeBadge accountKey={claimReward.accountKey} alignSelf="flex-start" />
+                    {vault ? (
+                        <Text
+                            variant="body-sm"
+                            color="contentSecondary"
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                        >
+                            {accountTitle}
+                        </Text>
+                    ) : (
+                        <AddressFormatter
+                            value={summary.accountDescriptor}
+                            format="short"
+                            variant="body-sm"
+                            color="contentSecondary"
+                            numberOfLines={1}
+                        />
+                    )}
+                    <AccountTypeBadge accountKey={summary.accountKey} alignSelf="flex-start" />
                 </VStack>
 
                 <HStack alignItems="center" spacing="sp8" style={applyStyle(itemValueStyle)}>
                     <BaseCurrencyAmountFormatter
-                        value={claimReward.fiatClaimableAmount}
+                        value={summary.fiatClaimableAmount}
                         variant="body-md"
                         isDiscreetText={false}
                         numberOfLines={1}
@@ -100,21 +121,21 @@ const StablecoinYieldClaimRewardsItem = ({
 
 type StablecoinYieldClaimRewardsBottomSheetProps = {
     ref: BottomSheetModalRef;
-    claimRewards: StablecoinYieldClaimSummary[];
-    onClaimRewardPress: (claimReward: StablecoinYieldClaimSummary) => void;
+    claimItems: StablecoinYieldClaimItem[];
+    onClaimRewardPress: (claimItem: StablecoinYieldClaimItem) => void;
     onClose: () => void;
 };
 
 export const StablecoinYieldClaimRewardsBottomSheet = ({
     ref,
-    claimRewards,
+    claimItems,
     onClaimRewardPress,
     onClose,
 }: StablecoinYieldClaimRewardsBottomSheetProps) => {
     const handleClaimRewardsSelect = useCallback(
-        (claimReward: StablecoinYieldClaimSummary) => {
+        (claimItem: StablecoinYieldClaimItem) => {
             onClose();
-            onClaimRewardPress(claimReward);
+            onClaimRewardPress(claimItem);
         },
         [onClaimRewardPress, onClose],
     );
@@ -122,15 +143,15 @@ export const StablecoinYieldClaimRewardsBottomSheet = ({
     return (
         <BottomSheetModal
             ref={ref}
-            title={<Translation id="earn.earnScreen.claimRewards.title" />}
+            title={<Translation id="earn.earnScreen.activeSheet.stablecoinYieldTitle" />}
             isCloseDisplayed
             onClose={onClose}
         >
             <Box paddingTop="sp16">
-                {claimRewards.map(claimReward => (
+                {claimItems.map(claimItem => (
                     <StablecoinYieldClaimRewardsItem
-                        key={claimReward.accountKey}
-                        claimReward={claimReward}
+                        key={claimItem.summary.accountKey}
+                        claimItem={claimItem}
                         onPress={handleClaimRewardsSelect}
                     />
                 ))}

--- a/suite-native/module-earn/src/components/YieldClaimRewardRow.tsx
+++ b/suite-native/module-earn/src/components/YieldClaimRewardRow.tsx
@@ -4,7 +4,7 @@ import {
     asBaseCurrencyAmount,
     toTokenSymbol,
 } from '@suite-common/wallet-types';
-import { HStack, Text } from '@suite-native/atoms';
+import { Box, HStack, Text } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import { TokenIcon } from '@suite-native/icons';
 import { BigNumber } from '@trezor/utils';
@@ -43,15 +43,17 @@ export const YieldClaimRewardRow = ({
                     contractAddress={tokenContractAddress}
                     size={20}
                 />
-                <CryptoAmountFormatter
-                    value={amount}
-                    symbol={toTokenSymbol(tokenSymbol)}
-                    decimals={tokenDecimals}
-                    variant="body-sm-strong"
-                    color="contentPrimary"
-                    isDiscreetText={false}
-                    numberOfLines={1}
-                />
+                <Box flexShrink={1}>
+                    <CryptoAmountFormatter
+                        value={amount}
+                        symbol={toTokenSymbol(tokenSymbol)}
+                        decimals={tokenDecimals}
+                        variant="body-sm-strong"
+                        color="contentPrimary"
+                        isDiscreetText={false}
+                        numberOfLines={2}
+                    />
+                </Box>
             </HStack>
             {isFiatAmountVisible && (
                 <HStack spacing="sp2" alignItems="center" justifyContent="flex-end">

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -13,8 +13,9 @@ import {
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, FullAlertBox, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import { Box, FullAlertBox, HStack, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { useFiatFromCryptoValue } from '@suite-native/formatters';
+import { TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 import { ContextMessage } from '@suite-native/message-system';
 import {
@@ -49,7 +50,7 @@ type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoute
 export const YieldClaimScreen = () => {
     const route = useRoute<RouteProps>();
     const navigation = useNavigation<NavigationProps>();
-    const { accountKey } = route.params;
+    const { accountKey, vault } = route.params;
     const isFocused = useIsFocused();
     const dispatch = useDispatch();
     const { analytics } = useServices(selectNativeAnalyticsDep);
@@ -236,6 +237,7 @@ export const YieldClaimScreen = () => {
     }
 
     const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
+    const headerLabel = vault ? `${vault.name} · ${accountLabel}` : accountLabel;
 
     return (
         <Screen
@@ -247,14 +249,25 @@ export const YieldClaimScreen = () => {
                             <Text variant="body-md-strong">
                                 <Translation id="earn.yieldClaimFlowScreen.title" />
                             </Text>
-                            <Text
-                                variant="body-md"
-                                color="contentSecondary"
-                                numberOfLines={1}
-                                ellipsizeMode="tail"
-                            >
-                                {accountLabel}
-                            </Text>
+                            <HStack spacing="sp4" alignItems="center">
+                                {!!vault && (
+                                    <TokenIcon
+                                        symbol={account.symbol}
+                                        contractAddress={vault.tokenContract}
+                                        size="tiny"
+                                    />
+                                )}
+                                <Box flexShrink={1}>
+                                    <Text
+                                        variant="body-md"
+                                        color="contentSecondary"
+                                        numberOfLines={1}
+                                        ellipsizeMode="tail"
+                                    >
+                                        {headerLabel}
+                                    </Text>
+                                </Box>
+                            </HStack>
                         </VStack>
                     }
                 />

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -12,11 +12,13 @@ import {
     selectAccountByKey,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
+import { selectAccountLabel } from '@suite-native/accounts';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Box, FullAlertBox, HStack, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import { useFiatFromCryptoValue } from '@suite-native/formatters';
 import { TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { type CombinedLabelingState } from '@suite-native/labeling';
 import { ContextMessage } from '@suite-native/message-system';
 import {
     Screen,
@@ -63,6 +65,11 @@ export const YieldClaimScreen = () => {
         useState<PreparedYieldClaimAction | null>(null);
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
+    );
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        account
+            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
+            : null,
     );
     const flowKey = account?.key ?? null;
     const {
@@ -236,8 +243,7 @@ export const YieldClaimScreen = () => {
         return null;
     }
 
-    const accountLabel = account.accountLabel ?? getNetwork(account.symbol).name;
-    const headerLabel = vault ? `${vault.name} · ${accountLabel}` : accountLabel;
+    const accountLabel = customAccountLabel ?? getNetwork(account.symbol).name;
 
     return (
         <Screen
@@ -249,25 +255,44 @@ export const YieldClaimScreen = () => {
                             <Text variant="body-md-strong">
                                 <Translation id="earn.yieldClaimFlowScreen.title" />
                             </Text>
-                            <HStack spacing="sp4" alignItems="center">
-                                {!!vault && (
-                                    <TokenIcon
-                                        symbol={account.symbol}
-                                        contractAddress={vault.tokenContract}
-                                        size="tiny"
-                                    />
-                                )}
-                                <Box flexShrink={1}>
+                            {vault ? (
+                                <>
+                                    <HStack spacing="sp4" alignItems="center">
+                                        <TokenIcon
+                                            symbol={account.symbol}
+                                            contractAddress={vault.tokenContract}
+                                            size="tiny"
+                                        />
+                                        <Box flexShrink={1}>
+                                            <Text
+                                                variant="body-md"
+                                                color="contentSecondary"
+                                                numberOfLines={1}
+                                                ellipsizeMode="tail"
+                                            >
+                                                {vault.name}
+                                            </Text>
+                                        </Box>
+                                    </HStack>
                                     <Text
-                                        variant="body-md"
+                                        variant="body-xs"
                                         color="contentSecondary"
                                         numberOfLines={1}
                                         ellipsizeMode="tail"
                                     >
-                                        {headerLabel}
+                                        {accountLabel}
                                     </Text>
-                                </Box>
-                            </HStack>
+                                </>
+                            ) : (
+                                <Text
+                                    variant="body-md"
+                                    color="contentSecondary"
+                                    numberOfLines={1}
+                                    ellipsizeMode="tail"
+                                >
+                                    {accountLabel}
+                                </Text>
+                            )}
                         </VStack>
                     }
                 />

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -3,7 +3,6 @@ import { type EarnDashboardType } from '@suite-common/message-system';
 import { type NetworkSymbol, type StakingNetworkSymbol } from '@suite-common/wallet-config';
 import {
     type Account,
-    type AccountDescriptor,
     type AccountKey,
     type BaseCurrencyAmount,
     type TokenAddress,
@@ -63,8 +62,6 @@ export type StablecoinYieldEarnItem = {
 export type StablecoinYieldClaimSummary = {
     type: 'stablecoin-yield';
     accountKey: AccountKey;
-    accountLabel?: Account['accountLabel'];
-    accountDescriptor: AccountDescriptor;
     networkSymbol: NetworkSymbol;
     claimableRewardsCount: number;
     fiatClaimableAmount: BaseCurrencyAmount | null;

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -122,8 +122,6 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             {
                 type: 'stablecoin-yield',
                 accountKey: ethereumAccount.key,
-                accountLabel: ethereumAccount.accountLabel,
-                accountDescriptor: ethereumAccount.descriptor,
                 networkSymbol: ethereumAccount.symbol,
                 claimableRewardsCount: 1,
                 fiatClaimableAmount: null,
@@ -269,19 +267,21 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             expect(items).toEqual([
                 {
                     summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
-                    vault: {
-                        name: 'Spark USDC Vault',
-                        tokenContract: underlyingTokenContract,
-                    },
+                    vaults: [
+                        {
+                            name: 'Spark USDC Vault',
+                            tokenContract: underlyingTokenContract,
+                        },
+                    ],
                 },
                 {
                     summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
-                    vault: null,
+                    vaults: [],
                 },
             ]);
         });
 
-        it('does not attach a vault when the account holds multiple vault positions', () => {
+        it('attaches all named vault positions when the account holds multiple', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
                 stablecoinYieldActiveItems: [
@@ -299,8 +299,13 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             });
 
             expect(items).toEqual([
-                expect.objectContaining({ vault: null }),
-                expect.objectContaining({ vault: null }),
+                expect.objectContaining({
+                    vaults: [
+                        expect.objectContaining({ name: 'Spark USDC Vault' }),
+                        expect.objectContaining({ name: 'Steakhouse USDT Vault' }),
+                    ],
+                }),
+                expect.objectContaining({ vaults: [] }),
             ]);
         });
 
@@ -329,14 +334,19 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             expect(items).toEqual([
                 {
                     summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
-                    vault: {
-                        name: 'Spark USDC Vault',
-                        tokenContract: underlyingTokenContract,
-                    },
+                    vaults: [
+                        {
+                            name: 'Spark USDC Vault',
+                            tokenContract: underlyingTokenContract,
+                        },
+                    ],
                 },
                 {
                     summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
-                    vault: null,
+                    vaults: [
+                        expect.objectContaining({ name: 'Steakhouse USDT Vault' }),
+                        expect.objectContaining({ name: 'Morpho USDC Vault' }),
+                    ],
                 },
             ]);
         });
@@ -359,7 +369,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             ]);
         });
 
-        it('does not attach a vault when the vault name is unknown', () => {
+        it('skips vault positions without a name', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
                 stablecoinYieldActiveItems: [
@@ -367,7 +377,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
                 ],
             });
 
-            expect(items[0]?.vault).toBeNull();
+            expect(items[0]?.vaults).toEqual([]);
         });
     });
 });

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -5,20 +5,24 @@ import {
     asAccountDescriptor,
     asBaseCurrencyAmount,
     toTokenAddress,
+    toTokenSymbol,
 } from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
 
 import {
+    buildStablecoinYieldClaimItems,
     buildStablecoinYieldClaimSummaries,
     getStablecoinYieldAccountRewards,
     getStablecoinYieldClaimRewardsSnapshot,
     getTotalFiatClaimableAmount,
 } from './stablecoinYieldClaimSummaryUtils';
+import { type StablecoinYieldEarnItem } from '../types';
 
 const ethSymbol = asNetworkSymbol('eth');
 
 const receiptTokenContract = toTokenAddress('0x0000000000000000000000000000000000000002');
+const underlyingTokenContract = toTokenAddress('0x0000000000000000000000000000000000000001');
 
 const ethereumAccount = mockWalletAccount({
     symbol: ethSymbol,
@@ -209,5 +213,161 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
                 fiatValue: '1.25',
             },
         ]);
+    });
+
+    describe('buildStablecoinYieldClaimItems', () => {
+        const createYieldEarnItem = ({
+            account,
+            vaultName,
+            id = `vault-${account.key}`,
+        }: {
+            account: Account;
+            vaultName: string;
+            id?: string;
+        }): StablecoinYieldEarnItem => ({
+            id,
+            type: 'stablecoin-yield',
+            yieldId: id,
+            vaultName,
+            tokenSymbol: toTokenSymbol('USDC'),
+            networkSymbol: ethSymbol,
+            underlyingTokenContract,
+            receiptTokenContract,
+            contractAddress: receiptTokenContract,
+            tokenContractAddress: underlyingTokenContract,
+            accountKey: account.key,
+            accountLabel: account.accountLabel,
+            tokenBalance: '42',
+            apy: 4.2,
+        });
+
+        const claimSummaries = buildStablecoinYieldClaimSummaries({
+            accounts: [ethereumAccount, exitedEthereumAccount],
+            chainsRewardsWithFiat: [
+                createChainRewards({
+                    account: ethereumAccount,
+                    rewards: [createReward({ claimable: '1000000', fiatClaimable: '1.25' })],
+                }),
+                createChainRewards({
+                    account: exitedEthereumAccount,
+                    rewards: [createReward({ claimable: '2000000', fiatClaimable: '2.5' })],
+                }),
+            ],
+        });
+
+        it('attaches the vault when the account holds exactly one named vault position', () => {
+            const items = buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries: claimSummaries,
+                stablecoinYieldActiveItems: [
+                    createYieldEarnItem({
+                        account: ethereumAccount,
+                        vaultName: 'Spark USDC Vault',
+                    }),
+                ],
+            });
+
+            expect(items).toEqual([
+                {
+                    summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
+                    vault: {
+                        name: 'Spark USDC Vault',
+                        tokenContract: underlyingTokenContract,
+                    },
+                },
+                {
+                    summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
+                    vault: null,
+                },
+            ]);
+        });
+
+        it('does not attach a vault when the account holds multiple vault positions', () => {
+            const items = buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries: claimSummaries,
+                stablecoinYieldActiveItems: [
+                    createYieldEarnItem({
+                        account: ethereumAccount,
+                        vaultName: 'Spark USDC Vault',
+                        id: 'vault-1',
+                    }),
+                    createYieldEarnItem({
+                        account: ethereumAccount,
+                        vaultName: 'Steakhouse USDT Vault',
+                        id: 'vault-2',
+                    }),
+                ],
+            });
+
+            expect(items).toEqual([
+                expect.objectContaining({ vault: null }),
+                expect.objectContaining({ vault: null }),
+            ]);
+        });
+
+        it('groups vaults per account, so one account having multiple positions does not affect another', () => {
+            const items = buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries: claimSummaries,
+                stablecoinYieldActiveItems: [
+                    createYieldEarnItem({
+                        account: ethereumAccount,
+                        vaultName: 'Spark USDC Vault',
+                        id: 'vault-1',
+                    }),
+                    createYieldEarnItem({
+                        account: exitedEthereumAccount,
+                        vaultName: 'Steakhouse USDT Vault',
+                        id: 'vault-2',
+                    }),
+                    createYieldEarnItem({
+                        account: exitedEthereumAccount,
+                        vaultName: 'Morpho USDC Vault',
+                        id: 'vault-3',
+                    }),
+                ],
+            });
+
+            expect(items).toEqual([
+                {
+                    summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
+                    vault: {
+                        name: 'Spark USDC Vault',
+                        tokenContract: underlyingTokenContract,
+                    },
+                },
+                {
+                    summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
+                    vault: null,
+                },
+            ]);
+        });
+
+        it('ignores active items for accounts without a claimable summary', () => {
+            const items = buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries: claimSummaries,
+                stablecoinYieldActiveItems: [
+                    createYieldEarnItem({
+                        account: anotherEthereumAccount,
+                        vaultName: 'Spark USDC Vault',
+                    }),
+                ],
+            });
+
+            expect(items).toHaveLength(2);
+            expect(items.map(item => item.summary.accountKey)).toEqual([
+                ethereumAccount.key,
+                exitedEthereumAccount.key,
+            ]);
+        });
+
+        it('does not attach a vault when the vault name is unknown', () => {
+            const items = buildStablecoinYieldClaimItems({
+                stablecoinYieldClaimSummaries: claimSummaries,
+                stablecoinYieldActiveItems: [
+                    createYieldEarnItem({ account: ethereumAccount, vaultName: '' }),
+                ],
+            });
+
+            expect(items[0]?.vault).toBeNull();
+        });
     });
 });

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -158,8 +158,6 @@ export const buildStablecoinYieldClaimSummaries = ({
             {
                 type: 'stablecoin-yield',
                 accountKey: account.key,
-                accountLabel: account.accountLabel,
-                accountDescriptor: account.descriptor,
                 networkSymbol: account.symbol,
                 claimableRewardsCount: accountRewards.rewards.length,
                 fiatClaimableAmount: accountRewards.totalFiatClaimableAmount,
@@ -170,11 +168,11 @@ export const buildStablecoinYieldClaimSummaries = ({
 
 export type StablecoinYieldClaimItem = {
     summary: StablecoinYieldClaimSummary;
-    vault: YieldClaimVaultParams | null;
+    vaults: YieldClaimVaultParams[];
 };
 
-// Rewards are claimed per account, so a claim can only be attributed to a vault
-// when the account holds exactly one vault position with a known name.
+// Rewards are claimed per account, so one item covers all of the account's vault positions
+// — and rewards outlive a fully withdrawn position, which leaves an item with no vaults.
 export const buildStablecoinYieldClaimItems = ({
     stablecoinYieldClaimSummaries,
     stablecoinYieldActiveItems,
@@ -182,22 +180,15 @@ export const buildStablecoinYieldClaimItems = ({
     stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[];
     stablecoinYieldActiveItems: StablecoinYieldEarnItem[];
 }): StablecoinYieldClaimItem[] =>
-    stablecoinYieldClaimSummaries.map(summary => {
-        const accountVaults = stablecoinYieldActiveItems.filter(
-            item => item.accountKey === summary.accountKey,
-        );
-        const accountVault = accountVaults.length === 1 ? accountVaults[0] : undefined;
-
-        return {
-            summary,
-            vault: accountVault?.vaultName
-                ? {
-                      name: accountVault.vaultName,
-                      tokenContract: accountVault.tokenContractAddress,
-                  }
-                : null,
-        };
-    });
+    stablecoinYieldClaimSummaries.map(summary => ({
+        summary,
+        vaults: stablecoinYieldActiveItems
+            .filter(item => item.accountKey === summary.accountKey && item.vaultName)
+            .map(item => ({
+                name: item.vaultName,
+                tokenContract: item.tokenContractAddress,
+            })),
+    }));
 
 export const getTotalFiatClaimableAmount = (
     stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[],

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -11,9 +11,10 @@ import {
     toTokenAddress,
 } from '@suite-common/wallet-types';
 import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
+import { type YieldClaimVaultParams } from '@suite-native/navigation';
 import { BigNumber } from '@trezor/utils';
 
-import { type StablecoinYieldClaimSummary } from '../types';
+import { type StablecoinYieldClaimSummary, type StablecoinYieldEarnItem } from '../types';
 
 type BuildStablecoinYieldClaimSummariesParams = {
     accounts: Account[];
@@ -166,6 +167,37 @@ export const buildStablecoinYieldClaimSummaries = ({
         ];
     });
 };
+
+export type StablecoinYieldClaimItem = {
+    summary: StablecoinYieldClaimSummary;
+    vault: YieldClaimVaultParams | null;
+};
+
+// Rewards are claimed per account, so a claim can only be attributed to a vault
+// when the account holds exactly one vault position with a known name.
+export const buildStablecoinYieldClaimItems = ({
+    stablecoinYieldClaimSummaries,
+    stablecoinYieldActiveItems,
+}: {
+    stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[];
+    stablecoinYieldActiveItems: StablecoinYieldEarnItem[];
+}): StablecoinYieldClaimItem[] =>
+    stablecoinYieldClaimSummaries.map(summary => {
+        const accountVaults = stablecoinYieldActiveItems.filter(
+            item => item.accountKey === summary.accountKey,
+        );
+        const accountVault = accountVaults.length === 1 ? accountVaults[0] : undefined;
+
+        return {
+            summary,
+            vault: accountVault?.vaultName
+                ? {
+                      name: accountVault.vaultName,
+                      tokenContract: accountVault.tokenContractAddress,
+                  }
+                : null,
+        };
+    });
 
 export const getTotalFiatClaimableAmount = (
     stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[],

--- a/suite-native/module-earn/tsconfig.json
+++ b/suite-native/module-earn/tsconfig.json
@@ -75,6 +75,7 @@
         { "path": "../helpers" },
         { "path": "../icons" },
         { "path": "../intl" },
+        { "path": "../labeling" },
         { "path": "../link" },
         { "path": "../message-system" },
         { "path": "../navigation" },

--- a/suite-native/navigation/src/navigators.ts
+++ b/suite-native/navigation/src/navigators.ts
@@ -94,8 +94,14 @@ export type YieldFlowParams = {
     yieldId?: string;
 };
 
+export type YieldClaimVaultParams = {
+    name: string;
+    tokenContract: TokenAddress;
+};
+
 export type YieldClaimParams = {
     accountKey: AccountKey;
+    vault?: YieldClaimVaultParams;
 };
 
 export type YieldInsufficientBalanceParams = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13084,6 +13084,7 @@ __metadata:
     "@suite-native/helpers": "workspace:*"
     "@suite-native/icons": "workspace:*"
     "@suite-native/intl": "workspace:*"
+    "@suite-native/labeling": "workspace:*"
     "@suite-native/link": "workspace:*"
     "@suite-native/message-system": "workspace:*"
     "@suite-native/navigation": "workspace:*"


### PR DESCRIPTION
## Description

Reworks the yield claim entry flow and fixes reward-value overflow:

- "Claim rewards" with more than one claimable account now opens the **Your yields** bottom sheet with the claimable fiat amount per row; with exactly one it navigates straight to the claim screen.
- Rows are one per claim summary (account) — Merkl rewards are claimed per account, one tx claims all of an account's rewards. A row (and the claim-screen header) shows the vault association (icon + vault name · account label) only when the account holds exactly one named vault position; multi-vault or exited accounts fall back to account-style display.
- The claim-screen header now truncates long vault/account labels correctly (flex-shrink fix).
- Long reward values wrap to two lines instead of overflowing into the fiat column (the original issue ask), on both the claim and complete screens.

Deliberate deviation from the literal spec: one account holding two vaults navigates directly to the claim screen — the sheet would contain a single actionable row.

## Notes for QA

- One account with claimable rewards → straight to claim screen; header shows vault icon + name when that account has exactly one named vault.
- Two+ accounts with rewards → "Your yields" sheet, one row per account with fiat amount.
- Long vault/account names ellipsize in the header; long reward amounts wrap to 2 lines and stay clear of the fiat column.
- Claim → review → back keeps the vault header; complete screen renders normally.

## Related Issue

Resolve #29806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/wrap-claim-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/wrap-claim-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/wrap-claim-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files live in the native mobile app (`suite-native/module-earn`, `suite-native/intl`, `suite-native/navigation`) and implement a mobile-specific stablecoin yield claim rewards feature. The available Playwright E2E catalog covers only the web/desktop Suite (`suite/e2e/tests`) and does not exercise native mobile screens, components, navigation, or the stablecoin yield claim flow. None of the desktop staking/earn tests are applicable because the feature and code paths are platform-specific. The included unit test for `stablecoinYieldClaimSummaryUtils` should provide local coverage, but no E2E tests from this catalog are warranted.

<details><summary><b>Changed files (11)</b></summary>

- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/components/EarnDepositsCard.tsx`
- `suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx`
- `suite-native/module-earn/src/components/YieldClaimRewardRow.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/types.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`
- `suite-native/module-earn/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (11)**
- `suite-native/intl/src/messages.ts`
- `suite-native/module-earn/package.json`
- `suite-native/module-earn/src/components/EarnDepositsCard.tsx`
- `suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx`
- `suite-native/module-earn/src/components/YieldClaimRewardRow.tsx`
- `suite-native/module-earn/src/screens/YieldClaimScreen.tsx`
- `suite-native/module-earn/src/types.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts`
- `suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts`
- `suite-native/module-earn/tsconfig.json`
- `suite-native/navigation/src/navigators.ts`

_Updated: 2026-08-10T08:56:25.660Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/wrap-claim-native/web/](https://dev.suite.sldev.cz/suite-web/feat/wrap-claim-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:58:50.723Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:58:48.299Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->