### PR TITLE
refactor(trading): type sell thunks

### DIFF
--- a/suite-common/trading/src/thunks/sell/confirmSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/confirmSellTradeThunk.ts
@@ -2,7 +2,11 @@ import { type BankAccount } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 
-import { type HandleSellTradeThunkProps, handleSellTradeThunk } from './handleSellTradeThunk';
+import {
+    type HandleSellTradeThunkProps,
+    type HandleSellTradeThunkState,
+    handleSellTradeThunk,
+} from './handleSellTradeThunk';
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
 import { selectTradingSellSelectedQuote } from '../../selectors/tradingSelectors';
@@ -12,16 +16,16 @@ export type ConfirmSellTradeThunkProps = {
     triggerAnalyticsTradeConfirmation: () => void;
 } & Omit<HandleSellTradeThunkProps, 'trade'>;
 
-export const confirmSellTradeThunk = createThunk(
+type ConfirmSellTradeThunkState = HandleSellTradeThunkState;
+
+export const confirmSellTradeThunk = createThunk<
+    void,
+    ConfirmSellTradeThunkProps,
+    { state: ConfirmSellTradeThunkState }
+>(
     `${TRADING_SELL_THUNK_PREFIX}/confirmTrade`,
     async (
-        {
-            account,
-            bankAccount,
-            returnUrl,
-            triggerAnalyticsTradeConfirmation,
-            processResponseData,
-        }: ConfirmSellTradeThunkProps,
+        { account, bankAccount, returnUrl, triggerAnalyticsTradeConfirmation, processResponseData },
         { dispatch, getState },
     ) => {
         const selectedQuote = selectTradingSellSelectedQuote(getState());

--- a/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts
@@ -6,7 +6,7 @@ import { convertAmountSubunitsToUnits } from '@suite-common/wallet-utils';
 
 import { TRADING_DEFAULT_SELL_FLOWS, TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingCoinSymbolByCryptoId } from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
 import {
@@ -82,21 +82,19 @@ const getQuoteRequestData = ({
     return request;
 };
 
+type HandleSellRequestThunkState = TradingRootState;
+
 export const handleSellRequestThunk = createThunk<
     SellFiatTrade[],
     HandleSellRequestThunkProps,
     {
         rejectValue: string;
+        state: HandleSellRequestThunkState;
     }
 >(
     `${TRADING_SELL_THUNK_PREFIX}/handleRequest`,
     async (
-        {
-            formValues,
-            network,
-            shouldSendInSats,
-            composeRequestCallback,
-        }: HandleSellRequestThunkProps,
+        { formValues, network, shouldSendInSats, composeRequestCallback },
         { dispatch, getState, fulfillWithValue, rejectWithValue, signal },
     ) => {
         const requestData = getQuoteRequestData({

--- a/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
+++ b/suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts
@@ -5,7 +5,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import { selectTradingSellInfo } from '../../selectors/tradingSelectors';
 import { tradeApi } from '../../tradeApi';
 import { getUnusedAddressFromAccount } from '../../utils';
@@ -19,10 +19,16 @@ export type HandleSellTradeThunkProps = {
     processResponseData: (response: SellFiatTradeResponse) => void;
 };
 
-export const handleSellTradeThunk = createThunk(
+export type HandleSellTradeThunkState = TradingRootState;
+
+export const handleSellTradeThunk = createThunk<
+    SellFiatTrade | undefined,
+    HandleSellTradeThunkProps,
+    { state: HandleSellTradeThunkState }
+>(
     `${TRADING_SELL_THUNK_PREFIX}/handleTrade`,
     async (
-        { account, trade, returnUrl, processResponseData }: HandleSellTradeThunkProps,
+        { account, trade, returnUrl, processResponseData },
         { dispatch, getState, fulfillWithValue },
     ) => {
         const sellInfo = selectTradingSellInfo(getState());

--- a/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
+++ b/suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts
@@ -9,7 +9,7 @@ import { regional } from '../../regional';
 import { tradeApi } from '../../tradeApi';
 import { toTradingCountryCode } from '../../utils/countryUtils';
 
-export const loadSellInfoThunk = createThunk<SellInfo>(
+export const loadSellInfoThunk = createThunk<SellInfo, void, void>(
     `${TRADING_SELL_THUNK_PREFIX}/loadInfo`,
     async (_, { fulfillWithValue }) => {
         const sellList = await tradeApi.getSellList();

--- a/suite-common/trading/src/thunks/sell/selectSellQuoteThunk.ts
+++ b/suite-common/trading/src/thunks/sell/selectSellQuoteThunk.ts
@@ -4,7 +4,7 @@ import { createThunk } from '@suite-common/redux-utils';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingSellInfo,
     selectTradingSellQuotesRequest,
@@ -15,17 +15,20 @@ export type SelectSellQuoteThunkProps = {
     nextStep: () => void;
 };
 
-export const selectSellQuoteThunk = createThunk(
-    `${TRADING_SELL_THUNK_PREFIX}/selectQuote`,
-    ({ quote, nextStep }: SelectSellQuoteThunkProps, { dispatch, getState }) => {
-        const sellInfo = selectTradingSellInfo(getState());
-        const quotesRequest = selectTradingSellQuotesRequest(getState());
-        const provider = quote.exchange ? sellInfo?.providerInfos[quote.exchange] : undefined;
+type SelectSellQuoteThunkState = TradingRootState;
 
-        if (!quotesRequest || !provider || !quote.cryptoCurrency) return;
+export const selectSellQuoteThunk = createThunk<
+    void,
+    SelectSellQuoteThunkProps,
+    { state: SelectSellQuoteThunkState }
+>(`${TRADING_SELL_THUNK_PREFIX}/selectQuote`, ({ quote, nextStep }, { dispatch, getState }) => {
+    const sellInfo = selectTradingSellInfo(getState());
+    const quotesRequest = selectTradingSellQuotesRequest(getState());
+    const provider = quote.exchange ? sellInfo?.providerInfos[quote.exchange] : undefined;
 
-        dispatch(tradingSellActions.saveSelectedQuote(quote));
-        dispatch(tradingActions.stopRefetchQuotes());
-        nextStep();
-    },
-);
+    if (!quotesRequest || !provider || !quote.cryptoCurrency) return;
+
+    dispatch(tradingSellActions.saveSelectedQuote(quote));
+    dispatch(tradingActions.stopRefetchQuotes());
+    nextStep();
+});

--- a/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
+++ b/suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts
@@ -6,7 +6,7 @@ import { type Account } from '@suite-common/wallet-types';
 
 import { TRADING_SELL_THUNK_PREFIX } from '../../constants';
 import { tradingSellActions } from '../../reducers/sellReducer';
-import { tradingActions } from '../../reducers/tradingCommonReducer';
+import { type TradingRootState, tradingActions } from '../../reducers/tradingCommonReducer';
 import {
     selectTradingSellProviders,
     selectTradingSellSelectedQuote,
@@ -28,7 +28,13 @@ export type SendSellTransactionThunkProps = {
     signAndPushSendFormTransaction: RecomposeAndSignTxThunkProps['signAndPushSendFormTransaction'];
 };
 
-export const sendSellTransactionThunk = createThunk(
+type SendSellTransactionThunkState = TradingRootState;
+
+export const sendSellTransactionThunk = createThunk<
+    undefined,
+    SendSellTransactionThunkProps,
+    { state: SendSellTransactionThunkState }
+>(
     `${TRADING_SELL_THUNK_PREFIX}/sendTransaction`,
     async (
         {
@@ -39,7 +45,7 @@ export const sendSellTransactionThunk = createThunk(
             isSlip24Active,
             nextStep,
             signAndPushSendFormTransaction,
-        }: SendSellTransactionThunkProps,
+        },
         { dispatch, getState, rejectWithValue },
     ) => {
         const selectedQuote = selectTradingSellSelectedQuote(getState());


### PR DESCRIPTION
## Description

The sell thunk batch still inherited the global thunk API despite using only trading state. This adds named minimal state contracts to quote selection, request handling, confirmation, trade handling, and transaction signing/sending; the stateless info loader is explicitly dependency-free. The confirmation thunk composes its child thunk's state contract, while the shared sell trade watcher is already covered by #31039. Runtime behavior is unchanged.\n\n- Production sell thunks using the global default: **6 -> 0**\n- Explicit selective-state contracts: **0 -> 5**\n- Explicit dependency-free contracts: **0 -> 1**\n- Focused sell tests: **46 passed**\n\nPart of #30770.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are tightly scoped to the suite-common sell trading thunks, so risk is concentrated in the sell flow across multiple networks and token types. The five sell-focused E2E tests should be run at high priority to catch regressions in quote handling, confirmation, and transaction sending. The trading navigation test is recommended at medium priority as a lightweight check that the sell form still initializes correctly from various entry points. Unrelated buy, swap, staking, and onboarding suites do not need to run based on these changes.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/trading/src/thunks/sell/confirmSellTradeThunk.ts`
- `suite-common/trading/src/thunks/sell/handleSellRequestThunk.ts`
- `suite-common/trading/src/thunks/sell/handleSellTradeThunk.ts`
- `suite-common/trading/src/thunks/sell/loadSellInfoThunk.ts`
- `suite-common/trading/src/thunks/sell/selectSellQuoteThunk.ts`
- `suite-common/trading/src/thunks/sell/sendSellTransactionThunk.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Directly exercises the full BTC sell flow end-to-end, including quote selection, trade confirmation, provider redirection, and on-device send transaction signing — all paths driven by the changed sell thunks.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Tests selling an ERC-20 token (USDC) through the sell flow, covering token-specific quote handling, confirmation payload construction, and send transaction thunk execution that the changed files implement.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Validates the ETH sell flow with custom gas fees and device confirmation, directly exercising confirmSellTradeThunk and sendSellTransactionThunk paths for native coin sales.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Covers sell form validation, percentage/max amount calculations, fiat currency handling, and fee logic for BTC and SOL, which depend on loadSellInfoThunk and selectSellQuoteThunk behavior.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Exercises the SOL sell flow including offer comparison, trade confirmation, sending crypto to the provider, and watch-status polling — all backed by the changed sell thunks.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Navigates to the Sell form from multiple entry points; mounting the sell form likely triggers loadSellInfoThunk, so changes to sell initialization or state could affect whether the form renders the expected coin context.

</details>

_Updated: 2026-08-08T19:02:50.558Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-sell-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-trading-sell-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-trading-sell-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-trading-sell-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-trading-sell-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-08T19:05:40.981Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-08T19:05:14.306Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->