### PR TITLE
fix(connect): serve trezor-common fixtures via virtual module

### DIFF
--- a/packages/connect/.depcheckrc.json
+++ b/packages/connect/.depcheckrc.json
@@ -8,6 +8,7 @@
         "process",
         "stream-browserify",
         "tsx",
+        "virtual:common-fixtures",
         "virtual:txcache",
         "vm-browserify"
     ]

--- a/packages/connect/e2e/__fixtures__/commonFixtures.ts
+++ b/packages/connect/e2e/__fixtures__/commonFixtures.ts
@@ -1,33 +1,15 @@
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { FIXTURES } from 'virtual:common-fixtures';
 
-/**
- * Firmware ground-truth test vectors live in the `trezor-common` git submodule.
- * That submodule is a read-only export of `trezor-firmware/common`, where the
- * very same vectors drive the firmware device tests, so they are intentionally
- * NOT vendored into this repo — `trezor-firmware` remains their single source of
- * truth. The submodule is only required to actually run the connect e2e suite
- * and is cloned just for that CI job (see template-connect-test-params.yml).
- *
- * To keep type-checking, unit tests and local dev working without the submodule
- * checked out, the vectors are loaded lazily at runtime: when the submodule is
- * present its fixtures are returned, otherwise a loud warning is printed once
- * and an empty fixture is returned so the affected test cases are simply
- * skipped instead of crashing the whole run.
- *
- * Clone with: `git submodule update --init submodules/trezor-common`
- */
+// Firmware test vectors from the `trezor-common` submodule (not vendored). They
+// are injected at build time by `commonFixturesPlugin` (vitest.config.ts) so no
+// `fs` reaches the browser. When the submodule is absent the map is empty and the
+// affected cases are skipped. Clone: `git submodule update --init submodules/trezor-common`.
 
 export interface CommonFixture {
     setup: { mnemonic: string; [key: string]: unknown };
-    // Vectors are firmware ground truth with a per-method shape; consumers pick
-    // the fields they need, so `unknown` keeps them honest without duplicating
-    // every fixture schema here.
+    // Per-method shape; consumers pick the fields they need.
     tests: any[];
 }
-
-// commonFixtures.ts -> __fixtures__ -> e2e -> connect -> packages -> repo root
-const FIXTURES_ROOT = join(__dirname, '../../../../submodules/trezor-common/tests/fixtures');
 
 const EMPTY_FIXTURE: CommonFixture = { setup: { mnemonic: '' }, tests: [] };
 
@@ -53,23 +35,17 @@ const warnSubmoduleMissing = () => {
     );
 };
 
-/** Whether the trezor-common submodule is checked out and its fixtures are usable. */
-export const commonFixturesAvailable = () => existsSync(FIXTURES_ROOT);
+/** Whether the trezor-common submodule is checked out. */
+export const commonFixturesAvailable = () => Object.keys(FIXTURES).length > 0;
 
