### PR TITLE
fix(suite-native): displaying of earn rewards 

### DIFF
--- a/suite-native/module-earn/src/components/EarnEstimatedRewards.tsx
+++ b/suite-native/module-earn/src/components/EarnEstimatedRewards.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from 'react';
+import { useSelector } from 'react-redux';
+
+import { calculateRewards } from '@suite-common/wallet-utils';
+import { Box, HStack, Text, VStack } from '@suite-native/atoms';
+import { selectSupportedLanguageLocale } from '@suite-native/intl';
+
+import { formatEarnAmount } from '../utils/earnAmountUtils';
+
+type EarnEstimatedRewardsProps = {
+    amountValue: string;
+    apy: number | null;
+    label: ReactNode;
+    symbol: string;
+};
+
+export const EarnEstimatedRewards = ({
+    amountValue,
+    apy,
+    label,
+    symbol,
+}: EarnEstimatedRewardsProps) => {
+    const locale = useSelector(selectSupportedLanguageLocale);
+
+    const rewards = formatEarnAmount({ amount: calculateRewards(amountValue, apy), locale });
+
+    return (
+        <VStack spacing="sp4" paddingHorizontal="sp16">
+            <Text variant="body-sm" color="contentPrimary" textAlign="center">
+                {label}
+            </Text>
+            {/* A dust-sized estimate keeps its full precision, so the amount is the part that
+            ellipsizes to keep the symbol on the same row. */}
+            <HStack spacing="sp4" justifyContent="center" alignItems="center">
+                <Box flexShrink={1}>
+                    <Text
+                        variant="headline-sm"
+                        color="contentBrand"
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                    >
+                        {rewards}
+                    </Text>
+                </Box>
+                <Text variant="headline-sm" color="contentBrand">
+                    {symbol}
+                </Text>
+            </HStack>
+        </VStack>
+    );
+};

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -1,15 +1,12 @@
-import { useMemo } from 'react';
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
-import { useSelector } from 'react-redux';
 
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { calculateRewards } from '@suite-common/wallet-utils';
-import { Box, Button, ScreenFooterGradient, Text, VStack } from '@suite-native/atoms';
-import { Translation, selectSupportedLanguageLocale, useTranslate } from '@suite-native/intl';
+import { Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
+import { Translation, useTranslate } from '@suite-native/intl';
 import { selectApy, useSelector as useStakingSelector } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { formatEarnTokenAmount } from '../utils/earnAmountUtils';
+import { EarnEstimatedRewards } from './EarnEstimatedRewards';
 
 const screenFooterStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
@@ -48,25 +45,12 @@ export const EarnFormScreenFooter = ({
 }: EarnFormScreenFooterProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
-    const locale = useSelector(selectSupportedLanguageLocale);
 
     const apy = useStakingSelector(state => selectApy(state, { networkSymbol: symbol }));
 
-    const estimatedRewards = useMemo(() => {
-        if (!amountValue) return null;
-
-        const rewards = calculateRewards(amountValue, apy);
-
-        return formatEarnTokenAmount({
-            amount: rewards,
-            locale,
-            symbol: getNetworkDisplaySymbol(symbol),
-        });
-    }, [amountValue, apy, locale, symbol]);
-
     const buttonIntent = isDisabled ? 'neutral' : 'brand';
     const buttonPriority = isDisabled ? 'secondary' : 'primary';
-    const isRewardsBoxVisible = estimatedRewards !== null && !isDisabled;
+    const isRewardsBoxVisible = !!amountValue && !isDisabled;
 
     return (
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
@@ -74,19 +58,16 @@ export const EarnFormScreenFooter = ({
             <Box style={applyStyle(screenFooterStyle)}>
                 {isRewardsBoxVisible && (
                     <Box style={applyStyle(rewardsBoxStyle)}>
-                        <VStack
-                            spacing="sp4"
-                            paddingTop="sp12"
-                            paddingHorizontal="sp16"
-                            alignItems="center"
-                        >
-                            <Text variant="body-sm" color="contentPrimary" textAlign="center">
-                                <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
-                            </Text>
-                            <Text variant="headline-sm" color="contentBrand" textAlign="center">
-                                {estimatedRewards}
-                            </Text>
-                        </VStack>
+                        <Box paddingTop="sp12">
+                            <EarnEstimatedRewards
+                                amountValue={amountValue}
+                                apy={apy}
+                                label={
+                                    <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
+                                }
+                                symbol={getNetworkDisplaySymbol(symbol)}
+                            />
+                        </Box>
                     </Box>
                 )}
                 <Button

--- a/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
@@ -1,20 +1,11 @@
-import { useMemo } from 'react';
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
-import { useSelector } from 'react-redux';
 
 import { type YieldApprovalAction } from '@suite-common/wallet-core';
-import { type TokenSymbol } from '@suite-common/wallet-types';
-import { calculateRewards } from '@suite-common/wallet-utils';
-import { Box, Button, ScreenFooterGradient, Text, VStack } from '@suite-native/atoms';
-import {
-    Translation,
-    type TxKeyPath,
-    selectSupportedLanguageLocale,
-    useTranslate,
-} from '@suite-native/intl';
+import { Box, Button, ScreenFooterGradient, VStack } from '@suite-native/atoms';
+import { Translation, type TxKeyPath, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { formatEarnTokenAmount } from '../utils/earnAmountUtils';
+import { EarnEstimatedRewards } from './EarnEstimatedRewards';
 
 const screenFooterStyle = prepareNativeStyle(utils => ({
     paddingHorizontal: utils.spacings.sp16,
@@ -40,7 +31,8 @@ type YieldDepositFlowFooterProps = {
     onPress: () => void;
     onSkipPress?: () => void;
     shouldKeepEstimatedRewardsVisible?: boolean;
-    tokenSymbol: TokenSymbol;
+    /** For a wrapped-native vault this is the native symbol the user thinks in, e.g. ETH. */
+    tokenSymbol: string;
 };
 
 const getSubmitButtonTranslationId = (
@@ -71,21 +63,13 @@ export const YieldDepositFlowFooter = ({
 }: YieldDepositFlowFooterProps) => {
     const { applyStyle } = useNativeStyles();
     const { translate } = useTranslate();
-    const locale = useSelector(selectSupportedLanguageLocale);
-
-    const estimatedRewards = useMemo(() => {
-        if (!amountValue || apy === null) return null;
-
-        const rewards = calculateRewards(amountValue, apy);
-
-        return formatEarnTokenAmount({ amount: rewards, locale, symbol: tokenSymbol });
-    }, [amountValue, apy, locale, tokenSymbol]);
 
     const buttonTranslationId = getSubmitButtonTranslationId(approvalAction);
     const isApprovalLimitAction = approvalAction === 'increase' || approvalAction === 'revoke';
     const isEstimatedRewardsVisible =
         (shouldKeepEstimatedRewardsVisible || (!isApprovalLimitAction && !isDisabled)) &&
-        estimatedRewards !== null;
+        !!amountValue &&
+        apy !== null;
 
     return (
         <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
@@ -96,19 +80,16 @@ export const YieldDepositFlowFooter = ({
                         style={isEstimatedRewardsVisible ? applyStyle(rewardsBoxStyle) : undefined}
                     >
                         {isEstimatedRewardsVisible && (
-                            <VStack
-                                spacing="sp4"
-                                paddingVertical="sp12"
-                                paddingHorizontal="sp16"
-                                alignItems="center"
-                            >
-                                <Text variant="body-sm" color="contentPrimary" textAlign="center">
-                                    <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
-                                </Text>
-                                <Text variant="headline-sm" color="contentBrand" textAlign="center">
-                                    {estimatedRewards}
-                                </Text>
-                            </VStack>
+                            <Box paddingVertical="sp12">
+                                <EarnEstimatedRewards
+                                    amountValue={amountValue}
+                                    apy={apy}
+                                    label={
+                                        <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
+                                    }
+                                    symbol={tokenSymbol}
+                                />
+                            </Box>
                         )}
                         <Button
                             accessibilityRole="button"

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -378,7 +378,7 @@ export const YieldDepositApprovalScreen = () => {
                     isSkipDisabled={isApprovalPending || isCheckingApproval}
                     onPress={handleSubmit}
                     onSkipPress={canSkipApproval ? handleSkipApproval : undefined}
-                    tokenSymbol={tokenSymbol}
+                    tokenSymbol={wrappedNativeSymbol ?? tokenSymbol}
                 />
             }
         >

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -404,7 +404,7 @@ export const YieldDepositScreen = () => {
                     isLoading={isActionSubmitting}
                     onPress={handleContinue}
                     shouldKeepEstimatedRewardsVisible={isApprovalInsufficient}
-                    tokenSymbol={tokenSymbol}
+                    tokenSymbol={wrappedNativeSymbol ?? tokenSymbol}
                 />
             }
         >

--- a/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
@@ -3,7 +3,11 @@ import { asBaseCurrencyAmount, toTokenAddress, toTokenSymbol } from '@suite-comm
 import { mockAccountKey } from '@suite-common/wallet-types/mocks';
 import { BigNumber } from '@trezor/utils';
 
-import { formatEarnActiveItemBalance, formatEarnTokenAmount } from './earnAmountUtils';
+import {
+    formatEarnActiveItemBalance,
+    formatEarnAmount,
+    formatEarnTokenAmount,
+} from './earnAmountUtils';
 import { type EarnDepositsCardActiveItem } from '../types';
 
 const ethSymbol = asNetworkSymbol('eth');
@@ -32,6 +36,18 @@ const stakingItem = (balance: string): EarnDepositsCardActiveItem => ({
     accountKey,
     balance,
     fiatAmount,
+});
+
+describe(formatEarnAmount.name, () => {
+    it('leaves out the symbol so it can be rendered as a separate element', () => {
+        expect(formatEarnAmount({ amount: '10000.123', locale: 'en-US' })).toBe('10,000.123');
+    });
+
+    it('shows a dust amount in full precision instead of rounding it to zero', () => {
+        expect(formatEarnAmount({ amount: '0.000000000000000001', locale: 'en-US' })).toBe(
+            '0.000000000000000001',
+        );
+    });
 });
 
 describe(formatEarnTokenAmount.name, () => {

--- a/suite-native/module-earn/src/utils/earnAmountUtils.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.ts
@@ -5,26 +5,34 @@ import { BigNumber } from '@trezor/utils';
 import { CRYPTO_BALANCE_DECIMALS } from '../constants';
 import { type EarnDepositsCardActiveItem } from '../types';
 
-type FormatEarnTokenAmountParams = {
+type FormatEarnAmountParams = {
     amount: string;
     locale: Locale;
+};
+
+type FormatEarnTokenAmountParams = FormatEarnAmountParams & {
     symbol: string;
 };
 
 // formatCoinBalance rounds amounts below this threshold away to "0.00".
 const COIN_BALANCE_DUST_THRESHOLD = new BigNumber('1e-8');
 
-// A fixed decimal cap would round dust-sized deposited and received amounts away to zero.
-export const formatEarnTokenAmount = ({ amount, locale, symbol }: FormatEarnTokenAmountParams) => {
+/**
+ * Formats an amount without its symbol, for callers rendering the symbol as a separate element.
+ */
+export const formatEarnAmount = ({ amount, locale }: FormatEarnAmountParams) => {
+    // A fixed decimal cap would round dust-sized deposited and received amounts away to zero.
     const amountBig = new BigNumber(amount);
     const isBelowCoinBalancePrecision =
         !amountBig.isZero() && amountBig.abs().lt(COIN_BALANCE_DUST_THRESHOLD);
-    const formattedAmount = isBelowCoinBalancePrecision
+
+    return isBelowCoinBalancePrecision
         ? localizeNumber(amount, locale)
         : formatCoinBalance(amount, locale);
-
-    return `${formattedAmount} ${symbol}`;
 };
+
+export const formatEarnTokenAmount = ({ amount, locale, symbol }: FormatEarnTokenAmountParams) =>
+    `${formatEarnAmount({ amount, locale })} ${symbol}`;
 
 type FormatEarnActiveItemBalanceParams = {
     item: EarnDepositsCardActiveItem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-uses component for rewards and renames weth->eth 

## Notes for QA

Need to make sure that estimated rewards is consistently displayed 

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31094

## Screenshots:

| Before | After |
|--------|--------|
| <img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/221ba46b-8526-461b-9a01-21ebb113e051" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-12 at 11 02 59" src="https://github.com/user-attachments/assets/8fd54906-4b35-43b5-be09-81455823f424" /> | 


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-estimates-wrapping&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->