### PR TITLE
fix(suite-native): re-use drawer with positions and ensure wrapping on the claim page

### DIFF
--- a/suite-native/module-earn/src/components/EarnAccountCard.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCard.tsx
@@ -8,9 +8,8 @@ import {
 } from '@suite-common/earn-staking-api';
 import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
 import { isApyAvailable, isSupportedStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { AccountTypeBadge } from '@suite-native/accounts';
-import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
-import { Icon, TokenIcon } from '@suite-native/icons';
+import { Text } from '@suite-native/atoms';
+import { TokenIcon } from '@suite-native/icons';
 import { Translation, selectSupportedLanguageLocale } from '@suite-native/intl';
 import {
     selectApy,
@@ -21,44 +20,21 @@ import {
     selectTronVotesByAccountKey,
     useSelector as useStakingSelector,
 } from '@suite-native/staking';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { EarnAccountCardLayout } from './EarnAccountCardLayout';
 import { EarnClaimAlert } from './EarnClaimAlert';
 import { EarnTronVotingAlert } from './EarnTronVotingAlert';
 import { useMessageSystemStaking } from '../hooks/useMessageSystemStaking';
 import { type EarnDepositsCardActiveItem } from '../types';
 import { formatEarnActiveItemBalance } from '../utils/earnAmountUtils';
 
-const itemCardStyle = prepareNativeStyle(utils => ({
-    marginBottom: utils.spacings.sp16,
-}));
-
-const rowStyle = prepareNativeStyle(utils => ({
-    paddingLeft: utils.spacings.sp16,
-    paddingRight: utils.spacings.sp12,
-    paddingVertical: utils.spacings.sp12,
-    flexDirection: 'row',
-    alignItems: 'center',
-    minHeight: 70,
-}));
-
-const contentStyle = prepareNativeStyle(_ => ({
-    flex: 1,
-}));
-
-const valuesStyle = prepareNativeStyle(utils => ({
-    alignItems: 'flex-end',
-    paddingLeft: utils.spacings.sp8,
-}));
-
 type EarnAccountCardProps = {
     item: EarnDepositsCardActiveItem;
     onPress: () => void;
-    onClaimPress: () => void;
+    onClaimPress?: () => void;
 };
 
 export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCardProps) => {
-    const { applyStyle } = useNativeStyles();
     const isStakingItem = item.type === 'staking';
     const isDefiYieldItem = item.type === 'stablecoin-yield';
     const isSupportedStaking = isStakingItem && isSupportedStakingNetworkSymbol(item.symbol);
@@ -121,73 +97,69 @@ export const EarnAccountCard = ({ item, onPress, onClaimPress }: EarnAccountCard
         : null;
 
     return (
-        <Card borderColor="borderNeutral" noPadding style={applyStyle(itemCardStyle)}>
-            <PressableOpacity onPress={onPress} style={applyStyle(rowStyle)}>
-                <Box marginRight="sp12">
-                    <TokenIcon
-                        symbol={symbol}
-                        contractAddress={contractAddress}
-                        size="extraSmall"
-                        showNetworkIcon
-                        wrappedTokenIcon={isDefiYieldItem ? 'network' : 'token'}
-                    />
-                </Box>
-
-                <VStack spacing="sp2" style={applyStyle(contentStyle)}>
-                    <Text>{item.title}</Text>
-                    {secondaryDescription && (
-                        <Text variant="body-sm" color="contentSecondary">
-                            {secondaryDescription}
-                        </Text>
-                    )}
-                    <AccountTypeBadge accountKey={item.accountKey} alignSelf="flex-start" />
-                </VStack>
-
-                <VStack spacing="sp2" style={applyStyle(valuesStyle)}>
-                    <Text variant="body-md">{formatEarnActiveItemBalance({ item, locale })}</Text>
-                    {(isAdaStakedOutsideEverstake || apyValue != null) && (
-                        <Text variant="body-sm" color="contentSecondary">
-                            {isAdaStakedOutsideEverstake || !isApyAvailable(apyValue) ? (
-                                <Translation id="earn.notAvailableShort" />
-                            ) : (
-                                <>
-                                    {item.type === 'staking' ? (
-                                        <Translation
-                                            id={
-                                                symbol === 'trx'
-                                                    ? 'earn.aprPercentage'
-                                                    : 'earn.apyPercentage'
-                                            }
-                                            values={{ apy: apyValue }}
-                                        />
-                                    ) : (
-                                        <Translation
-                                            id="earn.ratePercentage"
-                                            values={{ apy: apyValue }}
-                                        />
-                                    )}
-                                </>
-                            )}
-                        </Text>
-                    )}
-                </VStack>
-
-                <Box marginLeft="sp12">
-                    <Icon name="caretRight" size="mediumLarge" color="contentSecondary" />
-                </Box>
-            </PressableOpacity>
-
-            {showClaimAlert && (
-                <EarnClaimAlert
-                    claimableAmount={claimableAmount}
+        <EarnAccountCardLayout
+            accountKey={item.accountKey}
+            icon={
+                <TokenIcon
                     symbol={symbol}
-                    onClaimPress={onClaimPress}
+                    contractAddress={contractAddress}
+                    size="extraSmall"
+                    showNetworkIcon
+                    wrappedTokenIcon={isDefiYieldItem ? 'network' : 'token'}
                 />
-            )}
+            }
+            title={item.title}
+            description={
+                secondaryDescription && (
+                    <Text variant="body-sm" color="contentSecondary">
+                        {secondaryDescription}
+                    </Text>
+                )
+            }
+            value={<Text variant="body-md">{formatEarnActiveItemBalance({ item, locale })}</Text>}
+            valueDescription={
+                (isAdaStakedOutsideEverstake || apyValue != null) && (
+                    <Text variant="body-sm" color="contentSecondary">
+                        {isAdaStakedOutsideEverstake || !isApyAvailable(apyValue) ? (
+                            <Translation id="earn.notAvailableShort" />
+                        ) : (
+                            <>
+                                {item.type === 'staking' ? (
+                                    <Translation
+                                        id={
+                                            symbol === 'trx'
+                                                ? 'earn.aprPercentage'
+                                                : 'earn.apyPercentage'
+                                        }
+                                        values={{ apy: apyValue }}
+                                    />
+                                ) : (
+                                    <Translation
+                                        id="earn.ratePercentage"
+                                        values={{ apy: apyValue }}
+                                    />
+                                )}
+                            </>
+                        )}
+                    </Text>
+                )
+            }
+            alerts={
+                <>
+                    {showClaimAlert && onClaimPress && (
+                        <EarnClaimAlert
+                            claimableAmount={claimableAmount}
+                            symbol={symbol}
+                            onClaimPress={onClaimPress}
+                        />
+                    )}
 
-            {showTronVotingAlert && (
-                <EarnTronVotingAlert votesRemaining={availableTronVotingPower} />
-            )}
-        </Card>
+                    {showTronVotingAlert && (
+                        <EarnTronVotingAlert votesRemaining={availableTronVotingPower} />
+                    )}
+                </>
+            }
+            onPress={onPress}
+        />
     );
 };

--- a/suite-native/module-earn/src/components/EarnAccountCardLayout.tsx
+++ b/suite-native/module-earn/src/components/EarnAccountCardLayout.tsx
@@ -1,0 +1,78 @@
+import { type ReactNode } from 'react';
+
+import { type AccountKey } from '@suite-common/wallet-types';
+import { AccountTypeBadge } from '@suite-native/accounts';
+import { Box, Card, PressableOpacity, Text, VStack } from '@suite-native/atoms';
+import { Icon } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
+
+const itemCardStyle = prepareNativeStyle(utils => ({
+    marginBottom: utils.spacings.sp16,
+}));
+
+const rowStyle = prepareNativeStyle(utils => ({
+    paddingLeft: utils.spacings.sp16,
+    paddingRight: utils.spacings.sp12,
+    paddingVertical: utils.spacings.sp12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    minHeight: 70,
+}));
+
+const contentStyle = prepareNativeStyle(_ => ({
+    flex: 1,
+}));
+
+const valuesStyle = prepareNativeStyle(utils => ({
+    alignItems: 'flex-end',
+    paddingLeft: utils.spacings.sp8,
+}));
+
+type EarnAccountCardLayoutProps = {
+    accountKey: AccountKey;
+    icon: ReactNode;
+    title: string;
+    value: ReactNode;
+    onPress: () => void;
+    description?: ReactNode;
+    valueDescription?: ReactNode;
+    alerts?: ReactNode;
+};
+
+export const EarnAccountCardLayout = ({
+    accountKey,
+    icon,
+    title,
+    value,
+    onPress,
+    description,
+    valueDescription,
+    alerts,
+}: EarnAccountCardLayoutProps) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <Card borderColor="borderNeutral" noPadding style={applyStyle(itemCardStyle)}>
+            <PressableOpacity onPress={onPress} style={applyStyle(rowStyle)}>
+                <Box marginRight="sp12">{icon}</Box>
+
+                <VStack spacing="sp2" style={applyStyle(contentStyle)}>
+                    <Text>{title}</Text>
+                    {description}
+                    <AccountTypeBadge accountKey={accountKey} alignSelf="flex-start" />
+                </VStack>
+
+                <VStack spacing="sp2" style={applyStyle(valuesStyle)}>
+                    {value}
+                    {valueDescription}
+                </VStack>
+
+                <Box marginLeft="sp12">
+                    <Icon name="caretRight" size="mediumLarge" color="contentSecondary" />
+                </Box>
+            </PressableOpacity>
+
+            {alerts}
+        </Card>
+    );
+};

