### PR TITLE
feat(suite-native): introduce earn promo account banners for eth and sol

### DIFF
--- a/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
+++ b/packages/suite/src/components/wallet/WalletLayout/AccountBanners/AccountBanners.tsx
@@ -62,7 +62,7 @@ export const AccountBanners = ({ account }: AccountBannersProps) => {
             <TaprootBanner account={account} />
             <CardanoLegacyBanner account={account} />
             {account?.networkType === 'stellar' && <StellarLimitedHistoryBanner />}
-            {account?.symbol && <StakingBanner account={account} />}
+            {account?.symbol === 'eth' && <StakingBanner account={account} />}
             {account?.symbol && account?.accountType && (
                 <ContextMessage context={Context.getAccount(account.symbol, account.accountType)} />
             )}

--- a/packages/theme/src/typography.ts
+++ b/packages/theme/src/typography.ts
@@ -11,6 +11,7 @@ export const nativeTypographyStyles = [
     'body-md', // 'body',
     'body-sm-strong', // 'callout',
     'body-sm', // 'hint',
+    'body-xs-strong', // 'caption',
     'body-xs', // 'label'
 ] as const;
 
@@ -83,6 +84,12 @@ export const typographyStylesBase: Record<NativeTypographyStyle, TypographyStyle
         fontWeight: fontWeights.medium,
         letterSpacing: -0.08,
     },
