### PR TITLE
Fix: connect thp pairing

### DIFF
--- a/packages/connect/src/device/thp/handshake.ts
+++ b/packages/connect/src/device/thp/handshake.ts
@@ -118,7 +118,8 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
         encryptedPayload: handshakeCredentials.encryptedPayload,
     });
 
-    if (!handshakeCompletion.message.state && handshakeCredentials.credentials) {
+    const completionState = handshakeCompletion.message.state;
+    if (!completionState && handshakeCredentials.credentials) {
         // Known credentials was used but not accepted by device -> throw them away
         thpState.removePairingCredential(handshakeCredentials.credentials);
 
@@ -129,10 +130,18 @@ export const thpHandshake = async (device: IDevice, unlockPin = false) => {
         }
     }
 
-    thpState.setIsPaired(handshakeCompletion.message.state !== 0);
+    // Spec HH3 step 3: if no credential was presented the device MUST report STATE_UNPAIRED.
+    if (!handshakeCredentials.credentials && completionState !== 0) {
+        throw ERRORS.TypedError(
+            'Device_InvalidState',
+            'Device returned paired state without valid credentials',
+        );
+    }
+
+    thpState.setIsPaired(completionState !== 0);
     thpState.setPhase('pairing');
 
-    if (thpState.isAutoconnectPaired || handshakeCompletion.message.state === 2) {
+    if (handshakeCredentials.credentials?.autoconnect || completionState === 2) {
         // State HC1 -> HC2 pairing complete
         // finish pairing. device is ready to communicate without further interaction
         await thpCall(device, 'ThpEndRequest', {});

--- a/packages/connect/src/device/thp/pairing.ts
+++ b/packages/connect/src/device/thp/pairing.ts
@@ -95,20 +95,7 @@ const processCodeEntry = async (device: IDevice, value: string) => {
     return codeEntrySecret;
 };
 
-const processThpPairingResponse = (
-    device: IDevice,
-    payload: UiResponseThpPairingTag['payload'],
-) => {
-    if ('selectedMethod' in payload) {
-        // change pairing method
-        const selectedMethod = protocolThp.getThpPairingMethod(payload.selectedMethod);
-        device.getThpState()?.setPairingMethod(selectedMethod);
-
-        return thpCall(device, 'ThpSelectMethod', {
-            selected_pairing_method: selectedMethod,
-        });
-    }
-
+const processThpPairingResponse = (device: IDevice, payload: { tag: string }) => {
     const selectedMethod = device.getThpState()?.pairingMethod;
     if (selectedMethod === ThpPairingMethod.QrCode) {
         return processQrCodeTag(device, payload.tag);
@@ -123,6 +110,51 @@ const processThpPairingResponse = (
     }
 
     throw ERRORS.TypedError('Device_ThpPairingMethodsException');
+};
+
+// Handles the ThpSelectMethod response that arrives both during initial pairing (thpPairing)
+// and after a mid-flow method change (waitForPairingTag). Sets up per-method state so the
+// caller can proceed to waitForPairingTag.
+const applySelectMethodResponse = async (
+    device: IDevice,
+    response: protocolThp.ThpMessageResponse<
+        | 'ThpCodeEntryCommitment'
+        | 'ThpPairingPreparationsFinished'
+        | 'ThpEndResponse'
+        | 'ThpPairingRequestApproved'
+    >,
+) => {
+    const thpState = device.getThpState();
+    if (!thpState?.handshakeCredentials) {
+        throw ERRORS.TypedError('Device_ThpStateMissing');
+    }
+
+    if (response.type === 'ThpCodeEntryCommitment') {
+        const codeEntryChallenge = Buffer.from(randomBytes(32));
+        const handshakeCommitment = Buffer.from(response.message.commitment, 'hex');
+        thpState.updateHandshakeCredentials({ handshakeCommitment, codeEntryChallenge });
+
+        const codeEntryCpace = await thpCall(device, 'ThpCodeEntryChallenge', {
+            challenge: codeEntryChallenge.toString('hex'),
+        });
+        thpState.updateHandshakeCredentials({
+            trezorCpacePublicKey: Buffer.from(
+                codeEntryCpace.message.cpace_trezor_public_key,
+                'hex',
+            ),
+        });
+    } else if (response.type === 'ThpPairingPreparationsFinished') {
+        if (thpState.pairingMethod === ThpPairingMethod.NFC) {
+            thpState.setNfcSecret(Buffer.from(randomBytes(16)));
+        }
+    } else {
+        // ThpEndResponse is in the ThpSelectMethod allowed-response set but must never bypass
+        // the pairing ceremony — reject it here.
+        throw ERRORS.TypedError(
+            'Device_InvalidState',
+            `Unexpected response type: ${response.type}`,
+        );
+    }
 };
 
 const waitForPairingCancel = (device: IDevice) => {
@@ -212,6 +244,22 @@ const waitForPairingTag = async (device: IDevice) => {
     // node-bridge + usb: abort received on client side of http request resolves faster than server. result with "device call in progress"
     await resolveAfter(500);
 
+    if ('selectedMethod' in pairingResponse) {
+        // User changed the pairing method. Send the new ThpSelectMethod to the device, set up
+        // per-method state (CodeEntry challenge, NFC secret), then re-enter this function so the
+        // ceremony for the newly selected method is completed before credential issuance.
+        const selectedMethod = protocolThp.getThpPairingMethod(pairingResponse.selectedMethod);
+        thpState.setPairingMethod(selectedMethod);
+
+        const response = await thpCall(device, 'ThpSelectMethod', {
+            selected_pairing_method: selectedMethod,
+        });
+        await applySelectMethodResponse(device, response);
+
+        // re-enter to collect the tag for the newly selected method
+        return waitForPairingTag(device);
+    }
+
     return processThpPairingResponse(device, pairingResponse).catch(e => {
         // catch pairing tag mismatch
         // DataError since 2.10.0 https://github.com/trezor/trezor-firmware/commit/b0c3be9b1d95946471ebdab27918a3f652cf11e9
@@ -297,47 +345,18 @@ export const thpPairing = async (device: IDevice) => {
 
     // selected_pairing_method === ThpPairingMethod.SkipPairing
     if (selectMethod.type === 'ThpEndResponse') {
+        if (thpState.pairingMethod !== protocolThp.ThpPairingMethod.SkipPairing) {
+            throw ERRORS.TypedError('Device_ThpPairingMethodsException');
+        }
         thpState.setIsPaired(true);
         device.getThpState()?.setPhase('paired');
 
         return;
     }
 
-    // State HP2
-    if (selectMethod.type === 'ThpCodeEntryCommitment') {
-        // store handshakeCommitment and validate later in `processCodeEntry`
-        const codeEntryChallenge = Buffer.from(randomBytes(32));
-        const handshakeCommitment = Buffer.from(selectMethod.message.commitment, 'hex');
-        thpState.updateHandshakeCredentials({
-            handshakeCommitment,
-            codeEntryChallenge,
-        });
-
-        // State HP3a
-        const codeEntryCpace = await thpCall(device, 'ThpCodeEntryChallenge', {
-            challenge: codeEntryChallenge.toString('hex'),
-        });
-
-        thpState.updateHandshakeCredentials({
-            trezorCpacePublicKey: Buffer.from(
-                codeEntryCpace.message.cpace_trezor_public_key,
-                'hex',
-            ),
-        });
-
-        // State HP4 -> HP5
-        await waitForPairingTag(device);
-    }
-
-    if (selectMethod.type === 'ThpPairingPreparationsFinished') {
-        if (thpState.pairingMethod === protocolThp.ThpPairingMethod.NFC) {
-            // generate random secret and store it
-            thpState.setNfcSecret(Buffer.from(randomBytes(16)));
-        }
-
-        // State HP6 and HP7
-        await waitForPairingTag(device);
-    }
+    // State HP2, HP3a, HP6
+    await applySelectMethodResponse(device, selectMethod);
+    await waitForPairingTag(device);
 
     // State HC0
     // generate new credentials and send

--- a/packages/connect/src/device/thp/thpCall.ts
+++ b/packages/connect/src/device/thp/thpCall.ts
@@ -4,25 +4,30 @@ import type { thp as protocolThp } from '@trezor/protocol';
 
 import type { IDevice } from '../../types/idevice';
 
-type ThpTypedCall = {
-    ThpCreateChannelRequest: 'ThpCreateChannelResponse';
-    ThpHandshakeInitRequest: 'ThpHandshakeInitResponse';
-    ThpHandshakeCompletionRequest: 'ThpHandshakeCompletionResponse';
-    ThpPairingRequest: 'ThpPairingRequestApproved';
+// Runtime gate: every request maps to the exact set of response types it may receive.
+// ThpTypedCall is derived directly from this object, so the type map and the runtime
+// check are always in sync — adding or changing a response type here is the only edit needed.
+const ALLOWED_RESPONSE_TYPES = {
+    ThpCreateChannelRequest: ['ThpCreateChannelResponse'],
+    ThpHandshakeInitRequest: ['ThpHandshakeInitResponse'],
+    ThpHandshakeCompletionRequest: ['ThpHandshakeCompletionResponse'],
+    ThpPairingRequest: ['ThpPairingRequestApproved'],
     ThpSelectMethod: [
         'ThpCodeEntryCommitment',
         'ThpEndResponse',
         'ThpPairingRequestApproved',
         'ThpPairingPreparationsFinished',
-    ];
-    ThpCodeEntryChallenge: ['ThpCodeEntryCpaceTrezor'];
-    ThpCodeEntryCpaceHostTag: 'ThpCodeEntrySecret';
-    ThpQrCodeTag: 'ThpQrCodeSecret';
-    ThpNfcTagHost: 'ThpNfcTagTrezor';
-    ThpCredentialRequest: 'ThpCredentialResponse';
-    ThpEndRequest: 'ThpEndResponse';
-    ThpCreateNewSession: 'Success';
-};
+    ],
+    ThpCodeEntryChallenge: ['ThpCodeEntryCpaceTrezor'],
+    ThpCodeEntryCpaceHostTag: ['ThpCodeEntrySecret'],
+    ThpQrCodeTag: ['ThpQrCodeSecret'],
+    ThpNfcTagHost: ['ThpNfcTagTrezor'],
+    ThpCredentialRequest: ['ThpCredentialResponse'],
+    ThpEndRequest: ['ThpEndResponse'],
+    ThpCreateNewSession: ['Success'],
+} as const;
+
+type ThpTypedCall = typeof ALLOWED_RESPONSE_TYPES;
 
 type ThpMessage = protocolThp.ThpMessageType & { Success: Record<never, never> };
 type TypedPayloadItem<K> = K extends keyof ThpMessage
@@ -31,20 +36,27 @@ type TypedPayloadItem<K> = K extends keyof ThpMessage
           message: ThpMessage[K];
       }
     : never;
-type ExtractFromArray<A extends any[]> = {
+type ExtractFromArray<A extends readonly any[]> = {
     [K in keyof A]: TypedPayloadItem<A[K]>;
 }[number];
 
 type MessageKey = keyof ThpTypedCall;
-type TypedPayload<T extends MessageKey> = ThpTypedCall[T] extends any[]
-    ? ExtractFromArray<ThpTypedCall[T]>
-    : TypedPayloadItem<ThpTypedCall[T]>;
+type TypedPayload<T extends MessageKey> = ExtractFromArray<ThpTypedCall[T]>;
 
 type ThpCallResponse = {
     [K in keyof ThpTypedCall]: TypedPayload<K>;
 };
 
 type ThpMessagePayload<T extends MessageKey = MessageKey> = ThpMessage[T];
+
+// TypeScript types ReadonlyArray<T>.includes as (value: T), which rejects a wider string
+// argument when the array is a narrow const tuple. This helper widens the element type to
+// string so callers don't need a cast at every use site.
+const assertResponse = (type: string, allowed: readonly string[]) => {
+    if (!allowed.includes(type)) {
+        throw TypedError('Device_InvalidState', `Unexpected response type: ${type}`);
+    }
+};
 
 export const thpCall = async <T extends MessageKey>(
     device: IDevice,
@@ -83,6 +95,12 @@ export const thpCall = async <T extends MessageKey>(
     if (result.payload.type === 'ThpError') {
         const { code, message } = result.payload.message;
         throw TypedError(code, message);
+    }
+
+    // Runtime gate: reject any response type not in the allowed set for this call.
+    // ButtonAck is passed via recursive call and has no entry in ALLOWED_RESPONSE_TYPES.
+    if (name in ALLOWED_RESPONSE_TYPES) {
+        assertResponse(result.payload.type, ALLOWED_RESPONSE_TYPES[name]);
     }
 
     return result.payload as ThpCallResponse[T];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Addresses few runtime issues reported in notion:

https://app.notion.com/p/satoshilabs/THP-pairing-rogue-device-answers-ThpSelectMethod-out-of-spec-instant-silent-pairing-unhandled-re-3b9dc52606068040a5e5db6f09bcf864?v=2f0dc5260606803d9312000cc11b4e74
- enforce selected_method === SkipPairing before accepting ThpEndResponse
- wire expected responses into thpCall as a real runtime gate

https://app.notion.com/p/satoshilabs/THP-missing-HH3-assertion-forged-trezor_state-in-an-anonymous-handshake-silently-bypasses-the-ent-3b8dc52606068026ba4ce005bcaebbf0?v=2f0dc5260606803d9312000cc11b4e74
- reject if device return paired state without host credentials
- gate the autoconnect branch

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-thp-pairing/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-thp-pairing/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-thp-pairing&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-thp-pairing&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-thp-pairing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:15:13.994Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-04T11:57:49.195Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are confined to the THP (Trezor Host Protocol) layer in @trezor/connect (handshake, pairing, thpCall). Although static coverage maps these files to 139 tests—indicating they are broadly imported—the actual user-visible risk is limited to onboarding and initial-run flows for THP-capable devices, primarily T3W1. I recommend running the small set of tests that explicitly exercise THP pairing code paths rather than the full mapped suite.

<details><summary><b>Changed files (3)</b></summary>

- `packages/connect/src/device/thp/handshake.ts`
- `packages/connect/src/device/thp/pairing.ts`
- `packages/connect/src/device/thp/thpCall.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The test explicitly covers the THP pairing code flow for devices that support THP and directly navigates through onboarding where handshake/pairing logic runs. A regression in the THP handshake or pairing call would likely surface here.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This is the only test that explicitly invokes onboardingPage.pairTHP for the T3W1 (THP-capable) device and exercises the full wallet creation flow through THP pairing. It directly validates the changed handshake/pairing/call stack.
- `suite/e2e/tests/suite/initial-run.test.ts` — The test verifies THP-specific behavior: when a THP device is used, the user is prompted to allow connection and enter a THP pairing code during the initial run. Changes to THP handshake/pairing could break this first-run experience.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — The onboarding authenticity check flow relies on THP connect/pairing prompt handling to reach device interaction. While not a dedicated THP test, a regression in pairing call setup could prevent the device prompt from appearing.

</details>

_Updated: 2026-09-04T11:54:56.656Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->