### PR TITLE
fix(suite-native): put asset price card below empty transactions state

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx
@@ -1,0 +1,44 @@
+import { useSelector } from 'react-redux';
+
+import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
+import {
+    type AccountsRootState,
+    selectAccountByKey,
+    useDisplayBaseCurrency,
+} from '@suite-common/wallet-core';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { VStack } from '@suite-native/atoms';
+import { TransactionsEmptyState } from '@suite-native/transactions';
+
+import { selectIsUnrecognizedToken } from '../selectors';
+import { AssetPriceCard } from './AssetPriceCard';
+
+type AccountDetailEmptyStateProps = {
+    accountKey: AccountKey;
+    tokenContract?: TokenAddress;
+};
+
+export const AccountDetailEmptyState = ({
+    accountKey,
+    tokenContract,
+}: AccountDetailEmptyStateProps) => {
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account?.symbol);
+    const isUnrecognizedToken = useSelector(
+        (state: TokenDefinitionsRootState & AccountsRootState) =>
+            selectIsUnrecognizedToken(state, accountKey, tokenContract),
+    );
+
+    const isPriceCardDisplayed = shallDisplayBaseCurrency && !isUnrecognizedToken;
+
+    return (
+        <VStack spacing="sp24">
+            <TransactionsEmptyState accountKey={accountKey} />
+            {isPriceCardDisplayed && (
+                <AssetPriceCard accountKey={accountKey} tokenContract={tokenContract} />
+            )}
+        </VStack>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -27,7 +27,7 @@ import {
     type StackNavigationProps,
 } from '@suite-native/navigation';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
-import { selectHasAccountAnyTransactions } from '@suite-native/transactions';
+import { selectHasAccountAnyTransactionsForToken } from '@suite-native/transactions';
 
 import { selectIsNetworkSendFlowEnabled, selectIsUnrecognizedToken } from '../selectors';
 import { AccountDiscoveryFailedBanner } from './AccountBanners/AccountDiscoveryFailedBanner';
@@ -59,8 +59,8 @@ const TransactionListHeaderContent = ({
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
-    const hasAccountTransactions = useSelector((state: TransactionsRootState & TokensRootState) =>
-        selectHasAccountAnyTransactions(state, accountKey),
+    const hasAccountTransactions = useSelector((state: AccountsRootState & TransactionsRootState) =>
+        selectHasAccountAnyTransactionsForToken(state, accountKey, tokenContract),
     );
     const isTestnetAccount = useSelector((state: AccountsRootState) =>
         selectIsTestnetAccount(state, accountKey),
@@ -90,8 +90,8 @@ export const TransactionListHeader = memo(
         const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account?.symbol);
 
         const hasAccountTransactions = useSelector(
-            (state: TransactionsRootState & TokensRootState) =>
-                selectHasAccountAnyTransactions(state, accountKey),
+            (state: AccountsRootState & TransactionsRootState) =>
+                selectHasAccountAnyTransactionsForToken(state, accountKey, tokenContract),
         );
         const isNetworkSendFlowEnabled = useSelector((state: FeatureFlagsRootState) =>
             selectIsNetworkSendFlowEnabled(state, account?.symbol),
@@ -149,7 +149,8 @@ export const TransactionListHeader = memo(
             });
         };
 
-        const isPriceCardDisplayed = shallDisplayBaseCurrency && !isUnrecognizedToken;
+        const isPriceCardDisplayed =
+            shallDisplayBaseCurrency && !isUnrecognizedToken && hasAccountTransactions;
         const isStellarAccount = account.networkType === 'stellar';
 
         const isSendButtonDisplayed = isNetworkSendFlowEnabled && !isPortfolioTrackerDevice;

--- a/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountDetailContentScreen.tsx
@@ -8,6 +8,7 @@ import { Screen } from '@suite-native/navigation';
 import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { TransactionList } from '@suite-native/transactions';
 
+import { AccountDetailEmptyState } from '../components/AccountDetailEmptyState';
 import { AssetDetailScreenHeader } from '../components/AssetDetailScreenHeader';
 import { TransactionListHeader } from '../components/TransactionListHeader';
 
@@ -43,6 +44,11 @@ export const AccountDetailContentScreen = ({
         [account.key, tokenContract],
     );
 
+    const listEmptyComponent = useMemo(
+        () => <AccountDetailEmptyState accountKey={account.key} tokenContract={tokenContract} />,
+        [account.key, tokenContract],
+    );
+
     return (
         <Screen
             /** Adding scrollable wraps content in ScrollView which is unwanted for this screen because list component already adds the scrollview **/
@@ -56,6 +62,7 @@ export const AccountDetailContentScreen = ({
                 account={account}
                 tokenContract={tokenContract}
                 listHeaderComponent={listHeaderComponent}
+                listEmptyComponent={listEmptyComponent}
             />
         </Screen>
     );

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -37,6 +37,7 @@ import { useFetchMissingTransactionFiatRates } from '../hooks/useFetchMissingTra
 
 type AccountTransactionProps = {
     listHeaderComponent: JSX.Element;
+    listEmptyComponent?: JSX.Element;
     account: Account;
     tokenContract?: TokenAddress;
     stakingOnly?: boolean;
@@ -129,6 +130,7 @@ const renderSectionHeader = ({ section: { monthKey } }: RenderSectionHeaderParam
 
 export const TransactionList = ({
     listHeaderComponent,
+    listEmptyComponent,
     account,
     tokenContract,
     stakingOnly = false,
@@ -226,20 +228,24 @@ export const TransactionList = ({
         ) as MonthKey[];
 
         if (tokenContract) {
-            return transactionMonthKeys.flatMap(monthKey => [
-                monthKey,
-                ...(accountTransactionsByMonth[monthKey] ?? []).flatMap(transaction =>
-                    transaction.tokens
-                        .filter(token => token.contract === tokenContract)
-                        .map(
-                            tokenTransfer =>
-                                ({
-                                    ...tokenTransfer,
-                                    originalTransaction: transaction,
-                                }) as TypedTokenTransferWithTx,
-                        ),
-                ),
-            ]);
+            return transactionMonthKeys.flatMap(monthKey => {
+                const tokenTransfers = (accountTransactionsByMonth[monthKey] ?? []).flatMap(
+                    transaction =>
+                        transaction.tokens
+                            .filter(token => token.contract === tokenContract)
+                            .map(
+                                tokenTransfer =>
+                                    ({
+                                        ...tokenTransfer,
+                                        originalTransaction: transaction,
+                                    }) as TypedTokenTransferWithTx,
+                            ),
+                );
+
+                // Months without any transfer of the token are dropped entirely, so an account
+                // with no transactions of the token results in empty data and shows the empty state.
+                return tokenTransfers.length > 0 ? [monthKey, ...tokenTransfers] : [];
+            });
         }
 
         return transactionMonthKeys.flatMap(monthKey => [
@@ -292,9 +298,9 @@ export const TransactionList = ({
                 renderItem={renderItem}
                 contentContainerStyle={applyStyle(sectionListContainerStyle)}
                 ListEmptyComponent={
-                    shouldDeferEmptyState ? null : (
-                        <TransactionsEmptyState accountKey={accountKey} />
-                    )
+                    shouldDeferEmptyState
+                        ? null
+                        : (listEmptyComponent ?? <TransactionsEmptyState accountKey={accountKey} />)
                 }
                 ListHeaderComponent={listHeaderComponent}
                 ListFooterComponent={

--- a/suite-native/transactions/src/index.ts
+++ b/suite-native/transactions/src/index.ts
@@ -9,6 +9,7 @@ export * from './components/TransactionOutputLabelEditable';
 export * from './components/TokenTransferListItem';
 export * from './components/TransactionListItem';
 export * from './components/TransactionListItemContainer';
+export * from './components/TransactionsEmptyState';
 export * from './hooks/useFetchMissingTransactionFiatRates';
 export * from './components/TransactionTarget';
 export * from './selectors';

--- a/suite-native/transactions/src/selectors.ts
+++ b/suite-native/transactions/src/selectors.ts
@@ -9,6 +9,7 @@ import {
 } from '@suite-common/token-definitions';
 import { type NetworkSymbol, getNetworkType } from '@suite-common/wallet-config';
 import {
+    type AccountsRootState,
     type FiatRatesRootState,
     type TransactionsRootState,
     type WalletSettingsRootState,
@@ -195,6 +196,24 @@ export const selectHasAccountAnyTransactions = createMemoizedSelector(
         return transactions.length > 0;
     },
 );
+
+// Unlike selectHasAccountAnyTransactions, the token branch can only inspect already fetched
+// transactions, so it returns false until the first transactions page is loaded.
+export const selectHasAccountAnyTransactionsForToken = (
+    state: AccountsRootState & TransactionsRootState,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
+): boolean => {
+    if (!tokenContract) {
+        return selectHasAccountAnyTransactions(state, accountKey);
+    }
+
+    const transactions = selectAccountTransactions(state, accountKey);
+
+    return transactions.some(transaction =>
+        transaction.tokens.some(token => token.contract === tokenContract),
+    );
+};
 
 export const selectTransactionFiatRate = (
     state: WalletSettingsRootState & FiatRatesRootState,


### PR DESCRIPTION
## Description

Fix account empty transaction state UI.

VERY HACKY SOLUTION, but works for now. We should refactor the entire `TransactionList` component so that the entire screen content is not in `TransactionListHeader`, but instead is composed directly inside the screen component.

## Screenshots:

<table>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-11 at 19 26 28" src="https://github.com/user-attachments/assets/18724d5c-b511-4f09-bab1-37e8a0c87168" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-11 at 19 31 45" src="https://github.com/user-attachments/assets/e78fdde6-63ff-4d47-af53-e718ec561f19" />
</td>
</tr>
<tr>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-11 at 19 26 21" src="https://github.com/user-attachments/assets/0e0f2b1b-2de9-4918-95ac-0c0000137683" />
</td>
<td>
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-08-11 at 19 31 53" src="https://github.com/user-attachments/assets/e53d2e5a-b1da-4610-8d3c-e75e80ef6c97" />
</td>
</tr>
</table>

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/empty-txs-asset-price-card&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->