### PR TITLE
fix(suite-native): communicate weth vault as eth

### DIFF
--- a/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
+++ b/suite-native/module-accounts-management/src/components/StablecoinYieldTokenOverview.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
+import { isNetworkSymbol } from '@suite-common/wallet-config';
 import {
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getYieldVaultContractAddress,
@@ -66,7 +67,7 @@ export const StablecoinYieldTokenOverview = ({
     const { isFirmwareSupported, showFirmwareUpdateAlert } =
         useStablecoinYieldFirmwareUpdateAlert();
     const { analytics } = useServices(selectNativeAnalyticsDep);
-    const { account, apy, resolutionStatus, depositedSharesAmount, vault } =
+    const { account, apy, resolutionStatus, depositedSharesAmount, vault, wrappedNativeSymbol } =
         useResolvedYieldFlowData({
             accountKey,
             tokenContract,
@@ -256,14 +257,23 @@ export const StablecoinYieldTokenOverview = ({
                         {depositedPosition && (
                             <HStack alignItems="center" spacing="sp8">
                                 <TokenIcon
-                                    symbol={depositedPosition.symbol}
+                                    symbol={
+                                        wrappedNativeSymbol !== null &&
+                                        isNetworkSymbol(wrappedNativeSymbol)
+                                            ? wrappedNativeSymbol
+                                            : depositedPosition.symbol
+                                    }
                                     contractAddress={depositedPosition.contractAddress}
                                     size="extraSmall"
                                     showNetworkIcon
                                 />
                                 <TokenAmountFormatter
                                     value={depositedPosition.balance}
-                                    tokenSymbol={depositedPosition.tokenSymbol}
+                                    tokenSymbol={
+                                        wrappedNativeSymbol !== null
+                                            ? toTokenSymbol(wrappedNativeSymbol)
+                                            : depositedPosition.tokenSymbol
+                                    }
                                     color="contentPrimary"
                                     variant="body-sm"
                                 />

--- a/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositInfoBottomSheet.tsx
@@ -27,6 +27,7 @@ type YieldDepositInfoBottomSheetProps = {
     vaultTokenSymbol: string;
     account: Account;
     vault: YieldDtoV2;
+    wrappedNativeSymbol: string | null;
 };
 
 export const YieldDepositInfoBottomSheet = ({
@@ -38,6 +39,7 @@ export const YieldDepositInfoBottomSheet = ({
     vaultTokenSymbol,
     account,
     vault,
+    wrappedNativeSymbol,
 }: YieldDepositInfoBottomSheetProps) => {
     const apyBreakdownAlert = useApyBreakdownAlert({ account, vault });
 
@@ -51,8 +53,7 @@ export const YieldDepositInfoBottomSheet = ({
         bonusRewardTokenSymbol,
         tokenSymbol,
         vaultTokenSymbol,
-        isWrappedNativeVault,
-        nativeSymbol,
+        wrappedNativeSymbol,
     });
 
     return (

--- a/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
+++ b/suite-native/module-earn/src/hooks/useResolvedYieldFlowData.ts
@@ -8,7 +8,11 @@ import {
     getProtocolIncentiveRewardTokens,
     useAllYieldOpportunities,
 } from '@suite-common/earn-stablecoin-api';
-import { getNetworkByYieldXyzId, isWrappedNativeToken } from '@suite-common/wallet-config';
+import {
+    getNetworkByYieldXyzId,
+    getNetworkDisplaySymbol,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
 import {
     type AccountsRootState,
     type YieldFlowDisplayToken,
@@ -46,6 +50,7 @@ type UnresolvedYieldFlowData = {
     vaultTokenName: string | null;
     vaultTokenSymbol: string | null;
     vaultName: string | null;
+    wrappedNativeSymbol: string | null;
 };
 
 type YieldFlowDataResolved = {
@@ -65,6 +70,7 @@ type YieldFlowDataResolved = {
     vaultTokenName: string;
     vaultTokenSymbol: string;
     vaultName: string;
+    wrappedNativeSymbol: string | null;
 };
 
 export type ResolvedYieldFlowData = UnresolvedYieldFlowData | YieldFlowDataResolved;
@@ -95,6 +101,7 @@ const defaultFlowData: ResolvedYieldFlowData = {
     vaultTokenName: null,
     vaultTokenSymbol: null,
     vaultName: null,
+    wrappedNativeSymbol: null,
 };
 
 export const resolveYieldFlowData = ({
@@ -127,6 +134,11 @@ export const resolveYieldFlowData = ({
         return defaultFlowData;
     }
 
+    const isWrappedNativeVault =
+        !!vault && !!account && isWrappedNativeToken(account.symbol, vault.token.address);
+    const nativeSymbol = account ? getNetworkDisplaySymbol(account.symbol) : null;
+    const wrappedNativeSymbol = isWrappedNativeVault && nativeSymbol ? nativeSymbol : null;
+
     const network = getNetworkByYieldXyzId(vault.network);
     const apy = getApyPercent(vault.rewardRate.total);
     const providerName = capitalizeFirstLetter(vault.providerId);
@@ -148,6 +160,7 @@ export const resolveYieldFlowData = ({
         vaultTokenName,
         vaultTokenSymbol,
         vaultName,
+        wrappedNativeSymbol,
     };
 
     if (!network) {

--- a/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/presets/HowEarnWorks/yieldPresets.tsx
@@ -18,8 +18,7 @@ type UseHowYieldWorksPresetProps = {
     apy: number | null;
     onApyPress: () => void;
     bonusRewardTokenSymbol?: string | null;
-    isWrappedNativeVault: boolean;
-    nativeSymbol: string | null;
+    wrappedNativeSymbol: string | null;
 };
 
 export const useHowYieldWorksPreset = ({
@@ -28,11 +27,10 @@ export const useHowYieldWorksPreset = ({
     apy,
     onApyPress,
     bonusRewardTokenSymbol,
-    isWrappedNativeVault,
-    nativeSymbol,
+    wrappedNativeSymbol,
 }: UseHowYieldWorksPresetProps): HowEarnWorksScreenPreset => {
     const benefitItems: HowEarnWorksBenefitItem[] = useMemo(() => {
-        if (isWrappedNativeVault) {
+        if (wrappedNativeSymbol !== null) {
             return [
                 {
                     id: 'yield-benefit-lock',
@@ -40,13 +38,13 @@ export const useHowYieldWorksPreset = ({
                     title: (
                         <Translation
                             id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.first.title"
-                            values={{ nativeSymbol }}
+                            values={{ nativeSymbol: wrappedNativeSymbol }}
                         />
                     ),
                     description: (
                         <Translation
                             id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.first.description"
-                            values={{ nativeSymbol }}
+                            values={{ nativeSymbol: wrappedNativeSymbol }}
                         />
                     ),
                 },
@@ -56,7 +54,7 @@ export const useHowYieldWorksPreset = ({
                     title: (
                         <Translation
                             id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.second.title"
-                            values={{ nativeSymbol, vaultTokenSymbol }}
+                            values={{ nativeSymbol: wrappedNativeSymbol, vaultTokenSymbol }}
                         />
                     ),
                     description: (
@@ -75,7 +73,7 @@ export const useHowYieldWorksPreset = ({
                     description: (
                         <Translation
                             id="earn.howYieldWorksScreen.benefits.wrappedNativeVault.third.description"
-                            values={{ nativeSymbol }}
+                            values={{ nativeSymbol: wrappedNativeSymbol }}
                         />
                     ),
                 },
@@ -152,7 +150,7 @@ export const useHowYieldWorksPreset = ({
                   ]
                 : []),
         ];
-    }, [isWrappedNativeVault, nativeSymbol, tokenSymbol, vaultTokenSymbol, bonusRewardTokenSymbol]);
+    }, [wrappedNativeSymbol, tokenSymbol, vaultTokenSymbol, bonusRewardTokenSymbol]);
 
     const timelineSections: HowEarnWorksTimelineSectionPreset[] = useMemo(
         () => [
@@ -161,14 +159,17 @@ export const useHowYieldWorksPreset = ({
                 title: <Translation id="earn.howYieldWorksScreen.depositTimelineTitle" />,
                 iconName: 'arrowUpRight',
                 items: [
-                    ...(isWrappedNativeVault
+                    ...(wrappedNativeSymbol !== null
                         ? [
                               {
                                   id: 'deposit.wrap',
                                   title: (
                                       <Translation
                                           id="earn.howYieldWorksScreen.depositTimeline.wrap.title"
-                                          values={{ nativeSymbol, tokenSymbol }}
+                                          values={{
+                                              nativeSymbol: wrappedNativeSymbol,
+                                              tokenSymbol,
+                                          }}
                                       />
                                   ),
                                   description: (
@@ -231,14 +232,17 @@ export const useHowYieldWorksPreset = ({
                             <Translation id="earn.howYieldWorksScreen.withdrawTimeline.first.description" />
                         ),
                     },
-                    ...(isWrappedNativeVault
+                    ...(wrappedNativeSymbol !== null
                         ? [
                               {
                                   id: 'withdraw.unwrap',
                                   title: (
                                       <Translation
                                           id="earn.howYieldWorksScreen.withdrawTimeline.unwrap.title"
-                                          values={{ nativeSymbol, tokenSymbol }}
+                                          values={{
+                                              nativeSymbol: wrappedNativeSymbol,
+                                              tokenSymbol,
+                                          }}
                                       />
                                   ),
                                   description: (
@@ -252,7 +256,9 @@ export const useHowYieldWorksPreset = ({
                         title: (
                             <Translation
                                 id="earn.howYieldWorksScreen.withdrawTimeline.second.title"
-                                values={{ tokenSymbol }}
+                                values={{
+                                    tokenSymbol: wrappedNativeSymbol ?? tokenSymbol,
+                                }}
                             />
                         ),
                         description: (
@@ -295,8 +301,7 @@ export const useHowYieldWorksPreset = ({
                 : []),
         ],
         [
-            isWrappedNativeVault,
-            nativeSymbol,
+            wrappedNativeSymbol,
             tokenSymbol,
             vaultTokenSymbol,
             apy,

--- a/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
+++ b/suite-native/module-earn/src/screens/HowYieldWorksScreen.tsx
@@ -2,9 +2,7 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
-import { isWrappedNativeToken } from '@suite-common/wallet-utils';
 import { selectNativeAnalyticsDep } from '@suite-native/analytics';
 import { Button, TimelineDetailsCard, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
@@ -39,6 +37,7 @@ export const HowYieldWorksScreen = () => {
         vaultTokenSymbol,
         bonusRewardTokenSymbol,
         resolutionStatus,
+        wrappedNativeSymbol,
     } = useResolvedYieldFlowData(route.params);
 
     const apyBreakdownAlert = useApyBreakdownAlert({ account, vault });
@@ -60,10 +59,6 @@ export const HowYieldWorksScreen = () => {
         content: depositDisabledContent,
         variant: depositDisabledVariant,
     } = useMessageSystemYield('deposit', { vaultContractAddress });
-
-    const isWrappedNativeVault =
-        !!vault && !!account && isWrappedNativeToken(account.symbol, vault.token.address);
-    const nativeSymbol = account ? getNetworkDisplaySymbol(account.symbol) : null;
 
     const handleNavigateToYieldConsents = () => {
         analytics.report({
@@ -98,8 +93,7 @@ export const HowYieldWorksScreen = () => {
         apy,
         onApyPress: apyBreakdownAlert.onPress,
         bonusRewardTokenSymbol,
-        isWrappedNativeVault,
-        nativeSymbol,
+        wrappedNativeSymbol,
     });
 
     if (resolutionStatus !== 'resolved') {
@@ -114,21 +108,21 @@ export const HowYieldWorksScreen = () => {
                         title={
                             <Translation
                                 id={
-                                    isWrappedNativeVault
+                                    wrappedNativeSymbol !== null
                                         ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldTitle'
                                         : 'earn.howYieldWorksScreen.defiYieldTitle'
                                 }
-                                values={{ nativeSymbol }}
+                                values={{ nativeSymbol: wrappedNativeSymbol }}
                             />
                         }
                         subtitle={
                             <Translation
                                 id={
-                                    isWrappedNativeVault
+                                    wrappedNativeSymbol !== null
                                         ? 'earn.howYieldWorksScreen.wrappedNativeVault.defiYieldSubtitle'
                                         : 'earn.howYieldWorksScreen.defiYieldSubtitle'
                                 }
-                                values={{ nativeSymbol }}
+                                values={{ nativeSymbol: wrappedNativeSymbol }}
                             />
                         }
                     />

--- a/suite-native/module-earn/src/screens/YieldConsentsScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldConsentsScreen.tsx
@@ -27,14 +27,23 @@ type RouteProps = RouteProp<YieldStackParamList, YieldStackRoutes.YieldConsents>
 export const YieldConsentsScreen = () => {
     const { applyStyle } = useNativeStyles();
     const route = useRoute<RouteProps>();
-    const { account, flowData, flowKey, providerName, tokenSymbol, vault, resolutionStatus } =
-        useResolvedYieldFlowData(route.params);
+    const {
+        account,
+        flowData,
+        flowKey,
+        providerName,
+        tokenSymbol,
+        vault,
+        resolutionStatus,
+        wrappedNativeSymbol,
+    } = useResolvedYieldFlowData(route.params);
     const { analytics } = useServices(selectNativeAnalyticsDep);
     const { handleStartYieldDepositFlow, isStartingDepositFlow } = useStartYieldDepositFlow({
         flowData,
         flowKey,
         routeParams: route.params,
     });
+
     const registerNavigateBackAnalytics = useNavigateBackAnalytics({
         type: events.yieldNavigateEvent.name,
         payload: {
@@ -78,7 +87,7 @@ export const YieldConsentsScreen = () => {
                 </Text>
                 <YieldConsentsProviderCard
                     providerName={providerName}
-                    tokenSymbol={tokenSymbol}
+                    tokenSymbol={wrappedNativeSymbol ?? tokenSymbol}
                     onConfirm={handleConfirmConsents}
                     isConfirmLoading={isStartingDepositFlow}
                 />

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -88,6 +88,7 @@ export const YieldDepositApprovalScreen = () => {
         vaultTokenSymbol,
         vaultTokenName,
         resolutionStatus,
+        wrappedNativeSymbol,
     } = resolvedFlowData;
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
@@ -491,6 +492,7 @@ export const YieldDepositApprovalScreen = () => {
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}
                 vault={resolvedFlowData.vault}
+                wrappedNativeSymbol={wrappedNativeSymbol}
             />
             <YieldDepositApprovalLimitBottomSheet
                 ref={approvalLimitBottomSheetRef}

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -93,6 +93,7 @@ export const YieldDepositScreen = () => {
         vaultTokenSymbol,
         vaultTokenName,
         resolutionStatus,
+        wrappedNativeSymbol,
     } = resolvedFlowData;
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
@@ -521,6 +522,7 @@ export const YieldDepositScreen = () => {
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}
                 vault={resolvedFlowData.vault}
+                wrappedNativeSymbol={wrappedNativeSymbol}
             />
             {simulationPreparedAction && (
                 <YieldTxSimulationBottomSheet

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -83,6 +83,7 @@ export const YieldDepositWrapScreen = () => {
         vaultTokenSymbol,
         vaultTokenName,
         resolutionStatus,
+        wrappedNativeSymbol,
     } = resolvedFlowData;
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
@@ -417,6 +418,7 @@ export const YieldDepositWrapScreen = () => {
                 vaultTokenSymbol={vaultTokenSymbol}
                 account={account}
                 vault={vault}
+                wrappedNativeSymbol={wrappedNativeSymbol}
             />
             {simulation.preparedTx && (
                 <YieldTxSimulationBottomSheet

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -131,6 +131,7 @@ export const YieldWithdrawScreen = () => {
         vault,
         vaultTokenSymbol: resolvedVaultTokenSymbol,
         vaultTokenName,
+        wrappedNativeSymbol,
     } = useResolvedYieldFlowData(route.params);
 
     const vaultContractAddress = vault ? getYieldVaultContractAddress(vault) : undefined;
@@ -720,6 +721,7 @@ export const YieldWithdrawScreen = () => {
                 vaultTokenSymbol={resolvedVaultTokenSymbol}
                 account={account}
                 vault={vault}
+                wrappedNativeSymbol={wrappedNativeSymbol}
             />
         </Screen>
     );


### PR DESCRIPTION
## Description

Communicate WETH vaults as ETH.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30984

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-10 at 11 53 42" src="https://github.com/user-attachments/assets/a01c69b2-2742-413c-bace-1f6737e5c2ae" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-10 at 11 53 46" src="https://github.com/user-attachments/assets/c6700f90-4473-4466-b0b4-c7a4aaeeefd1" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-10 at 11 53 50" src="https://github.com/user-attachments/assets/a347fe0b-637c-4d89-9a43-6a899eb6ceaa" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-10 at 11 54 03" src="https://github.com/user-attachments/assets/800ded25-65d5-4ce7-b7f3-9fb93d11c87d" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/communicate-weth-vault-as-eth&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->