### PR TITLE
fix(suite): hide "No trading pair" status in send asset selector

### DIFF
--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx
@@ -12,7 +12,7 @@ export type AssetAmountProps = {
     amount: string;
     contractAddress: string;
     fiatAmount?: BaseCurrencyAmount;
-    fiatFallackText?: boolean;
+    showNoTradingPairText?: boolean;
 };
 
 export function AssetAmount({
@@ -20,7 +20,7 @@ export function AssetAmount({
     symbol,
     fiatAmount,
     contractAddress,
-    fiatFallackText = false,
+    showNoTradingPairText = false,
 }: AssetAmountProps) {
     const { BaseCurrencyAmountFormatter } = useFormatters();
     const fiatCurrency = useSelector(selectBaseCurrency);
@@ -41,7 +41,7 @@ export function AssetAmount({
                     <BaseCurrencyAmountFormatter value={fiatAmount} currency={fiatCurrency} />
                 </Text>
             )}
-            {!fiatAmount && fiatFallackText && (
+            {!fiatAmount && showNoTradingPairText && (
                 <Text intent="neutral" priority="secondary" typographyStyle="body-sm">
                     <Translation id="TR_HIDDEN_TOKEN_WITHOUT_FIAT" />
                 </Text>

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx
@@ -15,6 +15,7 @@ export type AssetRowTokenProps = {
     onClick?: (token: TokensWithRates, account: Account) => void;
     dataTestId?: string;
     isHiddenToken?: boolean;
+    showNoTradingPairText?: boolean;
 };
 
 export function AssetRowToken({
@@ -23,6 +24,7 @@ export function AssetRowToken({
     dataTestId,
     onClick,
     isHiddenToken = false,
+    showNoTradingPairText = false,
 }: AssetRowTokenProps) {
     return (
         <ItemClickableContainer
@@ -55,7 +57,7 @@ export function AssetRowToken({
                         }
                         contractAddress={token.contract}
                         amount={token.balance}
-                        fiatFallackText={isHiddenToken}
+                        showNoTradingPairText={showNoTradingPairText}
                     />
                 </Row>
             )}

--- a/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
+++ b/packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx
@@ -32,6 +32,7 @@ export interface ExpandableAssetRowTokensProps {
     height: number;
     dataTestId?: string;
     showTokensPreview?: boolean;
+    showNoTradingPairText?: boolean;
 }
 
 export function ExpandableAssetRowTokens({
@@ -44,6 +45,7 @@ export function ExpandableAssetRowTokens({
     height,
     dataTestId,
     showTokensPreview = false,
+    showNoTradingPairText = false,
 }: ExpandableAssetRowTokensProps) {
     const tokensContentHeight = expanded ? getExpandableTokensContentHeight(tokens.length) : 0;
 
@@ -101,6 +103,7 @@ export function ExpandableAssetRowTokens({
                                     account={account}
                                     onClick={onTokenClick}
                                     isHiddenToken={true}
+                                    showNoTradingPairText={showNoTradingPairText}
                                 />
                             ))}
                     </CollapsibleContent>

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx
@@ -87,6 +87,7 @@ export const AssetPickerModal = memo(function AssetPickerModalInner({
                             height={item.height}
                             dataTestId={`@asset-picker/sell/option/non-tradable-tokens/${item.account.symbol}`}
                             showTokensPreview
+                            showNoTradingPairText
                         />
                     );
             }


### PR DESCRIPTION
## Description

Hidden tokens in the send flow asset selector no longer show the "No trading pair" status. The text was driven by the shared `isHiddenToken` flag in `AssetRowToken`, so every expandable token group (send "Hidden tokens" and trading "Non-tradable tokens") displayed it. It is now controlled by a dedicated `showNoTradingPairText` prop that only the trading sell asset picker sets for its "Non-tradable tokens" group. The `isHiddenToken` flag keeps controlling only the nested row padding. Also renames the misspelled `fiatFallackText` prop.

## Notes for QA

- Send > select an account with hidden tokens > open the asset selector > expand "Hidden tokens": rows show balance only, no "No trading pair" text. Same for the global send modal (header Send button).
- Trade > Sell > asset picker > expand "Non-tradable tokens": "No trading pair" still shows for tokens without a fiat rate.

## Related Issue

Resolve #31108

## Screenshots:

<img width="702" height="730" alt="Screenshot 2026-08-18 at 14 52 44" src="https://github.com/user-attachments/assets/27371885-2fa9-464f-b4b9-b9340c2a348d" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31108-send-asset-picker-no-trading-pair/web/](https://dev.suite.sldev.cz/suite-web/fix/31108-send-asset-picker-no-trading-pair/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31108-send-asset-picker-no-trading-pair&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31108-send-asset-picker-no-trading-pair&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T12:46:14.487Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T12:45:44.531Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to asset-picker UI components that render token rows, expandable token lists, and the sell-asset modal in trading forms. The highest risk is that token selection, token amount display, or network filtering in swap/sell/buy forms breaks. The recommended set focuses on tests that explicitly use the asset picker to select tokens, supplemented by buy/sell smoke tests and live swap equivalents. Broad tests mapped only through the shared ExpandableAssetRowTokens component are omitted because they do not exercise trading asset selection.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetAmount.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/AssetRowToken/AssetRowToken.tsx`
- `packages/suite/src/components/suite/asset-picker/components/AssetRow/ExpandableAssetRowTokens/ExpandableAssetRowTokens.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingFormInput/TradingFormInputSellAsset/AssetPickerModal/AssetPickerModal.tsx`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — This test explicitly selects the Jupiter (JUP) Solana token through the asset picker with network/search filters and verifies quote details. Because the changed files render and control token rows and the sell-asset asset picker modal, this token-selection path is directly impacted. (This test was not statically mapped to the changed files but is inferred from the LLM description.)
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — The test fills the swap form by selecting SOL as the sell asset and a USDC token as the buy asset, then asserts quote and confirmation details. Changes to token rows and the asset picker modal could alter how tokens are displayed or selected in this flow.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Directly exercises the swap asset picker by selecting sell/buy assets including USDC on ETH, USDC on SOL, and USDT on ETH, and checks ticker, quotes, fraction buttons, and validation. This is the most concentrated coverage of the changed asset-picker UI.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Selects a Solana USDT token and Bitcoin in the swap form and verifies the best-offer quote and trade confirmation. This covers token row rendering and selection for a cross-chain token-to-coin swap.
- `suite/e2e/tests/trading/swap-token-to-disabled-network.test.ts` — Chooses USDT on Solana and an XLM asset on a disabled network in the swap form and asserts provider information. This specifically stresses network filtering and token row behavior when non-enabled networks are involved.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Performs an SPL token-to-token swap (USDT to USDC) on Solana, relying on the asset picker to select both token sell and buy assets. Changes to token amount display or row expansion could break this flow.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Selects Ethereum as the asset to buy using the asset picker with network filter and search. It is not statically mapped to the changed files but uses the same asset-picker infrastructure, so it provides coverage for the buy-side picker path. (Inferred from the LLM description.)
- `suite/e2e/tests/trading/navigation.test.ts` — Navigates to buy, sell, and swap forms from token pages (e.g., TUSD, USDC) and verifies the correct cryptocurrency is preselected. This touches asset-picker-related routing/preselection without deep quote validation, making it a good smoke test.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Exercises the sell form for BTC and SOL, including amount validation, fraction buttons, and currency ticker display. It references the sell-asset asset picker modal, so changes there could affect form initialization or ticker rendering.
- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — Live swap flow selects SOL and a USDC token across chains, relying on the same asset picker components used by the mocked token-selection tests. It adds real-environment confidence but is redundant with the mocked coin-to-token test.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Live swap flow selects an SPL token (USDT) and SOL coin, exercising token row selection in the live trading environment. It complements the mocked token-to-coin tests with real backend interaction.

</details>

_Updated: 2026-08-11T12:47:24.320Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->