### PR TITLE
fix(suite-native): display clamped max APY on the eth

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountEarnPromoBanner.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountEarnPromoBanner.tsx
@@ -1,3 +1,4 @@
+import { type ComponentType } from 'react';
 import { useSelector } from 'react-redux';
 
 import { type Account } from '@suite-common/wallet-types';
@@ -7,10 +8,16 @@ import {
     SolEarnPromoBanner,
     selectIsEarnBannerClosed,
 } from '@suite-native/banners';
+import { type EarnPromoSymbol } from '@suite-native/module-earn';
 
 interface AccountEarnPromoBannerProps {
     account?: Account | null;
 }
+
+const earnPromoBanners: Partial<Record<EarnPromoSymbol, ComponentType<{ account: Account }>>> = {
+    eth: EthEarnPromoBanner,
+    sol: SolEarnPromoBanner,
+};
 
 export const AccountEarnPromoBanner = ({ account }: AccountEarnPromoBannerProps) => {
     const symbol = account?.symbol;
@@ -19,17 +26,13 @@ export const AccountEarnPromoBanner = ({ account }: AccountEarnPromoBannerProps)
         symbol !== undefined ? selectIsEarnBannerClosed(state, symbol) : false,
     );
 
-    if (isClosed) {
+    if (isClosed || !account?.symbol) {
         return null;
     }
 
-    if (account?.symbol === 'eth') {
-        return <EthEarnPromoBanner account={account} />;
-    }
+    const BannerToRender = earnPromoBanners[account?.symbol];
 
-    if (account?.symbol === 'sol') {
-        return <SolEarnPromoBanner account={account} />;
-    }
+    if (BannerToRender) return <BannerToRender account={account} />;
 
     return null;
 };

--- a/suite-native/module-accounts-management/src/hooks/useYourPositionCardYieldBadge.tsx
+++ b/suite-native/module-accounts-management/src/hooks/useYourPositionCardYieldBadge.tsx
@@ -1,8 +1,14 @@
 import { useAllYieldOpportunities } from '@suite-common/earn-stablecoin-api';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account, type TokenInfoBranded } from '@suite-common/wallet-types';
