### PR TITLE
fix(suite): build buy redirect url from receive account

### DIFF
--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -8,6 +8,7 @@ import {
     cryptoIdToNetworkSymbolAndContractAddress,
     selectTradingBuyInfo,
     selectTradingBuyQuotesRequest,
+    selectTradingBuyReceiveAccount,
     selectTradingBuyReceiveAddress,
     selectTradingCoinInfoByCryptoId,
     selectTradingFormAccount,
@@ -24,6 +25,7 @@ export const selectBuyQuoteThunk = createThunk(
         const quotesRequest = selectTradingBuyQuotesRequest(getState());
         const receiveAddress = selectTradingBuyReceiveAddress(getState());
         const account = selectTradingFormAccount(getState(), 'buy');
+        const receiveAccount = selectTradingBuyReceiveAccount(getState());
 
         const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
 
@@ -33,7 +35,7 @@ export const selectBuyQuoteThunk = createThunk(
 
         const returnUrl = await createQuoteLink(
             { ...quotesRequest, paymentMethod: quote.paymentMethod },
-            account,
+            receiveAccount ?? account,
         );
 
         const { symbol: cryptoNetworkSymbol, contractAddress: cryptoContractAddress } =

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
@@ -36,6 +36,7 @@ jest.mock('@suite-common/trading', () => {
 });
 
 const ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('btc') });
+const RECEIVE_ACCOUNT = mockWalletAccount({ symbol: asNetworkSymbol('eth') });
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
 
@@ -60,19 +61,21 @@ type StateOverrides = {
     receiveAddress?: string;
     isLoading?: boolean;
     accountKey?: AccountKey;
+    receiveAccountKey?: AccountKey;
     accounts?: Account[];
 };
 
-const DEFAULTS: Required<StateOverrides> = {
+const DEFAULTS = {
     selectedQuote: SELECTED_QUOTE,
     receiveAddress: 'bc1qreceive',
     isLoading: false,
     accountKey: ACCOUNT.key,
+    receiveAccountKey: undefined,
     accounts: [ACCOUNT],
-};
+} satisfies StateOverrides;
 
 const buildState = (overrides: StateOverrides = {}) => {
-    const { selectedQuote, receiveAddress, isLoading, accountKey, accounts } = {
+    const { selectedQuote, receiveAddress, isLoading, accountKey, receiveAccountKey, accounts } = {
         ...DEFAULTS,
         ...overrides,
     };
@@ -86,7 +89,7 @@ const buildState = (overrides: StateOverrides = {}) => {
                     receiveAddress,
                     isLoading,
                     tradingAccountKey: accountKey,
-                    receiveAccountKey: undefined,
+                    receiveAccountKey,
                     buyInfo: undefined,
                 },
                 sell: {
@@ -177,6 +180,34 @@ describe('useTradingBuyConfirm', () => {
             await result.current.confirmTrade();
 
             expect(mockConfirmTradeThunk).not.toHaveBeenCalled();
+        });
+
+        it('uses the receive account, not the form account, for the trade and return url', async () => {
+            const { result } = renderConfirm({
+                receiveAccountKey: RECEIVE_ACCOUNT.key,
+                accounts: [ACCOUNT, RECEIVE_ACCOUNT],
+            });
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    account: RECEIVE_ACCOUNT,
+                    returnUrl: expect.stringContaining(
+                        `detail/${RECEIVE_ACCOUNT.symbol}/${RECEIVE_ACCOUNT.accountType}/${RECEIVE_ACCOUNT.index}/`,
+                    ),
+                }),
+            );
+        });
+
+        it('falls back to the form account when there is no Suite receive account', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({ account: ACCOUNT }),
+            );
         });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
