### PR TITLE
Add performance skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ A package may only import from scopes listed above it (e.g. `suite` can depend o
 - [Common Issues](skills/common-issues/SKILL.md) – Known issues and their solutions
 - [Components](skills/components/SKILL.md) – React component file structure and patterns
 - [Common Tasks](skills/common-tasks/SKILL.md) – Dependency management, package creation, and troubleshooting
-- [Defensive Programming](skills/defensive-programming/SKILL.md) – Exhaustive checks and safe defaults
+- [Defensive Programming](skills/defensive-programming/SKILL.md) – Exhaustive checks, safe defaults, and non-mutating array methods
 - [Dependency Injection](skills/dependency-injection/SKILL.md) – DI pattern for service definitions, factories, and composition roots
 - [Development Commands](skills/development-commands/SKILL.md) – Running apps, linting, testing, and building
 - [Git and Commit Guidelines](skills/git-and-commit-guidelines/SKILL.md) – Conventional Commits format and best practices
@@ -34,6 +34,10 @@ A package may only import from scopes listed above it (e.g. `suite` can depend o
 - [Import/Export](skills/import-export/SKILL.md) – Named exports and import ordering
 - [Naming](skills/naming/SKILL.md) – Naming conventions for variables, functions, and files
 - [Packages](skills/packages/SKILL.md) – How to create and structure packages
+- [Performance Complexity](skills/performance-complexity/SKILL.md) – Asymptotic complexity: indexing before iteration, sort comparators, reduce accumulators
+- [Performance DOM](skills/performance-dom/SKILL.md) – Forced layout from DOM reads, observer APIs, and transitioning only compositor properties
+- [Performance React Hooks](skills/performance-react-hooks/SKILL.md) – Memoization under React Compiler, stable hook dependencies, and telling a wasted memo from a render loop
+- [Performance Scheduling](skills/performance-scheduling/SKILL.md) – Breaking up long tasks and deferring non-essential work off the critical path
 - [Project Overview](skills/project-structure/SKILL.md) – What Trezor Suite is and how the monorepo is organized
 - [Publish Config](skills/publish-config/SKILL.md) – publishConfig rules for public npm packages
 - [Redux](skills/redux/SKILL.md) – Redux Toolkit patterns and best practices

--- a/skills/defensive-programming/SKILL.md
+++ b/skills/defensive-programming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: defensive-programming
-description: Type safety practices including exhaustive checks, explicit return types, and Result-based error handling. Use when writing TypeScript logic that handles multiple cases or error conditions.
+description: Type safety practices including exhaustive checks, explicit return types, Result-based error handling, and non-mutating array methods. Use when writing TypeScript logic that handles multiple cases or error conditions, or when sorting, reversing, splicing, or replacing an element (indexed assignment) in an array you did not create.
 ---
 
 # Defensive Programming
@@ -58,6 +58,18 @@ type Schema = {
 const result: { [K in keyof Schema]: () => void } = {
     a: () => console.log('This is A'),
 };
+```
+
+## Prefer the non-mutating array methods to copy-then-mutate
+
+`[...items].sort()` and `items.slice().sort()` are workarounds for `sort` mutating in place, and they only work if you remember the copy. `toSorted`, `toReversed`, `toSpliced` and [`with`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with) return a new array, so forgetting is not an option — and forgetting matters here, because the arrays in play are usually a selector result or Redux state that something else is still holding. Nothing will catch it either: `immutableCheck` is `false` in both stores ([suite](../../packages/suite/src/reducers/store.ts), [native](../../suite-native/state/src/store.ts)), so a mutated slice surfaces later as a stale render or a wrong total, far from the `.sort()` that caused it.
+
+```ts
+// bad - two steps to say "sorted copy", and `.sort()` mutates whatever it is handed
+const sorted = [...accounts].sort(byBalance);
+
+// good - one call, nothing to forget
+const sorted = accounts.toSorted(byBalance);
 ```
 
 ## Do not use exceptions

--- a/skills/performance-complexity/SKILL.md
+++ b/skills/performance-complexity/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: performance-complexity
+description: Collection-handling performance for Trezor Suite — indexing before iteration, O(1) sort comparators, and reduce accumulators that don't allocate. Use when writing a loop, sort or reduce over accounts, tokens, transactions or UTXOs.
+---
+
+# Asymptotic Complexity
+
+Work that grows faster than the collection it runs on. Ask what `n` is at runtime first: network lists,
+fee levels and account types are bounded at a few dozen forever, so a nested scan over them is fine and
+always will be. Transactions, UTXOs, tokens, contracts and rates grow with the account or with upstream
+data, and the large end is real — `buildCoinDataForPlatform` returns a `Set` so callers avoid "a linear
+scan over tens of thousands of contracts"
+([fetchCoins.ts](../../suite-common/token-definitions/scripts/utils/fetchCoins.ts)). Anything a linter
+could decide belongs in [`noRestrictedSyntax`](../../packages/eslint/src/javascriptConfig.mjs) or
+[`eslint-local-rules/rules.ts`](../../eslint-local-rules/rules.ts) instead.
+
+## Index by key before iterating, don't scan inside a loop
+
+A `.find()`, `.some()` or `.includes()` inside a `.map()` or `.filter()` is O(n·m), and anything not
+derived from the callback parameter belongs above the loop. Key the `Set` or `Map` on whatever the inner
+comparison actually compares, reusing the key helper that already exists (`getUtxoOutpoint`,
+`getAccountKey`) rather than inventing one.
+
+```ts
+// bad - simpleSearchTransactions.ts:239 rebuilds a deduped array per transaction, O(n²)
+const found = transactions.filter(transaction => unique(txsToSearch).includes(transaction.txid));
+
+// good - advancedSearchTransactions.ts:23 - index once, O(1) per transaction
+const searchedTxIds = new Set(txsToSearch);
+
+const found = transactions.filter(transaction => searchedTxIds.has(transaction.txid));
+```
+
+The costly instances span two files, so no grep finds them: `UtxoSelectionList.tsx:66` runs
+`accountTransactions.find()` per row while `UtxoSelection.tsx:112` runs `selectedUtxos.some(isSameUtxo)`
+per row ([#25937](https://github.com/trezor/trezor-suite/pull/25937#discussion_r2939995684),
+[#26344](https://github.com/trezor/trezor-suite/pull/26344#discussion_r3027690127)).
+
+## Keep a sort comparator to O(1) field reads
+
+A scan inside a comparator is strictly worse than the same scan in a `.map()` — you pay an extra `log n`
+factor — and allocating in one is nearly as bad: `utxoSortingUtils.ts:33` builds two `new BigNumber` per
+comparison, and `sortUtxos` runs bare in a hook body at `useUtxoSelection.ts:94`.
+
+```ts
+// bad - utxoSortingUtils.ts:43 - getBlockTime scans txs, twice per comparison
+const sorted = [...utxos].sort((a, b) => getBlockTime(b, txs) - getBlockTime(a, txs));
+
+// good - index once, then the comparator is two Map reads
+const blockTimeByTxid = new Map(txs.map(tx => [tx.txid, tx.blockTime ?? 0]));
+const blockTimeOf = (utxo: AccountUtxo) => blockTimeByTxid.get(utxo.txid) ?? 0;
+
+const sorted = utxos.toSorted((a, b) => blockTimeOf(b) - blockTimeOf(a));
+```
+
+## Don't spread the accumulator in `.reduce()` — use a `Map` or a keyed assign
+
+Each `{ ...acc }` copies everything accumulated so far, making the `reduce` O(n²) in allocations.
+
+```ts
+// bad - fiatRatesReducer.ts:130 - one key per point of price history, merged in on every rate update
+const byTimestamp = rates.reduce(
+    (acc, rate) => ({ ...acc, [rate.lastTickerTimestamp]: rate.rate }),
+    {},
+);
+
+// good - one insertion per rate
+const byTimestamp = new Map(rates.map(rate => [rate.lastTickerTimestamp, rate.rate]));
+
+// also good - a plain object, mutating the accumulator the reduce already owns
+const byTimestamp = rates.reduce<Record<string, number>>((acc, rate) => {
+    acc[rate.lastTickerTimestamp] = rate.rate;
+
+    return acc;
+}, {});
+```
+
+## Related skills
+
+- [Defensive programming](../defensive-programming/SKILL.md) — why the sort above is `toSorted` and not
+  `[...utxos].sort()`: the non-mutating array methods.
+- [React hooks](../performance-react-hooks/SKILL.md) — memoization, dependency arrays, render loops.
+- [DOM and CSS](../performance-dom/SKILL.md) — forced layout, observers, compositor-only animation.
+- [Long and non-essential tasks](../performance-scheduling/SKILL.md) — yielding long tasks, deferring
+  background work.

--- a/skills/performance-dom/SKILL.md
+++ b/skills/performance-dom/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: performance-dom
+description: Browser rendering performance for Trezor Suite — forced synchronous layout from geometry reads, observer APIs instead of measuring an element, and transitioning only compositor properties. Use when measuring, scrolling or animating a DOM element, or when writing a CSS transition. Web and desktop only.
+---
+
+# DOM Manipulation and CSS Properties
+
+Reads that force the browser to lay out again mid-frame, and animations that make it lay out on every
+frame. Web and desktop only.
+
+## Optimize DOM reads and writes, and never interleave them
+
+All of the below properties or methods, when requested/called in JavaScript, will trigger the browser to synchronously calculate the style and layout*. This is also called reflow or layout thrashing, and is common performance bottleneck.
+
+Generally, all APIs that synchronously provide layout metrics will trigger forced reflow / layout. Read on for additional cases and details
+
+Getting box metrics
+
+- `elem.offsetLeft`, `elem.offsetTop`, `elem.offsetWidth`, `elem.offsetHeight`, `elem.offsetParent`
+- `elem.clientLeft`, `elem.clientTop`, `elem.clientWidth`, `elem.clientHeight`
+- `elem.getClientRects()`, `elem.getBoundingClientRect()`
+
+Scroll stuff
+
+- `elem.scrollBy()`, `elem.scrollTo()`
+- `elem.scrollIntoView()`, `elem.scrollIntoViewIfNeeded()`
+- `elem.scrollWidth`, `elem.scrollHeight`
+- `elem.scrollLeft`, `elem.scrollTop` also, setting them
+
+- `elem.focus()` ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/dom/element.cc;l=4206-4225;drc=d685ea3c9ffcb18c781bc3a0bdbb92eb88842b1b))
+
+- `elem.computedRole`, `elem.computedName`
+- `elem.innerText` ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/editing/element_inner_text.cc;l=462-468;drc=d685ea3c9ffcb18c781bc3a0bdbb92eb88842b1b))
+
+- `window.scrollX`, `window.scrollY`
+- `window.innerHeight`, `window.innerWidth`
+- window.visualViewport.height / width / offsetTop / offsetLeft ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/frame/visual_viewport.cc;l=435-461;drc=a3c165458e524bdc55db15d2a5714bb9a0c69c70?originalUrl=https:%2F%2Fcs.chromium.org%2F))
+
+- `document.scrollingElement` only forces style
+- `document.elementFromPoint`
+
+- `inputElem.focus()`
+- `inputElem.select()`, `textareaElem.select()`
+
+- `mouseEvt.layerX`, `mouseEvt.layerY`, `mouseEvt.offsetX`, `mouseEvt.offsetY` ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/events/mouse_event.cc;l=476-487;drc=52fd700fb07a43b740d24595d42d8a6a57a43f81))
+
+`window.getComputedStyle()` will typically force style recalc.
+
+`window.getComputedStyle()` will often force layout, as well.
+
+Details of the conditions where gCS() forces layout
+
+`window.getComputedStyle()` will force layout in one of 3 conditions:
+
+1. The element is in a shadow tree
+2. There are media queries (viewport-related ones). Specifically, one of the following: ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/media_query_exp.cc;l=240-256;drc=4c8db70889f2d2fae8338b16f553c646dd20bf78)
+    - `min-width`, `min-height`, `max-width`, `max-height`, `width`, `height`
+    - `aspect-ratio`, `min-aspect-ratio`, `max-aspect-ratio`
+    - `device-pixel-ratio`, `resolution`, `orientation` , `min-device-pixel-ratio`, `max-device-pixel-ratio`
+3. The property requested is one of the following: ([source](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/css/properties/css_property.h;l=69;drc=d685ea3c9ffcb18c781bc3a0bdbb92eb88842b1b))
+    - `height`, `width`
+    - `top`, `right`, `bottom`, `left`
+    - `margin` [`-top`, `-right`, `-bottom`, `-left`, or _shorthand_] only if the margin is fixed.
+    - `padding` [`-top`, `-right`, `-bottom`, `-left`, or _shorthand_] only if the padding is fixed.
+    - `transform`, `transform-origin`, `perspective-origin`
+    - `translate`, `rotate`, `scale`
+    - `grid`, `grid-template`, `grid-template-columns`, `grid-template-rows`
+    - `perspective-origin`
+    - These items were previously in the list but appear to not be any longer (as of Feb 2018): `motion-path`, `motion-offset`, `motion-rotation`, `x`, `y`, `rx`, `ry`
+
+- `range.getClientRects()`, `range.getBoundingClientRect()`
+
+### SVG
+
+Quite a lot of properties/methods force. This list in incomplete:
+
+- SVGLocatable: `computeCTM()`, `getBBox()`
+- SVGTextContent: `getCharNumAtPosition()`, `getComputedTextLength()`, `getEndPositionOfChar()`, `getExtentOfChar()`, `getNumberOfChars()`, `getRotationOfChar()`, `getStartPositionOfChar()`, `getSubStringLength()`, `selectSubString()`
+- SVGUse: `instanceRoot`
+
+- Lots & lots of stuff, including copying an image to clipboard ([source](https://source.chromium.org/search?q=UpdateStyleAndLayout%20-f:test&ss=chromium%2Fchromium%2Fsrc:third_party%2Fblink%2Frenderer%2Fcore%2Fediting%2F))
+
+[Source](https://gist.githubusercontent.com/paulirish/5d52fb081b3570c81e3a/raw/6e6fd7096c505d3b536f0612f3dc91a9dec97302/what-forces-layout.md)
+
+```ts
+// bad - collapse.tsx:37 - line two re-reads the clientWidth that line one's write just invalidated
+inner.style.width = `${inner.clientWidth}px`;
+container.style.width = `${inner.clientWidth}px`;
+
+// good - one read, then the writes
+const innerWidth = inner.clientWidth;
+
+inner.style.width = `${innerWidth}px`;
+container.style.width = `${innerWidth}px`;
+```
+
+- Where geometry _can_ come from an observer, take it there: an `IntersectionObserver` or `ResizeObserver`
+  callback runs after layout, so reading in it is cheap (example: [`useAnchor.ts:25`](../../suite/router/src/useAnchor.ts)).
+- `requestAnimationFrame` requests the browser to call a user-supplied callback function before the next repaint.
+
+## Transition compositor properties, and never leave the property unnamed
+
+- `width`, `height`, `top`, `margin` and `min-width` re-run layout on every frame of the animation
+- `transform`, `opacity` are composited and do not.
+- `transition: all` is the same defect with nothing named — and so is the bare-duration shorthand, because an omitted `transition-property` resets to `all`.
+
+```tsx
+// bad - ProgressBar.tsx:22 - lays out the bar every frame for half a second
+width: ${({ $max, $value }) => `calc((100% / ${$max}) * ${$value})`};
+transition: width 0.5s;
+
+// good - laid out once at full width, then scaled
+width: 100%;
+transform-origin: left;
+transform: scaleX(${({ $max, $value }) => $value / $max});
+transition: transform 0.5s;
+```
+
+- `transform-origin` is load-bearing: the default origin is the centre, so without it every bar in the app
+  grows from its middle. Scale is also the weakest case for `transform` — a scale change re-rasters unless
+  `will-change: transform` pins the texture, and then it stretches a bitmap — so it is safe for a solid
+  childless fill like this one and wrong for a pill-shaped or labelled bar, where it distorts the radius and
+  the text. Translation and opacity are the genuinely composite-only changes.
+
+## Related skills
+
+- [Asymptotic complexity](../performance-complexity/SKILL.md) — indexing, sorting and reducing over
+  collections that grow.
+- [React hooks](../performance-react-hooks/SKILL.md) — memoization, dependency arrays, render loops.
+- [Long and non-essential tasks](../performance-scheduling/SKILL.md) — yielding long tasks, deferring
+  background work.

--- a/skills/performance-react-hooks/SKILL.md
+++ b/skills/performance-react-hooks/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: performance-react-hooks
+description: React render performance for Trezor Suite — memoization under React Compiler, referentially stable hook dependencies, minimal dependency arrays, and telling a wasted memo from a render loop. Use when adding useMemo, useCallback or memo, when writing a dependency array, or when a component re-renders or refetches more than it should.
+---
+
+# React Hooks Performance
+
+Values that change identity on every render, and the memos, effects and requests that fire because of it.
+Check a re-render claim before and after: [`DebugView`](../../suite-native/atoms/src/DebugView.tsx) plus
+the dev-utils rerender-count toggle on mobile, the React DevTools Profiler on web. React Compiler doesn't
+run in native jest (`@swc/jest`), so render-count assertions there say nothing about production.
+
+## Check which app you are in before adding or removing a memo
+
+- **Mobile (`suite-native`) is compiled.** `experiments.reactCompiler: true` in
+  [`app.config.ts`](../../suite-native/app/app.config.ts) auto-memoizes every component and hook, so
+  don't add new manual memoization. A bail-out is worse than a missing memo — it silently drops
+  auto-memoization for the whole component; `react-hook-form`'s `watch()` causes one, use `useWatch()`.
+- **Web and desktop (`packages/suite`) are not compiled.** Manual memoization is the only mechanism at
+  runtime. `suite-common/*` and `packages/components` ship to both, so memoize for the web consumer.
+- **The compiler's lint rules apply everywhere, but only on CI.**
+  [`reactConfig.mjs`](../../packages/eslint/src/reactConfig.mjs) switches off ten of them —
+  `preserve-manual-memoization`, `immutability`, `purity`, `incompatible-library`, `globals`,
+  `error-boundaries`, `set-state-in-render`, `unsupported-syntax`, `config`, `gating` — unless
+  `ESLINT_RUN_EXPENSIVE_CHECKS=true`, which CI sets and your local `yarn lint:js` does not. The same flag
+  gates `reportUnusedDisableDirectives` ([`index.mjs:52`](../../packages/eslint/src/index.mjs)), so a
+  suppression that has stopped being necessary is also only reported on CI. Reproduce a green-locally,
+  red-on-CI run with `ESLINT_RUN_EXPENSIVE_CHECKS=true yarn lint:js`. `rules-of-hooks` and
+  `exhaustive-deps` are `error` everywhere, always.
+
+## Relocate render-body work before memoizing it, and memoize only what pays
+
+A bare `.find` / `.filter` / `.sort` over `accounts`, `account.tokens`, `transactions` or
+`availableVaults` in a component body re-runs on every render, and moving it is the preferred fix: an
+existing memoized selector, a named hook (`useEnabledNetworkOptions`), or a child component. Build new
+selectors with `createWeakMapSelector`
+([selectorsUtils.ts](../../suite-common/redux-utils/src/selectorsUtils.ts)). What stays in the component earns a `useMemo`
+only if the work is genuinely expensive over a real list, or a downstream component or hook needs the
+result's identity to be stable — O(1) arithmetic and formatting belong in a plain util. Redundant memos
+get flagged about as often as missing ones:
+([#25937](https://github.com/trezor/trezor-suite/pull/25937#discussion_r2939547571),
+[#22136](https://github.com/trezor/trezor-suite/pull/22136#discussion_r2401589060)).
+
+## Keep hook dependencies referentially stable
+
+`?? []`, `{}`, a default parameter, an inline arrow and every `.filter()` result produce a new reference
+per render, so each memo, callback and effect below them re-runs. `exhaustive-deps` stays silent because
+the dependency _is_ listed, and two shapes are provably invisible to it: one derived from a call
+expression (`const filtered = items.filter(...)`), and one that crosses the hook boundary
+(`useThing({ list: maybe ?? [] })` feeding a `useMemo` inside `useThing`). Fix with a module-level
+constant, or `returnStableArrayIfEmpty`
+([selectorsUtils.ts](../../suite-common/redux-utils/src/selectorsUtils.ts), 115 call sites) in a selector.
+
+```tsx
+// bad - useAccounts.ts:9 - ethereum, solana, ripple, stellar and tron have no `addresses`, so both
+// defaults are a fresh array and the useMemo that lists them never hits
+const { unused = [], used = [] } = addresses ?? {};
+
+// good - one reference for the life of the module
+const EMPTY_ADDRESSES: readonly AccountAddress[] = [];
+
+const { unused = EMPTY_ADDRESSES, used = EMPTY_ADDRESSES } = addresses ?? {};
+```
+
+[#29054](https://github.com/trezor/trezor-suite/pull/29054#discussion_r3466751441),
+[#24493](https://github.com/trezor/trezor-suite/pull/24493#discussion_r2720871227)
+
+## Minimal required dependencies
+
+Narrower than the containing object, never wider than the closure: `accountKey`, not `account`;
+`payload.amount`, not `payload` ([#23523](https://github.com/trezor/trezor-suite/pull/23523#discussion_r2576737518)).
+
+## Distinguish a wasted memo from a render loop
+
+The failure modes are nothing alike, and only one of them is a loop:
+
+- An unstable dependency on `useMemo` or `useCallback` recomputes every render. Memoization is gone, the
+  render count stays bounded. Wasteful, terminates — and it is this repo's actual recurring pain.
+- The same dependency on a `useEffect` that fires a request refires it every render. The render count
+  still doesn't grow, so this looks like the mild case, and it is the worst one: the request count is
+  unbounded, and if the response writes to state the next render fires the next request. That cycle is
+  paced by network latency rather than by React, so it never trips "Maximum update depth exceeded" —
+  that guard only counts synchronous nested updates. It fails silently against the backend instead of
+  loudly in dev.
+- The same dependency on a `useEffect` that stores a fresh reference is a synchronous cycle: render mints
+  a new array, the effect runs, `setState` renders again, "Maximum update depth exceeded" on about the
+  fiftieth nested update. Storing a primitive from it (`setState(claimable.length)`) terminates, because
+  React bails out on `Object.is` — an unstable dependency is necessary but not sufficient.
+
+```tsx
+// silent and unbounded - `account` is a new object after every blockchain update, so this refetches
+// every transaction again, and the fetch writes back to the account. Shipped in the Ethereum staking
+// dashboard from 2024-08 until #23523 narrowed it 15 months later.
+useEffect(() => {
+    dispatch(fetchAllTransactionsForAccountThunk({ accountKey, noLoading: true }));
+}, [account, accountKey, dispatch]);
+
+// loud and immediate - a fresh array each render, stored by the effect that re-renders to mint the next
+const claimable = rewards.filter(reward => reward.isClaimable);
+
+useEffect(() => setClaimableRewards(claimable), [claimable]);
+
+// good - AdaStakingDashboard.tsx:52 - the effect depends on stable primitives only
+useEffect(() => {
+    dispatch(fetchAllTransactionsForAccountThunk({ accountKey, noLoading: true }));
+}, [accountKey, dispatch]);
+
+// good - derived state is not state; there is no effect left to cycle
+const claimable = useMemo(() => rewards.filter(reward => reward.isClaimable), [rewards]);
+```
+
+State that can be computed from what you already have is not state; derive it during render and there is
+no cycle to have. When an effect really must fetch, depend on the identifier and not the record —
+`accountKey`, never `account`. `react-hooks/set-state-in-effect` is **off** here, so nothing warns you
+about the third case, and nothing warns you about the second one at all.
+
+## Never add a new `eslint-disable` for `exhaustive-deps`
+
+"Please, let's never use this comment. It leads to bugs and mem leaks." The failure mode is a lying
+dependency array on a memo whose callback reads through a ref. Restructure instead: read imperatively
+(`getValues()`), convert the memo to `useState` + `useEffect`, or hold the value in a ref — but check
+which one. When the value is genuinely read through a stable callback and the linter therefore cannot see
+it, keep the dependency listed and reference it with a `void` statement so the rule stays live rather than
+suppressed — `useTradingBuyFormDefaultValues.ts:45` does exactly that with `void coins;`, and carries no
+`eslint-disable` at all.
+[`useFreshRef`](../../packages/react-utils/src/hooks/useFreshRef.ts) assigns during render, so `.current`
+is always the newest value; it is the only correct choice when the ref is read in render or inside a
+`useMemo`. [`useCurrentRef`](../../packages/react-utils/src/hooks/useCurrentRef.ts) assigns in an effect,
+so during render `.current` still holds the last committed value. Neither tracks the previous value — for
+that, assign a plain `useRef` at the end of the effect. And confirm the dependency is genuinely unstable
+at its declaration first: a `useCallback(…, [])` handler is already stable and belongs in the array
+([#26319](https://github.com/trezor/trezor-suite/pull/26319#discussion_r3137461927),
+[#27384](https://github.com/trezor/trezor-suite/pull/27384#discussion_r3193474335)).
+
+## Related skills
+
+- [Components](../components/SKILL.md) — hook order, pass the narrow prop, and don’t optimise until you
+  can point at the cost.
+- [Redux](../redux/SKILL.md) — one `useSelector` per value. `packages/suite` wraps `useSelector` with a
+  `shallowEqual` default, which absorbs a fresh object of primitives one level deep; `suite-native` uses
+  react-redux directly, where the same selector re-renders on every dispatch.
+
+- [Asymptotic complexity](../performance-complexity/SKILL.md) — indexing, sorting and reducing over
+  collections that grow.
+- [DOM and CSS](../performance-dom/SKILL.md) — forced layout, observers, compositor-only animation.
+- [Long and non-essential tasks](../performance-scheduling/SKILL.md) — yielding long tasks, deferring
+  background work.

--- a/skills/performance-scheduling/SKILL.md
+++ b/skills/performance-scheduling/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: performance-scheduling
+description: Deferring non-essential work with requestIdleCallback. Use when a startup path blocks interaction, or when scheduling analytics, prefetch or other background work.
+---
+
+# Long and Non-Essential Tasks
+
+Work that is correct but runs at the wrong moment. JavaScript runs to completion, so a task that holds the main thread holds every interaction queued behind it, and work the user is not waiting for should not compete with work they are.
+
+## Schedule non-essential work in an idle callback
+
+Analytics, telemetry, prefetch and cache warming are not what the user is waiting for, so they should not
+compete with what is. `requestIdleCallback` runs them in the gaps between frames instead of on the
+startup path — `analyticsActions.init()` currently dispatches from a `useEffect` in `Preloader.tsx`, which
+is exactly the critical path this moves work off.
+
+```ts
+// bad - Preloader.tsx - analytics init competes with first paint and device discovery
+useEffect(() => {
+    dispatch(analyticsActions.init());
+}, [dispatch]);
+
+// good - the user sees the app first; the timeout guarantees it still runs
+useEffect(() => {
+    const id = requestIdleCallback(() => dispatch(analyticsActions.init()), { timeout: 2000 });
+
+    return () => cancelIdleCallback(id);
+}, [dispatch]);
+```
+
+Always pass `timeout`: without one a busy page can go seconds before the callback fires, and on a page
+that never idles it may not fire at all. `requestIdleCallback` is not Baseline — no Safari — so web needs
+a `setTimeout` fallback, and React Native has no such API, so this is a web and desktop rule only. It is
+also not a dumping ground: nothing the user is waiting on, and no DOM writes that have to land in a
+particular frame, because the callback runs with a budget it expects you to respect. There are no call
+sites in the repo yet, so the first one sets the pattern.
+
+## Related skills
+
+- [Asymptotic complexity](../performance-complexity/SKILL.md) — indexing, sorting and reducing over
+  collections that grow.
+- [React hooks](../performance-react-hooks/SKILL.md) — memoization, dependency arrays, render loops.
+- [DOM and CSS](../performance-dom/SKILL.md) — forced layout, observers, compositor-only animation.


### PR DESCRIPTION
## Description

Add 4 new skills:
- `performance-complexity`: indexing before iteration,  reduce accumulators that don't allocate
- `performance-react-hooks`: memoization under React Compiler, referentially stable dependencies, telling a wasted memo from a render loop
- `performance-dom`: observer APIs instead of old JS methods causing perf. issue, transitioning only compositor properties (web and desktop only)
- `performance-scheduling`: breaking up long tasks, deferring non-essential work off the startup path

Also extend `defensive-programming` skill: add non-mutating array methods rule.

## Related Issue

Resolves #31109
Relates #30497
