### PR TITLE
chore(connect): update eth definitions URL

### DIFF
--- a/packages/connect/src/api/ethereum/ethereumDefinitions.ts
+++ b/packages/connect/src/api/ethereum/ethereumDefinitions.ts
@@ -23,7 +23,7 @@ interface GetEthereumDefinitions {
 const getDefinitionsBaseUrl = (channel: DefinitionsChannel = 'production') => {
     switch (channel) {
         case 'production':
-            return 'https://data.trezor.io/firmware/eth-definitions';
+            return 'https://data.trezor.io/firmware/definitions/eth';
         case 'development':
             return 'https://data.trezor.io/dev/firmware/dev-definitions/eth';
         case 'local':
@@ -69,7 +69,7 @@ export const getEthereumDefinitions = async ({
 
     try {
         if (contractAddress) {
-            // Contract address has to be in lowercase in order to be found in eth-definitions.
+            // Contract address has to be in lowercase in order to be found in definitions/eth.
             const lowerCaseContractAddress = contractAddress.toLowerCase();
             const tokenDefinitionUrl = `${baseUrl}/${chainId ? 'chain-id' : 'slip44'}/${chainId ?? slip44}/token-${lowerCaseContractAddress}.dat`;
             const tokenDefinition = await fetch(tokenDefinitionUrl);
@@ -110,7 +110,7 @@ export const getEthereumDefinitions = async ({
 };
 
 /**
- * decoded content of data retrieved from https://data.trezor.io/firmware/eth-definitions/...
+ * decoded content of data retrieved from https://data.trezor.io/firmware/definitions/eth/...
  */
 export type EthereumNetworkDefinitionDecoded = Static<typeof EthereumNetworkDefinitionDecoded>;
 export const EthereumNetworkDefinitionDecoded = Type.Object({
@@ -121,7 +121,7 @@ export const EthereumNetworkDefinitionDecoded = Type.Object({
 });
 
 /**
- * decoded content of data retreived from https://data.trezor.io/firmware/eth-definitions/...
+ * decoded content of data retreived from https://data.trezor.io/firmware/definitions/eth/...
  */
 export type EthereumTokenDefinitionDecoded = Static<typeof EthereumTokenDefinitionDecoded>;
 export const EthereumTokenDefinitionDecoded = Type.Object({

--- a/suite-common/wallet-core/src/send/sendFormThunks.ts
+++ b/suite-common/wallet-core/src/send/sendFormThunks.ts
@@ -853,7 +853,7 @@ export const enhancePrecomposedTransactionThunk = createThunk<
             selectedAccountNetwork.chainId
         ) {
             isTokenKnown = await fetch(
-                `https://data.trezor.io/firmware/eth-definitions/chain-id/${
+                `https://data.trezor.io/firmware/definitions/eth/chain-id/${
                     selectedAccountNetwork.chainId
                 }/token-${enhancedPrecomposedTransaction.token.contract.substring(2).toLowerCase()}.dat`,
                 { method: 'HEAD' },


### PR DESCRIPTION
## Description

Update base URL for ETH definitions from

https://data.trezor.io/firmware/eth-definitions

to 

https://data.trezor.io/firmware/definitions/eth

## Notes for QA

Test token send on EVM - correct token definition should appear on FW.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/eth-definitions-url/web/](https://dev.suite.sldev.cz/suite-web/eth-definitions-url/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=eth-definitions-url&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=eth-definitions-url&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=eth-definitions-url&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T13:33:06.478Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes modify Ethereum network definitions and core send-form thunks, so risk is concentrated in Ethereum send/swap/stake flows and generic send-form composition/validation across networks. A small, targeted set covering ETH sell/send, representative BTC and SOL send forms, plus ETH staking/swap and edge-case DOGE/LTC sends provides high confidence without running the full suite.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/ethereum/ethereumDefinitions.ts`
- `suite-common/wallet-core/src/send/sendFormThunks.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Sells ETH with custom gas fees and executes an on-device send confirmation; directly exercises sendFormThunks for composed ETH transaction info and ethereumDefinitions for chain/network definitions.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Fills the ETH send form, sets custom gas fees, and verifies composed amount/fee on the device prompt; directly hits sendFormThunks and ethereumDefinitions.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Adds/removes outputs, configures locktime and OP_RETURN, switches display units, and broadcasts a BTC transaction; exercises core send-form thunk logic for transaction composition and validation.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Uses the SOL send form with Send Max, fee/reserve calculation, and device confirmation; exercises sendFormThunks for Solana transaction composition.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Creates the first ETH stake transaction and verifies device prompt details; ethereumDefinitions changes could affect network/contract transaction signing.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Unstakes ETH and claims rewards, relying on Ethereum transaction signing and device prompts; affected by ethereumDefinitions changes.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Swaps from ETH with custom fees and verifies composed gas limit/fee info on the device; uses ethereumDefinitions and the sendFormThunks composed transaction path.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Sends a DOGE amount near MAX_SAFE_INTEGER and expects a specific sign-transaction error; exercises sendFormThunks amount validation and edge-case handling.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Sends LTC spending a MimbleWimble peg-out output with set-max; exercises sendFormThunks output selection and transaction composition for an altcoin.

</details>

_Updated: 2026-08-11T13:33:28.230Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->