@@ -9,6 +9,7 @@ import {
     buyThunks,
     selectTradingAccountKeyByTradeType,
     selectTradingBuyIsLoading,
+    selectTradingBuyReceiveAccount,
     selectTradingBuyReceiveAddress,
     selectTradingBuySelectedQuote,
     tradingBuyActions,
@@ -29,6 +30,7 @@ export const useTradingBuyConfirm = () => {
     const isLoading = useSelector(selectTradingBuyIsLoading);
     const accountKey = useSelector(state => selectTradingAccountKeyByTradeType(state, 'buy'));
     const account = useSelector(state => selectAccountByKey(state, accountKey) ?? undefined);
+    const receiveAccount = useSelector(selectTradingBuyReceiveAccount);
 
     const isReady = !!selectedQuote && !!receiveAddress && !!account;
     const isConfirmDisabled = isLoading || !selectedQuote || !receiveAddress || !account;
@@ -42,7 +44,8 @@ export const useTradingBuyConfirm = () => {
     const confirmTrade = async (): Promise<BuyTrade | undefined> => {
         if (!account || !receiveAddress || !selectedQuote) return;
 
-        const returnUrl = await createTxLink(selectedQuote, account);
+        const tradeAccount = receiveAccount ?? account;
+        const returnUrl = await createTxLink(selectedQuote, tradeAccount);
 
         const processResponseData = (response: BuyTradeResponse) => {
             if (response.tradeForm) {
@@ -68,7 +71,7 @@ export const useTradingBuyConfirm = () => {
                 quote: selectedQuote,
                 address: receiveAddress,
                 returnUrl,
-                account,
+                account: tradeAccount,
                 processResponseData,
                 triggerAnalyticsTradeConfirmation,
             }),

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
@@ -75,6 +75,7 @@ export const TradingBuyDetailContent = () => {
     };
 
     const receiveAccount = accounts.find(account => account.key === trade?.receiveAccountKey);
+    const waitingStepAccount = receiveAccount ?? account;
 
     useEffect(() => {
         // if tradeStatus hasn't changed, don't send the analytics event
@@ -115,10 +116,10 @@ export const TradingBuyDetailContent = () => {
                         />
                         <Box margin={{ top: 32, bottom: 12 }}>
                             <TradingDetailStepList>
-                                {account && (
+                                {waitingStepAccount && (
                                     <TradingBuyDetailPaymentWaitingForUserStep
                                         trade={trade.data}
-                                        account={account}
+                                        account={waitingStepAccount}
                                         providerName={provider?.brandName || provider?.companyName}
                                     />
                                 )}

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -42,6 +42,7 @@ import {
     selectTradingBuyQuotesByPaymentMethod,
     selectTradingBuyQuotesPerPaymentMethod,
     selectTradingBuyQuotesRequest,
+    selectTradingBuyReceiveAccount,
     selectTradingBuySelectedQuote,
     selectTradingBuySupportedCryptoIds,
     selectTradingCoinInfoByCryptoId,
@@ -2366,6 +2367,28 @@ describe('tradingSelectors', () => {
         it('should return supported symbols for exchange', () => {
             expect(selectTradingSupportedSymbols(state, 'exchange', supportedCoins)).toEqual(
                 supportedSymbols,
+            );
+        });
+    });
+
+    describe(selectTradingBuyReceiveAccount.name, () => {
+        it('should return account for receiveAccountKey', () => {
+            state.wallet.trading.buy.receiveAccountKey = accountBtc.key;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBe(accountBtc);
+        });
+
+        it('should return undefined when receiveAccountKey is not set', () => {
+            state.wallet.trading.buy.receiveAccountKey = undefined;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBeUndefined();
+        });
+
+        it('should be stable', () => {
+            state.wallet.trading.buy.receiveAccountKey = accountBtc.key;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBe(
+                selectTradingBuyReceiveAccount(state),
             );
         });
     });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -97,9 +97,10 @@ type SelectedAccountRootState = {
     };
 };
 
-export type TradingRootStateWithDeviceAndAccounts = TradingRootState &
+export type TradingRootStateWithAccounts = TradingRootState & AccountsRootState;
+
+export type TradingRootStateWithDeviceAndAccounts = TradingRootStateWithAccounts &
     DeviceRootState &
-    AccountsRootState &
     SelectedAccountRootState;
 
 export type TradingFormAccountRootState = TradingRootStateWithDeviceAndAccounts &
@@ -148,6 +149,8 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange' | 'sell
 };
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
+const createMemoizedSelectorWithAccounts =
+    createWeakMapSelector.withTypes<TradingRootStateWithAccounts>();
 const createMemoizedSelectorWithDeviceAndAccounts =
     createWeakMapSelector.withTypes<TradingRootStateWithDeviceAndAccounts>();
 const createMemoizedFormAccountSelector =
@@ -918,6 +921,17 @@ export const selectTradingBuyReceiveAccountKey = (state: TradingRootState) =>
     state.wallet.trading.buy.receiveAccountKey;
 export const selectTradingBuyReceiveAddress = (state: TradingRootState) =>
     state.wallet.trading.buy.receiveAddress;
+
+export const selectTradingBuyReceiveAccount = createMemoizedSelectorWithAccounts(
+    [selectAccounts, selectTradingBuyReceiveAccountKey],
+    (accounts, receiveAccountKey): Account | undefined => {
+        if (!receiveAccountKey) {
+            return undefined;
+        }
+
+        return accounts.find(account => account.key === receiveAccountKey);
+    },
+);
 
 export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
     state.wallet.trading.exchange.tradingAccountKey;


### PR DESCRIPTION
## Description

Buy redirect callbacks and the saved buy trade were tied to the wrong account (e.g. `detail/btc/normal/0/<paymentId>` when buying ETH).

**Root cause:** the buy account key (`buyAccountKey` / `selectTradingAccountKeyByTradeType(state, 'buy')`) is set once when the Buy form opens and is never re-synced when the bought crypto changes (see TODO #29479). Picking a different crypto updates only the form field, so a buy confirmed while the form was opened on a BTC account kept the BTC account — leaking into the partner return URL, the offers redirect URL, and the trade record (`selectedAccountKey`), pointing everything at the wrong account/fee network/history entry.

**Fix:** a buy is received into the account that matches the selected crypto, which is already tracked correctly as the receive account (`receiveAccountKey`). Use the receive account for:
- the confirm return URL (`createTxLink`) and the saved trade's `selectedAccountKey` (`useTradingBuyConfirm`),
- the offers redirect URL (`createQuoteLink` in `selectBuyQuoteThunk`),
- the buy detail "go to payment" resubmit (`TradingBuyDetailContent`).

`buyAccountKey` stays a form-UI default (seeds the default crypto) and no longer defines the trade. Falls back to the form account only for non-Suite (external) receive addresses. Added unit coverage in `useTradingBuyConfirm.test.tsx`.

Not addressed here (separate concern): the detail page bounces to the buy form when the trade for that `paymentId` isn't in local storage; trades are resolved by `paymentId` only.

## Related Issue

Resolve #29566

---


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly focused on the trading buy flow: quote selection, confirmation hook, buy detail view, and shared trading selectors. The highest risk is in buy quote confirmation and detail rendering, so the minimal high-confidence set is the three buy-specific E2E tests (BTC, ETH, Solana token). The negative buy test adds medium-confidence coverage for edge cases. tradingSelectors.ts maps to many tests, but without specific evidence of broad impact, the buy tests sufficiently cover the likely selector changes. The changed unit test files do not require E2E coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts`
- `packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx`
- `packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts`
- `packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`
- `suite-common/trading/src/selectors/tradingSelectors.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — This is the only E2E test statically mapped to useTradingBuyConfirm and directly exercises the full BTC buy flow, including quote selection (selectBuyQuoteThunk), confirmation, and the TradingBuyDetailContent component. It is the highest-confidence regression detector for this change set.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Directly covers the ETH buy flow end-to-end and is statically mapped to both selectBuyQuoteThunk and TradingBuyDetailContent. ETH buy uses different networks/accounts than BTC, so it can catch buy-specific regressions not exposed by the BTC test.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Exercises the buy flow for a Solana SPL token and is mapped to selectBuyQuoteThunk and TradingBuyDetailContent. Token buys involve additional asset-picker and quote logic, increasing coverage of the changed buy confirmation and detail paths.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/buy-negative.test.ts` — Tests buy form validation and empty/no-offers states. It shares the buy quote and form infrastructure (selectBuyQuoteThunk) and can reveal regressions in how quote selection handles invalid or missing quotes after the thunk changes.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx`
- `suite-common/trading/src/selectors/tradingSelectors.test.ts`

_Updated: 2026-08-12T10:26:56.218Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix-buy-redirect-account&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix-buy-redirect-account&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-buy-redirect-account&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T10:29:28.289Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T10:28:30.160Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix-buy-redirect-account/web/](https://dev.suite.sldev.cz/suite-web/fix-buy-redirect-account/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->