### PR TITLE
feat(suite-native): report mobile performance to Sentry

### DIFF
--- a/suite-native/app/src/App.tsx
+++ b/suite-native/app/src/App.tsx
@@ -19,7 +19,11 @@ import { useFormattersConfig } from '@suite-native/formatters-config';
 import { IntlProvider } from '@suite-native/intl';
 import { KillswitchMessageScreen } from '@suite-native/message-system';
 import { NavigationContainerWithAnalytics } from '@suite-native/navigation';
-import { initSentry } from '@suite-native/sentry';
+import {
+    initSentry,
+    markStartupJsBundleEvaluated,
+    reportStartupAppLoaded,
+} from '@suite-native/sentry';
 import {
     type PreloadedState,
     StoreProvider,
@@ -39,6 +43,8 @@ import { disableRTL } from './rtl';
 // The constant has to be placed at the beginning of this file to be initialized as soon as possible.
 // TODO: This method of measuring app loading time is not ideal, Should be substituted by some more sophisticated solution in the future.
 const APP_STARTED_TIMESTAMP = Date.now();
+
+markStartupJsBundleEvaluated();
 
 if (__DEV__) {
     require('./LogBox');
@@ -79,7 +85,8 @@ const AppComponent = () => {
 
     useEffect(() => {
         if (isAppReady) {
-            SplashScreen.hideAsync();
+            // Report the first usable frame even if the native splash API fails to resolve.
+            void SplashScreen.hideAsync().then(reportStartupAppLoaded, reportStartupAppLoaded);
         }
     }, [isAppReady]);
 

--- a/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
+++ b/suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx
@@ -10,7 +10,11 @@ import { useReactNavigationDevTools } from '@rozenite/react-navigation-plugin';
 
 import { useServices } from '@suite-common/dependency-injection';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { addSentryBreadcrumb, setSentryTag } from '@suite-native/sentry';
+import {
+    addSentryBreadcrumb,
+    registerSentryNavigationContainer,
+    setSentryTag,
+} from '@suite-native/sentry';
 import { useNativeStyles } from '@trezor/styles-native';
 
 import { useReportSendFlowExitToAnalytics } from '../hooks/useReportSendFlowExitToAnalytics';
@@ -55,6 +59,7 @@ export const NavigationContainerWithAnalytics = ({ children }: { children: React
     }, [colors, isDarkColor]);
 
     const handleNavigationReady = () => {
+        registerSentryNavigationContainer(navigationContainerRef);
         routeNameRef.current = navigationContainerRef.getCurrentRoute()?.name;
         if (!isNavigationReady) setIsNavigationReady(true);
     };

--- a/suite-native/sentry/package.json
+++ b/suite-native/sentry/package.json
@@ -15,6 +15,7 @@
         "@sentry/react-native": "8.22.0",
         "@suite-common/sentry": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
-        "@suite-native/config": "workspace:*"
+        "@suite-native/config": "workspace:*",
+        "@suite-native/storage": "workspace:*"
     }
 }

--- a/suite-native/sentry/src/index.ts
+++ b/suite-native/sentry/src/index.ts
@@ -1,2 +1,4 @@
 export * from './sentry';
 export { reportSecurityCheck } from './reportSecurityCheck';
+export { registerSentryNavigationContainer } from './navigationPerformance';
+export { markStartupJsBundleEvaluated, reportStartupAppLoaded } from './startupMetrics';

--- a/suite-native/sentry/src/navigationPerformance.ts
+++ b/suite-native/sentry/src/navigationPerformance.ts
@@ -1,0 +1,60 @@
+import { type TransactionEvent } from '@sentry/core';
+import * as Sentry from '@sentry/react-native';
+
+const allowedNavigationMeasurementNames = new Set([
+    'frames_frozen',
+    'frames_slow',
+    'frames_total',
+    'stall_count',
+    'stall_longest_time',
+    'stall_total_time',
+    'time_to_initial_display',
+]);
+
+type NavigationPerformanceIntegration = ReturnType<typeof Sentry.reactNavigationIntegration>;
+
+let navigationPerformanceIntegration: NavigationPerformanceIntegration | undefined;
+
+export const createNavigationPerformanceIntegration = (): NavigationPerformanceIntegration => {
+    navigationPerformanceIntegration = Sentry.reactNavigationIntegration({
+        enableTimeToInitialDisplay: true,
+        ignoreEmptyBackNavigationTransactions: true,
+        useDispatchedActionData: true,
+    });
+
+    return navigationPerformanceIntegration;
+};
+
+export const registerSentryNavigationContainer = (navigationContainerRef: unknown) => {
+    navigationPerformanceIntegration?.registerNavigationContainer(navigationContainerRef);
+};
+
+export const sanitizeNavigationPerformanceTransaction = (
+    event: TransactionEvent,
+): TransactionEvent | null => {
+    if (event.contexts?.trace?.op !== 'navigation') return null;
+
+    delete event.breadcrumbs;
+    delete event.extra;
+    delete event.request;
+    delete event.spans;
+    delete event.user;
+
+    event.tags = { navigationPerformanceReport: true };
+    event.contexts = {
+        app: event.contexts.app,
+        device: event.contexts.device,
+        os: event.contexts.os,
+        trace: {
+            ...event.contexts.trace,
+            data: {},
+        },
+    };
+    event.measurements = Object.fromEntries(
+        Object.entries(event.measurements ?? {}).filter(([name]) =>
+            allowedNavigationMeasurementNames.has(name),
+        ),
+    );
+
+    return event;
+};

--- a/suite-native/sentry/src/performance.ts
+++ b/suite-native/sentry/src/performance.ts
@@ -1,0 +1,24 @@
+import { type TransactionEvent } from '@sentry/core';
+
+import { sanitizeNavigationPerformanceTransaction } from './navigationPerformance';
+import { getSentryPerformanceEnabledOnAppStart } from './performanceConsent';
+import { sanitizeStartupPerformanceTransaction } from './startupPerformance';
+
+let isPerformanceReportAllowed: boolean | undefined;
+
+export const setPerformanceReportAllowed = (isAllowed: boolean) => {
+    isPerformanceReportAllowed = isAllowed;
+};
+
+export const beforeSendPerformanceTransaction = (
+    event: TransactionEvent,
+): TransactionEvent | null => {
+    if (!getSentryPerformanceEnabledOnAppStart() || isPerformanceReportAllowed !== true) {
+        return null;
+    }
+
+    return (
+        sanitizeStartupPerformanceTransaction(event) ??
+        sanitizeNavigationPerformanceTransaction(event)
+    );
+};

--- a/suite-native/sentry/src/performanceConsent.ts
+++ b/suite-native/sentry/src/performanceConsent.ts
@@ -1,0 +1,18 @@
+import { unecryptedJotaiStorage } from '@suite-native/storage';
+
+const sentryPerformanceConsentKey = 'sentryPerformanceAnalyticsConfirmedAndEnabled';
+
+let isPerformanceEnabledOnAppStart = false;
+
+export const getPersistedSentryPerformanceConsent = () =>
+    unecryptedJotaiStorage.getBoolean(sentryPerformanceConsentKey) === true;
+
+export const setPersistedSentryPerformanceConsent = (isEnabled: boolean) => {
+    unecryptedJotaiStorage.set(sentryPerformanceConsentKey, isEnabled);
+};
+
+export const setSentryPerformanceEnabledOnAppStart = (isEnabled: boolean) => {
+    isPerformanceEnabledOnAppStart = isEnabled;
+};
+
+export const getSentryPerformanceEnabledOnAppStart = () => isPerformanceEnabledOnAppStart;

--- a/suite-native/sentry/src/sentry.ts
+++ b/suite-native/sentry/src/sentry.ts
@@ -2,9 +2,16 @@ import { captureConsoleIntegration } from '@sentry/core';
 import * as Sentry from '@sentry/react-native';
 
 import { ALLOW_REPORT_TAG, redactSentryEvent } from '@suite-common/sentry';
-import { getEnv, isDebugEnv, isDetoxTestBuild } from '@suite-native/config';
+import { getEnv, isDebugEnv, isDetoxTestBuild, isProduction } from '@suite-native/config';
 
 import { ignoreErrors } from './ignoreErrors';
+import { createNavigationPerformanceIntegration } from './navigationPerformance';
+import { beforeSendPerformanceTransaction, setPerformanceReportAllowed } from './performance';
+import {
+    getPersistedSentryPerformanceConsent,
+    setPersistedSentryPerformanceConsent,
+    setSentryPerformanceEnabledOnAppStart,
+} from './performanceConsent';
 
 export const setSentryContext = Sentry.setContext;
 
@@ -20,6 +27,8 @@ export const captureSentryMessage = Sentry.captureMessage;
 
 export const allowSentryReport = (value: boolean) => {
     Sentry.setTag(ALLOW_REPORT_TAG, value);
+    setPerformanceReportAllowed(value);
+    setPersistedSentryPerformanceConsent(value);
 };
 
 export const setSentryUser = (instanceId: string) => {
@@ -27,19 +36,38 @@ export const setSentryUser = (instanceId: string) => {
 };
 
 export const initSentry = () => {
+    const isPerformanceEnabledOnAppStart = getPersistedSentryPerformanceConsent();
+    let performanceTracesSampleRate = 0;
+
+    if (isPerformanceEnabledOnAppStart) {
+        performanceTracesSampleRate = isProduction() ? 0.1 : 1;
+    }
+
+    setSentryPerformanceEnabledOnAppStart(isPerformanceEnabledOnAppStart);
+
     Sentry.init({
         dsn: 'https://d473f56df60c4974ae3f3ce00547c2a9@o117836.ingest.sentry.io/4504214699245568',
         enableAutoSessionTracking: false,
         environment: isDetoxTestBuild() ? 'test' : getEnv(),
         // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
         integrations: defaults => [
-            // remove consoleLoggingIntegration, which sends console.errors as logs
-            ...defaults.filter(i => i.name !== 'ConsoleLogs'),
-            // use this instead, which sends console.errors as error events
+            // Remove consoleLoggingIntegration, which sends console.errors as logs, and
+            // AppStart, which is reported through a manually bounded transaction.
+            ...defaults.filter(i => i.name !== 'ConsoleLogs' && i.name !== 'AppStart'),
+            ...(isPerformanceEnabledOnAppStart ? [createNavigationPerformanceIntegration()] : []),
+            // Use this instead, which sends console.errors as error events.
             captureConsoleIntegration({ levels: ['error'] }),
         ],
+        tracesSampleRate: performanceTracesSampleRate,
+        // Keep auto performance tracing enabled for navigation TTID/native frame/stall measurements;
+        // beforeSendTransaction allowlists which performance transactions may leave the app.
+        enableAutoPerformanceTracing: isPerformanceEnabledOnAppStart,
+        enableNativeFramesTracking: isPerformanceEnabledOnAppStart,
+        enableStallTracking: isPerformanceEnabledOnAppStart,
+        enableUserInteractionTracing: false,
         enableLogs: true,
         beforeSend: redactSentryEvent,
+        beforeSendTransaction: beforeSendPerformanceTransaction,
         ignoreErrors,
 
         // You can put EXPO_PUBLIC_IS_SENTRY_ON_DEBUG_BUILD_ENABLED=true to `.env.development.local` to debug Sentry locally.

--- a/suite-native/sentry/src/startupMetrics.ts
+++ b/suite-native/sentry/src/startupMetrics.ts
@@ -1,0 +1,29 @@
+import { captureStartupPerformanceReport } from './startupPerformance';
+
+let jsBundleEvaluatedAtMs: number | undefined;
+let hasReportedAppLoad = false;
+
+export const markStartupJsBundleEvaluated = () => {
+    if (jsBundleEvaluatedAtMs) return;
+
+    jsBundleEvaluatedAtMs = performance.now();
+};
+
+export const reportStartupAppLoaded = () => {
+    if (hasReportedAppLoad) return;
+
+    if (!jsBundleEvaluatedAtMs) return;
+
+    hasReportedAppLoad = true;
+
+    const endedAtMs = performance.now();
+    const appLoadDurationMs = endedAtMs - jsBundleEvaluatedAtMs;
+
+    captureStartupPerformanceReport({
+        startedAtMs: jsBundleEvaluatedAtMs,
+        endedAtMs,
+        measurements: {
+            appLoad: appLoadDurationMs,
+        },
+    });
+};

--- a/suite-native/sentry/src/startupPerformance.ts
+++ b/suite-native/sentry/src/startupPerformance.ts
@@ -1,0 +1,57 @@
+import { type TransactionEvent } from '@sentry/core';
+import * as Sentry from '@sentry/react-native';
+
+import { getSentryPerformanceEnabledOnAppStart } from './performanceConsent';
+
+type StartupPerformanceReport = {
+    startedAtMs: number;
+    endedAtMs: number;
+    measurements: Record<string, number>;
+};
+
+const appLoadTransactionName = 'Mobile App Load';
+const startupPerformanceReportTag = 'appLoad';
+
+let report: StartupPerformanceReport | undefined;
+
+export const captureStartupPerformanceReport = (startupReport: StartupPerformanceReport) => {
+    if (!getSentryPerformanceEnabledOnAppStart()) return;
+
+    report = startupReport;
+
+    const span = Sentry.startInactiveSpan({
+        forceTransaction: true,
+        name: appLoadTransactionName,
+        op: 'mobile.app_load',
+        startTime: startupReport.startedAtMs / 1000,
+    });
+    span.end(startupReport.endedAtMs / 1000);
+};
+
+export const sanitizeStartupPerformanceTransaction = (
+    event: TransactionEvent,
+): TransactionEvent | null => {
+    if (event.transaction !== appLoadTransactionName || !report) return null;
+
+    delete event.breadcrumbs;
+    delete event.extra;
+    delete event.request;
+    delete event.spans;
+    delete event.user;
+
+    event.tags = { startupPerformanceReport: startupPerformanceReportTag };
+    event.contexts = {
+        app: event.contexts?.app,
+        device: event.contexts?.device,
+        os: event.contexts?.os,
+        trace: event.contexts?.trace,
+    };
+    event.measurements = Object.fromEntries(
+        Object.entries(report.measurements).map(([name, value]) => [
+            `mobile.startup.${name}`,
+            { value, unit: 'millisecond' },
+        ]),
+    );
+
+    return event;
+};

--- a/suite-native/sentry/tsconfig.json
+++ b/suite-native/sentry/tsconfig.json
@@ -6,6 +6,7 @@
         {
             "path": "../../suite-common/suite-types"
         },
-        { "path": "../config" }
+        { "path": "../config" },
+        { "path": "../storage" }
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13750,6 +13750,7 @@ __metadata:
     "@suite-common/sentry": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-native/config": "workspace:*"
+    "@suite-native/storage": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description
Adds a gradual Sentry performance rollout for Suite Native.

- **Mobile App Load** — a manually bounded transaction with one mobile.startup.appLoad measurement (JS bundle eval → first usable frame / splash hide)
- **React Navigation** — screen transactions with Time to Initial Display, plus slow/frozen-frame and JS stall measurements

Performance reporting follows the existing analytics consent flow and is gated by a persisted flag set via `allowSentryReport`. Sentry’s default AppStart integration is removed in favor of the manual startup transaction.

Trace sampling is 10% in production, 100% elsewhere. User interaction tracing, request tracing, and profiling remain disabled.

Note: Performance SDK options are configured at initSentry() from persisted consent, so the first cold start after upgrade (or first opt-in) won’t emit performance data until the next launch. This is expected for the gradual rollout.



## Related issue

Closes #31009

## Screenshots
<img width="1362" height="917" alt="Snímek obrazovky 2026-08-19 v 15 20 28" src="https://github.com/user-attachments/assets/eb8b63e7-02ce-49c4-a81c-2394762e79d4" />
<img width="1364" height="536" alt="Snímek obrazovky 2026-08-19 v 15 20 56" src="https://github.com/user-attachments/assets/465e622d-b0d0-4236-bf07-ef9efb9e693a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in suite-native (React Native mobile app), specifically Sentry integration, startup/navigation performance metrics, and the app entry point. The provided candidate E2E tests are all Playwright-based web/desktop Suite tests and do not exercise any suite-native code paths. Therefore, none of these desktop E2E tests will provide meaningful coverage or regression signal for this change set. Mobile-native E2E tests would be needed instead.

<details><summary><b>Changed files (11)</b></summary>

- `suite-native/app/src/App.tsx`
- `suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx`
- `suite-native/sentry/package.json`
- `suite-native/sentry/src/index.ts`
- `suite-native/sentry/src/navigationPerformance.ts`
- `suite-native/sentry/src/performance.ts`
- `suite-native/sentry/src/performanceConsent.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite-native/sentry/src/startupMetrics.ts`
- `suite-native/sentry/src/startupPerformance.ts`
- `suite-native/sentry/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (11)**
- `suite-native/app/src/App.tsx`
- `suite-native/navigation/src/components/NavigationContainerWithAnalytics.tsx`
- `suite-native/sentry/package.json`
- `suite-native/sentry/src/index.ts`
- `suite-native/sentry/src/navigationPerformance.ts`
- `suite-native/sentry/src/performance.ts`
- `suite-native/sentry/src/performanceConsent.ts`
- `suite-native/sentry/src/sentry.ts`
- `suite-native/sentry/src/startupMetrics.ts`
- `suite-native/sentry/src/startupPerformance.ts`
- `suite-native/sentry/tsconfig.json`

_Updated: 2026-08-20T07:59:17.044Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/local-measurement/web/](https://dev.suite.sldev.cz/suite-web/juriczech/local-measurement/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/local-measurement&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/local-measurement&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T14:39:45.498Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T08:02:22.446Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->