--- a/suite-native/module-earn/src/components/EarnDepositsCard.tsx
+++ b/suite-native/module-earn/src/components/EarnDepositsCard.tsx
@@ -107,9 +107,9 @@ export const EarnDepositsCard = ({
         () =>
             buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries,
-                stablecoinYieldActiveItems,
+                earnDepositsActiveItems: stablecoinYieldRow?.activeItems ?? [],
             }),
-        [stablecoinYieldActiveItems, stablecoinYieldClaimSummaries],
+        [stablecoinYieldClaimSummaries, stablecoinYieldRow?.activeItems],
     );
 
     const handleStablecoinYieldClaimRewardPress = useCallback(

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimAccountCard.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimAccountCard.tsx
@@ -1,0 +1,56 @@
+import { useSelector } from 'react-redux';
+
+import { type NetworkSymbol, getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
+import { type AccountKey, type BaseCurrencyAmount } from '@suite-common/wallet-types';
+import { parseAccountKey } from '@suite-common/wallet-utils';
+import { selectAccountLabel } from '@suite-native/accounts';
+import { AddressFormatter, BaseCurrencyAmountFormatter } from '@suite-native/formatters';
+import { TokenIcon } from '@suite-native/icons';
+import { type CombinedLabelingState } from '@suite-native/labeling';
+
+import { EarnAccountCardLayout } from './EarnAccountCardLayout';
+
+type StablecoinYieldClaimAccountCardProps = {
+    accountKey: AccountKey;
+    fiatClaimableAmount: BaseCurrencyAmount | null;
+    networkSymbol: NetworkSymbol;
+    onPress: () => void;
+};
+
+export const StablecoinYieldClaimAccountCard = ({
+    accountKey,
+    fiatClaimableAmount,
+    networkSymbol,
+    onPress,
+}: StablecoinYieldClaimAccountCardProps) => {
+    const { accountDescriptor, deviceStaticSessionId } = parseAccountKey(accountKey);
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        selectAccountLabel(state, deviceStaticSessionId, accountDescriptor, networkSymbol),
+    );
+
+    return (
+        <EarnAccountCardLayout
+            accountKey={accountKey}
+            icon={<TokenIcon symbol={networkSymbol} size="extraSmall" />}
+            title={customAccountLabel ?? getNetworkDisplaySymbolName(networkSymbol)}
+            description={
+                <AddressFormatter
+                    value={accountDescriptor}
+                    format="short"
+                    variant="body-sm"
+                    color="contentSecondary"
+                    numberOfLines={1}
+                />
+            }
+            value={
+                <BaseCurrencyAmountFormatter
+                    value={fiatClaimableAmount}
+                    variant="body-md"
+                    isDiscreetText={false}
+                    numberOfLines={1}
+                />
+            }
+            onPress={onPress}
+        />
+    );
+};

--- a/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
+++ b/suite-native/module-earn/src/components/StablecoinYieldClaimRewardsBottomSheet.tsx
@@ -1,130 +1,11 @@
 import { useCallback } from 'react';
-import { useSelector } from 'react-redux';
 
-import { getNetworkDisplaySymbolName } from '@suite-common/wallet-config';
-import { parseAccountKey } from '@suite-common/wallet-utils';
-import { AccountTypeBadge, selectAccountLabel } from '@suite-native/accounts';
-import {
-    BottomSheetModal,
-    type BottomSheetModalRef,
-    Box,
-    Card,
-    HStack,
-    PressableOpacity,
-    Text,
-    VStack,
-} from '@suite-native/atoms';
-import { AddressFormatter, BaseCurrencyAmountFormatter } from '@suite-native/formatters';
-import { Icon, TokenIcon } from '@suite-native/icons';
+import { BottomSheetModal, type BottomSheetModalRef, Box } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import { type CombinedLabelingState } from '@suite-native/labeling';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
+import { EarnAccountCard } from './EarnAccountCard';
+import { StablecoinYieldClaimAccountCard } from './StablecoinYieldClaimAccountCard';
 import { type StablecoinYieldClaimItem } from '../utils/stablecoinYieldClaimSummaryUtils';
-
-const itemCardStyle = prepareNativeStyle(utils => ({
-    marginBottom: utils.spacings.sp16,
-}));
-
-const itemRowStyle = prepareNativeStyle(utils => ({
-    minHeight: 70,
-    paddingLeft: utils.spacings.sp16,
-    paddingRight: utils.spacings.sp12,
-    paddingVertical: utils.spacings.sp12,
-    flexDirection: 'row',
-    alignItems: 'center',
-}));
-
-const itemContentStyle = prepareNativeStyle(() => ({
-    flex: 1,
-}));
-
-const itemValueStyle = prepareNativeStyle(utils => ({
-    maxWidth: '40%',
-    flexShrink: 0,
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    paddingLeft: utils.spacings.sp8,
-}));
-
-type StablecoinYieldClaimRewardsItemProps = {
-    claimItem: StablecoinYieldClaimItem;
-    onPress: (claimItem: StablecoinYieldClaimItem) => void;
-};
-
-const StablecoinYieldClaimRewardsItem = ({
-    claimItem,
-    onPress,
-}: StablecoinYieldClaimRewardsItemProps) => {
-    const { applyStyle } = useNativeStyles();
-    const { summary, vaults } = claimItem;
-
-    const { accountDescriptor, deviceStaticSessionId } = parseAccountKey(summary.accountKey);
-    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
-        selectAccountLabel(state, deviceStaticSessionId, accountDescriptor, summary.networkSymbol),
-    );
-
-    const handlePress = useCallback(() => {
-        onPress(claimItem);
-    }, [claimItem, onPress]);
-
-    const accountTitle = customAccountLabel ?? getNetworkDisplaySymbolName(summary.networkSymbol);
-    const hasVaults = vaults.length > 0;
-    const singleVault = vaults.length === 1 ? vaults[0] : undefined;
-    const vaultsTitle = vaults.map(vault => vault.name).join(', ');
-
-    return (
-        <Card borderColor="borderNeutral" noPadding style={applyStyle(itemCardStyle)}>
-            <PressableOpacity onPress={handlePress} style={applyStyle(itemRowStyle)}>
-                <Box marginRight="sp12">
-                    <TokenIcon
-                        symbol={summary.networkSymbol}
-                        contractAddress={singleVault?.tokenContract}
-                        size="small"
-                        showNetworkIcon={!!singleVault}
-                        wrappedTokenIcon="network"
-                    />
-                </Box>
-
-                <VStack spacing="sp2" style={applyStyle(itemContentStyle)}>
-                    <Text numberOfLines={1} ellipsizeMode="tail">
-                        {hasVaults ? vaultsTitle : accountTitle}
-                    </Text>
-                    {hasVaults ? (
-                        <Text
-                            variant="body-sm"
-                            color="contentSecondary"
-                            numberOfLines={1}
-                            ellipsizeMode="tail"
-                        >
-                            {accountTitle}
-                        </Text>
-                    ) : (
-                        <AddressFormatter
-                            value={accountDescriptor}
-                            format="short"
-                            variant="body-sm"
-                            color="contentSecondary"
-                            numberOfLines={1}
-                        />
-                    )}
-                    <AccountTypeBadge accountKey={summary.accountKey} alignSelf="flex-start" />
-                </VStack>
-
-                <HStack alignItems="center" spacing="sp8" style={applyStyle(itemValueStyle)}>
-                    <BaseCurrencyAmountFormatter
-                        value={summary.fiatClaimableAmount}
-                        variant="body-md"
-                        isDiscreetText={false}
-                        numberOfLines={1}
-                        adjustsFontSizeToFit
-                    />
-                    <Icon name="caretRight" size="mediumLarge" color="contentSecondary" />
-                </HStack>
-            </PressableOpacity>
-        </Card>
-    );
-};
 
 type StablecoinYieldClaimRewardsBottomSheetProps = {
     ref: BottomSheetModalRef;
@@ -155,13 +36,25 @@ export const StablecoinYieldClaimRewardsBottomSheet = ({
             onClose={onClose}
         >
             <Box paddingTop="sp16">
-                {claimItems.map(claimItem => (
-                    <StablecoinYieldClaimRewardsItem
-                        key={claimItem.summary.accountKey}
-                        claimItem={claimItem}
-                        onPress={handleClaimRewardsSelect}
-                    />
-                ))}
+                {claimItems.map(claimItem =>
+                    claimItem.positions.length > 0 ? (
+                        claimItem.positions.map(position => (
+                            <EarnAccountCard
+                                key={position.id}
+                                item={position}
+                                onPress={() => handleClaimRewardsSelect(claimItem)}
+                            />
+                        ))
+                    ) : (
+                        <StablecoinYieldClaimAccountCard
+                            key={claimItem.summary.accountKey}
+                            accountKey={claimItem.summary.accountKey}
+                            fiatClaimableAmount={claimItem.summary.fiatClaimableAmount}
+                            networkSymbol={claimItem.summary.networkSymbol}
+                            onPress={() => handleClaimRewardsSelect(claimItem)}
+                        />
+                    ),
+                )}
             </Box>
         </BottomSheetModal>
     );

--- a/suite-native/module-earn/src/components/YieldClaimRewardRow.tsx
+++ b/suite-native/module-earn/src/components/YieldClaimRewardRow.tsx
@@ -7,7 +7,14 @@ import {
 import { Box, HStack, Text } from '@suite-native/atoms';
 import { BaseCurrencyAmountFormatter, CryptoAmountFormatter } from '@suite-native/formatters';
 import { TokenIcon } from '@suite-native/icons';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { BigNumber } from '@trezor/utils';
+
+// Capped so that the reward amount keeps enough of the row to wrap its full precision to two
+// lines — the fiat approximation is the one allowed to ellipsize.
+const fiatAmountStyle = prepareNativeStyle(() => ({
+    maxWidth: '32%',
+}));
 
 type YieldClaimRewardRowProps = {
     amount: string;
@@ -33,6 +40,8 @@ export const YieldClaimRewardRow = ({
     tokenDecimals,
     tokenSymbol,
 }: YieldClaimRewardRowProps) => {
+    const { applyStyle } = useNativeStyles();
+
     const isFiatAmountVisible = fiatAmount !== null || isFiatLoading;
 
     return (
@@ -56,7 +65,13 @@ export const YieldClaimRewardRow = ({
                 </Box>
             </HStack>
             {isFiatAmountVisible && (
-                <HStack spacing="sp2" alignItems="center" justifyContent="flex-end">
+                <HStack
+                    spacing="sp2"
+                    alignItems="center"
+                    justifyContent="flex-end"
+                    flexShrink={1}
+                    style={applyStyle(fiatAmountStyle)}
+                >
                     {!isFiatLoading && (
                         <Text variant="body-sm" color="contentSecondary">
                             ≈

--- a/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
@@ -2,12 +2,38 @@ import { type ReactNode } from 'react';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteRewardItem } from '@suite-common/wallet-core';
-import { HStack, Text, VStack } from '@suite-native/atoms';
+import { Box, HStack, Text, VStack } from '@suite-native/atoms';
 import { Icon, TokenIcon } from '@suite-native/icons';
 import { Translation } from '@suite-native/intl';
 
 import { YieldClaimRewardRow, getYieldClaimRewardFiatAmount } from './YieldClaimRewardRow';
 import { type YieldCompleteSummaryRow } from './YieldCompleteScreenContent';
+
+type YieldCompleteAmountValueParams = {
+    accountSymbol: NetworkSymbol;
+    amount: string;
+    tokenContract?: string;
+};
+
+const getYieldCompleteAmountValue = ({
+    accountSymbol,
+    amount,
+    tokenContract,
+}: YieldCompleteAmountValueParams): ReactNode => (
+    <HStack spacing="sp4" alignItems="center" flexShrink={1}>
+        <TokenIcon symbol={accountSymbol} contractAddress={tokenContract} size="extraSmall" />
+        <Box flexShrink={1}>
+            <Text
+                variant="body-md-strong"
+                color="contentPrimary"
+                numberOfLines={2}
+                textAlign="right"
+            >
+                {amount}
+            </Text>
+        </Box>
+    </HStack>
+);
 
 type GetYieldDepositCompleteRowsParams = {
     accountSymbol: NetworkSymbol;
@@ -51,34 +77,20 @@ export const getYieldDepositCompleteRows = ({
     {
         key: 'sent',
         label: <Translation id="earn.yieldCompleteScreen.deposited" />,
-        value: (
-            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                <TokenIcon
-                    symbol={accountSymbol}
-                    contractAddress={sentTokenContract}
-                    size="extraSmall"
-                />
-                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    {sentAmount}
-                </Text>
-            </HStack>
-        ),
+        value: getYieldCompleteAmountValue({
+            accountSymbol,
+            amount: sentAmount,
+            tokenContract: sentTokenContract,
+        }),
     },
     {
         key: 'received',
         label: <Translation id="earn.yieldCompleteScreen.received" />,
-        value: (
-            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                <TokenIcon
-                    symbol={accountSymbol}
-                    contractAddress={receivedTokenContract}
-                    size="extraSmall"
-                />
-                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    {receivedAmount}
-                </Text>
-            </HStack>
-        ),
+        value: getYieldCompleteAmountValue({
+            accountSymbol,
+            amount: receivedAmount,
+            tokenContract: receivedTokenContract,
+        }),
     },
 ];
 
@@ -117,18 +129,11 @@ export const getYieldWithdrawCompleteRows = ({
     {
         key: 'received',
         label: <Translation id="earn.yieldCompleteScreen.received" />,
-        value: (
-            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                <TokenIcon
-                    symbol={accountSymbol}
-                    contractAddress={receivedTokenContract}
-                    size="extraSmall"
-                />
-                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    {receivedAmount}
-                </Text>
-            </HStack>
-        ),
+        value: getYieldCompleteAmountValue({
+            accountSymbol,
+            amount: receivedAmount,
+            tokenContract: receivedTokenContract,
+        }),
     },
 ];
 
@@ -151,34 +156,20 @@ export const getWrappedNativeCompleteRows = ({
     {
         key: 'sent',
         label: <Translation id="earn.yieldCompleteScreen.sent" />,
-        value: (
-            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                <TokenIcon
-                    symbol={accountSymbol}
-                    contractAddress={sentTokenContract}
-                    size="extraSmall"
-                />
-                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    {sentAmount}
-                </Text>
-            </HStack>
-        ),
+        value: getYieldCompleteAmountValue({
+            accountSymbol,
+            amount: sentAmount,
+            tokenContract: sentTokenContract,
+        }),
     },
     {
         key: 'received',
         label: <Translation id="earn.yieldCompleteScreen.received" />,
-        value: (
-            <HStack spacing="sp4" alignItems="center" flexShrink={1}>
-                <TokenIcon
-                    symbol={accountSymbol}
-                    contractAddress={receivedTokenContract}
-                    size="extraSmall"
-                />
-                <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    {receivedAmount}
-                </Text>
-            </HStack>
-        ),
+        value: getYieldCompleteAmountValue({
+            accountSymbol,
+            amount: receivedAmount,
+            tokenContract: receivedTokenContract,
+        }),
     },
 ];
 

--- a/suite-native/module-earn/src/types.ts
+++ b/suite-native/module-earn/src/types.ts
@@ -148,6 +148,11 @@ export type EarnDepositsCardActiveItem =
           apy: number | null;
       };
 
+export type StablecoinYieldPositionItem = Extract<
+    EarnDepositsCardActiveItem,
+    { type: 'stablecoin-yield' }
+>;
+
 export type EarnDepositsCardRow = {
     type: EarnPromoSectionType;
     title: string;

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.test.ts
@@ -17,7 +17,7 @@ import {
     getStablecoinYieldClaimRewardsSnapshot,
     getTotalFiatClaimableAmount,
 } from './stablecoinYieldClaimSummaryUtils';
-import { type StablecoinYieldEarnItem } from '../types';
+import { type StablecoinYieldPositionItem } from '../types';
 
 const ethSymbol = asNetworkSymbol('eth');
 
@@ -214,7 +214,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
     });
 
     describe('buildStablecoinYieldClaimItems', () => {
-        const createYieldEarnItem = ({
+        const createYieldPositionItem = ({
             account,
             vaultName,
             id = `vault-${account.key}`,
@@ -222,20 +222,18 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             account: Account;
             vaultName: string;
             id?: string;
-        }): StablecoinYieldEarnItem => ({
+        }): StablecoinYieldPositionItem => ({
             id,
             type: 'stablecoin-yield',
-            yieldId: id,
-            vaultName,
-            tokenSymbol: toTokenSymbol('USDC'),
+            title: vaultName,
             networkSymbol: ethSymbol,
-            underlyingTokenContract,
-            receiptTokenContract,
+            tokenSymbol: toTokenSymbol('USDC'),
             contractAddress: receiptTokenContract,
             tokenContractAddress: underlyingTokenContract,
             accountKey: account.key,
             accountLabel: account.accountLabel,
-            tokenBalance: '42',
+            balance: '42',
+            fiatAmount: asBaseCurrencyAmount(new BigNumber('42')),
             apy: 4.2,
         });
 
@@ -254,19 +252,20 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
         });
 
         it('attaches the vault when the account holds exactly one named vault position', () => {
+            const position = createYieldPositionItem({
+                account: ethereumAccount,
+                vaultName: 'Spark USDC Vault',
+            });
+
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
-                stablecoinYieldActiveItems: [
-                    createYieldEarnItem({
-                        account: ethereumAccount,
-                        vaultName: 'Spark USDC Vault',
-                    }),
-                ],
+                earnDepositsActiveItems: [position],
             });
 
             expect(items).toEqual([
                 {
                     summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
+                    positions: [position],
                     vaults: [
                         {
                             name: 'Spark USDC Vault',
@@ -276,6 +275,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
                 },
                 {
                     summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
+                    positions: [],
                     vaults: [],
                 },
             ]);
@@ -284,13 +284,13 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
         it('attaches all named vault positions when the account holds multiple', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
-                stablecoinYieldActiveItems: [
-                    createYieldEarnItem({
+                earnDepositsActiveItems: [
+                    createYieldPositionItem({
                         account: ethereumAccount,
                         vaultName: 'Spark USDC Vault',
                         id: 'vault-1',
                     }),
-                    createYieldEarnItem({
+                    createYieldPositionItem({
                         account: ethereumAccount,
                         vaultName: 'Steakhouse USDT Vault',
                         id: 'vault-2',
@@ -300,30 +300,34 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
 
             expect(items).toEqual([
                 expect.objectContaining({
+                    positions: [
+                        expect.objectContaining({ title: 'Spark USDC Vault' }),
+                        expect.objectContaining({ title: 'Steakhouse USDT Vault' }),
+                    ],
                     vaults: [
                         expect.objectContaining({ name: 'Spark USDC Vault' }),
                         expect.objectContaining({ name: 'Steakhouse USDT Vault' }),
                     ],
                 }),
-                expect.objectContaining({ vaults: [] }),
+                expect.objectContaining({ positions: [], vaults: [] }),
             ]);
         });
 
-        it('groups vaults per account, so one account having multiple positions does not affect another', () => {
+        it('groups positions per account, so one account having multiple positions does not affect another', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
-                stablecoinYieldActiveItems: [
-                    createYieldEarnItem({
+                earnDepositsActiveItems: [
+                    createYieldPositionItem({
                         account: ethereumAccount,
                         vaultName: 'Spark USDC Vault',
                         id: 'vault-1',
                     }),
-                    createYieldEarnItem({
+                    createYieldPositionItem({
                         account: exitedEthereumAccount,
                         vaultName: 'Steakhouse USDT Vault',
                         id: 'vault-2',
                     }),
-                    createYieldEarnItem({
+                    createYieldPositionItem({
                         account: exitedEthereumAccount,
                         vaultName: 'Morpho USDC Vault',
                         id: 'vault-3',
@@ -332,7 +336,7 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
             });
 
             expect(items).toEqual([
-                {
+                expect.objectContaining({
                     summary: expect.objectContaining({ accountKey: ethereumAccount.key }),
                     vaults: [
                         {
@@ -340,22 +344,22 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
                             tokenContract: underlyingTokenContract,
                         },
                     ],
-                },
-                {
+                }),
+                expect.objectContaining({
                     summary: expect.objectContaining({ accountKey: exitedEthereumAccount.key }),
                     vaults: [
                         expect.objectContaining({ name: 'Steakhouse USDT Vault' }),
                         expect.objectContaining({ name: 'Morpho USDC Vault' }),
                     ],
-                },
+                }),
             ]);
         });
 
-        it('ignores active items for accounts without a claimable summary', () => {
+        it('ignores positions of accounts without a claimable summary', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
-                stablecoinYieldActiveItems: [
-                    createYieldEarnItem({
+                earnDepositsActiveItems: [
+                    createYieldPositionItem({
                         account: anotherEthereumAccount,
                         vaultName: 'Spark USDC Vault',
                     }),
@@ -367,16 +371,18 @@ describe('stablecoinYieldClaimSummaryUtils', () => {
                 ethereumAccount.key,
                 exitedEthereumAccount.key,
             ]);
+            expect(items.every(item => item.positions.length === 0)).toBe(true);
         });
 
-        it('skips vault positions without a name', () => {
+        it('keeps a position row without a vault name, but does not attach it as a vault', () => {
             const items = buildStablecoinYieldClaimItems({
                 stablecoinYieldClaimSummaries: claimSummaries,
-                stablecoinYieldActiveItems: [
-                    createYieldEarnItem({ account: ethereumAccount, vaultName: '' }),
+                earnDepositsActiveItems: [
+                    createYieldPositionItem({ account: ethereumAccount, vaultName: '' }),
                 ],
             });
 
+            expect(items[0]?.positions).toHaveLength(1);
             expect(items[0]?.vaults).toEqual([]);
         });
     });

--- a/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
+++ b/suite-native/module-earn/src/utils/stablecoinYieldClaimSummaryUtils.ts
@@ -6,6 +6,7 @@ import { getNetwork } from '@suite-common/wallet-config';
 import { type YieldFlowCompleteRewardItem } from '@suite-common/wallet-core';
 import {
     type Account,
+    type AccountKey,
     type BaseCurrencyAmount,
     asBaseCurrencyAmount,
     toTokenAddress,
@@ -14,7 +15,11 @@ import { asAmountSubunit, subunitsToUnits } from '@suite-common/wallet-utils';
 import { type YieldClaimVaultParams } from '@suite-native/navigation';
 import { BigNumber } from '@trezor/utils';
 
-import { type StablecoinYieldClaimSummary, type StablecoinYieldEarnItem } from '../types';
+import {
+    type EarnDepositsCardActiveItem,
+    type StablecoinYieldClaimSummary,
+    type StablecoinYieldPositionItem,
+} from '../types';
 
 type BuildStablecoinYieldClaimSummariesParams = {
     accounts: Account[];
@@ -168,27 +173,40 @@ export const buildStablecoinYieldClaimSummaries = ({
 
 export type StablecoinYieldClaimItem = {
     summary: StablecoinYieldClaimSummary;
+    positions: StablecoinYieldPositionItem[];
     vaults: YieldClaimVaultParams[];
 };
 
+const getAccountPositions = (
+    earnDepositsActiveItems: EarnDepositsCardActiveItem[],
+    accountKey: AccountKey,
+): StablecoinYieldPositionItem[] =>
+    earnDepositsActiveItems.flatMap(item =>
+        item.type === 'stablecoin-yield' && item.accountKey === accountKey ? [item] : [],
+    );
+
 // Rewards are claimed per account, so one item covers all of the account's vault positions
-// — and rewards outlive a fully withdrawn position, which leaves an item with no vaults.
+// — and rewards outlive a fully withdrawn position, which leaves an item with no positions.
 export const buildStablecoinYieldClaimItems = ({
     stablecoinYieldClaimSummaries,
-    stablecoinYieldActiveItems,
+    earnDepositsActiveItems,
 }: {
     stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[];
-    stablecoinYieldActiveItems: StablecoinYieldEarnItem[];
+    earnDepositsActiveItems: EarnDepositsCardActiveItem[];
 }): StablecoinYieldClaimItem[] =>
-    stablecoinYieldClaimSummaries.map(summary => ({
-        summary,
-        vaults: stablecoinYieldActiveItems
-            .filter(item => item.accountKey === summary.accountKey && item.vaultName)
-            .map(item => ({
-                name: item.vaultName,
-                tokenContract: item.tokenContractAddress,
-            })),
-    }));
+    stablecoinYieldClaimSummaries.map(summary => {
+        const positions = getAccountPositions(earnDepositsActiveItems, summary.accountKey);
+
+        return {
+            summary,
+            positions,
+            vaults: positions.flatMap(position =>
+                position.title
+                    ? [{ name: position.title, tokenContract: position.tokenContractAddress }]
+                    : [],
+            ),
+        };
+    });
 
 export const getTotalFiatClaimableAmount = (
     stablecoinYieldClaimSummaries: StablecoinYieldClaimSummary[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-uses the existing component to ensure rewards % is displayed and enforced wrapping on the summary screen

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29806

## Screenshots:

| Manual override | Drawer |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 14 11 10" src="https://github.com/user-attachments/assets/b839096f-451a-4954-9467-fa76f549b598" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 14 22 29" src="https://github.com/user-attachments/assets/031dee9e-7266-4bde-a583-b4adcaaf139c" /> | 


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/wrap-values-summary-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->