### PR TITLE
fix(suite-native): adds parity with outcomes with desktop flows

### DIFF
--- a/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
+++ b/packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { type YieldDtoV2 } from '@suite-common/earn-stablecoin-api';
-import { type YieldFlowCompleteValue, type YieldWithdrawFlowType } from '@suite-common/wallet-core';
+import {
+    type YieldFlowCompleteValue,
+    type YieldWithdrawFlowType,
+    getYieldWithdrawCompletedValues,
+} from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 
-import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
 import { type YieldFlowContextValues, useYieldFlow } from '../hooks/useYieldFlow';
 
 type UseYieldWithdrawProps = {

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -78,6 +78,7 @@ export * from './stablecoin-yield/utils/stablecoinYieldDeviceUtils';
 export * from './stablecoin-yield/utils/stablecoinYieldFeeEstimation';
 export * from './stablecoin-yield/stablecoinYieldTypes';
 export * from './stablecoin-yield/utils/stablecoinYieldUtils';
+export * from './stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues';
 export * from './stablecoin-yield/thunks/stablecoinYieldWrapThunks';
 export * from './stablecoin-yield/hooks/useWrappedNativePendingTx';
 export * from './stake/tron/tronStakeReducer';

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.test.ts
@@ -1,7 +1,7 @@
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { type YieldFlowDisplayToken, type YieldFlowToken } from '@suite-common/wallet-core';
 
-import { getYieldWithdrawCompletedValues } from './getYieldWithdrawCompletedValues';
+import { type YieldFlowDisplayToken, type YieldFlowToken } from '../stablecoinYieldTypes';
+import { getYieldWithdrawCompletedValues } from './stablecoinYieldWithdrawCompletedValues';
 
 type Params = Parameters<typeof getYieldWithdrawCompletedValues>[0];
 
@@ -87,4 +87,20 @@ describe('getYieldWithdrawCompletedValues', () => {
         expect(output.token.symbol).toBe('ETH');
         expect(output.amount).toBe('2.1');
     });
+
+    it.each(['redeem', 'withdraw'] as const)(
+        '%s without a known price per share: falls back to the completed amount for both legs',
+        flowType => {
+            const { input, output } = getYieldWithdrawCompletedValues({
+                ...base,
+                pricePerShareState: undefined,
+                flowType,
+                completedAmount: '2.1',
+                unwrappedAmount: null,
+            });
+
+            expect(input).toEqual({ token: receiptToken, amount: '2.1' });
+            expect(output).toEqual({ token, amount: '2.1' });
+        },
+    );
 });

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.ts
@@ -4,14 +4,17 @@ import {
     getNetwork,
     getNetworkDisplaySymbol,
 } from '@suite-common/wallet-config';