-/**
- * Lazily load a firmware test-vector file from the trezor-common submodule.
- *
- * @param relativePath path within `trezor-common/tests/fixtures`, e.g. `ethereum/getaddress.json`
- * @returns the parsed fixture, or an empty fixture (and a one-off warning) when
- *          the submodule is not checked out
- */
+/** Load a fixture by its path within `trezor-common/tests/fixtures`, e.g. `ethereum/getaddress.json`. */
 export const loadCommonFixture = (relativePath: string): CommonFixture => {
-    const absolutePath = join(FIXTURES_ROOT, relativePath);
-    if (!existsSync(absolutePath)) {
+    const fixture = FIXTURES[relativePath];
+    if (!fixture) {
         warnSubmoduleMissing();
 
         return EMPTY_FIXTURE;
     }
 
-    return JSON.parse(readFileSync(absolutePath, 'utf8')) as CommonFixture;
+    return fixture;
 };

--- a/packages/connect/e2e/virtual-common-fixtures.d.ts
+++ b/packages/connect/e2e/virtual-common-fixtures.d.ts
@@ -1,0 +1,5 @@
+declare module 'virtual:common-fixtures' {
+    import type { CommonFixture } from './__fixtures__/commonFixtures';
+
+    export const FIXTURES: Record<string, CommonFixture>;
+}

--- a/packages/connect/e2e/vitest.config.ts
+++ b/packages/connect/e2e/vitest.config.ts
@@ -105,6 +105,44 @@ function txCachePlugin(): Plugin {
 }
 
 /**
+ * Serves the trezor-common fixtures as `virtual:common-fixtures` so no `fs` reaches the browser
+ * (see commonFixtures.ts). Walks the fixtures dir at build time into a map keyed by relative path
+ * (e.g. `ethereum/getaddress.json`); empty when the submodule is absent.
+ */
+function commonFixturesPlugin(): Plugin {
+    const virtualModuleId = 'virtual:common-fixtures';
+    const resolvedVirtualModuleId = '\0' + virtualModuleId;
+    const fixturesRoot = path.resolve(e2eDir, '../../../submodules/trezor-common/tests/fixtures');
+
+    const readFixtures = (dir: string, base = '', out: Record<string, unknown> = {}) => {
+        if (!fs.existsSync(dir)) return out;
+        fs.readdirSync(dir, { withFileTypes: true }).forEach(entry => {
+            const absolutePath = path.join(dir, entry.name);
+            const relativePath = base ? `${base}/${entry.name}` : entry.name;
+            if (entry.isDirectory()) {
+                readFixtures(absolutePath, relativePath, out);
+            } else if (entry.name.endsWith('.json')) {
+                out[relativePath] = JSON.parse(fs.readFileSync(absolutePath, 'utf-8'));
+            }
+        });
+
+        return out;
+    };
+
+    return {
+        name: 'common-fixtures',
+        resolveId(id: string) {
+            if (id === virtualModuleId) return resolvedVirtualModuleId;
+        },
+        load(id: string) {
+            if (id === resolvedVirtualModuleId) {
+                return `export const FIXTURES = ${JSON.stringify(readFixtures(fixturesRoot))};`;
+            }
+        },
+    };
+}
+
+/**
  * Vite plugin that transforms coins.json to redirect blockchain_link URLs
  * to the local WS cache server when TESTS_USE_WS_CACHE is enabled.
  */
@@ -223,6 +261,7 @@ export default defineConfig(
                 ],
             },
             plugins: [
+                commonFixturesPlugin(),
                 txCachePlugin(),
                 resolveWorkerUrlsPlugin(),
                 ...(isWebProject

--- a/packages/connect/src/api/ethereum/transformTypedData.test.ts
+++ b/packages/connect/src/api/ethereum/transformTypedData.test.ts
@@ -3,13 +3,20 @@
 // Verifies byte-equivalence of the new viem-backed transformTypedData against
 // the firmware ground-truth fixtures in trezor-common.
 
-import { transformTypedData } from './ethereumSignTypedData';
-import {
-    commonFixturesAvailable,
-    loadCommonFixture,
-} from '../../../e2e/__fixtures__/commonFixtures';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 
-const commonFixtures = loadCommonFixture('ethereum/sign_typed_data.json');
+import { transformTypedData } from './ethereumSignTypedData';
+
+// Node-only parity test: read the vector from the trezor-common submodule directly
+// (no need for the browser `virtual:common-fixtures` loader). Skips when absent.
+const FIXTURE_PATH = join(
+    __dirname,
+    '../../../../../submodules/trezor-common/tests/fixtures/ethereum/sign_typed_data.json',
+);
+const commonFixtures = existsSync(FIXTURE_PATH)
+    ? JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8'))
+    : null;
 
 // fixtures sometimes start with 0x, sometimes not — normalize for comparison
 function messageToHex(string: string) {
@@ -21,7 +28,7 @@ function messageToHex(string: string) {
 const SKIP_FIXTURES = new Set(['array_of_structs', 'injective_testcase']);
 
 describe('transformTypedData (firmware-fixture parity)', () => {
-    if (!commonFixturesAvailable()) {
+    if (!commonFixtures) {
         // trezor-common submodule is not checked out; nothing to verify against.
         it.skip('skipped: trezor-common submodule not checked out', () => {});
 


### PR DESCRIPTION
## Description

The connect e2e fixtures loaded `trezor-common` vectors via Node `fs` at runtime (introduced in #29943), which crashes the browser (chromium) e2e project with *"Module fs has been externalized for browser compatibility."* This serves the fixtures through a `virtual:common-fixtures` module — inlined at build time by a Vite plugin mirroring the existing `virtual:txcache` — so no `fs` reaches the browser while the Node project still works. The `transformTypedData` jest unit test now reads its single vector directly, so it needs no virtual-module bridge and unit tests stay on jest like the rest of the monorepo. Behavior when the submodule is absent is unchanged: the map is empty and the affected cases are skipped with a warning.

## Notes for QA

CI only. Finished run: https://github.com/trezor/trezor-suite/actions/runs/31370865113

## Related Issue

Fixes the e2e regression from #29943

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all internal to the @trezor/connect package (dependency-check config, connect e2e fixture files, and a connect unit test for ethereum typed-data transformation). None of them are referenced by the suite E2E tests in the candidate set, and there is no plausible user-facing Suite flow that would be exercised by these changes. Therefore no suite-level Playwright E2E tests need to be run; validation should happen at the connect package level instead.

<details><summary><b>Changed files (4)</b></summary>

- `packages/connect/.depcheckrc.json`
- `packages/connect/e2e/__fixtures__/commonFixtures.ts`
- `packages/connect/e2e/virtual-common-fixtures.d.ts`
- `packages/connect/src/api/ethereum/transformTypedData.test.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (4)**
- `packages/connect/.depcheckrc.json`
- `packages/connect/e2e/__fixtures__/commonFixtures.ts`
- `packages/connect/e2e/virtual-common-fixtures.d.ts`
- `packages/connect/src/api/ethereum/transformTypedData.test.ts`

_Updated: 2026-08-10T08:02:17.582Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-e2e-fs-externalized/web/](https://dev.suite.sldev.cz/suite-web/fix-e2e-fs-externalized/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-e2e-fs-externalized&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-e2e-fs-externalized&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-e2e-fs-externalized&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:04:51.643Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T08:04:33.715Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->