### PR TITLE
refactor(native): type infrastructure thunks

### DIFF
--- a/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
+++ b/suite-common/token-definitions/src/tokenDefinitionsThunks.ts
@@ -39,10 +39,10 @@ export const getTokenDefinitionThunk = createThunk<
     },
 );
 
-type InitTokenDefinitionsThunkDeps = {
+export type InitTokenDefinitionsThunkDeps = {
     services: GetTokenDefinitionsEnabledNetworksDep;
 };
-type InitTokenDefinitionsThunkState = TokenDefinitionsRootState;
+export type InitTokenDefinitionsThunkState = TokenDefinitionsRootState;
 
 export const initTokenDefinitionsThunk = createThunk<
     unknown[],

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -112,8 +112,10 @@ export const setCustomBackendThunk = createThunk<
     return setBackendsToConnect(backends);
 });
 
-type InitBlockchainThunkState = AccountsRootState & BlockchainRootState & WalletSettingsRootState;
-type InitBlockchainThunkDeps = {
+export type InitBlockchainThunkState = AccountsRootState &
+    BlockchainRootState &
+    WalletSettingsRootState;
+export type InitBlockchainThunkDeps = {
     services: AnalyticsDep;
 };
 

--- a/suite-common/wallet-core/src/device/deviceThunks.ts
+++ b/suite-common/wallet-core/src/device/deviceThunks.ts
@@ -259,7 +259,7 @@ export const initDevices = createThunk<void, void, { state: InitDevicesThunkStat
     },
 );
 
-type CreateImportedDeviceThunkState = DeviceRootState;
+export type CreateImportedDeviceThunkState = DeviceRootState;
 
 export const createImportedDeviceThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
+++ b/suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts
@@ -419,10 +419,10 @@ type PeriodicFetchFiatRatesThunkPayload = {
     localCurrency: BaseCurrencyCode;
 };
 
