### PR TITLE
fix(suite-native): remove minus sign from withdraw complete sent amount

### DIFF
--- a/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
+++ b/suite-native/module-earn/src/components/YieldCompleteScreenPresets.tsx
@@ -109,7 +109,7 @@ export const getYieldWithdrawCompleteRows = ({
                     size="extraSmall"
                 />
                 <Text variant="body-md-strong" color="contentPrimary" numberOfLines={1}>
-                    -{withdrawalAmount}
+                    {withdrawalAmount}
                 </Text>
             </HStack>
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the hardcoded minus sign from the Sent row on the withdraw complete screen, matching the desktop withdrawal completion and the wrap/unwrap complete screens fixed in [#31076](https://github.com/trezor/trezor-suite/pull/31076).

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31078

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-withdraw-complete-sent-sign&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->