### PR TITLE
fix(suite-native-31096): preserve TRON fee precision in trade form

### DIFF
--- a/suite-native/module-trading/src/thunks.ts
+++ b/suite-native/module-trading/src/thunks.ts
@@ -55,6 +55,7 @@ import {
 import TrezorConnect from '@trezor/connect';
 
 import { createFormStateForSendForm } from './utils';
+import { getTradingFormDraftFeeLimit } from './utils/getTradingFormDraftFeeLimit';
 
 const NATIVE_TRADING_EXCHANGE_THUNK_PREFIX = 'trading/native';
 
@@ -234,7 +235,12 @@ export const composeTradingTransactionThunk = createThunk(
                                 ...formState,
                                 selectedFee: selectedFeeLevel,
                                 feePerUnit: composed.feePerByte,
-                                feeLimit: composed.feeLimit ?? '',
+                                feeLimit: getTradingFormDraftFeeLimit({
+                                    networkType: account.networkType,
+                                    fee: composed.fee,
+                                    feeLimit: composed.feeLimit,
+                                    estimatedFeeLimit: composed.estimatedFeeLimit,
+                                }),
                             },
                         }),
                     );

--- a/suite-native/module-trading/src/utils/getTradingFormDraftFeeLimit.test.ts
+++ b/suite-native/module-trading/src/utils/getTradingFormDraftFeeLimit.test.ts
@@ -1,0 +1,35 @@
+import { getTradingFormDraftFeeLimit } from './getTradingFormDraftFeeLimit';
+
+describe(getTradingFormDraftFeeLimit.name, () => {
+    it('uses the estimated fee limit in SUN for TRON', () => {
+        expect(
+            getTradingFormDraftFeeLimit({
+                networkType: 'tron',
+                fee: '13028500',
+                feeLimit: '130285',
+                estimatedFeeLimit: '13028500',
+            }),
+        ).toBe('13028500');
+    });
+
+    it('falls back to the fee in SUN for TRON', () => {
+        expect(
+            getTradingFormDraftFeeLimit({
+                networkType: 'tron',
+                fee: '13028500',
+                feeLimit: '130285',
+            }),
+        ).toBe('13028500');
+    });
+
+    it('uses the fee limit for other networks', () => {
+        expect(
+            getTradingFormDraftFeeLimit({
+                networkType: 'ethereum',
+                fee: '109200000000000',
+                feeLimit: '21000',
+                estimatedFeeLimit: '22000',
+            }),
+        ).toBe('21000');
+    });
+});

--- a/suite-native/module-trading/src/utils/getTradingFormDraftFeeLimit.ts
+++ b/suite-native/module-trading/src/utils/getTradingFormDraftFeeLimit.ts
@@ -1,0 +1,21 @@
+import { type NetworkType } from '@suite-common/wallet-config';
+
+type GetTradingFormDraftFeeLimitParams = {
+    networkType: NetworkType;
+    fee: string;
+    feeLimit?: string;
+    estimatedFeeLimit?: string;
+};
+
+export const getTradingFormDraftFeeLimit = ({
+    networkType,
+    fee,
+    feeLimit,
+    estimatedFeeLimit,
+}: GetTradingFormDraftFeeLimitParams): string => {
+    if (networkType === 'tron') {
+        return estimatedFeeLimit ?? fee;
+    }
+
+    return feeLimit ?? '';
+};


### PR DESCRIPTION
## Description
Found similar solution in `useFeesForm.ts`
- Preserve the full TRON fee value in SUN when composing trading transactions.
- Add utility coverage for TRON and non-TRON fee-limit handling.

## Notes for QA

- Verify TRON trade forms retain the complete fee amount, including the final digits.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31096

## Screenshots:
<img width="320" alt="Screenshot 2026-08-10 at 22 26 08" src="https://github.com/user-attachments/assets/b1270015-db52-48fe-b85a-982cc80a9f3d" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 22 47 25" src="https://github.com/user-attachments/assets/964c363b-7de2-4fa0-b2d1-f39b06c77163" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31096-tron-fee-missing-last-2-digits-in-trade-form&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->