### PR TITLE
fix(protocol): throw meaningful error while encoding THP protobuf

### DIFF
--- a/packages/protocol/src/protocol-thp/decode.ts
+++ b/packages/protocol/src/protocol-thp/decode.ts
@@ -92,11 +92,15 @@ const readProtobufMessage = (
     { payload, thpState }: ThpMessage,
     protobufDecoder: ProtobufDecoder,
 ): ThpMessageResponse => {
+    if (!thpState.handshakeCredentials) {
+        throw new Error('ThpStateMissing');
+    }
+
     const tagPos = payload.length - TAG_LENGTH - CRC_LENGTH;
     const cipheredMessage = payload.subarray(0, tagPos);
     const tag = payload.subarray(tagPos, payload.length - CRC_LENGTH);
     const decipheredMessage = decipherMessage(
-        thpState.handshakeCredentials!.trezorKey,
+        thpState.handshakeCredentials.trezorKey,
         thpState.recvNonce,
         cipheredMessage,
         tag,

--- a/packages/protocol/src/protocol-thp/encode.ts
+++ b/packages/protocol/src/protocol-thp/encode.ts
@@ -180,7 +180,7 @@ export const encodeProtobufMessage = (
     channel: Buffer,
     thpState?: ThpState,
 ) => {
-    if (!thpState) {
+    if (!thpState?.handshakeCredentials) {
         throw new Error('ThpStateMissing');
     }
 
@@ -198,7 +198,7 @@ export const encodeProtobufMessage = (
     const messageTypeBytes = Buffer.alloc(2);
     messageTypeBytes.writeUInt16BE(messageType);
     const cipheredMessage = cipherMessage(
-        thpState.handshakeCredentials!.hostKey,
+        thpState.handshakeCredentials.hostKey,
         thpState.sendNonce,
         Buffer.alloc(0),
         Buffer.concat([thpState.sessionId, messageTypeBytes, data]),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
It does not solve the reason of the [sentry reported issue](https://app.notion.com/p/satoshilabs/Error-Cannot-read-property-hostKey-of-undefined-90846b3e1ead4311b4d55a88076e2c65), it just throws meaningful error

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/thp-protobuf-encode/web/](https://dev.suite.sldev.cz/suite-web/fix/thp-protobuf-encode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are low-level THP codec utilities with a very broad static footprint, so the safest minimal strategy is to run only tests that explicitly exercise THP pairing/device communication. The selected high-priority tests cover THP pairing code entry, initial-run persistence, and a full T3W1 wallet creation, while a single analytics test acts as a canary for device-connect event paths.

<details><summary><b>Changed files (2)</b></summary>

- `packages/protocol/src/protocol-thp/decode.ts`
- `packages/protocol/src/protocol-thp/encode.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The test explicitly exercises the THP pairing code flow during onboarding, which directly depends on protocol-thp encode/decode. A regression here would break device connection for THP-capable devices.
- `suite/e2e/tests/onboarding/initial-run.test.ts` — It validates initial-run onboarding with THP pairing code entry and reload behavior, directly using the THP protocol path affected by the changed files.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This is the only test that performs a full wallet creation on T3W1 and explicitly includes 'Device pairing via THP', covering encode/decode for pairing, firmware, backup, PIN, and network activation.
- `suite/e2e/tests/suite/initial-run.test.ts` — It covers the same THP pairing code flow as the onboarding initial-run test but from the suite-level route, including page reloads, making it a direct regression test for THP onboarding state.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The source hints list THP pairing flow and the test exercises device connect/disconnect lifecycle; a THP protocol regression could alter device metadata or event capture.

</details>

_Updated: 2026-08-11T10:39:08.544Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-protobuf-encode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-protobuf-encode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T10:41:42.863Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T10:40:42.220Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->