### PR TITLE
Fix/connect TPN handler

### DIFF
--- a/packages/connect/src/device/DeviceList.ts
+++ b/packages/connect/src/device/DeviceList.ts
@@ -225,7 +225,9 @@ export class DeviceList extends TypedEmitter<DeviceListEvents> implements IDevic
     private onPushNotification(event: { id: string; data: number[] }) {
         const device = this.devices.find(d => d.descriptor.id === event.id);
         if (device) {
-            trezorPushNotificationHandler({ device, message: event.data });
+            trezorPushNotificationHandler({ device, message: event.data }).catch(error => {
+                console.error('Error handling Trezor Push Notification', error);
+            });
         }
     }
 

--- a/packages/connect/src/device/workflow/trezorPushNotification.ts
+++ b/packages/connect/src/device/workflow/trezorPushNotification.ts
@@ -5,6 +5,23 @@ import { resolveAfter } from '@trezor/utils';
 import type { TpnWorkflowContext } from '../../types/workflow';
 import { getThpChannel } from '../thp';
 
+const assureThpState = async (device: TpnWorkflowContext['device']) => {
+    const thpState = device.getThpState();
+    if (thpState?.phase !== 'paired') {
+        // try THP pairing without interaction
+        await getThpChannel(device, false);
+    }
+
+    if (device.getThpState()?.phase === 'paired') {
+        // and proceed only if further interaction is not required
+        await device.getFeatures();
+    } else {
+        // otherwise wait for start pairing request
+        device.setBusy('thp-locked');
+        device.emitDeviceChanged();
+    }
+};
+
 const setupDeviceMode = async (
     device: TpnWorkflowContext['device'],
     mode: TrezorPushNotificationMode,
@@ -27,16 +44,7 @@ const setupDeviceMode = async (
         // wait. THP may not be ready yet
         await resolveAfter(1000);
 
-        // try THP pairing without interaction
-        await getThpChannel(device, false);
-        if (device.getThpState()?.phase === 'paired') {
-            // and proceed only if further interaction is not required
-            await device.getFeatures();
-        } else {
-            // otherwise wait for start pairing request
-            device.setBusy('thp-locked');
-            device.emitDeviceChanged();
-        }
+        await assureThpState(device);
 
         await device.release();
     }
@@ -75,7 +83,7 @@ export const trezorPushNotificationHandler = async ({ device, message }: TpnWork
         case TrezorPushNotificationType.NOTIFY_POWER_STATUS_CHANGE:
             if (!device.isUsed()) {
                 await device.acquire();
-                await device.getFeatures();
+                await assureThpState(device);
                 await device.release();
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Followup for https://github.com/trezor/trezor-suite/pull/31111

This should resolve [this sentry issue](https://app.notion.com/p/satoshilabs/Error-Cannot-read-property-hostKey-of-undefined-90846b3e1ead4311b4d55a88076e2c65)

When ThpState is reset (for whatever reason) `trezorPushNotificationHandler` can call `device.getFeatures()` directly - this  bypasses THP pairing sequence and leads to "Cannot read property 'hostKey' of undefined" in protobuf encode (error message fixed in #31111)

Additionally added global error handler for `trezorPushNotificationHandler` with console.error to be logged in the sentry (hopefully will never happen again but just to be sure)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-tpn-handler/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-tpn-handler/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** Both changed files sit in @trezor/connect's device layer: DeviceList.ts manages device enumeration and sessions, while trezorPushNotification.ts handles async device notifications. Because they are broad dependencies imported by many tests, the strategy is to target tests that directly verify device connect/disconnect lifecycle and session management, where regressions are user-visible and hard to catch through unit tests alone.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/device/DeviceList.ts`
- `packages/connect/src/device/workflow/trezorPushNotification.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/suite/multiple-sessions.test.ts` — Directly exercises Bridge session enumeration, acquisition, and takeover across browser tabs/windows. DeviceList.ts is the core source for device/session state, so a regression here would manifest as incorrect 'Use Here'/'Connected' statuses or failed session reclaiming.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — Asserts that DeviceConnect, DeviceDisconnect, and TransportType analytics events contain correct metadata. These events are emitted from the device/transport layer managed by DeviceList, so changes there could corrupt event payloads or timing.
- `suite/e2e/tests/backup/t2t1-misc.test.ts` — Verifies device-disconnected status is detected and surfaced when the emulator is powered off mid-backup. This tests the device-list disconnect notification path that would be affected by changes to device enumeration or push notifications.
- `suite/e2e/tests/onboarding/t2t1/t2t1-recovery-persistence.test.ts` — Covers device power-off, page reload, and reconnect during recovery, asserting the connect-device/confirm-on-device prompts reappear. This relies on persisted device state and reconnect detection handled by the device layer.
- `suite/e2e/tests/recovery/dry-run.test.ts` — Simulates device disconnection by stopping/starting the bridge and verifies the recovery prompt reinitializes after reconnect. A change to DeviceList session or transport reconnection logic could break this flow.
- `suite/e2e/tests/wallet/without-device.test.ts` — Checks that disconnecting the device surfaces the disconnected status banner and connection modal in the send flow. This validates the device-list disconnect state propagation into Suite UI.

</details>

_Updated: 2026-08-11T13:49:42.622Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-tpn-handler&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-tpn-handler&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-tpn-handler&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T13:51:29.338Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T13:50:23.790Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->