### PR TITLE
fix(protocol): validate v1 message length

### DIFF
--- a/packages/protocol/src/protocol-v1/constants.ts
+++ b/packages/protocol/src/protocol-v1/constants.ts
@@ -1,3 +1,4 @@
 export const MESSAGE_MAGIC_HEADER_BYTE = 63;
 export const MESSAGE_HEADER_BYTE = 0x23;
 export const HEADER_SIZE = 1 + 1 + 1 + 2 + 4; // MESSAGE_MAGIC_HEADER_BYTE + MESSAGE_HEADER_BYTE + MESSAGE_HEADER_BYTE + messageType + dataLength
+export const MESSAGE_MAX_LENGTH = 16 * 1024 * 1024; // 16 MB

--- a/packages/protocol/src/protocol-v1/decode.ts
+++ b/packages/protocol/src/protocol-v1/decode.ts
@@ -1,5 +1,10 @@
 import { PROTOCOL_MALFORMED } from '../errors';
-import { HEADER_SIZE, MESSAGE_HEADER_BYTE, MESSAGE_MAGIC_HEADER_BYTE } from './constants';
+import {
+    HEADER_SIZE,
+    MESSAGE_HEADER_BYTE,
+    MESSAGE_MAGIC_HEADER_BYTE,
+    MESSAGE_MAX_LENGTH,
+} from './constants';
 import { type TransportProtocolDecode } from '../types';
 
 /**
@@ -37,7 +42,8 @@ export const decode: TransportProtocolDecode = bytes => {
     if (
         magic !== MESSAGE_MAGIC_HEADER_BYTE ||
         sharp1 !== MESSAGE_HEADER_BYTE ||
-        sharp2 !== MESSAGE_HEADER_BYTE
+        sharp2 !== MESSAGE_HEADER_BYTE ||
+        length > MESSAGE_MAX_LENGTH
     ) {
         // read-write is out of sync
         throw new Error(PROTOCOL_MALFORMED);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

protocol-v1 announces message length as a uint32 that is never validated before Buffer.alloc(length); v2 is bounded only incidentally, by its uint16 wire field.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/protocol-v1-max-length/web/](https://dev.suite.sldev.cz/suite-web/fix/protocol-v1-max-length/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/protocol-v1-max-length&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/protocol-v1-max-length&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:32:54.111Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T15:31:28.079Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are low-level protocol-v1 constants and decode logic that are transitively imported by nearly every device-communication path (135 static matches), so the broad-utility heuristic applies. The highest risk is for tests that directly exercise device message exchange, especially on T1B1 which uses protocol-v1. I recommend a small, high-impact set covering T1B1 onboarding, receive verification, Bitcoin signing, message signing, and recovery dry-run, plus a couple of medium-priority settings and cross-coin signing tests.

<details><summary><b>Changed files (2)</b></summary>

- `packages/protocol/src/protocol-v1/constants.ts`
- `packages/protocol/src/protocol-v1/decode.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/onboarding/t1b1/t1b1-create-wallet.test.ts` — T1B1 (Model One) relies on protocol-v1 for all device communication during wallet creation, backup, PIN entry, and device confirmations. A regression in protocol-v1 decode or constants would likely break this end-to-end flow.
- `suite/e2e/tests/wallet/receive.test.ts` — Receive address verification depends on the device returning the correct address over the wire and Suite decoding the response accurately. Protocol-v1 decode/constants changes could corrupt the address or cause verification prompts to fail.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Sending a Bitcoin transaction requires decoding device-signed transaction responses and prompt state. Protocol-v1 decode changes could break transaction signing or misparse returned signatures.
- `suite/e2e/tests/wallet/sign-and-verify.test.ts` — Bitcoin message signing and verification produce and consume device signatures and address confirmations. Decode/constants regressions could corrupt the signature payload or fail the signing response.
- `suite/e2e/tests/recovery/t1b1-dry-run.test.ts` — T1B1 recovery dry run exercises protocol-v1 for mnemonic input, device prompts, and success status decoding. Changes to decode/constants could corrupt recovery words or the final success indication.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/settings/t1b1-device-settings.test.ts` — T1B1 device settings (PIN change, homescreen change) send configuration messages over protocol-v1 and decode confirmation responses. A regression could cause settings to fail silently or show wrong prompt state.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — BTC swap signing follows the same device signing path as send flows and verifies decoded amounts and fee rates on the device prompt. It exercises transaction-level protocol messages end-to-end.
- `suite/e2e/tests/wallet/send-eth.test.ts` — ETH transaction signing uses device prompts and response decoding. While newer transports may prefer protocol-v2, protocol-v1 fallback paths or shared message constants could still affect parsing.

</details>

_Updated: 2026-08-11T15:31:31.536Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->