### PR TITLE
fix(31103): prevent trading header tabs from being cut off

### DIFF
--- a/suite-native/atoms/src/SubTabs.test.tsx
+++ b/suite-native/atoms/src/SubTabs.test.tsx
@@ -6,6 +6,7 @@ import {
     within,
 } from '@suite-native/test-utils';
 import { type NativeStyleUtils, useNativeStyles } from '@trezor/styles-native';
+import { type NativeSpacing } from '@trezor/theme';
 
 import { type SubTabItem, SubTabs } from './SubTabs';
 
@@ -34,15 +35,24 @@ describe('SubTabs', () => {
 
     const renderSubTabs = ({
         onChange = jest.fn(),
+        paddingHorizontal,
         size = 'normal',
         value = 'exchange',
     }: {
         onChange?: (value: string) => void;
+        paddingHorizontal?: NativeSpacing;
         size?: 'normal' | 'large';
         value?: string;
     } = {}) =>
         renderWithBasicProvider(
-            <SubTabs items={items} onChange={onChange} size={size} value={value} />,
+            <SubTabs
+                items={items}
+                onChange={onChange}
+                paddingHorizontal={paddingHorizontal}
+                size={size}
+                testID="sub-tabs"
+                value={value}
+            />,
         );
 
     it('renders the active and inactive tabs with accessible selected states', () => {
@@ -62,6 +72,14 @@ describe('SubTabs', () => {
         fireEvent.press(getByText('Buy'));
 
         expect(onChange).toHaveBeenCalledWith('buy');
+    });
+
+    it('applies configurable horizontal padding to the tab list', () => {
+        const { getByTestId } = renderSubTabs({ paddingHorizontal: 'sp4' });
+
+        expect(getByTestId('sub-tabs').props.contentContainerStyle).toEqual(
+            expect.objectContaining({ paddingHorizontal: 4 }),
+        );
     });
 
     it('uses normal size dimensions, typography, icon size, and active colors', () => {

--- a/suite-native/atoms/src/SubTabs.tsx
+++ b/suite-native/atoms/src/SubTabs.tsx
@@ -3,7 +3,7 @@ import { FlatList } from 'react-native-gesture-handler';
 
 import { Icon, type IconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
-import { type Color, type NativeTypographyStyle } from '@trezor/theme';
+import { type Color, type NativeSpacing, type NativeTypographyStyle } from '@trezor/theme';
 
 import { PressableOpacity } from './Pressable';
 import { Text } from './Text';
@@ -22,6 +22,7 @@ export type SubTabItem<TValue> = {
 export type SubTabsProps<TValue> = {
     items: SubTabItem<TValue>[];
     onChange: (value: TValue) => void;
+    paddingHorizontal?: NativeSpacing;
     value?: TValue;
     size?: SubTabsSize;
     keyExtractor?: (item: SubTabItem<TValue>) => string;
@@ -40,6 +41,10 @@ type SubTabStyleProps = {
     size: SubTabsSize;
 };
 
+type TabsStyleProps = {
+    paddingHorizontal?: NativeSpacing;
+};
+
 const typographyBySize = {
     normal: 'body-sm',
     large: 'body-md',
@@ -50,8 +55,9 @@ const iconSizeBySize = {
     large: 24,
 } as const satisfies Record<SubTabsSize, number>;
 
-const tabsStyle = prepareNativeStyle(({ spacings }) => ({
-    gap: spacings.sp12,
+const tabsStyle = prepareNativeStyle<TabsStyleProps>((utils, { paddingHorizontal }) => ({
+    gap: utils.spacings.sp12,
+    paddingHorizontal: paddingHorizontal ? utils.spacings[paddingHorizontal] : undefined,
 }));
 
 const tabStyle = prepareNativeStyle<SubTabStyleProps>((utils, { isActive, size }) => ({
@@ -126,6 +132,7 @@ export const SubTabs = <TValue,>({
     items,
     keyExtractor = item => String(item.value),
     onChange,
+    paddingHorizontal,
     size = 'normal',
     testID,
     value,
@@ -152,7 +159,7 @@ export const SubTabs = <TValue,>({
             ref={listRef}
             accessibilityRole="tablist"
             accessible={true}
-            contentContainerStyle={applyStyle(tabsStyle)}
+            contentContainerStyle={applyStyle(tabsStyle, { paddingHorizontal })}
             data={items}
             extraData={{ size, value }}
             horizontal={true}

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, EdgeFades, HStack, type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { Box, EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -67,11 +67,14 @@ export const HeaderTabs = () => {
     };
 
     return (
-        <Box paddingHorizontal="sp16">
-            <HStack spacing={0}>
-                <SubTabs items={data} onChange={onTabPress} value={activeTab} />
-                <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
-            </HStack>
+        <Box>
+            <SubTabs
+                items={data}
+                onChange={onTabPress}
+                paddingHorizontal="sp16"
+                value={activeTab}
+            />
+            <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
         </Box>
     );
 };

--- a/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
+++ b/suite-native/module-trading/src/components/general/Header/HeaderTabs.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useServices } from '@suite-common/dependency-injection';
 import { type TradingTypeWithConcierge } from '@suite-common/trading';
 import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { useTranslate } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -67,7 +67,7 @@ export const HeaderTabs = () => {
     };
 
     return (
-        <Box>
+        <>
             <SubTabs
                 items={data}
                 onChange={onTabPress}
@@ -75,6 +75,6 @@ export const HeaderTabs = () => {
                 value={activeTab}
             />
             <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
-        </Box>
+        </>
     );
 };

--- a/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
@@ -1,6 +1,7 @@
 import { type TradingType } from '@suite-common/trading';
-import { Box, type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { Box, EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
+import { useNativeStyles } from '@trezor/styles-native';
 
 export type TradingHistoryFilter = TradingType | 'all';
 
@@ -35,14 +36,20 @@ const items: SubTabItem<TradingHistoryFilter>[] = [
     },
 ];
 
-export const TradingHistoryTabs = ({ value, onChange }: TradingHistoryTabsProps) => (
-    <Box paddingHorizontal="sp16">
-        <SubTabs
-            items={items}
-            onChange={onChange}
-            size="large"
-            testID="@trading/history/tabs"
-            value={value}
-        />
-    </Box>
-);
+export const TradingHistoryTabs = ({ value, onChange }: TradingHistoryTabsProps) => {
+    const { utils } = useNativeStyles();
+
+    return (
+        <Box>
+            <SubTabs
+                items={items}
+                onChange={onChange}
+                paddingHorizontal="sp16"
+                size="large"
+                testID="@trading/history/tabs"
+                value={value}
+            />
+            <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
+        </Box>
+    );
+};

--- a/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
+++ b/suite-native/trading-history/src/components/TradingHistoryTabs.tsx
@@ -1,5 +1,5 @@
 import { type TradingType } from '@suite-common/trading';
-import { Box, EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
+import { EdgeFades, type SubTabItem, SubTabs } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { useNativeStyles } from '@trezor/styles-native';
 
@@ -40,7 +40,7 @@ export const TradingHistoryTabs = ({ value, onChange }: TradingHistoryTabsProps)
     const { utils } = useNativeStyles();
 
     return (
-        <Box>
+        <>
             <SubTabs
                 items={items}
                 onChange={onChange}
@@ -50,6 +50,6 @@ export const TradingHistoryTabs = ({ value, onChange }: TradingHistoryTabsProps)
                 value={value}
             />
             <EdgeFades direction="horizontal" startSize={utils.spacings.sp20} />
-        </Box>
+        </>
     );
 };


### PR DESCRIPTION
## Description

- Adds configurable horizontal padding to `SubTabs`.
- Applies padding and edge fades to trading header and trading history tabs.


## Notes for QA
- no QA 

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31103

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31103-trading-header-tabs-padding-cut-off&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->