-import { isApyAvailable, isErc4626 } from '@suite-common/wallet-utils';
-import { useNativeYieldVault, useStakingRate, useYieldBadge } from '@suite-native/module-earn';
+import { isErc4626 } from '@suite-common/wallet-utils';
+import {
+    getBestPromotedRate,
+    isEarnPromoSymbol,
+    useNativeYieldVault,
+    useStakingRate,
+    useYieldBadge,
+} from '@suite-native/module-earn';
 
 interface UseYourPositionCardYieldBadgeProps {
     account?: Account | null;
@@ -24,16 +30,16 @@ export const useYourPositionCardYieldBadge = ({
         accountKey: account?.key,
     });
 
-    const promoYieldBadge =
-        !token && nativeYieldVault?.bestVault
-            ? {
-                  apy:
-                      stakingRate !== null && isApyAvailable(stakingRate)
-                          ? Math.max(nativeYieldVault.bestVault.apy, stakingRate)
-                          : nativeYieldVault.bestVault.apy,
-                  vaultId: nativeYieldVault.bestVault.id,
-              }
-            : null;
+    const bestPromotedRate = token
+        ? null
+        : getBestPromotedRate({
+              vaultApy: nativeYieldVault.bestVault?.apy ?? null,
+              stakingRate: isEarnPromoSymbol(account?.symbol) ? stakingRate : null,
+          });
+
+    const promoYieldBadge = bestPromotedRate
+        ? { apy: bestPromotedRate.apy, vaultId: nativeYieldVault.bestVault?.id ?? null }
+        : null;
 
     const yieldBadge = useYieldBadge({
         networkSymbol: symbol ?? undefined,

--- a/suite-native/module-earn/src/components/YieldBadge.tsx
+++ b/suite-native/module-earn/src/components/YieldBadge.tsx
@@ -56,12 +56,8 @@ export const YieldBadge = ({ apy, variant, account, vaultId, tokenContract }: Yi
     const vaultTokenContract = vault ? getYieldVaultContractAddress(vault) : null;
 
     const goToVault = () => {
-        if (!vaultTokenContract) return;
-
-        // if we're on the vault token detail screen, don't navigate
-        if (vaultTokenContract === tokenContract) return;
-
-        // for promo, we want to navigate to the earn tab screen
+        // for promo, we want to navigate to the earn tab screen — it also promotes staking,
+        // so there is not always a vault behind it
         if (variant === 'promo') {
             navigation.popTo(RootStackRoutes.AppTabs, {
                 screen: AppTabsRoutes.EarnStack,
@@ -70,6 +66,11 @@ export const YieldBadge = ({ apy, variant, account, vaultId, tokenContract }: Yi
 
             return;
         }
+
+        if (!vaultTokenContract) return;
+
+        // if we're on the vault token detail screen, don't navigate
+        if (vaultTokenContract === tokenContract) return;
 
         // otherwise navigate to the vault token detail screen
         navigation.push(RootStackRoutes.AccountDetail, {
@@ -80,7 +81,7 @@ export const YieldBadge = ({ apy, variant, account, vaultId, tokenContract }: Yi
     };
 
     return (
-        <Pressable onPress={goToVault} disabled={!vaultTokenContract}>
+        <Pressable onPress={goToVault} disabled={variant !== 'promo' && !vaultTokenContract}>
             <Badge
                 intent={intent}
                 size="small"

--- a/suite-native/module-earn/src/hooks/useTokenYieldRate.ts
+++ b/suite-native/module-earn/src/hooks/useTokenYieldRate.ts
@@ -11,9 +11,11 @@ import { type Account } from '@suite-common/wallet-types';
 import { getApyPercent } from '@suite-common/wallet-utils';
 
 import { useMessageSystemYield } from './useMessageSystemYield';
+import { useStakingRate } from './useStakingRate';
 import { selectBestEnabledYieldVault } from '../selectors';
 import { getWrappedNativeYieldVaults } from '../utils/getWrappedNativeYieldVaults';
 import { type YieldRateLabelType, getYieldRateLabelType } from '../utils/getYieldRateLabelType';
+import { getBestPromotedRate, isEarnPromoSymbol } from '../utils/promotedRateUtils';
 
 /** `inactive` = token eligible for a deposit, `active` = vault receipt token already earning. */
 export type TokenYieldRateVariant = 'inactive' | 'active';
@@ -39,8 +41,9 @@ type TokenYieldRate = {
 const emptyVaults: YieldDtoV2[] = [];
 
 /**
- * The yield rate a token row may advertise — the rate of the best not-killed vault
- * matching the token, or `null` when there is nothing to advertise.
+ * The rate a row may advertise — the best not-killed vault matching the token, or for a
+ * native-coin row the higher of that vault and staking. `null` when there is nothing to
+ * advertise.
  */
 export const useTokenYieldRate = ({
     account,
@@ -98,20 +101,29 @@ export const useTokenYieldRate = ({
         selectBestEnabledYieldVault(state, matchedVaults),
     );
 
+    // The native coin can also earn by staking, which is what the account's promo banner
+    // advertises — the row must not undersell it with the vault rate alone.
+    const { rate: stakingRate } = useStakingRate({
+        symbol: networkSymbol,
+        accountKey: account.key,
+    });
+    const promotedStakingRate =
+        tokenContract === undefined && isEarnPromoSymbol(networkSymbol) ? stakingRate : null;
+
     return useMemo(() => {
-        if (!bestVault) {
-            return null;
-        }
+        const vaultApy = bestVault ? getApyPercent(bestVault.rewardRate.total) : null;
+        const bestRate = getBestPromotedRate({ vaultApy, stakingRate: promotedStakingRate });
 
-        const apy = getApyPercent(bestVault.rewardRate.total);
-
-        if (apy === null) {
+        if (!bestRate) {
             return null;
         }
 
         return {
-            apy,
-            labelType: getYieldRateLabelType(bestVault.rewardRate),
+            apy: bestRate.apy,
+            labelType:
+                bestRate.isVaultRate && bestVault
+                    ? getYieldRateLabelType(bestVault.rewardRate)
+                    : 'apy',
         };
-    }, [bestVault]);
+    }, [bestVault, promotedStakingRate]);
 };

--- a/suite-native/module-earn/src/index.ts
+++ b/suite-native/module-earn/src/index.ts
@@ -32,3 +32,5 @@ export { UnstakeTransactionDataReviewScreen } from './screens/UnstakeTransaction
 export { YieldConsentsScreen } from './screens/YieldConsentsScreen';
 export { YieldInsufficientBalanceScreen } from './screens/YieldInsufficientBalanceScreen';
 export { navigateByAccountState } from './utils/navigateByAccountState';
+export { getBestPromotedRate, isEarnPromoSymbol } from './utils/promotedRateUtils';
+export type { EarnPromoSymbol } from './utils/promotedRateUtils';

--- a/suite-native/module-earn/src/utils/promotedRateUtils.test.ts
+++ b/suite-native/module-earn/src/utils/promotedRateUtils.test.ts
@@ -1,0 +1,85 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+
+import { getBestPromotedRate, isEarnPromoSymbol } from './promotedRateUtils';
+
+describe('getBestPromotedRate', () => {
+    it('promotes the vault rate when there is no staking rate', () => {
+        expect(getBestPromotedRate({ vaultApy: 2.48, stakingRate: null })).toEqual({
+            apy: 2.48,
+            isVaultRate: true,
+        });
+    });
+
+    it('promotes the staking rate when there is no vault rate', () => {
+        expect(getBestPromotedRate({ vaultApy: null, stakingRate: 2.95 })).toEqual({
+            apy: 2.95,
+            isVaultRate: false,
+        });
+    });
+
+    it('promotes the staking rate when it beats the vault rate', () => {
+        expect(getBestPromotedRate({ vaultApy: 2.48, stakingRate: 2.95 })).toEqual({
+            apy: 2.95,
+            isVaultRate: false,
+        });
+    });
+
+    it('promotes the vault rate when it beats the staking rate', () => {
+        expect(getBestPromotedRate({ vaultApy: 6.42, stakingRate: 2.95 })).toEqual({
+            apy: 6.42,
+            isVaultRate: true,
+        });
+    });
+
+    it('keeps the vault label when both rates are equal', () => {
+        expect(getBestPromotedRate({ vaultApy: 2.95, stakingRate: 2.95 })).toEqual({
+            apy: 2.95,
+            isVaultRate: true,
+        });
+    });
+
+    it('returns null when neither rate is on offer', () => {
+        expect(getBestPromotedRate({ vaultApy: null, stakingRate: null })).toBeNull();
+    });
+
+    it.each([
+        ['zero', 0],
+        ['negative', -1],
+        ['not finite', Number.POSITIVE_INFINITY],
+    ])('ignores a staking rate that is %s', (_description, stakingRate) => {
+        expect(getBestPromotedRate({ vaultApy: 2.48, stakingRate })).toEqual({
+            apy: 2.48,
+            isVaultRate: true,
+        });
+    });
+
+    it.each([
+        ['zero', 0],
+        ['negative', -1],
+        ['not finite', Number.POSITIVE_INFINITY],
+    ])('ignores a vault rate that is %s', (_description, vaultApy) => {
+        expect(getBestPromotedRate({ vaultApy, stakingRate: 2.95 })).toEqual({
+            apy: 2.95,
+            isVaultRate: false,
+        });
+    });
+});
+
+describe('isEarnPromoSymbol', () => {
+    it.each([
+        ['eth', true],
+        ['sol', true],
+        ['ada', false],
+        ['trx', false],
+        ['btc', false],
+    ])('%s is promoted: %s', (symbol, expected) => {
+        expect(isEarnPromoSymbol(asNetworkSymbol(symbol))).toBe(expected);
+    });
+
+    it.each([
+        ['undefined', undefined],
+        ['null', null],
+    ])('returns false for %s', (_description, symbol) => {
+        expect(isEarnPromoSymbol(symbol)).toBe(false);
+    });
+});

--- a/suite-native/module-earn/src/utils/promotedRateUtils.ts
+++ b/suite-native/module-earn/src/utils/promotedRateUtils.ts
@@ -1,0 +1,48 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { isApyAvailable } from '@suite-common/wallet-utils';
+
+export const EARN_PROMO_SYMBOLS: NetworkSymbol[] = ['eth', 'sol'] as const;
+export type EarnPromoSymbol = (typeof EARN_PROMO_SYMBOLS)[number];
+
+export const isEarnPromoSymbol = (symbol?: NetworkSymbol | null) =>
+    symbol != null && EARN_PROMO_SYMBOLS.includes(symbol);
+
+type GetBestPromotedRateParams = {
+    vaultApy: number | null;
+    stakingRate: number | null;
+};
+
+type BestPromotedRate = {
+    apy: number;
+    /** Which rate won — the vault's label and link only apply to a vault rate. */
+    isVaultRate: boolean;
+};
+
+/**
+ * The best rate a native coin can earn by any means: its wrapped-native vault, staking, or
+ * whichever of the two is higher when both are on offer. `null` when neither is available.
+ */
+export const getBestPromotedRate = ({
+    vaultApy,
+    stakingRate,
+}: GetBestPromotedRateParams): BestPromotedRate | null => {
+    const promotableVaultApy = isApyAvailable(vaultApy) ? vaultApy : null;
+    const promotableStakingRate =
+        stakingRate !== null && isApyAvailable(stakingRate) ? stakingRate : null;
+
+    if (promotableVaultApy !== null && promotableStakingRate !== null) {
+        return promotableVaultApy >= promotableStakingRate
+            ? { apy: promotableVaultApy, isVaultRate: true }
+            : { apy: promotableStakingRate, isVaultRate: false };
+    }
+
+    if (promotableVaultApy !== null) {
+        return { apy: promotableVaultApy, isVaultRate: true };
+    }
+
+    if (promotableStakingRate !== null) {
+        return { apy: promotableStakingRate, isVaultRate: false };
+    }
+
+    return null;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds utils and displays max available rewards for the asset (yield or stake)

## Notes for QA

Makes sense to check navigation from other CTAs with rewards %

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31146

## Screenshots:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 17 02 30" src="https://github.com/user-attachments/assets/daba946c-2b41-4951-86ca-e65953863275" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/clamp-max-apy&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->