### PR TITLE
refactor(suite): type stablecoin yield thunks

### DIFF
--- a/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts
@@ -1,9 +1,15 @@
 import { closeModal } from '@suite/modal';
 import { createThunk } from '@suite-common/redux-utils';
-import { STABLECOIN_YIELD_PREFIX, selectStablecoinYieldTxReview } from '@suite-common/wallet-core';
+import {
+    STABLECOIN_YIELD_PREFIX,
+    type StablecoinYieldRootState,
+    selectStablecoinYieldTxReview,
+} from '@suite-common/wallet-core';
 import TrezorConnect from '@trezor/connect';
 
-export const cancelSignYieldTx = createThunk(
+type CancelSignYieldTxState = StablecoinYieldRootState;
+
+export const cancelSignYieldTx = createThunk<void, void, { state: CancelSignYieldTxState }>(
     `${STABLECOIN_YIELD_PREFIX}/thunk/cancelSignYieldTx`,
     (_params, { dispatch, getState }) => {
         const { serializedTx } = selectStablecoinYieldTxReview(getState());

--- a/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts
@@ -1,7 +1,7 @@
-import { asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
 import { closeModal, openDeferredModal, preserveModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
-import { selectSelectedDevice } from '@suite-common/device';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import {
     type StablecoinYieldTxSimulationParams,
     buildClaimCalldata,
@@ -9,12 +9,17 @@ import {
     buildUnsignedClaimTransaction,
 } from '@suite-common/earn-stablecoin';
 import { type YieldAccountsRewards } from '@suite-common/earn-stablecoin-api';
+import { type MessageSystemRootState } from '@suite-common/message-system';
 import { selectIsMevProtectionFeatureEnabled } from '@suite-common/mev';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import { getEarnYieldClaimContractAddress, getNetwork } from '@suite-common/wallet-config';
 import {
+    type EthereumGetCurrentNonceThunkState,
     STABLECOIN_YIELD_PREFIX,
+    type SynchronizeSentTransactionThunkDeps,
+    type SynchronizeSentTransactionThunkState,
+    type WalletSettingsRootState,
     type YieldEstimatedFeeLevel,
     estimateYieldFeeLevel,
     selectAddressDisplayType,
@@ -61,13 +66,22 @@ type ClaimMerklRewardsParams = {
     flowKey: string;
     rewards: ClaimMerklReward[];
 };
+type ClaimMerklRewardsThunkState = DeviceRootState &
+    EthereumGetCurrentNonceThunkState &
+    MessageSystemRootState &
+    SynchronizeSentTransactionThunkState &
+    WalletSettingsRootState;
+type ClaimMerklRewardsThunkDeps = SynchronizeSentTransactionThunkDeps & {
+    services: DesktopAnalyticsDep;
+};
 
-export const claimMerklRewardsThunk = createThunk(
+export const claimMerklRewardsThunk = createThunk<
+    { txid: string } | null | undefined,
+    ClaimMerklRewardsParams,
+    { state: ClaimMerklRewardsThunkState; extra: ClaimMerklRewardsThunkDeps }
+>(
     `${STABLECOIN_YIELD_PREFIX}/thunk/claimMerklRewards`,
-    async (
-        { account, flowKey, rewards }: ClaimMerklRewardsParams,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ account, flowKey, rewards }, { dispatch, getState, extra }) => {
         const device = selectSelectedDevice(getState());
         const addressDisplayType = selectAddressDisplayType(getState());
 

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -1,7 +1,11 @@
+import { type ThunkDispatch, type UnknownAction } from '@reduxjs/toolkit';
+
 import { asEvmAddress } from '@suite-common/calldata';
 import { getYieldVault } from '@suite-common/earn-stablecoin-api';
 import { getNetwork } from '@suite-common/wallet-config';
 import {
+    type EthereumGetCurrentNonceThunkState,
+    type GetOrFetchRawFeeInfoThunkState,
     type YieldFeeEstimationError,
     type YieldFlowResolvedData,
     type YieldWithdrawFlowType,
@@ -15,14 +19,20 @@ import { type Account } from '@suite-common/wallet-types';
 import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { type Result, err, ok } from '@trezor/type-utils';
 
-import type { Dispatch } from 'src/types/suite';
+export type ComposeYieldWithdrawTransactionState = EthereumGetCurrentNonceThunkState &
+    GetOrFetchRawFeeInfoThunkState;
+type ComposeYieldWithdrawTransactionDispatch = ThunkDispatch<
+    ComposeYieldWithdrawTransactionState,
+    Record<never, never>,
+    UnknownAction
+>;
 
 export type ComposeYieldWithdrawTransactionParams = {
     account: Account & { networkType: 'ethereum' };
     flowData: YieldFlowResolvedData;
     amount: string;
     flowType: YieldWithdrawFlowType;
-    dispatch: Dispatch;
+    dispatch: ComposeYieldWithdrawTransactionDispatch;
 };
 
 export const composeYieldWithdrawTransaction = async ({

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts
@@ -1,10 +1,11 @@
-import { asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
 import { openDeferredModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin';
 import { createThunk } from '@suite-common/redux-utils';
 import { notificationsActions } from '@suite-common/toast-notifications';
 import {
+    type ComposeYieldDepositTransactionThunkState,
     STABLECOIN_YIELD_PREFIX,
     type YieldFlowResolvedData,
     composeYieldDepositTransactionThunk,
@@ -15,6 +16,8 @@ import {
 } from '@suite-common/wallet-core';
 
 import {
+    type SendYieldTransactionDeps,
+    type SendYieldTransactionState,
     getYieldErrorTranslationKey,
     getYieldSubmitErrorAnalyticsMessage,
     sendYieldTransaction,
@@ -25,13 +28,19 @@ type SubmitYieldDepositPayload = {
     flowData: YieldFlowResolvedData;
     amount: string;
 };
+type SubmitYieldDepositThunkState = ComposeYieldDepositTransactionThunkState &
+    SendYieldTransactionState;
+type SubmitYieldDepositThunkDeps = SendYieldTransactionDeps & {
+    services: DesktopAnalyticsDep;
+};
 
-export const submitYieldDepositThunk = createThunk(
+export const submitYieldDepositThunk = createThunk<
+    void,
+    SubmitYieldDepositPayload,
+    { state: SubmitYieldDepositThunkState; extra: SubmitYieldDepositThunkDeps }
+>(
     `${STABLECOIN_YIELD_PREFIX}/thunk/submitDeposit`,
-    async (
-        { flowKey, flowData, amount }: SubmitYieldDepositPayload,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ flowKey, flowData, amount }, { dispatch, getState, extra }) => {
         const flowType = 'deposit' as const;
 
         try {

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -1,4 +1,4 @@
-import { asTypedDesktopAnalytics } from '@suite/analytics';
+import { type DesktopAnalyticsDep, asTypedDesktopAnalytics } from '@suite/analytics';
 import { openDeferredModal } from '@suite/modal';
 import { events } from '@suite-common/analytics';
 import { type StablecoinYieldTxSimulationParams } from '@suite-common/earn-stablecoin';
@@ -11,8 +11,13 @@ import {
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
 
-import { composeYieldWithdrawTransaction } from './composeYieldWithdrawTransaction';
 import {
+    type ComposeYieldWithdrawTransactionState,
+    composeYieldWithdrawTransaction,
+} from './composeYieldWithdrawTransaction';
+import {
+    type SendYieldTransactionDeps,
+    type SendYieldTransactionState,
     getYieldErrorTranslationKey,
     getYieldSubmitErrorAnalyticsMessage,
     sendYieldTransaction,
@@ -24,13 +29,19 @@ type SubmitYieldWithdrawPayload = {
     amount: string;
     flowType: YieldWithdrawFlowType;
 };
+type SubmitYieldWithdrawThunkState = ComposeYieldWithdrawTransactionState &
+    SendYieldTransactionState;
+type SubmitYieldWithdrawThunkDeps = SendYieldTransactionDeps & {
+    services: DesktopAnalyticsDep;
+};
 
-export const submitYieldWithdrawThunk = createThunk(
+export const submitYieldWithdrawThunk = createThunk<
+    void,
+    SubmitYieldWithdrawPayload,
+    { state: SubmitYieldWithdrawThunkState; extra: SubmitYieldWithdrawThunkDeps }
+>(
     `${STABLECOIN_YIELD_PREFIX}/thunk/submitWithdraw`,
-    async (
-        { flowKey, flowData, amount, flowType }: SubmitYieldWithdrawPayload,
-        { dispatch, getState, extra },
-    ) => {
+    async ({ flowKey, flowData, amount, flowType }, { dispatch, getState, extra }) => {
         const reportSubmitError = (errorMessage = 'submit-failed') =>
             asTypedDesktopAnalytics(extra.services.analytics).report({
                 type: events.yieldWithdrawEvent.name,

--- a/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormEthereumThunks.ts
@@ -543,7 +543,7 @@ interface EthereumGetCurrentNonceThunkParams {
     // See ResolveEthereumNonceParams: temporarily required so no caller can silently fall back to the stale nonce.
     fetchConfirmedNonce?: boolean;
 }
-type EthereumGetCurrentNonceThunkState = AccountsRootState & TransactionsRootState;
+export type EthereumGetCurrentNonceThunkState = AccountsRootState & TransactionsRootState;
 
 export const ethereumGetCurrentNonceThunk = createThunk<
     ResolveEthereumNonceResult,

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
@@ -67,7 +67,7 @@ type ComposeYieldDepositTransactionPayload = {
     flowData: YieldFlowResolvedData;
     amount: string;
 };
-type ComposeYieldDepositTransactionThunkState = AccountsRootState &
+export type ComposeYieldDepositTransactionThunkState = AccountsRootState &
     GetOrFetchRawFeeInfoThunkState &
     TransactionsRootState;
 


### PR DESCRIPTION
## Description

Desktop stablecoin-yield deposit, withdraw, claim, and cancellation still inherited the global Redux state/dependency graph, and the withdraw composition helper accepted global Suite dispatch/state. This adds named selective contracts, composes the shared signing and child-thunk contracts, and narrows the helper without changing transaction behavior. This PR is stacked on #31050 because it reuses the selective `sendYieldTransaction` contract introduced there.\n\n- Global-default stablecoin-yield wrappers: **4 -> 0**\n- Global helper state/dispatch contracts: **1 -> 0**\n- Validation: focused ESLint and Prettier plus the **@trezor/suite** integration type-check; no colocated unit tests exist

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches stablecoin yield withdrawal/deposit thunks and Ethereum send-form thunks. The most targeted coverage comes from the yield withdrawal test and the ETH send-form test. Broad static mappings (136 tests per file) indicate these are widely imported modules, so only tests with explicit LLM evidence of exercising the changed flows are recommended. Deposit and reward-claim thunks appear to lack direct E2E coverage.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/wallet/stablecoin-yield/cancelSignYieldTx.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `suite-common/wallet-core/src/send/sendFormEthereumThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/send-eth.test.ts` — This test directly exercises the Ethereum send form with custom gas parameters and device confirmation, which is the primary user flow backed by suite-common/wallet-core/src/send/sendFormEthereumThunks.ts.
- `suite/e2e/tests/yield/withdrawal.test.ts` — This is the only E2E test covering the stablecoin yield withdrawal flow; it composes and submits a yield withdrawal transaction and confirms it on device, directly exercising composeYieldWithdrawTransaction and submitYieldWithdrawThunk.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — This swap test sets custom Ethereum fee parameters and proceeds through transaction composition/signing, so it shares the sendFormEthereumThunks code path and could surface regressions in fee handling.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/actions/wallet/stablecoin-yield/claimMerklRewardsThunk.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldDepositThunk.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts`

_Updated: 2026-08-24T10:24:22.177Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-desktop-stablecoin-yield-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-desktop-stablecoin-yield-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-desktop-stablecoin-yield-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T10:27:11.109Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T10:26:59.695Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-stablecoin-yield-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-desktop-stablecoin-yield-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->