### PR TITLE
fix(suite): show sender account label for received native transfers

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeader.tsx
@@ -258,10 +258,11 @@ export const TransactionHeader = ({ transaction, isPending }: TransactionHeaderP
 
     const isMultiTokenTransaction = transaction.tokens.length > 1;
     const transactionSymbol = getTxHeaderSymbol(transaction);
+    // token symbols carry their own casing (trSHUSDTp), only network symbols are stored lowercase
     const symbol =
         transactionSymbol && isNetworkSymbol(transactionSymbol)
             ? getNetworkDisplaySymbol(transactionSymbol)
-            : transactionSymbol?.toUpperCase();
+            : transactionSymbol;
 
     return (
         <BlurUrls

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TargetAddressLabel.tsx
@@ -1,36 +1,44 @@
+import { useMemo } from 'react';
+
 import { Address, selectAddressLabelsForAccount } from '@suite/address';
 import { Translation } from '@suite/intl';
-import type { NetworkSymbol } from '@suite-common/wallet-config';
+import { selectAccounts } from '@suite-common/wallet-core';
 import type { AccountKey } from '@suite-common/wallet-types';
-import type { StaticSessionId } from '@trezor/connect';
+import { findTransactionSenderAccount } from '@suite-common/wallet-utils';
 import { type ArrayElement } from '@trezor/type-utils';
 
 import { AccountLabelForOwnAddress } from 'src/components/suite/labeling/AccountLabelForOwnAddress';
+import { AccountLabeling } from 'src/components/suite/labeling/AccountLabeling';
 import { useSelector } from 'src/hooks/suite';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
 type TargetAddressLabelProps = {
-    symbol: NetworkSymbol;
+    transaction: WalletAccountTransaction;
     target: ArrayElement<WalletAccountTransaction['targets']>;
-    type: WalletAccountTransaction['type'];
     accountKey: AccountKey;
-    deviceStaticSessionId: StaticSessionId;
 };
 
 export const TargetAddressLabel = ({
-    symbol,
+    transaction,
     target,
-    type,
     accountKey,
-    deviceStaticSessionId,
 }: TargetAddressLabelProps) => {
+    const { symbol, type } = transaction;
     const isLocalTarget = (type === 'sent' || type === 'self') && target.isAccountTarget;
     const addressLabels = useSelector(state =>
         selectAddressLabelsForAccount(state, {
             addresses: target.addresses ?? [],
             accountKey,
-            deviceStaticId: deviceStaticSessionId,
+            deviceStaticId: transaction.deviceState,
         }),
+    );
+    const accounts = useSelector(selectAccounts);
+
+    // Targets of a received transaction hold the account's own receiving address, so the sender is
+    // resolved instead — a transfer from a sibling account shows its label, like token transfers do.
+    const senderAccount = useMemo(
+        () => (type === 'recv' ? findTransactionSenderAccount(transaction, accounts) : undefined),
+        [type, transaction, accounts],
     );
 
     if (isLocalTarget) {
@@ -46,11 +54,30 @@ export const TargetAddressLabel = ({
 
                 // either it may be AccountLabelForOwnAddress - sent to another account associated with this device, e.g: "Bitcoin #2"
                 // or it may show address metadata label added from receive tab e.g "My address for illegal things"
-                return type === 'sent' ? (
+                if (type === 'sent') {
                     // Using index as a key is safe as the array doesn't change (no filter/reordering, pushing new items)
-                    <AccountLabelForOwnAddress key={i} address={a} symbol={symbol} />
-                ) : (
-                    <span key={i}>{addressLabels[a] ?? <Address value={a} isTruncated />}</span>
+                    return <AccountLabelForOwnAddress key={i} address={a} symbol={symbol} />;
+                }
+
+                if (addressLabels[a]) {
+                    return <span key={i}>{addressLabels[a]}</span>;
+                }
+
+                if (senderAccount) {
+                    return (
+                        <AccountLabeling
+                            key={i}
+                            account={senderAccount}
+                            accountTypeBadgeSize="small"
+                            showAccountTypeBadge
+                        />
+                    );
+                }
+
+                return (
+                    <span key={i}>
+                        <Address value={a} isTruncated />
+                    </span>
                 );
             })}
         </span>

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -169,11 +169,9 @@ export const TransactionTarget = ({
             case 'target':
                 return (
                     <TargetAddressLabel
-                        symbol={transaction.symbol}
+                        transaction={transaction}
                         accountKey={accountKey}
                         target={payload}
-                        type={transaction.type}
-                        deviceStaticSessionId={transaction.deviceState}
                     />
                 );
             case 'token':

--- a/suite-common/wallet-utils/src/accountUtils.test.ts
+++ b/suite-common/wallet-utils/src/accountUtils.test.ts
@@ -1,6 +1,11 @@
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { type NetworkFeature, asNetworkSymbol } from '@suite-common/wallet-config';
-import { type Account, asAccountDescriptor, createAccountKey } from '@suite-common/wallet-types';
+import {
+    type Account,
+    type WalletAccountTransaction,
+    asAccountDescriptor,
+    createAccountKey,
+} from '@suite-common/wallet-types';
 import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import * as fixtures from './__fixtures__/accountUtils';
@@ -9,6 +14,7 @@ import {
     enhanceAddresses,
     findAccountDevice,
     findAccountsByAddress,
+    findTransactionSenderAccount,
     getAccountIdentifier,
     getBip43Type,
     getNetworkAccountFeatures,
@@ -124,6 +130,60 @@ describe('account utils', () => {
 
         expect(findAccountsByAddress(ethSymbol, '0xAccountAddress', [account])).toEqual([account]);
         expect(findAccountsByAddress(ethSymbol, '0xOtherAddress', [account])).toEqual([]);
+    });
+
+    describe('findTransactionSenderAccount', () => {
+        const senderAccount = mockWalletAccount({
+            symbol: ethSymbol,
+            descriptor: asAccountDescriptor('0xSender'),
+        });
+        const otherAccount = mockWalletAccount({
+            symbol: ethSymbol,
+            descriptor: asAccountDescriptor('0xOther'),
+        });
+        const accounts = [senderAccount, otherAccount];
+
+        const mockTx = (vin: Array<{ addresses?: string[] }>) =>
+            ({ symbol: ethSymbol, details: { vin } }) as unknown as Pick<
+                WalletAccountTransaction,
+                'details' | 'symbol'
+            >;
+
+        it('resolves the account owning the input address', () => {
+            expect(
+                findTransactionSenderAccount(mockTx([{ addresses: ['0xSender'] }]), accounts),
+            ).toBe(senderAccount);
+        });
+
+        it('resolves the account owning every input of a multi-input transaction', () => {
+            const tx = mockTx([{ addresses: ['0xSender'] }, { addresses: ['0xSender'] }]);
+            expect(findTransactionSenderAccount(tx, accounts)).toBe(senderAccount);
+        });
+
+        it('returns undefined for an unknown sender', () => {
+            expect(
+                findTransactionSenderAccount(mockTx([{ addresses: ['0xExternal'] }]), accounts),
+            ).toBeUndefined();
+        });
+
+        it('returns undefined when inputs belong to different known accounts', () => {
+            const tx = mockTx([{ addresses: ['0xSender'] }, { addresses: ['0xOther'] }]);
+            expect(findTransactionSenderAccount(tx, accounts)).toBeUndefined();
+        });
+
+        it('returns undefined when any input is unknown (multi-party transaction)', () => {
+            const tx = mockTx([{ addresses: ['0xSender'] }, { addresses: ['0xExternal'] }]);
+            expect(findTransactionSenderAccount(tx, accounts)).toBeUndefined();
+        });
+
+        it('returns undefined when an input has no addresses', () => {
+            const tx = mockTx([{ addresses: ['0xSender'] }, {}]);
+            expect(findTransactionSenderAccount(tx, accounts)).toBeUndefined();
+        });
+
+        it('returns undefined without inputs', () => {
+            expect(findTransactionSenderAccount(mockTx([]), accounts)).toBeUndefined();
+        });
     });
 
     it('getAccountKey', () => {

--- a/suite-common/wallet-utils/src/accountUtils.ts
+++ b/suite-common/wallet-utils/src/accountUtils.ts
@@ -23,6 +23,7 @@ import {
     type RatesByKey,
     type SuccessfulAccount,
     type TokenAddress,
+    type WalletAccountTransaction,
     asBaseCurrencyAmount,
     createAccountKey,
 } from '@suite-common/wallet-types';
@@ -324,6 +325,33 @@ export const findAccountsByAddress = (
 
             return a.descriptor === address;
         });
+
+/**
+ * The account that owns every input of the transaction, or undefined when any input is missing,
+ * unknown, or owned by a different account — a single input must not be presented as "the sender"
+ * of a multi-party transaction (e.g. coinjoin, payjoin).
+ */
+export const findTransactionSenderAccount = (
+    transaction: Pick<WalletAccountTransaction, 'details' | 'symbol'>,
+    accounts: Account[],
+): Account | undefined => {
+    const inputs = transaction.details?.vin ?? [];
+    if (!inputs.length) return undefined;
+
+    let senderAccount: Account | undefined;
+    for (const input of inputs) {
+        if (!input.addresses?.length) return undefined;
+        for (const address of input.addresses) {
+            const [account] = findAccountsByAddress(transaction.symbol, address, accounts);
+            if (!account || (senderAccount && account.key !== senderAccount.key)) {
+                return undefined;
+            }
+            senderAccount = account;
+        }
+    }
+
+    return senderAccount;
+};
 
 export const findAccountDevice = (account: Account, devices: TrezorDevice[]) =>
     devices.find(d => d.state?.staticSessionId === account.deviceState);


### PR DESCRIPTION
## Description

- both native token and token between two accounts of the same wallet show the sending account's label 

## Notes for QA

- Send native coin (e.g. ETH) between two accounts of the same wallet: the receiving account's history row should show the sending account's label (e.g. "Ethereum 1"), matching what an equivalent token transfer already shows.
- Receiving from an external address is unchanged (shows the receiving address; a receive-tab label still takes priority).
- A token with mixed-case symbol (e.g. `trSHUSDTp`) reads the same in the row heading as in the amount. Native coins still read `Sent ETH`, `Sent BTC`.

## Related Issue

Resolve #30739

## Screenshots:

- casing fixed, not in screenshot
<img width="1152" height="358" alt="Screenshot 2026-08-19 at 7 48 24" src="https://github.com/user-attachments/assets/a6e5d41c-735c-40b0-80bf-349f3f804b67" />
<img width="1151" height="417" alt="Screenshot 2026-08-19 at 7 48 17" src="https://github.com/user-attachments/assets/b9f38856-c4b6-44ca-aafd-4ae86a9009ff" />
