### PR TITLE
feat: exclude phishing transactions from activity center notifications

### DIFF
--- a/packages/suite/src/views/suite/notifications/index.tsx
+++ b/packages/suite/src/views/suite/notifications/index.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
 import { Translation } from '@suite/intl';
+import { isTransactionNotification } from '@suite-common/toast-notifications';
 import {
-    isTransactionNotification,
-    selectHasUnseenTransactionNotifications,
-} from '@suite-common/toast-notifications';
+    selectHasUnseenNonPhishingTransactionNotifications,
+    selectNonPhishingTransactionNotifications,
+} from '@suite-common/wallet-core';
 import { Card, CollapsibleBox, Column, Dot, Row } from '@trezor/components';
 
 import {
@@ -25,8 +26,8 @@ const NotificationsView = () => {
     const [selectedTab, setSelectedTab] = useState<ActivityTab>('transactions');
 
     const notifications = useSelector(state => state.notifications);
-    const hasUnseenNotifications = useSelector(selectHasUnseenTransactionNotifications);
-    const transactionNotifications = notifications.filter(isTransactionNotification);
+    const hasUnseenNotifications = useSelector(selectHasUnseenNonPhishingTransactionNotifications);
+    const transactionNotifications = useSelector(selectNonPhishingTransactionNotifications);
     const activityNotifications = notifications.filter(
         notification => !isTransactionNotification(notification),
     );

--- a/suite-common/toast-notifications/src/notificationsSelectors.ts
+++ b/suite-common/toast-notifications/src/notificationsSelectors.ts
@@ -1,7 +1,11 @@
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 
 import { isTransactionNotification } from './notificationsUtils';
-import { type NotificationsRootState, type NotificationsState, type ToastPayload } from './types';
+import {
+    type NotificationsRootState,
+    type ToastPayload,
+    type TransactionNotification,
+} from './types';
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<NotificationsRootState>();
 
@@ -9,7 +13,7 @@ export const selectNotifications = (state: NotificationsRootState) => state.noti
 
 export const selectTransactionNotifications = createMemoizedSelector(
     [selectNotifications],
-    (notifications): NotificationsState => notifications.filter(isTransactionNotification),
+    (notifications): TransactionNotification[] => notifications.filter(isTransactionNotification),
 );
 
 export const selectHasUnseenTransactionNotifications = (state: NotificationsRootState): boolean =>

--- a/suite-common/toast-notifications/src/types.ts
+++ b/suite-common/toast-notifications/src/types.ts
@@ -294,10 +294,10 @@ export type NotificationsRootState<TranslationKey extends string = UnknownTransl
     notifications: NotificationsState<TranslationKey>;
 };
 
-export type TransactionNotification = (
-    SentTransactionNotification | ReceivedTransactionNotification
-) &
-    CommonNotificationPayload;
+export type TransactionNotification = Extract<
+    NotificationEntry,
+    { type: TransactionNotificationType }
+>;
 
 export type TransactionNotificationType =
     | 'tx-sent'

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -478,8 +478,3 @@ export const selectHasUnseenNonPhishingTransactionNotifications =
         [selectNonPhishingTransactionNotifications],
         notifications => notifications.some(n => !n.seen),
     );
-
-export const selectNonPhishingTransactionTxids = createPhishingNotificationsSelector(
-    [selectNonPhishingTransactionNotifications],
-    notifications => new Set(notifications.map(n => n.txid)),
-);

--- a/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsSelectors.ts
@@ -1,11 +1,18 @@
 import { A, D, pipe } from '@mobily/ts-belt';
 
+import { type DeviceRootState } from '@suite-common/device';
 import { createWeakMapSelector, returnStableArrayIfEmpty } from '@suite-common/redux-utils';
