### PR TITLE
refactor(suite): type trading wrapper thunks

### DIFF
--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -1,9 +1,10 @@
 import { type BuyTrade } from 'invity-api';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type TradingFormAccountRootState,
     buyThunks,
     cryptoIdToNetworkSymbolAndContractAddress,
     selectTradingBuyInfo,
@@ -18,58 +19,63 @@ import { createQuoteLink } from 'src/utils/wallet/trading/buyUtils';
 
 import { submitRequestForm } from '../tradingCommonActions';
 
-export const selectBuyQuoteThunk = createThunk(
-    'trading/buy/selectQuoteWithAnalytics',
-    async ({ quote }: { quote: BuyTrade }, { dispatch, getState, extra }) => {
-        const buyInfo = selectTradingBuyInfo(getState());
-        const quotesRequest = selectTradingBuyQuotesRequest(getState());
-        const receiveAddress = selectTradingBuyReceiveAddress(getState());
-        const account = selectTradingFormAccount(getState(), 'buy');
-        const receiveAccount = selectTradingBuyReceiveAccount(getState());
+type SelectBuyQuoteThunkParams = { quote: BuyTrade };
+type SelectBuyQuoteThunkState = GotoThunkState & TradingFormAccountRootState;
+type SelectBuyQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
 
-        const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
+export const selectBuyQuoteThunk = createThunk<
+    void,
+    SelectBuyQuoteThunkParams,
+    { state: SelectBuyQuoteThunkState; extra: SelectBuyQuoteThunkDeps }
+>('trading/buy/selectQuoteWithAnalytics', async ({ quote }, { dispatch, getState, extra }) => {
+    const buyInfo = selectTradingBuyInfo(getState());
+    const quotesRequest = selectTradingBuyQuotesRequest(getState());
+    const receiveAddress = selectTradingBuyReceiveAddress(getState());
+    const account = selectTradingFormAccount(getState(), 'buy');
+    const receiveAccount = selectTradingBuyReceiveAccount(getState());
 
-        if (!quotesRequest || !provider || !receiveAddress || !account) {
-            return;
-        }
+    const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
 
-        const returnUrl = await createQuoteLink(
-            { ...quotesRequest, paymentMethod: quote.paymentMethod },
-            receiveAccount ?? account,
-        );
+    if (!quotesRequest || !provider || !receiveAddress || !account) {
+        return;
+    }
 
-        const { symbol: cryptoNetworkSymbol, contractAddress: cryptoContractAddress } =
-            cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.receiveCurrency);
-        const cryptoLabel = selectTradingCoinInfoByCryptoId(
-            getState(),
-            quotesRequest.receiveCurrency,
-        )?.name;
+    const returnUrl = await createQuoteLink(
+        { ...quotesRequest, paymentMethod: quote.paymentMethod },
+        receiveAccount ?? account,
+    );
 
-        asTypedDesktopAnalytics(extra.services.analytics).report({
-            type: events.tradeBuyEvent.name,
-            payload: {
-                action: 'continue',
-                step: 'buy-form',
-                cryptoLabel,
-                cryptoNetworkSymbol,
-                cryptoContractAddress,
-                exchangeName: quote.exchange,
-                paymentMethod: quote.paymentMethod,
-                countryOfResidence: quotesRequest.country,
+    const { symbol: cryptoNetworkSymbol, contractAddress: cryptoContractAddress } =
+        cryptoIdToNetworkSymbolAndContractAddress(quotesRequest.receiveCurrency);
+    const cryptoLabel = selectTradingCoinInfoByCryptoId(
+        getState(),
+        quotesRequest.receiveCurrency,
+    )?.name;
+
+    asTypedDesktopAnalytics(extra.services.analytics).report({
+        type: events.tradeBuyEvent.name,
+        payload: {
+            action: 'continue',
+            step: 'buy-form',
+            cryptoLabel,
+            cryptoNetworkSymbol,
+            cryptoContractAddress,
+            exchangeName: quote.exchange,
+            paymentMethod: quote.paymentMethod,
+            countryOfResidence: quotesRequest.country,
+        },
+    });
+
+    await dispatch(
+        buyThunks.selectQuoteThunk({
+            quote,
+            returnUrl,
+            loginRequest: form => {
+                dispatch(submitRequestForm(form));
             },
-        });
-
-        await dispatch(
-            buyThunks.selectQuoteThunk({
-                quote,
-                returnUrl,
-                loginRequest: form => {
-                    dispatch(submitRequestForm(form));
-                },
-                nextStep: () => {
-                    dispatch(goto({ routeName: 'wallet-trading-buy-confirm' }));
-                },
-            }),
-        );
-    },
-);
+            nextStep: () => {
+                dispatch(goto({ routeName: 'wallet-trading-buy-confirm' }));
+            },
+        }),
+    );
+});

