### PR TITLE
fix(suite-native): ensure screen header title is centered

### DIFF
--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -22,6 +22,8 @@ export type ScreenHeaderProps = ScreenHeaderContentProps &
         rightIcon?: ReactNode;
     };
 
+const ICON_SIZE = 40; // i.e. medium IconButton size
+
 const headerStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -30,7 +32,11 @@ const headerStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
     paddingBottom: utils.spacings.sp16,
     backgroundColor: utils.colors.surfaceFillPage,
-    minHeight: 40, // i.e. medium IconButton size
+    minHeight: ICON_SIZE,
+}));
+
+const iconWrapperStyle = prepareNativeStyle(() => ({
+    minWidth: ICON_SIZE,
 }));
 
 export const ScreenHeader = ({
@@ -45,7 +51,7 @@ export const ScreenHeader = ({
 
     return (
         <Box style={applyStyle(headerStyle)}>
-            <Box testID="@screen/sub-header/icon-left">
+            <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-left">
                 {leftIcon !== undefined ? (
                     leftIcon
                 ) : (
@@ -57,7 +63,9 @@ export const ScreenHeader = ({
                 )}
             </Box>
             <ScreenHeaderContent title={title} customContent={customContent} />
-            <Box testID="@screen/sub-header/icon-right">{rightIcon}</Box>
+            <Box style={applyStyle(iconWrapperStyle)} testID="@screen/sub-header/icon-right">
+                {rightIcon}
+            </Box>
         </Box>
     );
 };


### PR DESCRIPTION
## Description

Ensure that the screen header title is centered even if only one icon is used.

## Related Issue

Follow-up for #31023.

## Screenshots:

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f4f0c85a-ca36-4c03-aad5-12426640db1d" /> | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/53148195-417b-45f3-ad88-60f0290376ad" /> |

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/screen-header-icon-placeholder&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->