-type PeriodicFetchFiatRatesThunkDeps = {
+export type PeriodicFetchFiatRatesThunkDeps = {
     services: GetIsWindowVisibleDep;
 };
-type PeriodicFetchFiatRatesThunkState = FetchFiatRatesThunkState;
+export type PeriodicFetchFiatRatesThunkState = FetchFiatRatesThunkState;
 
 export const periodicFetchFiatRatesThunk = createThunk<
     void,

--- a/suite-common/wallet-core/src/stake/stakeThunks.ts
+++ b/suite-common/wallet-core/src/stake/stakeThunks.ts
@@ -24,7 +24,7 @@ function stakingDataNeedsRefetch(data: StakeRootState['wallet']['stake']['data']
 
     return shouldRefetch;
 }
-type InitStakeDataThunkState = StakeRootState & WalletSettingsRootState;
+export type InitStakeDataThunkState = StakeRootState & WalletSettingsRootState;
 
 export const initStakeDataThunk = createThunk<void, void, { state: InitStakeDataThunkState }>(
     `${STAKE_MODULE}/initStakeDataThunk`,

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -792,7 +792,7 @@ type FetchTransactionsFromNowUntilTimestampParams = {
     accountKey: AccountKey;
     timestamp: Timestamp | null;
 };
-type FetchTransactionsFromNowUntilTimestampState = AccountsRootState &
+export type FetchTransactionsFromNowUntilTimestampState = AccountsRootState &
     TransactionsRootState &
     FetchAllTransactionsForAccountThunkState &
     FetchTransactionsPageThunkState;

--- a/suite-native/analytics-redux/src/analyticsThunks.ts
+++ b/suite-native/analytics-redux/src/analyticsThunks.ts
@@ -1,4 +1,5 @@
 import {
+    type AnalyticsRootState,
     analyticsActions,
     selectAnalyticsInstanceId,
     selectCustomAnalyticsUrl,
@@ -8,7 +9,7 @@ import {
     selectLoggerEnabled,
 } from '@suite-common/analytics-redux';
 import { createThunk } from '@suite-common/redux-utils';
-import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
 import { isProduction } from '@suite-native/config';
 import { allowSentryReport, setSentryUser } from '@suite-native/sentry';
 import { type InitOptions, getTrackingRandomId } from '@trezor/analytics-uploader';
@@ -16,72 +17,82 @@ import { getCommitHash } from '@trezor/env-utils';
 
 const ACTION_PREFIX = '@suite-native/analytics';
 
-const enableAnalyticsThunk = createThunk(
-    `${ACTION_PREFIX}/enableAnalyticsThunk`,
-    (_, { dispatch, extra }) => {
-        asTypedNativeAnalytics(extra.services.analytics).report({
+type EnableAnalyticsThunkDeps = { services: NativeAnalyticsDep };
+
+const enableAnalyticsThunk = createThunk<
+    void,
+    void,
+    { state: void; extra: EnableAnalyticsThunkDeps }
+>(`${ACTION_PREFIX}/enableAnalyticsThunk`, (_, { dispatch, extra }) => {
+    asTypedNativeAnalytics(extra.services.analytics).report({
+        type: events.settingsDataPermissionEvent.name,
+        payload: { analyticsPermission: true },
+    });
+    allowSentryReport(true);
+    dispatch(analyticsActions.enableAnalytics());
+});
+
+type DisableAnalyticsThunkDeps = { services: NativeAnalyticsDep };
+
+const disableAnalyticsThunk = createThunk<
+    void,
+    void,
+    { state: void; extra: DisableAnalyticsThunkDeps }
+>(`${ACTION_PREFIX}/disableAnalyticsThunk`, (_, { dispatch, extra }) => {
+    asTypedNativeAnalytics(extra.services.analytics).report(
+        {
             type: events.settingsDataPermissionEvent.name,
-            payload: { analyticsPermission: true },
-        });
-        allowSentryReport(true);
-        dispatch(analyticsActions.enableAnalytics());
-    },
-);
+            payload: { analyticsPermission: false },
+        },
+        { force: true },
+    );
+    allowSentryReport(false);
+    dispatch(analyticsActions.disableAnalytics());
+});
 
-const disableAnalyticsThunk = createThunk(
-    `${ACTION_PREFIX}/disableAnalyticsThunk`,
-    (_, { dispatch, extra }) => {
-        asTypedNativeAnalytics(extra.services.analytics).report(
-            {
-                type: events.settingsDataPermissionEvent.name,
-                payload: { analyticsPermission: false },
-            },
-            { force: true },
-        );
-        allowSentryReport(false);
-        dispatch(analyticsActions.disableAnalytics());
-    },
-);
+export type InitAnalyticsThunkState = AnalyticsRootState;
+export type InitAnalyticsThunkDeps = { services: NativeAnalyticsDep };
 
-export const initAnalyticsThunk = createThunk(
-    `${ACTION_PREFIX}/init`,
-    (_, { dispatch, getState, extra }) => {
-        const sessionId = getTrackingRandomId();
-        const instanceId = selectAnalyticsInstanceId(getState()) ?? getTrackingRandomId();
-        const hasUserAllowedTracking = selectHasUserAllowedTracking(getState());
+export const initAnalyticsThunk = createThunk<
+    void,
+    void,
+    { state: InitAnalyticsThunkState; extra: InitAnalyticsThunkDeps }
+>(`${ACTION_PREFIX}/init`, (_, { dispatch, getState, extra }) => {
+    const sessionId = getTrackingRandomId();
+    const instanceId = selectAnalyticsInstanceId(getState()) ?? getTrackingRandomId();
+    const hasUserAllowedTracking = selectHasUserAllowedTracking(getState());
 
-        const isAnalyticsEnabled = selectIsAnalyticsEnabled(getState());
-        const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(getState());
+    const isAnalyticsEnabled = selectIsAnalyticsEnabled(getState());
+    const isAnalyticsConfirmed = selectIsAnalyticsConfirmed(getState());
 
-        const customAnalyticsUrl = selectCustomAnalyticsUrl(getState());
-        const loggerEnabled = selectLoggerEnabled(getState());
+    const customAnalyticsUrl = selectCustomAnalyticsUrl(getState());
+    const loggerEnabled = selectLoggerEnabled(getState());
 
-        const options: InitOptions = {
+    const options: InitOptions = {
+        instanceId,
+        sessionId,
+        environment: 'mobile',
+        url: customAnalyticsUrl,
+        loggerEnabled,
+        commitId: getCommitHash(),
+        isDev: !isProduction(),
+        callbacks: {
+            onEnable: () => dispatch(enableAnalyticsThunk()),
+            onDisable: () => dispatch(disableAnalyticsThunk()),
+        },
+    };
+
+    extra.services.analytics.init(hasUserAllowedTracking, options);
+
+    allowSentryReport(isAnalyticsEnabled);
+    setSentryUser(instanceId);
+
+    dispatch(
+        analyticsActions.initAnalytics({
             instanceId,
             sessionId,
-            environment: 'mobile',
-            url: customAnalyticsUrl,
-            loggerEnabled,
-            commitId: getCommitHash(),
-            isDev: !isProduction(),
-            callbacks: {
-                onEnable: () => dispatch(enableAnalyticsThunk()),
-                onDisable: () => dispatch(disableAnalyticsThunk()),
-            },
-        };
-
-        extra.services.analytics.init(hasUserAllowedTracking, options);
-
-        allowSentryReport(isAnalyticsEnabled);
-        setSentryUser(instanceId);
-
-        dispatch(
-            analyticsActions.initAnalytics({
-                instanceId,
-                sessionId,
-                enabled: isAnalyticsEnabled,
-                confirmed: isAnalyticsConfirmed,
-            }),
-        );
-    },
-);
+            enabled: isAnalyticsEnabled,
+            confirmed: isAnalyticsConfirmed,
+        }),
+    );
+});

--- a/suite-native/app-init/src/appInitThunks.ts
+++ b/suite-native/app-init/src/appInitThunks.ts
@@ -1,16 +1,31 @@
-import { connectInitThunk } from '@suite-common/connect-init';
+import {
+    type ConnectInitThunkDeps,
+    type ConnectInitThunkState,
+    connectInitThunk,
+} from '@suite-common/connect-init';
 import {
     defaultEarnYieldWorkerBaseUrl,
     earnYieldWorkerBaseUrl,
 } from '@suite-common/earn-stablecoin-api';
 import {
+    type MessageSystemRootState,
     initMessageSystemThunk,
     prepareCachedEnvData,
     selectActiveKillswitchMessage,
 } from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
-import { periodicCheckTokenDefinitionsThunk } from '@suite-common/token-definitions';
 import {
+    type InitTokenDefinitionsThunkDeps,
+    type InitTokenDefinitionsThunkState,
+    periodicCheckTokenDefinitionsThunk,
+} from '@suite-common/token-definitions';
+import {
+    type CreateImportedDeviceThunkState,
+    type InitBlockchainThunkDeps,
+    type InitBlockchainThunkState,
+    type InitStakeDataThunkState,
+    type PeriodicFetchFiatRatesThunkDeps,
+    type PeriodicFetchFiatRatesThunkState,
     createImportedDeviceThunk,
     initBlockchainThunk,
     initDevices,
@@ -18,71 +33,104 @@ import {
     periodicFetchFiatRatesThunk,
     selectBaseCurrency,
 } from '@suite-common/wallet-core';
-import { walletConnectInitThunk } from '@suite-common/walletconnect';
-import { initAnalyticsThunk } from '@suite-native/analytics-redux';
-import { selectEarnYieldWorkerBaseUrl, selectIsOnboardingFinished } from '@suite-native/settings';
+import {
+    type WalletConnectInitThunkDeps,
+    type WalletConnectInitThunkState,
+    walletConnectInitThunk,
+} from '@suite-common/walletconnect';
+import {
+    type InitAnalyticsThunkDeps,
+    type InitAnalyticsThunkState,
+    initAnalyticsThunk,
+} from '@suite-native/analytics-redux';
+import {
+    type SettingsSliceRootState,
+    selectEarnYieldWorkerBaseUrl,
+    selectIsOnboardingFinished,
+} from '@suite-native/settings';
 import { setIsAppReady } from '@suite-native/state';
 
 const ACTION_PREFIX = '@suite-native/app';
 
-export const postOnboardingInit = createThunk(
-    `${ACTION_PREFIX}/postOnboardingInit`,
-    async (_, { dispatch, getState }) => {
-        // Do not initialize Connect or anything else related to it, if there is an app-wide killswitch via message-system.
-        const activeKillswitchMessage = selectActiveKillswitchMessage(getState());
-        if (activeKillswitchMessage) return;
+type PostOnboardingInitThunkState = ConnectInitThunkState &
+    InitBlockchainThunkState &
+    InitTokenDefinitionsThunkState &
+    InitStakeDataThunkState &
+    PeriodicFetchFiatRatesThunkState &
+    CreateImportedDeviceThunkState &
+    WalletConnectInitThunkState;
+type PostOnboardingInitThunkDeps = ConnectInitThunkDeps &
+    InitBlockchainThunkDeps &
+    InitTokenDefinitionsThunkDeps &
+    PeriodicFetchFiatRatesThunkDeps &
+    WalletConnectInitThunkDeps;
 
-        try {
-            await dispatch(connectInitThunk()).unwrap();
-        } catch (error) {
-            console.error(`Connect init error: ${JSON.stringify(error)}`);
-        }
+export const postOnboardingInit = createThunk<
+    void,
+    void,
+    { state: PostOnboardingInitThunkState; extra: PostOnboardingInitThunkDeps }
+>(`${ACTION_PREFIX}/postOnboardingInit`, async (_, { dispatch, getState }) => {
+    // Do not initialize Connect or anything else related to it, if there is an app-wide killswitch via message-system.
+    const activeKillswitchMessage = selectActiveKillswitchMessage(getState());
+    if (activeKillswitchMessage) return;
 
-        try {
-            // Needs to be finished before any TrezorConnect.blockchain* calls.
-            await dispatch(initBlockchainThunk()).unwrap();
-        } catch (error) {
-            console.error(`Blockchain init error: ${JSON.stringify(error)}`);
-        }
+    try {
+        await dispatch(connectInitThunk()).unwrap();
+    } catch (error) {
+        console.error(`Connect init error: ${JSON.stringify(error)}`);
+    }
 
-        dispatch(periodicCheckTokenDefinitionsThunk());
-        dispatch(initStakeDataThunk());
+    try {
+        // Needs to be finished before any TrezorConnect.blockchain* calls.
+        await dispatch(initBlockchainThunk()).unwrap();
+    } catch (error) {
+        console.error(`Blockchain init error: ${JSON.stringify(error)}`);
+    }
 
-        dispatch(
-            periodicFetchFiatRatesThunk({
-                rateType: 'current',
-                localCurrency: selectBaseCurrency(getState()),
-            }),
-        );
+    dispatch(periodicCheckTokenDefinitionsThunk());
+    dispatch(initStakeDataThunk());
 
-        // Create Portfolio Tracker device if it doesn't exist
-        dispatch(createImportedDeviceThunk());
+    dispatch(
+        periodicFetchFiatRatesThunk({
+            rateType: 'current',
+            localCurrency: selectBaseCurrency(getState()),
+        }),
+    );
 
-        dispatch(walletConnectInitThunk());
-    },
-);
+    // Create Portfolio Tracker device if it doesn't exist
+    dispatch(createImportedDeviceThunk());
 
-export const applicationInit = createThunk(
-    `${ACTION_PREFIX}/applicationInit`,
-    async (_, { dispatch, getState }) => {
-        await prepareCachedEnvData();
+    dispatch(walletConnectInitThunk());
+});
 
-        // apply the earn yield worker base url from debug settings (or the default for this build)
-        earnYieldWorkerBaseUrl.set(
-            selectEarnYieldWorkerBaseUrl(getState()) ?? defaultEarnYieldWorkerBaseUrl,
-        );
+type ApplicationInitThunkState = SettingsSliceRootState &
+    MessageSystemRootState &
+    InitAnalyticsThunkState &
+    PostOnboardingInitThunkState;
+type ApplicationInitThunkDeps = InitAnalyticsThunkDeps & PostOnboardingInitThunkDeps;
 
-        dispatch(initAnalyticsThunk());
-        dispatch(initMessageSystemThunk());
+export const applicationInit = createThunk<
+    void,
+    void,
+    { state: ApplicationInitThunkState; extra: ApplicationInitThunkDeps }
+>(`${ACTION_PREFIX}/applicationInit`, async (_, { dispatch, getState }) => {
+    await prepareCachedEnvData();
 
-        // Select latest remembered device or Portfolio Tracker device.
-        dispatch(initDevices());
+    // apply the earn yield worker base url from debug settings (or the default for this build)
+    earnYieldWorkerBaseUrl.set(
+        selectEarnYieldWorkerBaseUrl(getState()) ?? defaultEarnYieldWorkerBaseUrl,
+    );
 
-        if (selectIsOnboardingFinished(getState())) {
-            await dispatch(postOnboardingInit());
-        }
+    dispatch(initAnalyticsThunk());
+    dispatch(initMessageSystemThunk());
 
-        // Tell the application to render
-        dispatch(setIsAppReady(true));
-    },
-);
+    // Select latest remembered device or Portfolio Tracker device.
+    dispatch(initDevices());
+
+    if (selectIsOnboardingFinished(getState())) {
+        await dispatch(postOnboardingInit());
+    }
+
+    // Tell the application to render
+    dispatch(setIsAppReady(true));
+});

--- a/suite-native/biometrics/src/biometricsThunks.ts
+++ b/suite-native/biometrics/src/biometricsThunks.ts
@@ -5,7 +5,7 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import type { LocalAuthenticationResult } from 'expo-local-authentication';
 
 import { createThunk } from '@suite-common/redux-utils';
-import { asTypedNativeAnalytics, events } from '@suite-native/analytics';
+import { type NativeAnalyticsDep, asTypedNativeAnalytics, events } from '@suite-native/analytics';
 
 import {
     selectGoneToBackgroundAtTimestamp,
@@ -15,7 +15,7 @@ import {
     selectShouldUserBeAuthenticated,
 } from './biometricsSelectors';
 import { getIsBiometricsFeatureAvailable, getShouldRevokeAuth } from './biometricsUtils';
-import { AuthenticateError } from './types';
+import { AuthenticateError, type BiometricsSliceRootState } from './types';
 
 export enum BiometricsToggleResult {
     Enabled = 'enabled',
@@ -44,7 +44,7 @@ const BIOMETRICS_THUNK_PREFIX = 'biometrics';
 export const authenticateUserThunk = createThunk<
     LocalAuthenticationResult,
     void,
-    { rejectValue: AuthenticateError }
+    { rejectValue: AuthenticateError; state: void }
 >(`${BIOMETRICS_THUNK_PREFIX}/authenticate`, async (_, { rejectWithValue }) => {
     const isBiometricsAvailable = await getIsBiometricsFeatureAvailable();
 
@@ -61,10 +61,17 @@ export const authenticateUserThunk = createThunk<
     return result;
 });
 
+type ToggleBiometricsSettingsThunkState = BiometricsSliceRootState;
+type ToggleBiometricsSettingsThunkDeps = { services: NativeAnalyticsDep };
+
 export const toggleBiometricsSettingsThunk = createThunk<
     BiometricsToggleFulfilledResult,
     void,
-    { rejectValue: BiometricsToggleRejectReason }
+    {
+        rejectValue: BiometricsToggleRejectReason;
+        state: ToggleBiometricsSettingsThunkState;
+        extra: ToggleBiometricsSettingsThunkDeps;
+    }
 >(
     `${BIOMETRICS_THUNK_PREFIX}/toggleBiometricsSettings`,
     async (_, { getState, rejectWithValue, dispatch, extra }) => {
@@ -101,10 +108,15 @@ export const toggleBiometricsSettingsThunk = createThunk<
     },
 );
 
+type HandleBiometricsAppStateChangeThunkState = BiometricsSliceRootState;
+
 export const handleBiometricsAppStateChangeThunk = createThunk<
     BiometricsAppStateChangePayload | undefined,
     { nextAppState: AppStateStatus },
-    { rejectValue: BiometricsAppStateChangeRejectReason }
+    {
+        rejectValue: BiometricsAppStateChangeRejectReason;
+        state: HandleBiometricsAppStateChangeThunkState;
+    }
 >(
     `${BIOMETRICS_THUNK_PREFIX}/handleAppStateChange`,
     ({ nextAppState }, { getState, dispatch, rejectWithValue }) => {

--- a/suite-native/device/src/deviceThunks.ts
+++ b/suite-native/device/src/deviceThunks.ts
@@ -1,15 +1,20 @@
 import {
+    type DeviceRootState,
     selectDevicePath,
     selectIsDeviceInitialized,
     selectSelectedDevice,
     selectSimulatedEntropyCheckFail,
 } from '@suite-common/device';
-import { Feature, selectIsFeatureEnabled } from '@suite-common/message-system';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsFeatureEnabled,
+} from '@suite-common/message-system';
 import { createThunk } from '@suite-common/redux-utils';
-import { type BackupType } from '@suite-common/suite-types';
+import { type BackupType, type ReportSecurityCheckDep } from '@suite-common/suite-types';
 import { processEntropyCheckResultThunk } from '@suite-common/wallet-core';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect, { type OkWithDevice, PROTO } from '@trezor/connect';
+import TrezorConnect, { type OkWithDevice, PROTO, type Response } from '@trezor/connect';
 import { type SerializedError } from '@trezor/connect-common/src/constants/errors';
 import { type Err, exhaustive } from '@trezor/type-utils';
 
@@ -36,10 +41,17 @@ const getResetDeviceConfig = (walletBackupType: BackupType): PROTO.ResetDevice =
     }
 };
 
+type CreateAndBackupWalletThunkState = DeviceRootState & MessageSystemRootState;
+type CreateAndBackupWalletThunkDeps = { services: ReportSecurityCheckDep };
+
 export const createAndBackupWalletThunk = createThunk<
     Err<SerializedError> | OkWithDevice<PROTO.Success>,
     { walletBackupType: BackupType },
-    { rejectValue: string }
+    {
+        rejectValue: string;
+        state: CreateAndBackupWalletThunkState;
+        extra: CreateAndBackupWalletThunkDeps;
+    }
 >(
     `${NATIVE_DEVICE_MODULE_PREFIX}/createAndBackupWalletThunk`,
     async ({ walletBackupType }, { getState, dispatch, fulfillWithValue, rejectWithValue }) => {
@@ -110,19 +122,22 @@ export const createAndBackupWalletThunk = createThunk<
     },
 );
 
-export const recoverWalletThunk = createThunk(
-    `${NATIVE_DEVICE_MODULE_PREFIX}/recoverWalletThunk`,
-    async (_, { getState }) => {
-        const devicePath = selectDevicePath(getState());
+type RecoverWalletThunkState = DeviceRootState;
 
-        const deviceResponse = await requestPrioritizedDeviceAccess(() =>
-            TrezorConnect.recoveryDevice({ device: { path: devicePath } }),
-        );
+export const recoverWalletThunk = createThunk<
+    Response<PROTO.Success>,
+    void,
+    { state: RecoverWalletThunkState }
+>(`${NATIVE_DEVICE_MODULE_PREFIX}/recoverWalletThunk`, async (_, { getState }) => {
+    const devicePath = selectDevicePath(getState());
 
-        if (!deviceResponse.success) {
-            throw new Error(deviceResponse.error);
-        }
+    const deviceResponse = await requestPrioritizedDeviceAccess(() =>
+        TrezorConnect.recoveryDevice({ device: { path: devicePath } }),
+    );
 
-        return deviceResponse.payload;
-    },
-);
+    if (!deviceResponse.success) {
+        throw new Error(deviceResponse.error);
+    }
+
+    return deviceResponse.payload;
+});

--- a/suite-native/firmware/src/firmwareThunks.ts
+++ b/suite-native/firmware/src/firmwareThunks.ts
@@ -1,14 +1,18 @@
-import { deviceActions, selectSelectedDevice } from '@suite-common/device';
+import { type DeviceRootState, deviceActions, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 
 const NATIVE_FIRMWARE_MODULE_PREFIX = 'nativeFirmware';
 
-export const setTemporaryRememberedDeviceThunk = createThunk(
+type SetTemporaryRememberedDeviceThunkPayload = { temporaryRemember: boolean };
+type SetTemporaryRememberedDeviceThunkState = DeviceRootState;
+
+export const setTemporaryRememberedDeviceThunk = createThunk<
+    void,
+    SetTemporaryRememberedDeviceThunkPayload,
+    { rejectValue: string; state: SetTemporaryRememberedDeviceThunkState }
+>(
     `${NATIVE_FIRMWARE_MODULE_PREFIX}/setTemporaryRememberedDevice`,
-    (
-        { temporaryRemember }: { temporaryRemember: boolean },
-        { getState, rejectWithValue, dispatch },
-    ) => {
+    ({ temporaryRemember }, { getState, rejectWithValue, dispatch }) => {
         const device = selectSelectedDevice(getState());
         if (!device) {
             return rejectWithValue('Device not found');

--- a/suite-native/graph/src/graphThunks.e2e.ts
+++ b/suite-native/graph/src/graphThunks.e2e.ts
@@ -8,10 +8,12 @@ import { type RefetchGraphThunkParams, type RefetchGraphThunkResult } from './gr
 const GRAPH_MODULE_PREFIX = '@suite-native/graph';
 const GRAPH_DISABLED_ERROR_MESSAGE = 'Graph is disabled for E2E tests for performance reasons.';
 
+type RefetchGraphThunkState = void;
+
 export const refetchGraphThunk = createThunk<
     RefetchGraphThunkResult,
     RefetchGraphThunkParams,
-    { rejectValue: string }
+    { rejectValue: string; state: RefetchGraphThunkState }
 >(`${GRAPH_MODULE_PREFIX}/refetchGraph`, (_params, { rejectWithValue }) =>
     rejectWithValue(GRAPH_DISABLED_ERROR_MESSAGE),
 );

--- a/suite-native/graph/src/graphThunks.ts
+++ b/suite-native/graph/src/graphThunks.ts
@@ -12,6 +12,7 @@ import {
     getTimeFrameForHistoryHours,
 } from '@suite-common/graph';
 import { createThunk } from '@suite-common/redux-utils';
+import { type FetchTransactionsFromNowUntilTimestampState } from '@suite-common/wallet-core';
 
 import { accountDetailGraphAtoms } from './accountDetailGraphAtoms';
 import { type GraphInstanceId, isPortfolioGraphInstanceId } from './graphInstances';
@@ -26,6 +27,8 @@ import { checkAndReportGraphError, omitErrorMessageSensitiveData } from './utils
 
 const GRAPH_MODULE_PREFIX = '@suite-native/graph';
 const GRAPH_NOT_AVAILABLE_ERROR_MESSAGE = 'Graph is not available for testnet coins.';
+
+type RefetchGraphThunkState = FetchTransactionsFromNowUntilTimestampState;
 
 // The app doesn't mount any jotai Provider, so all atoms live in the default store
 // and it is safe to write them from outside of React. Do not add a jotai Provider.
@@ -126,7 +129,7 @@ const fetchGraphDataToAtoms = async ({
 export const refetchGraphThunk = createThunk<
     RefetchGraphThunkResult,
     RefetchGraphThunkParams,
-    { rejectValue: string }
+    { rejectValue: string; state: RefetchGraphThunkState }
 >(`${GRAPH_MODULE_PREFIX}/refetchGraph`, async (params, { dispatch, rejectWithValue }) => {
     const {
         instanceId,

--- a/suite-native/module-accounts-import/src/accountsImportThunks.ts
+++ b/suite-native/module-accounts-import/src/accountsImportThunks.ts
@@ -1,6 +1,8 @@
 import { PORTFOLIO_TRACKER_DEVICE_STATE } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import {
+    type GetTokenDefinitionsEnabledNetworksDep,
+    type TokenDefinitionsRootState,
     getSupportedDefinitionTypes,
     getTokenDefinitionThunk,
     periodicCheckTokenDefinitionsThunk,
@@ -9,6 +11,8 @@ import {
 } from '@suite-common/token-definitions';
 import { type AccountType, type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
+    type UpdateFiatRatesThunkState,
     accountsActions,
     selectAccountsByNetworkAndDeviceState,
     updateFiatRatesThunk,
@@ -40,9 +44,16 @@ const getAccountTypeFromDescriptor = (descriptor: string, symbol: NetworkSymbol)
     return paymentTypeToAccountType[paymentType];
 };
 
-export const importAccountThunk = createThunk(
+type ImportAccountThunkState = AccountsRootState & TokenDefinitionsRootState;
+type ImportAccountThunkDeps = { services: GetTokenDefinitionsEnabledNetworksDep };
+
+export const importAccountThunk = createThunk<
+    void,
+    ImportAssetThunkPayload,
+    { state: ImportAccountThunkState; extra: ImportAccountThunkDeps }
+>(
     `${ACCOUNTS_IMPORT_MODULE_PREFIX}/importAccountThunk`,
-    ({ accountInfo, accountLabel, symbol }: ImportAssetThunkPayload, { dispatch, getState }) => {
+    ({ accountInfo, accountLabel, symbol }, { dispatch, getState }) => {
         const deviceState = PORTFOLIO_TRACKER_DEVICE_STATE;
 
         const deviceNetworkAccounts = selectAccountsByNetworkAndDeviceState(
@@ -77,10 +88,12 @@ export const importAccountThunk = createThunk(
     },
 );
 
+type GetAccountInfoThunkState = UpdateFiatRatesThunkState;
+
 export const getAccountInfoThunk = createThunk<
     AccountInfo,
     { symbol: NetworkSymbol; baseCurrencyCode: BaseCurrencyCode; xpubAddress: string },
-    { rejectValue: string }
+    { rejectValue: string; state: GetAccountInfoThunkState }
 >(
     `${ACCOUNTS_IMPORT_MODULE_PREFIX}/getAccountInfo`,
     async ({ symbol, baseCurrencyCode, xpubAddress }, { dispatch, rejectWithValue, getState }) => {

--- a/suite-native/module-check-backup/src/checkBackupThunks.ts
+++ b/suite-native/module-check-backup/src/checkBackupThunks.ts
@@ -1,36 +1,39 @@
-import { selectSelectedDevice } from '@suite-common/device';
+import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
 import { requestPrioritizedDeviceAccess } from '@suite-native/device-mutex';
-import TrezorConnect from '@trezor/connect';
+import TrezorConnect, { type PROTO, type Response } from '@trezor/connect';
 
 const CHECK_BACKUP_MODULE_PREFIX = 'checkBackup';
 
-export const checkBackupThunk = createThunk(
-    `${CHECK_BACKUP_MODULE_PREFIX}/checkDeviceBackup`,
-    async (_, { getState }) => {
-        const device = selectSelectedDevice(getState());
+type CheckBackupThunkState = DeviceRootState;
 
-        if (!device?.features) throw new Error('Device is not ready for check backup.');
+export const checkBackupThunk = createThunk<
+    Response<PROTO.Success>,
+    void,
+    { state: CheckBackupThunkState }
+>(`${CHECK_BACKUP_MODULE_PREFIX}/checkDeviceBackup`, async (_, { getState }) => {
+    const device = selectSelectedDevice(getState());
 
-        const mutexResponse = await requestPrioritizedDeviceAccess(() =>
-            TrezorConnect.recoveryDevice({
-                type: 'DryRun',
-                device: {
-                    path: device.path,
-                },
-            }),
-        );
+    if (!device?.features) throw new Error('Device is not ready for check backup.');
 
-        if (!mutexResponse.success) throw new Error(mutexResponse.error);
+    const mutexResponse = await requestPrioritizedDeviceAccess(() =>
+        TrezorConnect.recoveryDevice({
+            type: 'DryRun',
+            device: {
+                path: device.path,
+            },
+        }),
+    );
 
-        const connectResponse = mutexResponse.payload;
+    if (!mutexResponse.success) throw new Error(mutexResponse.error);
 
-        if (!connectResponse.success) {
-            // TODO: failure analytics (https://github.com/trezor/trezor-suite/issues/19846)
-        } else {
-            // TODO: success analytics (https://github.com/trezor/trezor-suite/issues/19846)
-        }
+    const connectResponse = mutexResponse.payload;
 
-        return connectResponse;
-    },
-);
+    if (!connectResponse.success) {
+        // TODO: failure analytics (https://github.com/trezor/trezor-suite/issues/19846)
+    } else {
+        // TODO: success analytics (https://github.com/trezor/trezor-suite/issues/19846)
+    }
+
+    return connectResponse;
+});


### PR DESCRIPTION
## Description

Native application and state infrastructure thunks still inherited the global state and extra-dependency contract, hiding their real selector, service, and child-thunk requirements. This adds named minimal contracts for app initialization, analytics, biometrics, device, graph, firmware, account import, and backup checks; Bluetooth was already explicit. Parent orchestration composes child contracts, with the required WalletConnect contract coming from #31008. Runtime behavior is unchanged.\n\n- Global-fallback declarations in scope, including the graph E2E replacement: **16 -> 0**\n- Focused biometrics tests: **12/12 passed**\n- Native app aggregate type-check: **231 dependent projects passed**

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by broad shared thunks (wallet-core, token definitions, WalletConnect, connect popup) that statically map to nearly all tests. The highest-risk, most targeted regressions are in WalletConnect and TrezorConnect popup permissions, so the recommended strategy is to run those direct feature tests first. Token trading and staking tests provide medium confidence for the token and stake thunk changes without falling back to the full suite. The remaining wallet-core thunks and all suite-native mobile files lack specific web/desktop E2E coverage in this set.

<details><summary><b>Changed files (26)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/mev/src/index.ts`
- `suite-common/mev/src/mevProtectionSettings.ts`
- `suite-common/token-definitions/src/tokenDefinitionsThunks.ts`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/device/deviceThunks.ts`
- `suite-common/wallet-core/src/fiat-rates/fiatRatesThunks.ts`
- `suite-common/wallet-core/src/stake/stakeThunks.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`
- `suite-common/walletconnect/src/adapters/bitcoin.ts`
- `suite-common/walletconnect/src/adapters/ethereum.ts`
- `suite-common/walletconnect/src/adapters/index.ts`
- `suite-common/walletconnect/src/adapters/solana.ts`
- `suite-common/walletconnect/src/adapters/stellar.ts`
- `suite-common/walletconnect/src/adapters/tron.ts`
- `suite-common/walletconnect/src/walletConnectReducer.ts`
- `suite-common/walletconnect/src/walletConnectThunks.ts`
- `suite-native/analytics-redux/src/analyticsThunks.ts`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/biometrics/src/biometricsThunks.ts`
- `suite-native/device/src/deviceThunks.ts`
- `suite-native/firmware/src/firmwareThunks.ts`
- `suite-native/graph/src/graphThunks.e2e.ts`
- `suite-native/graph/src/graphThunks.ts`
- `suite-native/module-accounts-import/src/accountsImportThunks.ts`
- `suite-native/module-check-backup/src/checkBackupThunks.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This test directly exercises WalletConnect initialization, pairing, and proposal approval/rejection flows. The changed WalletConnect adapter files, reducer, and thunks are the core implementation these analytics events depend on, so regressions here would be immediately visible.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Tests the core TrezorConnect popup lifecycle including permissions, address confirmation, cancellation, and popup management. connectPopupThunks.ts directly drives this popup/permission flow, making this the most relevant regression test.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Specifically validates permission granting, remembering, revoking, and the connected apps list. These permissions are managed by connectPopupThunks.ts, so changes there would directly affect this test.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests silent mode behavior in the permissions modal and focus suppression, which is part of the connect popup thunk logic. A regression in connectPopupThunks.ts would likely break this flow.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Tests declaring upfront permissions and batch approval, directly involving connectPopupThunks.ts permission handling. This is a focused permissions feature that would catch thunk regressions.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Exercises the full ETH staking flow including transaction composition and device confirmation. Changes to stakeThunks.ts could affect staking transaction creation or state updates, and this representative test covers the happy path end-to-end.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Buys a Jupiter SPL token on Solana, relying on token definitions loaded by tokenDefinitionsThunks.ts. This is a concrete token-dependent trading flow that could regress if token definition loading or caching changed.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — Sells a USDC ERC-20 token on Ethereum, relying on token definitions loaded by tokenDefinitionsThunks.ts. This covers a different token standard and chain than the Solana token test, giving broader confidence for token definition thunk changes.

</details>

⚠️ **Changes with no test coverage (9)**
- `suite-native/analytics-redux/src/analyticsThunks.ts`
- `suite-native/app-init/src/appInitThunks.ts`
- `suite-native/biometrics/src/biometricsThunks.ts`
- `suite-native/device/src/deviceThunks.ts`
- `suite-native/firmware/src/firmwareThunks.ts`
- `suite-native/graph/src/graphThunks.e2e.ts`
- `suite-native/graph/src/graphThunks.ts`
- `suite-native/module-accounts-import/src/accountsImportThunks.ts`
- `suite-native/module-check-backup/src/checkBackupThunks.ts`

_Updated: 2026-08-07T22:48:15.628Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=refactor/selective-native-infrastructure-thunks&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=refactor/selective-native-infrastructure-thunks&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=refactor/selective-native-infrastructure-thunks&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-07T22:51:13.776Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-07T22:50:25.131Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/refactor/selective-native-infrastructure-thunks/web/](https://dev.suite.sldev.cz/suite-web/refactor/selective-native-infrastructure-thunks/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->