### PR TITLE
fix(suite-common): exclude failed eth txs from balance history graph

### DIFF
--- a/suite-common/graph/src/__fixtures__/eth.ts
+++ b/suite-common/graph/src/__fixtures__/eth.ts
@@ -2180,3 +2180,134 @@ export const l2AccountBalanceHistoryResult: AccountHistoryMovementItem[] = [
         sentToSelf: new BigNumber('0'),
     },
 ];
+
+export const ethRevertedAndUnknownStatusTransactions: WalletAccountTransaction[] = [
+    {
+        // Reverted tx (status 0) carrying native value: only the fee is spent.
+        // Fee = 7000000000 * 21000 = 147000000000000.
+        descriptor: asAccountDescriptor('0x1111111111111111111111111111111111111111'),
+        deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
+        symbol: 'eth',
+        type: 'failed',
+        txid: '0xbbb1',
+        blockTime: 1721000000,
+        blockHeight: 200,
+        blockHash: '0xblock200',
+        amount: '0',
+        fee: '147000000000000',
+        targets: [],
+        tokens: [],
+        internalTransfers: [],
+        ethereumSpecific: {
+            status: 0,
+            error: 'Reverted',
+            nonce: 3,
+            gasLimit: 21000,
+            gasUsed: 21000,
+            gasPrice: '7000000000',
+            data: '0x',
+            internalTransfers: [
+                {
+                    type: 0,
+                    from: '0x2222222222222222222222222222222222222222',
+                    to: '0x1111111111111111111111111111111111111111',
+                    value: '10000000000000000',
+                },
+            ],
+        },
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    addresses: ['0x1111111111111111111111111111111111111111'],
+                    isAddress: true,
+                },
+            ],
+            vout: [
+                {
+                    value: '50000000000000000',
+                    n: 0,
+                    addresses: ['0x2222222222222222222222222222222222222222'],
+                    isAddress: true,
+                },
+            ],
+            size: 0,
+            totalInput: '0',
+            totalOutput: '50000000000000000',
+        },
+    },
+    {
+        // Unknown status tx (status -2, pre-Byzantium): value is counted, matching blockbook.
+        // Sent = 40000000000000000 + 7000000000 * 21000.
+        descriptor: asAccountDescriptor('0x1111111111111111111111111111111111111111'),
+        deviceState: 'state@hiddenDeviceWithImportedAccounts:1',
+        symbol: 'eth',
+        type: 'sent',
+        txid: '0xbbb2',
+        blockTime: 1721000100,
+        blockHeight: 201,
+        blockHash: '0xblock201',
+        amount: '40000000000000000',
+        fee: '147000000000000',
+        targets: [],
+        tokens: [],
+        internalTransfers: [],
+        ethereumSpecific: {
+            status: -2,
+            nonce: 4,
+            gasLimit: 21000,
+            gasUsed: 21000,
+            gasPrice: '7000000000',
+            data: '0x',
+            internalTransfers: [
+                {
+                    type: 0,
+                    from: '0x2222222222222222222222222222222222222222',
+                    to: '0x1111111111111111111111111111111111111111',
+                    value: '20000000000000000',
+                },
+            ],
+        },
+        details: {
+            vin: [
+                {
+                    n: 0,
+                    addresses: ['0x1111111111111111111111111111111111111111'],
+                    isAddress: true,
+                },
+            ],
+            vout: [
+                {
+                    value: '40000000000000000',
+                    n: 0,
+                    addresses: ['0x2222222222222222222222222222222222222222'],
+                    isAddress: true,
+                },
+            ],
+            size: 0,
+            totalInput: '0',
+            totalOutput: '40000000000000000',
+        },
+    },
+];
+
+export const ethRevertedAndUnknownStatusBalanceHistoryResult: AccountHistoryMovementItem[] = [
+    {
+        time: 1721000000,
+        txs: 1,
+        // the reverted internal transfer is not received
+        received: new BigNumber('0'),
+        // fee only, the reverted value is not spent
+        sent: new BigNumber('147000000000000'),
+        sentToSelf: new BigNumber('0'),
+    },
+    {
+        time: 1721000100,
+        txs: 1,
+        // the internal transfer
+        received: new BigNumber('20000000000000000'),
+        // value (40000000000000000) + fee (147000000000000)
+        sent: new BigNumber('40147000000000000'),
+        sentToSelf: new BigNumber('0'),
+    },
+];

