### PR TITLE
fix(suite): make missing exchange rate tooltip generic

### DIFF
--- a/packages/suite/src/components/suite/Ticker/NoRatesTooltip.tsx
+++ b/packages/suite/src/components/suite/Ticker/NoRatesTooltip.tsx
@@ -21,7 +21,7 @@ interface NoRatesTooltipProps {
 export const NoRatesTooltip = ({ customText, customTooltip, className }: NoRatesTooltipProps) => (
     <NoRatesMessage className={className}>
         <Tooltip
-            content={<Translation id={customTooltip || 'TR_FIAT_RATES_NOT_AVAILABLE_TOOLTIP'} />}
+            content={<Translation id={customTooltip || 'TR_EXCHANGE_RATE_NOT_AVAILABLE_TOOLTIP'} />}
             maxWidth={250}
             hasIcon
         >

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -2525,9 +2525,9 @@ export const messages = defineMessages({
         defaultMessage: 'Rate not available',
         id: 'TR_FIAT_RATES_NOT_AVAILABLE',
     },
-    TR_FIAT_RATES_NOT_AVAILABLE_TOOLTIP: {
-        defaultMessage: 'The 7D change rate is currently not available.',
-        id: 'TR_FIAT_RATES_NOT_AVAILABLE_TOOLTIP',
+    TR_EXCHANGE_RATE_NOT_AVAILABLE_TOOLTIP: {
+        defaultMessage: 'The exchange rate is currently not available.',
+        id: 'TR_EXCHANGE_RATE_NOT_AVAILABLE_TOOLTIP',
     },
     TR_FIRMWARE: {
         defaultMessage: 'Firmware',


### PR DESCRIPTION
## Description

When a coin has no fiat rate, the dashboard assets table showed "The 7D change rate is currently not available." under **both** the Price and 7D change columns — the tooltip is shared by `PriceTicker` and `TrendTicker` via `NoRatesTooltip`. The message is now generic: "The exchange rate is currently not available."

The key is replaced (`TR_FIAT_RATES_NOT_AVAILABLE_TOOLTIP` → `TR_EXCHANGE_RATE_NOT_AVAILABLE_TOOLTIP`) instead of edited in place, so the new copy shows immediately rather than after a Crowdin round-trip; the old key had no other consumers.

## Notes for QA

- Dashboard → My assets, with a coin that has no fiat rate (e.g. a coin CoinGecko doesn't track): the "?" tooltip under both the Price and 7D change columns reads "The exchange rate is currently not available."
- Components passing a custom tooltip are unaffected.

## Related Issue

Resolve #29700

## Screenshots:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/no-rates-tooltip-generic/web/](https://dev.suite.sldev.cz/suite-web/fix/no-rates-tooltip-generic/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** NoRatesTooltip is a broadly-shared component (135 static references), so only the tests that actually render and interact with fiat-denominated values are worth running. The highest confidence comes from dashboard discreet-mode and settings/general, which exercise hover/tooltip and fiat-currency switching paths. Two additional medium-priority tests cover asset and balance widgets where the tooltip may appear. The messages.ts change cannot be targeted precisely because the specific modified translation key is unknown; it is treated as uncovered.

<details><summary><b>Changed files (2)</b></summary>

- `packages/suite/src/components/suite/Ticker/NoRatesTooltip.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — This test hovers over fiat-denominated dashboard values (account balances, asset cards, portfolio, wallet value) to reveal hidden amounts. NoRatesTooltip is designed to surface when fiat rates are unavailable, and the hover interactions on these exact value elements are the most likely place for the tooltip to appear or change behavior.
- `suite/e2e/tests/settings/general.test.ts` — The test changes the active fiat currency and verifies that fiat-denominated dashboard values update (e.g., $0.00 → €0.00). This directly exercises the ticker/fiat-rate display path that NoRatesTooltip participates in, and any message changes for rate-related tooltips would be visible in this flow.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/dashboard/assets.test.ts` — Asset cards and the asset table display fiat values for each coin. NoRatesTooltip can be rendered inside these asset value widgets when a rate is missing, so a change to the tooltip could affect asset content rendering.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — This test enables Bitcoin Regtest and asserts that the account balance is displayed. Regtest networks typically lack fiat rate feeds, making this a plausible scenario where NoRatesTooltip would be presented on the balance widget.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-08-11T07:46:10.828Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/no-rates-tooltip-generic&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/no-rates-tooltip-generic&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T07:47:06.085Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T07:46:17.867Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->