### PR TITLE
fix(suite-native): header paddings

### DIFF
--- a/suite-native/navigation/src/components/ScreenHeader.tsx
+++ b/suite-native/navigation/src/components/ScreenHeader.tsx
@@ -26,6 +26,9 @@ const headerStyle = prepareNativeStyle(utils => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    // With `space-between` this only engages once the row is full, i.e. exactly when wide
+    // content would otherwise butt against the side icons on a narrow screen.
+    gap: utils.spacings.sp12,
     paddingTop: utils.spacings.sp8,
     paddingHorizontal: utils.spacings.sp16,
     paddingBottom: utils.spacings.sp16,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds gap for the header on smaller devices

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31148

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-11 at 18 39 42" src="https://github.com/user-attachments/assets/bd11a280-bd88-4bff-8432-da293aa49fb6" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/padding-header-buttons&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->