### PR TITLE
docs(redux): document selective thunk contracts

### DIFF
--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -259,6 +259,102 @@ export const closeDialogThunk = createThunk<void, CloseDialogParams, void>(
 );
 ```
 
+### Testing thunks without a Redux store
+
+Unit-test a thunk as a function. Redux thunk middleware ultimately calls a thunk with three
+arguments: `dispatch`, `getState`, and `extra`. A unit test can provide those arguments directly; it
+does not need `configureMockStore`, application reducers, or the global dependency graph.
+
+Use `createMockDispatch` from `@suite-common/redux-utils/mocks`. It stores every plain dispatched
+action in an array and recursively executes function actions with the same test dependencies. Build
+`getState` and `extra` from the thunk's exported contracts, and keep the fixture local to the test.
+Mock external I/O at its own boundary; a Redux store is not needed for that either. For example,
+`connectInitThunk` is tested with this shape:
+
+```ts
+type ConnectInitThunkTestDeps = {
+    actions: unknown[];
+    waitForThunks: () => Promise<void>;
+    dispatch: ConnectInitThunkDispatch;
+    getState: () => ConnectInitThunkState;
+    extra: ConnectInitThunkDeps;
+};
+
+const state: ConnectInitThunkState = {
+    wallet: { settings: initialWalletSettingsState },
+    device: deviceInitialState,
+    firmware: firmwareInitialState,
+    messageSystem: messageSystemInitialState,
+};
+
+const createThunkDeps = (
+    services: Partial<ConnectInitThunkDeps['services']> = {},
+): ConnectInitThunkTestDeps => {
+    const getState = (): ConnectInitThunkState => state;
+    const extra: ConnectInitThunkDeps = {
+        actions: {
+            lockDevice: createAction<boolean>('@test/lock-device'),
+        },
+        services: {
+            analytics: { report: jest.fn() },
+            connectInitHooks: { deviceEvent: {}, uiEvent: {} },
+            connectInitSettings: {
+                manifest: {
+                    email: 'info@trezor.io',
+                    appName: 'Trezor Suite',
+                    appUrl: '@trezor/suite',
+                },
+            },
+            createTransports: () => [],
+            getAllowPrerelease: asGetter(() => false),
+            getBinFilesBaseUrl: asGetter(() => '/bin'),
+            getDebugSettings: asGetter(() => ({
+                transports: [],
+                showConnectLogs: false,
+            })),
+            getThpSettings: asGetter(() => ({ pairingMethods: ['CodeEntry'] })),
+            thpHostName: undefined,
+            ...services,
+        },
+    };
+    const { actions, dispatch, waitForThunks } = createMockDispatch({ getState, extra });
+
+    return { actions, waitForThunks, dispatch, getState, extra };
+};
+
+beforeEach(() => {
+    testMocks.setTrezorConnectFixtures();
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+it('uses the injected bin files base URL', async () => {
+    const getBinFilesBaseUrl = jest.fn(() => '/custom-bin-files');
+    const initSpy = jest.spyOn(TrezorConnect, 'init');
+    const { actions, dispatch, getState, extra } = createThunkDeps({
+        getBinFilesBaseUrl: asGetter(getBinFilesBaseUrl),
+    });
+
+    // The first call supplies the thunk payload; the second call runs the returned thunk directly.
+    await connectInitThunk()(dispatch, getState, extra);
+
+    expect(actions).toEqual([
+        expect.objectContaining({ type: connectInitThunk.pending.type }),
+        expect.objectContaining({ type: connectInitThunk.fulfilled.type }),
+    ]);
+    expect(initSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ binFilesBaseUrl: '/custom-bin-files' }),
+    );
+});
+```
+
+Await the directly invoked thunk immediately in ordinary tests. Use `waitForThunks()` only when code
+outside that awaited call, such as an event listener installed by `connectInitThunk`, later dispatches
+a fire-and-forget asynchronous thunk. In that case there is no returned promise for the test to await,
+so `waitForThunks()` drains the nested promises collected by the fake dispatch.
+
 Global application state and dependency contracts are wiring details. Application code may refer to
 them only in these composition-root files, where the final stores and service graphs are assembled:
 

--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -274,7 +274,6 @@ Mock external I/O at its own boundary; a Redux store is not needed for that eith
 ```ts
 type ConnectInitThunkTestDeps = {
     actions: unknown[];
-    waitForThunks: () => Promise<void>;
     dispatch: ConnectInitThunkDispatch;
     getState: () => ConnectInitThunkState;
     extra: ConnectInitThunkDeps;
@@ -317,9 +316,9 @@ const createThunkDeps = (
             ...services,
         },
     };
