### PR TITLE
feat(suite-native): add wrap/unwrap info to how yield works screen

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2972,6 +2972,11 @@ export const messages = {
         howYieldWorksScreen: {
             defiYieldTitle: 'How DeFi Yield works',
             defiYieldSubtitle: 'Put your assets to work and earn rewards.',
+            wrappedNativeVault: {
+                defiYieldTitle: 'How {nativeSymbol} vaults work',
+                defiYieldSubtitle:
+                    'You deposit {nativeSymbol}, other people borrow it, and the interest they pay becomes your earnings.',
+            },
             benefits: {
                 first: {
                     title: 'The deposited amount of {tokenSymbol} is always available.',
@@ -2990,11 +2995,36 @@ export const messages = {
                     title: 'You will also earn {bonusRewardTokenName} tokens as rewards.',
                     description: 'These must be claimed separately.',
                 },
+                wrappedNativeVault: {
+                    first: {
+                        title: 'This vault takes wrapped {nativeSymbol}',
+                        description: 'You can wrap your {nativeSymbol} during the deposit.',
+                    },
+                    second: {
+                        title: 'You put in {nativeSymbol} and get {vaultTokenSymbol} back',
+                        description:
+                            'Your receipt for the position. Value builds up in the position, not in the token count.',
+                    },
+                    third: {
+                        title: 'Return the {vaultTokenSymbol} to withdraw',
+                        description:
+                            'Any time you like. This is how earnings become {nativeSymbol} you can spend.',
+                    },
+                    fourth: {
+                        title: 'Bonus rewards you claim yourself',
+                        description:
+                            '{bonusRewardTokenSymbol} tokens, for a limited time, in the Earn tab.',
+                    },
+                },
             },
             timelineCardTitle: 'Deposit timeline',
             timelineBottomSheetTitle: 'Deposit timeline',
             depositTimelineTitle: 'Deposit',
             depositTimeline: {
+                wrap: {
+                    title: 'Wrap {nativeSymbol} to {tokenSymbol}',
+                    description: 'Network fee',
+                },
                 first: {
                     title: 'Approve spending transaction',
                     description: 'Network fee',
@@ -3012,6 +3042,10 @@ export const messages = {
             withdrawTimeline: {
                 first: {
                     title: 'Sign withdrawal transaction',
+                    description: 'Network fee',
+                },
+                unwrap: {
+                    title: 'Unwrap {tokenSymbol} to {nativeSymbol}',
                     description: 'Network fee',
                 },
                 second: {

--- a/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
@@ -1,5 +1,7 @@
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import {
     BottomSheetModal,
     type BottomSheetModalRef,
@@ -14,7 +16,7 @@ import { Translation } from '@suite-native/intl';
 import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { HowEarnWorksBenefitsSection } from './HowEarnWorks/HowEarnWorksBenefitsSection';
 import { HowEarnWorksTimelineCard } from './HowEarnWorks/HowEarnWorksTimelineCard';
-import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
+import { useHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
 type YieldDepositInfoBottomSheetProps = {
     apy: number | null;
@@ -39,18 +41,33 @@ export const YieldDepositInfoBottomSheet = ({
 }: YieldDepositInfoBottomSheetProps) => {
     const apyBreakdownAlert = useApyBreakdownAlert({ account, vault });
 
-    const { benefitItems, timelineSections } = createHowYieldWorksPreset({
+    const isWrappedNativeVault =
+        !!vault && !!account && isWrappedNativeToken(account.symbol, vault.token.address);
+    const nativeSymbol = account ? getNetworkDisplaySymbol(account.symbol) : null;
+
+    const { benefitItems, timelineSections } = useHowYieldWorksPreset({
         apy,
         onApyPress: apyBreakdownAlert.onPress,
         bonusRewardTokenSymbol,
         tokenSymbol,
         vaultTokenSymbol,
+        isWrappedNativeVault,
+        nativeSymbol,
     });
 
     return (
         <BottomSheetModal
             ref={ref}
-            title={<Translation id="earn.howYieldWorksScreen.defiYieldTitle" />}
+            title={
+                <Translation
+                    id={
+                        isWrappedNativeVault
+                            ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldTitle'
+                            : 'earn.howYieldWorksScreen.defiYieldTitle'
+                    }
+                    values={{ nativeSymbol }}
+                />
+            }
             isCloseDisplayed
             onClose={onClose}
             footer={
@@ -63,7 +80,14 @@ export const YieldDepositInfoBottomSheet = ({
         >
             <VStack spacing="sp32">
                 <Text variant="body-sm" color="contentSecondary">
-                    <Translation id="earn.howYieldWorksScreen.defiYieldSubtitle" />
+                    <Translation
+                        id={
+                            isWrappedNativeVault
+                                ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldSubtitle'
+                                : 'earn.howYieldWorksScreen.defiYieldSubtitle'
+                        }
+                        values={{ nativeSymbol }}
+                    />
                 </Text>
                 <HowEarnWorksBenefitsSection items={benefitItems} />
                 <HowEarnWorksTimelineCard

--- a/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
+
 import { Translation } from '@suite-native/intl';
 import { prepareNativeStyle } from '@trezor/styles-native';
 
-import { type HowEarnWorksScreenPreset } from './types';
+import { type HowEarnWorksScreenPreset, type HowEarnWorksTimelineSectionPreset } from './types';
+import { type HowEarnWorksBenefitItem } from '../../components/HowEarnWorks/HowEarnWorksBenefitsSection';
 
 const abbrStyle = prepareNativeStyle(({ colors }) => ({
     borderStyle: 'dotted',
@@ -9,173 +12,301 @@ const abbrStyle = prepareNativeStyle(({ colors }) => ({
     borderColor: colors.contentSecondary,
 }));
 
-type CreateHowYieldWorksPresetProps = {
+type UseHowYieldWorksPresetProps = {
     tokenSymbol: string;
     vaultTokenSymbol: string;
     apy: number | null;
     onApyPress: () => void;
     bonusRewardTokenSymbol?: string | null;
+    isWrappedNativeVault: boolean;
+    nativeSymbol: string | null;
 };
 
-export const createHowYieldWorksPreset = ({
+export const useHowYieldWorksPreset = ({
     tokenSymbol,
     vaultTokenSymbol,
     apy,
     onApyPress,
     bonusRewardTokenSymbol,
-}: CreateHowYieldWorksPresetProps): HowEarnWorksScreenPreset => ({
-    benefitItems: [
-        {
-            id: 'yield-benefit-lock',
-            icon: 'lock',
-            title: (
-                <Translation
-                    id="earn.howYieldWorksScreen.benefits.first.title"
-                    values={{ tokenSymbol }}
-                />
-            ),
-            description: <Translation id="earn.howYieldWorksScreen.benefits.first.description" />,
-        },
-        {
-            id: 'yield-benefit-rewards',
-            icon: 'trendUp',
-            title: <Translation id="earn.howYieldWorksScreen.benefits.second.title" />,
-            description: <Translation id="earn.howYieldWorksScreen.benefits.second.description" />,
-        },
-        {
-            id: 'yield-benefit-representation',
-            icon: 'coins',
-            title: (
-                <Translation
-                    id="earn.howYieldWorksScreen.benefits.third.title"
-                    values={{ tokenSymbol, vaultTokenSymbol }}
-                />
-            ),
-            description: <Translation id="earn.howYieldWorksScreen.benefits.third.description" />,
-        },
-        ...(bonusRewardTokenSymbol
-            ? [
-                  {
-                      id: 'yield-benefit-bonus-reward',
-                      icon: 'coin' as const,
-                      title: (
-                          <Translation
-                              id="earn.howYieldWorksScreen.benefits.fourth.title"
-                              values={{ bonusRewardTokenSymbol }}
-                          />
-                      ),
-                      description: (
-                          <Translation id="earn.howYieldWorksScreen.benefits.fourth.description" />
-                      ),
-                  },
-              ]
-            : []),
-    ],
-    timelineSections: [
-        {
-            id: 'deposit',
-            title: <Translation id="earn.howYieldWorksScreen.depositTimelineTitle" />,
-            iconName: 'arrowUpRight',
-            items: [
+    isWrappedNativeVault,
+    nativeSymbol,
+}: UseHowYieldWorksPresetProps): HowEarnWorksScreenPreset => {
+    const benefitItems: HowEarnWorksBenefitItem[] = useMemo(() => {
+        if (isWrappedNativeVault) {
+            return [
                 {
-                    id: 'deposit.first',
-                    title: (
-                        <Translation id="earn.howYieldWorksScreen.depositTimeline.first.title" />
-                    ),
-                    description: (
-                        <Translation id="earn.howYieldWorksScreen.depositTimeline.first.description" />
-                    ),
-                },
-                {
-                    id: 'deposit.second',
-                    title: (
-                        <Translation id="earn.howYieldWorksScreen.depositTimeline.second.title" />
-                    ),
-                    description: (
-                        <Translation id="earn.howYieldWorksScreen.depositTimeline.second.description" />
-                    ),
-                },
-                {
-                    id: 'deposit.third',
+                    id: 'yield-benefit-lock',
+                    icon: 'coins',
                     title: (
                         <Translation
-                            id="earn.howYieldWorksScreen.depositTimeline.third.title"
+                            id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.first.title"
+                            values={{ nativeSymbol }}
+                        />
+                    ),
+                    description: (
+                        <Translation
+                            id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.first.description"
+                            values={{ nativeSymbol }}
+                        />
+                    ),
+                },
+                {
+                    id: 'yield-benefit-rewards',
+                    icon: 'coins',
+                    title: (
+                        <Translation
+                            id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.second.title"
+                            values={{ nativeSymbol, vaultTokenSymbol }}
+                        />
+                    ),
+                    description: (
+                        <Translation id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.second.description" />
+                    ),
+                },
+                {
+                    id: 'yield-benefit-representation',
+                    icon: 'lock',
+                    title: (
+                        <Translation
+                            id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.third.title"
                             values={{ vaultTokenSymbol }}
                         />
                     ),
-                    description:
-                        apy !== null ? (
-                            <Translation
-                                id="earn.howYieldWorksScreen.depositTimeline.third.description"
-                                values={{ apy }}
-                            />
-                        ) : (
-                            <Translation id="earn.notAvailableShort" />
-                        ),
-                    style: abbrStyle,
-                    onPress: onApyPress,
-                },
-            ],
-        },
-        {
-            id: 'withdraw',
-            title: <Translation id="earn.howYieldWorksScreen.withdrawTimelineTitle" />,
-            iconName: 'arrowDownLeft',
-            items: [
-                {
-                    id: 'withdraw.first',
-                    title: (
-                        <Translation id="earn.howYieldWorksScreen.withdrawTimeline.first.title" />
-                    ),
                     description: (
-                        <Translation id="earn.howYieldWorksScreen.withdrawTimeline.first.description" />
-                    ),
-                },
-                {
-                    id: 'withdraw.second',
-                    title: (
                         <Translation
-                            id="earn.howYieldWorksScreen.withdrawTimeline.second.title"
-                            values={{ tokenSymbol }}
+                            id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.third.description"
+                            values={{ nativeSymbol }}
                         />
                     ),
-                    description: (
-                        <Translation id="earn.howYieldWorksScreen.withdrawTimeline.second.description" />
-                    ),
                 },
-            ],
-        },
-        ...(bonusRewardTokenSymbol
-            ? [
-                  {
-                      id: 'claim',
-                      title: <Translation id="earn.howYieldWorksScreen.claimTimelineTitle" />,
-                      iconName: 'coins' as const,
-                      items: [
+                ...(bonusRewardTokenSymbol
+                    ? [
                           {
-                              id: 'claim.first',
-                              title: (
-                                  <Translation id="earn.howYieldWorksScreen.claimTimeline.first.title" />
-                              ),
-                              description: (
-                                  <Translation id="earn.howYieldWorksScreen.claimTimeline.first.description" />
-                              ),
-                          },
-                          {
-                              id: 'claim.second',
+                              id: 'yield-benefit-bonus-reward',
+                              icon: 'coins' as const,
                               title: (
                                   <Translation
-                                      id="earn.howYieldWorksScreen.claimTimeline.second.title"
+                                      id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.fourth.title"
                                       values={{ bonusRewardTokenSymbol }}
                                   />
                               ),
                               description: (
-                                  <Translation id="earn.howYieldWorksScreen.claimTimeline.second.description" />
+                                  <Translation id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.fourth.description" />
                               ),
                           },
-                      ],
-                  },
-              ]
-            : []),
-    ],
-});
+                      ]
+                    : []),
+            ];
+        }
+
+        return [
+            {
+                id: 'yield-benefit-lock',
+                icon: 'lock',
+                title: (
+                    <Translation
+                        id="earn.howYieldWorksScreen.benefits.first.title"
+                        values={{ tokenSymbol }}
+                    />
+                ),
+                description: (
+                    <Translation id="earn.howYieldWorksScreen.benefits.first.description" />
+                ),
+            },
+            {
+                id: 'yield-benefit-rewards',
+                icon: 'trendUp',
+                title: <Translation id="earn.howYieldWorksScreen.benefits.second.title" />,
+                description: (
+                    <Translation id="earn.howYieldWorksScreen.benefits.second.description" />
+                ),
+            },
+            {
+                id: 'yield-benefit-representation',
+                icon: 'coins',
+                title: (
+                    <Translation
+                        id="earn.howYieldWorksScreen.benefits.third.title"
+                        values={{ tokenSymbol, vaultTokenSymbol }}
+                    />
+                ),
+                description: (
+                    <Translation id="earn.howYieldWorksScreen.benefits.third.description" />
+                ),
+            },
+            ...(bonusRewardTokenSymbol
+                ? [
+                      {
+                          id: 'yield-benefit-bonus-reward',
+                          icon: 'coin' as const,
+                          title: (
+                              <Translation
+                                  id="earn.howYieldWorksScreen.benefits.fourth.title"
+                                  values={{ bonusRewardTokenSymbol }}
+                              />
+                          ),
+                          description: (
+                              <Translation id="earn.howYieldWorksScreen.benefits.fourth.description" />
+                          ),
+                      },
+                  ]
+                : []),
+        ];
+    }, [isWrappedNativeVault, nativeSymbol, tokenSymbol, vaultTokenSymbol, bonusRewardTokenSymbol]);
+
+    const timelineSections: HowEarnWorksTimelineSectionPreset[] = useMemo(
+        () => [
+            {
+                id: 'deposit',
+                title: <Translation id="earn.howYieldWorksScreen.depositTimelineTitle" />,
+                iconName: 'arrowUpRight',
+                items: [
+                    ...(isWrappedNativeVault
+                        ? [
+                              {
+                                  id: 'deposit.wrap',
+                                  title: (
+                                      <Translation
+                                          id="earn.howYieldWorksScreen.depositTimeline.wrap.title"
+                                          values={{ nativeSymbol, tokenSymbol }}
+                                      />
+                                  ),
+                                  description: (
+                                      <Translation id="earn.howYieldWorksScreen.depositTimeline.wrap.description" />
+                                  ),
+                              },
+                          ]
+                        : []),
+                    {
+                        id: 'deposit.first',
+                        title: (
+                            <Translation id="earn.howYieldWorksScreen.depositTimeline.first.title" />
+                        ),
+                        description: (
+                            <Translation id="earn.howYieldWorksScreen.depositTimeline.first.description" />
+                        ),
+                    },
+                    {
+                        id: 'deposit.second',
+                        title: (
+                            <Translation id="earn.howYieldWorksScreen.depositTimeline.second.title" />
+                        ),
+                        description: (
+                            <Translation id="earn.howYieldWorksScreen.depositTimeline.second.description" />
+                        ),
+                    },
+                    {
+                        id: 'deposit.third',
+                        title: (
+                            <Translation
+                                id="earn.howYieldWorksScreen.depositTimeline.third.title"
+                                values={{ vaultTokenSymbol }}
+                            />
+                        ),
+                        description:
+                            apy !== null ? (
+                                <Translation
+                                    id="earn.howYieldWorksScreen.depositTimeline.third.description"
+                                    values={{ apy }}
+                                />
+                            ) : (
+                                <Translation id="earn.notAvailableShort" />
+                            ),
+                        style: abbrStyle,
+                        onPress: onApyPress,
+                    },
+                ],
+            },
+            {
+                id: 'withdraw',
+                title: <Translation id="earn.howYieldWorksScreen.withdrawTimelineTitle" />,
+                iconName: 'arrowDownLeft',
+                items: [
+                    {
+                        id: 'withdraw.first',
+                        title: (
+                            <Translation id="earn.howYieldWorksScreen.withdrawTimeline.first.title" />
+                        ),
+                        description: (
+                            <Translation id="earn.howYieldWorksScreen.withdrawTimeline.first.description" />
+                        ),
+                    },
+                    ...(isWrappedNativeVault
+                        ? [
+                              {
+                                  id: 'withdraw.unwrap',
+                                  title: (
+                                      <Translation
+                                          id="earn.howYieldWorksScreen.withdrawTimeline.unwrap.title"
+                                          values={{ nativeSymbol, tokenSymbol }}
+                                      />
+                                  ),
+                                  description: (
+                                      <Translation id="earn.howYieldWorksScreen.withdrawTimeline.unwrap.description" />
+                                  ),
+                              },
+                          ]
+                        : []),
+                    {
+                        id: 'withdraw.second',
+                        title: (
+                            <Translation
+                                id="earn.howYieldWorksScreen.withdrawTimeline.second.title"
+                                values={{ tokenSymbol }}
+                            />
+                        ),
+                        description: (
+                            <Translation id="earn.howYieldWorksScreen.withdrawTimeline.second.description" />
+                        ),
+                    },
+                ],
+            },
+            ...(bonusRewardTokenSymbol
+                ? [
+                      {
+                          id: 'claim',
+                          title: <Translation id="earn.howYieldWorksScreen.claimTimelineTitle" />,
+                          iconName: 'coins' as const,
+                          items: [
+                              {
+                                  id: 'claim.first',
+                                  title: (
+                                      <Translation id="earn.howYieldWorksScreen.claimTimeline.first.title" />
+                                  ),
+                                  description: (
+                                      <Translation id="earn.howYieldWorksScreen.claimTimeline.first.description" />
+                                  ),
+                              },
+                              {
+                                  id: 'claim.second',
+                                  title: (
+                                      <Translation
+                                          id="earn.howYieldWorksScreen.claimTimeline.second.title"
+                                          values={{ bonusRewardTokenSymbol }}
+                                      />
+                                  ),
+                                  description: (
+                                      <Translation id="earn.howYieldWorksScreen.claimTimeline.second.description" />
+                                  ),
+                              },
+                          ],
+                      },
+                  ]
+                : []),
+        ],
+        [
+            isWrappedNativeVault,
+            nativeSymbol,
+            tokenSymbol,
+            vaultTokenSymbol,
+            apy,
+            onApyPress,
+            bonusRewardTokenSymbol,
+        ],
+    );
+
+    return {
+        benefitItems,
+        timelineSections,
+    };
+};

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -2,7 +2,9 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
+import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, TimelineDetailsCard, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -22,7 +24,7 @@ import { useApyBreakdownAlert } from '../hooks/useApyBreakdownAlert';
 import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
-import { createHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
+import { useHowYieldWorksPreset } from '../presets/HowEarnWorks/yieldPresets';
 
 type NavigationProps = StackNavigationProps<YieldStackParamList, YieldStackRoutes.HowYieldWorks>;
 
@@ -59,6 +61,10 @@ export const HowYieldWorksScreen = () => {
         variant: depositDisabledVariant,
     } = useMessageSystemYield('deposit', { vaultContractAddress });
 
+    const isWrappedNativeVault =
+        !!vault && !!account && isWrappedNativeToken(account.symbol, vault.token.address);
+    const nativeSymbol = account ? getNetworkDisplaySymbol(account.symbol) : null;
+
     const handleNavigateToYieldConsents = () => {
         analytics.report({
             type: events.yieldNavigateEvent.name,
@@ -86,25 +92,45 @@ export const HowYieldWorksScreen = () => {
         });
     };
 
-    if (resolutionStatus !== 'resolved') {
-        return null;
-    }
-
-    const { benefitItems, timelineSections } = createHowYieldWorksPreset({
-        tokenSymbol,
-        vaultTokenSymbol,
+    const { benefitItems, timelineSections } = useHowYieldWorksPreset({
+        tokenSymbol: tokenSymbol ?? '',
+        vaultTokenSymbol: vaultTokenSymbol ?? '',
         apy,
         onApyPress: apyBreakdownAlert.onPress,
         bonusRewardTokenSymbol,
+        isWrappedNativeVault,
+        nativeSymbol,
     });
+
+    if (resolutionStatus !== 'resolved') {
+        return null;
+    }
 
     return (
         <Screen header={<ScreenHeader closeActionType="back" />}>
             <VStack flex={1} justifyContent="space-between">
                 <VStack alignItems="flex-start" spacing="sp32">
                     <HowEarnWorksHeaderSection
-                        title={<Translation id="earn.howYieldWorksScreen.defiYieldTitle" />}
-                        subtitle={<Translation id="earn.howYieldWorksScreen.defiYieldSubtitle" />}
+                        title={
+                            <Translation
+                                id={
+                                    isWrappedNativeVault
+                                        ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldTitle'
+                                        : 'earn.howYieldWorksScreen.defiYieldTitle'
+                                }
+                                values={{ nativeSymbol }}
+                            />
+                        }
+                        subtitle={
+                            <Translation
+                                id={
+                                    isWrappedNativeVault
+                                        ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldSubtitle'
+                                        : 'earn.howYieldWorksScreen.defiYieldSubtitle'
+                                }
+                                values={{ nativeSymbol }}
+                            />
+                        }
                     />
                     <HowEarnWorksBenefitsSection items={benefitItems} />
                     <HowEarnWorksTimelineCard


### PR DESCRIPTION
## Description

Add info about wrap/unwrap to how yield works screen.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29880

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 40 16" src="https://github.com/user-attachments/assets/87272fe6-9493-4ef0-ac89-ca7d88fc291b" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 40 22" src="https://github.com/user-attachments/assets/294e4597-3d8f-44ba-b6c7-06b8b5507a38" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 43 02" src="https://github.com/user-attachments/assets/f622faef-184d-40c7-a8f3-d665811d1e4a" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 43 09" src="https://github.com/user-attachments/assets/e92c384a-7f50-44a9-9cdc-78c1df358331" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 48 28" src="https://github.com/user-attachments/assets/b2c1db34-4832-463c-b0fb-c945ca5d44ca" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-08 at 17 48 31" src="https://github.com/user-attachments/assets/bd69282c-be95-44e1-83b5-14dd8420b121" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/how-yield-works-weth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->