--- a/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts
@@ -1,9 +1,10 @@
 import { type ExchangeTrade } from 'invity-api';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type TradingRootState,
     cryptoIdToNetworkSymbolAndContractAddress,
     exchangeThunks,
     selectTradingCoinSymbolByCryptoId,
@@ -17,13 +18,16 @@ type SelectExchangeQuoteThunkProps = {
     rateType?: string;
     fractionButton?: number;
 };
+type SelectExchangeQuoteThunkState = GotoThunkState & TradingRootState;
+type SelectExchangeQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
 
-export const selectExchangeQuoteThunk = createThunk(
+export const selectExchangeQuoteThunk = createThunk<
+    void,
+    SelectExchangeQuoteThunkProps,
+    { state: SelectExchangeQuoteThunkState; extra: SelectExchangeQuoteThunkDeps }
+>(
     'trading/exchange/selectQuoteWithAnalytics',
-    async (
-        { quote, exchangeType, rateType, fractionButton }: SelectExchangeQuoteThunkProps,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ quote, exchangeType, rateType, fractionButton }, { dispatch, getState, extra }) => {
         const exchangeInfo = selectTradingExchangeInfo(getState());
         const quotesRequest = selectTradingExchangeQuotesRequest(getState());
 

--- a/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts
@@ -2,6 +2,7 @@ import { type SellFiatTrade } from 'invity-api';
 
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type TradingFormAccountRootState,
     selectTradingComposedTransactionInfo,
     selectTradingSellInfo,
     selectTradingSellQuotesRequest,
@@ -13,36 +14,40 @@ import { buildSellReturnUrl } from 'src/utils/wallet/trading/buildSellReturnUrl'
 
 import { submitRequestForm } from '../tradingCommonActions';
 
-export const requestSellTradeThunk = createThunk(
-    'trading/sell/requestTrade',
-    async ({ quote }: { quote: SellFiatTrade }, { dispatch, getState }) => {
-        const account = selectTradingSendAccount(getState(), 'sell');
+type RequestSellTradeThunkParams = { quote: SellFiatTrade };
+export type RequestSellTradeThunkState = TradingFormAccountRootState;
 
-        if (!account) {
-            return;
-        }
+export const requestSellTradeThunk = createThunk<
+    void,
+    RequestSellTradeThunkParams,
+    { state: RequestSellTradeThunkState }
+>('trading/sell/requestTrade', async ({ quote }, { dispatch, getState }) => {
+    const account = selectTradingSendAccount(getState(), 'sell');
 
-        const returnUrl = await buildSellReturnUrl({
-            quote,
+    if (!account) {
+        return;
+    }
+
+    const returnUrl = await buildSellReturnUrl({
+        quote,
+        account,
+        sellInfo: selectTradingSellInfo(getState()),
+        quotesRequest: selectTradingSellQuotesRequest(getState()),
+        composedInfo: selectTradingComposedTransactionInfo(getState()),
+    });
+
+    if (!returnUrl) {
+        return;
+    }
+
+    await dispatch(
+        sellThunks.handleTradeThunk({
             account,
-            sellInfo: selectTradingSellInfo(getState()),
-            quotesRequest: selectTradingSellQuotesRequest(getState()),
-            composedInfo: selectTradingComposedTransactionInfo(getState()),
-        });
-
-        if (!returnUrl) {
-            return;
-        }
-
-        await dispatch(
-            sellThunks.handleTradeThunk({
-                account,
-                trade: quote,
-                returnUrl,
-                processResponseData: response => {
-                    dispatch(submitRequestForm(response.tradeForm?.form));
-                },
-            }),
-        );
-    },
-);
+            trade: quote,
+            returnUrl,
+            processResponseData: response => {
+                dispatch(submitRequestForm(response.tradeForm?.form));
+            },
+        }),
+    );
+});

--- a/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts
@@ -1,7 +1,7 @@
 import { type SellFiatTrade } from 'invity-api';
 
-import { asTypedDesktopAnalytics, events } from '@suite/analytics';
-import { goto } from '@suite/router';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics, events } from '@suite/analytics';
+import { type GotoThunkDeps, type GotoThunkState, goto } from '@suite/router';
 import { createThunk } from '@suite-common/redux-utils';
 import {
     cryptoIdToNetworkSymbolAndContractAddress,
@@ -12,14 +12,19 @@ import {
     sellUtils,
 } from '@suite-common/trading';
 
-import { requestSellTradeThunk } from './requestSellTradeThunk';
+import { type RequestSellTradeThunkState, requestSellTradeThunk } from './requestSellTradeThunk';
 
-export const selectSellQuoteThunk = createThunk(
+type SelectSellQuoteThunkParams = { quote: SellFiatTrade; fractionButton?: number };
+type SelectSellQuoteThunkState = GotoThunkState & RequestSellTradeThunkState;
+type SelectSellQuoteThunkDeps = GotoThunkDeps & { services: DesktopAnalyticsDep };
+
+export const selectSellQuoteThunk = createThunk<
+    void,
+    SelectSellQuoteThunkParams,
+    { state: SelectSellQuoteThunkState; extra: SelectSellQuoteThunkDeps }
+>(
     'trading/sell/selectQuoteWithAnalytics',
-    async (
-        { quote, fractionButton }: { quote: SellFiatTrade; fractionButton?: number },
-        { dispatch, getState, extra },
-    ) => {
+    async ({ quote, fractionButton }, { dispatch, getState, extra }) => {
         const sellInfo = selectTradingSellInfo(getState());
         const quotesRequest = selectTradingSellQuotesRequest(getState());
 

--- a/suite/router/src/routerThunks.ts
+++ b/suite/router/src/routerThunks.ts
@@ -78,8 +78,8 @@ type GotoPayload = {
     anchor?: AnchorType;
 };
 
-type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
-type GotoThunkDeps = { services: SuiteRouterHistoryDep };
+export type GotoThunkState = LocksRootState & ModalRootState & RouterRootState;
+export type GotoThunkDeps = { services: SuiteRouterHistoryDep };
 
 export const goto = createThunk<void, GotoPayload, { state: GotoThunkState; extra: GotoThunkDeps }>(
     '@router/goto',


### PR DESCRIPTION
## Description

The desktop buy, exchange, and sell wrappers still inherited the global Redux state and dependency graph. This gives all four wrappers named selective contracts, composes the navigation state/service contract where callbacks dispatch `goto`, and exposes the router contract for reuse while preserving the existing trading and analytics behavior.\n\n- Global-default desktop trading wrappers: **4 -> 0**\n- Focused tests: **11 passed**\n- Validation: focused ESLint and Prettier plus the **@trezor/suite** integration type-check

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies core trading thunks for selecting buy/sell/swap quotes and requesting sell trades, plus router thunks. The highest regression risk lies in trading quote selection and sell trade request flows. The recommended strategy is to run targeted buy, sell, and swap trading tests that explicitly click offers and confirm trades, plus a navigation test to cover the router thunk change.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts`
- `packages/suite/src/actions/wallet/trading/exchange/selectExchangeQuoteThunk.ts`
- `packages/suite/src/actions/wallet/trading/sell/requestSellTradeThunk.ts`
- `packages/suite/src/actions/wallet/trading/sell/selectSellQuoteThunk.ts`
- `suite/router/src/routerThunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This test directly exercises the buy quote selection flow, including opening the offer comparison modal, selecting a non-best offer, and continuing from the best offer to the trade preview. These actions invoke selectBuyQuoteThunk, making this the most direct regression test for the changed buy thunk.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy flow initiated from the global trading button and verifies the best offer quote and trade confirmation. It covers a different entry point into selectBuyQuoteThunk and ensures the buy quote selection logic works for Ethereum.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Validates the full sell flow: filling the sell form, selecting the best offer, confirming the trade (requestSellTradeThunk), and initiating the send. This directly exercises both selectSellQuoteThunk and requestSellTradeThunk for Bitcoin.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Covers sell offer comparison (selecting a second/computed offer) and the complete sell trade request flow on Solana. It explicitly tests offer selection and trade request payloads, directly hitting the changed sell thunks.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Tests selecting and confirming the best swap offer when swapping BTC for an ERC-20 token, including device confirmation. This directly invokes selectExchangeQuoteThunk and covers cross-chain token swap paths.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Exercises the swap quote selection and confirmation flow for ETH to SOL, including verifying composed transaction info. It directly tests selectExchangeQuoteThunk on another cross-chain route.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — A live swap test that exercises the real swap quote selection and trade execution path end-to-end. Because it runs against live provider APIs it is less deterministic, but it provides valuable real-world coverage of selectExchangeQuoteThunk behavior.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap of an SPL token to a native coin, testing the quote selection and confirmation flow with real provider interaction. It complements the mocked swap tests by covering token-to-coin swap paths.
- `suite/e2e/tests/trading/navigation.test.ts` — Tests navigation into buy/sell/swap forms from dashboard cards, account trade sections, global header, and token pages. This is the most plausible coverage for the changed routerThunks.ts, which likely powers programmatic routing to these trading routes (inferred, not statically mapped).

</details>

_Updated: 2026-08-24T09:52:34.937Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-trading-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-trading-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-desktop-trading-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-desktop-trading-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T09:51:40.334Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T09:51:21.093Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->