### PR TITLE
feat(suite-native): require firmware 2.12.4 for weth vault and wrap/unwrap flows

### DIFF
--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.test.ts
@@ -1,0 +1,48 @@
+import {
+    type DeviceRootState,
+    deviceInitialState,
+    portfolioTrackerDevice,
+} from '@suite-common/device';
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
+import { DeviceModelInternal } from '@trezor/device-utils';
+
+import { selectIsWrappedNativeFlowSupported } from './stablecoinYieldSelectors';
+
+const createState = (selectedDevice?: TrezorDevice): DeviceRootState => ({
+    device: { ...deviceInitialState, selectedDevice },
+});
+
+const createStateWithFirmware = ([major, minor, patch]: [number, number, number]) =>
+    createState(
+        mockSuiteDevice({}, { major_version: major, minor_version: minor, patch_version: patch }),
+    );
+
+describe('selectIsWrappedNativeFlowSupported', () => {
+    it('returns false when no device is selected', () => {
+        expect(selectIsWrappedNativeFlowSupported(createState())).toBe(false);
+    });
+
+    it('requires firmware 2.12.4', () => {
+        expect(selectIsWrappedNativeFlowSupported(createStateWithFirmware([2, 12, 3]))).toBe(false);
+        expect(selectIsWrappedNativeFlowSupported(createStateWithFirmware([2, 12, 4]))).toBe(true);
+    });
+
+    it('returns true for T1B1 regardless of firmware version', () => {
+        const device = mockSuiteDevice(
+            {},
+            {
+                internal_model: DeviceModelInternal.T1B1,
+                major_version: 1,
+                minor_version: 10,
+                patch_version: 0,
+            },
+        );
+
+        expect(selectIsWrappedNativeFlowSupported(createState(device))).toBe(true);
+    });
+
+    it('returns false for the portfolio-tracker device', () => {
+        expect(selectIsWrappedNativeFlowSupported(createState(portfolioTrackerDevice))).toBe(false);
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.ts
@@ -1,3 +1,6 @@
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+
+import { isWrappedNativeFlowSupported } from './stablecoinYieldDeviceUtils';
 import {
     type StablecoinYieldRootState,
     type StablecoinYieldSessionState,
@@ -6,6 +9,9 @@ import {
     initialStablecoinYieldSessionState,
 } from './stablecoinYieldReducer';
 import type { YieldFlowType } from './stablecoinYieldTypes';
+
+export const selectIsWrappedNativeFlowSupported = (state: DeviceRootState): boolean =>
+    isWrappedNativeFlowSupported(selectSelectedDevice(state));
 
 export const selectStablecoinYield = (state: StablecoinYieldRootState) =>
     state.wallet.stablecoinYield;

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2677,6 +2677,9 @@ export const messages = {
         },
         wrappedNativeToken: {
             maxButton: 'Max',
+            featureName: 'wrapping and unwrapping',
+            firmwareOutdated:
+                'Update the firmware on your Trezor to continue with this transaction.',
         },
         wrapNativeToken: {
             entryButton: 'Wrap',

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { useNavigation } from '@react-navigation/native';
 
-import { selectSelectedDevice } from '@suite-common/device';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import {
     DefinitionType,
     type TokenDefinitionsRootState,
@@ -21,7 +21,6 @@ import {
 import {
     type AccountsRootState,
     type TokensRootState,
-    isWrappedNativeFlowSupported,
     selectAccountByKey,
     selectAccountHiddenTokens,
     selectAccountNetworkSymbol,
@@ -47,7 +46,7 @@ import {
 } from '@suite-native/formatters';
 import { TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
-import { useStablecoinYieldFirmwareUpdateAlert } from '@suite-native/module-earn';
+import { useWrappedNativeFirmwareUpdateAlert } from '@suite-native/module-earn';
 import {
     type RootStackParamList,
     RootStackRoutes,
@@ -126,8 +125,9 @@ export const TokenSettingsBottomSheet = forwardRef(
         const isUnrecognized = useSelector((state: TokenDefinitionsRootState & AccountsRootState) =>
             selectIsUnrecognizedToken(state, accountKey, tokenContract),
         );
-        const device = useSelector(selectSelectedDevice);
-        const { showFirmwareUpdateAlert } = useStablecoinYieldFirmwareUpdateAlert();
+        const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
+        const { isFirmwareSupported, showFirmwareUpdateAlert } =
+            useWrappedNativeFirmwareUpdateAlert();
 
         if (!account || !symbol) return null;
 
@@ -154,20 +154,20 @@ export const TokenSettingsBottomSheet = forwardRef(
         };
 
         const isUnwrapDisplayed =
+            !isPortfolioTrackerDevice &&
             account.networkType === 'ethereum' &&
             isWrappedNativeToken(account.symbol, tokenContract);
         const isWrapDisplayed =
+            !isPortfolioTrackerDevice &&
             isDevelopOrDebugEnv() &&
             !tokenContract &&
             account.networkType === 'ethereum' &&
             !!getWrappedNativeAddress(account.symbol);
 
-        const isWrappedNativeFirmwareSupported = isWrappedNativeFlowSupported(device);
-
         const handleUnwrapPress = () => {
             onNavigateAway?.();
 
-            if (!isWrappedNativeFirmwareSupported) {
+            if (!isFirmwareSupported) {
                 showFirmwareUpdateAlert();
 
                 return;
@@ -182,7 +182,7 @@ export const TokenSettingsBottomSheet = forwardRef(
         const handleWrapPress = () => {
             onNavigateAway?.();
 
-            if (!isWrappedNativeFirmwareSupported) {
+            if (!isFirmwareSupported) {
                 showFirmwareUpdateAlert();
 
                 return;

--- a/suite-native/module-earn/src/hooks/useFirmwareUpdateAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useFirmwareUpdateAlert.tsx
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { selectSelectedDeviceLabelOrName } from '@suite-common/device';
+import { useAlert } from '@suite-native/alerts';
+import { Translation, useTranslate } from '@suite-native/intl';
+import {
+    DeviceSettingsStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProps = StackNavigationProps<
+    RootStackParamList,
+    RootStackRoutes.DeviceSettingsStack
+>;
+
+export const useFirmwareUpdateAlert = (featureName: string) => {
+    const navigation = useNavigation<NavigationProps>();
+    const { showAlert } = useAlert();
+    const { translate } = useTranslate();
+    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+
+    return useCallback(() => {
+        showAlert({
+            title: (
+                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.title" />
+            ),
+            description: translate(
+                'moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.description',
+                {
+                    name: deviceLabel,
+                    featureName,
+                },
+            ),
+            primaryButtonTitle: (
+                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.primaryButtonTitle" />
+            ),
+            onPressPrimaryButton: () => {
+                navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
+                    screen: DeviceSettingsStackRoutes.DeviceFirmware,
+                    params: { closeActionType: 'close' },
+                });
+            },
+            primaryButtonColorProps: { intent: 'info', priority: 'primary' },
+            secondaryButtonColorProps: { intent: 'info', priority: 'secondary' },
+            secondaryButtonTitle: (
+                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.secondaryButtonTitle" />
+            ),
+            testID: '@account-detail/stablecoin-yield/firmware-update-alert',
+        });
+    }, [deviceLabel, featureName, navigation, showAlert, translate]);
+};

--- a/suite-native/module-earn/src/hooks/useStablecoinYieldFirmwareUpdateAlert.tsx
+++ b/suite-native/module-earn/src/hooks/useStablecoinYieldFirmwareUpdateAlert.tsx
@@ -1,70 +1,26 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
-import { selectSelectedDevice, selectSelectedDeviceLabelOrName } from '@suite-common/device';
+import { selectSelectedDevice } from '@suite-common/device';
 import {
     type StablecoinYieldVaultToken,
     type YieldFlowType,
     isStablecoinYieldSupported,
 } from '@suite-common/wallet-core';
-import { useAlert } from '@suite-native/alerts';
-import { Translation, useTranslate } from '@suite-native/intl';
-import {
-    DeviceSettingsStackRoutes,
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
+import { useTranslate } from '@suite-native/intl';
 
-type NavigationProps = StackNavigationProps<
-    RootStackParamList,
-    RootStackRoutes.DeviceSettingsStack
->;
+import { useFirmwareUpdateAlert } from './useFirmwareUpdateAlert';
 
 export const useStablecoinYieldFirmwareUpdateAlert = () => {
-    const navigation = useNavigation<NavigationProps>();
-    const { showAlert } = useAlert();
     const { translate } = useTranslate();
     const selectedDevice = useSelector(selectSelectedDevice);
-    const deviceLabel = useSelector(selectSelectedDeviceLabelOrName);
+    const showFirmwareUpdateAlert = useFirmwareUpdateAlert(translate('earn.defiYield'));
 
     const isFirmwareSupported = useCallback(
         (flowType: YieldFlowType, vaultToken?: StablecoinYieldVaultToken) =>
             isStablecoinYieldSupported(selectedDevice, { flowType, vaultToken }),
         [selectedDevice],
     );
-
-    const showFirmwareUpdateAlert = useCallback(() => {
-        showAlert({
-            title: (
-                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.title" />
-            ),
-            description: translate(
-                'moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.description',
-                {
-                    name: deviceLabel,
-                    featureName: translate('earn.defiYield'),
-                },
-            ),
-            primaryButtonTitle: (
-                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.primaryButtonTitle" />
-            ),
-            onPressPrimaryButton: () => {
-                navigation.navigate(RootStackRoutes.DeviceSettingsStack, {
-                    screen: DeviceSettingsStackRoutes.DeviceFirmware,
-                    params: { closeActionType: 'close' },
-                });
-            },
-            primaryButtonColorProps: { intent: 'info', priority: 'primary' },
-            secondaryButtonColorProps: { intent: 'info', priority: 'secondary' },
-            secondaryButtonTitle: (
-                <Translation id="moduleAccounts.accountDetail.stablecoinYield.firmwareUpdateAlert.secondaryButtonTitle" />
-            ),
-            testID: '@account-detail/stablecoin-yield/firmware-update-alert',
-        });
-    }, [deviceLabel, navigation, showAlert, translate]);
 
     return {
         isFirmwareSupported,

--- a/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
+++ b/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
@@ -117,6 +117,7 @@ export const useStandaloneWrappedNativeFlow = ({
         handleSubmit: simulation.handleSubmit,
         hasFlowFailed,
         isDeviceNotConnectedVisible: simulation.isDeviceNotConnectedVisible,
+        isFirmwareOutdatedVisible: simulation.isFirmwareOutdatedVisible,
         isPending: !!pendingParam,
         pendingBottomSheetRef,
         pendingModalProps,

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFirmwareUpdateAlert.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFirmwareUpdateAlert.ts
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+
+import { selectIsWrappedNativeFlowSupported } from '@suite-common/wallet-core';
+import { useTranslate } from '@suite-native/intl';
+
+import { useFirmwareUpdateAlert } from './useFirmwareUpdateAlert';
+
+export const useWrappedNativeFirmwareUpdateAlert = () => {
+    const { translate } = useTranslate();
+    const isFirmwareSupported = useSelector(selectIsWrappedNativeFlowSupported);
+    const showFirmwareUpdateAlert = useFirmwareUpdateAlert(
+        translate('earn.wrappedNativeToken.featureName'),
+    );
+
+    return { isFirmwareSupported, showFirmwareUpdateAlert };
+};

--- a/suite-native/module-earn/src/hooks/useWrappedNativeTxSimulation.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeTxSimulation.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { selectIsDeviceConnected } from '@suite-common/device';
+import { selectIsWrappedNativeFlowSupported } from '@suite-common/wallet-core';
 import { useBottomSheetModal } from '@suite-native/atoms';
 
 import { type PreparedWrappedNativeTokenAction } from './useWrappedNativeTokenFees';
@@ -16,7 +17,7 @@ type UseWrappedNativeTxSimulationParams = {
 
 /**
  * Steps between entering a wrap/unwrap amount and handing the transaction over to the review:
- * freezing the prepared transaction, the simulation sheet and the device-connected guard. What
+ * freezing the prepared transaction, the simulation sheet and the device guards. What
  * happens after the confirmation is injected, because the standalone and the in-deposit flows
  * store and navigate differently.
  */
@@ -27,6 +28,7 @@ export const useWrappedNativeTxSimulation = ({
     onConfirm,
 }: UseWrappedNativeTxSimulationParams) => {
     const [isDeviceNotConnectedVisible, setIsDeviceNotConnectedVisible] = useState(false);
+    const [isFirmwareOutdatedVisible, setIsFirmwareOutdatedVisible] = useState(false);
     const [preparedTx, setPreparedTx] = useState<PreparedWrappedNativeTokenAction | null>(null);
 
     const {
@@ -36,6 +38,7 @@ export const useWrappedNativeTxSimulation = ({
     } = useBottomSheetModal();
 
     const isDeviceConnected = useSelector(selectIsDeviceConnected);
+    const isFirmwareSupported = useSelector(selectIsWrappedNativeFlowSupported);
 
     const handleSubmit = useCallback(() => {
         if (preparedAction?.amount !== amountValue) {
@@ -54,15 +57,17 @@ export const useWrappedNativeTxSimulation = ({
             return;
         }
 
-        if (!isDeviceConnected) {
-            setIsDeviceNotConnectedVisible(true);
+        const isFirmwareOutdated = isDeviceConnected && !isFirmwareSupported;
 
+        setIsDeviceNotConnectedVisible(!isDeviceConnected);
+        setIsFirmwareOutdatedVisible(isFirmwareOutdated);
+
+        if (!isDeviceConnected || isFirmwareOutdated) {
             return;
         }
 
-        setIsDeviceNotConnectedVisible(false);
         onConfirm(preparedTx);
-    }, [closeSimulationBottomSheet, isDeviceConnected, onConfirm, preparedTx]);
+    }, [closeSimulationBottomSheet, isDeviceConnected, isFirmwareSupported, onConfirm, preparedTx]);
 
     const handleCancelSimulation = useCallback(() => {
         closeSimulationBottomSheet();
@@ -73,6 +78,7 @@ export const useWrappedNativeTxSimulation = ({
         handleConfirmSimulation,
         handleSubmit,
         isDeviceNotConnectedVisible,
+        isFirmwareOutdatedVisible,
         preparedTx,
         simulationBottomSheetRef,
     };

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -7,6 +7,7 @@ export { useStablecoinYieldFirmwareUpdateAlert } from './hooks/useStablecoinYiel
 export { useStakingDetailNavigation } from './hooks/useStakingDetailNavigation';
 export { useStakingNavigateAnalytics } from './hooks/useStakingNavigateAnalytics';
 export { useWorkInProgressAlert } from './hooks/useWorkInProgressAlert';
+export { useWrappedNativeFirmwareUpdateAlert } from './hooks/useWrappedNativeFirmwareUpdateAlert';
 export { EarnStackNavigator } from './navigation/EarnStackNavigator';
 export { WrappedNativeTokenStackNavigator } from './navigation/WrappedNativeTokenStackNavigator';
 export { YieldStackNavigator } from './navigation/YieldStackNavigator';

--- a/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
@@ -133,6 +133,12 @@ export const UnwrapNativeTokenScreen = () => {
                             }
                         />
                     )}
+                    {flow.isFirmwareOutdatedVisible && (
+                        <FullAlertBox
+                            intent="critical"
+                            title={<Translation id="earn.wrappedNativeToken.firmwareOutdated" />}
+                        />
+                    )}
                     {flow.hasFlowFailed && (
                         <FullAlertBox
                             intent="critical"

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -152,6 +152,12 @@ export const WrapNativeTokenScreen = () => {
                             }
                         />
                     )}
+                    {flow.isFirmwareOutdatedVisible && (
+                        <FullAlertBox
+                            intent="critical"
+                            title={<Translation id="earn.wrappedNativeToken.firmwareOutdated" />}
+                        />
+                    )}
                     {flow.hasFlowFailed && (
                         <FullAlertBox
                             intent="critical"

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -363,6 +363,17 @@ export const YieldDepositWrapScreen = () => {
                             </Box>
                         )}
 
+                        {simulation.isFirmwareOutdatedVisible && (
+                            <Box paddingHorizontal="sp16">
+                                <FullAlertBox
+                                    intent="critical"
+                                    title={
+                                        <Translation id="earn.wrappedNativeToken.firmwareOutdated" />
+                                    }
+                                />
+                            </Box>
+                        )}
+
                         {isFeeSectionDisplayed && (
                             <Box paddingHorizontal="sp16">
                                 <YieldFeeSection accountKey={account.key} fees={wrapFee} />

--- a/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
+++ b/suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts
@@ -81,6 +81,10 @@ describe(navigateByYieldAccountState.name, () => {
                 yieldId: 'ethereum-vault',
             },
         });
+        expect(isFirmwareSupported).toHaveBeenCalledWith('deposit', {
+            networkSymbol: ethSymbol,
+            contractAddress: WETH_ADDRESS,
+        });
     });
 
     it('counts a small native balance as fully depositable (no gas reserve deducted)', () => {

--- a/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
+++ b/suite-native/module-earn/src/wrappedNativeTokenThunks.ts
@@ -3,6 +3,7 @@ import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stable
 import { createThunk } from '@suite-common/redux-utils';
 import {
     type YieldFlowDisplayToken,
+    isWrappedNativeFlowSupported,
     selectAddressDisplayType,
     synchronizeSentTransactionThunk,
 } from '@suite-common/wallet-core';
@@ -68,6 +69,13 @@ export const signWrappedNativeTokenThunk = createThunk<
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Invalid input data.',
+            });
+        }
+
+        if (!isWrappedNativeFlowSupported(device)) {
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: 'Firmware does not support wrap/unwrap.',
             });
         }
 

--- a/suite-native/module-earn/src/yieldTransactionThunks.test.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.test.ts
@@ -1,9 +1,12 @@
 import { combineReducers, isFulfilled, isRejected } from '@reduxjs/toolkit';
 
+import { selectSelectedDevice } from '@suite-common/device';
+import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { configureMockStore } from '@suite-common/test-utils';
 import {
     type StablecoinYieldRootState,
     type YieldFlowResolvedData,
+    type YieldFlowToken,
     type YieldPositionFlowType,
     selectStablecoinYieldSession,
     selectStablecoinYieldTxReview,
@@ -20,17 +23,24 @@ import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import TrezorConnect from '@trezor/connect';
 import { type StaticSessionId } from '@trezor/device-utils';
 
-import { pushYieldActionReviewThunk } from './yieldTransactionThunks';
+import { pushYieldActionReviewThunk, signYieldActionReviewThunk } from './yieldTransactionThunks';
 
 jest.mock('@trezor/connect', () => ({
     __esModule: true,
     ...jest.requireActual('@trezor/connect'),
     default: {
+        ethereumSignTransaction: jest.fn(),
         pushTransaction: jest.fn().mockResolvedValue({
             success: true,
             payload: { txid: '0xpushedtxid' },
         }),
     },
+}));
+
+jest.mock('@suite-common/device', () => ({
+    __esModule: true,
+    ...jest.requireActual('@suite-common/device'),
+    selectSelectedDevice: jest.fn(),
 }));
 
 jest.mock('@suite-common/wallet-core', () => ({
@@ -67,8 +77,16 @@ const buildAccount = (descriptor: string) => {
 const account = buildAccount('0xfffffffffffffffffffffffffffffffffffffffe');
 const otherAccount = buildAccount('0xfffffffffffffffffffffffffffffffffffffffd');
 
-const buildFlowData = (flowAccount: Account) =>
-    ({ account: flowAccount }) as unknown as YieldFlowResolvedData;
+const wethVaultToken = {
+    networkSymbol: account.symbol,
+    symbol: 'weth',
+    decimals: 18,
+    contractAddress: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+    balance: '1',
+} satisfies YieldFlowToken;
+
+const buildFlowData = (flowAccount: Account, token?: YieldFlowToken) =>
+    ({ account: flowAccount, token }) as unknown as YieldFlowResolvedData;
 
 const precomposedForm = {
     outputs: [],
@@ -95,7 +113,9 @@ const precomposedTransaction = {
 } satisfies PrecomposedTransactionFinal;
 
 const pushTransactionMock = TrezorConnect.pushTransaction as jest.Mock;
+const ethereumSignTransactionMock = TrezorConnect.ethereumSignTransaction as jest.Mock;
 const synchronizeSentTransactionThunkMock = synchronizeSentTransactionThunk as unknown as jest.Mock;
+const selectSelectedDeviceMock = selectSelectedDevice as jest.Mock;
 
 const buildStore = () =>
     configureMockStore({
@@ -271,5 +291,35 @@ describe('pushYieldActionReviewThunk', () => {
             error: { error: 'push-transaction-failed', message: 'Transaction not found.' },
         });
         expect(pushTransactionMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('signYieldActionReviewThunk', () => {
+    beforeEach(() => {
+        ethereumSignTransactionMock.mockClear();
+        selectSelectedDeviceMock.mockReset();
+    });
+
+    it('rejects a wrapped-native vault deposit on firmware below 2.12.4 without signing on the device', async () => {
+        const store = buildStore();
+        prepareActionReview({ store, flowType: 'deposit', flowKey: FLOW_KEY });
+        selectSelectedDeviceMock.mockReturnValue(
+            mockSuiteDevice({}, { major_version: 2, minor_version: 12, patch_version: 3 }),
+        );
+
+        const action = await store.dispatch(
+            signYieldActionReviewThunk({
+                flowData: buildFlowData(account, wethVaultToken),
+                flowKey: FLOW_KEY,
+                flowType: 'deposit',
+            }) as any,
+        );
+
+        expect(isRejected(action)).toBe(true);
+        expect(action.payload).toMatchObject({
+            error: 'sign-transaction-failed',
+            message: 'Firmware does not support this yield action.',
+        });
+        expect(ethereumSignTransactionMock).not.toHaveBeenCalled();
     });
 });

--- a/suite-native/module-earn/src/yieldTransactionThunks.ts
+++ b/suite-native/module-earn/src/yieldTransactionThunks.ts
@@ -5,6 +5,7 @@ import {
     type YieldFlowDisplayToken,
     type YieldFlowResolvedData,
     type YieldPositionFlowType,
+    isStablecoinYieldSupported,
     isYieldTxReviewForFlow,
     selectAddressDisplayType,
     selectStablecoinYieldSession,
@@ -70,6 +71,13 @@ export const signYieldActionReviewThunk = createThunk<
             return rejectWithValue({
                 error: 'sign-transaction-failed',
                 message: 'Fee information is missing for the transaction.',
+            });
+        }
+
+        if (!isStablecoinYieldSupported(device, { flowType, vaultToken: flowData.token })) {
+            return rejectWithValue({
+                error: 'sign-transaction-failed',
+                message: 'Firmware does not support this yield action.',
             });
         }
 


### PR DESCRIPTION
## Description

Mobile counterpart of #30848: wrap/unwrap and ETH-vault interaction require firmware 2.12.4 (T1B1 exempt, matching desktop). The shared decision layer (`WRAPPED_NATIVE_MIN_FIRMWARE`, `isWrappedNativeFlowSupported`, `isStablecoinYieldSupported`) landed with the desktop fix; this PR closes the mobile gaps:

- New scoped selectors `selectIsWrappedNativeFlowSupported` / `selectIsStablecoinYieldSupported` in `@suite-common/wallet-core`.
- The standalone wrap/unwrap entry alert now says "wrapping and unwrapping" instead of "DeFi Yield".
- Portfolio-tracker mode no longer shows a bogus firmware-update alert (its fake features report 2.1.1) — wrap/unwrap entries are hidden there.
- In-flow guard: swapping to an older-firmware device while the simulation sheet is open now shows a firmware banner instead of reaching device review; observing an already-pending tx is deliberately not blocked.
- Signing-thunk backstops reject with `sign-transaction-failed` on unsupported firmware.

Known follow-up (deliberately out of scope): `StablecoinYieldTokenOverview` deposit/withdraw buttons have the same portfolio-tracker bogus-alert issue.

Stacked on #31024 (`feat/native-deposit-wrap-step`).

## Notes for QA

- Device on fw < 2.12.4: wrap/unwrap entries in token settings show the update-firmware alert on press; vault deposit entry ditto; claim still requires only 2.12.1.
- Device on fw ≥ 2.12.4: everything works as before.
- Portfolio tracker (view-only, no device): wrap/unwrap entries hidden, no firmware alert.
- T1B1: never prompted to update for these flows.

## Related Issue

Resolve #30985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native-fw-gate-wrap-vault&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-fw-gate-wrap-vault&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-fw-gate-wrap-vault&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are entirely in suite-native mobile code (module-earn, module-accounts-management, suite-native/intl) plus stablecoin-yield selectors/tests in suite-common/wallet-core. The available candidate E2E tests are web/desktop suite tests, none of which exercise React Native earn flows, wrapped native token screens, or stablecoin yield selectors. Although stablecoinYieldSelectors.ts is statically referenced by many suite E2E tests, it appears to be a broad shared import with no evidence these tests actually exercise stablecoin-yield behavior. Therefore no suite E2E tests need to run; rely on the included unit tests for selector logic and native/mobile test coverage elsewhere.

<details><summary><b>Changed files (17)</b></summary>

- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useFirmwareUpdateAlert.tsx`
- `suite-native/module-earn/src/hooks/useStablecoinYieldFirmwareUpdateAlert.tsx`
- `suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFirmwareUpdateAlert.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTxSimulation.ts`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts`
- `suite-native/module-earn/src/wrappedNativeTokenThunks.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.test.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (16)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldSelectors.test.ts`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-earn/src/hooks/useFirmwareUpdateAlert.tsx`
- `suite-native/module-earn/src/hooks/useStablecoinYieldFirmwareUpdateAlert.tsx`
- `suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFirmwareUpdateAlert.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTxSimulation.ts`
- `suite-native/module-earn/src/index.ts`
- `suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/utils/navigateByYieldAccountState.test.ts`
- `suite-native/module-earn/src/wrappedNativeTokenThunks.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.test.ts`
- `suite-native/module-earn/src/yieldTransactionThunks.ts`

_Updated: 2026-08-10T08:46:38.312Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-fw-gate-wrap-vault/web/](https://dev.suite.sldev.cz/suite-web/feat/native-fw-gate-wrap-vault/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:48:36.338Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:48:33.121Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->