### PR TITLE
Show pending transaction bottomsheet after staking actions

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -2795,6 +2795,8 @@ export const messages = {
         },
         earnTransactionDataReviewScreen: {
             title: 'Confirm on Trezor',
+            pendingTitle: 'Confirming stake',
+            amountLabel: 'Staking amount',
             viewTransactionButton: 'Stake now',
             pushTransactionFailedAlert: {
                 title: 'Transaction failed',
@@ -2816,6 +2818,8 @@ export const messages = {
         },
         unstakeTransactionDataReviewScreen: {
             title: 'Confirm on Trezor',
+            pendingTitle: 'Confirming unstake',
+            amountLabel: 'Unstaking amount',
             viewTransactionButton: 'Unstake now',
             pushTransactionFailedAlert: {
                 title: 'Transaction failed',
@@ -3586,6 +3590,8 @@ export const messages = {
         },
         claimTransactionDataReviewScreen: {
             title: 'Confirm on Trezor',
+            pendingTitle: 'Confirming claim',
+            amountLabel: 'Claiming amount',
             viewTransactionButton: 'Claim now',
             pushTransactionFailedAlert: {
                 title: 'Transaction failed',

--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -3935,6 +3935,7 @@ export const messages = {
             pending: 'Pending',
             error: 'Failed to confirm transaction. Try again.',
             date: 'Date',
+            transactionId: 'Transaction id',
             exploreInBlockchain: 'Explore on blockchain',
             approvalPendingAlert:
                 'Your approval is still processing. When confirmed, you’ll be able to use this approval with the same provider.',

--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
@@ -25,7 +25,7 @@ import { BigNumber } from '@trezor/utils';
 import { ClaimOutputItem } from './ClaimOutputItem';
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
-import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
+import { getEarnPendingAmountInBaseUnits } from '../utils/getEarnPendingAmountInBaseUnits';
 
 type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.ClaimTransactionDataReview>;
 
@@ -60,12 +60,13 @@ export const ClaimTransactionDataReviewStepList = () => {
     const isSolanaClaim = !!accountSymbol && isSupportedSolStakingNetworkSymbol(accountSymbol);
 
     // Solana: show composed lamports (totalSpent − fee), fall back to the claimable amount.
-    const claimableAmountInWei =
-        isSolanaClaim && precomposedTransaction
-            ? getSolanaPrecomposedNetAmount(precomposedTransaction)
-            : new BigNumber(claimableAmount || '0')
-                  .times(new BigNumber(10).pow(networkDecimals))
-                  .toFixed(0);
+    const claimableAmountInWei = getEarnPendingAmountInBaseUnits({
+        fallbackAmountInBaseUnits: new BigNumber(claimableAmount || '0')
+            .times(new BigNumber(10).pow(networkDecimals))
+            .toFixed(0),
+        isSolanaStaking: isSolanaClaim,
+        precomposedTransaction,
+    });
 
     return (
         <View>

--- a/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/ClaimTransactionDataReviewStepList.tsx
@@ -25,6 +25,7 @@ import { BigNumber } from '@trezor/utils';
 import { ClaimOutputItem } from './ClaimOutputItem';
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
+import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
 
 type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.ClaimTransactionDataReview>;
 
@@ -61,9 +62,7 @@ export const ClaimTransactionDataReviewStepList = () => {
     // Solana: show composed lamports (totalSpent − fee), fall back to the claimable amount.
     const claimableAmountInWei =
         isSolanaClaim && precomposedTransaction
-            ? new BigNumber(precomposedTransaction.totalSpent)
-                  .minus(precomposedTransaction.fee)
-                  .toFixed(0)
+            ? getSolanaPrecomposedNetAmount(precomposedTransaction)
             : new BigNumber(claimableAmount || '0')
                   .times(new BigNumber(10).pow(networkDecimals))
                   .toFixed(0);

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -3,11 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type AccountKey } from '@suite-common/wallet-types';
-import {
-    asAmountUnit,
-    isSupportedSolStakingNetworkSymbol,
-    unitsToSubunits,
-} from '@suite-common/wallet-utils';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { VStack } from '@suite-native/atoms';
 import {
     LIST_VERTICAL_SPACING,
@@ -17,11 +13,12 @@ import {
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
-import { BigNumber } from '@trezor/utils';
 
 import { EarnStakeOutputItem } from './EarnStakeOutputItem';
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
+import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
+import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
 
 type EarnTransactionDataReviewStepListProps = {
     accountKey: AccountKey;
@@ -49,17 +46,12 @@ export const EarnTransactionDataReviewStepList = ({
 
     const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
 
-    const amountInBaseUnits = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(amount)),
-        symbol: accountSymbol,
-    }).toString();
+    const amountInBaseUnits = getAmountInBaseUnits(amount, accountSymbol);
 
     const isSolanaStake = isSupportedSolStakingNetworkSymbol(accountSymbol);
     const displayedAmountInBaseUnits =
         isSolanaStake && selectedPrecomposed
-            ? new BigNumber(selectedPrecomposed.totalSpent)
-                  .minus(selectedPrecomposed.fee)
-                  .toFixed(0)
+            ? getSolanaPrecomposedNetAmount(selectedPrecomposed)
             : amountInBaseUnits;
 
     return (

--- a/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/EarnTransactionDataReviewStepList.tsx
@@ -18,7 +18,7 @@ import { EarnStakeOutputItem } from './EarnStakeOutputItem';
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
-import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
+import { getEarnPendingAmountInBaseUnits } from '../utils/getEarnPendingAmountInBaseUnits';
 
 type EarnTransactionDataReviewStepListProps = {
     accountKey: AccountKey;
@@ -46,13 +46,12 @@ export const EarnTransactionDataReviewStepList = ({
 
     const { activeStepBottomOffset, handleReadListItemHeight } = useActiveStepOffset(activeStep);
 
-    const amountInBaseUnits = getAmountInBaseUnits(amount, accountSymbol);
-
     const isSolanaStake = isSupportedSolStakingNetworkSymbol(accountSymbol);
-    const displayedAmountInBaseUnits =
-        isSolanaStake && selectedPrecomposed
-            ? getSolanaPrecomposedNetAmount(selectedPrecomposed)
-            : amountInBaseUnits;
+    const displayedAmountInBaseUnits = getEarnPendingAmountInBaseUnits({
+        fallbackAmountInBaseUnits: getAmountInBaseUnits(amount, accountSymbol),
+        isSolanaStaking: isSolanaStake,
+        precomposedTransaction: selectedPrecomposed,
+    });
 
     return (
         <View>

--- a/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
+++ b/suite-native/module-earn/src/components/UnstakeTransactionDataReviewStepList.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { type RouteProp, useRoute } from '@react-navigation/native';
 
 import { type AccountsRootState, selectAccountNetworkSymbol } from '@suite-common/wallet-core';
-import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { VStack } from '@suite-native/atoms';
 import { type RootStackParamList, type RootStackRoutes } from '@suite-native/navigation';
 import {
@@ -15,11 +14,11 @@ import {
     selectReviewSummaryOutput,
     useActiveStepOffset,
 } from '@suite-native/transaction-management';
-import { BigNumber } from '@trezor/utils';
 
 import { EarnSummaryOutputItem } from './EarnSummaryOutputItem';
 import { UnstakeOutputItem } from './UnstakeOutputItem';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
+import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
 
 type RouteProps = RouteProp<RootStackParamList, RootStackRoutes.UnstakeTransactionDataReview>;
 
@@ -50,10 +49,7 @@ export const UnstakeTransactionDataReviewStepList = () => {
         return null;
     }
 
-    const amountInBaseUnits = unitsToSubunits({
-        value: asAmountUnit(new BigNumber(amount)),
-        symbol: accountSymbol,
-    }).toString();
+    const amountInBaseUnits = getAmountInBaseUnits(amount, accountSymbol);
 
     return (
         <View>

--- a/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
+++ b/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
@@ -14,20 +14,24 @@ import { useFormatters } from '@suite-common/formatters';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type TokenAddress, type TokenSymbol } from '@suite-common/wallet-types';
 import {
-    Badge,
     BottomSheetModal,
     type BottomSheetModalRef,
     Box,
-    Button,
     Card,
     CircularSpinner,
     HStack,
+    IconButton,
     Text,
     VStack,
 } from '@suite-native/atoms';
-import { CryptoAmountFormatter, CryptoToFiatAmountFormatter } from '@suite-native/formatters';
+import { useCopyToClipboard } from '@suite-native/clipboard';
+import {
+    CryptoAmountFormatter,
+    CryptoToFiatAmountFormatter,
+    TransactionIdFormatter,
+} from '@suite-native/formatters';
 import { Icon, NetworkIcon, TokenIcon } from '@suite-native/icons';
-import { Translation } from '@suite-native/intl';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { YieldPendingTransactionModalBackdrop } from './YieldPendingTransactionModalBackdrop';
@@ -46,10 +50,10 @@ type YieldPendingTransactionModalProps = {
     isExploreDisabled?: boolean;
     onDismiss?: () => void;
     onExplorePress: () => void;
-    pendingLabel?: ReactNode;
     ref: BottomSheetModalRef;
     submittedAt: Date;
     title: ReactNode;
+    txid: string;
     vaultName?: string;
     vaultTokenContract?: TokenAddress;
 };
@@ -69,9 +73,9 @@ const valueStyle = prepareNativeStyle(() => ({
     flexShrink: 1,
 }));
 
-const constrainedValueTextStyle = prepareNativeStyle(() => ({
-    minWidth: 0,
-    flexShrink: 1,
+const roundNetworkIconStyle = prepareNativeStyle(utils => ({
+    borderRadius: utils.borders.radii.round,
+    overflow: 'hidden',
 }));
 
 const getBottomSheet = (ref: BottomSheetModalRef): BottomSheetModalMethods | null => {
@@ -99,17 +103,19 @@ export const YieldPendingTransactionModal = ({
     isExploreDisabled,
     onDismiss,
     onExplorePress,
-    pendingLabel = <Translation id="moduleTrading.tradingConfirmationScreen.pending" />,
     ref,
     submittedAt,
     title,
+    txid,
     vaultName,
     vaultTokenContract,
 }: YieldPendingTransactionModalProps) => {
     const { applyStyle } = useNativeStyles();
     const { DateFormatter, TimeFormatter } = useFormatters();
+    const { translate } = useTranslate();
+    const copyToClipboard = useCopyToClipboard();
     const animatedIndex = useSharedValue<number>(modalSnap.expandedIndex);
-    const snapPoints = useMemo(() => [modalSnap.collapsedHeight, modalSnap.expandedHeight], []);
+    const snapPoints = useMemo(() => [modalSnap.collapsedHeight], []);
     const caretAnimatedStyle = useAnimatedStyle(() => {
         const rotation = interpolate(
             animatedIndex.value,
@@ -139,13 +145,24 @@ export const YieldPendingTransactionModal = ({
         [],
     );
 
+    const handleCopyTxid = useCallback(
+        () =>
+            copyToClipboard(
+                txid,
+                translate(
+                    'transactions.TransactionDetailScreen.parametersSheet.transactionIdCopied',
+                ),
+            ),
+        [copyToClipboard, translate, txid],
+    );
+
     return (
         <BottomSheetModal
             ref={ref}
             onDismiss={onDismiss}
             bottomSheetCustomProps={{
                 backdropComponent: renderBackdrop,
-                enableDynamicSizing: false,
+                enableDynamicSizing: true,
                 enablePanDownToClose: false,
                 handleComponent: () => (
                     <YieldPendingTransactionModalHeader
@@ -161,13 +178,12 @@ export const YieldPendingTransactionModal = ({
             }}
         >
             <VStack spacing="sp16" paddingBottom="sp16">
-                <VStack spacing="sp12" alignItems="center">
-                    <Badge intent="warning" label={pendingLabel} />
+                <Box alignItems="center">
                     <Box style={applyStyle(pendingIconStyle)}>
                         <CircularSpinner size={56} color="elementFillWarningBold" width={2} />
                         <Icon name="arrowUp" color="contentPrimary" size="large" />
                     </Box>
-                </VStack>
+                </Box>
 
                 <Card noPadding>
                     <YieldPendingTransactionModalRow
@@ -220,7 +236,7 @@ export const YieldPendingTransactionModal = ({
                                     color="contentPrimary"
                                     numberOfLines={1}
                                     ellipsizeMode="tail"
-                                    style={applyStyle(constrainedValueTextStyle)}
+                                    style={applyStyle(valueStyle)}
                                 >
                                     {vaultName}
                                 </Text>
@@ -246,15 +262,24 @@ export const YieldPendingTransactionModal = ({
                                         color="contentPrimary"
                                         numberOfLines={1}
                                         ellipsizeMode="tail"
-                                        style={applyStyle(constrainedValueTextStyle)}
+                                        style={applyStyle(valueStyle)}
                                     >
                                         {amount} {amountTokenSymbol}
                                     </Text>
                                 </HStack>
                             ) : (
-                                <Text variant="body-sm" color="contentPrimary">
-                                    {amount}
-                                </Text>
+                                <HStack
+                                    spacing="sp4"
+                                    alignItems="center"
+                                    style={applyStyle(valueStyle)}
+                                >
+                                    <Box style={applyStyle(roundNetworkIconStyle)}>
+                                        <NetworkIcon symbol={accountSymbol} size={20} />
+                                    </Box>
+                                    <Text variant="body-sm" color="contentPrimary">
+                                        {amount}
+                                    </Text>
+                                </HStack>
                             )}
                         </YieldPendingTransactionModalRow>
                     )}
@@ -287,17 +312,42 @@ export const YieldPendingTransactionModal = ({
                             </Text>
                         )}
                     </YieldPendingTransactionModalRow>
-                </Card>
 
-                <Button
-                    iconRight="arrowUpRight"
-                    intent="neutral"
-                    priority="secondary"
-                    isDisabled={isExploreDisabled}
-                    onPress={onExplorePress}
-                >
-                    <Translation id="moduleTrading.tradingConfirmationScreen.exploreInBlockchain" />
-                </Button>
+                    <YieldPendingTransactionModalRow
+                        label={
+                            <Translation id="moduleTrading.tradingConfirmationScreen.transactionId" />
+                        }
+                    >
+                        <HStack spacing="sp4" alignItems="center" style={applyStyle(valueStyle)}>
+                            <TransactionIdFormatter
+                                value={txid}
+                                color="contentPrimary"
+                                style={applyStyle(valueStyle)}
+                            />
+                            <IconButton
+                                iconName="copy"
+                                onPress={handleCopyTxid}
+                                intent="neutral"
+                                priority="secondary"
+                                size="small"
+                                accessibilityLabel={translate(
+                                    'transactions.TransactionDetailScreen.parametersSheet.transactionId',
+                                )}
+                            />
+                            <IconButton
+                                iconName="arrowUpRight"
+                                onPress={onExplorePress}
+                                isDisabled={isExploreDisabled}
+                                intent="neutral"
+                                priority="secondary"
+                                size="small"
+                                accessibilityLabel={translate(
+                                    'moduleTrading.tradingConfirmationScreen.exploreInBlockchain',
+                                )}
+                            />
+                        </HStack>
+                    </YieldPendingTransactionModalRow>
+                </Card>
             </VStack>
         </BottomSheetModal>
     );

--- a/suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts
+++ b/suite-native/module-earn/src/components/YieldPendingTransactionModalConstants.ts
@@ -2,7 +2,6 @@ export const modalSnap = {
     collapsedIndex: 0,
     expandedIndex: 1,
     collapsedHeight: 148,
-    expandedHeight: 592,
     indexMidpoint: 0.5,
     collapsedBackdropOpacity: 0,
     expandedBackdropOpacity: 0.5,

--- a/suite-native/module-earn/src/hooks/useEarnAccountLabel.ts
+++ b/suite-native/module-earn/src/hooks/useEarnAccountLabel.ts
@@ -1,0 +1,16 @@
+import { useSelector } from 'react-redux';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import { type Account } from '@suite-common/wallet-types';
+import { selectAccountLabel } from '@suite-native/accounts';
+import { type CombinedLabelingState } from '@suite-native/labeling';
+
+export const useEarnAccountLabel = (account: Account | null | undefined) => {
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        account
+            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
+            : null,
+    );
+
+    return account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
+};

--- a/suite-native/module-earn/src/hooks/useEarnPendingTransactionSheet.ts
+++ b/suite-native/module-earn/src/hooks/useEarnPendingTransactionSheet.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+
+import { type AccountKey } from '@suite-common/wallet-types';
+import { useBottomSheetModal } from '@suite-native/atoms';
+import { useTransactionDetails } from '@suite-native/transaction-management';
+
+type UseEarnPendingTransactionSheetParams = {
+    accountKey: AccountKey;
+    isPending: boolean;
+    pendingTxid: string | undefined;
+};
+
+export const useEarnPendingTransactionSheet = ({
+    accountKey,
+    isPending,
+    pendingTxid,
+}: UseEarnPendingTransactionSheetParams) => {
+    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
+        useBottomSheetModal();
+
+    useEffect(() => {
+        if (isPending) {
+            openPendingBottomSheet();
+        }
+    }, [isPending, openPendingBottomSheet]);
+
+    const { explorerUrl, openInBlockchain } = useTransactionDetails({
+        accountKey,
+        txid: pendingTxid ?? null,
+    });
+
+    return {
+        pendingBottomSheetRef,
+        isExploreDisabled: !explorerUrl,
+        openInBlockchain,
+    };
+};

--- a/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useNavigateAfterPushedTransaction.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { CommonActions, useNavigation } from '@react-navigation/native';
@@ -15,7 +15,10 @@ import {
     sendFormActions,
 } from '@suite-common/wallet-core';
 import { type AccountKey } from '@suite-common/wallet-types';
-import { getPollIntervalMs } from '@suite-common/wallet-utils';
+import {
+    getPollIntervalMs,
+    isPending as isTransactionDataPending,
+} from '@suite-common/wallet-utils';
 import {
     AppTabsRoutes,
     type RootStackParamList,
@@ -74,21 +77,23 @@ export const useNavigateAfterPushedTransaction = ({
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
     const [txid, setTxid] = useState('');
+    const [submittedAt, setSubmittedAt] = useState<Date | null>(null);
 
     const networkSymbol = useSelector((state: AccountsRootState) =>
         selectAccountNetworkSymbol(state, accountKey),
     );
 
-    const isTransactionProcessedByBackend = !!useSelector((state: TransactionsRootState) =>
+    const transaction = useSelector((state: TransactionsRootState) =>
         selectTransactionByAccountKeyAndTxid(state, accountKey, txid),
     );
+    const isTransactionConfirmed = !!transaction && !isTransactionDataPending(transaction);
 
     const feeInfo = useSelector((state: FeesRootState) =>
         networkSymbol ? selectConvertedNetworkFeeInfo(state, networkSymbol) : null,
     );
     const pollIntervalMs = getPollIntervalMs(feeInfo?.blockTime);
 
-    const shouldPollPendingTransaction = !!txid && !isTransactionProcessedByBackend;
+    const shouldPollPendingTransaction = !!txid && !isTransactionConfirmed;
 
     useEffect(() => {
         if (!shouldPollPendingTransaction) {
@@ -103,7 +108,7 @@ export const useNavigateAfterPushedTransaction = ({
     }, [accountKey, dispatch, pollIntervalMs, shouldPollPendingTransaction]);
 
     useEffect(() => {
-        if (txid && isTransactionProcessedByBackend && networkSymbol) {
+        if (txid && isTransactionConfirmed && networkSymbol) {
             markReviewNavigationSuccess();
             navigation.dispatch(
                 navigateToPushedTransactionAction({ accountKey, symbol: networkSymbol, txid }),
@@ -111,7 +116,7 @@ export const useNavigateAfterPushedTransaction = ({
         }
     }, [
         accountKey,
-        isTransactionProcessedByBackend,
+        isTransactionConfirmed,
         markReviewNavigationSuccess,
         navigation,
         networkSymbol,
@@ -126,5 +131,15 @@ export const useNavigateAfterPushedTransaction = ({
         };
     }, [txid, dispatch]);
 
-    return { trackPushedTransaction: setTxid };
+    const trackPushedTransaction = useCallback((pushedTxid: string) => {
+        setTxid(pushedTxid);
+        setSubmittedAt(new Date());
+    }, []);
+
+    return {
+        trackPushedTransaction,
+        pendingTxid: txid || undefined,
+        isPending: shouldPollPendingTransaction,
+        submittedAt,
+    };
 };

--- a/suite-native/module-earn/src/hooks/useYieldDepositRevokeScreen.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositRevokeScreen.ts
@@ -338,6 +338,7 @@ export const useYieldDepositRevokeScreen = () => {
                   isExploreDisabled: pendingModalProps.isExploreDisabled,
                   onExplorePress: pendingModalProps.onExplorePress,
                   submittedAt: pendingModalProps.submittedAt,
+                  txid: pendingModalProps.txid,
               }
             : null;
 

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
@@ -57,6 +57,7 @@ export const useYieldPendingTransaction = ({
                   onDismiss: handleSheetDismissed,
                   onExplorePress: openInBlockchain,
                   submittedAt: new Date(displayedPendingTransaction.submittedAt ?? 0),
+                  txid: displayedPendingTransaction.txid,
               }
             : null;
 

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -1,44 +1,43 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getNetwork, getNetworkDecimals } from '@suite-common/wallet-config';
+import { getNetworkDecimals } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { selectAccountLabel } from '@suite-native/accounts';
-import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
-import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     ScreenHeader,
     type StackProps,
 } from '@suite-native/navigation';
+import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     selectClaimableAmountByAccountKey,
     useSelector as useNativeStakingSelector,
 } from '@suite-native/staking';
-import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
-    useTransactionDetails,
 } from '@suite-native/transaction-management';
 import { BigNumber } from '@trezor/utils';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
+import { useEarnAccountLabel } from '../hooks/useEarnAccountLabel';
+import { useEarnPendingTransactionSheet } from '../hooks/useEarnPendingTransactionSheet';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
-import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
+import { getEarnPendingAmountInBaseUnits } from '../utils/getEarnPendingAmountInBaseUnits';
 
 export const ClaimTransactionDataReviewScreen = ({
     route,
@@ -55,11 +54,7 @@ export const ClaimTransactionDataReviewScreen = ({
         selectAccountByKey(state, accountKey),
     );
 
-    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
-        account
-            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
-            : null,
-    );
+    const accountLabel = useEarnAccountLabel(account);
 
     const claimableAmount = useNativeStakingSelector(state =>
         selectClaimableAmountByAccountKey(state, accountKey),
@@ -79,19 +74,8 @@ export const ClaimTransactionDataReviewScreen = ({
             markReviewNavigationSuccess,
         });
 
-    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
-        useBottomSheetModal();
-
-    useEffect(() => {
-        if (isPending) {
-            openPendingBottomSheet();
-        }
-    }, [isPending, openPendingBottomSheet]);
-
-    const { explorerUrl, openInBlockchain } = useTransactionDetails({
-        accountKey,
-        txid: pendingTxid ?? null,
-    });
+    const { pendingBottomSheetRef, isExploreDisabled, openInBlockchain } =
+        useEarnPendingTransactionSheet({ accountKey, isPending, pendingTxid });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({
@@ -135,16 +119,16 @@ export const ClaimTransactionDataReviewScreen = ({
         setIsPushing(false);
     }, [claimableAmount, handlePush, trackPushedTransaction]);
 
-    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
-
     const networkDecimals = account ? (getNetworkDecimals(account.symbol) ?? 18) : 18;
     const isSolanaClaim = !!account && isSupportedSolStakingNetworkSymbol(account.symbol);
-    const pendingAmountInBaseUnits =
-        isSolanaClaim && precomposedTransaction
-            ? getSolanaPrecomposedNetAmount(precomposedTransaction)
-            : new BigNumber(frozenClaimableAmount ?? claimableAmount ?? '0')
-                  .times(new BigNumber(10).pow(networkDecimals))
-                  .toFixed(0);
+
+    const pendingAmountInBaseUnits = getEarnPendingAmountInBaseUnits({
+        fallbackAmountInBaseUnits: new BigNumber(frozenClaimableAmount ?? claimableAmount ?? '0')
+            .times(new BigNumber(10).pow(networkDecimals))
+            .toFixed(0),
+        isSolanaStaking: isSolanaClaim,
+        precomposedTransaction,
+    });
 
     return (
         <ConfirmOnTrezorWrapper
@@ -191,7 +175,7 @@ export const ClaimTransactionDataReviewScreen = ({
                 )}
             </VStack>
 
-            {isPending && pendingTxid && submittedAt && account && (
+            {isPending && !!pendingTxid && !!submittedAt && !!account && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
@@ -209,7 +193,7 @@ export const ClaimTransactionDataReviewScreen = ({
                         <Translation id="earn.claimTransactionDataReviewScreen.amountLabel" />
                     }
                     fee={precomposedTransaction?.fee}
-                    isExploreDisabled={!explorerUrl}
+                    isExploreDisabled={isExploreDisabled}
                     onExplorePress={openInBlockchain}
                     submittedAt={submittedAt}
                     title={<Translation id="earn.claimTransactionDataReviewScreen.pendingTitle" />}

--- a/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/ClaimTransactionDataReviewScreen.tsx
@@ -1,31 +1,44 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getNetwork, getNetworkDecimals } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { Button, Text, VStack } from '@suite-native/atoms';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
+import { selectAccountLabel } from '@suite-native/accounts';
+import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
+import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
     ScreenHeader,
     type StackProps,
 } from '@suite-native/navigation';
+import {
+    selectClaimableAmountByAccountKey,
+    useSelector as useNativeStakingSelector,
+} from '@suite-native/staking';
 import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
+    useTransactionDetails,
 } from '@suite-native/transaction-management';
+import { BigNumber } from '@trezor/utils';
 
 import { ClaimTransactionDataReviewStepList } from '../components/ClaimTransactionDataReviewStepList';
+import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
+import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
 
 export const ClaimTransactionDataReviewScreen = ({
     route,
@@ -34,11 +47,22 @@ export const ClaimTransactionDataReviewScreen = ({
         useConfirmOnTrezorController();
     const { accountKey } = route.params;
     const [isPushing, setIsPushing] = useState(false);
+    const [frozenClaimableAmount, setFrozenClaimableAmount] = useState<string | null>(null);
 
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
+    );
+
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        account
+            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
+            : null,
+    );
+
+    const claimableAmount = useNativeStakingSelector(state =>
+        selectClaimableAmountByAccountKey(state, accountKey),
     );
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('claim', accountKey);
@@ -49,9 +73,24 @@ export const ClaimTransactionDataReviewScreen = ({
             stakeType: 'claim',
         });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+    const { trackPushedTransaction, pendingTxid, isPending, submittedAt } =
+        useNavigateAfterPushedTransaction({
+            accountKey,
+            markReviewNavigationSuccess,
+        });
+
+    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
+        useBottomSheetModal();
+
+    useEffect(() => {
+        if (isPending) {
+            openPendingBottomSheet();
+        }
+    }, [isPending, openPendingBottomSheet]);
+
+    const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey,
-        markReviewNavigationSuccess,
+        txid: pendingTxid ?? null,
     });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
@@ -83,6 +122,7 @@ export const ClaimTransactionDataReviewScreen = ({
 
     const handleClaimNow = useCallback(async () => {
         setIsPushing(true);
+        setFrozenClaimableAmount(claimableAmount ?? null);
 
         const pushedTxid = await handlePush();
 
@@ -93,7 +133,18 @@ export const ClaimTransactionDataReviewScreen = ({
         }
 
         setIsPushing(false);
-    }, [handlePush, trackPushedTransaction]);
+    }, [claimableAmount, handlePush, trackPushedTransaction]);
+
+    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
+
+    const networkDecimals = account ? (getNetworkDecimals(account.symbol) ?? 18) : 18;
+    const isSolanaClaim = !!account && isSupportedSolStakingNetworkSymbol(account.symbol);
+    const pendingAmountInBaseUnits =
+        isSolanaClaim && precomposedTransaction
+            ? getSolanaPrecomposedNetAmount(precomposedTransaction)
+            : new BigNumber(frozenClaimableAmount ?? claimableAmount ?? '0')
+                  .times(new BigNumber(10).pow(networkDecimals))
+                  .toFixed(0);
 
     return (
         <ConfirmOnTrezorWrapper
@@ -139,6 +190,32 @@ export const ClaimTransactionDataReviewScreen = ({
                     </ScrollToEndOnMount>
                 )}
             </VStack>
+
+            {isPending && pendingTxid && submittedAt && account && (
+                <YieldPendingTransactionModal
+                    ref={pendingBottomSheetRef}
+                    accountLabel={accountLabel}
+                    accountSymbol={account.symbol}
+                    amount={
+                        <CryptoAmountFormatter
+                            value={pendingAmountInBaseUnits}
+                            symbol={account.symbol}
+                            color="contentPrimary"
+                            isBalance={false}
+                            isDiscreetText={false}
+                        />
+                    }
+                    amountLabel={
+                        <Translation id="earn.claimTransactionDataReviewScreen.amountLabel" />
+                    }
+                    fee={precomposedTransaction?.fee}
+                    isExploreDisabled={!explorerUrl}
+                    onExplorePress={openInBlockchain}
+                    submittedAt={submittedAt}
+                    title={<Translation id="earn.claimTransactionDataReviewScreen.pendingTitle" />}
+                    txid={pendingTxid}
+                />
+            )}
         </ConfirmOnTrezorWrapper>
     );
 };

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -1,18 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
-import { selectAccountLabel } from '@suite-native/accounts';
-import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
-import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -23,18 +20,19 @@ import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
-    useTransactionDetails,
 } from '@suite-native/transaction-management';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
+import { useEarnAccountLabel } from '../hooks/useEarnAccountLabel';
+import { useEarnPendingTransactionSheet } from '../hooks/useEarnPendingTransactionSheet';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
 import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
-import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
+import { getEarnPendingAmountInBaseUnits } from '../utils/getEarnPendingAmountInBaseUnits';
 
 export const EarnTransactionDataReviewScreen = ({
     route,
@@ -50,11 +48,7 @@ export const EarnTransactionDataReviewScreen = ({
         selectAccountByKey(state, accountKey),
     );
 
-    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
-        account
-            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
-            : null,
-    );
+    const accountLabel = useEarnAccountLabel(account);
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
@@ -70,19 +64,8 @@ export const EarnTransactionDataReviewScreen = ({
             markReviewNavigationSuccess,
         });
 
-    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
-        useBottomSheetModal();
-
-    useEffect(() => {
-        if (isPending) {
-            openPendingBottomSheet();
-        }
-    }, [isPending, openPendingBottomSheet]);
-
-    const { explorerUrl, openInBlockchain } = useTransactionDetails({
-        accountKey,
-        txid: pendingTxid ?? null,
-    });
+    const { pendingBottomSheetRef, isExploreDisabled, openInBlockchain } =
+        useEarnPendingTransactionSheet({ accountKey, isPending, pendingTxid });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({
@@ -124,17 +107,13 @@ export const EarnTransactionDataReviewScreen = ({
         setIsPushing(false);
     }, [handlePush, trackPushedTransaction]);
 
-    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
-
     const isSolanaStake = !!account && isSupportedSolStakingNetworkSymbol(account.symbol);
 
-    let pendingAmountInBaseUnits = '0';
-
-    if (isSolanaStake && precomposedTransaction) {
-        pendingAmountInBaseUnits = getSolanaPrecomposedNetAmount(precomposedTransaction);
-    } else if (account) {
-        pendingAmountInBaseUnits = getAmountInBaseUnits(amount, account.symbol);
-    }
+    const pendingAmountInBaseUnits = getEarnPendingAmountInBaseUnits({
+        fallbackAmountInBaseUnits: account ? getAmountInBaseUnits(amount, account.symbol) : '0',
+        isSolanaStaking: isSolanaStake,
+        precomposedTransaction,
+    });
 
     return (
         <ConfirmOnTrezorWrapper
@@ -187,7 +166,7 @@ export const EarnTransactionDataReviewScreen = ({
                 )}
             </VStack>
 
-            {isPending && pendingTxid && submittedAt && account && (
+            {isPending && !!pendingTxid && !!submittedAt && !!account && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
@@ -205,7 +184,7 @@ export const EarnTransactionDataReviewScreen = ({
                         <Translation id="earn.earnTransactionDataReviewScreen.amountLabel" />
                     }
                     fee={precomposedTransaction?.fee}
-                    isExploreDisabled={!explorerUrl}
+                    isExploreDisabled={isExploreDisabled}
                     onExplorePress={openInBlockchain}
                     submittedAt={submittedAt}
                     title={<Translation id="earn.earnTransactionDataReviewScreen.pendingTitle" />}

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -3,11 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import {
-    asAmountUnit,
-    isSupportedSolStakingNetworkSymbol,
-    unitsToSubunits,
-} from '@suite-common/wallet-utils';
+import { isSupportedSolStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { selectAccountLabel } from '@suite-native/accounts';
 import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import {
@@ -29,7 +25,6 @@ import {
     selectIsTransactionAlreadySigned,
     useTransactionDetails,
 } from '@suite-native/transaction-management';
-import { BigNumber } from '@trezor/utils';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
@@ -38,6 +33,7 @@ import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedP
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
+import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
 import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
 
 export const EarnTransactionDataReviewScreen = ({
@@ -137,10 +133,7 @@ export const EarnTransactionDataReviewScreen = ({
     if (isSolanaStake && precomposedTransaction) {
         pendingAmountInBaseUnits = getSolanaPrecomposedNetAmount(precomposedTransaction);
     } else if (account) {
-        pendingAmountInBaseUnits = unitsToSubunits({
-            value: asAmountUnit(new BigNumber(amount)),
-            symbol: account.symbol,
-        }).toString();
+        pendingAmountInBaseUnits = getAmountInBaseUnits(amount, account.symbol);
     }
 
     return (

--- a/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/EarnTransactionDataReviewScreen.tsx
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { Button, Text, VStack } from '@suite-native/atoms';
+import {
+    asAmountUnit,
+    isSupportedSolStakingNetworkSymbol,
+    unitsToSubunits,
+} from '@suite-common/wallet-utils';
+import { selectAccountLabel } from '@suite-native/accounts';
+import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
+import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -18,14 +27,18 @@ import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
+    useTransactionDetails,
 } from '@suite-native/transaction-management';
+import { BigNumber } from '@trezor/utils';
 
 import { EarnTransactionDataReviewStepList } from '../components/EarnTransactionDataReviewStepList';
+import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
+import { getSolanaPrecomposedNetAmount } from '../utils/getSolanaPrecomposedNetAmount';
 
 export const EarnTransactionDataReviewScreen = ({
     route,
@@ -41,6 +54,12 @@ export const EarnTransactionDataReviewScreen = ({
         selectAccountByKey(state, accountKey),
     );
 
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        account
+            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
+            : null,
+    );
+
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('stake', accountKey);
 
     const { handleSign, handlePush, closeReview, markReviewNavigationSuccess } =
@@ -49,9 +68,24 @@ export const EarnTransactionDataReviewScreen = ({
             stakeType: 'stake',
         });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+    const { trackPushedTransaction, pendingTxid, isPending, submittedAt } =
+        useNavigateAfterPushedTransaction({
+            accountKey,
+            markReviewNavigationSuccess,
+        });
+
+    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
+        useBottomSheetModal();
+
+    useEffect(() => {
+        if (isPending) {
+            openPendingBottomSheet();
+        }
+    }, [isPending, openPendingBottomSheet]);
+
+    const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey,
-        markReviewNavigationSuccess,
+        txid: pendingTxid ?? null,
     });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
@@ -93,6 +127,21 @@ export const EarnTransactionDataReviewScreen = ({
 
         setIsPushing(false);
     }, [handlePush, trackPushedTransaction]);
+
+    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
+
+    const isSolanaStake = !!account && isSupportedSolStakingNetworkSymbol(account.symbol);
+
+    let pendingAmountInBaseUnits = '0';
+
+    if (isSolanaStake && precomposedTransaction) {
+        pendingAmountInBaseUnits = getSolanaPrecomposedNetAmount(precomposedTransaction);
+    } else if (account) {
+        pendingAmountInBaseUnits = unitsToSubunits({
+            value: asAmountUnit(new BigNumber(amount)),
+            symbol: account.symbol,
+        }).toString();
+    }
 
     return (
         <ConfirmOnTrezorWrapper
@@ -144,6 +193,32 @@ export const EarnTransactionDataReviewScreen = ({
                     </ScrollToEndOnMount>
                 )}
             </VStack>
+
+            {isPending && pendingTxid && submittedAt && account && (
+                <YieldPendingTransactionModal
+                    ref={pendingBottomSheetRef}
+                    accountLabel={accountLabel}
+                    accountSymbol={account.symbol}
+                    amount={
+                        <CryptoAmountFormatter
+                            value={pendingAmountInBaseUnits}
+                            symbol={account.symbol}
+                            color="contentPrimary"
+                            isBalance={false}
+                            isDiscreetText={false}
+                        />
+                    }
+                    amountLabel={
+                        <Translation id="earn.earnTransactionDataReviewScreen.amountLabel" />
+                    }
+                    fee={precomposedTransaction?.fee}
+                    isExploreDisabled={!explorerUrl}
+                    onExplorePress={openInBlockchain}
+                    submittedAt={submittedAt}
+                    title={<Translation id="earn.earnTransactionDataReviewScreen.pendingTitle" />}
+                    txid={pendingTxid}
+                />
+            )}
         </ConfirmOnTrezorWrapper>
     );
 };

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 
 import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
 import { selectAccountLabel } from '@suite-native/accounts';
 import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import {
@@ -25,7 +24,6 @@ import {
     selectIsTransactionAlreadySigned,
     useTransactionDetails,
 } from '@suite-native/transaction-management';
-import { BigNumber } from '@trezor/utils';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
@@ -34,6 +32,7 @@ import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedP
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
 import { useHandleOnEarnTransactionReview } from '../hooks/useHandleOnEarnTransactionReview';
 import { useNavigateAfterPushedTransaction } from '../hooks/useNavigateAfterPushedTransaction';
+import { getAmountInBaseUnits } from '../utils/getAmountInBaseUnits';
 
 export const UnstakeTransactionDataReviewScreen = ({
     route,
@@ -125,12 +124,7 @@ export const UnstakeTransactionDataReviewScreen = ({
 
     const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
 
-    const pendingAmountInBaseUnits = account
-        ? unitsToSubunits({
-              value: asAmountUnit(new BigNumber(amount)),
-              symbol: account.symbol,
-          }).toString()
-        : '0';
+    const pendingAmountInBaseUnits = account ? getAmountInBaseUnits(amount, account.symbol) : '0';
 
     return (
         <ConfirmOnTrezorWrapper

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { Button, Text, VStack } from '@suite-native/atoms';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import { selectAccountLabel } from '@suite-native/accounts';
+import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
+import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
+import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -18,9 +23,12 @@ import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
+    useTransactionDetails,
 } from '@suite-native/transaction-management';
+import { BigNumber } from '@trezor/utils';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
+import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
@@ -32,13 +40,19 @@ export const UnstakeTransactionDataReviewScreen = ({
 }: StackProps<RootStackParamList, RootStackRoutes.UnstakeTransactionDataReview>) => {
     const { confirmOnTrezorRef, revealConfirmOnTrezorSheet, closeSheet } =
         useConfirmOnTrezorController();
-    const { accountKey } = route.params;
+    const { accountKey, amount } = route.params;
     const [isPushing, setIsPushing] = useState(false);
 
     const isTransactionAlreadySigned = useSelector(selectIsTransactionAlreadySigned);
 
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
+    );
+
+    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
+        account
+            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
+            : null,
     );
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
@@ -49,9 +63,24 @@ export const UnstakeTransactionDataReviewScreen = ({
             stakeType: 'unstake',
         });
 
-    const { trackPushedTransaction } = useNavigateAfterPushedTransaction({
+    const { trackPushedTransaction, pendingTxid, isPending, submittedAt } =
+        useNavigateAfterPushedTransaction({
+            accountKey,
+            markReviewNavigationSuccess,
+        });
+
+    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
+        useBottomSheetModal();
+
+    useEffect(() => {
+        if (isPending) {
+            openPendingBottomSheet();
+        }
+    }, [isPending, openPendingBottomSheet]);
+
+    const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey,
-        markReviewNavigationSuccess,
+        txid: pendingTxid ?? null,
     });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
@@ -93,6 +122,15 @@ export const UnstakeTransactionDataReviewScreen = ({
 
         setIsPushing(false);
     }, [handlePush, trackPushedTransaction]);
+
+    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
+
+    const pendingAmountInBaseUnits = account
+        ? unitsToSubunits({
+              value: asAmountUnit(new BigNumber(amount)),
+              symbol: account.symbol,
+          }).toString()
+        : '0';
 
     return (
         <ConfirmOnTrezorWrapper
@@ -138,6 +176,34 @@ export const UnstakeTransactionDataReviewScreen = ({
                     </ScrollToEndOnMount>
                 )}
             </VStack>
+
+            {isPending && pendingTxid && submittedAt && account && (
+                <YieldPendingTransactionModal
+                    ref={pendingBottomSheetRef}
+                    accountLabel={accountLabel}
+                    accountSymbol={account.symbol}
+                    amount={
+                        <CryptoAmountFormatter
+                            value={pendingAmountInBaseUnits}
+                            symbol={account.symbol}
+                            color="contentPrimary"
+                            isBalance={false}
+                            isDiscreetText={false}
+                        />
+                    }
+                    amountLabel={
+                        <Translation id="earn.unstakeTransactionDataReviewScreen.amountLabel" />
+                    }
+                    fee={precomposedTransaction?.fee}
+                    isExploreDisabled={!explorerUrl}
+                    onExplorePress={openInBlockchain}
+                    submittedAt={submittedAt}
+                    title={
+                        <Translation id="earn.unstakeTransactionDataReviewScreen.pendingTitle" />
+                    }
+                    txid={pendingTxid}
+                />
+            )}
         </ConfirmOnTrezorWrapper>
     );
 };

--- a/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnstakeTransactionDataReviewScreen.tsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import { getNetwork } from '@suite-common/wallet-config';
 import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
-import { selectAccountLabel } from '@suite-native/accounts';
-import { Button, Text, VStack, useBottomSheetModal } from '@suite-native/atoms';
+import { Button, Text, VStack } from '@suite-native/atoms';
 import {
     ConfirmOnTrezorWrapper,
     useConfirmOnTrezorController,
 } from '@suite-native/confirm-on-trezor';
 import { CryptoAmountFormatter } from '@suite-native/formatters';
 import { Translation } from '@suite-native/intl';
-import { type CombinedLabelingState } from '@suite-native/labeling';
 import {
     type RootStackParamList,
     type RootStackRoutes,
@@ -22,11 +19,12 @@ import { ScrollToEndOnMount } from '@suite-native/scrollview';
 import {
     TxValidityTimer,
     selectIsTransactionAlreadySigned,
-    useTransactionDetails,
 } from '@suite-native/transaction-management';
 
 import { UnstakeTransactionDataReviewStepList } from '../components/UnstakeTransactionDataReviewStepList';
 import { YieldPendingTransactionModal } from '../components/YieldPendingTransactionModal';
+import { useEarnAccountLabel } from '../hooks/useEarnAccountLabel';
+import { useEarnPendingTransactionSheet } from '../hooks/useEarnPendingTransactionSheet';
 import { useEarnReviewAutoStart } from '../hooks/useEarnReviewAutoStart';
 import { useEarnSelectedPrecomposedTransaction } from '../hooks/useEarnSelectedPrecomposedTransaction';
 import { useEarnTxValidityFlow } from '../hooks/useEarnTxValidityFlow';
@@ -48,11 +46,7 @@ export const UnstakeTransactionDataReviewScreen = ({
         selectAccountByKey(state, accountKey),
     );
 
-    const customAccountLabel = useSelector((state: CombinedLabelingState) =>
-        account
-            ? selectAccountLabel(state, account.deviceState, account.descriptor, account.symbol)
-            : null,
-    );
+    const accountLabel = useEarnAccountLabel(account);
 
     const precomposedTransaction = useEarnSelectedPrecomposedTransaction('unstake', accountKey);
 
@@ -68,19 +62,8 @@ export const UnstakeTransactionDataReviewScreen = ({
             markReviewNavigationSuccess,
         });
 
-    const { bottomSheetRef: pendingBottomSheetRef, openModal: openPendingBottomSheet } =
-        useBottomSheetModal();
-
-    useEffect(() => {
-        if (isPending) {
-            openPendingBottomSheet();
-        }
-    }, [isPending, openPendingBottomSheet]);
-
-    const { explorerUrl, openInBlockchain } = useTransactionDetails({
-        accountKey,
-        txid: pendingTxid ?? null,
-    });
+    const { pendingBottomSheetRef, isExploreDisabled, openInBlockchain } =
+        useEarnPendingTransactionSheet({ accountKey, isPending, pendingTxid });
 
     const { showTimer, secondsLeft, isPastDeadline, isBroadcasting, onRetry, isRetryDisabled } =
         useEarnTxValidityFlow({
@@ -121,8 +104,6 @@ export const UnstakeTransactionDataReviewScreen = ({
 
         setIsPushing(false);
     }, [handlePush, trackPushedTransaction]);
-
-    const accountLabel = account ? (customAccountLabel ?? getNetwork(account.symbol).name) : '';
 
     const pendingAmountInBaseUnits = account ? getAmountInBaseUnits(amount, account.symbol) : '0';
 
@@ -171,7 +152,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                 )}
             </VStack>
 
-            {isPending && pendingTxid && submittedAt && account && (
+            {isPending && !!pendingTxid && !!submittedAt && !!account && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
@@ -189,7 +170,7 @@ export const UnstakeTransactionDataReviewScreen = ({
                         <Translation id="earn.unstakeTransactionDataReviewScreen.amountLabel" />
                     }
                     fee={precomposedTransaction?.fee}
-                    isExploreDisabled={!explorerUrl}
+                    isExploreDisabled={isExploreDisabled}
                     onExplorePress={openInBlockchain}
                     submittedAt={submittedAt}
                     title={

--- a/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/UnwrapNativeTokenScreen.tsx
@@ -213,6 +213,7 @@ export const UnwrapNativeTokenScreen = () => {
                     isExploreDisabled={flow.pendingModalProps.isExploreDisabled}
                     onExplorePress={flow.pendingModalProps.onExplorePress}
                     submittedAt={flow.pendingModalProps.submittedAt}
+                    txid={flow.pendingModalProps.txid}
                     title={<Translation id="earn.unwrapNativeToken.pendingTransactionTitle" />}
                 />
             )}

--- a/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
+++ b/suite-native/module-earn/src/screens/WrapNativeTokenScreen.tsx
@@ -223,6 +223,7 @@ export const WrapNativeTokenScreen = () => {
                     isExploreDisabled={flow.pendingModalProps.isExploreDisabled}
                     onExplorePress={flow.pendingModalProps.onExplorePress}
                     submittedAt={flow.pendingModalProps.submittedAt}
+                    txid={flow.pendingModalProps.txid}
                     title={<Translation id="earn.wrapNativeToken.pendingTransactionTitle" />}
                 />
             )}

--- a/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldClaimScreen.tsx
@@ -355,6 +355,7 @@ export const YieldClaimScreen = () => {
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
+                    txid={pendingModalProps.txid}
                     title={<Translation id="earn.yieldClaimFlowScreen.claimPendingTitle" />}
                 />
             )}

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -494,6 +494,7 @@ export const YieldDepositApprovalScreen = () => {
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
+                    txid={pendingModalProps.txid}
                     title={
                         <Translation id="moduleTrading.tradingConfirmationScreen.approveTitle" />
                     }

--- a/suite-native/module-earn/src/screens/YieldDepositRevokeScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositRevokeScreen.tsx
@@ -113,6 +113,7 @@ export const YieldDepositRevokeScreen = () => {
                     isExploreDisabled={pendingModal.isExploreDisabled}
                     onExplorePress={pendingModal.onExplorePress}
                     submittedAt={pendingModal.submittedAt}
+                    txid={pendingModal.txid}
                     title={<Translation id="earn.yieldDepositRevokeScreen.pendingTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={tokenContract}

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -509,6 +509,7 @@ export const YieldDepositScreen = () => {
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
+                    txid={pendingModalProps.txid}
                     title={<Translation id="earn.yieldDepositFlowScreen.depositPendingTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={route.params.tokenContract}

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -427,6 +427,7 @@ export const YieldDepositWrapScreen = () => {
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
+                    txid={pendingModalProps.txid}
                     title={<Translation id="earn.wrapNativeToken.pendingTransactionTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={route.params.tokenContract}

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -766,6 +766,7 @@ export const YieldWithdrawScreen = () => {
                     onDismiss={handleSheetDismissed}
                     onExplorePress={openInBlockchain}
                     submittedAt={new Date(displayedPendingTransaction.submittedAt ?? 0)}
+                    txid={displayedPendingTransaction.txid}
                     title={<Translation id="earn.yieldWithdrawFlowScreen.withdrawPendingTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={vaultTokenContract}

--- a/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
@@ -441,6 +441,7 @@ export const YieldWithdrawUnwrapScreen = () => {
                     onDismiss={pendingModalProps.onDismiss}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
+                    txid={pendingModalProps.txid}
                     title={<Translation id="earn.yieldWithdrawFlowScreen.unwrapPendingTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={route.params.tokenContract}

--- a/suite-native/module-earn/src/utils/getAmountInBaseUnits.ts
+++ b/suite-native/module-earn/src/utils/getAmountInBaseUnits.ts
@@ -1,0 +1,9 @@
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { asAmountUnit, unitsToSubunits } from '@suite-common/wallet-utils';
+import { BigNumber } from '@trezor/utils';
+
+export const getAmountInBaseUnits = (amount: string, symbol: NetworkSymbol) =>
+    unitsToSubunits({
+        value: asAmountUnit(new BigNumber(amount)),
+        symbol,
+    }).toString();

--- a/suite-native/module-earn/src/utils/getEarnPendingAmountInBaseUnits.ts
+++ b/suite-native/module-earn/src/utils/getEarnPendingAmountInBaseUnits.ts
@@ -1,0 +1,18 @@
+import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+
+import { getSolanaPrecomposedNetAmount } from './getSolanaPrecomposedNetAmount';
+
+type GetEarnPendingAmountInBaseUnitsParams = {
+    fallbackAmountInBaseUnits: string;
+    isSolanaStaking: boolean;
+    precomposedTransaction: Pick<PrecomposedTransactionFinal, 'totalSpent' | 'fee'> | undefined;
+};
+
+export const getEarnPendingAmountInBaseUnits = ({
+    fallbackAmountInBaseUnits,
+    isSolanaStaking,
+    precomposedTransaction,
+}: GetEarnPendingAmountInBaseUnitsParams) =>
+    isSolanaStaking && precomposedTransaction
+        ? getSolanaPrecomposedNetAmount(precomposedTransaction)
+        : fallbackAmountInBaseUnits;

--- a/suite-native/module-earn/src/utils/getSolanaPrecomposedNetAmount.ts
+++ b/suite-native/module-earn/src/utils/getSolanaPrecomposedNetAmount.ts
@@ -1,0 +1,6 @@
+import { type PrecomposedTransactionFinal } from '@suite-common/wallet-types';
+import { BigNumber } from '@trezor/utils';
+
+export const getSolanaPrecomposedNetAmount = (
+    precomposedTransaction: Pick<PrecomposedTransactionFinal, 'totalSpent' | 'fee'>,
+) => new BigNumber(precomposedTransaction.totalSpent).minus(precomposedTransaction.fee).toFixed(0);


### PR DESCRIPTION
## Description

After a stake, unstake, or claim transaction is pushed, the native app now shows a pending transaction bottom sheet with the transaction ID, copy action, and a link to view it in the explorer.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31005

## Screenshots:

https://github.com/user-attachments/assets/153ddb38-27d2-4398-949a-ba81344f9bcc