### PR TITLE
refactor(suite): type shell thunks

### DIFF
--- a/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
+++ b/packages/suite/src/actions/labels/exportMetadataToBip329File.ts
@@ -16,7 +16,7 @@ export const exportMetadataToBip329File = createThunk<
         account: Account;
         defaultAccountLabel: string;
     },
-    { extra: ExportMetadataToBip329FileThunkDeps }
+    { state: void; extra: ExportMetadataToBip329FileThunkDeps }
 >(
     METADATA.EXPORT_METADATA_TO_BIP329_FILE,
     ({ account, defaultAccountLabel }, { dispatch, extra: { services } }) => {

--- a/packages/suite/src/actions/suite/autoEjectThunks.ts
+++ b/packages/suite/src/actions/suite/autoEjectThunks.ts
@@ -1,19 +1,23 @@
-import { goto } from '@suite/router';
-import { type DeviceRootState, selectDevices } from '@suite-common/device';
+import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
+import { selectDevices } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
-import { setDeviceAutoEjectThunk } from '@suite-common/wallet-core';
+import {
+    type SetDeviceAutoEjectThunkState,
+    setDeviceAutoEjectThunk,
+} from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
 
 const AUTO_EJECT_PREFIX = '@suite/autoEject';
 
 type SetAutoEjectEnabledThunkProps = { shouldEnable: boolean };
-type SetAutoEjectEnabledThunkState = DeviceRootState;
+type SetAutoEjectEnabledThunkState = GotoThunkState & SetDeviceAutoEjectThunkState;
+type SetAutoEjectEnabledThunkDeps = GotoThunkDeps;
 
 export const setAutoEjectEnabledThunk = createThunk<
     void,
     SetAutoEjectEnabledThunkProps,
-    { state: SetAutoEjectEnabledThunkState }
+    { state: SetAutoEjectEnabledThunkState; extra: SetAutoEjectEnabledThunkDeps }
 >(`${AUTO_EJECT_PREFIX}/enableAutoEjectThunk`, async ({ shouldEnable }, { dispatch, getState }) => {
     // Disconnected devices are purged from local redux (awaited because the subsequent code may rely on updated deviceReducer state)
     await dispatch(setDeviceAutoEjectThunk({ shouldEnable }));

--- a/packages/suite/src/actions/suite/bioAuthThunks.ts
+++ b/packages/suite/src/actions/suite/bioAuthThunks.ts
@@ -11,7 +11,7 @@ const BIO_AUTH_PREFIX = '@suite/bioAuth';
 const KNOWN_ERROR_MESSAGES = ['Authentication canceled.', 'Authentication cancelled.'];
 
 const handleError = (error: string, dispatch: Dispatch, message: string) => {
-    if (KNOWN_ERROR_MESSAGES.some(message => error.includes(message))) {
+    if (KNOWN_ERROR_MESSAGES.some(knownErrorMessage => error.includes(knownErrorMessage))) {
         // NOTE: known error message
         return;
     }
@@ -23,33 +23,36 @@ const handleError = (error: string, dispatch: Dispatch, message: string) => {
     );
 };
 
-export const init = createThunk(`${BIO_AUTH_PREFIX}/init`, (_args, { dispatch }) => {
-    // only fetches settings from electron-store, not dependent on BioAuthModule, see bio-auth/get-bio-auth-settings
-    desktopApi.getBioAuthSettings().then(settings => {
-        dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
-    });
-    desktopApi.on('bio-auth/settings-changed', settings => {
-        dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
-    });
+export const init = createThunk<void, void, void>(
+    `${BIO_AUTH_PREFIX}/init`,
+    (_args, { dispatch }) => {
+        // only fetches settings from electron-store, not dependent on BioAuthModule, see bio-auth/get-bio-auth-settings
+        desktopApi.getBioAuthSettings().then(settings => {
+            dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
+        });
+        desktopApi.on('bio-auth/settings-changed', settings => {
+            dispatch(bioAuthActions.setBioAuthEnabled(settings.enabled));
+        });
 
-    const onBioAuthAvailable = (available: boolean) => {
-        dispatch(bioAuthActions.setIsBioAuthAvailable(available));
-        // ensure this api is called regardlesss if the bio auth is available or not
-        desktopApi.getBioAuthStatus().then(validated => {
+        const onBioAuthAvailable = (available: boolean) => {
+            dispatch(bioAuthActions.setIsBioAuthAvailable(available));
+            // ensure this api is called regardlesss if the bio auth is available or not
+            desktopApi.getBioAuthStatus().then(validated => {
+                dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
+            });
+        };
+
+        // We don't know what will be faster, BioAuthModule may initialize before or after this thunk.
+        // Fetch api availability if BioAuthModule is initialized (though it may never become available, depending on the system)
+        desktopApi.isBioAuthAvailable().then(onBioAuthAvailable);
+
+        // If BioAuthModule initializes later, it will emit an event, which will be caught here
+        desktopApi.on('bio-auth/bio-auth-availability-changed', onBioAuthAvailable);
+        desktopApi.on('bio-auth/validation-status-changed', validated => {
             dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
         });
-    };
-
-    // We don't know what will be faster, BioAuthModule may initialize before or after this thunk.
-    // Fetch api availability if BioAuthModule is initialized (though it may never become available, depending on the system)
-    desktopApi.isBioAuthAvailable().then(onBioAuthAvailable);
-
-    // If BioAuthModule initializes later, it will emit an event, which will be caught here
-    desktopApi.on('bio-auth/bio-auth-availability-changed', onBioAuthAvailable);
-    desktopApi.on('bio-auth/validation-status-changed', validated => {
-        dispatch(bioAuthActions.setIsBioAuthValidationRequired(!validated));
-    });
-});
+    },
+);
 
 interface RequestBioAuthChangeThunkParams {
     payload: boolean;
@@ -57,12 +60,9 @@ interface RequestBioAuthChangeThunkParams {
     messageError: string;
 }
 
-export const requestBioAuthChangeThunk = createThunk(
+export const requestBioAuthChangeThunk = createThunk<void, RequestBioAuthChangeThunkParams, void>(
     `${BIO_AUTH_PREFIX}/requestBioAuthChangeThunk`,
-    async (
-        { payload, messageSuccess, messageError }: RequestBioAuthChangeThunkParams,
-        { dispatch },
-    ) => {
+    async ({ payload, messageSuccess, messageError }, { dispatch }) => {
         if (!(await desktopApi.isBioAuthAvailable())) {
             dispatch(
                 notificationsActions.addToast({
@@ -90,29 +90,30 @@ interface RequestBioAuthValidationThunkParams {
     messageError: string;
 }
 
-export const requestBioAuthValidationThunk = createThunk(
-    `${BIO_AUTH_PREFIX}/validateAuth`,
-    async ({ messageSuccess, messageError }: RequestBioAuthValidationThunkParams, { dispatch }) => {
-        if (!(await desktopApi.isBioAuthAvailable())) {
-            dispatch(
-                notificationsActions.addToast({
-                    type: 'error',
-                    error: 'Biometric authentication not available',
-                }),
-            );
+export const requestBioAuthValidationThunk = createThunk<
+    void,
+    RequestBioAuthValidationThunkParams,
+    void
+>(`${BIO_AUTH_PREFIX}/validateAuth`, async ({ messageSuccess, messageError }, { dispatch }) => {
+    if (!(await desktopApi.isBioAuthAvailable())) {
+        dispatch(
+            notificationsActions.addToast({
+                type: 'error',
+                error: 'Biometric authentication not available',
+            }),
+        );
 
-            return;
-        }
+        return;
+    }
 
-        dispatch(bioAuthActions.setCancelled(false));
+    dispatch(bioAuthActions.setCancelled(false));
 
-        const result = await desktopApi.validateBioAuth({
-            message: messageSuccess,
-        });
-        if (!result.success) {
-            dispatch(bioAuthActions.setCancelled(true));
+    const result = await desktopApi.validateBioAuth({
+        message: messageSuccess,
+    });
+    if (!result.success) {
+        dispatch(bioAuthActions.setCancelled(true));
 
-            return handleError(result.message, dispatch, messageError);
-        }
-    },
-);
+        return handleError(result.message, dispatch, messageError);
+    }
+});

--- a/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
+++ b/packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts
@@ -1,7 +1,11 @@
 import { selectDevices, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { type TrezorDevice } from '@suite-common/suite-types';
-import { forgetDeviceThunk } from '@suite-common/wallet-core';
+import {
+    type ForgetDeviceThunkDeps,
+    type ForgetDeviceThunkState,
+    forgetDeviceThunk,
+} from '@suite-common/wallet-core';
 
 import * as storageActions from 'src/actions/suite/storageActions';
 
@@ -14,15 +18,17 @@ export type ForgetDeviceThunkParams = {
     deviceId?: TrezorDevice['id'];
 };
 
-export const suiteForgetDeviceThunk = createThunk(
+type SuiteForgetDeviceThunkState = ForgetDeviceThunkState;
+type SuiteForgetDeviceThunkDeps = ForgetDeviceThunkDeps;
+
+export const suiteForgetDeviceThunk = createThunk<
+    void,
+    ForgetDeviceThunkParams | undefined,
+    { state: SuiteForgetDeviceThunkState; extra: SuiteForgetDeviceThunkDeps }
+>(
     SUITE_FORGET_DEVICE,
     async (
-        {
-            skipToggleModalConnection,
-            isOsUnpairingFinished,
-            skipDisconnect,
-            deviceId,
-        }: ForgetDeviceThunkParams | undefined = {},
+        { skipToggleModalConnection, isOsUnpairingFinished, skipDisconnect, deviceId } = {},
         { dispatch, getState },
     ) => {
         const devices = selectDevices(getState());

--- a/packages/suite/src/actions/suite/suiteThunks.ts
+++ b/packages/suite/src/actions/suite/suiteThunks.ts
@@ -1,29 +1,31 @@
-import { goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import { type ReloadAppDep } from '@suite-common/suite-types';
 import { desktopApi } from '@trezor/suite-desktop-api';
 
 import { removeDatabase } from './storageActions';
 
-type ResetSuiteAppThunkDeps = {
+type ResetSuiteAppThunkState = GotoThunkState;
+type ResetSuiteAppThunkDeps = GotoThunkDeps & {
     services: ReloadAppDep;
 };
 
-export const resetSuiteAppThunk = createThunk<void, void, { extra: ResetSuiteAppThunkDeps }>(
-    '@suite/reset-app',
-    async (_, { dispatch, extra }) => {
-        localStorage.clear();
-        dispatch(removeDatabase());
+export const resetSuiteAppThunk = createThunk<
+    void,
+    void,
+    { state: ResetSuiteAppThunkState; extra: ResetSuiteAppThunkDeps }
+>('@suite/reset-app', async (_, { dispatch, extra }) => {
+    localStorage.clear();
+    dispatch(removeDatabase());
 
-        if (desktopApi.available) {
-            // Reset the desktop-specific store.
-            desktopApi.clearStore();
-            desktopApi.appAutoStart(false);
-        } else {
-            // redirect to / and reload the web
-            await dispatch(goto({ routeName: 'suite-index' }));
-        }
+    if (desktopApi.available) {
+        // Reset the desktop-specific store.
+        desktopApi.clearStore();
+        desktopApi.appAutoStart(false);
+    } else {
+        // redirect to / and reload the web
+        await dispatch(goto({ routeName: 'suite-index' }));
+    }
 
-        extra.services.reloadApp();
-    },
-);
+    extra.services.reloadApp();
+});

--- a/packages/suite/src/actions/wallet/addWalletThunk.ts
+++ b/packages/suite/src/actions/wallet/addWalletThunk.ts
@@ -1,15 +1,14 @@
-import { type SuiteRouterHistoryDep, findRoute, goto } from '@suite/router';
+import { type GotoThunkDeps, type GotoThunkState, findRoute, goto } from '@suite/router';
 import { DEVICE_MODULE_PREFIX } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 
-type RedirectAfterWalletSelectedThunkDeps = {
-    services: SuiteRouterHistoryDep;
-};
+type RedirectAfterWalletSelectedThunkState = GotoThunkState;
+type RedirectAfterWalletSelectedThunkDeps = GotoThunkDeps;
 
 export const redirectAfterWalletSelectedThunk = createThunk<
     void,
     { forceDeviceDashboard?: boolean } | undefined,
-    { extra: RedirectAfterWalletSelectedThunkDeps }
+    { state: RedirectAfterWalletSelectedThunkState; extra: RedirectAfterWalletSelectedThunkDeps }
 >(
     `${DEVICE_MODULE_PREFIX}/redirectAfterWalletSelectedThunk`,
     async (options, { dispatch, extra }) => {
@@ -40,9 +39,13 @@ export const redirectAfterWalletSelectedThunk = createThunk<
     },
 );
 
-export const openSwitchDeviceDialog = createThunk<void, void, void>(
-    `${DEVICE_MODULE_PREFIX}/openSwitchDeviceDialog`,
-    (_, { dispatch }) => {
-        dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
-    },
-);
+type OpenSwitchDeviceDialogThunkState = GotoThunkState;
+type OpenSwitchDeviceDialogThunkDeps = GotoThunkDeps;
+
+export const openSwitchDeviceDialog = createThunk<
+    void,
+    void,
+    { state: OpenSwitchDeviceDialogThunkState; extra: OpenSwitchDeviceDialogThunkDeps }
+>(`${DEVICE_MODULE_PREFIX}/openSwitchDeviceDialog`, (_, { dispatch }) => {
+    dispatch(goto({ routeName: 'suite-switch-device', params: { cancelable: true } }));
+});

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -377,7 +377,7 @@ export const deviceConnectThunks = createThunk<
 type SetDeviceAutoEjectThunkParams = {
     shouldEnable: boolean;
 };
-type SetDeviceAutoEjectThunkState = DeviceRootState & WalletSettingsRootState;
+export type SetDeviceAutoEjectThunkState = DeviceRootState & WalletSettingsRootState;
 
 export const setDeviceAutoEjectThunk = createThunk<
     void,
@@ -505,8 +505,8 @@ export type ForgetDeviceThunkParams = {
     skipDisconnect?: boolean;
     deviceId?: TrezorDevice['id'];
 };
-type ForgetDeviceThunkState = ForgetDevicePersistentDataThunkState;
-type ForgetDeviceThunkDeps = {
+export type ForgetDeviceThunkState = ForgetDevicePersistentDataThunkState;
+export type ForgetDeviceThunkDeps = {
     thunks: ForgetBluetoothDeviceDep;
 };
 

--- a/suite/flags/src/flagsThunks.ts
+++ b/suite/flags/src/flagsThunks.ts
@@ -9,9 +9,9 @@ type InitialRunCompletedParams = {
     isFreshDeviceSetup: boolean;
 };
 
-export const initialRunCompleted = createThunk(
+export const initialRunCompleted = createThunk<void, InitialRunCompletedParams, void>(
     `${FLAGS_MODULE_PREFIX}/initialRunCompleted`,
-    ({ isFreshDeviceSetup }: InitialRunCompletedParams, { dispatch }) => {
+    ({ isFreshDeviceSetup }, { dispatch }) => {
         dispatch(setFlag({ key: 'initialRun', value: false }));
 
         // Only offer the feedback banner to users arriving from a fresh device setup. Pairing an

--- a/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
+++ b/suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts
@@ -27,7 +27,7 @@ type ProcessLegacyMetadataIntoSuiteSyncThunkDeps = { services: SuiteSyncDep };
 export const processLegacyMetadataIntoSuiteSyncThunk = createThunk<
     Result<void, EnsureWalletSuiteSyncOnErrors | SuiteSyncUpdateError>,
     ProcessMetadataMessageThunkParams,
-    { extra: ProcessLegacyMetadataIntoSuiteSyncThunkDeps }
+    { state: void; extra: ProcessLegacyMetadataIntoSuiteSyncThunkDeps }
 >(
     '@suite/labeling/processMetadataMessageThunk',
     async ({ payload, deviceStaticSessionId, value }, { dispatch, extra: { services } }) => {

--- a/suite/metadata/src/metadataThunks.ts
+++ b/suite/metadata/src/metadataThunks.ts
@@ -4,11 +4,17 @@ import { type StaticSessionId } from '@trezor/connect';
 
 import * as metadataLabelingActions from './metadataLabelingActions';
 import * as METADATA_LABELING from './metadataLabelingConstants';
-import { selectIsMetadataEnabled } from './metadataReducer';
+import { type MetadataRootState, selectIsMetadataEnabled } from './metadataReducer';
 
 export * from './metadataDataThunks';
 
-export const initNewDeviceStateMetadataThunk = createThunk<void, StaticSessionId>(
+type InitNewDeviceStateMetadataThunkState = MetadataRootState;
+
+export const initNewDeviceStateMetadataThunk = createThunk<
+    void,
+    StaticSessionId,
+    { state: InitNewDeviceStateMetadataThunkState }
+>(
     '@suite/metadata/initNewDeviceStateMetadataThunk',
     async (staticSessionId, { getState, dispatch }) => {
         if (!selectIsMetadataEnabled(getState())) {

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -78,8 +78,8 @@ type GotoPayload = {
     anchor?: AnchorType;
 };
 
-type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
-type GotoThunkDeps = { services: SuiteRouterHistoryDep };
+export type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
+export type GotoThunkDeps = { services: SuiteRouterHistoryDep };
 
 export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extra: GotoThunkDeps }>(
     '@router/goto',
@@ -137,12 +137,13 @@ export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extr
  * Application modal does not push route into router history, it changes it only in reducer (see goto action).
  * Reverse operation (again without touching history) needs to be done in back action.
  */
-type CloseModalAppThunkDeps = { services: SuiteRouterHistoryDep };
+type CloseModalAppThunkState = GotoThunkState;
+type CloseModalAppThunkDeps = GotoThunkDeps;
 
 export const closeModalApp = createThunk<
     void,
     boolean | undefined,
-    { extra: CloseModalAppThunkDeps }
+    { state: CloseModalAppThunkState; extra: CloseModalAppThunkDeps }
 >('@router/closeModalApp', (preserveParams = true, { dispatch, extra }) => {
     dispatch(lockRouter(false));
 
@@ -168,15 +169,16 @@ export const closeModalApp = createThunk<
  * Called from `@suite-middlewares/suiteMiddleware`
  * Redirects to requested modal app or welcome screen if `suite.flags.initialRun` is set to true
  */
-type InitialRedirectionThunkDeps = { services: SuiteRouterHistoryDep };
 type InitialRedirectionThunkParams = {
     isInitialRun?: boolean;
 };
+type InitialRedirectionThunkState = GotoThunkState;
+type InitialRedirectionThunkDeps = GotoThunkDeps;
 
 export const initialRedirection = createThunk<
     void,
     InitialRedirectionThunkParams,
-    { extra: InitialRedirectionThunkDeps }
+    { state: InitialRedirectionThunkState; extra: InitialRedirectionThunkDeps }
 >('@suite/initial-redirection', ({ isInitialRun = true }, { dispatch, extra }) => {
     const location = extra.services.suiteRouterHistory.getLocation();
     const route = findRoute(location.pathname);


### PR DESCRIPTION
## Description

The desktop shell batch still had RTK thunks inheriting global state through an omitted third generic or an extra-only config. This gives the Suite shell, router, device-forget, auto-eject, wallet-selection, metadata/labeling, flags, and biometric flows explicit state/dependency contracts. Parent navigation and device thunks compose the contracts of the child thunks they dispatch; the shared child contracts are exported from their owning domains. Runtime behavior is unchanged.\n\n- Global-default declarations in this batch: **12 -> 0**\n- Incomplete explicit parent contracts corrected: **2**\n- Focused router/flags tests: **19 passed**\n- Validation: **Suite integration type-check, focused ESLint, and Prettier passed**\n\nPart of #30770.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set is dominated by suite-level thunk refactorings across device, wallet, metadata, and routing concerns. The highest-risk, narrowly-scoped files (autoEjectThunks, suiteForgetDeviceThunk, processLegacyMetadataIntoSuiteSyncThunk) have direct e2e coverage and should be run unconditionally. The broadly-imported thunks (suiteThunks, addWalletThunk, deviceThunks, metadataThunks, routerThunks) are represented by targeted tests covering their core user flows. flagsThunks has no identifiable e2e coverage.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/actions/labels/exportMetadataToBip329File.ts`
- `packages/suite/src/actions/suite/autoEjectThunks.ts`
- `packages/suite/src/actions/suite/bioAuthThunks.ts`
- `packages/suite/src/actions/suite/suiteForgetDeviceThunk.ts`
- `packages/suite/src/actions/suite/suiteThunks.ts`
- `packages/suite/src/actions/wallet/addWalletThunk.ts`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite/flags/src/flagsThunks.ts`
- `suite/labeling/src/processLegacyMetadataIntoSuiteSyncThunk.ts`
- `suite/metadata/src/metadataThunks.ts`
- `suite/router/src/routerThunks.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — Explicitly verifies the auto-eject wallet setting migrates across IndexedDB schema versions and reflects correctly in the UI, directly exercising autoEjectThunks and suiteThunks.
- `suite/e2e/tests/metadata/legacy-label-to-suiteSync.test.ts` — Tests migrating legacy Dropbox-based account labels to Suite Sync, which is the exact workflow implemented by processLegacyMetadataIntoSuiteSyncThunk.
- `suite/e2e/tests/metadata/legacy-to-suiteSync-migration.test.ts` — Covers migrating local file-based legacy labels (account, output, address) into Suite Sync and confirms the migration toast and Evolu relay sync, directly exercising processLegacyMetadataIntoSuiteSyncThunk.
- `suite/e2e/tests/settings/forget-device.test.ts` — Directly exercises suiteForgetDeviceThunk through the device forget/unpair flow for TS7/TS5 devices, including discovery state, wallet cleanup, and device session handling via deviceThunks.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Validates SuiteReady and DeviceConnect events after settings and network changes, which depends on suiteThunks for suite initialization and addWalletThunk/deviceThunks for wallet/device state.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — Creates, updates, and removes Suite Sync labels for account/wallet/address/output entities and verifies relay synchronization, exercising metadataThunks end-to-end.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — Adds hidden passphrase wallets, switches between them, and verifies addresses, which is a core addWalletThunk and device wallet-management flow.
- `suite/e2e/tests/suite/initial-run.test.ts` — Tests onboarding initial-run persistence across reloads and THP pairing, which relies on suiteThunks for suite state initialization.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Exercises Bridge session stealing/reclaiming and device switching flows, which depend on deviceThunks for session enumeration, acquisition, and device status updates.
- `suite/e2e/tests/trading/navigation.test.ts` — Validates navigation between buy/sell/swap forms and account/token pages, directly exercising routerThunks routing logic.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/flags/src/flagsThunks.ts`

_Updated: 2026-08-07T21:18:21.453Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-suite-shell-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-suite-shell-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-suite-shell-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-suite-shell-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-suite-shell-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T21:19:33.276Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T21:19:18.229Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->