### PR TITLE
refactor(suite-native): replace IconButton with TouchableOpacity in Banner close button

### DIFF
--- a/suite-native/banners/src/components/Banner.tsx
+++ b/suite-native/banners/src/components/Banner.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode } from 'react';
-import { type ImageSourcePropType } from 'react-native';
+import { type ImageSourcePropType, TouchableOpacity } from 'react-native';
 
-import { Card, HStack, IconButton, Image, Text, TextButton, VStack } from '@suite-native/atoms';
-import { type IconName } from '@suite-native/icons';
+import { Card, HStack, Image, Text, TextButton, VStack } from '@suite-native/atoms';
+import { Icon, type IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 const IMAGE_SIZE = 80;
@@ -16,8 +16,16 @@ const imageStyle = prepareNativeStyle(utils => ({
     overflow: 'hidden',
 }));
 
+// IconButton can not be used here because of the glitch in the dark mode implementation. Might be revisited in the followup.
+const CloseButton = ({ onPress, testID }: { onPress?: () => void; testID?: string }) => (
+    <TouchableOpacity onPress={onPress} hitSlop={8} testID={testID}>
+        <Icon name="x" size="medium" color="contentNeutral" />
+    </TouchableOpacity>
+);
+
 const cardBackgroundStyle = prepareNativeStyle(utils => ({
     padding: utils.spacings.sp4,
+    paddingRight: utils.spacings.sp16,
     borderWidth: utils.borders.widths.small,
     backgroundColor: utils.colors.surfaceFillRaised,
     borderColor: utils.colors.surfaceBorderRaised,
@@ -45,10 +53,10 @@ export const Banner = ({
     const { applyStyle } = useNativeStyles();
 
     return (
-        <Card noPadding style={applyStyle(cardBackgroundStyle)}>
+        <Card style={applyStyle(cardBackgroundStyle)}>
             <HStack spacing="sp12" alignItems="center" justifyContent="space-between">
                 <Image source={imageSource} contentFit="contain" style={applyStyle(imageStyle)} />
-                <VStack flex={1} spacing="sp2">
+                <VStack flex={1} spacing={0}>
                     <Text variant="body-md-strong" color="contentPrimary">
                         {title}
                     </Text>
@@ -66,15 +74,7 @@ export const Banner = ({
                         </TextButton>
                     </HStack>
                 </VStack>
-                <IconButton
-                    intent="neutral"
-                    priority="primary"
-                    isInverse={true}
-                    iconName="x"
-                    size="medium"
-                    onPress={onClose}
-                    testID={testID && `${testID}/close`}
-                />
+                <CloseButton onPress={onClose} testID={testID && `${testID}/close`} />
             </HStack>
         </Card>
     );


### PR DESCRIPTION
## Description
FIXES THE DESIGN QA of mobile dashboard banners findings.
- Replace `IconButton` with a custom `CloseButton` component (`TouchableOpacity` + `Icon`) in `Banner`
- Add `hitSlop={8}` to preserve accessible touch target
- Add `paddingRight` to card background style and adjust `VStack` spacing

## Notes for QA

- Open any banner in the app and verify the close (×) button is tappable and dismisses the banner
- Check both light and dark themes

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30078

## Screenshots:

<img width="409" height="876" alt="Screenshot 2026-08-10 at 18 01 22" src="https://github.com/user-attachments/assets/101ea1b6-c74f-4142-8896-30bb0edfdf0f" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=suite-native/banner-close-button-refactor&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->