+import {
+    type NotificationsRootState,
+    type TransactionNotification,
+    selectTransactionNotifications,
+} from '@suite-common/toast-notifications';
 import {
     type TokenDefinitionsRootState,
     createPhishingResult,
     isPhishingTransaction,
     selectNetworkTokenDefinitions,
+    selectTokenDefinitions,
 } from '@suite-common/token-definitions';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import type {
@@ -34,7 +41,7 @@ import { isNotNullOrUndefined, typedObjectKeys } from '@trezor/utils';
 
 import type { TransactionsByAccount, TransactionsRootState } from './transactionsReducerTypes';
 import type { AccountsRootState } from '../accounts/accountsReducer';
-import { selectAccountByKey } from '../accounts/accountsSelectors';
+import { selectAccountByKey, selectDeviceAccounts } from '../accounts/accountsSelectors';
 import {
     type BlockchainRootState,
     selectBlockchainHeightBySymbol,
@@ -184,6 +191,9 @@ export const selectAccountTransactionsMarkedAsNotScam = (
     state: TransactionsRootState,
     accountKey: AccountKey,
 ) => state.wallet.transactions.phishing[accountKey] ?? EMPTY_STABLE_TXIDS_ARRAY;
+
+export const selectPhishingTransactions = (state: TransactionsRootState) =>
+    state.wallet.transactions.phishing;
 
 export const selectPhishingTransactionsContext = createPhishingContextMemoizedSelector(
     [
@@ -414,3 +424,62 @@ export const selectTransactionsWithMissingRates = (
         txs: WalletAccountTransaction[];
     }[];
 };
+
+const createPhishingNotificationsSelector = createWeakMapSelector.withTypes<
+    NotificationsRootState &
+        TokenDefinitionsRootState &
+        TransactionsRootState &
+        AccountsRootState &
+        FiatRatesRootState &
+        PhishingRootState &
+        DeviceRootState
+>();
+
+// Returns a stable predicate; recomputed only when phishing-relevant slices change.
+const selectIsNotificationPhishing = createPhishingNotificationsSelector(
+    [
+        selectDeviceAccounts,
+        selectTransactions,
+        selectPhishingTransactions,
+        selectHistoricFiatRates,
+        selectTokenDefinitions,
+        selectActiveDustPhishingThreshold,
+    ],
+    (deviceAccounts, transactions, phishingMap, historicRates, tokenDefinitions, dustThreshold) =>
+        (notification: TransactionNotification): boolean => {
+            const account = deviceAccounts.find(
+                a => a.descriptor === notification.descriptor && a.symbol === notification.symbol,
+            );
+            if (!account) return false;
+
+            const transaction = transactions[account.key]?.find(
+                tx => tx?.txid === notification.txid,
+            );
+            if (!transaction) return false;
+
+            return isPhishingTransaction({
+                transaction,
+                tokenDefinitions: tokenDefinitions?.[transaction.symbol],
+                historicRates,
+                txsMarkedAsNotScam: phishingMap[account.key] ?? [],
+                dustThreshold,
+            }).isPhishing;
+        },
+);
+
+export const selectNonPhishingTransactionNotifications = createPhishingNotificationsSelector(
+    [selectTransactionNotifications, selectIsNotificationPhishing],
+    (notifications, isNotificationPhishing) =>
+        returnStableArrayIfEmpty(notifications.filter(n => !isNotificationPhishing(n))),
+);
+
+export const selectHasUnseenNonPhishingTransactionNotifications =
+    createPhishingNotificationsSelector(
+        [selectNonPhishingTransactionNotifications],
+        notifications => notifications.some(n => !n.seen),
+    );
+
+export const selectNonPhishingTransactionTxids = createPhishingNotificationsSelector(
+    [selectNonPhishingTransactionNotifications],
+    notifications => new Set(notifications.map(n => n.txid)),
+);

--- a/suite-native/analytics/tsconfig.json
+++ b/suite-native/analytics/tsconfig.json
@@ -5,9 +5,7 @@
         {
             "path": "../../suite-common/analytics"
         },
-        {
-            "path": "../../suite-common/feedback"
-        },
+        { "path": "../../suite-common/feedback" },
         {
             "path": "../../suite-common/suite-constants"
         },

--- a/suite-native/device-manager/package.json
+++ b/suite-native/device-manager/package.json
@@ -21,7 +21,6 @@
         "@suite-common/suite-sync": "workspace:*",
         "@suite-common/suite-types": "workspace:*",
         "@suite-common/suite-utils": "workspace:*",
-        "@suite-common/toast-notifications": "workspace:*",
         "@suite-common/wallet-core": "workspace:*",
         "@suite-common/wallet-types": "workspace:^",
         "@suite-native/activity-center": "workspace:*",

--- a/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
+++ b/suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx
@@ -5,7 +5,7 @@ import {
     type MessageSystemRootState,
     selectIsFeatureEnabled,
 } from '@suite-common/message-system';
-import { selectHasUnseenTransactionNotifications } from '@suite-common/toast-notifications';
+import { selectHasUnseenNonPhishingTransactionNotifications } from '@suite-common/wallet-core';
 import { ActivityCenterButton } from '@suite-native/activity-center';
 import { HStack, ScreenHeaderWrapper } from '@suite-native/atoms';
 
@@ -21,7 +21,7 @@ export const DeviceManagerScreenHeader = ({
     const isActivityCenterEnabled = useSelector((state: MessageSystemRootState) =>
         selectIsFeatureEnabled(state, Feature.activityCenter, true),
     );
-    const hasUnseenNotifications = useSelector(selectHasUnseenTransactionNotifications);
+    const hasUnseenNotifications = useSelector(selectHasUnseenNonPhishingTransactionNotifications);
 
     return (
         <ScreenHeaderWrapper noBottomPadding={noBottomPadding}>

--- a/suite-native/device-manager/tsconfig.json
+++ b/suite-native/device-manager/tsconfig.json
@@ -22,9 +22,6 @@
             "path": "../../suite-common/suite-utils"
         },
         {
-            "path": "../../suite-common/toast-notifications"
-        },
-        {
             "path": "../../suite-common/wallet-core"
         },
         {

--- a/suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx
@@ -1,16 +1,14 @@
 import { useSelector } from 'react-redux';
 
-import {
-    getSeenAndUnseenNotifications,
-    selectTransactionNotifications,
-} from '@suite-common/toast-notifications';
+import { getSeenAndUnseenNotifications } from '@suite-common/toast-notifications';
+import { selectNonPhishingTransactionNotifications } from '@suite-common/wallet-core';
 import { Box } from '@suite-native/atoms';
 
 import { ActivityCenterEmptyState } from './ActivityCenterEmptyState';
 import { NotificationList } from './NotificationList';
 
 export const NotificationsTabContent = () => {
-    const txNotifications = useSelector(selectTransactionNotifications);
+    const txNotifications = useSelector(selectNonPhishingTransactionNotifications);
     const { seenNotifications, unseenNotifications } =
         getSeenAndUnseenNotifications(txNotifications);
 

--- a/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
+++ b/suite-native/module-trading/src/test-utils/tradingTestUtils.ts
@@ -10,6 +10,7 @@ import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/t
 import {
     formDraftReducer,
     initialWalletSettingsState,
+    phishingInitialState,
     transactionsInitialState,
 } from '@suite-common/wallet-core';
 import { bluetoothInitialState } from '@suite-native/bluetooth';
@@ -48,10 +49,14 @@ const createBaseTradingPreloadedState = (tradeType: TradingTestTradeType) => ({
     messageSystem: messageSystemInitialState,
     suiteSync: initialSuiteSyncState,
     suiteSyncData: initialSuiteSyncDataState,
+    notifications: [],
+    tokenDefinitions: {},
     wallet: {
         ...getWalletState({ tradeType }),
         fees: {},
         formDrafts: {},
+        phishing: phishingInitialState,
+        transactions: transactionsInitialState,
     },
 });
 
@@ -109,8 +114,10 @@ export const createTradingLightStore = (args?: {
         geolocation: createStaticReducer(preloadedState.geolocation),
         locale: createStaticReducer(preloadedState.locale),
         messageSystem: createStaticReducer(preloadedState.messageSystem),
+        notifications: createStaticReducer(preloadedState.notifications),
         suiteSync: createStaticReducer(preloadedState.suiteSync),
         suiteSyncData: createStaticReducer(preloadedState.suiteSyncData),
+        tokenDefinitions: createStaticReducer(preloadedState.tokenDefinitions),
         wallet: combineReducers({
             settings: createStaticReducer(
                 preloadedState.wallet.settings ?? initialWalletSettingsState,
@@ -119,6 +126,7 @@ export const createTradingLightStore = (args?: {
             fiat: createStaticReducer(preloadedState.wallet.fiat ?? {}),
             fees: createStaticReducer(preloadedState.wallet.fees ?? {}),
             formDrafts: formDraftReducer,
+            phishing: createStaticReducer(preloadedState.wallet.phishing),
             send: createStaticReducer(preloadedState.wallet.send ?? {}),
             transactions: createStaticReducer(transactionsInitialState),
             trading: tradingSlice.prepareReducer(extraDependenciesCommonMock),

--- a/suite/analytics/tsconfig.json
+++ b/suite/analytics/tsconfig.json
@@ -5,9 +5,7 @@
         {
             "path": "../../suite-common/analytics"
         },
-        {
-            "path": "../../suite-common/feedback"
-        },
+        { "path": "../../suite-common/feedback" },
         {
             "path": "../../suite-common/metadata-types"
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12128,7 +12128,6 @@ __metadata:
     "@suite-common/suite-sync": "workspace:*"
     "@suite-common/suite-types": "workspace:*"
     "@suite-common/suite-utils": "workspace:*"
-    "@suite-common/toast-notifications": "workspace:*"
     "@suite-common/wallet-core": "workspace:*"
     "@suite-common/wallet-types": "workspace:^"
     "@suite-native/activity-center": "workspace:*"


### PR DESCRIPTION
## Description

- Transactions detected as phishing are now silently hidden from the activity center on both mobile and desktop

## Notes for QA

open the activity  (notifications) center — phishing transactions should not appear in the notification list and the bell badge should not light up for them

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies global toast-notification and transaction-selection core, the Suite web/desktop notifications view, and several native-mobile-only config/files. The highest regression risk is in transaction grouping and toast visibility. Run a focused trio: a transaction-list test, a toast-lifecycle test, and a smoke test for the /notifications route. The native and tsconfig changes are not exercised by this web/desktop e2e suite.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/views/suite/notifications/index.tsx`
- `suite-common/toast-notifications/src/notificationsSelectors.ts`
- `suite-common/toast-notifications/src/types.ts`
- `suite-common/wallet-core/src/transactions/transactionsSelectors.ts`
- `suite-native/analytics/tsconfig.json`
- `suite-native/device-manager/package.json`
- `suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx`
- `suite-native/device-manager/tsconfig.json`
- `suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx`
- `suite-native/module-trading/src/test-utils/tradingTestUtils.ts`
- `suite/analytics/tsconfig.json`

</details>

**Recommended tests (3)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test directly exercises transaction grouping, pending/confirmed status transitions, and pending counts that are derived from wallet-core transaction selectors. A change to transactionsSelectors.ts could break these assertions.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — The /notifications route is rendered by packages/suite/src/views/suite/notifications/index.tsx. This test navigates to that route and verifies the page loads and its links are valid, providing a smoke test for the changed notifications view.
- `suite/e2e/tests/settings/passphrase.test.ts` — It asserts the '@toast/settings-applied' toast appears after enabling passphrase and then detaches, directly exercising the toast-notifications selectors and types that were changed.

</details>

⚠️ **Changes with no test coverage (7)**
- `suite-native/analytics/tsconfig.json`
- `suite-native/device-manager/package.json`
- `suite-native/device-manager/src/components/DeviceManagerScreenHeader.tsx`
- `suite-native/device-manager/tsconfig.json`
- `suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx`
- `suite-native/module-trading/src/test-utils/tradingTestUtils.ts`
- `suite/analytics/tsconfig.json`

_Updated: 2026-08-12T10:44:17.849Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/filter-phishing-notifications/web/](https://dev.suite.sldev.cz/suite-web/feat/filter-phishing-notifications/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/filter-phishing-notifications&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/filter-phishing-notifications&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/filter-phishing-notifications&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T10:45:27.499Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T10:44:14.740Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->