### PR TITLE
fix(suite, suite-native): always label failed transactions as failed

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -130,6 +130,10 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
         return <Translation id="TR_UNCONFIRMED_TX_LONG" />;
     }
 
+    if (transaction.type === 'failed') {
+        return <Translation id="TR_FAILED_TRANSACTION" />;
+    }
+
     // WETH wrap/unwrap are shown as their own labels instead of the generic contract-call name
     // ("deposit"/"withdraw") that the indexer parses. The wrapped-token amount isn't obvious from
     // the transaction row, so it's spelled out while the native side stays a bare symbol
@@ -149,7 +153,6 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     if (
         transaction?.ethereumSpecific?.parsedData?.name &&
-        transaction.type !== 'failed' &&
         // Exclude Transfer txs, the default messages are more descriptive
         transaction.ethereumSpecific.parsedData.name !== 'Transfer'
     ) {

--- a/suite-native/transactions/src/components/TransactionName.tsx
+++ b/suite-native/transactions/src/components/TransactionName.tsx
@@ -118,6 +118,14 @@ export const TransactionName = ({ transaction, isPending, variant }: Transaction
     const { isDiscreetMode } = useDiscreetMode();
     const ethName = transaction.ethereumSpecific?.parsedData?.name;
 
+    if (transaction.type === 'failed') {
+        return (
+            <Text variant={variant}>
+                <Translation id="transactions.name.failed" />
+            </Text>
+        );
+    }
+
     // WETH wrap/unwrap get their own label (with the amount) instead of the generic contract-call
     // method name ("deposit"/"withdraw") that the indexer parses.
     const wrapKind = getNativeWrapTxKind(transaction);


### PR DESCRIPTION

## Description

Failed transactions were labeled by a method-derived name — on EVM the contract-method name parsed from calldata (e.g. "Transfer Tokens", "Sweep Token"), on other networks e.g. the Tron contract type — instead of "Failed". A failed transaction now always shows the "Failed" label:

- **suite-native**: `TransactionName` returns the failed label before the wrap/unwrap, Stellar, Tron, stake, and parsed-method branches (previously only `self` was excluded from the parsed-method name). Covers both the transaction list and the detail screen.
- **suite (desktop)**: `TransactionHeader` returns `TR_FAILED_TRANSACTION` early, so failed wrap/unwrap and stake transactions no longer show their method-derived label (the parsed-method branch already excluded failed transactions; that now-redundant condition was removed). Covers the transaction list and the transaction detail modal.

## Notes for QA

- On an EVM account with failed (reverted) transactions, every failed transaction in the list and its detail must be titled "Failed" (localized), matching the prohibit icon — never a contract method name such as "Transfer Tokens"/"Sweep Token", a wrap/unwrap label, or a stake label. Best verified on an EVM account, where reverted transactions are common.
- Pending EVM transactions still show "Unconfirmed"/pending labels; successful contract calls still show their parsed method name; wrap/unwrap and staking labels are unchanged for successful transactions.
- The rule applies to all networks: a failed Tron transaction shows "Failed" instead of its contract-type label (freeze, vote, …).

## Related Issue

Resolve #30740

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The web change targets TransactionHeader, a widely-referenced transaction list component, but only a handful of tests actually assert transaction list header/name rendering. I recommend running the two high-priority tests that exercise output labels and pending transaction status headings, plus a small set of medium-priority transaction-list tests that share the rendering path. The suite-native TransactionName change has no corresponding Playwright coverage in the provided test list, so it remains uncovered.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx`
- `suite-native/transactions/src/components/TransactionName.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test directly adds and edits labels on transaction outputs and asserts the displayed label text in the account transaction list, which is rendered through the TransactionItem/TransactionHeader component path. A regression here would be immediately visible to users relying on labeled transactions.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test verifies pending transaction headings in the transaction list, including self-send, outgoing, and incoming states, all of which are surfaced by the transaction header rendering. Changes to TransactionHeader could break these status labels.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/pagination.test.ts` — The test navigates paginated transaction lists and checks that transaction addresses render correctly on each page. Since TransactionHeader is responsible for displaying transaction targets, a change there could affect how addresses appear in the list.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — It asserts that a pending transaction list shows the OP_RETURN target as 'OP_RETURN (meow)', which depends on how the transaction header formats non-standard targets. This shares the transaction list rendering path with the changed component.
- `suite/e2e/tests/wallet/transactions.test.ts` — This test searches and inspects transaction entries in the account overview, including the latest transaction address. TransactionHeader changes could alter the rendered address or summary text that this test observes.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-native/transactions/src/components/TransactionName.tsx`

_Updated: 2026-08-10T15:22:36.269Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/failed-evm-tx-always-labeled-failed/web/](https://dev.suite.sldev.cz/suite-web/fix/failed-evm-tx-always-labeled-failed/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/failed-evm-tx-always-labeled-failed&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/failed-evm-tx-always-labeled-failed&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/failed-evm-tx-always-labeled-failed&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T15:22:54.880Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T15:23:07.820Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->
