### PR TITLE
refactor(suite): type Bluetooth storage thunks

### DIFF
--- a/packages/suite/src/actions/suite/storageActions.ts
+++ b/packages/suite/src/actions/suite/storageActions.ts
@@ -1,13 +1,13 @@
 import { selectCoinjoinAccountByKey } from '@suite/coinjoin';
 import { selectSuiteSettings } from '@suite/settings';
-import { selectKnownDevices } from '@suite-common/bluetooth';
+import { type WithBluetoothState, selectKnownDevices } from '@suite-common/bluetooth';
 import { deviceActions, selectDevices, selectPersistentDeviceData } from '@suite-common/device';
 import { type MetadataState } from '@suite-common/metadata-types';
 import { type EncryptedHex } from '@suite-common/platform-encryption';
 import { createThunk } from '@suite-common/redux-utils/';
 import { type SuiteSyncOwnerSerialized } from '@suite-common/suite-sync-storage';
 import { isDeviceAcquired } from '@suite-common/suite-utils';
-import { selectThp } from '@suite-common/thp';
+import { type ThpRootState, selectThp } from '@suite-common/thp';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { type DefinitionType, type TokenManagementAction } from '@suite-common/token-definitions';
 import type { TradingTransaction } from '@suite-common/trading';
@@ -142,7 +142,9 @@ export const saveCoinjoinDebugSettings = () => (_dispatch: Dispatch, getState: G
     db.addItem('coinjoinDebugSettings', debug || {}, 'debug', true);
 };
 
-export const saveThpCredentials = createThunk(
+type SaveThpCredentialsThunkState = ThpRootState;
+
+export const saveThpCredentials = createThunk<void, void, { state: SaveThpCredentialsThunkState }>(
     `${STORAGE.MODULE_PREFIX}/saveThpCredentials`,
     async (_, { getState }) => {
         if (!db.isAccessible()) return;
@@ -151,7 +153,9 @@ export const saveThpCredentials = createThunk(
     },
 );
 
-export const saveKnownDevices = createThunk(
+type SaveKnownDevicesThunkState = WithBluetoothState<DesktopBluetoothDevice>;
+
+export const saveKnownDevices = createThunk<void, void, { state: SaveKnownDevicesThunkState }>(
     `${STORAGE.MODULE_PREFIX}/saveKnownDevices`,
     async (_, { getState }) => {
         if (!db.isAccessible()) return;


### PR DESCRIPTION
## Description

The desktop Bluetooth thunks themselves already have selective contracts from #30767, but their two storage persistence thunks still inherited the global thunk API. This gives THP credential persistence the exact ThpRootState contract and known Bluetooth device persistence the exact WithBluetoothState<DesktopBluetoothDevice> contract. The existing storage middleware remains a valid parent dispatcher, and runtime behavior is unchanged.\n\n- Remaining Bluetooth/THP storage thunks using the global default: **2 -> 0**\n- Explicit selective-state contracts added: **2**\n- Validation: **Suite type-check passed**; focused formatting and ESLint passed.\n\nPart of #30770.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** storageActions.ts is a global persistence layer used across the suite, so the 135 static mappings are mostly incidental. The highest-risk areas for a change here are database migrations, initial-run/onboarding state persistence, discovery resume after reload, remembered-device state, metadata lifecycle, and device removal. The recommended tests target those specific storage-dependent flows. Broader functional tests are unlikely to catch storage-layer regressions and are omitted to keep the run minimal.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/actions/suite/storageActions.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/metadata/legacy/metadata-lifecycle.test.ts` — This test explicitly verifies metadata/labeling choice persistence across wallet sessions, device resets, ejection, and reload, all of which are read from and written to suite storage via storageActions.
- `suite/e2e/tests/metadata/legacy/remembered-device.test.ts` — It tests remembered-device state: labels survive disconnecting the provider and disabling metadata, and edited labels persist on a remembered device after the emulator is powered off. These flows depend on the device/metadata storage layer.
- `suite/e2e/tests/settings/forget-device.test.ts` — The forget-device flow removes persisted device state, including Bluetooth pairing history, and confirms the UI reflects removal. storageActions is directly involved in clearing that persisted state.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test directly exercises IndexedDB migration between Suite versions and asserts that the language setting is preserved, making it a direct check of storageActions migration/load behavior.
- `suite/e2e/tests/suite/db-migration.test.ts` — It validates that IndexedDB settings migrate correctly from an old schema (suiteSettings.suite.settings.autoEject) to the new one (walletSettings.wallet.isAutoEjectEnabled), which is a core storageActions responsibility.
- `suite/e2e/tests/suite/initial-run.test.ts` — The test asserts that onboarding progress and analytics-consent state persist across page reloads and that completed onboarding is skipped after reload, relying on the initialRun and settings storage handled by storageActions.
- `suite/e2e/tests/wallet/discovery.test.ts` — It verifies that multi-coin discovery recovers correctly after a page reload mid-discovery, which requires persisted discovery state to be loaded and resumed by the storage layer.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — This flow creates multiple passphrase wallets and enables Suite Sync for them; wallet/sync key state may be persisted locally, so a storage regression could affect how wallets and sync state are retained.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Session takeover and reload/new-tab behavior depend on persisted device/session state being correctly loaded after navigation, which is in storageActions' domain.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — The test seeds a remembered wallet from an IndexedDB dump and opens the swap form without a connected device; if storage-based wallet/device loading changes, this dump-based remembered wallet may not restore correctly.

</details>

_Updated: 2026-08-07T21:06:02.928Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-bluetooth-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-bluetooth-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-desktop-bluetooth-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-desktop-bluetooth-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T21:08:08.036Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T21:07:46.544Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->