### PR TITLE
fix(connect-data): use slip44 60 for all evm networks except etc

### DIFF
--- a/packages/connect-data/files/coins-eth.json
+++ b/packages/connect-data/files/coins-eth.json
@@ -34,7 +34,7 @@
             "label": "ETH",
             "name": "Optimism",
             "shortcut": "OP",
-            "slip44": 614,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -56,7 +56,7 @@
             "label": "AVAX",
             "name": "Avalanche C-Chain",
             "shortcut": "AVAX",
-            "slip44": 9000,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -78,7 +78,7 @@
             "label": "BNB",
             "name": "BNB Smart Chain",
             "shortcut": "BSC",
-            "slip44": 714,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -122,7 +122,7 @@
             "label": "POL",
             "name": "Polygon",
             "shortcut": "POL",
-            "slip44": 966,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -144,7 +144,7 @@
             "label": "HYPE",
             "name": "HyperEVM",
             "shortcut": "HYPE",
-            "slip44": 999,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -166,7 +166,7 @@
             "label": "ETH",
             "name": "Robinhood Chain",
             "shortcut": "RHC",
-            "slip44": 4663,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -188,7 +188,7 @@
             "label": "ETH",
             "name": "Base",
             "shortcut": "BASE",
-            "slip44": 8453,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -209,7 +209,7 @@
             "label": "tHOD",
             "name": "Hoodi",
             "shortcut": "tHOD",
-            "slip44": 1,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.11.3",
                 "T2B1": "2.6.4",
@@ -231,7 +231,7 @@
             "label": "ETH",
             "name": "Arbitrum One",
             "shortcut": "ARB",
-            "slip44": 9001,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.9.4",
                 "T2B1": "2.6.1",
@@ -252,7 +252,7 @@
             "label": "tSEP",
             "name": "Sepolia",
             "shortcut": "tSEP",
-            "slip44": 1,
+            "slip44": 60,
             "support": {
                 "T1B1": "1.11.3",
                 "T2B1": "2.6.4",

--- a/packages/connect/src/data/coinInfo.test.ts
+++ b/packages/connect/src/data/coinInfo.test.ts
@@ -12,12 +12,12 @@ describe('data/coinInfo', () => {
         expect(getCoinInfoOrThrow('rhc')).toMatchObject({
             shortcut: 'RHC',
             chainId: 4663,
-            slip44: 4663,
+            slip44: 60,
         });
         expect(getCoinInfoOrThrow('hype')).toMatchObject({
             shortcut: 'HYPE',
             chainId: 999,
-            slip44: 999,
+            slip44: 60,
         });
 
         // the network name and label forms are no longer accepted (D2/D3)
@@ -38,6 +38,20 @@ describe('data/coinInfo', () => {
             type: 'blockbook',
             url: ['https://hype.trezor.io'],
         });
+    });
+
+    it('every evm network uses slip44 60, except ETC (61)', () => {
+        // Suite derives all EVM accounts at m/44'/60' (ETC at m/44'/61'), and slip44 drives the
+        // default discovery path in connect popup — a per-chain registry value (as ethereum-lists
+        // has for e.g. BSC or Optimism) would discover accounts Suite never shows.
+        getAllNetworks()
+            .filter(network => network.type === 'ethereum')
+            .forEach(network => {
+                expect({ shortcut: network.shortcut, slip44: network.slip44 }).toEqual({
+                    shortcut: network.shortcut,
+                    slip44: network.shortcut === 'ETC' ? 61 : 60,
+                });
+            });
     });
 
     it('resolves every misc firmware-gating shortcut (requiredFirmwareCoins is never [undefined])', () => {


### PR DESCRIPTION
## Description

All EVM networks in `coins-eth.json` now use `slip44: 60`, matching how Suite and firmware actually derive every EVM account (`m/44'/60'/0'/0/i`). The old values came from the ethereum-lists chains registry (op 614, bsc 714, pol 966, avax 9000, arb 9001, base 8453, hype 999, rhc 4663, sep/hod 1).

**Deliberate exceptions:**
- **ETC keeps 61** — official SLIP-0044 value, registered in firmware, and Suite derives ETC at `m/44'/61'`.
- **Sepolia/Hoodi testnets move 1 → 60** — Suite's default testnet account type is also `m/44'/60'` (the `m/44'/1'` legacy type remains a non-default account type).

A new invariant test locks the policy in (`every evm network uses slip44 60, except ETC (61)`), so a future hand-added chain can't reintroduce a registry value — which is how HyperEVM and Robinhood Chain got theirs.

**`coins.json` audit** (second part of the issue): all bitcoin-family and misc coins already match SLIP-0044 (BTC 0, LTC 2, DOGE 3, BCH 145, ZEC 133, QTUM 2301, FIRO 136, ADA 1815, SOL 501, XRP 144, XLM 148, TRX 195, XTZ 1729, XMR 128, NOSTR 1237; testnets 1, with tADA/tTRX/tXLM matching real firmware derivation). No changes needed.

## Notes for QA

Nothing should change anywhere. Suite derives EVM paths from `wallet-config`, and the connect paths that read slip44 already resolved to Ethereum.

- Regression check only: existing and newly added EVM accounts in Suite (desktop and mobile) derive and display as before.
- Connect: an EVM `getAccountInfo({ coin, path })` and an EIP-7702 signature on an `m/44'/60'` path behave as before.
- ETC accounts still derive at `m/44'/61'`.

## Related Issue

Resolve #30492

## Screenshots:
