### PR TITLE
fix(suite): clamp graph tooltip to chart edge so sidebar does not clip it

### DIFF
--- a/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
+++ b/packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx
@@ -12,32 +12,14 @@ import { type CommonAggregatedHistory, type GraphRange } from 'src/types/wallet/
 // Used for triggering custom Tooltip alignment
 const OFFSET_LIMIT_HORIZONTAL = 125;
 
-// When the Tooltip gets triggered near to the horizontal boundaries, it might overflow outside of the screen
-// These positioning functions are used to align it properly from each side
-const calculateXPosition = (x: number, offset = 0) => `calc(${x}px - ${x / 2}px + ${offset}px)`;
-const calculateXPositionRight = (x: number, offset = 0) => `calc(${x}px + 25% + ${offset}px)`;
+// The Tooltip is centered above the hovered point, but ancestors of the chart clip horizontal
+// overflow (the app content is a scroll container), so the box is clamped to the chart's left
+// edge and only the arrow keeps following the cursor
+const getTooltipXPosition = (x: number, width: number): string =>
+    x >= width - OFFSET_LIMIT_HORIZONTAL ? `calc(${x}px + 25%)` : `max(0px, calc(${x}px - 50%))`;
 
-// Tooltip should be centered and above the chart bars but should not overflow horizontally thanks to the positioning functions
-const getTooltipXPosition = (x: number, width: number): string => {
-    if (x <= OFFSET_LIMIT_HORIZONTAL) {
-        return calculateXPosition(x, -30);
-    }
-
-    if (x >= width - OFFSET_LIMIT_HORIZONTAL) {
-        return calculateXPositionRight(x);
-    }
-
-    return `calc(${x}px - 50%)`;
-};
-
-// Align the triangle arrow in a similar manner
-const getTooltipArrowXPosition = (x: number, width: number): string => {
-    if (x <= OFFSET_LIMIT_HORIZONTAL) {
-        return `left: ${calculateXPosition(x, -30)};`;
-    }
-
-    return x >= width - OFFSET_LIMIT_HORIZONTAL ? `left: calc(75% + 1px);` : `left: 50%;`;
-};
+const getTooltipArrowXPosition = (x: number, width: number): string =>
+    x >= width - OFFSET_LIMIT_HORIZONTAL ? `left: calc(75% + 1px);` : `left: min(${x}px, 50%);`;
 
 interface WrapperProps {
     $positionX: number;
@@ -65,8 +47,7 @@ const CustomTooltipWrapper = styled.div<WrapperProps>`
         content: '';
         top: 100%;
         ${({ $positionX, $boxWidth }) => getTooltipArrowXPosition($positionX, $boxWidth)}
-        margin-left: ${({ $positionX }) =>
-            $positionX <= OFFSET_LIMIT_HORIZONTAL ? `50px` : `-10px`};
+        margin-left: -10px;
         width: 0;
         height: 0;
         /* stylelint-disable trezor/dimension-token-values -- These borders construct the tooltip arrow. */


### PR DESCRIPTION
## Description

The graph tooltip is not hidden by the sidebar's z-index — it is clipped by the scrollable app content (`AppWrapper` / `MainContentContainer` in `SuiteLayout`), whose left edge sits exactly at the sidebar border. The tooltip's "centered" positioning (`calc(x - 50%)`) assumed a tooltip at most ~250px wide, but the account tooltip with full-precision amounts is far wider, so on left-side data points its left half crossed the chart's left edge into the clipped region.

The tooltip box is now clamped to the chart's left edge with CSS `max()`, and the arrow keeps tracking the cursor via `min()`, so no part of it can reach the clipping boundary. Right-edge behavior is unchanged.

## Notes for QA

- Account overview graph: hover the left-most data points (long ETH balances make the tooltip widest) at various window and sidebar widths — the tooltip must stay fully visible, flush with the chart's left edge, with the arrow still pointing at the hovered bar.
- Check the dashboard portfolio graph too (shared tooltip base).
- Hovering middle and right-edge points is unchanged.

## Related Issue

Resolve #25245

## Screenshots:

<img width="579" height="519" alt="Screenshot 2026-08-18 at 13 34 33" src="https://github.com/user-attachments/assets/528c1319-38bc-4c3d-b0cb-584227a2d0b5" />
<img width="486" height="542" alt="Screenshot 2026-08-18 at 13 34 29" src="https://github.com/user-attachments/assets/b123b463-5043-4b66-92f6-7e22e633bf2c" />


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a shared graph tooltip base component with static references across 135 tests, so it should be treated as a broad global dependency. Most mapped tests do not specifically exercise graph or tooltip behavior. The recommended strategy is to run the account transactions graph test as a high-priority direct check, and a portfolio graph visibility test as a medium-priority smoke check, while omitting the large volume of indirectly mapped tests.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/components/suite/graph/TransactionsGraph/GraphTooltipBase.tsx`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/transactions.test.ts` — This test directly exercises the account transactions overview graph by cycling through time range filters (day/week/month/year/all) and verifying the transaction summary. Any change to GraphTooltipBase could affect how the graph renders tooltips or date labels on this page, making this the strongest proxy for regression detection.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — This test verifies that the portfolio graph becomes visible on the dashboard after custom Blockbook discovery completes. While it does not interact with tooltips directly, it is one of the few tests that explicitly asserts graph rendering and would catch a tooltip-base regression that breaks graph mounting or display.

</details>

_Updated: 2026-08-11T18:49:07.886Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/25245-graph-tooltip-sidebar-overlap&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/25245-graph-tooltip-sidebar-overlap&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-11T18:52:26.108Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Analytics Events - Promo Banner > Should log promo/dashboard-banner - TEX from dashboard promo banner | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-11T18:51:27.184Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/25245-graph-tooltip-sidebar-overlap/web/](https://dev.suite.sldev.cz/suite-web/fix/25245-graph-tooltip-sidebar-overlap/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->