### PR TITLE
feat(suite-native): add wrapping and unwrapping analytics

### DIFF
--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -48,7 +48,7 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
         },
         type: {
             description:
-                '`approve-skipped` = user explicitly skipped the approval step because an existing allowance already covers the deposit — distinct from `type=approve` `action=cancel` (cancelled before submitting the allowance transaction) and `type=approve-modal` `action=cancel` (declined the allowance simulation modal)',
+                '`approve-skipped` = user skipped the approval step to continue with the allowance already granted — distinct from `type=approve` `action=cancel` (cancelled before submitting the allowance transaction) and `type=approve-modal` `action=cancel` (declined the allowance simulation modal)',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -87,7 +87,10 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
         wrappedNative: {
             description:
                 'Whether the deposited vault token is the wrapped-native token of the network (e.g. WETH on Ethereum), meaning the deposit involves a native wrap step. Reported on `type=deposit` (submit) and `type=success` (confirmed).',
-            changelog: [{ version: '26.8.0', notes: 'added' }],
+            changelog: [
+                { version: '26.8.0', notes: 'added' },
+                { version: '26.8.1', notes: 'reported from mobile as well' },
+            ],
         },
     },
 };

--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -9,6 +9,7 @@ type Attributes = {
         | 'approve'
         | 'approve-modal'
         | 'approve-success'
+        | 'approve-skipped'
         | 'revoke'
         | 'revoke-modal'
         | 'revoke-success'
@@ -46,6 +47,8 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
             changelog: [{ version: '26.5.0', notes: 'added' }],
         },
         type: {
+            description:
+                '`approve-skipped` = user explicitly skipped the approval step because an existing allowance already covers the deposit — distinct from `type=approve` `action=cancel` (cancelled before submitting the allowance transaction) and `type=approve-modal` `action=cancel` (declined the allowance simulation modal)',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -53,6 +56,7 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
                     notes: 'added `approve-success`, `revoke-success`, `leftPending`, `tx-simulation-modal`, `firmware-upgrade-needed-modal` values',
                 },
                 { version: '26.8.0', notes: 'added `wrap` and `wrap-success` values' },
+                { version: '26.8.1', notes: 'added `approve-skipped` value (mobile)' },
             ],
         },
         networkSymbol: {

--- a/suite-common/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite-common/analytics/src/events/yieldInteractionEvent.ts
@@ -37,7 +37,7 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
     attributes: {
         element: {
             description:
-                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `amount-currency-toggle` = crypto/fiat amount input switch (any yield amount form), `insufficient-funds-banner` = get-token button. The max-button values name the form the button belongs to: `deposit-max` / `withdraw-max` cover the deposit and withdraw forms including their in-flow wrap/unwrap steps, while `wrap-max` / `unwrap-max` are the standalone wrap/unwrap pages (desktop only, no `vaultId`).',
+                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `amount-currency-toggle` = crypto/fiat amount input switch (any yield amount form), `insufficient-funds-banner` = get-token button. The max-button values name the form the button belongs to: `deposit-max` / `withdraw-max` cover the deposit and withdraw forms including their in-flow wrap/unwrap steps, while `wrap-max` / `unwrap-max` are the standalone wrap/unwrap pages (no `vaultId`).',
             changelog: [
                 { version: '26.5.2', notes: 'added' },
                 {
@@ -47,6 +47,10 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
                 {
                     version: '26.8.0',
                     notes: 'added `amount-currency-toggle`, `wrap-max`, `unwrap-max` values (desktop)',
+                },
+                {
+                    version: '26.8.1',
+                    notes: '`wrap-max` / `unwrap-max` reported from mobile as well',
                 },
             ],
         },

--- a/suite-common/analytics/src/events/yieldInteractionEvent.ts
+++ b/suite-common/analytics/src/events/yieldInteractionEvent.ts
@@ -37,7 +37,7 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
     attributes: {
         element: {
             description:
-                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `amount-currency-toggle` = crypto/fiat amount input switch (any yield amount form), `insufficient-funds-banner` = get-token button. The max-button values name the form the button belongs to: `deposit-max` / `withdraw-max` cover the deposit and withdraw forms including their in-flow wrap/unwrap steps, while `wrap-max` / `unwrap-max` are the standalone wrap/unwrap pages (no `vaultId`).',
+                'Which UI element the user interacted with — e.g. `apy-tooltip` = APY breakdown tooltip/alert, `how-it-works` = yield info modal (desktop), `earn-dashboard-claim-rewards` = claimable-rewards section on the mobile earn dashboard, `in-a-nutshell-process-tab` = deposit/withdraw/claim process timeline (modal tab on desktop, info bottom sheet on mobile), `withdraw-unit-toggle` = asset/shares input switch, `amount-currency-toggle` = crypto/fiat amount input switch (any yield amount form; no `vaultId` on the standalone wrap/unwrap forms, which are not tied to a vault), `insufficient-funds-banner` = get-token button. The max-button values name the form the button belongs to: `deposit-max` / `withdraw-max` cover the deposit and withdraw forms including their in-flow wrap/unwrap steps, while `wrap-max` / `unwrap-max` are the standalone wrap/unwrap pages (no `vaultId`).',
             changelog: [
                 { version: '26.5.2', notes: 'added' },
                 {
@@ -50,7 +50,7 @@ export const yieldInteractionEvent: EventDef<Attributes, EventType.YieldInteract
                 },
                 {
                     version: '26.8.1',
-                    notes: '`wrap-max` / `unwrap-max` reported from mobile as well',
+                    notes: '`wrap-max` / `unwrap-max` / `amount-currency-toggle` reported from mobile as well; mobile now also reports `deposit-max` from the approval and in-flow wrap steps and `withdraw-max` from the in-flow unwrap step, which previously reported no max event',
                 },
             ],
         },

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -57,7 +57,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         from: {
             description:
-                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only as an origin, `account-defi-tokens`, `claim-select-account-modal`, `wrap-form` and `unwrap-form` are desktop-only; `account-tokens` = yield badge on the account Tokens tab or the token row actions there, `account-defi-tokens` also covers the yield badge and token row actions on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
+                'Origin of the navigation. On mobile, `deposit-in-a-nutshell-modal` = How yield works screen and `deposit-legal-modal` = consents screen (named after their desktop counterparts); `choose-account-sheet`, `account-detail` and `insufficient-balance-screen` are mobile-only as an origin, `account-defi-tokens` and `claim-select-account-modal` are desktop-only; `account-tokens` = yield badge on the account Tokens tab or the token row actions there, `account-defi-tokens` also covers the yield badge and token row actions on the DeFi tab, `account-tradebox` = yield badge or Earn button in the account trade box',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -68,11 +68,15 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
                     version: '26.8.0',
                     notes: 'added `account-tokens`, `account-tradebox` values, and `wrap-form`, `unwrap-form` values (desktop)',
                 },
+                {
+                    version: '26.8.1',
+                    notes: '`wrap-form` / `unwrap-form` reported from mobile as well',
+                },
             ],
         },
         to: {
             description:
-                'Destination of the navigation. Desktop also reports `account-detail` when leaving the wrap/unwrap pages, where it means the account Tokens tab',
+                'Destination of the navigation. Also reports `account-detail` when leaving the wrap/unwrap pages, where it means the account Tokens tab',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -82,6 +86,10 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
                 {
                     version: '26.8.0',
                     notes: 'added `wrap-form` and `unwrap-form` values, and `account-detail` is now also reported (desktop)',
+                },
+                {
+                    version: '26.8.1',
+                    notes: '`wrap-form` / `unwrap-form` reported from mobile as well',
                 },
             ],
         },

--- a/suite-common/analytics/src/events/yieldNavigateEvent.ts
+++ b/suite-common/analytics/src/events/yieldNavigateEvent.ts
@@ -76,7 +76,7 @@ export const yieldNavigateEvent: EventDef<Attributes, EventType.YieldNavigate> =
         },
         to: {
             description:
-                'Destination of the navigation. Also reports `account-detail` when leaving the wrap/unwrap pages, where it means the account Tokens tab',
+                'Destination of the navigation. Also reports `account-detail` when leaving the wrap/unwrap pages — the account Tokens tab on desktop, the account detail screen on mobile',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {

--- a/suite-common/analytics/src/events/yieldUnwrapEvent.ts
+++ b/suite-common/analytics/src/events/yieldUnwrapEvent.ts
@@ -8,7 +8,10 @@ import {
 export const yieldUnwrapEvent: EventDef<WrappedNativeFlowAttributes, EventType.YieldUnwrap> = {
     name: EventType.YieldUnwrap,
     descriptionTrigger: 'fired on native-token unwrap actions (e.g. WETH → ETH)',
-    changelog: [{ version: '26.8.0', notes: 'added' }],
+    changelog: [
+        { version: '26.8.0', notes: 'added' },
+        { version: '26.8.1', notes: 'reported from mobile as well' },
+    ],
 
     attributes: wrappedNativeFlowAttributes,
 };

--- a/suite-common/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite-common/analytics/src/events/yieldWithdrawEvent.ts
@@ -76,8 +76,11 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
         },
         wrappedNative: {
             description:
-                'Whether the withdrawn vault token is the wrapped-native token of the network (e.g. WETH on Ethereum), meaning the withdraw involves a native unwrap step. Reported on `type=withdraw` (submit) and `type=success` (confirmed). Desktop only for now.',
-            changelog: [{ version: '26.8.0', notes: 'added' }],
+                'Whether the withdrawn vault token is the wrapped-native token of the network (e.g. WETH on Ethereum), meaning the withdraw involves a native unwrap step. Reported on `type=withdraw` (submit) and `type=success` (confirmed).',
+            changelog: [
+                { version: '26.8.0', notes: 'added' },
+                { version: '26.8.1', notes: 'reported from mobile as well' },
+            ],
         },
     },
 };

