### PR TITLE
feat(suite-native): token yield badge

### DIFF
--- a/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type AccountsRootState, selectFormattedAccountType } from '@suite-common/wallet-core';
@@ -16,6 +16,8 @@ import { Translation } from '@suite-native/intl';
 import { type NativeStakingRootState, selectAccountHasStaking } from '@suite-native/staking';
 import { isNetworkWithTokens } from '@suite-native/tokens';
 
+import { AccountsListItemBase } from './AccountsListItemBase';
+import { StakingBadge } from './StakingBadge';
 import {
     type NativeAccountsRootState,
     selectAccountFiatBalance,
@@ -23,8 +25,6 @@ import {
 } from '../../selectors';
 import { type OnSelectAccount } from '../../types';
 import { AccountLabel } from '../AccountLabel';
-import { AccountsListItemBase } from './AccountsListItemBase';
-import { StakingBadge } from './StakingBadge';
 
 type AccountListItemProps = {
     account: Account;
@@ -35,6 +35,7 @@ type AccountListItemProps = {
     isFirst?: boolean;
     isLast?: boolean;
     showDivider?: boolean;
+    badges?: React.ReactNode;
 };
 
 const TokenBadge = React.memo(({ accountKey }: { accountKey: AccountKey }) => {
@@ -59,6 +60,7 @@ const AccountsListItemComponent = ({
     isFirst = false,
     isLast = false,
     showDivider = false,
+    badges,
 }: AccountListItemProps) => {
     const formattedAccountType = useSelector((state: AccountsRootState) =>
         selectFormattedAccountType(state, account.key),
@@ -82,11 +84,6 @@ const AccountsListItemComponent = ({
         });
     }, [account, accountHasKnownTokensWithBalance, onPress]);
 
-    const icon = useMemo(
-        () => <TokenIcon symbol={account.symbol} showNetworkIcon={isNativeCoinOnly} />,
-        [account.symbol, isNativeCoinOnly],
-    );
-
     const isNetworkSupportingTokens = isNetworkWithTokens(account.symbol);
     const shouldShowAccountLabel = !isNetworkSupportingTokens || !isNativeCoinOnly;
     const shouldShowTokenBadge = accountHasKnownTokensWithBalance && !isNativeCoinOnly;
@@ -105,15 +102,6 @@ const AccountsListItemComponent = ({
                 symbol={account.symbol}
             />
         );
-    const cryptoBalanceValue = (
-        <CryptoAmountFormatter
-            value={account.formattedBalance}
-            symbol={account.symbol}
-            numberOfLines={1}
-            adjustsFontSizeToFit
-        />
-    );
-
     const isFailed = isAccountFailed(account);
 
     const title = shouldShowAccountLabel ? (
@@ -130,7 +118,7 @@ const AccountsListItemComponent = ({
             showDivider={showDivider}
             onPress={handleOnPress}
             disabled={disabled}
-            icon={icon}
+            icon={<TokenIcon symbol={account.symbol} showNetworkIcon={isNativeCoinOnly} />}
             title={title}
             titleBadge={
                 !isNativeCoinOnly && formattedAccountType ? (
@@ -143,6 +131,7 @@ const AccountsListItemComponent = ({
                         <StakingBadge networkSymbol={account.symbol} account={account} />
                     )}
                     {shouldShowTokenBadge && <TokenBadge accountKey={account.key} />}
+                    {badges}
                 </>
             }
             mainValue={
@@ -152,7 +141,16 @@ const AccountsListItemComponent = ({
                     fiatBalanceValue
                 )
             }
-            secondaryValue={isFailed ? undefined : cryptoBalanceValue}
+            secondaryValue={
+                isFailed ? undefined : (
+                    <CryptoAmountFormatter
+                        value={account.formattedBalance}
+                        symbol={account.symbol}
+                        numberOfLines={1}
+                        adjustsFontSizeToFit
+                    />
+                )
+            }
         />
     );
 };

--- a/suite-native/accounts/src/components/AccountsList/AccountsListTokenItem.tsx
+++ b/suite-native/accounts/src/components/AccountsList/AccountsListTokenItem.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type Account, type TokenInfoBranded } from '@suite-common/wallet-types';
@@ -12,6 +13,7 @@ type AccountListTokenItemProps = {
     account: Account;
     onSelectAccount: () => void;
 
+    badges?: ReactNode;
     hasBackground?: boolean;
     isFirst?: boolean;
     isLast?: boolean;
@@ -22,6 +24,7 @@ export const AccountsListTokenItem = ({
     token,
     account,
     onSelectAccount,
+    badges,
     hasBackground,
     isFirst,
     isLast,
@@ -46,6 +49,7 @@ export const AccountsListTokenItem = ({
                 />
             }
             title={getTokenName(token.name)}
+            badges={badges}
             mainValue={
                 showFiatValue && (
                     <TokenToFiatAmountFormatter

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3497,6 +3497,14 @@ export const messages = {
         aprPercentage: '~{apy}% APR',
         ratePercentage: '~{apy}% Rate',
         notAvailableShort: 'N/A',
+        yieldRateBadge: {
+            apy: '{value}% APY',
+            apr: '{value}% APR',
+            rate: '{value}% Rate',
+            upToApy: 'up to {value}% APY',
+            upToApr: 'up to {value}% APR',
+            upToRate: 'up to {value}% Rate',
+        },
         messageSystem: {
             depositDisabled: 'Deposits currently disabled.',
             withdrawDisabled: 'Withdrawals currently disabled.',

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ActiveTokensTab.tsx
@@ -12,7 +12,7 @@ import {
     type OnSelectAccount,
     selectAccountListSectionsWithZeroBalanceGroup,
 } from '@suite-native/accounts';
-import { useStakingDetailNavigation } from '@suite-native/module-earn';
+import { TokenYieldRateBadge, useStakingDetailNavigation } from '@suite-native/module-earn';
 
 import { ZeroBalanceTokensSection } from './ZeroBalanceTokensSection';
 import { type OnSelectAsset } from './types';
@@ -81,6 +81,9 @@ export const ActiveTokensTab = ({
                             hasBackground
                             showDivider
                             onPress={handleSelectAccount}
+                            badges={
+                                <TokenYieldRateBadge account={item.account} variant="inactive" />
+                            }
                         />
                     );
                 case 'staking':
@@ -102,6 +105,13 @@ export const ActiveTokensTab = ({
                         <AccountsListTokenItem
                             {...item}
                             hasBackground
+                            badges={
+                                <TokenYieldRateBadge
+                                    account={item.account}
+                                    token={item.token}
+                                    variant="inactive"
+                                />
+                            }
                             onSelectAccount={() =>
                                 handleSelectAccount({
                                     account: item.account,

--- a/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
@@ -11,6 +11,7 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
+import { TokenYieldRateBadge } from '@suite-native/module-earn';
 
 import { type OnSelectAsset } from './types';
 
@@ -55,6 +56,9 @@ export const DefiTokensTab = ({ accountKey, onSelect }: DefiTokensTabProps) => {
                 hasBackground
                 isFirst={item.isFirst}
                 isLast={item.isLast}
+                badges={
+                    <TokenYieldRateBadge account={account!} token={item.token} variant="active" />
+                }
                 onSelectAccount={() =>
                     onSelect({ tokenContract: item.token.contract, tokenSymbol: item.token.symbol })
                 }

--- a/suite-native/module-accounts-management/src/components/AccountAssets/ZeroBalanceTokensSection.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/ZeroBalanceTokensSection.tsx
@@ -6,6 +6,7 @@ import { AccountsListTokenItem } from '@suite-native/accounts';
 import { AccordionContent, AnimatedBox, PressableOpacity, Text } from '@suite-native/atoms';
 import { Icon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
+import { TokenYieldRateBadge } from '@suite-native/module-earn';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { type OnSelectAsset } from './types';
@@ -77,6 +78,13 @@ export const ZeroBalanceTokensSection = ({
                         isFirst={false}
                         isLast={index === tokens.length - 1}
                         showFiatValue={false}
+                        badges={
+                            <TokenYieldRateBadge
+                                account={account}
+                                token={token}
+                                variant="inactive"
+                            />
+                        }
                         onSelectAccount={() =>
                             onSelect({ tokenContract: token.contract, tokenSymbol: token.symbol })
                         }

--- a/suite-native/module-earn/src/components/TokenYieldRateBadge.tsx
+++ b/suite-native/module-earn/src/components/TokenYieldRateBadge.tsx
@@ -1,0 +1,54 @@
+import { type Account } from '@suite-common/wallet-types';
+import { HStack, Text } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { Translation, type TxKeyPath } from '@suite-native/intl';
+
+import {
+    type TokenYieldRateToken,
+    type TokenYieldRateVariant,
+    useTokenYieldRate,
+} from '../hooks/useTokenYieldRate';
+import { type YieldRateLabelType } from '../utils/getYieldRateLabelType';
+
+const translationIds: Record<TokenYieldRateVariant, Record<YieldRateLabelType, TxKeyPath>> = {
+    inactive: {
+        apy: 'earn.yieldRateBadge.upToApy',
+        apr: 'earn.yieldRateBadge.upToApr',
+        rate: 'earn.yieldRateBadge.upToRate',
+    },
+    active: {
+        apy: 'earn.yieldRateBadge.apy',
+        apr: 'earn.yieldRateBadge.apr',
+        rate: 'earn.yieldRateBadge.rate',
+    },
+};
+
+type TokenYieldRateBadgeProps = {
+    account: Account;
+    /** Native-coin rows pass no token — the rate of wrapped-native vaults is shown. */
+    token?: TokenYieldRateToken;
+    variant: TokenYieldRateVariant;
+};
+
+/** Rate of the best yield vault a token row can earn with, e.g. `up to 6.42% APY`. */
+export const TokenYieldRateBadge = ({ account, token, variant }: TokenYieldRateBadgeProps) => {
+    const yieldRate = useTokenYieldRate({ account, token, variant });
+
+    if (!yieldRate) {
+        return null;
+    }
+
+    const color = variant === 'active' ? 'borderOnDarkBrand' : 'contentBrand';
+
+    return (
+        <HStack spacing="sp8" alignItems="center" testID="@accountList/item/yieldRateBadge">
+            {variant === 'active' && <Icon name="trendUp" size="medium" color={color} />}
+            <Text variant="body-sm" color={color}>
+                <Translation
+                    id={translationIds[variant][yieldRate.labelType]}
+                    values={{ value: yieldRate.apy }}
+                />
+            </Text>
+        </HStack>
+    );
+};

--- a/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
+++ b/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
@@ -30,15 +30,17 @@ export const useNativeYieldVault = ({ account }: UseNativeYieldVaultProps) => {
         enabled: isYieldOptionRelevant,
     });
 
+    const networkSymbol = account?.symbol;
+
     const wrappedNativeVaults = useMemo(
         () =>
-            isYieldOptionRelevant
+            isYieldOptionRelevant && networkSymbol !== undefined
                 ? getWrappedNativeYieldVaults({
                       vaults: availableVaults,
-                      networkSymbol: account.symbol,
+                      networkSymbol,
                   })
                 : emptyVaults,
-        [account?.symbol, availableVaults, isYieldOptionRelevant],
+        [availableVaults, isYieldOptionRelevant, networkSymbol],
     );
 
     const hasYieldOption = useSelector((state: MessageSystemRootState) =>

--- a/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
+++ b/suite-native/module-earn/src/hooks/useNativeYieldVault.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
@@ -6,13 +7,13 @@ import {
     type MessageSystemRootState,
     selectIsYieldFeatureDisabled,
 } from '@suite-common/message-system';
-import { getNetworkByYieldXyzId, isWrappedNativeToken } from '@suite-common/wallet-config';
-import { getYieldVaultContractAddress, isYieldVaultOperational } from '@suite-common/wallet-core';
+import { getYieldVaultContractAddress } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent } from '@suite-common/wallet-utils';
 
 import { useMessageSystemYield } from './useMessageSystemYield';
 import { selectBestEnabledYieldVault } from '../selectors';
+import { getWrappedNativeYieldVaults } from '../utils/getWrappedNativeYieldVaults';
 
 const emptyVaults: YieldDtoV2[] = [];
 
@@ -29,15 +30,16 @@ export const useNativeYieldVault = ({ account }: UseNativeYieldVaultProps) => {
         enabled: isYieldOptionRelevant,
     });
 
-    const wrappedNativeVaults = isYieldOptionRelevant
-        ? (availableVaults ?? emptyVaults).filter(
-              vault =>
-                  isYieldVaultOperational(vault) &&
-                  vault.status.enter &&
-                  getNetworkByYieldXyzId(vault.network)?.symbol === account.symbol &&
-                  isWrappedNativeToken(account.symbol, vault.token.address),
-          )
-        : emptyVaults;
+    const wrappedNativeVaults = useMemo(
+        () =>
+            isYieldOptionRelevant
+                ? getWrappedNativeYieldVaults({
+                      vaults: availableVaults,
+                      networkSymbol: account.symbol,
+                  })
+                : emptyVaults,
+        [account?.symbol, availableVaults, isYieldOptionRelevant],
+    );
 
     const hasYieldOption = useSelector((state: MessageSystemRootState) =>
         wrappedNativeVaults.some(

--- a/suite-native/module-earn/src/hooks/useTokenYieldRate.ts
+++ b/suite-native/module-earn/src/hooks/useTokenYieldRate.ts
@@ -1,0 +1,117 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { type YieldDtoV2, useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
+import { type MessageSystemRootState } from '@suite-common/message-system';
+import {
+    getYieldVaultForOutputToken,
+    getYieldVaultsForInputToken,
+} from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { getApyPercent } from '@suite-common/wallet-utils';
+
+import { useMessageSystemYield } from './useMessageSystemYield';
+import { selectBestEnabledYieldVault } from '../selectors';
+import { getWrappedNativeYieldVaults } from '../utils/getWrappedNativeYieldVaults';
+import { type YieldRateLabelType, getYieldRateLabelType } from '../utils/getYieldRateLabelType';
+
+/** `inactive` = token eligible for a deposit, `active` = vault receipt token already earning. */
+export type TokenYieldRateVariant = 'inactive' | 'active';
+
+export type TokenYieldRateToken = {
+    contract: string;
+    symbol?: string;
+    decimals: number;
+};
+
+type UseTokenYieldRateParams = {
+    account: Account;
+    /** Native-coin rows pass no token — wrapped-native vaults match the native balance. */
+    token?: TokenYieldRateToken;
+    variant: TokenYieldRateVariant;
+};
+
+type TokenYieldRate = {
+    apy: number;
+    labelType: YieldRateLabelType;
+};
+
+const emptyVaults: YieldDtoV2[] = [];
+
+/**
+ * The yield rate a token row may advertise — the rate of the best not-killed vault
+ * matching the token, or `null` when there is nothing to advertise.
+ */
+export const useTokenYieldRate = ({
+    account,
+    token,
+    variant,
+}: UseTokenYieldRateParams): TokenYieldRate | null => {
+    const yieldDepositMessageSystem = useMessageSystemYield('deposit');
+    const isYieldRateRelevant =
+        account.networkType === 'ethereum' && !yieldDepositMessageSystem.isDisabled;
+
+    const { data: vaults } = useAllYieldOpportunities({ enabled: isYieldRateRelevant });
+
+    const networkSymbol = account.symbol;
+    const tokenContract = token?.contract;
+    const tokenSymbol = token?.symbol;
+    const tokenDecimals = token?.decimals;
+
+    const matchedVaults = useMemo(() => {
+        if (!isYieldRateRelevant) {
+            return emptyVaults;
+        }
+
+        if (tokenContract === undefined || tokenDecimals === undefined) {
+            return getWrappedNativeYieldVaults({ vaults, networkSymbol });
+        }
+
+        const heldToken = {
+            address: tokenContract,
+            symbol: tokenSymbol ?? '',
+            decimals: tokenDecimals,
+        };
+
+        if (variant === 'active') {
+            const vault = getYieldVaultForOutputToken({
+                vaults,
+                networkSymbol,
+                token: heldToken,
+            });
+
+            return vault ? [vault] : emptyVaults;
+        }
+
+        return getYieldVaultsForInputToken({ vaults, networkSymbol, token: heldToken });
+    }, [
+        isYieldRateRelevant,
+        vaults,
+        networkSymbol,
+        tokenContract,
+        tokenSymbol,
+        tokenDecimals,
+        variant,
+    ]);
+
+    const bestVault = useSelector((state: MessageSystemRootState) =>
+        selectBestEnabledYieldVault(state, matchedVaults),
+    );
+
+    return useMemo(() => {
+        if (!bestVault) {
+            return null;
+        }
+
+        const apy = getApyPercent(bestVault.rewardRate.total);
+
+        if (apy === null) {
+            return null;
+        }
+
+        return {
+            apy,
+            labelType: getYieldRateLabelType(bestVault.rewardRate),
+        };
+    }, [bestVault]);
+};

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -3,6 +3,7 @@ export { useNativeYieldVault } from './hooks/useNativeYieldVault';
 export { useStakingRate } from './hooks/useStakingRate';
 export { StablecoinYieldApyBreakdown } from './components/StablecoinYieldApyBreakdown';
 export { YieldDisabledAlert } from './components/YieldDisabledAlert';
+export { TokenYieldRateBadge } from './components/TokenYieldRateBadge';
 export { useApyBreakdownAlert } from './hooks/useApyBreakdownAlert';
 export { useMessageSystemWrappedNative } from './hooks/useMessageSystemWrappedNative';
 export { useMessageSystemYield } from './hooks/useMessageSystemYield';

--- a/suite-native/module-earn/src/utils/getWrappedNativeYieldVaults.test.ts
+++ b/suite-native/module-earn/src/utils/getWrappedNativeYieldVaults.test.ts
@@ -1,0 +1,81 @@
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+
+import { getWrappedNativeYieldVaults } from './getWrappedNativeYieldVaults';
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+type VaultFixtureParams = {
+    network?: YieldDtoV2['network'];
+    tokenAddress?: string;
+    tokenSymbol?: string;
+    underMaintenance?: boolean;
+    deprecated?: boolean;
+    enter?: boolean;
+};
+
+const createVaultFixture = ({
+    network = 'ethereum',
+    tokenAddress = WETH_ADDRESS,
+    tokenSymbol = 'WETH',
+    underMaintenance = false,
+    deprecated = false,
+    enter = true,
+}: VaultFixtureParams) =>
+    ({
+        metadata: { name: 'Vault', underMaintenance, deprecated },
+        network,
+        status: { enter, exit: true },
+        token: {
+            symbol: tokenSymbol,
+            network,
+            name: tokenSymbol,
+            decimals: 18,
+            address: tokenAddress,
+        },
+    }) satisfies Pick<YieldDtoV2, 'metadata' | 'network' | 'status' | 'token'>;
+
+describe('getWrappedNativeYieldVaults', () => {
+    it('returns vaults taking the wrapped-native token of the network', () => {
+        const wethVault = createVaultFixture({});
+        const usdcVault = createVaultFixture({ tokenAddress: USDC_ADDRESS, tokenSymbol: 'USDC' });
+
+        expect(
+            getWrappedNativeYieldVaults({ vaults: [wethVault, usdcVault], networkSymbol: 'eth' }),
+        ).toEqual([wethVault]);
+    });
+
+    it('filters out vaults on other networks', () => {
+        const baseVault = createVaultFixture({ network: 'base' });
+
+        expect(getWrappedNativeYieldVaults({ vaults: [baseVault], networkSymbol: 'eth' })).toEqual(
+            [],
+        );
+    });
+
+    it('filters out vaults under maintenance or deprecated', () => {
+        const maintainedVault = createVaultFixture({ underMaintenance: true });
+        const deprecatedVault = createVaultFixture({ deprecated: true });
+
+        expect(
+            getWrappedNativeYieldVaults({
+                vaults: [maintainedVault, deprecatedVault],
+                networkSymbol: 'eth',
+            }),
+        ).toEqual([]);
+    });
+
+    it('filters out vaults with deposits closed', () => {
+        const closedVault = createVaultFixture({ enter: false });
+
+        expect(
+            getWrappedNativeYieldVaults({ vaults: [closedVault], networkSymbol: 'eth' }),
+        ).toEqual([]);
+    });
+
+    it('returns an empty array when vaults are not loaded', () => {
+        expect(getWrappedNativeYieldVaults({ vaults: undefined, networkSymbol: 'eth' })).toEqual(
+            [],
+        );
+    });
+});

--- a/suite-native/module-earn/src/utils/getWrappedNativeYieldVaults.ts
+++ b/suite-native/module-earn/src/utils/getWrappedNativeYieldVaults.ts
@@ -1,0 +1,30 @@
+import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+import {
+    type NetworkSymbol,
+    getNetworkByYieldXyzId,
+    isWrappedNativeToken,
+} from '@suite-common/wallet-config';
+import { isYieldVaultOperational } from '@suite-common/wallet-core';
+
+type WrappedNativeVaultFields = Pick<YieldDtoV2, 'metadata' | 'network' | 'status' | 'token'>;
+
+type GetWrappedNativeYieldVaultsParams<TVault extends WrappedNativeVaultFields> = {
+    vaults: TVault[] | undefined;
+    networkSymbol: NetworkSymbol;
+};
+
+/**
+ * Deposit-open vaults taking the network's wrapped-native token — the native balance
+ * can be wrapped on the way into them, so they represent the native coin's yield options.
+ */
+export const getWrappedNativeYieldVaults = <TVault extends WrappedNativeVaultFields>({
+    vaults = [],
+    networkSymbol,
+}: GetWrappedNativeYieldVaultsParams<TVault>): TVault[] =>
+    vaults.filter(
+        vault =>
+            isYieldVaultOperational(vault) &&
+            vault.status.enter &&
+            getNetworkByYieldXyzId(vault.network)?.symbol === networkSymbol &&
+            isWrappedNativeToken(networkSymbol, vault.token.address),
+    );

--- a/suite-native/module-earn/src/utils/getYieldRateLabelType.test.ts
+++ b/suite-native/module-earn/src/utils/getYieldRateLabelType.test.ts
@@ -1,0 +1,85 @@
+import { getYieldRateLabelType } from './getYieldRateLabelType';
+
+type RewardRateFixtureParams = {
+    rateType?: string;
+    components?: { rate: number; rateType: string }[];
+};
+
+const createRewardRate = ({ rateType = 'APY', components = [] }: RewardRateFixtureParams) => ({
+    rateType,
+    components,
+});
+
+describe('getYieldRateLabelType', () => {
+    it('returns apy when all components carry an APY rate', () => {
+        const rewardRate = createRewardRate({
+            components: [{ rate: 0.05, rateType: 'APY' }],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('apy');
+    });
+
+    it('returns apr when all components carry an APR rate', () => {
+        const rewardRate = createRewardRate({
+            components: [{ rate: 0.02, rateType: 'APR' }],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('apr');
+    });
+
+    it('returns rate when components mix APY and APR', () => {
+        const rewardRate = createRewardRate({
+            components: [
+                { rate: 0.05, rateType: 'APY' },
+                { rate: 0.02, rateType: 'APR' },
+            ],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('rate');
+    });
+
+    it('ignores components without a positive rate', () => {
+        const rewardRate = createRewardRate({
+            components: [
+                { rate: 0.05, rateType: 'APY' },
+                { rate: 0, rateType: 'APR' },
+            ],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('apy');
+    });
+
+    it('reads the rate type case-insensitively', () => {
+        const rewardRate = createRewardRate({
+            components: [{ rate: 0.05, rateType: 'apr' }],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('apr');
+    });
+
+    it('returns rate when a known rate type mixes with an unrecognized one', () => {
+        const rewardRate = createRewardRate({
+            components: [
+                { rate: 0.04, rateType: 'APY' },
+                { rate: 0.02, rateType: 'variable' },
+            ],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('rate');
+    });
+
+    it('falls back to the aggregate rate type when no component has a usable rate', () => {
+        const rewardRate = createRewardRate({ rateType: 'APR' });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('apr');
+    });
+
+    it('returns rate when neither components nor the aggregate specify APY or APR', () => {
+        const rewardRate = createRewardRate({
+            rateType: 'variable',
+            components: [{ rate: 0.05, rateType: 'variable' }],
+        });
+
+        expect(getYieldRateLabelType(rewardRate)).toBe('rate');
+    });
+});

--- a/suite-native/module-earn/src/utils/getYieldRateLabelType.ts
+++ b/suite-native/module-earn/src/utils/getYieldRateLabelType.ts
@@ -1,0 +1,51 @@
+import { type RewardDtoV2, type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
+
+export type YieldRateLabelType = 'apy' | 'apr' | 'rate';
+
+type YieldRewardRateFields = {
+    rateType: YieldDtoV2['rewardRate']['rateType'];
+    components: Pick<RewardDtoV2, 'rate' | 'rateType'>[];
+};
+
+// The API declares the rate type as a plain string, so unexpected values must not
+// produce a false APY/APR claim.
+const normalizeRateKind = (rateType: string): 'apy' | 'apr' | null => {
+    const rateKind = rateType.toLowerCase();
+
+    if (rateKind === 'apy' || rateKind === 'apr') {
+        return rateKind;
+    }
+
+    return null;
+};
+
+/**
+ * Which label a vault's reward rate should carry: `apy`/`apr` only when every earning
+ * component agrees on it, the neutral `rate` when they mix or are unrecognized.
+ */
+export const getYieldRateLabelType = (rewardRate: YieldRewardRateFields): YieldRateLabelType => {
+    const rateKinds = new Set(
+        rewardRate.components
+            .filter(component => component.rate > 0)
+            .map(component => normalizeRateKind(component.rateType)),
+    );
+
+    const hasApy = rateKinds.has('apy');
+    const hasApr = rateKinds.has('apr');
+    const hasUnrecognizedKind = rateKinds.has(null);
+
+    if (hasApy && !hasApr && !hasUnrecognizedKind) {
+        return 'apy';
+    }
+
+    if (hasApr && !hasApy && !hasUnrecognizedKind) {
+        return 'apr';
+    }
+
+    if (hasApy || hasApr) {
+        return 'rate';
+    }
+
+    // No component carries a recognizable rate — fall back to the aggregate field.
+    return normalizeRateKind(rewardRate.rateType) ?? 'rate';
+};


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Display yield rate badge at earnable tokens based on rate kind.

## Related Issue

Resolve #28432

## Screenshots:

<img width="375" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 11 47 25" src="https://github.com/user-attachments/assets/6ccf92e4-8067-4732-bfcd-ae2c27604d79" />
<img width="375" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 11 50 27" src="https://github.com/user-attachments/assets/adb8d648-fb5b-49e8-b28d-ab7d28169d6e" />
<img width="375" alt="defi-tab" src="https://github.com/user-attachments/assets/29f18cb7-3736-40a6-97cc-2c083dacdc0c" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native/28432-token-yield-apy&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->