### PR TITLE
refactor(trading): type exchange thunks

### DIFF
--- a/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts
@@ -5,7 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeAccountKey,
@@ -26,16 +26,16 @@ export type ConfirmApprovalThunkProps = {
     processResponseData: (response: ExchangeTrade) => void;
 };
 
-export const confirmApprovalThunk = createThunk(
+type ConfirmApprovalThunkState = TradingRootState;
+
+export const confirmApprovalThunk = createThunk<
+    ExchangeTrade | undefined,
+    ConfirmApprovalThunkProps,
+    { state: ConfirmApprovalThunkState }
+>(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/confirmApproval`,
     async (
-        {
-            trade,
-            receiveAddress,
-            account,
-            extraField,
-            processResponseData,
-        }: ConfirmApprovalThunkProps,
+        { trade, receiveAddress, account, extraField, processResponseData },
         { dispatch, getState },
     ) => {
         const getCoinSymbol = (cryptoId: CryptoId) =>

--- a/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts
@@ -5,7 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeAccountKey,
@@ -31,7 +31,13 @@ export type ConfirmExchangeTradeThunkProps = {
     nextStep?: () => void;
 };
 
-export const confirmExchangeTradeThunk = createThunk(
+type ConfirmExchangeTradeThunkState = TradingRootState;
+
+export const confirmExchangeTradeThunk = createThunk<
+    ExchangeTrade | undefined,
+    ConfirmExchangeTradeThunkProps,
+    { state: ConfirmExchangeTradeThunkState }
+>(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/confirmTrade`,
     async (
         {
@@ -45,7 +51,7 @@ export const confirmExchangeTradeThunk = createThunk(
             triggerAnalyticsTradeConfirmation,
             processResponseData,
             nextStep,
-        }: ConfirmExchangeTradeThunkProps,
+        },
         { dispatch, getState, signal },
     ) => {
         const getCoinSymbol = (cryptoId: CryptoId) =>

--- a/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts
@@ -1,13 +1,14 @@
 import { type ExchangeTrade, type ExchangeTradeQuoteRequest } from 'invity-api';
 
+import { type AddressValidatorDep } from '@suite-common/address';
 import { createThunk } from '@suite-common/redux-utils';
 import { type Network } from '@suite-common/wallet-config';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingCoinSymbolByCryptoId,
     selectTradingExchangeQuotesRequest,
@@ -74,21 +75,23 @@ export const getQuoteRequestData = ({
     return request;
 };
 
+type HandleExchangeRequestThunkState = AccountsRootState & TradingRootState;
+type HandleExchangeRequestThunkDeps = {
+    services: AddressValidatorDep;
+};
+
 export const handleExchangeRequestThunk = createThunk<
     ExchangeTrade[],
     HandleExchangeRequestThunkProps,
     {
         rejectValue: string;
+        state: HandleExchangeRequestThunkState;
+        extra: HandleExchangeRequestThunkDeps;
     }
 >(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/handleRequest`,
     async (
-        {
-            formValues,
-            network,
-            shouldSendInSats,
-            composeRequestCallback,
-        }: HandleExchangeRequestThunkProps,
+        { formValues, network, shouldSendInSats, composeRequestCallback },
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal, extra },
     ) => {
         const requestData = getQuoteRequestData({

--- a/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts
@@ -7,7 +7,7 @@ import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { type ExchangeInfo } from '../../reducers/exchangeReducer';
 import { tradeApi } from '../../tradeApi';
 
-export const loadExchangeInfoThunk = createThunk<ExchangeInfo>(
+export const loadExchangeInfoThunk = createThunk<ExchangeInfo, void, void>(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/loadInfo`,
     async (_, { fulfillWithValue }) => {
         const exchangeList = await tradeApi.getExchangeList();

--- a/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts
@@ -5,6 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { type TradingRootState } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeDexQuoteApprovalPrefetchLoadingQuoteId,
     selectTradingExchangeQuotes,
@@ -17,9 +18,15 @@ export type PrefetchDexQuoteApprovalThunkProps = {
     trade: ExchangeTrade;
 };
 
-export const prefetchDexQuoteApprovalThunk = createThunk(
+type PrefetchDexQuoteApprovalThunkState = TradingRootState;
+
+export const prefetchDexQuoteApprovalThunk = createThunk<
+    ExchangeTrade | undefined,
+    PrefetchDexQuoteApprovalThunkProps,
+    { state: PrefetchDexQuoteApprovalThunkState }
+>(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/prefetchDexQuoteApproval`,
-    async ({ trade, account }: PrefetchDexQuoteApprovalThunkProps, { dispatch, getState }) => {
+    async ({ trade, account }, { dispatch, getState }) => {
         dispatch(tradingExchangeActions.setDexQuoteApprovalPrefetchLoadingQuoteId(trade?.quoteId));
 
         try {

--- a/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts
@@ -4,7 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingExchangeInfo } from '../../selectors/tradingSelectors';
 import { requiresTokenApproval } from '../../utils/exchange/exchangeUtils';
 
@@ -13,31 +13,34 @@ export type SelectExchangeQuoteThunkProps = {
     nextStep: () => void;
 };
 
-export const selectExchangeQuoteThunk = createThunk(
-    `${TRADING_EXCHANGE_THUNK_PREFIX}/selectQuote`,
-    ({ quote, nextStep }: SelectExchangeQuoteThunkProps, { dispatch, getState }) => {
-        const exchangeInfo = selectTradingExchangeInfo(getState());
-        const provider =
-            exchangeInfo?.providerInfos && quote.exchange
-                ? exchangeInfo?.providerInfos[quote.exchange]
-                : null;
+type SelectExchangeQuoteThunkState = TradingRootState;
 
-        if (!provider || !quote.send || !quote.receive) {
-            return;
-        }
+export const selectExchangeQuoteThunk = createThunk<
+    void,
+    SelectExchangeQuoteThunkProps,
+    { state: SelectExchangeQuoteThunkState }
+>(`${TRADING_EXCHANGE_THUNK_PREFIX}/selectQuote`, ({ quote, nextStep }, { dispatch, getState }) => {
+    const exchangeInfo = selectTradingExchangeInfo(getState());
+    const provider =
+        exchangeInfo?.providerInfos && quote.exchange
+            ? exchangeInfo?.providerInfos[quote.exchange]
+            : null;
 
-        // DEX ERC-20 swaps use preselectedQuote on approval screens until CONFIRM / SIGN_DATA.
-        // Native / no-approval DEX goes straight to preview and must be persisted as selectedQuote.
-        if (
-            !quote.isDex ||
-            quote.status === 'CONFIRM' ||
-            quote.status === 'SIGN_DATA' ||
-            !requiresTokenApproval(quote)
-        ) {
-            dispatch(tradingExchangeActions.saveSelectedQuote(quote));
-        }
+    if (!provider || !quote.send || !quote.receive) {
+        return;
+    }
 
-        dispatch(tradingActions.stopRefetchQuotes());
-        nextStep();
-    },
-);
+    // DEX ERC-20 swaps use preselectedQuote on approval screens until CONFIRM / SIGN_DATA.
+    // Native / no-approval DEX goes straight to preview and must be persisted as selectedQuote.
+    if (
+        !quote.isDex ||
+        quote.status === 'CONFIRM' ||
+        quote.status === 'SIGN_DATA' ||
+        !requiresTokenApproval(quote)
+    ) {
+        dispatch(tradingExchangeActions.saveSelectedQuote(quote));
+    }
+
+    dispatch(tradingActions.stopRefetchQuotes());
+    nextStep();
+});

--- a/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts
@@ -7,7 +7,7 @@ import { type Account } from '@suite-common/wallet-types';
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeAccountKey,
     selectTradingExchangeProviders,
@@ -32,11 +32,14 @@ export type SendDexTransactionThunkProps = {
     signAndPushSendFormTransaction: RecomposeAndSignTxThunkProps['signAndPushSendFormTransaction'];
 };
 
+type SendDexTransactionThunkState = TradingRootState;
+
 export const sendDexTransactionThunk = createThunk<
     undefined,
     SendDexTransactionThunkProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: SendDexTransactionThunkState;
     }
 >(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/sendDexTransaction`,
@@ -49,7 +52,7 @@ export const sendDexTransactionThunk = createThunk<
             processResponseData,
             triggerAnalyticsTradeConfirmation,
             signAndPushSendFormTransaction,
-        }: SendDexTransactionThunkProps,
+        },
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());

--- a/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts
@@ -10,7 +10,7 @@ import {
 } from './sendDexTransactionThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeAccountKey,
     selectTradingExchangeProviders,
@@ -28,11 +28,14 @@ export type SendTransactionThunkProps = {
     isSlip24Active?: boolean;
 } & SendDexTransactionThunkProps;
 
+type SendTransactionThunkState = TradingRootState;
+
 export const sendTransactionThunk = createThunk<
     undefined,
     SendTransactionThunkProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: SendTransactionThunkState;
     }
 >(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/sendTransaction`,
@@ -49,7 +52,7 @@ export const sendTransactionThunk = createThunk<
             processResponseData,
             triggerAnalyticsTradeConfirmation,
             signAndPushSendFormTransaction,
-        }: SendTransactionThunkProps,
+        },
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());

--- a/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts
@@ -10,7 +10,7 @@ import TrezorConnect, {
 
 import { confirmExchangeTradeThunk } from './confirmExchangeTradeThunk';
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingExchangeAccountKey,
     selectTradingExchangeReceiveAccountKey,
@@ -34,11 +34,14 @@ const signDataRejectedValue: TradingSendRejectedProps = {
     error: { id: 'TR_TRADING_CANNOT_SEND_TRANSACTION' },
 };
 
+type SignDataAndConfirmThunkState = TradingRootState;
+
 export const signDataAndConfirmThunk = createThunk<
     undefined,
     SignDataAndConfirmThunkProps,
     {
         rejectValue: TradingSendRejectedProps;
+        state: SignDataAndConfirmThunkState;
     }
 >(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/signDataAndConfirm`,
@@ -50,7 +53,7 @@ export const signDataAndConfirmThunk = createThunk<
             triggerAnalyticsTradeConfirmation,
             processResponseData,
             nextStep,
-        }: SignDataAndConfirmThunkProps,
+        },
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());

--- a/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
+++ b/suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts
@@ -1,8 +1,11 @@
+import { type ExchangeTrade } from 'invity-api';
+
 import { createThunk } from '@suite-common/redux-utils';
 import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_EXCHANGE_THUNK_PREFIX } from '../../constants';
 import { tradingExchangeActions } from '../../reducers/exchangeReducer';
+import { type TradingRootState } from '../../reducers/tradingCommonReducer';
 import { selectTradingExchangeSelectedQuote } from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
 
@@ -11,10 +14,16 @@ export type WatchExchangeApprovalThunkProps = {
     refreshCount: number;
 };
 
+type WatchExchangeApprovalThunkState = TradingRootState;
+
 // Read-only watch poll: saves the quote only when the backend advances its status.
-export const watchExchangeApprovalThunk = createThunk(
+export const watchExchangeApprovalThunk = createThunk<
+    ExchangeTrade | undefined,
+    WatchExchangeApprovalThunkProps,
+    { state: WatchExchangeApprovalThunkState }
+>(
     `${TRADING_EXCHANGE_THUNK_PREFIX}/watchExchangeApproval`,
-    async ({ account, refreshCount }: WatchExchangeApprovalThunkProps, { dispatch, getState }) => {
+    async ({ account, refreshCount }, { dispatch, getState }) => {
         const selectedQuote = selectTradingExchangeSelectedQuote(getState());
 
         if (!selectedQuote) {


### PR DESCRIPTION
## Description

The exchange thunk batch still inherited the global thunk API even though each thunk needs only a small state or service surface. This adds named minimal state contracts to every stateful exchange thunk, narrows the request thunk to the address-validator service, and marks the stateless info loader explicitly dependency-free. Runtime behavior is unchanged.\n\n- Production exchange thunks using the global default: **10 -> 0**\n- Explicit selective-state contracts: **0 -> 9**\n- Explicit dependency-free contracts: **0 -> 1**\n- Focused exchange tests: **101 passed**\n\nPart of #30770.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-exchange-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-exchange-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-trading-exchange-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-trading-exchange-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-trading-exchange-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T20:45:49.841Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T20:45:07.187Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR touches the core suite-common trading exchange thunks that drive swap and DEX transaction flows. Although static coverage maps these files to many tests transitively, only the trading swap tests directly exercise the changed logic. The highest risk areas are DEX token approvals, cross-chain swaps, quote selection, and transaction signing/broadcasting. I recommend running the focused set of swap E2E tests (especially DEX and cross-chain variants) to catch regressions in these critical user paths.

<details><summary><b>Changed files (10)</b></summary>

- `suite-common/trading/src/thunks/exchange/confirmApprovalThunk.ts`
- `suite-common/trading/src/thunks/exchange/confirmExchangeTradeThunk.ts`
- `suite-common/trading/src/thunks/exchange/handleExchangeRequestThunk.ts`
- `suite-common/trading/src/thunks/exchange/loadExchangeInfoThunk.ts`
- `suite-common/trading/src/thunks/exchange/prefetchDexQuoteApprovalThunk.ts`
- `suite-common/trading/src/thunks/exchange/selectExchangeQuoteThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/thunks/exchange/sendTransactionThunk.ts`
- `suite-common/trading/src/thunks/exchange/signDataAndConfirmThunk.ts`
- `suite-common/trading/src/thunks/exchange/watchExchangeApprovalThunk.ts`

</details>

**Recommended tests (14)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Executes a live SOL-to-USDC swap end-to-end, directly exercising the exchange trade confirmation, transaction send, and quote selection thunks changed in this PR.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Executes a live SPL-token-to-SOL swap, covering the same exchange trade confirmation and send thunks for token-swap scenarios.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Mocked SOL-to-USDC swap test that validates the full exchange flow including quote selection, confirmation, and transaction send.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — Directly tests the DEX token approval flow (approval confirmation, spending-limit toggle, and pending approval watching), which maps directly to confirmApprovalThunk, prefetchDexQuoteApprovalThunk, and watchExchangeApprovalThunk.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — End-to-end DEX swap via LI.FI covering DEX-specific quote selection, transaction signing, and broadcasting, directly exercising sendDexTransactionThunk and confirmExchangeTradeThunk.
- `suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts` — Cross-chain ERC-20-to-SPL-token swap that validates quote selection, recipient address verification, amount/fee display, and transaction signing through the exchange thunks.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Cross-chain SOL-to-BTC swap covering quote selection, device confirmation of address/amount/fee, and transaction broadcast via the exchange send and confirmation thunks.
- `suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts` — Cross-chain SPL-token-to-ETH swap that exercises the same exchange confirmation, quote selection, and send thunks for token-to-coin scenarios.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Solana USDT-to-BTC token-to-coin swap validating quote selection, receive account selection, and transaction signing/broadcasting through the changed exchange thunks.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — SPL-token-to-SPL-token swap (USDT-to-USDC) that directly exercises the exchange quote selection, confirmation, and send thunks for token swaps.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC-to-ETH swap with custom Bitcoin fee settings; validates that fee-rate handling still integrates correctly with the exchange transaction composition and send flow.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — ETH-to-BTC swap with custom Ethereum gas parameters; checks that custom fee logic works through the exchange send and confirmation path.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form asset selection, amount validation, fraction buttons, and crypto/fiat switching, which rely on the exchange quote loading and selection infrastructure.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Validates quote selection behavior when the buy asset is on a disabled network, ensuring loadExchangeInfoThunk and quote selection still function correctly.

</details>

_Updated: 2026-08-07T20:45:15.999Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->