### PR TITLE
fix(suite-native): track wrapped native token when starting deposit flow

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsActions.ts
+++ b/suite-common/wallet-core/src/accounts/accountsActions.ts
@@ -5,6 +5,7 @@ import {
     type Account,
     type AccountBackendSpecific,
     type AccountFailureSpecific,
+    type AccountKey,
     type SelectedAccountStatus,
     asAccountDescriptor,
     createAccountKey,
@@ -153,6 +154,13 @@ const updateAccount = createAction(
     },
 );
 
+const addAccountTokens = createAction(
+    `${ACCOUNTS_MODULE_PREFIX}/addAccountTokens`,
+    (accountKey: AccountKey, tokens: NonNullable<Account['tokens']>) => ({
+        payload: { accountKey, tokens },
+    }),
+);
+
 const renameAccount = createAction(
     `${ACCOUNTS_MODULE_PREFIX}/renameAccount`,
     (accountKey: string, accountLabel: string) => ({
@@ -198,6 +206,7 @@ export const accountsActions = {
     createAccount,
     createAccountFromAccountInfo,
     updateAccount,
+    addAccountTokens,
     renameAccount,
     updateSelectedAccount,
     changeAccountVisibility,

--- a/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.test.ts
@@ -4,6 +4,8 @@ import { type ExtraDependenciesPartial } from '@suite-common/redux-extra-depende
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type AccountInfo } from '@trezor/connect';
 import type { Bip43Path } from '@trezor/crypto-utils';
 
 import { accountsActions } from './accountsActions';
@@ -150,5 +152,88 @@ describe('Account Reducer', () => {
         spyWarn.mockRestore();
 
         expect(store.getState().wallet.accounts.length).toEqual(0);
+    });
+
+    describe('locally tracked tokens', () => {
+        const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+        const ethereumAccount = mockWalletAccount({
+            symbol: asNetworkSymbol('eth'),
+            deviceState: '1stTestnetAddress@device_id:0',
+        });
+
+        const wethAccountToken = mockAccountToken({
+            contract: WETH_ADDRESS,
+            symbol: 'WETH',
+            balance: '1.5',
+        });
+
+        const accountInfo: AccountInfo = {
+            descriptor: ethereumAccount.descriptor,
+            balance: '1000',
+            availableBalance: '1000',
+            empty: false,
+            history: { total: 1, unconfirmed: 0, transactions: [] },
+            tokens: [],
+            misc: { nonce: '2' },
+        };
+
+        const initStoreWithTrackedToken = () =>
+            initStore({
+                preloadedState: {
+                    wallet: {
+                        accounts: [{ ...ethereumAccount, tokens: [wethAccountToken] }],
+                    },
+                },
+            });
+
+        it('keeps a locally tracked token when an update from an older snapshot omits it', () => {
+            const store = initStoreWithTrackedToken();
+
+            // The stale snapshot and the account info payload know nothing about the token.
+            store.dispatch(accountsActions.updateAccount(ethereumAccount, accountInfo));
+
+            expect(store.getState().wallet.accounts[0]?.tokens).toEqual([
+                expect.objectContaining({ contract: WETH_ADDRESS, balance: '1.5' }),
+            ]);
+        });
+
+        it('does not duplicate a tracked token once the update reports it itself', () => {
+            const store = initStoreWithTrackedToken();
+
+            store.dispatch(
+                accountsActions.updateAccount(ethereumAccount, {
+                    ...accountInfo,
+                    tokens: [
+                        {
+                            standard: 'ERC20',
+                            contract: WETH_ADDRESS,
+                            symbol: 'WETH',
+                            name: 'Wrapped Ether',
+                            decimals: 18,
+                            balance: '2500000000000000000',
+                        },
+                    ],
+                }),
+            );
+
+            expect(store.getState().wallet.accounts[0]?.tokens).toEqual([
+                expect.objectContaining({ contract: WETH_ADDRESS, balance: '2.5' }),
+            ]);
+        });
+
+        it('adds tokens to the account via addAccountTokens', () => {
+            const store = initStore({
+                preloadedState: { wallet: { accounts: [ethereumAccount] } },
+            });
+
+            store.dispatch(
+                accountsActions.addAccountTokens(ethereumAccount.key, [wethAccountToken]),
+            );
+
+            expect(store.getState().wallet.accounts[0]?.tokens).toEqual([
+                expect.objectContaining({ contract: WETH_ADDRESS, balance: '1.5' }),
+            ]);
+        });
     });
 });

--- a/suite-common/wallet-core/src/accounts/accountsReducer.ts
+++ b/suite-common/wallet-core/src/accounts/accountsReducer.ts
@@ -50,6 +50,7 @@ const update = (state: Account[], account: Account) => {
     const prev = state[accountIndex];
 
     if (prev) {
+        const prevUnwrapped = current(prev);
         const next: Account = {
             ...account,
             // remove "transactions" field, they are stored in "transactionReducer"
@@ -61,10 +62,24 @@ const update = (state: Account[], account: Account) => {
             delete next.marker;
         }
 
+        // Locally tracked tokens must survive an update built from an older account snapshot
+        // (e.g. a concurrent sync). A wrapped-native (WETH) balance exists only as a local entry:
+        // wrapping emits no ERC-20 Transfer, so the backend never reports the token on its own.
+        if (next.networkType === 'ethereum' && prevUnwrapped.tokens?.length) {
+            const nextContracts = new Set(next.tokens?.map(token => token.contract.toLowerCase()));
+            const locallyTrackedTokens = prevUnwrapped.tokens.filter(
+                token => !nextContracts.has(token.contract.toLowerCase()),
+            );
+
+            if (locallyTrackedTokens.length > 0) {
+                next.tokens = (next.tokens ?? []).concat(locallyTrackedTokens);
+            }
+        }
+
         // Skip the write when nothing changed, so the entity reference (and the components subscribed
         // to it) stay stable. current() unwraps the immer draft, otherwise reads of nested fields
         // return proxies and the reference compare would never match.
-        if (isUnchangedAccount(current(prev), next)) return;
+        if (isUnchangedAccount(prevUnwrapped, next)) return;
 
         state[accountIndex] = next;
     } else {
@@ -129,6 +144,13 @@ export const prepareAccountsReducer = createReducerWithExtraDeps(
             })
             .addCase(accountsActions.updateAccount, (state, action) => {
                 update(state, action.payload);
+            })
+            .addCase(accountsActions.addAccountTokens, (state, action) => {
+                const { accountKey, tokens } = action.payload;
+                const accountByAccountKey = state.find(account => account.key === accountKey);
+                if (accountByAccountKey) {
+                    accountByAccountKey.tokens = (accountByAccountKey.tokens ?? []).concat(tokens);
+                }
             })
             .addCase(accountsActions.renameAccount, (state, action) => {
                 const { accountKey, accountLabel } = action.payload;

--- a/suite-common/wallet-core/src/index.ts
+++ b/suite-common/wallet-core/src/index.ts
@@ -70,6 +70,7 @@ export * from './stake/stakeSelectors';
 export * from './stake/stakeThunks';
 export * from './stablecoin-yield/stablecoinYieldReducer';
 export * from './stablecoin-yield/stablecoinYieldSelectors';
+export * from './stablecoin-yield/utils/fetchWrappedNativeTokenInfo';
 export * from './stablecoin-yield/utils/stablecoinYieldApprovalActionUtils';
 export * from './stablecoin-yield/thunks/stablecoinYieldApprovalThunks';
 export * from './stablecoin-yield/stablecoinYieldConstants';

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts
@@ -1,0 +1,189 @@
+import { createMockDispatch } from '@suite-common/redux-utils/mocks';
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account, asAccountDescriptor } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type TokenInfo } from '@trezor/connect';
+
+import {
+    type TrackWrappedNativeTokenThunkState,
+    trackWrappedNativeTokenThunk,
+} from './stablecoinYieldWrapThunks';
+import { accountsActions } from '../../accounts/accountsActions';
+import { fetchWrappedNativeTokenInfo } from '../utils/fetchWrappedNativeTokenInfo';
+
+jest.mock('../utils/fetchWrappedNativeTokenInfo', () => ({
+    fetchWrappedNativeTokenInfo: jest.fn(),
+}));
+
+const fetchWrappedNativeTokenInfoMock = jest.mocked(fetchWrappedNativeTokenInfo);
+
+const OWNER_ADDRESS = '0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326';
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+const ethereumAccount = mockWalletAccount({
+    symbol: asNetworkSymbol('eth'),
+    descriptor: asAccountDescriptor(OWNER_ADDRESS),
+    deviceState: 'mock@device:0',
+});
+
+const wethTokenInfo: TokenInfo = {
+    standard: 'ERC20',
+    contract: WETH_ADDRESS,
+    symbol: 'WETH',
+    name: 'Wrapped Ether',
+    decimals: 18,
+    balance: '2500000000000000000',
+};
+
+const buildState = (account: Account): TrackWrappedNativeTokenThunkState => ({
+    wallet: { accounts: [account] },
+});
+
+const runThunk = async (
+    getState: () => TrackWrappedNativeTokenThunkState,
+    accountKey = ethereumAccount.key,
+) => {
+    const { actions, dispatch } = createMockDispatch({ getState, extra: {} });
+    const balance = await trackWrappedNativeTokenThunk({ accountKey })(
+        dispatch,
+        getState,
+        {},
+    ).unwrap();
+    const addTokensActions = actions.filter(action =>
+        accountsActions.addAccountTokens.match(action),
+    );
+
+    return { addTokensActions, balance };
+};
+
+describe('trackWrappedNativeTokenThunk', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('fetches an untracked wrapped-native token and starts tracking its positive balance', async () => {
+        fetchWrappedNativeTokenInfoMock.mockResolvedValue(wethTokenInfo);
+
+        const { addTokensActions, balance } = await runThunk(() => buildState(ethereumAccount));
+
+        expect(balance).toBe('2.5');
+        expect(addTokensActions).toEqual([
+            expect.objectContaining({
+                payload: {
+                    accountKey: ethereumAccount.key,
+                    tokens: [
+                        expect.objectContaining({
+                            contract: WETH_ADDRESS,
+                            symbol: 'WETH',
+                            balance: '2.5',
+                        }),
+                    ],
+                },
+            }),
+        ]);
+    });
+
+    it('returns the tracked balance without refetching when the token is already tracked', async () => {
+        const trackedAccount = {
+            ...ethereumAccount,
+            tokens: [
+                mockAccountToken({
+                    contract: WETH_ADDRESS.toLowerCase(),
+                    symbol: 'WETH',
+                    balance: '1.5',
+                }),
+            ],
+        };
+
+        const { addTokensActions, balance } = await runThunk(() => buildState(trackedAccount));
+
+        expect(balance).toBe('1.5');
+        expect(fetchWrappedNativeTokenInfoMock).not.toHaveBeenCalled();
+        expect(addTokensActions).toHaveLength(0);
+    });
+
+    it('does not track a zero balance', async () => {
+        fetchWrappedNativeTokenInfoMock.mockResolvedValue({ ...wethTokenInfo, balance: '0' });
+
+        const { addTokensActions, balance } = await runThunk(() => buildState(ethereumAccount));
+
+        expect(balance).toBe('0');
+        expect(addTokensActions).toHaveLength(0);
+    });
+
+    it('returns null when the backend does not report the token', async () => {
+        fetchWrappedNativeTokenInfoMock.mockResolvedValue(null);
+
+        const { addTokensActions, balance } = await runThunk(() => buildState(ethereumAccount));
+
+        expect(balance).toBeNull();
+        expect(addTokensActions).toHaveLength(0);
+    });
+
+    it('returns null when the fetch fails', async () => {
+        fetchWrappedNativeTokenInfoMock.mockRejectedValue(new Error('Backend unavailable.'));
+
+        const { addTokensActions, balance } = await runThunk(() => buildState(ethereumAccount));
+
+        expect(balance).toBeNull();
+        expect(addTokensActions).toHaveLength(0);
+    });
+
+    it('returns null for a non-ethereum account', async () => {
+        const bitcoinAccount = mockWalletAccount({
+            symbol: asNetworkSymbol('btc'),
+            deviceState: 'mock@device:0',
+        });
+
+        const { addTokensActions, balance } = await runThunk(
+            () => buildState(bitcoinAccount),
+            bitcoinAccount.key,
+        );
+
+        expect(balance).toBeNull();
+        expect(fetchWrappedNativeTokenInfoMock).not.toHaveBeenCalled();
+        expect(addTokensActions).toHaveLength(0);
+    });
+
+    it('adds only the wrapped-native token when another token was tracked during the fetch', async () => {
+        let state = buildState(ethereumAccount);
+        fetchWrappedNativeTokenInfoMock.mockImplementation(() => {
+            state = buildState({
+                ...ethereumAccount,
+                tokens: [mockAccountToken({ contract: USDC_ADDRESS, symbol: 'USDC' })],
+            });
+
+            return Promise.resolve(wethTokenInfo);
+        });
+
+        const { addTokensActions, balance } = await runThunk(() => state);
+
+        expect(balance).toBe('2.5');
+        expect(addTokensActions).toEqual([
+            expect.objectContaining({
+                payload: {
+                    accountKey: ethereumAccount.key,
+                    tokens: [expect.objectContaining({ contract: WETH_ADDRESS })],
+                },
+            }),
+        ]);
+    });
+
+    it('does not create a duplicate when the token got tracked during the fetch', async () => {
+        let state = buildState(ethereumAccount);
+        fetchWrappedNativeTokenInfoMock.mockImplementation(() => {
+            state = buildState({
+                ...ethereumAccount,
+                tokens: [mockAccountToken({ contract: WETH_ADDRESS, symbol: 'WETH' })],
+            });
+
+            return Promise.resolve(wethTokenInfo);
+        });
+
+        const { addTokensActions, balance } = await runThunk(() => state);
+
+        expect(balance).toBe('2.5');
+        expect(addTokensActions).toHaveLength(0);
+    });
+});

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -1,19 +1,25 @@
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetwork } from '@suite-common/wallet-config';
+import { getNetwork, getWrappedNativeAddress } from '@suite-common/wallet-config';
 import { WETH_DEPOSIT_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
-import { type Account } from '@suite-common/wallet-types';
+import { type Account, type AccountKey } from '@suite-common/wallet-types';
 import {
+    enhanceTokens,
     getAccountIdentity,
     getConvertedOrDefaultFeeInfo,
     isWrappedNativeToken,
 } from '@suite-common/wallet-utils';
+import { type TokenInfo } from '@trezor/connect';
+import { BigNumber } from '@trezor/utils';
 
+import { accountsActions } from '../../accounts/accountsActions';
 import { type AccountsRootState } from '../../accounts/accountsReducer';
+import { selectAccountByKey } from '../../accounts/accountsSelectors';
 import { type FeesRootState, selectRawNetworkFeeInfo } from '../../fees/feesReducer';
 import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
 import { type TransactionsRootState } from '../../transactions/transactionsReducerTypes';
 import { STABLECOIN_YIELD_PREFIX } from '../stablecoinYieldConstants';
 import type { YieldFlowDisplayToken } from '../stablecoinYieldTypes';
+import { fetchWrappedNativeTokenInfo } from '../utils/fetchWrappedNativeTokenInfo';
 import { estimateYieldFeeLevel } from '../utils/stablecoinYieldFeeEstimation';
 import {
     buildYieldUnsignedTransaction,
@@ -138,6 +144,82 @@ export const composeYieldWrapTransactionThunk = createThunk<
         );
 
         return { type: 'action-ready', unsignedTransaction } as const;
+    },
+);
+
+export type TrackWrappedNativeTokenThunkState = AccountsRootState;
+
+type TrackWrappedNativeTokenPayload = {
+    accountKey: AccountKey;
+};
+
+/**
+ * Makes sure the account tracks the wrapped-native token (e.g. WETH) of its network. Wrapping
+ * calls WETH `deposit()`, which emits no ERC-20 `Transfer` event, so the backend never discovers
+ * the token on its own and the account may hold a balance without knowing about it.
+ *
+ * Returns the balance in display units: `null` means it could not be determined (the caller may
+ * fall back to its own value), `'0'` means it was fetched successfully and is really zero.
+ */
+export const trackWrappedNativeTokenThunk = createThunk<
+    string | null,
+    TrackWrappedNativeTokenPayload,
+    { state: TrackWrappedNativeTokenThunkState }
+>(
+    `${YIELD_WRAP_THUNK_PREFIX}/trackWrappedNativeToken`,
+    async ({ accountKey }, { dispatch, getState }) => {
+        const account = selectAccountByKey(getState(), accountKey);
+
+        if (!account || account.networkType !== 'ethereum') {
+            return null;
+        }
+
+        const wrappedNativeContract = getWrappedNativeAddress(account.symbol);
+
+        if (!wrappedNativeContract) {
+            return null;
+        }
+
+        const isWrappedNativeContract = (contract: string) =>
+            contract.toLowerCase() === wrappedNativeContract.toLowerCase();
+
+        const trackedToken = account.tokens?.find(token => isWrappedNativeContract(token.contract));
+
+        if (trackedToken) {
+            return trackedToken.balance ?? '0';
+        }
+
+        let tokenInfo: TokenInfo | null;
+        try {
+            tokenInfo = await fetchWrappedNativeTokenInfo({ account });
+        } catch {
+            return null;
+        }
+
+        if (!tokenInfo) {
+            return null;
+        }
+
+        const [wrappedNativeToken] = enhanceTokens([tokenInfo]);
+        const balance = wrappedNativeToken?.balance ?? '0';
+
+        // A zero balance is not tracked, so it does not clutter the account's token list.
+        if (!wrappedNativeToken || !new BigNumber(balance).gt(0)) {
+            return '0';
+        }
+
+        const currentAccount = selectAccountByKey(getState(), accountKey);
+
+        if (
+            !currentAccount ||
+            currentAccount.tokens?.some(token => isWrappedNativeContract(token.contract))
+        ) {
+            return balance;
+        }
+
+        dispatch(accountsActions.addAccountTokens(accountKey, [wrappedNativeToken]));
+
+        return balance;
     },
 );
 

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -170,7 +170,7 @@ export const trackWrappedNativeTokenThunk = createThunk<
     async ({ accountKey }, { dispatch, getState }) => {
         const account = selectAccountByKey(getState(), accountKey);
 
-        if (!account || account.networkType !== 'ethereum') {
+        if (account?.networkType !== 'ethereum') {
             return null;
         }
 

--- a/suite-common/wallet-core/src/stablecoin-yield/utils/fetchWrappedNativeTokenInfo.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/utils/fetchWrappedNativeTokenInfo.ts
@@ -1,0 +1,53 @@
+import { getWrappedNativeAddress } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import TrezorConnect, { type TokenInfo } from '@trezor/connect';
+import { asCoinSymbol } from '@trezor/connect-common';
+
+const WRAPPED_NATIVE_TOKEN_FETCH_TIMEOUT_MS = 15_000;
+
+type FetchWrappedNativeTokenInfoParams = {
+    account: Account;
+};
+
+/**
+ * Fetches the wrapped-native token (e.g. WETH) of the account's network with its current on-chain
+ * balance from the blockchain backend. Returns null when the network has no wrapped-native token
+ * or the backend does not report it.
+ */
+export const fetchWrappedNativeTokenInfo = async ({
+    account,
+}: FetchWrappedNativeTokenInfoParams): Promise<TokenInfo | null> => {
+    const wrappedNativeContract = getWrappedNativeAddress(account.symbol);
+
+    if (!wrappedNativeContract) {
+        return null;
+    }
+
+    const response = await Promise.race([
+        TrezorConnect.getAccountInfo({
+            coin: asCoinSymbol(account.symbol),
+            identity: tryGetAccountIdentity(account),
+            descriptor: account.descriptor,
+            details: 'tokenBalances',
+            contractFilter: wrappedNativeContract,
+            suppressBackupWarning: true,
+        }),
+        new Promise<never>((_, reject) =>
+            setTimeout(
+                () => reject(new Error('Wrapped-native token fetch timed out')),
+                WRAPPED_NATIVE_TOKEN_FETCH_TIMEOUT_MS,
+            ),
+        ),
+    ]);
+
+    if (!response.success) {
+        return null;
+    }
+
+    return (
+        response.payload.tokens?.find(
+            token => token.contract.toLowerCase() === wrappedNativeContract.toLowerCase(),
+        ) ?? null
+    );
+};

--- a/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
+++ b/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts
@@ -5,6 +5,7 @@ import {
     type StablecoinYieldRootState,
     type YieldFlowResolvedData,
     fetchAllowance,
+    fetchWrappedNativeTokenInfo,
     selectStablecoinYieldSession,
     stablecoinYieldActions,
     stablecoinYieldReducer,
@@ -33,8 +34,10 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('@suite-common/wallet-core/src/allowance/fetchAllowance');
+jest.mock('@suite-common/wallet-core/src/stablecoin-yield/utils/fetchWrappedNativeTokenInfo');
 
 const fetchAllowanceMock = jest.mocked(fetchAllowance);
+const fetchWrappedNativeTokenInfoMock = jest.mocked(fetchWrappedNativeTokenInfo);
 
 const accountKey = 'eth-account-key' as AccountKey;
 const ownerAddress = '0x0000000000000000000000000000000000000001';
@@ -55,7 +58,9 @@ const sessionParams = {
 const account = {
     key: accountKey,
     symbol: 'eth',
+    networkType: 'ethereum',
     descriptor: ownerAddress,
+    tokens: [],
 } as unknown as Account;
 
 const vault = {
@@ -87,9 +92,28 @@ const flowData = {
     },
 } satisfies YieldFlowResolvedData;
 
+const wethTokenContract = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as TokenAddress;
+const wethFlowKey = `${accountKey}:${yieldId}:${wethTokenContract}`;
+const wethRouteParams = {
+    accountKey,
+    tokenContract: wethTokenContract,
+    yieldId,
+} satisfies YieldFlowParams;
+
+const wethFlowData = {
+    ...flowData,
+    token: {
+        balance: '0',
+        contractAddress: wethTokenContract,
+        decimals: 18,
+        networkSymbol: 'eth',
+        symbol: 'WETH',
+    },
+} satisfies YieldFlowResolvedData;
+
 const allowanceSubunits = (value: string) => asAmountSubunit(new BigNumber(value));
 
-const buildStore = () =>
+const buildStore = (storeAccount: Account = account) =>
     createLightStore({
         reducer: {
             locale: createStaticReducer({
@@ -98,6 +122,7 @@ const buildStore = () =>
                 isSystemLocaleUsed: true,
             }),
             wallet: combineReducers({
+                accounts: createStaticReducer([storeAccount]),
                 settings: createStaticReducer({
                     localCurrency: 'usd',
                     bitcoinAmountUnit: 0,
@@ -107,21 +132,29 @@ const buildStore = () =>
         },
     });
 
-const renderUseStartYieldDepositFlow = (store: TestStore) =>
-    renderHookWithStoreProvider(
-        () =>
-            useStartYieldDepositFlow({
-                flowData,
-                flowKey,
-                routeParams,
-            }),
-        { store },
-    );
+type HookParams = {
+    flowData: YieldFlowResolvedData;
+    flowKey: string;
+    routeParams: YieldFlowParams;
+};
+
+const defaultHookParams: HookParams = { flowData, flowKey, routeParams };
+const wethHookParams: HookParams = {
+    flowData: wethFlowData,
+    flowKey: wethFlowKey,
+    routeParams: wethRouteParams,
+};
+
+const renderUseStartYieldDepositFlow = (
+    store: TestStore,
+    hookParams: HookParams = defaultHookParams,
+) => renderHookWithStoreProvider(() => useStartYieldDepositFlow(hookParams), { store });
 
 describe('useStartYieldDepositFlow', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         fetchAllowanceMock.mockResolvedValue(allowanceSubunits('0'));
+        fetchWrappedNativeTokenInfoMock.mockResolvedValue(null);
     });
 
     it('navigates to deposit when allowance initialization skips to action step', async () => {
@@ -185,6 +218,61 @@ describe('useStartYieldDepositFlow', () => {
         expect(mockNavigate).toHaveBeenCalledWith(
             YieldStackRoutes.YieldDepositApproval,
             routeParams,
+        );
+    });
+
+    it('skips the wrap step when an untracked wrapped-native balance is found on chain', async () => {
+        const store = buildStore();
+        fetchWrappedNativeTokenInfoMock.mockResolvedValue({
+            standard: 'ERC20',
+            contract: wethTokenContract,
+            symbol: 'WETH',
+            name: 'Wrapped Ether',
+            decimals: 18,
+            balance: '2500000000000000000',
+        });
+        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+
+        await act(async () => {
+            await result.current.handleStartYieldDepositFlow();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+            YieldStackRoutes.YieldDepositApproval,
+            wethRouteParams,
+        );
+    });
+
+    it('skips the wrap step when the wrapped-native token is already tracked with a balance', async () => {
+        const trackedAccount = {
+            ...account,
+            tokens: [{ contract: wethTokenContract, symbol: 'WETH', decimals: 18, balance: '3' }],
+        } as unknown as Account;
+        const store = buildStore(trackedAccount);
+        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+
+        await act(async () => {
+            await result.current.handleStartYieldDepositFlow();
+        });
+
+        expect(fetchWrappedNativeTokenInfoMock).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(
+            YieldStackRoutes.YieldDepositApproval,
+            wethRouteParams,
+        );
+    });
+
+    it('starts on the wrap step when no wrapped-native balance exists', async () => {
+        const store = buildStore();
+        const { result } = renderUseStartYieldDepositFlow(store, wethHookParams);
+
+        await act(async () => {
+            await result.current.handleStartYieldDepositFlow();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith(
+            YieldStackRoutes.YieldDepositWrap,
+            wethRouteParams,
         );
     });
 

--- a/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.ts
+++ b/suite-native/module-earn/src/hooks/useStartYieldDepositFlow.ts
@@ -14,6 +14,7 @@ import {
     selectStablecoinYieldSession,
     selectStablecoinYieldSessionByFlowKey,
     stablecoinYieldActions,
+    trackWrappedNativeTokenThunk,
 } from '@suite-common/wallet-core';
 import {
     type StackNavigationProps,
@@ -102,15 +103,24 @@ export const useStartYieldDepositFlow = ({
                 stablecoinYieldActions.resetSession({ ...sessionParams, isWrappedNativeVault }),
             );
 
-            // Mirrors desktop: holding any wrapped token skips the wrap step up front; the user
-            // can still come back to it from the approve step.
-            if (isWrappedNativeVault && new BigNumber(flowData.token.balance).gt(0)) {
-                dispatch(
-                    stablecoinYieldActions.resolveWrappedNativeStep({
-                        ...sessionParams,
-                        step: 'wrap',
-                    }),
+            if (isWrappedNativeVault) {
+                const trackResponse = await dispatch(
+                    trackWrappedNativeTokenThunk({ accountKey: flowData.account.key }),
                 );
+                const wrappedTokenBalance = isFulfilled(trackResponse)
+                    ? (trackResponse.payload ?? flowData.token.balance)
+                    : flowData.token.balance;
+
+                // Mirrors desktop: holding any wrapped token skips the wrap step up front; the
+                // user can still come back to it from the approve step.
+                if (new BigNumber(wrappedTokenBalance).gt(0)) {
+                    dispatch(
+                        stablecoinYieldActions.resolveWrappedNativeStep({
+                            ...sessionParams,
+                            step: 'wrap',
+                        }),
+                    );
+                }
             }
 
             const response = await dispatch(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

WETH acquired by wrapping is not reported by the backend (no ERC-20 `Transfer` event), so the account doesn't know about it and the yield deposit flow always forces the wrap step. Now the deposit flow fetches the real on-chain WETH balance on start, tracks the token on the account when positive and skips the wrap step. Accounts reducer newly preserves locally tracked tokens during account updates, so a concurrent sync can't remove them.

## Notes for QA

1. Fund a fresh ETH account (no WETH history) and wrap some ETH by wrapping flow.
2. Before the fix: WETH is not visible and the ETH vault deposit flow starts on the wrap step.
3. With the fix: the deposit flow skips to "Select amount & approve" with the real WETH balance and WETH appears in the assets list.

⚠️ The test address must have no WETH transfers (no vault deposits, no WETH sends/receives) - otherwise the backend reports the token itself and the bug can't be reproduced.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31085

## Screenshots:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 18 46 41" src="https://github.com/user-attachments/assets/73bc54f8-47a6-4a25-b605-aca75c720f29" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native/track-wrapped-native-token/web/](https://dev.suite.sldev.cz/suite-web/fix/native/track-wrapped-native-token/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies core wallet account state management (accountsActions, accountsReducer) and stablecoin-yield/earn code. Because the account files are broad shared dependencies referenced by many tests, only the most targeted account-creation and discovery E2E tests are recommended. The stablecoin-yield and mobile earn hook changes have no targeted functional E2E coverage in the current suite and should rely on unit tests and QA.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsActions.ts`
- `suite-common/wallet-core/src/accounts/accountsReducer.test.ts`
- `suite-common/wallet-core/src/accounts/accountsReducer.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/fetchWrappedNativeTokenInfo.ts`
- `suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts`
- `suite-native/module-earn/src/hooks/useStartYieldDepositFlow.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — Directly exercises the add-account flow and asserts the accountsNewAccountEvent, which is emitted through accountsActions and stored via accountsReducer. A regression in account creation, type selection, or reducer state would be immediately visible here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery is the primary path that populates and updates account state in the reducer. Changes to accountsActions or accountsReducer could affect how discovered accounts are added, ordered, or rendered on the dashboard.

</details>

⚠️ **Changes with no test coverage (6)**
- `suite-common/wallet-core/src/accounts/accountsReducer.test.ts`
- `suite-common/wallet-core/src/index.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/utils/fetchWrappedNativeTokenInfo.ts`
- `suite-native/module-earn/src/hooks/useStartYieldDepositFlow.test.ts`
- `suite-native/module-earn/src/hooks/useStartYieldDepositFlow.ts`

_Updated: 2026-08-12T07:28:31.935Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native/track-wrapped-native-token&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native/track-wrapped-native-token&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/track-wrapped-native-token&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T07:29:50.588Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T07:30:29.623Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->