### PR TITLE
feat(suite): show add label option even without connected trezor

### DIFF
--- a/suite-common/suite-sync/src/suiteSyncSelectors.test.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.test.ts
@@ -1,5 +1,6 @@
 import { deviceReducerInitialState } from '@suite-common/device';
 import {
+    Feature,
     type MessageSystemRootState,
     messageSystemInitialState,
 } from '@suite-common/message-system';
@@ -13,6 +14,43 @@ import type { WithSuiteSyncAndDeviceState } from './suiteSyncSelectors';
 import { type SuiteSyncState, initialSuiteSyncState } from './suiteSyncSlice';
 
 const DEVICE_STATIC_SESSION_ID_123: StaticSessionId = '1@2:3';
+
+const SUITE_SYNC_FEATURE_TOGGLE_MESSAGE_ID = 'test-toggle-suite-sync';
+
+const createSuiteSyncFeatureDisabledMessageSystemState =
+    (): MessageSystemRootState['messageSystem'] => ({
+        ...messageSystemInitialState,
+        validMessages: {
+            ...messageSystemInitialState.validMessages,
+            feature: [SUITE_SYNC_FEATURE_TOGGLE_MESSAGE_ID],
+        },
+        config: {
+            version: 1,
+            sequence: 1,
+            timestamp: '2020-01-01T00:00:00.000Z',
+            actions: [
+                {
+                    conditions: [
+                        {
+                            duration: {
+                                from: '2020-01-01T00:00:00.000Z',
+                                to: '2030-01-01T00:00:00.000Z',
+                            },
+                        },
+                    ],
+                    message: {
+                        id: SUITE_SYNC_FEATURE_TOGGLE_MESSAGE_ID,
+                        category: 'feature',
+                        priority: 1,
+                        dismissible: true,
+                        variant: 'info',
+                        content: { en: 't', es: 't', cs: 't', de: 't', fr: 't', pt: 't' },
+                        feature: [{ domain: Feature.suiteSync, flag: false }],
+                    },
+                },
+            ],
+        },
+    });
 
 const createMockState = (
     deviceOverrides: Parameters<typeof mockSuiteDevice>[0] = {},
@@ -150,10 +188,21 @@ describe(selectIsSuiteSyncInitPossible.name, () => {
         expect(result).toBe(true);
     });
 
-    it('returns false for a disconnected device', () => {
+    it('returns true for a disconnected supported device', () => {
         const state = createMockState({
             connected: false,
         });
+
+        const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
+
+        expect(result).toBe(true);
+    });
+
+    it('returns false when the Suite Sync feature is not available', () => {
+        const state = createMockState({
+            connected: true,
+        });
+        state.messageSystem = createSuiteSyncFeatureDisabledMessageSystemState();
 
         const result = selectIsSuiteSyncInitPossible(state, DEVICE_STATIC_SESSION_ID_123);
 

--- a/suite-common/suite-sync/src/suiteSyncSelectors.ts
+++ b/suite-common/suite-sync/src/suiteSyncSelectors.ts
@@ -27,7 +27,7 @@ export const selectIsSuiteSyncDebugEnabled = (state: WithSuiteSyncAndDeviceState
     state.suiteSync.settings.isSuiteSyncDebugEnabled;
 
 export const selectIsSuiteSyncInitPossible = (
-    state: WithSuiteSyncAndDeviceState,
+    state: WithSuiteSyncAndDeviceState & MessageSystemRootState,
     deviceStaticSessionId: StaticSessionId | null,
 ): boolean => {
     if (deviceStaticSessionId === null) {
@@ -40,7 +40,7 @@ export const selectIsSuiteSyncInitPossible = (
         return false;
     }
 
-    return device.connected && isSuiteSyncSupportedByDevice(device);
+    return selectIsSuiteSyncFeatureAvailable(state) && isSuiteSyncSupportedByDevice(device);
 };
 
 export const selectSuiteSyncOwnerForDeviceStaticId = (

--- a/suite/labeling/src/Labeling.tsx
+++ b/suite/labeling/src/Labeling.tsx
@@ -3,9 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { isFulfilled } from '@reduxjs/toolkit';
 
+import { setConnectionModal, setConnectionMode } from '@suite/device';
 import {
     type MetadataRootState,
     metadataLabelingActions,
+    metadataLabelingConstants,
     selectIsLabelingAvailableForEntity,
     selectIsMetadataEnabled,
     selectMetadata,
@@ -18,6 +20,7 @@ import {
     suiteSyncErrorHandler,
 } from '@suite/suite-sync';
 import { useServices } from '@suite-common/dependency-injection';
+import { selectDeviceByStaticSessionId } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import { type MetadataAddPayload } from '@suite-common/metadata-types';
 import {
@@ -67,6 +70,10 @@ export const Labeling = ({
         selectIsLabelActionEnabled(state, deviceStaticSessionId, payload.entityKey),
     );
 
+    const device = useSelector((state: LabelingState) =>
+        selectDeviceByStaticSessionId(state, deviceStaticSessionId),
+    );
+
     const deviceState =
         payload.type === 'walletLabel' ? (payload.entityKey as StaticSessionId) : undefined;
     const isLegacyLabelingEnabled = useSelector((state: LabelingState) =>
@@ -80,6 +87,22 @@ export const Labeling = ({
     const handleEdit = useCallback(async () => {
         if (isSuiteSyncEnabled && suiteSyncInteraction === null) {
             return true;
+        }
+
+        const promptDeviceConnection = () => {
+            if (device?.descriptor?.apiType === 'bluetooth') {
+                dispatch(setConnectionMode('bluetooth'));
+            }
+            dispatch(setConnectionModal(true));
+
+            return false;
+        };
+
+        if (
+            (suiteSyncInteraction === 'keys-needed' || suiteSyncInteraction === 'suite-sync-off') &&
+            !device?.connected
+        ) {
+            return promptDeviceConnection();
         }
 
         // When clicking on inline input edit, ensure that everything needed is already ready.
@@ -115,6 +138,13 @@ export const Labeling = ({
                     });
                 }
             } else {
+                if (
+                    !device?.metadata?.[metadataLabelingConstants.ENCRYPTION_VERSION] &&
+                    !device?.connected
+                ) {
+                    return promptDeviceConnection();
+                }
+
                 return await dispatch(
                     metadataLabelingActions.init(
                         // Provide force=true argument (user wants to enable metadata).
@@ -128,6 +158,7 @@ export const Labeling = ({
 
         return true;
     }, [
+        device,
         deviceState,
         deviceStaticSessionId,
         dispatch,

--- a/suite/labeling/src/selectIsLabelActionEnabled.test.ts
+++ b/suite/labeling/src/selectIsLabelActionEnabled.test.ts
@@ -175,7 +175,7 @@ describe(selectIsLabelActionEnabled.name, () => {
         expect(result).toBe(true);
     });
 
-    it('disables labeling when Suite Sync is enabled and remembered device is disconnected', () => {
+    it('allows labeling when Suite Sync is enabled and remembered device is disconnected', () => {
         const result = testLabelActionEnabled({
             unavailableCapabilities: {},
             isSuiteSyncFeatureEnabled: true,
@@ -187,7 +187,7 @@ describe(selectIsLabelActionEnabled.name, () => {
             },
         });
 
-        expect(result).toBe(false);
+        expect(result).toBe(true);
     });
 
     it('disables labeling for unsupported device', () => {
@@ -254,9 +254,26 @@ describe(selectIsLabelActionEnabled.name, () => {
 
         const result = testLabelActionEnabled({
             unavailableCapabilities: {},
-            isSuiteSyncFeatureEnabled: false,
+            isSuiteSyncFeatureEnabled: true,
             deviceOverrides: {
                 connected: true,
+            },
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it('allows labeling when Suite Sync feature is available, disabled, and remembered device is disconnected', () => {
+        jest.mocked(selectIsLabelingAvailableForEntity).mockReturnValue(false);
+        jest.mocked(selectIsLabelingInitPossible).mockReturnValue(false);
+
+        const result = testLabelActionEnabled({
+            unavailableCapabilities: {},
+            isSuiteSyncFeatureEnabled: true,
+            deviceOverrides: {
+                connected: false,
+                available: false,
+                remember: true,
             },
         });
 

--- a/suite/labeling/src/selectIsLabelActionEnabled.ts
+++ b/suite/labeling/src/selectIsLabelActionEnabled.ts
@@ -8,7 +8,6 @@ import {
     type DesktopSuiteSyncRootState,
     selectDesktopSuiteSyncInteraction,
 } from '@suite/suite-sync';
-import { selectDeviceByStaticSessionId } from '@suite-common/device';
 import { type MessageSystemRootState } from '@suite-common/message-system';
 import {
     type WithSuiteSyncAndDeviceState,
@@ -31,16 +30,11 @@ export const selectIsLabelActionEnabled = (
     const isSuiteSyncEnabled = selectIsSuiteSyncEnabled(state);
 
     if (isSuiteSyncEnabled) {
-        const device = selectDeviceByStaticSessionId(state, deviceStaticSessionId);
         const suiteSyncInteraction = selectDesktopSuiteSyncInteraction(
             state,
             deviceStaticSessionId,
             selectIsMetadataEnabled(state),
         );
-
-        if (suiteSyncInteraction === 'keys-needed' && device?.connected === false) {
-            return false;
-        }
 
         return getIsSuiteSyncLabelingActionEnabled(suiteSyncInteraction);
     }


### PR DESCRIPTION
> [!IMPORTANT]
> NOT READY FOR REVIEW
>
> Preview: https://dev.suite.sldev.cz/suite-web/feat/26653-desktop-add-label-without-device/web

## Description

Desktop hid or disabled the "Add label" affordance whenever the device was disconnected: an explicit `keys-needed && !connected` guard in `selectIsLabelActionEnabled` (Suite Sync on) and a `device.connected` requirement in `selectIsSuiteSyncInitPossible` (Suite Sync off). Mobile shows the option regardless and guides the user to connect.

This removes both connectivity gates (the follow-up anticipated in ab8e52e023e). When editing a label requires the device (Suite Sync keys missing, Suite Sync not yet turned on, or legacy labeling init without a master key), clicking now opens the standard connect-device modal instead of a silent no-op. `selectIsSuiteSyncInitPossible` now also respects the message-system kill-switch for Suite Sync.

## Notes for QA

- Remember a wallet and disconnect the Trezor: label edit affordances (account header, device switcher, receive, transactions, coin control) are visible and enabled.
- Clicking any of them while disconnected opens the "Connect your Trezor" modal (Bluetooth mode preselected for BT devices). After connecting and authorizing, clicking again proceeds with the normal flow (turn-on-Suite-Sync modal, key retrieval on device, or inline edit).
- With the device connected, all labeling flows are unchanged. Devices unsupported by Suite Sync keep current behavior (disabled with tooltip).

## Related Issue


## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/26653-desktop-add-label-without-device/web/](https://dev.suite.sldev.cz/suite-web/feat/26653-desktop-add-label-without-device/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/26653-desktop-add-label-without-device&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/26653-desktop-add-label-without-device&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/26653-desktop-add-label-without-device&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:08:33.925Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:07:40.588Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->