+    'body-xs-strong': {
+        fontSize: 12,
+        lineHeight: 16,
+        fontWeight: fontWeights.semiBold,
+        letterSpacing: 0,
+    },
     'body-xs': {
         fontSize: 12,
         lineHeight: 16,
@@ -99,6 +106,7 @@ const nativeFontFamilyStyle = {
     'body-md': 'TTSatoshi-Medium',
     'body-sm-strong': 'TTSatoshi-DemiBold',
     'body-sm': 'TTSatoshi-Medium',
+    'body-xs-strong': 'TTSatoshi-DemiBold',
     'body-xs': 'TTSatoshi-Medium',
 } as const satisfies Record<NativeTypographyStyle, NativeFont>;
 

--- a/suite-native/atoms/src/Button/types.ts
+++ b/suite-native/atoms/src/Button/types.ts
@@ -11,7 +11,7 @@ export type ButtonIntent = (typeof BUTTON_INTENTS)[number];
 export const BUTTON_PRIORITIES = ['primary', 'secondary'] as const;
 export type ButtonPriority = (typeof BUTTON_PRIORITIES)[number];
 
-export const BUTTON_SIZES = ['medium', 'large'] as const;
+export const BUTTON_SIZES = ['small', 'medium', 'large'] as const;
 export type ButtonSize = (typeof BUTTON_SIZES)[number];
 
 /**

--- a/suite-native/atoms/src/Button/utils.ts
+++ b/suite-native/atoms/src/Button/utils.ts
@@ -152,6 +152,11 @@ const backgroundMapPressed = {
 } as const satisfies Record<InverseKey, Record<ButtonPriority, Record<ButtonIntent, Color>>>;
 
 export const buttonSizeToDimensionsMap = {
+    small: {
+        paddingVertical: nativeSpacings.sp2,
+        paddingHorizontal: nativeSpacings.sp12,
+        borderRadius: nativeBorders.radii.r8,
+    },
     medium: {
         paddingVertical: nativeSpacings.sp10,
         paddingHorizontal: nativeSpacings.sp16,
@@ -168,16 +173,19 @@ export const buttonSizeToDimensionsMap = {
 >;
 
 export const buttonGapMap = {
+    small: nativeSpacings.sp2,
     medium: nativeSpacings.sp2,
     large: nativeSpacings.sp4,
 } as const satisfies Record<ButtonSize, number>;
 
 export const buttonToTextSizeMap = {
+    small: 'body-sm-strong',
     medium: 'body-sm-strong',
     large: 'body-md-strong',
 } as const satisfies Record<ButtonSize, TypographyStyle>;
 
 export const buttonToIconSizeMap = {
+    small: 'small',
     medium: 'medium',
     large: 'mediumLarge',
 } as const;
@@ -189,7 +197,7 @@ export const iconButtonToIconSizeMap = {
 } as const satisfies Record<DeprecatedIconButtonSize, (typeof buttonToIconSizeMap)[ButtonSize]>;
 
 export const iconButtonPaddingMap = {
-    small: nativeSpacings.sp6,
+    small: nativeSpacings.sp8,
     medium: nativeSpacings.sp12,
     large: 14,
 } as const satisfies Record<DeprecatedIconButtonSize, number>;

--- a/suite-native/atoms/src/FullAlertBox/FullAlertBox.tsx
+++ b/suite-native/atoms/src/FullAlertBox/FullAlertBox.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren } from 'react';
+import React, { type PropsWithChildren } from 'react';
 
 import { Icon, type IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';

--- a/suite-native/banner-flags/package.json
+++ b/suite-native/banner-flags/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@reduxjs/toolkit": "2.12.0",
+        "@suite-common/wallet-config": "workspace:*",
         "@trezor/connect": "workspace:*"
     }
 }

--- a/suite-native/banner-flags/src/bannerFlagsSlice.ts
+++ b/suite-native/banner-flags/src/bannerFlagsSlice.ts
@@ -1,5 +1,6 @@
 import { type PayloadAction, createSlice } from '@reduxjs/toolkit';
 
+import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { DEVICE } from '@trezor/connect';
 
 export interface BannerFlagsState {
@@ -8,6 +9,7 @@ export interface BannerFlagsState {
     isGetTrezorBannerClosed: boolean; // promo banner on Home dashboard nudging users without a device to the eShop
     areGetTrezorPromoBannersDisabled: boolean; // permanently disabled once a physical device has ever been connected
     isOnboardingFeedbackBannerEnabled: boolean; // feedback banner on Home dashboard shown after completing device onboarding
+    closedEarnBannerSymbols: NetworkSymbol[]; // networks for which the promo earn banner in account view was closed
 }
 
 export type BannerFlagsSliceRootState = {
@@ -20,6 +22,7 @@ export const bannerFlagsInitialState: BannerFlagsState = {
     isGetTrezorBannerClosed: false,
     areGetTrezorPromoBannersDisabled: false,
     isOnboardingFeedbackBannerEnabled: false,
+    closedEarnBannerSymbols: [],
 };
 
 export const bannerFlagsSlice = createSlice({
@@ -37,6 +40,11 @@ export const bannerFlagsSlice = createSlice({
         },
         setIsOnboardingFeedbackBannerEnabled: (state, action: PayloadAction<boolean>) => {
             state.isOnboardingFeedbackBannerEnabled = action.payload;
+        },
+        setIsEarnBannerClosed: (state, action: PayloadAction<NetworkSymbol>) => {
+            if (!state.closedEarnBannerSymbols.includes(action.payload)) {
+                state.closedEarnBannerSymbols.push(action.payload);
+            }
         },
     },
     extraReducers: builder => {
@@ -56,6 +64,7 @@ export const bannerFlagsPersistWhitelist: Array<keyof BannerFlagsState> = [
     'isGetTrezorBannerClosed',
     'areGetTrezorPromoBannersDisabled',
     'isOnboardingFeedbackBannerEnabled',
+    'closedEarnBannerSymbols',
 ];
 
 export const selectIsStellarLimitedHistoryBannerClosed = (state: BannerFlagsSliceRootState) =>
@@ -73,11 +82,15 @@ export const selectAreGetTrezorPromoBannersDisabled = (state: BannerFlagsSliceRo
 export const selectIsOnboardingFeedbackBannerEnabled = (state: BannerFlagsSliceRootState) =>
     state.bannerFlags.isOnboardingFeedbackBannerEnabled;
 
+export const selectIsEarnBannerClosed = (state: BannerFlagsSliceRootState, symbol: NetworkSymbol) =>
+    state.bannerFlags.closedEarnBannerSymbols.includes(symbol);
+
 export const {
     setIsStellarLimitedHistoryBannerClosed,
     setIsSolanaLimitedHistoryBannerClosed,
     setIsGetTrezorBannerClosed,
     setIsOnboardingFeedbackBannerEnabled,
+    setIsEarnBannerClosed,
 } = bannerFlagsSlice.actions;
 
 export const bannerFlagsReducer = bannerFlagsSlice.reducer;

--- a/suite-native/banner-flags/tsconfig.json
+++ b/suite-native/banner-flags/tsconfig.json
@@ -2,6 +2,9 @@
     "extends": "../../tsconfig.base.json",
     "compilerOptions": { "outDir": "libDev" },
     "references": [
+        {
+            "path": "../../suite-common/wallet-config"
+        },
         { "path": "../../packages/connect" }
     ]
 }

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2609,6 +2609,17 @@ export const messages = {
             unstakedTitle: '{amount} {displaySymbol} unstaked instantly',
             claimedTitle: '{amount} {displaySymbol} claimed',
         },
+        promoStakeBanner: {
+            eth: {
+                title: 'Earn up to {apy}% on your ETH',
+                description: 'Stake ETH for network rewards, or deposit it in a yield vault.',
+            },
+            sol: {
+                title: 'Earn ~{apy}% APY by staking your SOL',
+                description: 'Make your SOL work for you. Start staking to earn rewards.',
+            },
+            exploreButton: 'Explore',
+        },
         stakingDetailScreen: {
             title: 'Staking',
         },

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
@@ -15,7 +15,6 @@ const scrollStyle = prepareNativeStyle(() => ({
 const scrollContentStyle = prepareNativeStyle(({ spacings }) => ({
     alignItems: 'flex-start',
     gap: spacings.sp12,
-    paddingHorizontal: spacings.sp16,
     paddingVertical: spacings.sp8,
 }));
 

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountEarnBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountEarnBanner.tsx
@@ -1,0 +1,36 @@
+import { useSelector } from 'react-redux';
+
+import { type Account } from '@suite-common/wallet-types';
+import {
+    type BannerFlagsSliceRootState,
+    selectIsEarnBannerClosed,
+} from '@suite-native/banner-flags';
+
+import { EthEarnBanner } from './EthEarnBanner';
+import { SolEarnBanner } from './SolEarnBanner';
+
+interface AccountEarnBannerProps {
+    account?: Account | null;
+}
+
+export const AccountEarnBanner = ({ account }: AccountEarnBannerProps) => {
+    const symbol = account?.symbol;
+
+    const isClosed = useSelector((state: BannerFlagsSliceRootState) =>
+        symbol !== undefined ? selectIsEarnBannerClosed(state, symbol) : false,
+    );
+
+    if (isClosed) {
+        return null;
+    }
+
+    if (account?.symbol === 'eth') {
+        return <EthEarnBanner account={account} />;
+    }
+
+    if (account?.symbol === 'sol') {
+        return <SolEarnBanner account={account} />;
+    }
+
+    return null;
+};

--- a/suite-native/module-accounts-management/src/components/AccountAssets/EarnBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/EarnBanner.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { Button, FullAlertBox, HStack, IconButton } from '@suite-native/atoms';
+import { setIsEarnBannerClosed } from '@suite-native/banner-flags';
+import { Translation } from '@suite-native/intl';
+import {
+    AppTabsRoutes,
+    EarnStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+
+type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.AppTabs>;
+
+interface EarnBannerProps {
+    symbol: NetworkSymbol;
+    title: ReactNode;
+    description: ReactNode;
+}
+
+export const EarnBanner = ({ symbol, title, description }: EarnBannerProps) => {
+    const navigation = useNavigation<NavigationProp>();
+    const dispatch = useDispatch();
+
+    const onExploreClick = () => {
+        navigation.popTo(RootStackRoutes.AppTabs, {
+            screen: AppTabsRoutes.EarnStack,
+            params: { screen: EarnStackRoutes.Earn },
+        });
+    };
+
+    const onCloseClick = () => {
+        dispatch(setIsEarnBannerClosed(symbol));
+    };
+
+    return (
+        <FullAlertBox
+            iconName="piggyBank"
+            verticalAlignment="center"
+            title={title}
+            description={description}
+            intent="brand"
+        >
+            <HStack marginTop="sp8">
+                <Button intent="brand" size="small" onPress={onExploreClick}>
+                    <Translation id="earn.promoStakeBanner.exploreButton" />
+                </Button>
+
+                <IconButton
+                    intent="brand"
+                    priority="secondary"
+                    size="small"
+                    iconName="x"
+                    onPress={onCloseClick}
+                />
+            </HStack>
+        </FullAlertBox>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/AccountAssets/EthEarnBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/EthEarnBanner.tsx
@@ -1,0 +1,26 @@
+import { Translation } from '@suite-native/intl';
+import { EarnBanner } from './EarnBanner';
+import { useNativeYieldVault, useStakingRate } from '@suite-native/module-earn';
+import { Account } from '@suite-common/wallet-types';
+
+interface EthEarnBannerProps {
+    account: Account;
+}
+
+export const EthEarnBanner = ({ account }: EthEarnBannerProps) => {
+    const nativeYieldVault = useNativeYieldVault({ account });
+    const stakingRate = useStakingRate({ symbol: account.symbol, accountKey: account.key });
+
+    const apy = Math.max(nativeYieldVault.bestVault?.apy ?? 0, stakingRate.rate ?? 0);
+    const apyFormatted = apy.toFixed(2);
+
+    return (
+        <EarnBanner
+            symbol={account.symbol}
+            title={
+                <Translation id="earn.promoStakeBanner.eth.title" values={{ apy: apyFormatted }} />
+            }
+            description={<Translation id="earn.promoStakeBanner.eth.description" />}
+        />
+    );
+};

--- a/suite-native/module-accounts-management/src/components/AccountAssets/SolEarnBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/SolEarnBanner.tsx
@@ -1,0 +1,25 @@
+import { Translation } from '@suite-native/intl';
+import { EarnBanner } from './EarnBanner';
+import { Account } from '@suite-common/wallet-types';
+import { useStakingRate } from '@suite-native/module-earn';
+
+interface SolEarnBannerProps {
+    account: Account;
+}
+
+export const SolEarnBanner = ({ account }: SolEarnBannerProps) => {
+    const stakingRate = useStakingRate({ symbol: account.symbol, accountKey: account.key });
+
+    const apy = stakingRate.rate ?? 0;
+    const apyFormatted = apy.toFixed(2);
+
+    return (
+        <EarnBanner
+            symbol={account.symbol}
+            title={
+                <Translation id="earn.promoStakeBanner.sol.title" values={{ apy: apyFormatted }} />
+            }
+            description={<Translation id="earn.promoStakeBanner.sol.description" />}
+        />
+    );
+};

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -24,6 +24,7 @@ import { AccountAssetsTabBar } from '../components/AccountAssets/AccountAssetsTa
 import { AccountAssetsTabContent } from '../components/AccountAssets/AccountAssetsTabContent';
 import { type AccountAssetsTab } from '../components/AccountAssets/types';
 import { AccountDiscoveryFailedBanner } from '../components/AccountBanners/AccountDiscoveryFailedBanner';
+import { AccountEarnBanner } from '../components/AccountAssets/AccountEarnBanner';
 
 export const AccountAssetsScreen = ({
     route: {
@@ -77,7 +78,9 @@ export const AccountAssetsScreen = ({
             {isFailed ? (
                 <AccountDiscoveryFailedBanner accountKey={accountKey} />
             ) : (
-                <VStack spacing="sp32">
+                <VStack spacing="sp16">
+                    <AccountEarnBanner account={account} />
+
                     <AccountAssetsTabBar
                         activeTab={activeTab}
                         tokenCount={tokenCount}

--- a/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
+++ b/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
@@ -1,0 +1,64 @@
+import { useSelector } from 'react-redux';
+
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsYieldFeatureDisabled,
+} from '@suite-common/message-system';
+import { getNetworkByYieldXyzId, isWrappedNativeToken } from '@suite-common/wallet-config';
+import { getYieldVaultContractAddress, isYieldVaultOperational } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getApyPercent } from '@suite-common/wallet-utils';
+
+import { useMessageSystemYield } from './useMessageSystemYield';
+import { selectBestEnabledYieldVault } from '../selectors';
+
+const emptyVaults: YieldDtoV2[] = [];
+
+interface UseNativeYieldVaultProps {
+    account?: Account;
+}
+
+export const useNativeYieldVault = ({ account }: UseNativeYieldVaultProps) => {
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldOptionRelevant =
+        account?.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+
+    const { data: availableVaults } = useAllYieldOpportunities({
+        enabled: isYieldOptionRelevant,
+    });
+
+    const wrappedNativeVaults = isYieldOptionRelevant
+        ? (availableVaults ?? emptyVaults).filter(
+              vault =>
+                  isYieldVaultOperational(vault) &&
+                  vault.status.enter &&
+                  getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
+                  isWrappedNativeToken(account.symbol, vault.token.address),
+          )
+        : emptyVaults;
+
+    const hasYieldOption = useSelector((state: MessageSystemRootState) =>
+        wrappedNativeVaults.some(
+            vault =>
+                !selectIsYieldFeatureDisabled(
+                    state,
+                    Feature.earn.yield.deposit,
+                    getYieldVaultContractAddress(vault),
+                ),
+        ),
+    );
+
+    const bestVault = useSelector((state: MessageSystemRootState) =>
+        selectBestEnabledYieldVault(state, wrappedNativeVaults),
+    );
+
+    const bestVaultApy = bestVault ? getApyPercent(bestVault.rewardRate.total) : null;
+
+    return {
+        hasYieldOption,
+        bestVault:
+            bestVault && bestVaultApy !== null ? { id: bestVault.id, apy: bestVaultApy } : null,
+    };
+};

--- a/suite-native/module-earn/src/hooks/useStakingRate.tsx
+++ b/suite-native/module-earn/src/hooks/useStakingRate.tsx
@@ -1,0 +1,50 @@
+import { useSelector } from 'react-redux';
+
+import {
+    formatTronApr,
+    getTronVotedApr,
+    useTronStakingStats,
+} from '@suite-common/earn-staking-api';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey } from '@suite-common/wallet-types';
+import { getTronVotes } from '@suite-common/wallet-utils';
+import { selectApy, useSelector as useStakingSelector } from '@suite-native/staking';
+
+interface UseStakingRateProps {
+    symbol?: NetworkSymbol;
+    accountKey?: AccountKey;
+}
+
+export const useStakingRate = ({ symbol, accountKey }: UseStakingRateProps) => {
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+
+    const apy = useStakingSelector(state =>
+        selectApy(state, { networkSymbol: symbol, accountKey }),
+    );
+
+    const { stats, maxApr } = useTronStakingStats({
+        enabled: symbol === 'trx',
+    });
+
+    if (symbol !== 'trx') {
+        return { rate: apy };
+    }
+
+    if (!accountKey || !account) {
+        return { rate: formatTronApr(maxApr) };
+    }
+
+    const votes = getTronVotes(account);
+
+    const votedApr = getTronVotedApr(
+        stats.data,
+        votes.map(({ address }) => address),
+    );
+
+    const apr = votedApr ?? maxApr;
+
+    return { rate: formatTronApr(apr) };
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -2,6 +2,8 @@ export { FiveBinariesHomeBanner } from './components/FiveBinariesHomeBanner';
 export { StablecoinYieldApyBreakdown } from './components/StablecoinYieldApyBreakdown';
 export { useApyBreakdownAlert } from './hooks/useApyBreakdownAlert';
 export { useMessageSystemYield } from './hooks/useMessageSystemYield';
+export { useNativeYieldVault } from './hooks/useNativeYieldVault';
+export { useStakingRate } from './hooks/useStakingRate';
 export { useResolvedYieldFlowData } from './hooks/useResolvedYieldFlowData';
 export { useStablecoinYieldFirmwareUpdateAlert } from './hooks/useStablecoinYieldFirmwareUpdateAlert';
 export { useStakingDetailNavigation } from './hooks/useStakingDetailNavigation';

--- a/suite-native/module-earn/src/selectors.ts
+++ b/suite-native/module-earn/src/selectors.ts
@@ -1,0 +1,40 @@
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import {
+    Feature,
+    type MessageSystemRootState,
+    selectIsYieldFeatureDisabled,
+} from '@suite-common/message-system';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
+import { getApyPercent, isApyAvailable } from '@suite-common/wallet-utils';
+
+const selectIsYieldVaultDepositEnabled = (
+    state: MessageSystemRootState,
+    vault: Pick<YieldDtoV2, 'id' | 'outputToken'>,
+) =>
+    !selectIsYieldFeatureDisabled(
+        state,
+        Feature.earn.yield.deposit,
+        getYieldVaultContractAddress(vault),
+    );
+
+export const selectBestEnabledYieldVault = (
+    state: MessageSystemRootState,
+    vaults: YieldDtoV2[],
+): YieldDtoV2 | null =>
+    vaults.reduce<YieldDtoV2 | null>((best, vault) => {
+        if (!selectIsYieldVaultDepositEnabled(state, vault)) {
+            return best;
+        }
+
+        const vaultApy = getApyPercent(vault.rewardRate.total);
+
+        if (vaultApy === null || !isApyAvailable(vaultApy)) {
+            return best;
+        }
+
+        if (!best) {
+            return vault;
+        }
+
+        return (getApyPercent(best.rewardRate.total) ?? 0) >= vaultApy ? best : vault;
+    }, null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11834,6 +11834,7 @@ __metadata:
   resolution: "@suite-native/banner-flags@workspace:suite-native/banner-flags"
   dependencies:
     "@reduxjs/toolkit": "npm:2.12.0"
+    "@suite-common/wallet-config": "workspace:*"
     "@trezor/connect": "workspace:*"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Introduce earn promo banners for Ethereum and Solana.

## Screenshots:

Ethereum banner:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 16 22 14" src="https://github.com/user-attachments/assets/7139cdfa-5098-451f-a0cf-ede7936de053" />

Solana banner:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 16 22 22" src="https://github.com/user-attachments/assets/9afad98d-31d9-4c78-b081-bbe10e50f407" />

Base with no banner:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 16 22 29" src="https://github.com/user-attachments/assets/4b16b1ae-1548-4226-8aed-44094b1e9dce" />

Solana banner closed (and app refreshed):

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 16 23 15" src="https://github.com/user-attachments/assets/a5c11a3d-412e-4d12-b675-22f0ea54ca7b" />

