### PR TITLE
fix(suite): connect modal banner layering and walletconnect account select

### DIFF
--- a/packages/components/src/components/form/Select/Select.tsx
+++ b/packages/components/src/components/form/Select/Select.tsx
@@ -28,7 +28,7 @@ import {
     SingleValue,
     ValueContainer,
 } from './customComponents';
-import { type Option as OptionType } from './types';
+import { type CustomSelectProps, type Option as OptionType } from './types';
 import { createSharedMenuStyles } from './utils';
 import { type FrameProps } from '../../../utils/frameProps';
 
@@ -46,7 +46,8 @@ export type SelectRef = {
 
 export type SelectProps = AllowedFrameProps &
     Omit<FormCellProps, 'children'> &
-    Omit<ReactSelectProps<OptionType>, 'onChange' | 'menuIsOpen' | 'styles'> & {
+    Omit<ReactSelectProps<OptionType>, 'onChange' | 'menuIsOpen' | 'styles'> &
+    CustomSelectProps & {
         label?: ReactNode;
         size?: InputSize;
         minValueWidth?: number;

--- a/packages/components/src/components/form/Select/customComponents.tsx
+++ b/packages/components/src/components/form/Select/customComponents.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 
 import { CaretDownIcon } from '@trezor/icons';
 
-import type { Option as OptionType } from './types';
+import type { CustomSelectProps, Option as OptionType } from './types';
 import { Box } from '../../Box/Box';
 import { Column, Row } from '../../Flex/Flex';
 import { Icon } from '../../Icon/Icon';
@@ -100,23 +100,27 @@ export const Control = ({
     );
 };
 
-export const Menu = ({ children, ...props }: MenuProps<OptionType, boolean>) => (
-    <components.Menu {...props}>
-        <Box
-            flex="1"
-            minWidth={140}
-            borderRadius={16}
-            backgroundColor="surfaceFillModeless"
-            borderColor="surfaceBorderModeless"
-            borderWidth={1}
-            shadow="surfaceShadowModeless"
-            overflow="auto"
-            width="fit-content"
-        >
-            {children}
-        </Box>
-    </components.Menu>
-);
+export const Menu = ({ children, ...props }: MenuProps<OptionType, boolean>) => {
+    const { isMenuFullWidth } = props.selectProps as typeof props.selectProps & CustomSelectProps;
+
+    return (
+        <components.Menu {...props}>
+            <Box
+                flex="1"
+                minWidth={140}
+                borderRadius={16}
+                backgroundColor="surfaceFillModeless"
+                borderColor="surfaceBorderModeless"
+                borderWidth={1}
+                shadow="surfaceShadowModeless"
+                overflow="auto"
+                width={isMenuFullWidth ? '100%' : 'fit-content'}
+            >
+                {children}
+            </Box>
+        </components.Menu>
+    );
+};
 
 export const MenuList = ({ children, ...props }: MenuListProps<OptionType, boolean>) => {
     const isGrouped = props.selectProps.options.some(option => option.options);
@@ -244,7 +248,15 @@ export const ValueContainer = ({
     );
 
 export const SingleValue = ({ children }: SingleValueProps<OptionType>) => (
-    <Text ellipsisLineCount={1} as="div" maxWidth="100%" intent="neutral" priority="primary">
+    // full width so a formatOptionLabel row can align its own content, instead of shrinking to fit
+    <Text
+        ellipsisLineCount={1}
+        as="div"
+        width="100%"
+        maxWidth="100%"
+        intent="neutral"
+        priority="primary"
+    >
         {children}
     </Text>
 );

--- a/packages/components/src/components/form/Select/types.ts
+++ b/packages/components/src/components/form/Select/types.ts
@@ -1,1 +1,7 @@
 export type Option = any;
+
+/** Props threaded to the custom components through react-select's `selectProps`. */
+export type CustomSelectProps = {
+    /** Match the menu width to the control instead of sizing it to the longest option. */
+    isMenuFullWidth?: boolean;
+};

--- a/packages/suite/src/components/suite/ConnectModalBackdrop.tsx
+++ b/packages/suite/src/components/suite/ConnectModalBackdrop.tsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 import { selectConnectPopupCall } from '@suite-common/connect-popup';
+import { Column } from '@trezor/components';
 import {
     ModalBackdrop,
     type ModalBackdropProps,
@@ -32,7 +33,11 @@ export const ConnectModalBackdrop = ({
             padding={{ top: 64, bottom: 8, horizontal: 8 }}
         >
             <ConnectAppBar canSwitchDevice={canSwitchDevice} />
-            {children}
+            {/* Positioned so it paints above the absolutely positioned ConnectAppBar, whose
+                banners would otherwise overlay the modal content. */}
+            <Column position={{ type: 'relative' }} width="100%" alignItems="center" gap={16}>
+                {children}
+            </Column>
         </ModalBackdrop>
     );
 };

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx
@@ -1,0 +1,81 @@
+import { memo } from 'react';
+
+import { AccountLabel } from '@suite/account';
+import { Address } from '@suite/address';
+import { Translation } from '@suite/intl';
+import { useFormatters } from '@suite-common/formatters';
+import { selectAccountTokens, selectBaseCurrency } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { BASE_CURRENCY_ZERO, isUtxoBased } from '@suite-common/wallet-utils';
+import { Badge, Column, Row, Text } from '@trezor/components';
+import { TokenIcon } from '@trezor/product-components';
+
+import { CoinBalance, HiddenPlaceholder } from 'src/components/suite';
+import { useSelector } from 'src/hooks/suite';
+import { useFiatFromCryptoValue } from 'src/hooks/suite/useFiatFromCryptoValue';
+
+type WalletConnectAccountOptionProps = {
+    account: Account;
+};
+
+const WalletConnectAccountOptionComponent = ({ account }: WalletConnectAccountOptionProps) => {
+    const baseCurrency = useSelector(selectBaseCurrency);
+    const tokens = useSelector(state => selectAccountTokens(state, account.key));
+    const { BaseCurrencyAmountFormatter } = useFormatters();
+    const { fiatAmount } = useFiatFromCryptoValue({
+        amount: account.formattedBalance,
+        symbol: account.symbol,
+    });
+
+    const tokenCount = tokens?.shownWithBalance.length ?? 0;
+
+    return (
+        <Row gap={16} justifyContent="space-between" width="100%">
+            <Row gap={12} flex="1" minWidth={0} overflow="hidden">
+                <TokenIcon symbol={account.symbol} size={24} />
+                <Column alignItems="flex-start" minWidth={0} overflow="hidden" width="100%">
+                    <Row gap={8} minWidth={0} width="100%">
+                        <AccountLabel
+                            account={account}
+                            showAccountTypeBadge
+                            accountTypeBadgeSize="small"
+                            rowProps={{ flex: '1', minWidth: 0 }}
+                        />
+                        {tokenCount > 0 && (
+                            <Badge size="small">
+                                <Translation
+                                    id="TR_ACCOUNT_TOKENS_COUNT"
+                                    values={{ count: tokenCount }}
+                                />
+                            </Badge>
+                        )}
+                    </Row>
+                    {/* the descriptor of a UTXO account is an xpub, not an address */}
+                    {!isUtxoBased(account) && (
+                        <Address
+                            value={account.descriptor}
+                            intent="neutral"
+                            priority="secondary"
+                            typographyStyle="body-sm"
+                            isTruncated
+                        />
+                    )}
+                </Column>
+            </Row>
+            <Column alignItems="flex-end" flex="none">
+                <CoinBalance value={account.formattedBalance} symbol={account.symbol} />
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                    <HiddenPlaceholder>
+                        <BaseCurrencyAmountFormatter
+                            value={fiatAmount ?? BASE_CURRENCY_ZERO}
+                            currency={baseCurrency}
+                        />
+                    </HiddenPlaceholder>
+                </Text>
+            </Column>
+        </Row>
+    );
+};
+
+// formatOptionLabel runs for every option on every menu render
+export const WalletConnectAccountOption = memo(WalletConnectAccountOptionComponent);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -2,12 +2,12 @@ import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { AccountLabel } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
 import { useDappScan } from '@suite-common/tx-simulation';
+import { networkSymbolCollection } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
@@ -30,10 +30,12 @@ import {
     Tooltip,
 } from '@trezor/components';
 import { ShieldCheckFilledIcon, ShieldWarningFilledIcon } from '@trezor/icons';
-import { NetworkIcon, TokenIcon } from '@trezor/product-components';
+import { NetworkIcon } from '@trezor/product-components';
 
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { WalletConnectAccountOption } from './WalletConnectAccountOption';
 
 const NetworkItemWrapper = styled.div<{ $isDisabled: boolean }>`
     display: flex;
@@ -42,6 +44,13 @@ const NetworkItemWrapper = styled.div<{ $isDisabled: boolean }>`
     align-items: center;
     opacity: ${props => (props.$isDisabled ? 0.5 : 1)};
 `;
+
+// networks the dapp requests arrive in its own order, the modal follows the coin settings one
+const getNetworkOrder = (symbol?: string) => {
+    const index = networkSymbolCollection.findIndex(networkSymbol => networkSymbol === symbol);
+
+    return index === -1 ? networkSymbolCollection.length : index;
+};
 
 interface WalletConnectProposalModalProps {
     eventId: number;
@@ -61,6 +70,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     ) ?? [],
             ),
         [accounts, pendingProposal?.networks],
+    );
+    const requestedNetworks = useMemo(
+        () =>
+            (pendingProposal?.networks ?? [])
+                .filter(network => network.status !== 'unsupported')
+                .toSorted((a, b) => getNetworkOrder(a.symbol) - getNetworkOrder(b.symbol)),
+        [pendingProposal?.networks],
     );
     const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
         selectableAccounts[0] || null,
@@ -187,27 +203,22 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 </Text>
                 <Card>
                     <Row rowGap={8} columnGap={12} flexWrap="wrap">
-                        {pendingProposal.networks
-                            .filter(network => network.status !== 'unsupported')
-                            .map(network => (
-                                <Tooltip
-                                    content={getTooltipContent(network)}
-                                    key={network.namespaceId}
-                                >
-                                    <NetworkItemWrapper $isDisabled={network.status !== 'active'}>
-                                        {network.symbol && (
-                                            <NetworkIcon
-                                                networkSymbol={network.symbol as any}
-                                                size={24}
-                                            />
-                                        )}
-                                        <Text>
-                                            {network.name}
-                                            {network.required && <Text intent="critical">*</Text>}
-                                        </Text>
-                                    </NetworkItemWrapper>
-                                </Tooltip>
-                            ))}
+                        {requestedNetworks.map(network => (
+                            <Tooltip content={getTooltipContent(network)} key={network.namespaceId}>
+                                <NetworkItemWrapper $isDisabled={network.status !== 'active'}>
+                                    {network.symbol && (
+                                        <NetworkIcon
+                                            networkSymbol={network.symbol as any}
+                                            size={24}
+                                        />
+                                    )}
+                                    <Text>
+                                        {network.name}
+                                        {network.required && <Text intent="critical">*</Text>}
+                                    </Text>
+                                </NetworkItemWrapper>
+                            </Tooltip>
+                        ))}
                     </Row>
                 </Card>
 
@@ -215,30 +226,19 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     <Translation id="TR_DEFAULT_ACCOUNT" />
                 </Text>
                 {selectableAccounts.length > 0 && (
-                    <Card paddingType="none">
-                        <Select
-                            isSearchable={false}
-                            isClearable={false}
-                            size="large"
-                            value={selectedDefaultAccount}
-                            options={selectableAccounts}
-                            formatOptionLabel={(account: Account) => (
-                                <Row gap={8}>
-                                    {account.symbol && (
-                                        <TokenIcon symbol={account.symbol} size={24} />
-                                    )}
-                                    <AccountLabel
-                                        account={account}
-                                        key={account.descriptor}
-                                        showAccountTypeBadge
-                                        accountTypeBadgeSize="small"
-                                    />
-                                </Row>
-                            )}
-                            onChange={(option: Option) => setSelectedDefaultAccount(option)}
-                            closeMenuOnScroll={false}
-                        />
-                    </Card>
+                    <Select
+                        isSearchable={false}
+                        isClearable={false}
+                        size="large"
+                        isMenuFullWidth
+                        value={selectedDefaultAccount}
+                        options={selectableAccounts}
+                        formatOptionLabel={(account: Account) => (
+                            <WalletConnectAccountOption account={account} />
+                        )}
+                        onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                        closeMenuOnScroll={false}
+                    />
                 )}
 
                 {(requiredNetworksNotActivated ||

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { AccountLabel, AccountTypeBadge } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
@@ -13,10 +12,11 @@ import {
     switchSelectedAccountThunk,
     walletConnectActions,
 } from '@suite-common/walletconnect';
-import { Column, Modal, type Option, Row, Select } from '@trezor/components';
-import { TokenIcon } from '@trezor/product-components';
+import { Column, Modal, type Option, Select } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+
+import { WalletConnectAccountOption } from './WalletConnectAccountOption';
 
 interface WalletConnectSwitchAccountModalProps {
     sessionTopic: string;
@@ -80,18 +80,11 @@ export const WalletConnectSwitchAccountModal = ({
                     isSearchable={false}
                     isClearable={false}
                     size="large"
+                    isMenuFullWidth
                     value={selectedDefaultAccount}
                     options={selectableAccounts}
                     formatOptionLabel={(account: Account) => (
-                        <Row gap={8}>
-                            {account.symbol && <TokenIcon symbol={account.symbol} size={24} />}
-                            <AccountLabel account={account} key={account.descriptor} />
-                            <AccountTypeBadge
-                                accountType={account.accountType}
-                                networkType={account.networkType}
-                                size="small"
-                            />
-                        </Row>
+                        <WalletConnectAccountOption account={account} />
                     )}
                     onChange={(option: Option) => setSelectedDefaultAccount(option)}
                 />

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6785,6 +6785,10 @@ export const messages = defineMessages({
         defaultMessage: 'This is a change address created from a previous send.',
         description: 'Tooltip over an icon in Coin control section',
     },
+    TR_ACCOUNT_TOKENS_COUNT: {
+        id: 'TR_ACCOUNT_TOKENS_COUNT',
+        defaultMessage: '{count, plural, one {+{count} token} other {+{count} tokens}}',
+    },
     TR_IN_PENDING_TRANSACTION: {
         id: 'TR_IN_PENDING_TRANSACTION',
         defaultMessage: 'In pending transaction',


### PR DESCRIPTION
## Description

- fixed `Continue on Trezor` pill to not be under the navbar
- fix select border in wallet connect
- fix confusing account select in wallet connect
- sort networks by the order in networks settings

## Notes for QA

- Wallet switcher with a banner active: the banner stays behind the modal content.
- Confirm on Trezor during a WalletConnect flow, with a banner active so the app bar is at its tallest: the pill sits above the bar, not under it.
- Connect a dapp requesting several networks: "Requested networks" follows coin settings order, and the "Default account" select has one border.
- Open the select: the menu is as wide as the control, and options show address, balance and fiat. The balance in the closed control lines up with the balances in the menu. The chosen account is the one the dapp gets. Same select in WalletConnect session → switch account.
- Account holding tokens: a "+N tokens" badge next to the label; accounts without tokens have none.
- Bitcoin account: label, balance and fiat, no address line. Long custom account label: the menu should not outgrow the modal. Discreet mode: balance and fiat hidden.
- Other selects in Suite (send form, settings, trading) are unchanged — `isMenuFullWidth` is opt-in and only these two modals pass it.

## Related Issue

Resolve #29299
Resolve #29335
Resolve #29699

## Screenshots:

<img width="719" height="805" alt="Screenshot 2026-08-18 at 17 51 03" src="https://github.com/user-attachments/assets/f347e744-4928-4052-a931-19b4633f83b4" />
<img width="772" height="643" alt="Screenshot 2026-08-18 at 17 50 52" src="https://github.com/user-attachments/assets/3a60a658-4bf7-4ec6-8270-6c9af59e7462" />
<img width="975" height="698" alt="Screenshot 2026-08-18 at 16 56 48" src="https://github.com/user-attachments/assets/c67b5eaf-d3f9-422c-a2c6-4307435c2098" />


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29299-wallet-switcher-banner-position/web/](https://dev.suite.sldev.cz/suite-web/fix/29299-wallet-switcher-banner-position/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29299-wallet-switcher-banner-position&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29299-wallet-switcher-banner-position&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T17:22:25.147Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T17:24:13.272Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set mixes broad shared UI (Select component, modal backdrop) with specific WalletConnect modal changes. The highest-value tests are the WalletConnect events test and the settings tests that actively exercise Select dropdowns. TrezorConnect popup/permissions tests and a few Select-heavy trading/metadata tests provide medium-confidence coverage of the backdrop and Select changes without over-expanding the suite.

<details><summary><b>Changed files (8)</b></summary>

- `packages/components/src/components/form/Select/Select.tsx`
- `packages/components/src/components/form/Select/customComponents.tsx`
- `packages/components/src/components/form/Select/types.ts`
- `packages/suite/src/components/suite/ConnectModalBackdrop.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — Directly exercises the WalletConnect proposal, account option, and switch account modals that were changed. It verifies pairing, approval, and rejection flows, which would immediately surface regressions in the modified WalletConnect components.
- `suite/e2e/tests/settings/coins.test.ts` — Heavily uses the Select component for enabling networks, toggling testnet visibility, and configuring custom backends. Changes to Select rendering or custom components would directly impact these interactions and the discovery flow that follows.
- `suite/e2e/tests/settings/general.test.ts` — Explicitly changes language, fiat currency, and theme through Select dropdowns, and verifies analytics events fire correctly. A regression in Select behavior would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (5)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — Configures custom Blockbook backend types and URLs through Select and related form controls. It shares the network/backend selection infrastructure with settings/coins.test.ts and would catch Select-specific regressions in backend configuration.
- `suite/e2e/tests/metadata/legacy/switching-providers.test.ts` — Uses the metadata provider Select (metadataSelectInput) to switch between Dropbox and Google providers. Changes to Select option rendering or selection handling could break this labeling flow.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — Opens multiple Connect popups and permissions/address confirmation modals that rely on the modal backdrop component. A change to ConnectModalBackdrop could affect popup focus, dismissal, or overlay behavior.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Focused on the Connect permissions modal where the backdrop component is used. It verifies granting, remembering, and revoking permissions—flows that depend on stable modal rendering and dismissal.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Uses the asset picker Select to choose sell/buy assets and networks. Changes to Select search, filtering, or option rendering could break token/network selection in the swap form.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-08-18T17:21:40.760Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->