### PR TITLE
fix(connect): translate getPublicKey eth to ethereumGetPublicKey for v9 hosts

### DIFF
--- a/suite-common/connect-popup/src/connectPopupThunks.ts
+++ b/suite-common/connect-popup/src/connectPopupThunks.ts
@@ -86,7 +86,7 @@ export const connectPopupCallThunkInner = createThunk<
     `${CONNECT_POPUP_MODULE}/callThunk`,
     async ({ source, ...params }, { dispatch, getState, extra }) => {
         try {
-            const { method, payload } = compatibilityHooks(params);
+            const { method, payload } = compatibilityHooks({ ...params, source });
 
             if (!connectCallableMethods.includes(method)) throw TypedError('Method_Unsupported');
 

--- a/suite-common/connect-popup/src/methodHooks/composeTransaction.ts
+++ b/suite-common/connect-popup/src/methodHooks/composeTransaction.ts
@@ -1,16 +1,16 @@
 import type { CallMethodKeys } from '@trezor/connect';
 
-import type { CompatibilityHookParams } from './types';
+import type { CompatibilityHookParams, CompatibilityHookResult } from './types';
 
 const compatibilityHook = <M extends CallMethodKeys>({
     method,
     payload,
-}: CompatibilityHookParams<M>): CompatibilityHookParams<M> | undefined => {
+}: CompatibilityHookParams<M>): CompatibilityHookResult<M> | undefined => {
     if (method === 'composeTransaction') {
         return 'account' in payload && payload.account
             ? { method, payload }
             : // Interactive flow of composeTransaction was deprecated in favour of sendTransaction
-              ({ method: 'sendTransaction', payload } as CompatibilityHookParams<M>);
+              ({ method: 'sendTransaction', payload } as CompatibilityHookResult<M>);
     }
 };
 

--- a/suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.test.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.test.ts
@@ -1,0 +1,96 @@
+import { type CallMethodKeys } from '@trezor/connect';
+
+import { ethereumGetPublicKeyCompat } from './ethereumGetPublicKeyCompat';
+import { type CompatibilityHookParams } from './types';
+
+// Only host apps still on `@trezor/connect` 9.x get the compatibility rewrite.
+const v9Source = { manifest: { appName: 'app', npmVersion: '9.4.2' } };
+
+const run = (
+    params: Omit<CompatibilityHookParams<CallMethodKeys>, 'source'>,
+    source: { manifest: { appName: string; npmVersion?: string } } = v9Source,
+) => ethereumGetPublicKeyCompat.compatibilityHook({ ...params, source } as any);
+
+describe('ethereumGetPublicKeyCompat', () => {
+    it('rewrites an ethereum-coin getPublicKey to ethereumGetPublicKey for 9.x callers', () => {
+        const payload = { path: "m/44'/60'/0'/0/0", coin: 'eth' };
+
+        expect(run({ method: 'getPublicKey', payload } as any)).toEqual({
+            method: 'ethereumGetPublicKey',
+            payload,
+        });
+    });
+
+    it('is case-insensitive on the coin symbol', () => {
+        const payload = { path: "m/44'/60'/0'/0/0", coin: 'ETH' };
+
+        expect(run({ method: 'getPublicKey', payload } as any)).toEqual({
+            method: 'ethereumGetPublicKey',
+            payload,
+        });
+    });
+
+    it('leaves the call untouched for non-9.x callers', () => {
+        const payload = { path: "m/44'/60'/0'/0/0", coin: 'eth' };
+        const v10Source = { manifest: { appName: 'app', npmVersion: '10.0.0' } };
+
+        expect(run({ method: 'getPublicKey', payload } as any, v10Source)).toBeUndefined();
+    });
+
+    it('leaves the call untouched when the caller reports no npmVersion', () => {
+        const payload = { path: "m/44'/60'/0'/0/0", coin: 'eth' };
+        const noVersionSource = { manifest: { appName: 'app' } };
+
+        expect(run({ method: 'getPublicKey', payload } as any, noVersionSource)).toBeUndefined();
+    });
+
+    it('leaves bitcoin-coin getPublicKey untouched', () => {
+        expect(
+            run({ method: 'getPublicKey', payload: { path: "m/49'/0'/0'", coin: 'btc' } } as any),
+        ).toBeUndefined();
+    });
+
+    it('leaves a path-only (no coin) getPublicKey untouched', () => {
+        expect(
+            run({ method: 'getPublicKey', payload: { path: "m/49'/0'/0'" } } as any),
+        ).toBeUndefined();
+    });
+
+    it('leaves non-getPublicKey methods untouched', () => {
+        expect(
+            run({
+                method: 'getAddress',
+                payload: { path: "m/44'/60'/0'/0/0", coin: 'eth' },
+            } as any),
+        ).toBeUndefined();
+    });
+
+    it('rewrites a bundle when every batch is an ethereum coin', () => {
+        const payload = {
+            bundle: [
+                { path: "m/44'/60'/0'/0/0", coin: 'eth' },
+                { path: "m/44'/60'/0'/0/1", coin: 'eth' },
+            ],
+        };
+
+        expect(run({ method: 'getPublicKey', payload } as any)).toEqual({
+            method: 'ethereumGetPublicKey',
+            payload,
+        });
+    });
+
+    it('leaves a mixed bundle untouched', () => {
+        const payload = {
+            bundle: [
+                { path: "m/44'/60'/0'/0/0", coin: 'eth' },
+                { path: "m/49'/0'/0'", coin: 'btc' },
+            ],
+        };
+
+        expect(run({ method: 'getPublicKey', payload } as any)).toBeUndefined();
+    });
+
+    it('leaves an empty bundle untouched', () => {
+        expect(run({ method: 'getPublicKey', payload: { bundle: [] } } as any)).toBeUndefined();
+    });
+});

--- a/suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.ts
+++ b/suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.ts
@@ -1,0 +1,41 @@
+import { getNetworkOptional } from '@suite-common/wallet-config';
+import { type CallMethodKeys } from '@trezor/connect';
+
+import { type CompatibilityHookParams, type CompatibilityHookResult } from './types';
+
+const isEthereumCoin = (coin: unknown) =>
+    typeof coin === 'string' && getNetworkOptional(coin.toLowerCase())?.networkType === 'ethereum';
+
+/**
+ * Connect v9 `getPublicKey` accepted non-bitcoin coins (e.g. `coin: "eth"`) and
+ * silently fell back to btc. Connect v10 restricted `getPublicKey` to bitcoin-like
+ * coins (trezor-suite#30276), rejecting such calls with `Method_UnknownCoin`.
+ *
+ * Because the popup runs the v10 implementation, that change also broke host apps
+ * still pinned to a `9.x` version of `@trezor/connect`. For those callers, rewrite an
+ * ethereum-coin `getPublicKey` to `ethereumGetPublicKey`, which derives the network
+ * from the path and returns the same HDNode response shape. Callers on a newer version
+ * are expected to use `ethereumGetPublicKey` directly and are left untouched.
+ */
+const compatibilityHook = <M extends CallMethodKeys>({
+    method,
+    payload,
+    source,
+}: CompatibilityHookParams<M>): CompatibilityHookResult<M> | undefined => {
+    if (method !== 'getPublicKey' || !source.manifest.npmVersion?.startsWith('9.')) {
+        return undefined;
+    }
+
+    // `getPublicKey` accepts either a single request or a `bundle` of them.
+    const isEthereum =
+        'bundle' in payload && Array.isArray(payload.bundle)
+            ? payload.bundle.length > 0 &&
+              payload.bundle.every(batch => isEthereumCoin((batch as { coin?: unknown })?.coin))
+            : isEthereumCoin((payload as { coin?: unknown }).coin);
+
+    if (!isEthereum) return undefined;
+
+    return { method: 'ethereumGetPublicKey', payload } as CompatibilityHookResult<M>;
+};
+
+export const ethereumGetPublicKeyCompat = { compatibilityHook };

--- a/suite-common/connect-popup/src/methodHooks/index.ts
+++ b/suite-common/connect-popup/src/methodHooks/index.ts
@@ -4,11 +4,17 @@ import { addressConfirmationModalHooks } from './addressConfirmation';
 import { bitcoinSignTransaction } from './bitcoinSignTransaction';
 import { cardanoGetPublicKeyCompat } from './cardanoGetPublicKeyCompat';
 import { composeTransaction } from './composeTransaction';
+import { ethereumGetPublicKeyCompat } from './ethereumGetPublicKeyCompat';
 import { ethereumSignTransaction } from './ethereumSignTransaction';
 import { requestLoginHooks } from './requestLogin';
 import { selectAccountHooks } from './selectAccount';
 import { solanaSignTransaction } from './solanaSignTransaction';
-import type { CompatibilityHookParams, PostCallHookParams, PreCallHookParams } from './types';
+import type {
+    CompatibilityHookParams,
+    CompatibilityHookResult,
+    PostCallHookParams,
+    PreCallHookParams,
+} from './types';
 
 /**
  * May change the method and its payload before any other actions,
@@ -16,7 +22,10 @@ import type { CompatibilityHookParams, PostCallHookParams, PreCallHookParams } f
  */
 export const compatibilityHooks = <M extends CallMethodKeys>(
     params: CompatibilityHookParams<M>,
-): CompatibilityHookParams<M> => composeTransaction.compatibilityHook(params) ?? params;
+): CompatibilityHookResult<M> =>
+    composeTransaction.compatibilityHook(params) ??
+    ethereumGetPublicKeyCompat.compatibilityHook(params) ??
+    params;
 
 // Runs before the permissions modal, so a call the host cannot fulfil is rejected up front.
 export const validateCallHooks = <M extends CallMethodKeys>(

--- a/suite-common/connect-popup/src/methodHooks/types.ts
+++ b/suite-common/connect-popup/src/methodHooks/types.ts
@@ -16,7 +16,14 @@ export type DistributiveOmit<T, K extends keyof T> = T extends T ? Omit<T, K> : 
 export type CompatibilityHookParams<M extends CallMethodKeys> = {
     method: M;
     payload: DistributiveOmit<CallMethodParams<M>, 'method'>;
+    source: ConnectCallSource;
 };
+
+// A compatibility hook only rewrites the method/payload; `source` is input-only.
+export type CompatibilityHookResult<M extends CallMethodKeys> = Pick<
+    CompatibilityHookParams<M>,
+    'method' | 'payload'
+>;
 
 export type PreCallHookParams<M extends CallMethodKeys> = {
     method: M;


### PR DESCRIPTION
## Description

Connect v10 restricted `getPublicKey` to bitcoin-like coins (#30276), rejecting e.g. `coin: "eth"` with `Method_UnknownCoin`. Since the popup (in Suite) runs the v10 implementation, that change also broke host apps still pinned to `@trezor/connect` 9.x, which is where the method was actually served from. This adds a compatibility hook (`ethereumGetPublicKeyCompat`, mirroring `cardanoGetPublicKeyCompat`) that, for 9.x callers only, rewrites an ethereum-coin `getPublicKey` into `ethereumGetPublicKey` — which derives the network from the path and returns the same HDNode response shape. To gate on the caller version, `source` is now threaded into `compatibilityHooks` and the return type is split out into `CompatibilityHookResult` (method/payload only).

## Notes for QA

Test `getPublicKey` in Connect Explorer with payload 
```
{
  "path": "m/44'/60'/0'",
  "coin": "eth"
}
```
On v9 it should work, on v10 it should fail. 
Key import flow on Metamask should work.

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the connect-popup package (popup thunks, method hooks, and an ethereumGetPublicKey compat helper). The highest-risk regressions are in TrezorConnect popup flows—permissions, address export, account selection, and transaction signing. Run the focused trezor-connect E2E suite rather than the broad set of tests that only transitively import these shared files.

<details><summary><b>Changed files (6)</b></summary>

- `suite-common/connect-popup/src/connectPopupThunks.ts`
- `suite-common/connect-popup/src/methodHooks/composeTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.test.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`
- `suite-common/connect-popup/src/methodHooks/types.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (9)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Directly exercises the web Connect popup lifecycle (permissions, address confirmation, cancellation, popup reuse), which is driven by connectPopupThunks.ts and the methodHooks entry point.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Validates Ethereum transaction signing through the Connect popup, a path likely to invoke the composeTransaction method hook for transaction pre-composition.
- `suite/e2e/tests/trezor-connect/getAccountInfo.test.ts` — Covers the account selection/permissions flow for Connect calls, relying on connectPopupThunks.ts and the methodHooks orchestration.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Exercises Bitcoin address export via the Connect popup, including permissions, address confirmation and verification states controlled by the popup thunks.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Focused on Connect permission granting, remembering and revocation flows that are implemented in connectPopupThunks.ts and surfaced through the popup.
- `suite/e2e/tests/trezor-connect/selectAccount.test.ts` — Tests the Connect account selection modal and on-device verification, which depend on connectPopupThunks.ts and method hook integration.
- `suite/e2e/tests/trezor-connect/signTransaction.test.ts` — Validates Bitcoin transaction signing via TrezorConnect, a flow that uses the composeTransaction method hook and popup thunk orchestration.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Directly tests the silent-mode permission behavior managed by connectPopupThunks.ts, including subsequent Connect calls and focus handling.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Exercises the upfront declared permissions feature implemented in connectPopupThunks.ts, ensuring batch permission grants work across multiple coins.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — Tests Connect popup behavior from a webextension context, sharing the same popup lifecycle and permission logic as the web flow but in a different host environment.
- `suite/e2e/tests/trezor-connect/ethereumSignMessage.test.ts` — Uses the Connect popup permissions and signing flow; while it does not exercise transaction composition, it shares the popup thunk infrastructure and device prompt handling.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.test.ts`
- `suite-common/connect-popup/src/methodHooks/ethereumGetPublicKeyCompat.ts`
- `suite-common/connect-popup/src/methodHooks/types.ts`

_Updated: 2026-08-10T12:25:50.727Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/ethereum-getpublickey-compat-hook/web/](https://dev.suite.sldev.cz/suite-web/ethereum-getpublickey-compat-hook/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=ethereum-getpublickey-compat-hook&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=ethereum-getpublickey-compat-hook&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=ethereum-getpublickey-compat-hook&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-10T12:28:00.684Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-10T12:28:09.923Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->