--- a/suite-common/analytics/src/events/yieldWrapEvent.ts
+++ b/suite-common/analytics/src/events/yieldWrapEvent.ts
@@ -8,7 +8,10 @@ import {
 export const yieldWrapEvent: EventDef<WrappedNativeFlowAttributes, EventType.YieldWrap> = {
     name: EventType.YieldWrap,
     descriptionTrigger: 'fired on native-token wrap actions (e.g. ETH → WETH)',
-    changelog: [{ version: '26.8.0', notes: 'added' }],
+    changelog: [
+        { version: '26.8.0', notes: 'added' },
+        { version: '26.8.1', notes: 'reported from mobile as well' },
+    ],
 
     attributes: wrappedNativeFlowAttributes,
 };

--- a/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
+++ b/suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts
@@ -27,8 +27,11 @@ export const wrappedNativeFlowAttributes = {
     },
     type: {
         description:
-            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted — emitted with `action=continue` when the "transaction sent" toast is shown and again with `action=close` if the user dismisses that toast (letting it auto-close is not reported), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction',
-        changelog: [{ version: '26.8.0', notes: 'added' }],
+            '`submit` = user confirmed the wrap/unwrap form, `tx-simulation-modal` = simulation modal shown (with `action` continue/cancel), `sent` = transaction signed &amp; broadcast accepted — emitted with `action=continue` when the "transaction sent" toast is shown and again with `action=close` if the user dismisses that toast (letting it auto-close is not reported), `success` / `error` / `leftPending` = on-chain resolution of the broadcast transaction. Mobile shows a pending-transaction sheet instead of a toast and only reports `sent` with `action=continue`.',
+        changelog: [
+            { version: '26.8.0', notes: 'added' },
+            { version: '26.8.1', notes: 'reported from mobile as well' },
+        ],
     },
     networkSymbol: {
         changelog: [{ version: '26.8.0', notes: 'added' }],
@@ -45,7 +48,10 @@ export const wrappedNativeFlowAttributes = {
     },
     errorMessage: {
         description:
-            'Classified failure reason. On compose failure, the specific compose reason (e.g. `unsupported-network`, `not-wrapped-native`, `missing-chain-id`, `missing-fee-level`, `fee-estimation-failed`). On submit failure, `submit-failed` (signing/review cancelled or failed) or `push-failed` (broadcast rejected by backend). On on-chain revert, `on-chain-failure`.',
-        changelog: [{ version: '26.8.0', notes: 'added' }],
+            'Classified failure reason. On compose failure, the specific compose reason (e.g. `unsupported-network`, `not-wrapped-native`, `missing-chain-id`, `missing-fee-level`, `fee-estimation-failed`). On submit failure, `submit-failed` (signing/review cancelled or failed) or `push-failed` (broadcast rejected by backend). On on-chain revert, `on-chain-failure`. Mobile reports only `submit-failed`, `push-failed` and `on-chain-failure` — the form composes continuously in the background, so compose failures are not surfaced as an event.',
+        changelog: [
+            { version: '26.8.0', notes: 'added' },
+            { version: '26.8.1', notes: 'reported from mobile as well' },
+        ],
     },
 } satisfies WrappedNativeFlowAttributes;

--- a/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
+++ b/suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx
@@ -5,6 +5,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { type BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { useNavigation } from '@react-navigation/native';
 
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import {
     DefinitionType,
@@ -21,6 +23,7 @@ import {
     selectAccountNetworkSymbol,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress, toTokenSymbol } from '@suite-common/wallet-types';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import {
     BottomSheetModal,
     Box,
@@ -105,6 +108,7 @@ export const TokenSettingsBottomSheet = forwardRef(
     ) => {
         const { applyStyle } = useNativeStyles();
         const dispatch = useDispatch();
+        const { analytics } = useServices(selectNativeAnalyticsDep);
         const navigation =
             useNavigation<
                 StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>
@@ -182,6 +186,16 @@ export const TokenSettingsBottomSheet = forwardRef(
                 return;
             }
 
+            analytics.report({
+                type: events.yieldNavigateEvent.name,
+                payload: {
+                    action: 'continue',
+                    from: 'account-detail',
+                    to: 'unwrap-form',
+                    networkSymbol: account.symbol,
+                },
+            });
+
             navigation.navigate(RootStackRoutes.WrappedNativeTokenNavigator, {
                 screen: WrappedNativeTokenStackRoutes.UnwrapNativeToken,
                 params: { accountKey },
@@ -196,6 +210,16 @@ export const TokenSettingsBottomSheet = forwardRef(
 
                 return;
             }
+
+            analytics.report({
+                type: events.yieldNavigateEvent.name,
+                payload: {
+                    action: 'continue',
+                    from: 'account-detail',
+                    to: 'wrap-form',
+                    networkSymbol: account.symbol,
+                },
+            });
 
             navigation.navigate(RootStackRoutes.WrappedNativeTokenNavigator, {
                 screen: WrappedNativeTokenStackRoutes.WrapNativeToken,

--- a/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
@@ -22,6 +22,7 @@ type WrappedNativeTokenAmountInputCardProps = {
     balance: string;
     defaultAmount?: string;
     maxAmount?: string;
+    onMaxPress?: () => void;
     symbol: NetworkSymbol;
     tokenContract?: TokenAddress;
     tokenDecimals?: number;
@@ -33,6 +34,7 @@ export const WrappedNativeTokenAmountInputCard = ({
     balance,
     defaultAmount,
     maxAmount,
+    onMaxPress,
     symbol,
     tokenContract,
     tokenDecimals,
@@ -78,6 +80,7 @@ export const WrappedNativeTokenAmountInputCard = ({
     }, [defaultAmount, setAmountWithFiat]);
 
     const handleMaxPress = () => {
+        onMaxPress?.();
         setAmountWithFiat(maxAmount ?? balance);
     };
 

--- a/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx
@@ -5,7 +5,15 @@ import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { selectBaseCurrency, selectIsBaseCurrencyInSats } from '@suite-common/wallet-core';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import { getDecimalsForBaseCurrency } from '@suite-common/wallet-utils';
-import { BaseAmountInputs, Button, Card, HStack, Text, VStack } from '@suite-native/atoms';
+import {
+    type ActiveView,
+    BaseAmountInputs,
+    Button,
+    Card,
+    HStack,
+    Text,
+    VStack,
+} from '@suite-native/atoms';
 import { TokenAmountFormatter, useCryptoFiatConverters } from '@suite-native/formatters';
 import { useFormContext } from '@suite-native/forms';
 import { Translation } from '@suite-native/intl';
@@ -22,6 +30,7 @@ type WrappedNativeTokenAmountInputCardProps = {
     balance: string;
     defaultAmount?: string;
     maxAmount?: string;
+    onCurrencyChange?: (activeView: ActiveView) => void;
     onMaxPress?: () => void;
     symbol: NetworkSymbol;
     tokenContract?: TokenAddress;
@@ -34,6 +43,7 @@ export const WrappedNativeTokenAmountInputCard = ({
     balance,
     defaultAmount,
     maxAmount,
+    onCurrencyChange,
     onMaxPress,
     symbol,
     tokenContract,
@@ -89,6 +99,7 @@ export const WrappedNativeTokenAmountInputCard = ({
             <VStack spacing="sp12">
                 <BaseAmountInputs
                     symbol={symbol}
+                    onInputSwitch={onCurrencyChange}
                     unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
                     wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
                     renderTopRow={() => <Text variant="body-sm">{amountLabel}</Text>}

--- a/suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx
+++ b/suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx
@@ -54,11 +54,8 @@ export const WrappedNativeTokenCompleteContent = ({
 
     // The form replaced itself with this screen, so this stack holds it alone — any back
     // navigation leaves the whole flow, which is what closing should do. Intercepting it (as the
-    // session-driven complete screens do) would only make the interceptor catch its own GO_BACK.
-    //
-    // useNavigateBackAnalytics is not used here for the same reason: useNavigateToInitialScreen
-    // ends in a goBack, which would make the interceptor catch its own dismissal and report a
-    // bogus cancel, so the intentional `continue` is reported explicitly instead.
+    // session-driven complete screens do) or watching it with useNavigateBackAnalytics would only
+    // catch the GO_BACK this very handler dispatches, so it reports the `continue` itself.
     const handleClose = useCallback(() => {
         analytics.report({
             type: events.yieldNavigateEvent.name,
@@ -69,6 +66,7 @@ export const WrappedNativeTokenCompleteContent = ({
                 networkSymbol: account?.symbol,
             },
         });
+
         navigateToInitialScreen();
     }, [account?.symbol, analytics, flowType, navigateToInitialScreen]);
 

--- a/suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx
+++ b/suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
 import { WRAPPED_NATIVE, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
@@ -8,6 +10,7 @@ import {
     selectAccountByKey,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Translation, type TxKeyPath, selectSupportedLanguageLocale } from '@suite-native/intl';
 import { useNavigateToInitialScreen } from '@suite-native/navigation';
 
@@ -41,6 +44,7 @@ export const WrappedNativeTokenCompleteContent = ({
 }: WrappedNativeTokenCompleteContentProps) => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const locale = useSelector(selectSupportedLanguageLocale);
+    const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
@@ -51,9 +55,22 @@ export const WrappedNativeTokenCompleteContent = ({
     // The form replaced itself with this screen, so this stack holds it alone — any back
     // navigation leaves the whole flow, which is what closing should do. Intercepting it (as the
     // session-driven complete screens do) would only make the interceptor catch its own GO_BACK.
+    //
+    // useNavigateBackAnalytics is not used here for the same reason: useNavigateToInitialScreen
+    // ends in a goBack, which would make the interceptor catch its own dismissal and report a
+    // bogus cancel, so the intentional `continue` is reported explicitly instead.
     const handleClose = useCallback(() => {
+        analytics.report({
+            type: events.yieldNavigateEvent.name,
+            payload: {
+                action: 'continue',
+                from: flowType === 'wrap' ? 'wrap-form' : 'unwrap-form',
+                to: 'account-detail',
+                networkSymbol: account?.symbol,
+            },
+        });
         navigateToInitialScreen();
-    }, [navigateToInitialScreen]);
+    }, [account?.symbol, analytics, flowType, navigateToInitialScreen]);
 
     const rows = useMemo(() => {
         if (!account || !wrappedNative) {

--- a/suite-native/module-earn/src/components/YieldAmountInputCard.tsx
+++ b/suite-native/module-earn/src/components/YieldAmountInputCard.tsx
@@ -3,6 +3,7 @@ import { type ReactNode } from 'react';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import {
+    type ActiveView,
     BaseAmountInputs,
     Button,
     Card,
@@ -27,6 +28,7 @@ type YieldAmountInputCardProps = {
     balance?: string;
     isApprovalLimitDisabled?: boolean;
     onApprovalLimitPress?: () => void;
+    onCurrencyChange?: (activeView: ActiveView) => void;
     onMaxPress: () => void;
     symbol: NetworkSymbol;
     tokenContract?: TokenAddress;
@@ -40,6 +42,7 @@ export const YieldAmountInputCard = ({
     balance,
     isApprovalLimitDisabled = false,
     onApprovalLimitPress,
+    onCurrencyChange,
     onMaxPress,
     symbol,
     tokenContract,
@@ -72,6 +75,7 @@ export const YieldAmountInputCard = ({
             <VStack spacing="sp12" padding="sp16">
                 <BaseAmountInputs
                     symbol={symbol}
+                    onInputSwitch={onCurrencyChange}
                     unfocusedOffset={AMOUNT_INPUT_UNFOCUSED_OFFSET}
                     wrapperHeight={AMOUNT_INPUT_WRAPPER_HEIGHT}
                     renderTopRow={() => <Text variant="body-sm">{amountLabel}</Text>}

--- a/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
+++ b/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
@@ -15,6 +15,10 @@ import {
     type WrappedNativeTokenStackRoutes,
 } from '@suite-native/navigation';
 
+import {
+    useWrappedNativeFlowAnalytics,
+    useWrappedNativeFlowResolutionAnalytics,
+} from './useWrappedNativeFlowAnalytics';
 import { type PreparedWrappedNativeTokenAction } from './useWrappedNativeTokenFees';
 import { useWrappedNativeTxSimulation } from './useWrappedNativeTxSimulation';
 import { useYieldPendingTransaction } from './useYieldPendingTransaction';
@@ -49,7 +53,21 @@ export const useStandaloneWrappedNativeFlow = ({
 
     const [hasFlowFailed, setHasFlowFailed] = useState(false);
 
+    const networkSymbol = account?.symbol ?? '';
+    const { reportMaxSelected, reportSimulation, reportSubmit } = useWrappedNativeFlowAnalytics({
+        flowType,
+        networkSymbol,
+    });
+
     const pendingStatus = useWrappedNativePendingTx(account, pendingParam?.txid ?? null, flowType);
+
+    useWrappedNativeFlowResolutionAnalytics({
+        flowType,
+        networkSymbol,
+        status: pendingStatus,
+        txid: pendingParam?.txid ?? null,
+    });
+
     const pendingTransaction: YieldPendingTransactionState | null = useMemo(
         () =>
             pendingParam
@@ -91,9 +109,10 @@ export const useStandaloneWrappedNativeFlow = ({
         }
     }, [accountKey, flowType, navigation, pendingParam, pendingStatus]);
 
-    const handleFlowRetry = useCallback(() => {
+    const handleSubmitStart = useCallback(() => {
         setHasFlowFailed(false);
-    }, []);
+        reportSubmit();
+    }, [reportSubmit]);
 
     const handleSimulationConfirmed = useCallback(
         (preparedTx: PreparedWrappedNativeTokenAction) => {
@@ -110,13 +129,23 @@ export const useStandaloneWrappedNativeFlow = ({
         amountValue,
         isDisabled,
         onConfirm: handleSimulationConfirmed,
-        onSubmit: handleFlowRetry,
+        onSubmit: handleSubmitStart,
         preparedAction,
     });
 
+    const handleConfirmSimulation = useCallback(() => {
+        reportSimulation('continue');
+        simulation.handleConfirmSimulation();
+    }, [reportSimulation, simulation]);
+
+    const handleCancelSimulation = useCallback(() => {
+        reportSimulation('cancel');
+        simulation.handleCancelSimulation();
+    }, [reportSimulation, simulation]);
+
     return {
-        handleCancelSimulation: simulation.handleCancelSimulation,
-        handleConfirmSimulation: simulation.handleConfirmSimulation,
+        handleCancelSimulation,
+        handleConfirmSimulation,
         handleSubmit: simulation.handleSubmit,
         hasFlowFailed,
         isDeviceNotConnectedVisible: simulation.isDeviceNotConnectedVisible,
@@ -125,6 +154,7 @@ export const useStandaloneWrappedNativeFlow = ({
         pendingBottomSheetRef,
         pendingModalProps,
         preparedTx: simulation.preparedTx,
+        reportMaxSelected,
         simulationBottomSheetRef: simulation.simulationBottomSheetRef,
     };
 };

--- a/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
+++ b/suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts
@@ -15,10 +15,8 @@ import {
     type WrappedNativeTokenStackRoutes,
 } from '@suite-native/navigation';
 
-import {
-    useWrappedNativeFlowAnalytics,
-    useWrappedNativeFlowResolutionAnalytics,
-} from './useWrappedNativeFlowAnalytics';
+import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
+import { useWrappedNativeFlowResolutionAnalytics } from './useWrappedNativeFlowResolutionAnalytics';
 import { type PreparedWrappedNativeTokenAction } from './useWrappedNativeTokenFees';
 import { useWrappedNativeTxSimulation } from './useWrappedNativeTxSimulation';
 import { useYieldPendingTransaction } from './useYieldPendingTransaction';
@@ -53,7 +51,7 @@ export const useStandaloneWrappedNativeFlow = ({
 
     const [hasFlowFailed, setHasFlowFailed] = useState(false);
 
-    const networkSymbol = account?.symbol ?? '';
+    const networkSymbol = account?.symbol;
     const { reportMaxSelected, reportSimulation, reportSubmit } = useWrappedNativeFlowAnalytics({
         flowType,
         networkSymbol,
@@ -125,7 +123,15 @@ export const useStandaloneWrappedNativeFlow = ({
         [accountKey, flowType, navigation],
     );
 
-    const simulation = useWrappedNativeTxSimulation({
+    const {
+        handleCancelSimulation: cancelSimulation,
+        handleConfirmSimulation: confirmSimulation,
+        handleSubmit,
+        isDeviceNotConnectedVisible,
+        isFirmwareOutdatedVisible,
+        preparedTx,
+        simulationBottomSheetRef,
+    } = useWrappedNativeTxSimulation({
         amountValue,
         isDisabled,
         onConfirm: handleSimulationConfirmed,
@@ -135,26 +141,26 @@ export const useStandaloneWrappedNativeFlow = ({
 
     const handleConfirmSimulation = useCallback(() => {
         reportSimulation('continue');
-        simulation.handleConfirmSimulation();
-    }, [reportSimulation, simulation]);
+        confirmSimulation();
+    }, [confirmSimulation, reportSimulation]);
 
     const handleCancelSimulation = useCallback(() => {
         reportSimulation('cancel');
-        simulation.handleCancelSimulation();
-    }, [reportSimulation, simulation]);
+        cancelSimulation();
+    }, [cancelSimulation, reportSimulation]);
 
     return {
         handleCancelSimulation,
         handleConfirmSimulation,
-        handleSubmit: simulation.handleSubmit,
+        handleSubmit,
         hasFlowFailed,
-        isDeviceNotConnectedVisible: simulation.isDeviceNotConnectedVisible,
-        isFirmwareOutdatedVisible: simulation.isFirmwareOutdatedVisible,
+        isDeviceNotConnectedVisible,
+        isFirmwareOutdatedVisible,
         isPending: !!pendingParam,
         pendingBottomSheetRef,
         pendingModalProps,
-        preparedTx: simulation.preparedTx,
+        preparedTx,
         reportMaxSelected,
-        simulationBottomSheetRef: simulation.simulationBottomSheetRef,
+        simulationBottomSheetRef,
     };
 };

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
@@ -2,14 +2,9 @@ import { type NativeAnalyticsDep } from '@suite-native/analytics';
 import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
 import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
 
-import {
-    useWrappedNativeFlowAnalytics,
-    useWrappedNativeFlowResolutionAnalytics,
-} from './useWrappedNativeFlowAnalytics';
+import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
 
-const renderUseWrappedNativeFlowAnalytics = (
-    props: Parameters<typeof useWrappedNativeFlowAnalytics>[0],
-) => {
+const renderFlowAnalytics = (props: Parameters<typeof useWrappedNativeFlowAnalytics>[0]) => {
     const services: NativeAnalyticsDep = {
         analytics: mockNativeAnalytics(jest.fn()),
     };
@@ -22,24 +17,9 @@ const renderUseWrappedNativeFlowAnalytics = (
     return { ...view, analytics: services.analytics };
 };
 
-const renderUseWrappedNativeFlowResolutionAnalytics = (
-    props: Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0],
-) => {
-    const services: NativeAnalyticsDep = {
-        analytics: mockNativeAnalytics(jest.fn()),
-    };
-
-    const view = renderHookWithStoreProvider(useWrappedNativeFlowResolutionAnalytics, {
-        initialProps: props,
-        services,
-    });
-
-    return { ...view, analytics: services.analytics };
-};
-
 describe('useWrappedNativeFlowAnalytics', () => {
     it('reports submit as yield/wrap for the wrap flow', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+        const { result, analytics } = renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
@@ -54,24 +34,8 @@ describe('useWrappedNativeFlowAnalytics', () => {
         });
     });
 
-    it('reports submit as yield/unwrap for the unwrap flow', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
-            flowType: 'unwrap',
-            networkSymbol: 'eth',
-        });
-
-        act(() => {
-            result.current.reportSubmit();
-        });
-
-        expect(analytics.report).toHaveBeenCalledWith({
-            type: 'yield/unwrap',
-            payload: { type: 'submit', action: 'continue', networkSymbol: 'eth' },
-        });
-    });
-
     it('reports a cancelled simulation', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+        const { result, analytics } = renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
@@ -87,7 +51,7 @@ describe('useWrappedNativeFlowAnalytics', () => {
     });
 
     it('reports sent', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+        const { result, analytics } = renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
@@ -103,7 +67,7 @@ describe('useWrappedNativeFlowAnalytics', () => {
     });
 
     it('reports the given error message', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+        const { result, analytics } = renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
@@ -124,7 +88,7 @@ describe('useWrappedNativeFlowAnalytics', () => {
     });
 
     it('reports max selected as yield/interaction with no vaultId', () => {
-        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+        const { result, analytics } = renderFlowAnalytics({
             flowType: 'wrap',
             networkSymbol: 'eth',
         });
@@ -137,184 +101,5 @@ describe('useWrappedNativeFlowAnalytics', () => {
             type: 'yield/interaction',
             payload: { element: 'wrap-max', networkSymbol: 'eth' },
         });
-    });
-});
-
-describe('useWrappedNativeFlowResolutionAnalytics', () => {
-    it('reports success once when the status moves from pending to confirmed', () => {
-        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'wrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-1',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-        expect(analytics.report).toHaveBeenCalledWith({
-            type: 'yield/wrap',
-            payload: {
-                type: 'success',
-                action: 'continue',
-                networkSymbol: 'eth',
-                durationMs: expect.any(Number),
-            },
-        });
-    });
-
-    it('reports an on-chain-failure error when the status moves to failed', () => {
-        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'unwrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'unwrap',
-                networkSymbol: 'eth',
-                status: 'failed',
-                txid: 'tx-1',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-        expect(analytics.report).toHaveBeenCalledWith({
-            type: 'yield/unwrap',
-            payload: {
-                type: 'error',
-                action: 'continue',
-                networkSymbol: 'eth',
-                durationMs: expect.any(Number),
-                errorMessage: 'on-chain-failure',
-            },
-        });
-    });
-
-    it('reports the resolution only once when confirmed twice', () => {
-        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'wrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-1',
-            });
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-1',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-    });
-
-    it('reports leftPending on unmount while the transaction is still pending', () => {
-        const { unmount, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'wrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            unmount();
-        });
-
-        expect(analytics.report).toHaveBeenCalledWith({
-            type: 'yield/wrap',
-            payload: {
-                type: 'leftPending',
-                action: 'continue',
-                networkSymbol: 'eth',
-                durationMs: expect.any(Number),
-            },
-        });
-    });
-
-    it('does not report leftPending on unmount once the transaction already resolved', () => {
-        const { rerender, unmount, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'wrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-1',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-
-        act(() => {
-            unmount();
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-    });
-
-    it('resets the resolution guard when the txid changes', () => {
-        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
-            flowType: 'wrap',
-            networkSymbol: 'eth',
-            status: 'pending',
-            txid: 'tx-1',
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-1',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(1);
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'pending',
-                txid: 'tx-2',
-            });
-        });
-
-        act(() => {
-            rerender({
-                flowType: 'wrap',
-                networkSymbol: 'eth',
-                status: 'confirmed',
-                txid: 'tx-2',
-            });
-        });
-
-        expect(analytics.report).toHaveBeenCalledTimes(2);
     });
 });

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts
@@ -1,0 +1,320 @@
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+
+import {
+    useWrappedNativeFlowAnalytics,
+    useWrappedNativeFlowResolutionAnalytics,
+} from './useWrappedNativeFlowAnalytics';
+
+const renderUseWrappedNativeFlowAnalytics = (
+    props: Parameters<typeof useWrappedNativeFlowAnalytics>[0],
+) => {
+    const services: NativeAnalyticsDep = {
+        analytics: mockNativeAnalytics(jest.fn()),
+    };
+
+    const view = renderHookWithStoreProvider(useWrappedNativeFlowAnalytics, {
+        initialProps: props,
+        services,
+    });
+
+    return { ...view, analytics: services.analytics };
+};
+
+const renderUseWrappedNativeFlowResolutionAnalytics = (
+    props: Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0],
+) => {
+    const services: NativeAnalyticsDep = {
+        analytics: mockNativeAnalytics(jest.fn()),
+    };
+
+    const view = renderHookWithStoreProvider(useWrappedNativeFlowResolutionAnalytics, {
+        initialProps: props,
+        services,
+    });
+
+    return { ...view, analytics: services.analytics };
+};
+
+describe('useWrappedNativeFlowAnalytics', () => {
+    it('reports submit as yield/wrap for the wrap flow', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportSubmit();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: { type: 'submit', action: 'continue', networkSymbol: 'eth' },
+        });
+    });
+
+    it('reports submit as yield/unwrap for the unwrap flow', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'unwrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportSubmit();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/unwrap',
+            payload: { type: 'submit', action: 'continue', networkSymbol: 'eth' },
+        });
+    });
+
+    it('reports a cancelled simulation', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportSimulation('cancel');
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: { type: 'tx-simulation-modal', action: 'cancel', networkSymbol: 'eth' },
+        });
+    });
+
+    it('reports sent', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportSent();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: { type: 'sent', action: 'continue', networkSymbol: 'eth' },
+        });
+    });
+
+    it('reports the given error message', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportError('push-failed');
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: {
+                type: 'error',
+                action: 'continue',
+                networkSymbol: 'eth',
+                errorMessage: 'push-failed',
+            },
+        });
+    });
+
+    it('reports max selected as yield/interaction with no vaultId', () => {
+        const { result, analytics } = renderUseWrappedNativeFlowAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+        });
+
+        act(() => {
+            result.current.reportMaxSelected();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/interaction',
+            payload: { element: 'wrap-max', networkSymbol: 'eth' },
+        });
+    });
+});
+
+describe('useWrappedNativeFlowResolutionAnalytics', () => {
+    it('reports success once when the status moves from pending to confirmed', () => {
+        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-1',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: {
+                type: 'success',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+            },
+        });
+    });
+
+    it('reports an on-chain-failure error when the status moves to failed', () => {
+        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'unwrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'unwrap',
+                networkSymbol: 'eth',
+                status: 'failed',
+                txid: 'tx-1',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/unwrap',
+            payload: {
+                type: 'error',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+                errorMessage: 'on-chain-failure',
+            },
+        });
+    });
+
+    it('reports the resolution only once when confirmed twice', () => {
+        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-1',
+            });
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-1',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports leftPending on unmount while the transaction is still pending', () => {
+        const { unmount, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            unmount();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: {
+                type: 'leftPending',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+            },
+        });
+    });
+
+    it('does not report leftPending on unmount once the transaction already resolved', () => {
+        const { rerender, unmount, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-1',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            unmount();
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets the resolution guard when the txid changes', () => {
+        const { rerender, analytics } = renderUseWrappedNativeFlowResolutionAnalytics({
+            flowType: 'wrap',
+            networkSymbol: 'eth',
+            status: 'pending',
+            txid: 'tx-1',
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-1',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'pending',
+                txid: 'tx-2',
+            });
+        });
+
+        act(() => {
+            rerender({
+                flowType: 'wrap',
+                networkSymbol: 'eth',
+                status: 'confirmed',
+                txid: 'tx-2',
+            });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(2);
+    });
+});

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import {
+    type WrappedNativeFlowType,
+    type WrappedNativePendingTxStatus,
+} from '@suite-common/wallet-core';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import {
+    type WrappedNativeFlowPayload,
+    buildWrappedNativeFlowEvent,
+    getWrappedNativeMaxInteractionElement,
+    getWrappedNativeResolutionPayload,
+} from '../utils/wrappedNativeAnalyticsUtils';
+
+type UseWrappedNativeFlowAnalyticsParams = {
+    flowType: WrappedNativeFlowType;
+    networkSymbol: string;
+};
+
+export const useWrappedNativeFlowAnalytics = ({
+    flowType,
+    networkSymbol,
+}: UseWrappedNativeFlowAnalyticsParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+
+    const report = useCallback(
+        (payload: WrappedNativeFlowPayload) =>
+            analytics.report(buildWrappedNativeFlowEvent(flowType, payload)),
+        [analytics, flowType],
+    );
+
+    const reportSubmit = useCallback(() => {
+        report({ type: 'submit', action: 'continue', networkSymbol });
+    }, [report, networkSymbol]);
+
+    const reportSimulation = useCallback(
+        (action: 'continue' | 'cancel') => {
+            report({ type: 'tx-simulation-modal', action, networkSymbol });
+        },
+        [report, networkSymbol],
+    );
+
+    const reportSent = useCallback(() => {
+        report({ type: 'sent', action: 'continue', networkSymbol });
+    }, [report, networkSymbol]);
+
+    const reportError = useCallback(
+        (errorMessage: string) => {
+            report({ type: 'error', action: 'continue', networkSymbol, errorMessage });
+        },
+        [report, networkSymbol],
+    );
+
+    const reportMaxSelected = useCallback(() => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: getWrappedNativeMaxInteractionElement(flowType),
+                networkSymbol,
+            },
+        });
+    }, [analytics, flowType, networkSymbol]);
+
+    return { reportSubmit, reportSimulation, reportSent, reportError, reportMaxSelected };
+};
+
+type UseWrappedNativeFlowResolutionAnalyticsParams = {
+    flowType: WrappedNativeFlowType;
+    networkSymbol: string;
+    status: WrappedNativePendingTxStatus | null;
+    txid: string | null;
+};
+
+export const useWrappedNativeFlowResolutionAnalytics = ({
+    flowType,
+    networkSymbol,
+    status,
+    txid,
+}: UseWrappedNativeFlowResolutionAnalyticsParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const hasReportedResolutionRef = useRef(false);
+    const startRef = useRef<{ txid: string; startedAt: number } | null>(null);
+
+    const report = useCallback(
+        (payload: WrappedNativeFlowPayload) =>
+            analytics.report(buildWrappedNativeFlowEvent(flowType, payload)),
+        [analytics, flowType],
+    );
+
+    useEffect(() => {
+        if (txid && startRef.current?.txid !== txid) {
+            startRef.current = { txid, startedAt: Date.now() };
+            hasReportedResolutionRef.current = false;
+        }
+    }, [txid]);
+
+    useEffect(() => {
+        if (hasReportedResolutionRef.current) {
+            return;
+        }
+
+        const durationMs = startRef.current ? Date.now() - startRef.current.startedAt : undefined;
+        const payload = getWrappedNativeResolutionPayload({ durationMs, networkSymbol, status });
+
+        if (!payload) {
+            return;
+        }
+
+        hasReportedResolutionRef.current = true;
+        report(payload);
+    }, [networkSymbol, report, status]);
+
+    const latestRef = useCurrentRef({ status, networkSymbol });
+
+    useEffect(
+        () => () => {
+            const snapshot = latestRef.current;
+
+            if (hasReportedResolutionRef.current || snapshot.status !== 'pending') {
+                return;
+            }
+
+            report({
+                type: 'leftPending',
+                action: 'continue',
+                networkSymbol: snapshot.networkSymbol,
+                durationMs: startRef.current ? Date.now() - startRef.current.startedAt : undefined,
+            });
+        },
+        [report, latestRef],
+    );
+};

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts
@@ -1,24 +1,17 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import {
-    type WrappedNativeFlowType,
-    type WrappedNativePendingTxStatus,
-} from '@suite-common/wallet-core';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { useCurrentRef } from '@trezor/react-utils';
 
-import {
-    type WrappedNativeFlowPayload,
-    buildWrappedNativeFlowEvent,
-    getWrappedNativeMaxInteractionElement,
-    getWrappedNativeResolutionPayload,
-} from '../utils/wrappedNativeAnalyticsUtils';
+import { useWrappedNativeFlowReport } from './useWrappedNativeFlowReport';
+import { getWrappedNativeMaxInteractionElement } from '../utils/wrappedNativeAnalyticsUtils';
 
 type UseWrappedNativeFlowAnalyticsParams = {
     flowType: WrappedNativeFlowType;
-    networkSymbol: string;
+    networkSymbol: NetworkSymbol | undefined;
 };
 
 export const useWrappedNativeFlowAnalytics = ({
@@ -26,12 +19,7 @@ export const useWrappedNativeFlowAnalytics = ({
     networkSymbol,
 }: UseWrappedNativeFlowAnalyticsParams) => {
     const { analytics } = useServices(selectNativeAnalyticsDep);
-
-    const report = useCallback(
-        (payload: WrappedNativeFlowPayload) =>
-            analytics.report(buildWrappedNativeFlowEvent(flowType, payload)),
-        [analytics, flowType],
-    );
+    const report = useWrappedNativeFlowReport(flowType);
 
     const reportSubmit = useCallback(() => {
         report({ type: 'submit', action: 'continue', networkSymbol });
@@ -49,7 +37,7 @@ export const useWrappedNativeFlowAnalytics = ({
     }, [report, networkSymbol]);
 
     const reportError = useCallback(
-        (errorMessage: string) => {
+        (errorMessage: 'submit-failed' | 'push-failed') => {
             report({ type: 'error', action: 'continue', networkSymbol, errorMessage });
         },
         [report, networkSymbol],
@@ -66,71 +54,4 @@ export const useWrappedNativeFlowAnalytics = ({
     }, [analytics, flowType, networkSymbol]);
 
     return { reportSubmit, reportSimulation, reportSent, reportError, reportMaxSelected };
-};
-
-type UseWrappedNativeFlowResolutionAnalyticsParams = {
-    flowType: WrappedNativeFlowType;
-    networkSymbol: string;
-    status: WrappedNativePendingTxStatus | null;
-    txid: string | null;
-};
-
-export const useWrappedNativeFlowResolutionAnalytics = ({
-    flowType,
-    networkSymbol,
-    status,
-    txid,
-}: UseWrappedNativeFlowResolutionAnalyticsParams) => {
-    const { analytics } = useServices(selectNativeAnalyticsDep);
-    const hasReportedResolutionRef = useRef(false);
-    const startRef = useRef<{ txid: string; startedAt: number } | null>(null);
-
-    const report = useCallback(
-        (payload: WrappedNativeFlowPayload) =>
-            analytics.report(buildWrappedNativeFlowEvent(flowType, payload)),
-        [analytics, flowType],
-    );
-
-    useEffect(() => {
-        if (txid && startRef.current?.txid !== txid) {
-            startRef.current = { txid, startedAt: Date.now() };
-            hasReportedResolutionRef.current = false;
-        }
-    }, [txid]);
-
-    useEffect(() => {
-        if (hasReportedResolutionRef.current) {
-            return;
-        }
-
-        const durationMs = startRef.current ? Date.now() - startRef.current.startedAt : undefined;
-        const payload = getWrappedNativeResolutionPayload({ durationMs, networkSymbol, status });
-
-        if (!payload) {
-            return;
-        }
-
-        hasReportedResolutionRef.current = true;
-        report(payload);
-    }, [networkSymbol, report, status]);
-
-    const latestRef = useCurrentRef({ status, networkSymbol });
-
-    useEffect(
-        () => () => {
-            const snapshot = latestRef.current;
-
-            if (hasReportedResolutionRef.current || snapshot.status !== 'pending') {
-                return;
-            }
-
-            report({
-                type: 'leftPending',
-                action: 'continue',
-                networkSymbol: snapshot.networkSymbol,
-                durationMs: startRef.current ? Date.now() - startRef.current.startedAt : undefined,
-            });
-        },
-        [report, latestRef],
-    );
 };

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowReport.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowReport.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
+
+import {
+    type WrappedNativeFlowPayload,
+    buildWrappedNativeFlowEvent,
+} from '../utils/wrappedNativeAnalyticsUtils';
+
+export const useWrappedNativeFlowReport = (flowType: WrappedNativeFlowType) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+
+    return useCallback(
+        (payload: WrappedNativeFlowPayload) =>
+            analytics.report(buildWrappedNativeFlowEvent(flowType, payload)),
+        [analytics, flowType],
+    );
+};

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.test.ts
@@ -1,0 +1,137 @@
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { useWrappedNativeFlowResolutionAnalytics } from './useWrappedNativeFlowResolutionAnalytics';
+
+const renderResolutionAnalytics = (
+    props: Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0],
+) => {
+    const services: NativeAnalyticsDep = {
+        analytics: mockNativeAnalytics(jest.fn()),
+    };
+
+    const view = renderHookWithStoreProvider(useWrappedNativeFlowResolutionAnalytics, {
+        initialProps: props,
+        services,
+    });
+
+    return { ...view, analytics: services.analytics };
+};
+
+const pendingWrap = {
+    flowType: 'wrap',
+    networkSymbol: 'eth',
+    status: 'pending',
+    txid: 'tx-1',
+} as const satisfies Parameters<typeof useWrappedNativeFlowResolutionAnalytics>[0];
+
+describe('useWrappedNativeFlowResolutionAnalytics', () => {
+    it('reports success once when the status moves from pending to confirmed', () => {
+        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: {
+                type: 'success',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+            },
+        });
+    });
+
+    it('reports an on-chain-failure error when the status moves to failed', () => {
+        const pendingUnwrap = { ...pendingWrap, flowType: 'unwrap' } as const;
+        const { rerender, analytics } = renderResolutionAnalytics(pendingUnwrap);
+
+        act(() => {
+            rerender({ ...pendingUnwrap, status: 'failed' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/unwrap',
+            payload: {
+                type: 'error',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+                errorMessage: 'on-chain-failure',
+            },
+        });
+    });
+
+    it('reports the resolution only once when confirmed twice', () => {
+        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed' });
+        });
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports leftPending on unmount while the transaction is still pending', () => {
+        const { unmount, analytics } = renderResolutionAnalytics(pendingWrap);
+
+        act(() => {
+            unmount();
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/wrap',
+            payload: {
+                type: 'leftPending',
+                action: 'continue',
+                networkSymbol: 'eth',
+                durationMs: expect.any(Number),
+            },
+        });
+    });
+
+    it('does not report leftPending on unmount once the transaction already resolved', () => {
+        const { rerender, unmount, analytics } = renderResolutionAnalytics(pendingWrap);
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            unmount();
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets the resolution guard when the txid changes', () => {
+        const { rerender, analytics } = renderResolutionAnalytics(pendingWrap);
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'pending', txid: 'tx-2' });
+        });
+
+        act(() => {
+            rerender({ ...pendingWrap, status: 'confirmed', txid: 'tx-2' });
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(2);
+    });
+});

--- a/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeFlowResolutionAnalytics.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from 'react';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type WrappedNativeFlowType,
+    type WrappedNativePendingTxStatus,
+} from '@suite-common/wallet-core';
+import { useCurrentRef } from '@trezor/react-utils';
+
+import { useWrappedNativeFlowReport } from './useWrappedNativeFlowReport';
+import { getWrappedNativeResolutionPayload } from '../utils/wrappedNativeAnalyticsUtils';
+
+type UseWrappedNativeFlowResolutionAnalyticsParams = {
+    flowType: WrappedNativeFlowType;
+    networkSymbol: NetworkSymbol | undefined;
+    status: WrappedNativePendingTxStatus | null;
+    txid: string | null;
+};
+
+export const useWrappedNativeFlowResolutionAnalytics = ({
+    flowType,
+    networkSymbol,
+    status,
+    txid,
+}: UseWrappedNativeFlowResolutionAnalyticsParams) => {
+    const report = useWrappedNativeFlowReport(flowType);
+    const hasReportedResolutionRef = useRef(false);
+    const startRef = useRef<{ txid: string; startedAt: number } | null>(null);
+
+    useEffect(() => {
+        if (txid && startRef.current?.txid !== txid) {
+            startRef.current = { txid, startedAt: Date.now() };
+            hasReportedResolutionRef.current = false;
+        }
+    }, [txid]);
+
+    useEffect(() => {
+        if (hasReportedResolutionRef.current) {
+            return;
+        }
+
+        const durationMs = startRef.current ? Date.now() - startRef.current.startedAt : undefined;
+        const payload = getWrappedNativeResolutionPayload({ durationMs, networkSymbol, status });
+
+        if (!payload) {
+            return;
+        }
+
+        hasReportedResolutionRef.current = true;
+        report(payload);
+    }, [networkSymbol, report, status]);
+
+    const latestRef = useCurrentRef({ status, networkSymbol });
+
+    useEffect(
+        () => () => {
+            const snapshot = latestRef.current;
+
+            if (hasReportedResolutionRef.current || snapshot.status !== 'pending') {
+                return;
+            }
+
+            report({
+                type: 'leftPending',
+                action: 'continue',
+                networkSymbol: snapshot.networkSymbol,
+                durationMs: startRef.current ? Date.now() - startRef.current.startedAt : undefined,
+            });
+        },
+        [report, latestRef],
+    );
+};

--- a/suite-native/module-earn/src/hooks/useWrappedNativeTokenReview.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeTokenReview.ts
@@ -17,6 +17,7 @@ import {
     type YieldReviewStatus,
 } from '../types';
 import { useEarnTransactionReview } from './useEarnTransactionReview';
+import { useWrappedNativeFlowAnalytics } from './useWrappedNativeFlowAnalytics';
 import { wrappedNativeTokenFlowRoutes } from '../utils/wrappedNativeTokenFlowRoutes';
 import {
     type SignedWrappedNativeTokenTransaction,
@@ -62,6 +63,15 @@ export const useWrappedNativeTokenReview = ({
     const [signedTransaction, setSignedTransaction] =
         useState<SignedWrappedNativeTokenTransaction | null>(null);
 
+    // The in-flow wrap step (onBroadcast set) is already tracked as yield/deposit type:'wrap', so
+    // reporting yield/wrap|yield/unwrap here too would double-count it.
+    const isStandaloneFlow = !onBroadcast;
+    const { reportError, reportSent } = useWrappedNativeFlowAnalytics({
+        flowType,
+        networkSymbol: account.symbol,
+    });
+    const reportSubmitFailed = useCallback(() => reportError('submit-failed'), [reportError]);
+
     const signAction = useCallback(
         () =>
             dispatch(signWrappedNativeTokenThunk({ account, token, amount, unsignedTransaction })),
@@ -86,6 +96,7 @@ export const useWrappedNativeTokenReview = ({
                 return;
             }
 
+            reportSent();
             navigation.popTo(wrappedNativeTokenFlowRoutes[flowType].form, {
                 accountKey: account.key,
                 pendingTransaction: {
@@ -96,7 +107,7 @@ export const useWrappedNativeTokenReview = ({
                 },
             });
         },
-        [account, amount, flowType, navigation, onBroadcast, signedTransaction],
+        [account, amount, flowType, navigation, onBroadcast, reportSent, signedTransaction],
     );
 
     const review = useEarnTransactionReview({
@@ -106,6 +117,8 @@ export const useWrappedNativeTokenReview = ({
         onPushSuccess,
         onReviewLeave,
         onSignSuccess: setSignedTransaction,
+        reportCancel: isStandaloneFlow ? reportSubmitFailed : undefined,
+        reportError: isStandaloneFlow ? reportError : undefined,
         signAction,
         pushAction,
     });

--- a/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts
+++ b/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts
@@ -1,0 +1,93 @@
+import { type NativeAnalyticsDep } from '@suite-native/analytics';
+import { mockNativeAnalytics } from '@suite-native/analytics/mocks';
+import { act, renderHookWithStoreProvider } from '@suite-native/test-utils-store';
+
+import { useYieldCurrencyToggleAnalytics } from './useYieldCurrencyToggleAnalytics';
+
+const renderCurrencyToggleAnalytics = (
+    props: Parameters<typeof useYieldCurrencyToggleAnalytics>[0],
+) => {
+    const services: NativeAnalyticsDep = {
+        analytics: mockNativeAnalytics(jest.fn()),
+    };
+
+    const view = renderHookWithStoreProvider(useYieldCurrencyToggleAnalytics, {
+        initialProps: props,
+        services,
+    });
+
+    return { ...view, analytics: services.analytics };
+};
+
+describe('useYieldCurrencyToggleAnalytics', () => {
+    it('reports a switch to the fiat input', () => {
+        const { result, analytics } = renderCurrencyToggleAnalytics({
+            networkSymbol: 'eth',
+            vaultId: 'vault-1',
+        });
+
+        act(() => {
+            result.current('secondary');
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/interaction',
+            payload: {
+                element: 'amount-currency-toggle',
+                value: 'fiat',
+                networkSymbol: 'eth',
+                vaultId: 'vault-1',
+            },
+        });
+    });
+
+    it('reports a switch back to the crypto input', () => {
+        const { result, analytics } = renderCurrencyToggleAnalytics({
+            networkSymbol: 'eth',
+            vaultId: 'vault-1',
+        });
+
+        act(() => {
+            result.current('primary');
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/interaction',
+            payload: {
+                element: 'amount-currency-toggle',
+                value: 'crypto',
+                networkSymbol: 'eth',
+                vaultId: 'vault-1',
+            },
+        });
+    });
+
+    it('omits vaultId for the standalone wrap/unwrap forms', () => {
+        const { result, analytics } = renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
+
+        act(() => {
+            result.current('secondary');
+        });
+
+        expect(analytics.report).toHaveBeenCalledWith({
+            type: 'yield/interaction',
+            payload: {
+                element: 'amount-currency-toggle',
+                value: 'fiat',
+                networkSymbol: 'eth',
+                vaultId: undefined,
+            },
+        });
+    });
+
+    it('reports every switch, so a toggle back and forth is counted twice', () => {
+        const { result, analytics } = renderCurrencyToggleAnalytics({ networkSymbol: 'eth' });
+
+        act(() => {
+            result.current('secondary');
+            result.current('primary');
+        });
+
+        expect(analytics.report).toHaveBeenCalledTimes(2);
+    });
+});

--- a/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.ts
+++ b/suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+
+import { events } from '@suite-common/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { type ActiveView } from '@suite-native/atoms';
+
+type UseYieldCurrencyToggleAnalyticsParams = {
+    networkSymbol: NetworkSymbol | undefined;
+    vaultId?: string;
+};
+
+/**
+ * Reports the crypto/fiat switch of a yield amount input. Standalone wrap/unwrap forms have no
+ * vault, so they report without `vaultId`.
+ */
+export const useYieldCurrencyToggleAnalytics = ({
+    networkSymbol,
+    vaultId,
+}: UseYieldCurrencyToggleAnalyticsParams) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+
+    return useCallback(
+        (activeView: ActiveView) => {
+            analytics.report({
+                type: events.yieldInteractionEvent.name,
+                payload: {
+                    element: 'amount-currency-toggle',
+                    value: activeView === 'secondary' ? 'fiat' : 'crypto',
+                    networkSymbol,
+                    vaultId,
+                },
+            });
+        },
+        [analytics, networkSymbol, vaultId],
+    );
+};

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { type NetworkSymbol, isWrappedNativeToken } from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type FeesRootState,
@@ -39,7 +40,7 @@ type YieldResolutionOutcome = 'success' | 'error' | 'leftPending';
 
 type ReportYieldTransactionResolutionParams = {
     analytics: NativeAnalyticsDep['analytics'];
-    networkSymbol: string;
+    networkSymbol: NetworkSymbol;
     outcome: YieldResolutionOutcome;
     pendingTransactionType: YieldPendingTransactionState['type'];
     submittedAt: number | undefined;
@@ -61,6 +62,7 @@ const reportYieldTransactionResolution = ({
 }: ReportYieldTransactionResolutionParams) => {
     const durationMs = submittedAt ? Date.now() - submittedAt : undefined;
     const errorMessage = outcome === 'error' ? { errorMessage: 'on-chain-failure' } : {};
+    const wrappedNative = isWrappedNativeToken(networkSymbol, vault?.token.address);
 
     switch (pendingTransactionType) {
         case 'approve':
@@ -74,10 +76,10 @@ const reportYieldTransactionResolution = ({
                 wrap: 'wrap-success',
             } as const;
 
-            const apyBreakdown =
-                pendingTransactionType === 'deposit' && outcome === 'success'
-                    ? getApyBreakdown(vault?.rewardRate?.components)
-                    : '';
+            const isDepositSuccess = pendingTransactionType === 'deposit' && outcome === 'success';
+            const apyBreakdown = isDepositSuccess
+                ? getApyBreakdown(vault?.rewardRate?.components)
+                : '';
 
             analytics.report({
                 type: events.yieldDepositEvent.name,
@@ -88,6 +90,7 @@ const reportYieldTransactionResolution = ({
                     vaultId: vault?.id,
                     durationMs,
                     ...(apyBreakdown && { apyBreakdown }),
+                    ...(isDepositSuccess && { wrappedNative }),
                     ...errorMessage,
                 },
             });
@@ -109,6 +112,7 @@ const reportYieldTransactionResolution = ({
                     vaultId: vault?.id,
                     durationMs,
                     ...(apyBreakdown && { apyBreakdown }),
+                    ...(outcome === 'success' && { wrappedNative }),
                     ...errorMessage,
                 },
             });

--- a/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
+import { events } from '@suite-common/analytics';
 import { Context } from '@suite-common/message-system';
 import { WRAPPED_NATIVE, getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
@@ -23,6 +24,7 @@ import { YieldFeeSection } from '../components/YieldFeeSection';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
 import { useMessageSystemWrappedNative } from '../hooks/useMessageSystemWrappedNative';
+import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useStandaloneWrappedNativeFlow } from '../hooks/useStandaloneWrappedNativeFlow';
 import { useWrappedNativeTokenFees } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
@@ -84,6 +86,16 @@ export const UnwrapNativeTokenScreen = () => {
         preparedAction: unwrapFee.preparedAction,
     });
 
+    useNavigateBackAnalytics({
+        type: events.yieldNavigateEvent.name,
+        payload: {
+            action: 'cancel',
+            from: 'unwrap-form',
+            to: 'account-detail',
+            networkSymbol: account?.symbol,
+        },
+    });
+
     if (!account || !wrappedNative || account.networkType !== 'ethereum') {
         return null;
     }
@@ -126,6 +138,7 @@ export const UnwrapNativeTokenScreen = () => {
                         <WrappedNativeTokenAmountInputCard
                             amountLabel={<Translation id="earn.unwrapNativeToken.amountToUnwrap" />}
                             balance={wrappedBalance}
+                            onMaxPress={flow.reportMaxSelected}
                             symbol={account.symbol}
                             tokenContract={toTokenAddress(wrappedNative.address)}
                             tokenDecimals={wrappedNative.decimals}

--- a/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
@@ -28,6 +28,7 @@ import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useStandaloneWrappedNativeFlow } from '../hooks/useStandaloneWrappedNativeFlow';
 import { useWrappedNativeTokenFees } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 import { getAccountTokenByContract } from '../utils/contractTokenBalanceUtils';
 
 type RouteProps = RouteProp<
@@ -86,6 +87,10 @@ export const UnwrapNativeTokenScreen = () => {
         preparedAction: unwrapFee.preparedAction,
     });
 
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
+    });
+
     useNavigateBackAnalytics({
         type: events.yieldNavigateEvent.name,
         payload: {
@@ -138,6 +143,7 @@ export const UnwrapNativeTokenScreen = () => {
                         <WrappedNativeTokenAmountInputCard
                             amountLabel={<Translation id="earn.unwrapNativeToken.amountToUnwrap" />}
                             balance={wrappedBalance}
+                            onCurrencyChange={reportCurrencyToggle}
                             onMaxPress={flow.reportMaxSelected}
                             symbol={account.symbol}
                             tokenContract={toTokenAddress(wrappedNative.address)}

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -34,6 +34,7 @@ import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useStandaloneWrappedNativeFlow } from '../hooks/useStandaloneWrappedNativeFlow';
 import { useWrappedNativeTokenFees } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 
 type RouteProps = RouteProp<
     WrappedNativeTokenStackParamList,
@@ -86,6 +87,10 @@ export const WrapNativeTokenScreen = () => {
         isDisabled: isWrapDisabled,
         pendingParam: pendingTransaction,
         preparedAction: wrapFee.preparedAction,
+    });
+
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
     });
 
     useNavigateBackAnalytics({
@@ -141,6 +146,7 @@ export const WrapNativeTokenScreen = () => {
                             amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                             balance={account.formattedBalance}
                             maxAmount={getMaxWrapAmount(account.formattedBalance)}
+                            onCurrencyChange={reportCurrencyToggle}
                             onMaxPress={flow.reportMaxSelected}
                             symbol={account.symbol}
                             tokenSymbol={nativeSymbol}

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
+import { events } from '@suite-common/analytics';
 import { Context } from '@suite-common/message-system';
 import { WRAPPED_NATIVE, getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { WETH_WRAP_GAS_RESERVE } from '@suite-common/wallet-constants';
@@ -29,6 +30,7 @@ import { YieldFeeSection } from '../components/YieldFeeSection';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { YieldTxSimulationBottomSheet } from '../components/YieldTxSimulationBottomSheet';
 import { useMessageSystemWrappedNative } from '../hooks/useMessageSystemWrappedNative';
+import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useStandaloneWrappedNativeFlow } from '../hooks/useStandaloneWrappedNativeFlow';
 import { useWrappedNativeTokenFees } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
@@ -86,6 +88,16 @@ export const WrapNativeTokenScreen = () => {
         preparedAction: wrapFee.preparedAction,
     });
 
+    useNavigateBackAnalytics({
+        type: events.yieldNavigateEvent.name,
+        payload: {
+            action: 'cancel',
+            from: 'wrap-form',
+            to: 'account-detail',
+            networkSymbol: account?.symbol,
+        },
+    });
+
     if (!account || !wrappedNative || account.networkType !== 'ethereum') {
         return null;
     }
@@ -129,6 +141,7 @@ export const WrapNativeTokenScreen = () => {
                             amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                             balance={account.formattedBalance}
                             maxAmount={getMaxWrapAmount(account.formattedBalance)}
+                            onMaxPress={flow.reportMaxSelected}
                             symbol={account.symbol}
                             tokenSymbol={nativeSymbol}
                         />

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -44,6 +44,7 @@ import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransa
 import { useYieldApprovalFees } from '../hooks/useYieldApprovalFees';
 import { useYieldApprovalLimit } from '../hooks/useYieldApprovalLimit';
 import { useYieldApprovedAmountDisplay } from '../hooks/useYieldApprovedAmountDisplay';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 import { useYieldDepositApprovalSubmit } from '../hooks/useYieldDepositApprovalSubmit';
 import { useYieldDepositForm } from '../hooks/useYieldDepositForm';
 import { useYieldPendingTransaction } from '../hooks/useYieldPendingTransaction';
@@ -93,6 +94,10 @@ export const YieldDepositApprovalScreen = () => {
     } = resolvedFlowData;
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
+        vaultId: vault?.id,
+    });
     const {
         isDisabled: isDepositDisabled,
         content: depositDisabledContent,
@@ -139,6 +144,18 @@ export const YieldDepositApprovalScreen = () => {
         wrappedAmount: session?.result.wrappedAmount,
     });
     const { amountValue, availableBalance, form, handleMaxPress } = depositForm;
+    const handleMaxPressWithAnalytics = useCallback(() => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'deposit-max',
+                networkSymbol: account?.symbol,
+                vaultId: vault?.id,
+            },
+        });
+
+        handleMaxPress();
+    }, [account?.symbol, analytics, handleMaxPress, vault?.id]);
     const {
         formState: { isValid },
     } = form;
@@ -428,7 +445,8 @@ export const YieldDepositApprovalScreen = () => {
                                 balance={availableBalance}
                                 isApprovalLimitDisabled={isAllowanceAmountUnlimited}
                                 onApprovalLimitPress={openApprovalLimitBottomSheet}
-                                onMaxPress={handleMaxPress}
+                                onCurrencyChange={reportCurrencyToggle}
+                                onMaxPress={handleMaxPressWithAnalytics}
                                 symbol={account.symbol}
                                 tokenContract={getYieldTokenContract(token)}
                                 tokenDecimals={token.decimals}

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -223,8 +223,8 @@ export const YieldDepositApprovalScreen = () => {
         analytics.report({
             type: events.yieldDepositEvent.name,
             payload: {
-                action: 'cancel',
-                type: 'approve',
+                action: 'continue',
+                type: 'approve-skipped',
                 networkSymbol: account?.symbol,
                 vaultId: resolvedFlowData.vault?.id,
             },

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -46,6 +46,7 @@ import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useReturnToYieldDepositWrapStep } from '../hooks/useReturnToYieldDepositWrapStep';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
 import { useYieldApprovedAmountDisplay } from '../hooks/useYieldApprovedAmountDisplay';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 import { type PreparedYieldDepositAction, useYieldDepositFees } from '../hooks/useYieldDepositFees';
 import { useYieldDepositForm } from '../hooks/useYieldDepositForm';
 import { useYieldDepositSubmit } from '../hooks/useYieldDepositSubmit';
@@ -350,6 +351,11 @@ export const YieldDepositScreen = () => {
         handleMaxPress();
     }, [account?.symbol, analytics, handleMaxPress, resolvedFlowData.vault?.id]);
 
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
+        vaultId: resolvedFlowData.vault?.id,
+    });
+
     const handleOpenInfoBottomSheet = useCallback(() => {
         analytics.report({
             type: events.yieldInteractionEvent.name,
@@ -453,6 +459,7 @@ export const YieldDepositScreen = () => {
                                     <Translation id="earn.yieldDepositFlowScreen.amountToDeposit" />
                                 }
                                 balance={availableBalance}
+                                onCurrencyChange={reportCurrencyToggle}
                                 onMaxPress={handleMaxPressWithAnalytics}
                                 symbol={account.symbol}
                                 tokenContract={getYieldTokenContract(token)}

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -49,6 +49,7 @@ import {
 } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
 import { useWrappedNativeTxSimulation } from '../hooks/useWrappedNativeTxSimulation';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 import { useYieldPendingTransaction } from '../hooks/useYieldPendingTransaction';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
@@ -87,6 +88,24 @@ export const YieldDepositWrapScreen = () => {
     } = resolvedFlowData;
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
+        vaultId: vault?.id,
+    });
+
+    // The in-flow wrap step belongs to the deposit flow, so its max button reports `deposit-max`
+    // rather than the standalone `wrap-max`.
+    const reportMaxSelected = useCallback(() => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'deposit-max',
+                networkSymbol: account?.symbol,
+                vaultId: vault?.id,
+            },
+        });
+    }, [account?.symbol, analytics, vault?.id]);
+
     const {
         isDisabled: isDepositDisabled,
         content: depositDisabledContent,
@@ -329,6 +348,8 @@ export const YieldDepositWrapScreen = () => {
                                 amountLabel={<Translation id="earn.wrapNativeToken.amountToWrap" />}
                                 balance={nativeBalance}
                                 maxAmount={getMaxWrapAmount(nativeBalance)}
+                                onCurrencyChange={reportCurrencyToggle}
+                                onMaxPress={reportMaxSelected}
                                 symbol={account.symbol}
                                 tokenSymbol={nativeSymbol}
                             />

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -486,6 +486,7 @@ export const YieldWithdrawScreen = () => {
                 operation: flowType,
                 networkSymbol: account?.symbol,
                 vaultId: vault?.id,
+                wrappedNative: isWrappedNativeVault,
                 ...(apyBreakdown && { apyBreakdown }),
             },
         });
@@ -512,6 +513,7 @@ export const YieldWithdrawScreen = () => {
         flowKey,
         isWithdrawDisabled,
         isWithdrawReviewReady,
+        isWrappedNativeVault,
         navigation,
         preparedAction,
         route.params,

--- a/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
@@ -43,6 +43,7 @@ import {
 } from '../hooks/useWrappedNativeTokenFees';
 import { useWrappedNativeTokenForm } from '../hooks/useWrappedNativeTokenForm';
 import { useWrappedNativeTxSimulation } from '../hooks/useWrappedNativeTxSimulation';
+import { useYieldCurrencyToggleAnalytics } from '../hooks/useYieldCurrencyToggleAnalytics';
 import { useYieldPendingTransaction } from '../hooks/useYieldPendingTransaction';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
@@ -79,6 +80,26 @@ export const YieldWithdrawUnwrapScreen = () => {
         content: unwrapDisabledContent,
         variant: unwrapDisabledVariant,
     } = useMessageSystemWrappedNative('unwrap');
+
+    const reportCurrencyToggle = useYieldCurrencyToggleAnalytics({
+        networkSymbol: account?.symbol,
+        vaultId: vault?.id,
+    });
+
+    // The in-flow unwrap step belongs to the withdraw flow, so its max button reports
+    // `withdraw-max` rather than the standalone `unwrap-max`. The step has no asset/shares choice —
+    // the amount is always the wrapped token, i.e. the asset.
+    const reportMaxSelected = useCallback(() => {
+        analytics.report({
+            type: events.yieldInteractionEvent.name,
+            payload: {
+                element: 'withdraw-max',
+                value: 'asset',
+                networkSymbol: account?.symbol,
+                vaultId: vault?.id,
+            },
+        });
+    }, [account?.symbol, analytics, vault?.id]);
 
     const session = useYieldSession({
         flowKey,
@@ -354,6 +375,8 @@ export const YieldWithdrawUnwrapScreen = () => {
                                 }
                                 balance={wrappedBalance}
                                 defaultAmount={withdrawnAmount}
+                                onCurrencyChange={reportCurrencyToggle}
+                                onMaxPress={reportMaxSelected}
                                 symbol={account.symbol}
                                 tokenContract={wrappedTokenContract}
                                 tokenDecimals={token.decimals}

--- a/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.test.ts
+++ b/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.test.ts
@@ -1,0 +1,129 @@
+import { events } from '@suite-common/analytics';
+
+import {
+    type WrappedNativeFlowPayload,
+    buildWrappedNativeFlowEvent,
+    getWrappedNativeMaxInteractionElement,
+    getWrappedNativeResolutionPayload,
+} from './wrappedNativeAnalyticsUtils';
+
+const ALLOWED_PAYLOAD_KEYS = ['type', 'action', 'networkSymbol', 'durationMs', 'errorMessage'];
+
+const expectOnlyAllowedKeys = (payload: WrappedNativeFlowPayload | null) => {
+    expect(payload).not.toBeNull();
+    Object.keys(payload ?? {}).forEach(key => {
+        expect(ALLOWED_PAYLOAD_KEYS).toContain(key);
+    });
+};
+
+describe('buildWrappedNativeFlowEvent', () => {
+    it('builds a yield/wrap event for the wrap flow', () => {
+        const payload = { type: 'submit', action: 'continue', networkSymbol: 'eth' } as const;
+
+        expect(buildWrappedNativeFlowEvent('wrap', payload)).toEqual({
+            type: events.yieldWrapEvent.name,
+            payload,
+        });
+    });
+
+    it('builds a yield/unwrap event for the unwrap flow', () => {
+        const payload = { type: 'submit', action: 'continue', networkSymbol: 'eth' } as const;
+
+        expect(buildWrappedNativeFlowEvent('unwrap', payload)).toEqual({
+            type: events.yieldUnwrapEvent.name,
+            payload,
+        });
+    });
+
+    it('passes the payload through unchanged', () => {
+        const payload = {
+            type: 'error',
+            action: 'continue',
+            networkSymbol: 'eth',
+            durationMs: 1234,
+            errorMessage: 'push-failed',
+        } as const;
+
+        expect(buildWrappedNativeFlowEvent('wrap', payload).payload).toBe(payload);
+    });
+});
+
+describe('getWrappedNativeResolutionPayload', () => {
+    it('returns a success payload when the transaction confirmed', () => {
+        const payload = getWrappedNativeResolutionPayload({
+            durationMs: 5000,
+            networkSymbol: 'eth',
+            status: 'confirmed',
+        });
+
+        expect(payload).toEqual({
+            type: 'success',
+            action: 'continue',
+            networkSymbol: 'eth',
+            durationMs: 5000,
+        });
+        expectOnlyAllowedKeys(payload);
+    });
+
+    it('returns an on-chain-failure error payload when the transaction failed', () => {
+        const payload = getWrappedNativeResolutionPayload({
+            durationMs: 5000,
+            networkSymbol: 'eth',
+            status: 'failed',
+        });
+
+        expect(payload).toEqual({
+            type: 'error',
+            action: 'continue',
+            networkSymbol: 'eth',
+            durationMs: 5000,
+            errorMessage: 'on-chain-failure',
+        });
+        expectOnlyAllowedKeys(payload);
+    });
+
+    it('returns null while the transaction is still pending', () => {
+        expect(
+            getWrappedNativeResolutionPayload({
+                durationMs: 5000,
+                networkSymbol: 'eth',
+                status: 'pending',
+            }),
+        ).toBeNull();
+    });
+
+    it('returns null when there is no status', () => {
+        expect(
+            getWrappedNativeResolutionPayload({
+                durationMs: 5000,
+                networkSymbol: 'eth',
+                status: null,
+            }),
+        ).toBeNull();
+    });
+
+    it('preserves an undefined durationMs', () => {
+        const payload = getWrappedNativeResolutionPayload({
+            durationMs: undefined,
+            networkSymbol: 'eth',
+            status: 'confirmed',
+        });
+
+        expect(payload).toEqual({
+            type: 'success',
+            action: 'continue',
+            networkSymbol: 'eth',
+            durationMs: undefined,
+        });
+    });
+});
+
+describe('getWrappedNativeMaxInteractionElement', () => {
+    it('returns wrap-max for the wrap flow', () => {
+        expect(getWrappedNativeMaxInteractionElement('wrap')).toBe('wrap-max');
+    });
+
+    it('returns unwrap-max for the unwrap flow', () => {
+        expect(getWrappedNativeMaxInteractionElement('unwrap')).toBe('unwrap-max');
+    });
+});

--- a/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts
+++ b/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts
@@ -1,0 +1,46 @@
+import { type EventInstance, events } from '@suite-common/analytics';
+import {
+    type WrappedNativeFlowType,
+    type WrappedNativePendingTxStatus,
+} from '@suite-common/wallet-core';
+
+export type WrappedNativeFlowPayload = EventInstance<typeof events.yieldWrapEvent>['payload'];
+
+export const buildWrappedNativeFlowEvent = (
+    flowType: WrappedNativeFlowType,
+    payload: WrappedNativeFlowPayload,
+) => ({
+    type: flowType === 'wrap' ? events.yieldWrapEvent.name : events.yieldUnwrapEvent.name,
+    payload,
+});
+
+type WrappedNativeResolutionParams = {
+    durationMs: number | undefined;
+    networkSymbol: string;
+    status: WrappedNativePendingTxStatus | null;
+};
+
+export const getWrappedNativeResolutionPayload = ({
+    durationMs,
+    networkSymbol,
+    status,
+}: WrappedNativeResolutionParams): WrappedNativeFlowPayload | null => {
+    if (status === 'confirmed') {
+        return { type: 'success', action: 'continue', networkSymbol, durationMs };
+    }
+
+    if (status === 'failed') {
+        return {
+            type: 'error',
+            action: 'continue',
+            networkSymbol,
+            durationMs,
+            errorMessage: 'on-chain-failure',
+        };
+    }
+
+    return null;
+};
+
+export const getWrappedNativeMaxInteractionElement = (flowType: WrappedNativeFlowType) =>
+    flowType === 'wrap' ? 'wrap-max' : 'unwrap-max';

--- a/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts
+++ b/suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts
@@ -1,4 +1,5 @@
 import { type EventInstance, events } from '@suite-common/analytics';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
     type WrappedNativeFlowType,
     type WrappedNativePendingTxStatus,
@@ -16,7 +17,7 @@ export const buildWrappedNativeFlowEvent = (
 
 type WrappedNativeResolutionParams = {
     durationMs: number | undefined;
-    networkSymbol: string;
+    networkSymbol: NetworkSymbol | undefined;
     status: WrappedNativePendingTxStatus | null;
 };
 


### PR DESCRIPTION
## Description

Mobile counterpart of #29861 (desktop landed in #30537) — the shared schema already exists; this wires the mobile call sites:

- Standalone wrap/unwrap flows now report `yield/wrap` / `yield/unwrap` (`submit`, `tx-simulation-modal` continue/cancel, `sent`, `success`/`error` with `durationMs`, `leftPending`), plus `yield/navigate` for entry/back/close and `yield/interaction` `wrap-max`/`unwrap-max`.
- `wrappedNative` flag added to `yield/deposit` and `yield/withdraw` success payloads and the withdraw submit payload (mirroring desktop's guards).
- Schema docs/changelogs updated (26.8.1) — removes stale "desktop only" notes.
- Adds the `approve-skipped` value to `yield/deposit`'s `type` union, and fixes `handleSkipApproval` (from #31021, now in the base) to fire `type: 'approve-skipped', action: 'continue'` instead of `type: 'approve', action: 'cancel'` — the "currently it's canceled which is incorrect" part of the issue.

The in-deposit wrap step intentionally stays on `yield/deposit type:'wrap'` (no `yield/wrap` there — no double-counting). Open question for the issue author: should skipping the wrap step get a symmetric `wrap-skipped` value? Currently it reports `type:'wrap', action:'cancel'`, matching desktop.

Stacked on #31024 (`feat/native-deposit-wrap-step`).

## Notes for QA

- Standalone wrap/unwrap: check events fire on submit, simulation confirm/cancel, broadcast, on-chain confirm/revert, and leaving the screen with a pending tx.
- Payloads carry only `networkSymbol`/`durationMs`/`errorMessage` — no amounts, txids or account identifiers.
- Deposit/withdraw of a WETH vault: `wrappedNative: true` on submit/success events; USDC vaults report `false`.

## Related Issue

Resolve #30986

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/native-wrap-analytics/web/](https://dev.suite.sldev.cz/suite-web/feat/native-wrap-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is split between shared yield analytics event definitions and mobile-only earn module components under suite-native/module-earn. The analytics files are broad global dependencies touched by over a hundred tests, but none of the desktop E2E tests specifically exercise yield analytics or wrapped-native-token flows. The most relevant single check is the general analytics events test, which can catch module-level regressions. The native earn UI/flow changes have no coverage in the provided desktop E2E suite and should be covered by native/mobile tests instead.

<details><summary><b>Changed files (27)</b></summary>

- `suite-common/analytics/src/events/yieldDepositEvent.ts`
- `suite-common/analytics/src/events/yieldInteractionEvent.ts`
- `suite-common/analytics/src/events/yieldNavigateEvent.ts`
- `suite-common/analytics/src/events/yieldUnwrapEvent.ts`
- `suite-common/analytics/src/events/yieldWithdrawEvent.ts`
- `suite-common/analytics/src/events/yieldWrapEvent.ts`
- `suite-common/analytics/src/events/yieldWrappedNativeAttributes.ts`
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx`
- `suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx`
- `suite-native/module-earn/src/components/YieldAmountInputCard.tsx`
- `suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenReview.ts`
- `suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts`
- `suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts`
- `suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx`
- `suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.test.ts`
- `suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This is the broad analytics events test that statically references all changed yield*Event.ts files through the shared analytics events module. It verifies the analytics event infrastructure loads and emits correctly, so module-level breakage (e.g., broken exports or event definitions) would likely surface here, even though it does not assert yield-specific events.

</details>

⚠️ **Changes with no test coverage (20)**
- `suite-native/module-accounts-management/src/components/TokenSettingsBottomSheet.tsx`
- `suite-native/module-earn/src/components/WrappedNativeTokenAmountInputCard.tsx`
- `suite-native/module-earn/src/components/WrappedNativeTokenCompleteContent.tsx`
- `suite-native/module-earn/src/components/YieldAmountInputCard.tsx`
- `suite-native/module-earn/src/hooks/useStandaloneWrappedNativeFlow.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.test.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeFlowAnalytics.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenReview.ts`
- `suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.test.ts`
- `suite-native/module-earn/src/hooks/useYieldCurrencyToggleAnalytics.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransactionTracking.ts`
- `suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx`
- `suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.test.ts`
- `suite-native/module-earn/src/utils/wrappedNativeAnalyticsUtils.ts`

_Updated: 2026-08-12T07:37:15.336Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/native-wrap-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/native-wrap-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T08:04:20.707Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T08:03:16.798Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->