-    const { actions, dispatch, waitForThunks } = createMockDispatch({ getState, extra });
+    const { actions, dispatch } = createMockDispatch({ getState, extra });
 
-    return { actions, waitForThunks, dispatch, getState, extra };
+    return { actions, dispatch, getState, extra };
 };
 
 beforeEach(() => {
@@ -349,11 +348,6 @@ it('uses the injected bin files base URL', async () => {
     );
 });
 ```
-
-Await the directly invoked thunk immediately in ordinary tests. Use `waitForThunks()` only when code
-outside that awaited call, such as an event listener installed by `connectInitThunk`, later dispatches
-a fire-and-forget asynchronous thunk. In that case there is no returned promise for the test to await,
-so `waitForThunks()` drains the nested promises collected by the fake dispatch.
 
 Global application state and dependency contracts are wiring details. Application code may refer to
 them only in these composition-root files, where the final stores and service graphs are assembled:

--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -269,7 +269,9 @@ Use `createMockDispatch` from `@suite-common/redux-utils/mocks`. It stores every
 action in an array and recursively executes function actions with the same test dependencies. Build
 `getState` and `extra` from the thunk's exported contracts, and keep the fixture local to the test.
 Mock external I/O at its own boundary; a Redux store is not needed for that either. For example,
-`connectInitThunk` is tested with this shape:
+`connectInitThunk` is tested with this shape. Its concrete state and dependency values are ordinary
+local fixtures typed as `ConnectInitThunkState` and `ConnectInitThunkDeps`; they are omitted here so
+the example focuses on running the thunk:
 
 ```ts
 type ConnectInitThunkTestDeps = {
@@ -279,62 +281,21 @@ type ConnectInitThunkTestDeps = {
     extra: ConnectInitThunkDeps;
 };
 
-const state: ConnectInitThunkState = {
-    wallet: { settings: initialWalletSettingsState },
-    device: deviceInitialState,
-    firmware: firmwareInitialState,
-    messageSystem: messageSystemInitialState,
-};
-
 const createThunkDeps = (
-    services: Partial<ConnectInitThunkDeps['services']> = {},
+    state: ConnectInitThunkState,
+    extra: ConnectInitThunkDeps,
 ): ConnectInitThunkTestDeps => {
     const getState = (): ConnectInitThunkState => state;
-    const extra: ConnectInitThunkDeps = {
-        actions: {
-            lockDevice: createAction<boolean>('@test/lock-device'),
-        },
-        services: {
-            analytics: { report: jest.fn() },
-            connectInitHooks: { deviceEvent: {}, uiEvent: {} },
-            connectInitSettings: {
-                manifest: {
-                    email: 'info@trezor.io',
-                    appName: 'Trezor Suite',
-                    appUrl: '@trezor/suite',
-                },
-            },
-            createTransports: () => [],
-            getAllowPrerelease: asGetter(() => false),
-            getBinFilesBaseUrl: asGetter(() => '/bin'),
-            getDebugSettings: asGetter(() => ({
-                transports: [],
-                showConnectLogs: false,
-            })),
-            getThpSettings: asGetter(() => ({ pairingMethods: ['CodeEntry'] })),
-            thpHostName: undefined,
-            ...services,
-        },
-    };
     const { actions, dispatch } = createMockDispatch({ getState, extra });
 
     return { actions, dispatch, getState, extra };
 };
 
-beforeEach(() => {
-    testMocks.setTrezorConnectFixtures();
-});
-
-afterEach(() => {
-    jest.restoreAllMocks();
-});
-
-it('uses the injected bin files base URL', async () => {
-    const getBinFilesBaseUrl = jest.fn(() => '/custom-bin-files');
-    const initSpy = jest.spyOn(TrezorConnect, 'init');
-    const { actions, dispatch, getState, extra } = createThunkDeps({
-        getBinFilesBaseUrl: asGetter(getBinFilesBaseUrl),
-    });
+it('dispatches its lifecycle actions', async () => {
+    const { actions, dispatch, getState, extra } = createThunkDeps(
+        connectInitState,
+        connectInitExtra,
+    );
 
     // The first call supplies the thunk payload; the second call runs the returned thunk directly.
     await connectInitThunk()(dispatch, getState, extra);
@@ -343,9 +304,6 @@ it('uses the injected bin files base URL', async () => {
         expect.objectContaining({ type: connectInitThunk.pending.type }),
         expect.objectContaining({ type: connectInitThunk.fulfilled.type }),
     ]);
-    expect(initSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ binFilesBaseUrl: '/custom-bin-files' }),
-    );
 });
 ```
 

--- a/skills/redux/SKILL.md
+++ b/skills/redux/SKILL.md
@@ -216,6 +216,61 @@ await TrezorConnect.init({
 - For async thunks, try to make use of the [lifecycle actions](https://redux-toolkit.js.org/api/createAsyncThunk#promise-lifecycle-actions) whenever it makes sense. For example, when you have an async thunk that fetches something and saves in state. If fetching was not successful, you can explicitly modify the slice state in a relevant way: add an error message, change some status or reset the state (if business logic deems no data better than not-up-to-date data)
 - When using async thunks in effects, cancel the action by calling the [abort() method](https://redux-toolkit.js.org/api/createAsyncThunk#canceling-while-running) in effect cleanup.
 
+### State and dependency contracts
+
+A thunk must describe only the state and injected dependencies that it actually uses. This keeps
+the thunk reusable in every application whose store satisfies that small contract and lets tests
+provide only the relevant state and dependencies.
+
+- Declare a named `<ThunkName>State` type next to every thunk that calls `getState()`. Build it from
+  the smallest domain root-state types accepted by the selectors that the thunk calls. Do not use a
+  full application state or infer the state contract with `Parameters<typeof selector>[0]`.
+- Declare a named `<ThunkName>Deps` type next to every thunk that reads `extra`. Reuse domain-owned
+  dependency contracts and combine them with intersections (`&`) instead of repeating their shape.
+- A parent thunk must include the state and dependency contracts required by every child thunk it
+  dispatches. The parent's store and dependency object must be able to run the whole dispatched
+  chain, not only the first function.
+- Pass `{ state: <ThunkName>State; extra: <ThunkName>Deps }` as the third `createThunk` generic. Omit
+  whichever property the thunk does not need.
+- Pass explicit `void` as the third generic when a thunk needs neither state nor injected
+  dependencies. This is a compile-time guard against accidentally starting to use either one.
+- Let the `createThunk` payload generic type the callback argument. Do not repeat the payload type on
+  a destructured callback parameter.
+- Do not use `ExtraDependencies`, `CustomThunkAPI`, `as any`, or a full dependency mock as a shortcut
+  in feature code or tests.
+
+```ts
+type RefreshAccountThunkState = AccountsRootState & WalletSettingsRootState;
+type RefreshAccountThunkDeps = AnalyticsDep & RefreshAccountTokensThunkDeps;
+
+export const refreshAccountThunk = createThunk<
+    void,
+    RefreshAccountParams,
+    { state: RefreshAccountThunkState; extra: RefreshAccountThunkDeps }
+>(`${actionPrefix}/refreshAccount`, async ({ accountKey }, { dispatch, getState, extra }) => {
+    // The implementation can use only the contract declared above.
+});
+
+export const closeDialogThunk = createThunk<void, CloseDialogParams, void>(
+    `${actionPrefix}/closeDialog`,
+    ({ dialogId }, { dispatch }) => {
+        dispatch(closeDialog(dialogId));
+    },
+);
+```
+
+Global application state and dependency contracts are wiring details. Application code may refer to
+them only in these composition-root files, where the final stores and service graphs are assembled:
+
+- `packages/suite/src/support/extraDependencies.ts`
+- `packages/suite/src/reducers/store.ts`
+- `suite-native/state/src/extraDependencies.ts`
+- `suite-native/state/src/store.ts`
+
+Do not add another exception locally. If a new composition root is necessary, update this allowlist
+and the corresponding architectural enforcement in the same change so the exception remains
+visible and reviewable.
+
 ## Middlewares
 
 Avoid usage of `const state = getState()` because assigning result of `getState()` to variable will create snapshot of state at a given moment and could lead to unintentionally accessing some old version of state. For example:


### PR DESCRIPTION
## Description

Documents the selective thunk state and dependency conventions in the Redux contribution guidance. It covers named minimal contracts, parent/child composition, explicit dependency-free `void`, inferred payload callback types, and disallowed global shortcuts.\n\nAdds a concrete `connectInitThunk` unit-test example showing direct thunk invocation with typed `dispatch`, `getState`, and `extra`, minimal local fixtures, lifecycle-action assertions, nested-thunk handling through `createMockDispatch`, and no configured Redux store. The guidance also defines the four approved desktop and Native composition-root files where global application contracts may be wired.\n\nValidation: `git diff --check`; `yarn prettier --check skills/redux/SKILL.md`.\n\nTracks https://github.com/trezor/trezor-suite/issues/30770.