### PR TITLE
fix(suite-common): remove account type label for default bitcoin accounts

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsConstants.test.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.test.ts
@@ -1,0 +1,36 @@
+import { getFormattedAccountType, getFormattedAccountTypeWithDefault } from './accountsConstants';
+
+describe('getFormattedAccountType', () => {
+    it('returns no label for default account types', () => {
+        expect(getFormattedAccountType('bitcoin', 'normal')).toBeNull();
+        expect(getFormattedAccountType('ethereum', 'normal')).toBeNull();
+        expect(getFormattedAccountType('cardano', 'normal')).toBeNull();
+    });
+
+    it('returns labels for non-default bitcoin account types', () => {
+        expect(getFormattedAccountType('bitcoin', 'taproot')).toBe('Taproot');
+        expect(getFormattedAccountType('bitcoin', 'segwit')).toBe('Legacy SegWit');
+        expect(getFormattedAccountType('bitcoin', 'legacy')).toBe('Legacy');
+    });
+
+    it('returns labels for non-default account types of other networks', () => {
+        expect(getFormattedAccountType('cardano', 'legacy')).toBe('Legacy');
+        expect(getFormattedAccountType('cardano', 'ledger')).toBe('Ledger');
+    });
+});
+
+describe('getFormattedAccountTypeWithDefault', () => {
+    it('returns SegWit for the default bitcoin account type', () => {
+        expect(getFormattedAccountTypeWithDefault('bitcoin', 'normal')).toBe('SegWit');
+    });
+
+    it('returns Default for default account types of other networks', () => {
+        expect(getFormattedAccountTypeWithDefault('ethereum', 'normal')).toBe('Default');
+    });
+
+    it('returns labels for non-default bitcoin account types', () => {
+        expect(getFormattedAccountTypeWithDefault('bitcoin', 'taproot')).toBe('Taproot');
+        expect(getFormattedAccountTypeWithDefault('bitcoin', 'segwit')).toBe('Legacy SegWit');
+        expect(getFormattedAccountTypeWithDefault('bitcoin', 'legacy')).toBe('Legacy');
+    });
+});

--- a/suite-common/wallet-core/src/accounts/accountsConstants.ts
+++ b/suite-common/wallet-core/src/accounts/accountsConstants.ts
@@ -3,7 +3,7 @@ import { type AccountType, type NetworkType } from '@suite-common/wallet-config'
 export const ACCOUNTS_MODULE_PREFIX = '@common/wallet-core/accounts';
 
 const bitcoinFormattedAccountTypeMap: Record<AccountType, string | null> = {
-    normal: 'SegWit',
+    normal: null,
     taproot: 'Taproot',
     segwit: 'Legacy SegWit',
     legacy: 'Legacy',
@@ -29,6 +29,11 @@ const formattedAccountTypeWithDefaultMap: Record<AccountType, string | null> = {
     normal: 'Default',
 };
 
+const bitcoinFormattedAccountTypeWithDefaultMap: Record<AccountType, string | null> = {
+    ...bitcoinFormattedAccountTypeMap,
+    normal: 'SegWit',
+};
+
 export const getFormattedAccountType = (networkType: NetworkType, accountType: AccountType) =>
     (networkType === 'bitcoin' ? bitcoinFormattedAccountTypeMap : formattedAccountTypeMap)[
         accountType
@@ -39,5 +44,5 @@ export const getFormattedAccountTypeWithDefault = (
     accountType: AccountType,
 ) =>
     (networkType === 'bitcoin'
-        ? bitcoinFormattedAccountTypeMap
+        ? bitcoinFormattedAccountTypeWithDefaultMap
         : formattedAccountTypeWithDefaultMap)[accountType];


### PR DESCRIPTION

## Description

Segwit bitcoin accounts should not have label. I broke it when I was fixing that in the account detail, where Segwit (normal accounts) should have the account type.

## Notes for QA

- Default BTC account (`m/84'/0'/0'`): no badge in account list / account detail; Account settings shows Account type **Default**.
- Taproot / Legacy SegWit / Legacy BTC accounts: badges unchanged.
- ETH default account behavior unchanged (no badge, settings row **Default**).

## Related Issue

Resolve #31072

## Screenshots:


<img width="430" height="374" alt="Screenshot 2026-08-12 at 11 47 06" src="https://github.com/user-attachments/assets/bd45d301-5c22-4cde-a3ed-cc3a8d39a793" />
<img width="382" height="438" alt="Screenshot 2026-08-12 at 11 46 27" src="https://github.com/user-attachments/assets/9afa4b42-88b4-4b02-843f-a47a4391ec7c" />
<img width="419" height="426" alt="Screenshot 2026-08-12 at 11 45 10" src="https://github.com/user-attachments/assets/0c81a8ce-6fc9-4516-a4fa-bcb739fc5a6c" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** accountsConstants.ts is a broad shared dependency (135 static references), so most mapped tests are only indirect consumers. The change risk is concentrated on default account naming, account types, and derivation-path constants. Run the high-priority account-creation and account-label tests that directly assert these values, plus a couple of medium-priority tests covering search and regtest default labels for additional confidence.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsConstants.test.ts`
- `suite-common/wallet-core/src/accounts/accountsConstants.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test directly exercises account creation, account type selection, default account labels, and the derivation paths/types that are likely defined in accountsConstants.ts. A change to account-type constants or default naming would be immediately visible here.
- `suite/e2e/tests/metadata/legacy/account-metadata.test.ts` — The test asserts the default account label 'Bitcoin #1' before and after editing, which is derived from account constants. If accountsConstants.ts changes default labeling or account identifiers, this test will surface the regression.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/wallet/account-search.test.ts` — Account search relies on rendered account button labels and visibility. While not directly asserting constants, a change to default account naming or account ordering constants could break filtering behavior.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — The test verifies the default regtest account label 'Bitcoin Regtest #1'. If accountsConstants.ts affects default account naming for testnet/regtest coins, this test would catch it.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/wallet-core/src/accounts/accountsConstants.test.ts`

_Updated: 2026-08-12T09:10:41.473Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native-default-btc-account-type-label/web/](https://dev.suite.sldev.cz/suite-web/fix/native-default-btc-account-type-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native-default-btc-account-type-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native-default-btc-account-type-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-default-btc-account-type-label&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T09:13:00.642Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T09:13:13.880Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->