### PR TITLE
fix(suite-native): account list filter badge overflow

### DIFF
--- a/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
+++ b/suite-native/accounts/src/components/SearchableAccountsListHeader.tsx
@@ -33,6 +33,7 @@ const HEADER_ANIMATION_DURATION = 100;
 
 const searchFormContainerStyle = prepareNativeStyle(({ spacings }) => ({
     marginBottom: spacings.sp8,
+    paddingTop: spacings.sp16,
 }));
 
 export const SearchableAccountsListHeader = ({

--- a/suite-native/atoms/src/Input/Input.tsx
+++ b/suite-native/atoms/src/Input/Input.tsx
@@ -107,14 +107,12 @@ const inputWrapperStyle = prepareNativeStyle<InputWrapperStyleProps>(
                 condition: hasWarning,
                 style: {
                     borderColor: utils.colors.borderWarning,
-                    borderWidth: utils.borders.widths.large,
                 },
             },
             {
                 condition: hasError,
                 style: {
                     borderColor: utils.colors.elementBorderFieldError,
-                    backgroundColor: utils.colors.borderCritical,
                 },
             },
         ],

--- a/suite-native/atoms/src/ScreenHeaderWrapper.tsx
+++ b/suite-native/atoms/src/ScreenHeaderWrapper.tsx
@@ -7,26 +7,32 @@ import { Box, type BoxProps } from './Box';
 
 type ScreenHeaderWrapperProps = {
     children: ReactNode;
+    noBottomPadding?: boolean;
 } & BoxProps;
 
-const screenHeaderWrapperStyle = prepareNativeStyle<{ insets: EdgeInsets }>(
-    (utils, { insets }) => ({
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        paddingLeft: Math.max(insets.left, utils.spacings.sp16),
-        paddingRight: Math.max(insets.right, utils.spacings.sp16),
-        paddingTop: utils.spacings.sp8,
-        paddingBottom: utils.spacings.sp16,
-    }),
-);
+const screenHeaderWrapperStyle = prepareNativeStyle<{
+    insets: EdgeInsets;
+    noBottomPadding: boolean;
+}>((utils, { insets, noBottomPadding }) => ({
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingLeft: Math.max(insets.left, utils.spacings.sp16),
+    paddingRight: Math.max(insets.right, utils.spacings.sp16),
+    paddingTop: utils.spacings.sp8,
+    paddingBottom: noBottomPadding ? 0 : utils.spacings.sp16,
+}));
 
-export const ScreenHeaderWrapper = ({ children, ...rest }: ScreenHeaderWrapperProps) => {
+export const ScreenHeaderWrapper = ({
+    children,
+    noBottomPadding = false,
+    ...rest
+}: ScreenHeaderWrapperProps) => {
     const { applyStyle } = useNativeStyles();
     const insets = useSafeAreaInsets();
 
     return (
-        <Box style={applyStyle(screenHeaderWrapperStyle, { insets })} {...rest}>
+        <Box style={applyStyle(screenHeaderWrapperStyle, { insets, noBottomPadding })} {...rest}>
             {children}
         </Box>
     );

--- a/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
@@ -7,12 +7,18 @@ import { FeatureFlag, useFeatureFlag } from '@suite-native/feature-flags';
 
 import { DeviceManager } from './DeviceManager';
 
-export const DeviceManagerScreenHeader = () => {
+type DeviceManagerScreenHeaderProps = {
+    noBottomPadding?: boolean;
+};
+
+export const DeviceManagerScreenHeader = ({
+    noBottomPadding,
+}: DeviceManagerScreenHeaderProps = {}) => {
     const isActivityCenterEnabled = useFeatureFlag(FeatureFlag.IsActivityCenterEnabled);
     const hasUnseenNotifications = useSelector(selectHasUnseenNotifications);
 
     return (
-        <ScreenHeaderWrapper>
+        <ScreenHeaderWrapper noBottomPadding={noBottomPadding}>
             <HStack spacing="sp12">
                 <DeviceManager />
                 {isActivityCenterEnabled && (

--- a/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountsScreen.tsx
@@ -42,7 +42,8 @@ export const AccountsScreen = ({ navigation, route }: ScreenNavigationProps) => 
     };
 
     return (
-        <Screen header={<DeviceManagerScreenHeader />}>
+        // noBottomPadding: SearchableAccountsListHeader owns the top spacing to accommodate filter badge overflow.
+        <Screen header={<DeviceManagerScreenHeader noBottomPadding />}>
             <AccountsListWithFilter
                 title={<Translation id="moduleAccountManagement.accountsScreen.title" />}
                 onSelectAccount={handleSelectAccount}


### PR DESCRIPTION
## Description
Fixes two minor UI glitcher
1. input with error background
2. overflow cutoff of the account list filter badge

## Screenshots:

<table>
<tr>
 <td> BEFORE
 <td> AFTER
<tr>
 <td>  <img width="409" height="876" alt="image" src="https://github.com/user-attachments/assets/2b13c089-907b-4acf-90b2-af49c53a930a" />
<td> <img width="409" height="876" alt="Screenshot 2026-08-10 at 13 46 21" src="https://github.com/user-attachments/assets/63e47a5b-83a1-479a-9a98-4a7a5b2c01bb" />



<tr>
 <td> <img width="409" height="876" alt="image" src="https://github.com/user-attachments/assets/b695879a-8ee1-49d8-96e5-dade46cba40b" />
 <td> <img width="409" height="876" alt="Screenshot 2026-08-10 at 13 45 54" src="https://github.com/user-attachments/assets/c4d1c0e7-ca39-4a2a-9b11-4848b59b1280" />

</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/suite-native/color-and-spacing-discrepancies&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->