+
+import type {
+    YieldFlowCompleteValue,
+    YieldFlowDisplayToken,
+    YieldFlowToken,
+    YieldWithdrawFlowType,
+} from '../stablecoinYieldTypes';
 import {
-    type YieldFlowCompleteValue,
-    type YieldFlowDisplayToken,
-    type YieldFlowToken,
-    type YieldWithdrawFlowType,
     getConvertedOutputTokenBalanceToInputTokenAmount,
     getWithdrawRequestAmount,
-} from '@suite-common/wallet-core';
+} from './stablecoinYieldUtils';
 
 type PricePerShareState = NonNullable<YieldDtoV2['state']>['pricePerShareState'];
 

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -74,11 +74,16 @@ export const EarnFormScreenFooter = ({
             <Box style={applyStyle(screenFooterStyle)}>
                 {isRewardsBoxVisible && (
                     <Box style={applyStyle(rewardsBoxStyle)}>
-                        <VStack spacing="sp4" paddingTop="sp12" alignItems="center">
-                            <Text variant="body-sm" color="contentPrimary">
+                        <VStack
+                            spacing="sp4"
+                            paddingTop="sp12"
+                            paddingHorizontal="sp16"
+                            alignItems="center"
+                        >
+                            <Text variant="body-sm" color="contentPrimary" textAlign="center">
                                 <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
                             </Text>
-                            <Text variant="headline-sm" color="contentBrand">
+                            <Text variant="headline-sm" color="contentBrand" textAlign="center">
                                 {estimatedRewards}
                             </Text>
                         </VStack>

--- a/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
@@ -86,7 +86,7 @@ type GetYieldWithdrawCompleteRowsParams = {
     accountSymbol: NetworkSymbol;
     receivedAmount: string;
     receivedTokenContract?: string;
-    withdrawalAmount?: string;
+    withdrawalAmount: string;
     withdrawalTokenContract?: string;
 };
 
@@ -98,6 +98,22 @@ export const getYieldWithdrawCompleteRows = ({
     withdrawalTokenContract,
 }: GetYieldWithdrawCompleteRowsParams): YieldCompleteSummaryRow[] => [
     getYieldCompleteStatusRow(),
+    {
+        key: 'sent',
+        label: <Translation id="earn.yieldCompleteScreen.sent" />,
+        value: (
+            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
+                <TokenIcon
+                    symbol={accountSymbol}
+                    contractAddress={withdrawalTokenContract}
+                    size="extraSmall"
+                />
+                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
+                    -{withdrawalAmount}
+                </Text>
+            </HStack>
+        ),
+    },
     {
         key: 'received',
         label: <Translation id="earn.yieldCompleteScreen.received" />,
@@ -114,26 +130,6 @@ export const getYieldWithdrawCompleteRows = ({
             </HStack>
         ),
     },
-    ...(withdrawalAmount
-        ? [
-              {
-                  key: 'sent',
-                  label: <Translation id="earn.yieldCompleteScreen.sent" />,
-                  value: (
-                      <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                          <TokenIcon
-                              symbol={accountSymbol}
-                              contractAddress={withdrawalTokenContract}
-                              size="extraSmall"
-                          />
-                          <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                              -{withdrawalAmount}
-                          </Text>
-                      </HStack>
-                  ),
-              },
-          ]
-        : []),
 ];
 
 type GetWrappedNativeCompleteRowsParams = {

--- a/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
@@ -96,11 +96,16 @@ export const YieldDepositFlowFooter = ({
                         style={isEstimatedRewardsVisible ? applyStyle(rewardsBoxStyle) : undefined}
                     >
                         {isEstimatedRewardsVisible && (
-                            <VStack spacing="sp4" paddingVertical="sp12" alignItems="center">
-                                <Text variant="body-sm" color="contentPrimary">
+                            <VStack
+                                spacing="sp4"
+                                paddingVertical="sp12"
+                                paddingHorizontal="sp16"
+                                alignItems="center"
+                            >
+                                <Text variant="body-sm" color="contentPrimary" textAlign="center">
                                     <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
                                 </Text>
-                                <Text variant="headline-sm" color="contentBrand">
+                                <Text variant="headline-sm" color="contentBrand" textAlign="center">
                                     {estimatedRewards}
                                 </Text>
                             </VStack>

--- a/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx
@@ -6,10 +6,9 @@ import { type RouteProp, useNavigation, useRoute } from '@react-navigation/nativ
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
 import { buildUserFeedbackData, sendFeedbackAction } from '@suite-common/feedback';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
 import {
     type StablecoinYieldRootState,
-    getConvertedOutputTokenBalanceToInputTokenAmount,
+    getYieldWithdrawCompletedValues,
     selectStablecoinYieldSessionByFlowKey,
     stablecoinYieldActions,
 } from '@suite-common/wallet-core';
@@ -40,12 +39,12 @@ export const YieldWithdrawCompleteScreen = () => {
     const dispatch = useDispatch();
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const locale = useSelector(selectSupportedLanguageLocale);
-    const { account, flowKey, resolutionStatus, vault } = useResolvedYieldFlowData(route.params);
+    const { account, flowKey, receiptToken, resolutionStatus, token, vault } =
+        useResolvedYieldFlowData(route.params);
     const flowType = route.params.withdrawFlowType ?? 'withdraw';
     const session = useSelector((state: StablecoinYieldRootState) =>
         selectStablecoinYieldSessionByFlowKey(state, flowType, flowKey),
     );
-    const isSharesInput = flowType === 'redeem';
     const { analytics } = useServices(selectNativeAnalyticsDep);
 
     const feedbackForm = useFeedbackForm();
@@ -114,51 +113,38 @@ export const YieldWithdrawCompleteScreen = () => {
     }, [navigation, navigateToInitialScreen, resolutionStatus, route.params, session]);
 
     const rows = useMemo(() => {
-        if (resolutionStatus !== 'resolved' || !session || !vault.outputToken) {
+        if (resolutionStatus !== 'resolved' || !session) {
             return [];
         }
 
         const { completedAmount, unwrappedAmount } = session.result;
 
-        const hasUnwrappedOutput = unwrappedAmount !== null;
-        const underlyingSymbol = hasUnwrappedOutput
-            ? getNetworkDisplaySymbol(account.symbol)
-            : vault.token.symbol;
-        const withdrawnUnderlyingAmount = isSharesInput
-            ? getConvertedOutputTokenBalanceToInputTokenAmount({
-                  networkSymbol: account.symbol,
-                  token: vault.token,
-                  outputToken: vault.outputToken,
-                  outputTokenBalance: completedAmount,
-                  pricePerShareState: vault.state?.pricePerShareState,
-              })
-            : completedAmount;
-        const receivedUnderlyingAmount = unwrappedAmount ?? withdrawnUnderlyingAmount;
-
-        const receivedAmount = formatEarnTokenAmount({
-            amount: receivedUnderlyingAmount,
-            locale,
-            symbol: underlyingSymbol,
+        const { input, output } = getYieldWithdrawCompletedValues({
+            networkSymbol: account.symbol,
+            flowType,
+            completedAmount,
+            unwrappedAmount,
+            token,
+            receiptToken,
+            pricePerShareState: vault.state?.pricePerShareState,
         });
-
-        const withdrawalAmount = isSharesInput
-            ? formatEarnTokenAmount({
-                  amount: completedAmount,
-                  locale,
-                  symbol: vault.outputToken.symbol,
-              })
-            : undefined;
 
         return getYieldWithdrawCompleteRows({
             accountSymbol: account.symbol,
-            receivedAmount,
-            receivedTokenContract: hasUnwrappedOutput
-                ? undefined
-                : (vault.token.address ?? undefined),
-            withdrawalAmount,
-            withdrawalTokenContract: vault.outputToken.address ?? undefined,
+            receivedAmount: formatEarnTokenAmount({
+                amount: output.amount,
+                locale,
+                symbol: output.token.symbol,
+            }),
+            receivedTokenContract: output.token.contractAddress ?? undefined,
+            withdrawalAmount: formatEarnTokenAmount({
+                amount: input.amount,
+                locale,
+                symbol: input.token.symbol,
+            }),
+            withdrawalTokenContract: input.token.contractAddress ?? undefined,
         });
-    }, [account, isSharesInput, locale, resolutionStatus, session, vault]);
+    }, [account, flowType, locale, receiptToken, resolutionStatus, session, token, vault]);
 
     if (resolutionStatus !== 'resolved' || session?.step !== 'complete') {
         return null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses same tools for getting the outcomes, screenshots are below

## Notes for QA

I tested deposit/withdraw flows with both assets

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31094

## Screenshots:

| Deposit WETH | Deposit ETH |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 12 45 30" src="https://github.com/user-attachments/assets/2960238c-890b-4a5d-b00a-eb2abd545239" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 12 44 20" src="https://github.com/user-attachments/assets/f5e2e192-27e6-4184-a68b-0890f1c15695" /> | 


| Only withdraw | + Wrap |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 12 41 50" src="https://github.com/user-attachments/assets/c5673d3c-944b-4097-8e9f-fced1e711cb2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 12 41 02" src="https://github.com/user-attachments/assets/67d6fb7a-be8d-4090-82eb-c97394793b62" /> | 

### One more bug

| Before | Header |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 12 43 14" src="https://github.com/user-attachments/assets/f4a83ac2-7c8b-45b7-8c62-88c5530dcbc0" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 13 07 33" src="https://github.com/user-attachments/assets/e680cf7c-ffa6-4ac0-9de0-6f3869dbb481" /> | 


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes focus on stablecoin yield withdraw completion logic in web Suite (useYieldWithdraw hook and stablecoinYieldWithdrawCompletedValues utility) and native earn module screens. None of the 160 candidate Playwright E2E tests cover stablecoin yield withdraw flows; the closest tests are staking tests, which exercise different functionality. Native module changes are outside the scope of this web/desktop E2E suite. Therefore no E2E tests are recommended for this change set.

<details><summary><b>Changed files (8)</b></summary>

- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.ts`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (8)**
- `packages/suite/src/components/earn/yield/withdraw/useYieldWithdraw.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/stablecoinYieldWithdrawCompletedValues.ts`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawCompleteScreen.tsx`

_Updated: 2026-08-11T11:23:55.411Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/deposit-summary/web/](https://dev.suite.sldev.cz/suite-web/fix/deposit-summary/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/deposit-summary&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/deposit-summary&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/deposit-summary&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T11:26:45.169Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T11:25:55.045Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->