### PR TITLE
fix(suite): hide zero-balance accounts in global send selection

### DIFF
--- a/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts
@@ -13,6 +13,7 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { filterAccountsByNetworkSymbol } from '@suite-common/wallet-utils';
 import { type StaticSessionId } from '@trezor/connect';
 import { useCurrentRef } from '@trezor/react-utils';
+import { BigNumber } from '@trezor/utils';
 
 import { type AccountWithTokensOption } from 'src/components/suite/asset-picker/types';
 import {
@@ -57,9 +58,9 @@ export function useAccountWithTokensOptions({
     const fiatRatesRef = useCurrentRef(fiatRates);
 
     const accountsAndTokensSortedByCoin = useMemo(() => {
-        const fiatRates = fiatRatesRef.current;
+        const currentFiatRates = fiatRatesRef.current;
 
-        if (!fiatRates) {
+        if (!currentFiatRates) {
             return [];
         }
 
@@ -68,33 +69,42 @@ export function useAccountWithTokensOptions({
             networkSymbolFilter,
         );
 
-        return networkAccounts.map(account => {
-            const { shownWithBalance, hiddenWithBalance } = getTokens({
-                tokens: account.tokens ?? [],
-                symbol: account.symbol,
-                tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
-            });
+        return networkAccounts
+            .map(account => {
+                const { shownWithBalance, hiddenWithBalance } = getTokens({
+                    tokens: account.tokens ?? [],
+                    symbol: account.symbol,
+                    tokenDefinitions: tokenDefinitions?.[account.symbol]?.coin,
+                });
 
-            const sortedTokensByFiatBalance = enhanceTokensWithRates(
-                shownWithBalance,
-                baseCurrencyCode,
-                account.symbol,
-                fiatRates,
-            ).sort(sortTokensWithRates);
+                const sortedTokensByFiatBalance = enhanceTokensWithRates(
+                    shownWithBalance,
+                    baseCurrencyCode,
+                    account.symbol,
+                    currentFiatRates,
+                ).sort(sortTokensWithRates);
 
-            const sortedHiddenTokensByFiatBalance = enhanceTokensWithRates(
-                hiddenWithBalance,
-                baseCurrencyCode,
-                account.symbol,
-                fiatRates,
-            ).sort(sortTokensWithRates);
+                const sortedHiddenTokensByFiatBalance = enhanceTokensWithRates(
+                    hiddenWithBalance,
+                    baseCurrencyCode,
+                    account.symbol,
+                    currentFiatRates,
+                ).sort(sortTokensWithRates);
 
-            return {
-                account,
-                tokens: sortedTokensByFiatBalance,
-                hiddenTokens: sortedHiddenTokensByFiatBalance,
-            };
-        });
+                return {
+                    account,
+                    tokens: sortedTokensByFiatBalance,
+                    hiddenTokens: sortedHiddenTokensByFiatBalance,
+                };
+            })
+            .filter(
+                // There is nothing to send from an account with neither native nor token balance,
+                // consistent with the Swap and Sell account selection.
+                ({ account, tokens, hiddenTokens }) =>
+                    new BigNumber(account.balance).gt(0) ||
+                    tokens.length > 0 ||
+                    hiddenTokens.length > 0,
+            );
     }, [fiatRatesRef, throttledAccounts, networkSymbolFilter, baseCurrencyCode, tokenDefinitions]);
 
     return useMemo(() => {

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts
@@ -182,10 +182,7 @@ export function useAccountWithTokensOptions({
         const accountsWithTokensOptions: AccountWithTokensOption[] = [];
 
         for (const { account, tokens, nonTradableTokens } of accountsWithTokens) {
-            if (
-                supportedCryptoIds.has(getCryptoId(account.symbol)) &&
-                new BigNumber(account.balance).gt(0)
-            ) {
+            if (supportedCryptoIds.has(getCryptoId(account.symbol))) {
                 accountsWithTokensOptions.push(createAccountOption(account));
             }
 

--- a/suite/e2e/support/pageObjects/trading/assetsModal.ts
+++ b/suite/e2e/support/pageObjects/trading/assetsModal.ts
@@ -13,7 +13,7 @@ export class TradingAssetPicker {
     readonly displaySymbol: Locator;
     readonly networkFilterButton: Locator;
     readonly buyNetworkFilterButton: Locator;
-    readonly networkFilterOption = (tab: AssetPickerNetworkFilter) =>
+    readonly networkFilterOption = (tab: AssetPickerNetworkFilter | NetworkSymbol) =>
         this.page.getByTestId(`@asset-picker/search/filter/select-option/${tab}`);
     readonly globalAddAccountButton: Locator;
 
@@ -57,7 +57,7 @@ export class TradingAssetPicker {
     }
 
     @step()
-    async filterByNetwork(networkFilter: AssetPickerNetworkFilter) {
+    async filterByNetwork(networkFilter: AssetPickerNetworkFilter | NetworkSymbol) {
         // use global retry helper since opening the dropdown is flaky in automation
         await this.page.selectDropdownOptionWithRetry(
             this.networkFilterButton,

--- a/suite/e2e/tests/wallet/global-receive-send.test.ts
+++ b/suite/e2e/tests/wallet/global-receive-send.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from '../../support/fixtures';
 
 const ETHEREUM_ADDRESS_3 = '0x574BbB36871bA6b78E27f4B4dCFb76eA0091880B';
 const DEVICE_ETHEREUM_ADDRESS_3 = `${DEVICE_RENDERED_EVM_INDENT}${ETHEREUM_ADDRESS_3}`;
+const REGTEST_ADDRESS = 'bcrt1qkvwu9g3k2pdxewfqr7syz89r3gj557l374sg5v';
 
 test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
     test.use({ deviceSetup: { mnemonic: 'mnemonic_all' } });
@@ -55,20 +56,41 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         });
     });
 
-    test(`Global send`, async ({ page, devicePrompt, walletPage, tradingPage }) => {
+    test(`Global send`, async ({
+        page,
+        devicePrompt,
+        walletPage,
+        tradingPage,
+        settingsPage,
+        dashboardPage,
+        trezorUserEnv,
+    }) => {
+        // The send picker only lists accounts with a spendable balance and no mnemonic_all
+        // mainnet account is funded, so the test funds a regtest account first.
+        await test.step('Fund and enable a regtest account', async () => {
+            await trezorUserEnv.sendToAddressAndMineBlock({
+                address: REGTEST_ADDRESS,
+                btc_amount: 1,
+            });
+            await settingsPage.navigateTo('application');
+            await settingsPage.toggleDebugModeInSettings();
+            await settingsPage.toggleTestnetNetworks();
+            await settingsPage.changeNetworks({ enableNetworks: ['regtest'] });
+            await dashboardPage.navigateTo();
+        });
+
         await test.step('Open send form', async () => {
             await page.getByTestId('@wallet/menu/wallet-global-send').click();
             await expect(devicePrompt.header).toHaveTranslation('TR_NAV_SEND');
         });
 
-        await test.step('Bitcoin account selection', async () => {
-            await tradingPage.assetPicker.filterByNetwork('btc');
-            await tradingPage.assetPicker.searchAsset('3');
+        await test.step('Bitcoin Regtest account selection', async () => {
+            await tradingPage.assetPicker.filterByNetwork('regtest');
             await tradingPage.assetPicker
                 .sendOption({
                     accountType: 'normal',
-                    accountSymbol: 'btc',
-                    index: 2,
+                    accountSymbol: 'regtest',
+                    index: 0,
                 })
                 .click();
         });
@@ -76,9 +98,9 @@ test.describe('Global receive and send', { tag: ['@T3T1', '@T3W1'] }, () => {
         await test.step('Send form validation', async () => {
             await expect(walletPage.sendFormHeader).toHaveTranslation('TR_NAV_SEND');
             await expect(
-                page.getByTestId("@metadata/accountLabel/m/84'/0'/2'/hover-container"),
+                page.getByTestId("@metadata/accountLabel/m/84'/1'/0'/hover-container"),
             ).toHaveTranslation('LABELING_ACCOUNT', {
-                values: { networkName: 'Bitcoin', index: '3' },
+                values: { networkName: 'Bitcoin Regtest', index: '1' },
             });
         });
     });


### PR DESCRIPTION
## Description

The Global Send account selector listed accounts with zero balance even though there is nothing to send from them. An account with neither native balance nor any token with balance is now excluded entirely.

Also renames the memo-local `fiatRates` (→ `currentFiatRates`) that shadowed the selector result — a pre-existing `no-shadow` lint error in this file.

## Notes for QA

- Global Send (page header): accounts with 0 balance and no tokens no longer appear; accounts with only token balances show the native coin at 0 followed by the token entries; everything with a positive native balance is unchanged.
- Trading → Swap/Sell From picker: an account holding only tokens now lists its native coin at 0 again, alongside the token rows.
-
## Related Issue

Resolve #29768

## Screenshots:
Account number 8 is not visible, account 7 is visible even the zero native token becuase you need native token to send USDT, that's why we show it

<img width="288" height="421" alt="Screenshot 2026-08-19 at 11 19 24" src="https://github.com/user-attachments/assets/ec911916-dc3f-4d9e-86b6-9572fb514272" />
<img width="638" height="662" alt="Screenshot 2026-08-19 at 11 19 19" src="https://github.com/user-attachments/assets/3f3523e0-364e-4d18-9d3a-5aa9edbc683a" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files are identically-named asset-picker option hooks in different contexts (global send/receive and trading swap sell asset). The most targeted validation comes from tests that directly exercise picker behavior rather than the broader end-to-end swap execution tests that merely transitively import the hook. Running these two tests should catch regressions in account/token option generation, filtering, and selection in both contexts.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/layouts/SuiteLayout/PageHeader/GlobalSendReceive/GlobalSendModal/hooks/useAccountWithTokensOptions.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-inputs.test.ts` — This test directly exercises the sell/buy asset picker in the swap form, which is exactly where the changed TradingFormInputSellAsset/AssetPickerModal/hooks/useAccountWithTokensOptions.ts hook is used. It verifies asset selection, receive account selection, fraction buttons, and validation—behaviors that depend on correct account/token options generation.
- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the global receive/send asset picker where the changed GlobalSendModal/hooks/useAccountWithTokensOptions.ts hook is used. It verifies filtering accounts by network, adding a new account through the asset picker, and selecting specific accounts—core behaviors affected by the hook.

</details>

_Updated: 2026-08-21T09:48:03.127Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/global-send-zero-balance-accounts/web/](https://dev.suite.sldev.cz/suite-web/fix/global-send-zero-balance-accounts/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/global-send-zero-balance-accounts&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/global-send-zero-balance-accounts&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-22T08:34:12.675Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-22T08:33:36.206Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->
