### PR TITLE
fix(suite): show pending tx amount without subtracted fee in tx detail

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx
@@ -47,7 +47,6 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
 
     const fee = formatNetworkAmount(tx.fee, tx.symbol);
     const amount = new BigNumber(formatNetworkAmount(tx.amount, tx.symbol));
-    const displayAmount = tx.blockHash ? amount : amount.minus(fee);
     const cardanoWithdrawal = formatCardanoWithdrawal(tx);
     const cardanoDeposit = formatCardanoDeposit(tx);
     const selectedAccount = useSelector(state => state.wallet.selectedAccount);
@@ -125,7 +124,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                             <Table.Cell align="end">
                                 <Text intent="neutral">
                                     <FormattedCryptoAmount
-                                        value={displayAmount.abs().toString()}
+                                        value={amount.abs().toString()}
                                         symbol={tx.symbol}
                                         signValue={getAmountSignValue()}
                                     />
@@ -134,7 +133,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                             <Table.Cell align="end">
                                 <Text intent="neutral">
                                     <BaseCurrencyValue
-                                        amount={displayAmount.abs().toString()}
+                                        amount={amount.abs().toString()}
                                         symbol={tx.symbol}
                                         historicRate={historicRate}
                                         useHistoricRate
@@ -144,7 +143,7 @@ export const AmountDetails = ({ tx, isTestnet }: AmountDetailsProps) => {
                             <Table.Cell align="end">
                                 <Text intent="neutral">
                                     <BaseCurrencyValue
-                                        amount={displayAmount.abs().toString()}
+                                        amount={amount.abs().toString()}
                                         symbol={tx.symbol}
                                     />
                                 </Text>

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.test.ts
@@ -1,0 +1,52 @@
+import { configureMockStore } from '@suite-common/test-utils';
+import { type Account } from '@suite-common/wallet-types';
+
+import { transactionsActions } from './transactionsActions';
+import { addFakePendingCardanoTxThunk } from './transactionsThunks';
+
+const account = {
+    key: 'descriptor-ada-device',
+    descriptor: 'descriptor',
+    deviceState: 'device-state',
+    symbol: 'ada',
+    networkType: 'cardano',
+} as unknown as Account;
+
+const initStore = () =>
+    configureMockStore({
+        preloadedState: {
+            wallet: {
+                blockchain: { ada: { blockHeight: 100 } },
+            },
+        },
+    });
+
+describe('addFakePendingCardanoTxThunk', () => {
+    it('stores the pending tx with the fee excluded from the amount, matching the confirmed tx from blockfrost', async () => {
+        const store = initStore();
+
+        await store.dispatch(
+            addFakePendingCardanoTxThunk({
+                precomposedTransaction: { totalSpent: '2170000', fee: '170000' },
+                txid: 'test-txid',
+                account,
+            }),
+        );
+
+        const addTransactionAction = store
+            .getActions()
+            .find(action => action.type === transactionsActions.addTransaction.type);
+
+        expect(addTransactionAction?.payload.transactions).toEqual([
+            expect.objectContaining({
+                txid: 'test-txid',
+                type: 'sent',
+                amount: '2000000',
+                fee: '170000',
+                totalSpent: '2170000',
+                blockHash: undefined,
+                deadline: 110,
+            }),
+        ]);
+    });
+});

--- a/suite-common/wallet-core/src/transactions/transactionsThunks.ts
+++ b/suite-common/wallet-core/src/transactions/transactionsThunks.ts
@@ -36,6 +36,7 @@ import TrezorConnect, {
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- temporary diagnostic
 import { __btcUnknownTxDebug__ } from '@trezor/connect/src/utils/pathUtils';
 import { asCoinSymbol } from '@trezor/connect-common';
+import { BigNumber } from '@trezor/utils';
 
 import { TRANSACTIONS_MODULE_PREFIX, transactionsActions } from './transactionsActions';
 import { type TransactionsRootState } from './transactionsReducerTypes';
@@ -469,8 +470,10 @@ export const addFakePendingCardanoTxThunk = createThunk<
             txid,
             blockTime: Math.floor(new Date().getTime() / 1000),
             blockHash: undefined,
-            // amounts (as most of props below) don't matter much since it is temp fake anyway
-            amount: precomposedTransaction.totalSpent,
+            // fee is excluded to match the amount of the confirmed tx from blockfrost
+            amount: new BigNumber(precomposedTransaction.totalSpent)
+                .minus(precomposedTransaction.fee)
+                .toString(),
             fee: precomposedTransaction.fee,
             feeRate: '0',
             totalSpent: precomposedTransaction.totalSpent,


### PR DESCRIPTION

## Description

The tx detail modal subtracted the network fee from `tx.amount` for every pending transaction (`displayAmount = tx.blockHash ? amount : amount.minus(fee)`). Bitcoin pending txs are stored with the same fee-excluded amount semantics as confirmed blockbook txs, so the modal showed amount−fee for pending sends and even receives, disagreeing with the tx list until confirmation.

The subtraction was compensating for the one place with fee-inclusive amounts: the fake pending Cardano tx stored `amount = totalSpent` (outputs + fee). This fixes that at the data layer (`addFakePendingCardanoTxThunk` now stores `totalSpent − fee`, matching a confirmed Blockfrost tx) and removes the display-layer subtraction, so pending and confirmed txs render identically for all networks.

## Notes for QA

- Send BTC (testnet is fine), open the pending tx detail: the amount rows must show the sent amount and fee separately, matching the tx list — not amount−fee.
- Check the receiving account's pending tx detail: it must show the full received amount.
- After confirmation the values must not change.
- Regression: send ADA and check the pending tx detail still shows the amount without fee; EVM pending tx detail amounts unchanged.

## Related Issue

Resolve #28454

## Screenshots:

<img width="883" height="646" alt="Screenshot 2026-08-18 at 17 02 53" src="https://github.com/user-attachments/assets/134a973c-db79-4006-8cac-22910d86b335" />
<img width="1048" height="412" alt="Screenshot 2026-08-18 at 17 02 49" src="https://github.com/user-attachments/assets/e0172b73-feb4-40cf-b524-67d9059c6ea7" />
<img width="865" height="642" alt="Screenshot 2026-08-18 at 17 02 41" src="https://github.com/user-attachments/assets/f71058bd-5045-4899-a7b0-aa17298cd905" />
<img width="1024" height="401" alt="Screenshot 2026-08-18 at 17 02 38" src="https://github.com/user-attachments/assets/e83352b9-cd16-4c79-a470-122718fb75ec" />
<img width="714" height="768" alt="Screenshot 2026-08-18 at 17 02 26" src="https://github.com/user-attachments/assets/31c8862f-b6ae-47a3-bba4-0e1cb57ba677" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/28454-pending-btc-tx-detail-amount/web/](https://dev.suite.sldev.cz/suite-web/fix/28454-pending-btc-tx-detail-amount/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/28454-pending-btc-tx-detail-amount&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/28454-pending-btc-tx-detail-amount&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/28454-pending-btc-tx-detail-amount&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:08:03.790Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:07:37.998Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes affect both the transaction data layer (wallet-core thunks) and the transaction detail UI (AmountDetails), which are broad shared dependencies. Rather than running the full static-coverage list, focus on a small high-signal set: a regtest send flow and the pending/confirmed transaction flow with detail-modal coverage, supplemented by transaction-list/pagination/export tests to catch data-shape regressions. The unit test file for transactionsThunks has no E2E equivalent and should be validated separately.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/AmountDetails.tsx`
- `suite-common/wallet-core/src/transactions/transactionsThunks.test.ts`
- `suite-common/wallet-core/src/transactions/transactionsThunks.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Sends Bitcoin transactions and asserts pending/confirmed grouping in the account transaction list, then opens the transaction detail modal to verify the txid. This directly exercises both transactionsThunks (transaction state updates after send/mining) and the TxDetailModal/AmountDetails rendering path.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Broadcasts Bitcoin transactions with multiple outputs, locktime, and OP_RETURN data, then verifies the resulting entries in the transaction list. This exercises the full transaction creation, broadcast, and persistence flow driven by transactionsThunks, plus the transaction list UI that AmountDetails summarizes.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/export-transactions.test.ts` — Exports transaction history for BTC, LTC, ETH, and ADA in PDF/CSV/JSON formats. If transactionsThunks changes alter stored transaction metadata, ordering, or shape, the exported output would likely diverge from expectations.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates paginated transaction lists on a Bitcoin legacy account and checks that expected transaction addresses render on each page. This depends on transactionsThunks populating and ordering transaction data correctly.
- `suite/e2e/tests/wallet/transactions.test.ts` — Uses the account transaction list by cycling graph time ranges, finding the latest transaction, and searching by address. Changes to transaction thunk loading or ordering would directly impact these assertions.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/transactions/transactionsThunks.test.ts`

_Updated: 2026-08-11T15:08:26.228Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->