--- a/suite-common/graph/src/balanceHistoryUtils.test.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.test.ts
@@ -4,6 +4,8 @@ import { btcAccountBalanceHistoryResult, btcAccountTransactions } from './__fixt
 import {
     ethAccountBalanceHistoryResult,
     ethAccountTransactions,
+    ethRevertedAndUnknownStatusBalanceHistoryResult,
+    ethRevertedAndUnknownStatusTransactions,
     ethTokenBalanceHistoryResult,
     l2AccountBalanceHistoryResult,
     l2AccountTransactions,
@@ -71,6 +73,15 @@ describe('Account balance movement history', () => {
         });
 
         expect(balanceHistory.main).toMatchObject(ethAccountBalanceHistoryResult);
+    });
+
+    it('should count only the fee for reverted txs and the full value for unknown-status txs', async () => {
+        const balanceHistory = await getAccountHistoryMovementFromTransactions({
+            transactions: ethRevertedAndUnknownStatusTransactions,
+            symbol: 'eth',
+        });
+
+        expect(balanceHistory.main).toMatchObject(ethRevertedAndUnknownStatusBalanceHistoryResult);
     });
 
     it('should use effectiveGasPrice and add l1Fee for L2 fees, falling back to gasPrice', async () => {

--- a/suite-common/graph/src/balanceHistoryUtils.ts
+++ b/suite-common/graph/src/balanceHistoryUtils.ts
@@ -135,6 +135,10 @@ const getAccountHistoryMovementItemMisc = ({
     return { main: Array.from(summaryMap.values()).sort((a, b) => a.time - b.time), tokens: {} };
 };
 
+// Blockbook TxStatus: -2 unknown, -1 pending, 0 failure, 1 OK. Principal moves only for
+// OK and unknown txs (blockbook api/worker.go); a failed tx costs just its fee.
+const isPrincipalMovementCounted = (status: number) => status === 1 || status === -2;
+
 // this can be also used for networks of Ethereum type (like ETH, POL or BNB)
 const getAccountHistoryMovementItemETH = ({
     transactions,
@@ -166,10 +170,7 @@ const getAccountHistoryMovementItemETH = ({
         let countSentToSelf = false;
         const ethTxData = tx.ethereumSpecific;
 
-        if (
-            ethTxData.status === 1 /* TxStatusOK */ ||
-            ethTxData.status === 0 /* TxStatusUnknown */
-        ) {
+        if (isPrincipalMovementCounted(ethTxData.status)) {
             if (tx.details.vout.length > 0) {
                 const bchainVout = tx.details.vout[0];
                 if (bchainVout) {
@@ -215,7 +216,7 @@ const getAccountHistoryMovementItemETH = ({
                 const txAddrDesc = bchainVin.addresses[0];
 
                 if (txAddrDesc === tx.descriptor) {
-                    if (ethTxData.status === 1 || ethTxData.status === 0) {
+                    if (isPrincipalMovementCounted(ethTxData.status)) {
                         const value = new BigNumber(tx.details.vout[0]?.value || '0');
                         bh.sent = bh.sent.plus(value);
 


### PR DESCRIPTION
## Description

The locally-computed balance-history graph (eth, pol, bsc, arb, op, base, rhc, hype, avax) misread Blockbook's `ethereumSpecific.status` enum (`-2` unknown, `-1` pending, `0` failure, `1` OK): it counted principal movement for `status === 0` (failure) and skipped `status === -2` (unknown). A reverted transaction that carried native value was therefore counted as a spend, which offsets every earlier point of the graph because the series is reconstructed backwards from the current balance.

Both guards now use a shared `isPrincipalMovementCounted` predicate (`status === 1 || status === -2`), matching Blockbook's server-side balance history. Fees are still charged unconditionally for sender-side matches, so a failed transaction costs exactly its fee.

## Notes for QA

- ETH-family account with a reverted value-carrying tx (failed swap/send) is not present in the chart
- Graph should now reconcile with Blockbook's `/api/v2/balancehistory` for the same account.
- Covered by unit tests: reverted tx (status 0) counts only its fee (outgoing value and incoming internal transfers ignored), unknown status (-2) counts value + internal transfers, successful txs unchanged.

## Related Issue

Resolve #31113

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set updates graph balance-history utilities and their unit-test fixtures/tests, with no static E2E coverage mapping. The safest inferred coverage comes from E2E tests that render portfolio and transaction graphs, which depend on the changed balance-history aggregation logic. No other test in the candidate list has specific evidence of exercising this code path.

<details><summary><b>Changed files (3)</b></summary>

- `suite-common/graph/src/__fixtures__/eth.ts`
- `suite-common/graph/src/balanceHistoryUtils.test.ts`
- `suite-common/graph/src/balanceHistoryUtils.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test explicitly asserts that the portfolio graph is visible after account discovery with custom Blockbook backends. The portfolio graph renders balance-history data computed by balanceHistoryUtils, so changes to that utility directly affect this test's key assertions.
- `suite/e2e/tests/wallet/transactions.test.ts` — Cycles through account transaction graph time-range filters and verifies date labels on the transaction overview graph. This directly exercises the graph aggregation behavior produced by balanceHistoryUtils.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/graph/src/__fixtures__/eth.ts`
- `suite-common/graph/src/balanceHistoryUtils.test.ts`

_Updated: 2026-08-19T12:29:59.961Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/31113-graph-failed-eth-tx-value/web/](https://dev.suite.sldev.cz/suite-web/fix/31113-graph-failed-eth-tx-value/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/31113-graph-failed-eth-tx-value&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/31113-graph-failed-eth-tx-value&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31113-graph-failed-eth-tx-value&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T12:29:38.109Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T12:30:25.293Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->