### PR TITLE
perf(suite-native): resolve token icon synchronously when possible

### DIFF
--- a/packages/product-components/package.json
+++ b/packages/product-components/package.json
@@ -33,6 +33,7 @@
         "@trezor/device-utils": "workspace:*",
         "@trezor/env-utils": "workspace:*",
         "@trezor/icons": "workspace:*",
+        "@trezor/react-utils": "workspace:*",
         "@trezor/theme": "workspace:*",
         "@trezor/type-utils": "workspace:*",
         "@trezor/utils": "workspace:*",

--- a/packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx
+++ b/packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx
@@ -11,6 +11,7 @@ import {
     pickAndPrepareFrameProps,
     withFrameProps,
 } from '@trezor/components';
+import { useAsyncMemo } from '@trezor/react-utils';
 
 import { TokenInitials } from './TokenInitials';
 import { type TokenIconProps, allowedTokenIconFrameProps } from './tokenIconTypes';
@@ -75,11 +76,12 @@ export const NonNativeTokenIcon = ({
     'data-testid': dataTestId,
     ...rest
 }: NonNativeTokenIconProps) => {
-    const [contractAddressArray, setContractAddressArray] = useState<string[] | undefined>();
-
-    useEffect(() => {
-        getAssetLogoContractAddresses(symbol, contractAddress).then(setContractAddressArray);
-    }, [symbol, contractAddress]);
+    // resolves synchronously for everything except the first XLM token after a cold start
+    // so most icons render in the first frame without a placeholder flash
+    const contractAddressArray = useAsyncMemo(
+        () => getAssetLogoContractAddresses(symbol, contractAddress),
+        [symbol, contractAddress],
+    );
 
     const normalizedAddresses = useMemo(
         () =>

--- a/packages/product-components/tsconfig.json
+++ b/packages/product-components/tsconfig.json
@@ -39,6 +39,7 @@
         { "path": "../device-utils" },
         { "path": "../env-utils" },
         { "path": "../icons" },
+        { "path": "../react-utils" },
         { "path": "../theme" },
         { "path": "../type-utils" },
         { "path": "../utils" },

--- a/packages/react-utils/src/hooks/useAsyncMemo.test.ts
+++ b/packages/react-utils/src/hooks/useAsyncMemo.test.ts
@@ -5,6 +5,40 @@ import { createDeferred } from '@trezor/utils';
 import { useAsyncMemo } from './useAsyncMemo';
 
 describe('useAsyncMemo', () => {
+    it('returns a synchronously computed value already during the first render', () => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        const { result } = renderHook(() => useAsyncMemo(() => 1, ['a']));
+
+        expect(result.current).toBe(1);
+    });
+
+    it('returns a synchronously computed value immediately after the deps change', async () => {
+        const { result, rerender } = renderHook(
+            ({ key, value }: { key: string; value: number | Promise<number> }) =>
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                useAsyncMemo(() => value, [key]),
+            { initialProps: { key: 'a', value: Promise.resolve(1) as number | Promise<number> } },
+        );
+
+        await waitFor(() => {
+            expect(result.current).toBe(1);
+        });
+
+        // async -> sync
+        // the new value replaces the stale resolution without an undefined frame
+        rerender({ key: 'b', value: 2 });
+        expect(result.current).toBe(2);
+
+        // sync -> async
+        // back to undefined until the promise resolves
+        rerender({ key: 'c', value: Promise.resolve(3) });
+        expect(result.current).toBeUndefined();
+
+        await waitFor(() => {
+            expect(result.current).toBe(3);
+        });
+    });
+
     it('returns undefined until the value resolves, then the value', async () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
         const { result } = renderHook(() => useAsyncMemo(() => Promise.resolve(1), ['a']));

--- a/packages/react-utils/src/hooks/useAsyncMemo.ts
+++ b/packages/react-utils/src/hooks/useAsyncMemo.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useFreshRef } from './useFreshRef';
 
@@ -7,28 +7,37 @@ const depsEqual = (prev: readonly unknown[], next: readonly unknown[]) =>
     prev.length === next.length && prev.every((dep, i) => Object.is(dep, next[i]));
 
 /**
- * Resolves `getValue` asynchronously and returns the result only while `deps` match the deps
- * it was resolved for, otherwise `undefined`. A reused component instance (e.g. recycled list
- * cell) therefore never renders a stale resolution, even when promises settle out of order.
- * A rejected `getValue` is swallowed and the hook keeps returning `undefined` for those deps.
+ * Memoizes `getValue` by `deps`. A synchronously returned value is available already during
+ * the first render, exactly like with `useMemo`. A returned promise is awaited instead and its
+ * result is returned only while `deps` match the deps it was resolved for, otherwise
+ * `undefined`. A reused component instance (e.g. recycled list cell) therefore never renders
+ * a stale resolution, even when promises settle out of order. A rejected promise is swallowed
+ * and the hook keeps returning `undefined` for those deps.
  */
 export function useAsyncMemo<T>(
-    getValue: () => Promise<T>,
+    getValue: () => T | Promise<T>,
     deps: readonly unknown[],
 ): T | undefined {
     const [resolved, setResolved] = useState<{ deps: readonly unknown[]; value: T }>();
     const getValueRef = useFreshRef(getValue);
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const value = useMemo(() => getValueRef.current(), deps);
+
     useEffect(() => {
+        if (!(value instanceof Promise)) {
+            return;
+        }
+
         let cancelled = false;
 
-        getValueRef.current().then(
-            value => {
+        value.then(
+            resolvedValue => {
                 if (!cancelled) {
-                    setResolved({ deps, value });
+                    setResolved({ deps, value: resolvedValue });
                 }
             },
-            () => {}, // reject → stay undefined, callers render their fallback
+            () => {}, // Reject → stay undefined, callers render their fallback.
         );
 
         return () => {
@@ -36,6 +45,10 @@ export function useAsyncMemo<T>(
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, deps);
+
+    if (!(value instanceof Promise)) {
+        return value;
+    }
 
     return resolved && depsEqual(resolved.deps, deps) ? resolved.value : undefined;
 }

--- a/suite-common/wallet-utils/src/tokenUtils.test.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.test.ts
@@ -71,29 +71,35 @@ describe('isWrappedNativeToken', () => {
 });
 
 describe('getAssetLogoContractAddresses', () => {
-    it('returns [policyId, contract] for ada', async () => {
+    it('returns [policyId, contract] synchronously for ada', () => {
         const policyId = 'f43a62fdc3965df486de8a0d32fe800963589c41b38946602a0dc535';
         const contract = `${policyId}41474958`;
-        await expect(getAssetLogoContractAddresses('ada', contract)).resolves.toEqual([
-            policyId,
-            contract,
-        ]);
+        expect(getAssetLogoContractAddresses('ada', contract)).toEqual([policyId, contract]);
     });
 
-    it('returns [sacId, contract] for xlm', async () => {
+    it('resolves [contract, sacId] for xlm and returns synchronously once the stellar module is loaded', async () => {
         const classic = 'USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
         const expectedSACId = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
-        await expect(getAssetLogoContractAddresses('xlm', classic)).resolves.toEqual([
-            classic,
-            expectedSACId,
-        ]);
+
+        // the very first Xlm call has to wait for the lazily loaded stellar module
+        const coldResult = getAssetLogoContractAddresses('xlm', classic);
+        expect(coldResult).toBeInstanceOf(Promise);
+        await expect(coldResult).resolves.toEqual([classic, expectedSACId]);
+
+        // once the module is cached, the resolution is synchronous
+        expect(getAssetLogoContractAddresses('xlm', classic)).toEqual([classic, expectedSACId]);
     });
 
-    it('returns [contract] for eth', async () => {
+    it('falls back to [contract] for xlm when the soroban id cannot be derived', async () => {
+        const malformed = 'not-a-classic-contract';
+        await expect(
+            Promise.resolve(getAssetLogoContractAddresses('xlm', malformed)),
+        ).resolves.toEqual([malformed]);
+    });
+
+    it('returns [contract] synchronously for eth', () => {
         const contract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
-        await expect(getAssetLogoContractAddresses('eth', contract)).resolves.toEqual([
-            contract.toLowerCase(),
-        ]);
+        expect(getAssetLogoContractAddresses('eth', contract)).toEqual([contract.toLowerCase()]);
     });
 });
 

--- a/suite-common/wallet-utils/src/tokenUtils.ts
+++ b/suite-common/wallet-utils/src/tokenUtils.ts
@@ -39,10 +39,47 @@ export const getContractAddressForNetworkSymbol = (
 // Moved next to the WRAPPED_NATIVE config it reads; re-exported here for existing consumers.
 export { isWrappedNativeToken } from '@suite-common/wallet-config';
 
-export const getAssetLogoContractAddresses = async (
+type StellarRuntime = Awaited<ReturnType<typeof stellar>>;
+
+let loadedStellarRuntime: StellarRuntime | undefined;
+let stellarRuntimePromise: Promise<StellarRuntime> | undefined;
+
+// the Stellar module is chunk-split on web, so it is fetched lazily on the first
+// XLM call and cached, which lets all subsequent calls read it synchronously
+const loadStellarRuntime = () => {
+    stellarRuntimePromise ??= stellar().then(runtime => {
+        loadedStellarRuntime = runtime;
+
+        return runtime;
+    });
+
+    return stellarRuntimePromise;
+};
+
+const getXlmAssetLogoContractAddresses = (contract: string, stellarRuntime: StellarRuntime) => {
+    try {
+        const { sorobanAssetContractId } = stellarRuntime.computeSorobanAssetContractId(contract);
+
+        // keep the classic contract first until CoinGecko finishes the Stellar migration
+        // once Soroban ids become the primary CDN key, flip the order to reduce retries
+        return [contract, sorobanAssetContractId];
+    } catch {
+        // a malformed classic contract has no derivable Soroban ID
+        // but the classic ID itself may still resolve on the CDN
+        return [contract];
+    }
+};
+
+/**
+ * Returns the contract address candidates under which an asset logo may be stored on the
+ * CoinGecko CDN. Resolves synchronously whenever possible so hot paths like token icon lists
+ * can render without an async placeholder frame; only the first xlm call returns a promise
+ * while the lazily loaded stellar module is being fetched.
+ */
+export const getAssetLogoContractAddresses = (
     symbol: NetworkSymbolExtended | undefined,
     contract: string | null | undefined,
-) => {
+): string[] | Promise<string[]> | undefined => {
     if (!contract || !symbol) return undefined;
 
     if (symbol === 'ada') {
@@ -57,13 +94,13 @@ export const getAssetLogoContractAddresses = async (
     // filename. Fall back to the locally-derived Soroban asset contract id so
     // the icon is still reachable.
     if (symbol === 'xlm') {
-        const { computeSorobanAssetContractId } = await stellar();
-        const { sorobanAssetContractId } = computeSorobanAssetContractId(contract);
+        if (loadedStellarRuntime) {
+            return getXlmAssetLogoContractAddresses(contract, loadedStellarRuntime);
+        }
 
-        // Keep the classic contract first until CoinGecko finishes the Stellar
-        // migration. Once Soroban ids become the primary CDN key, flip the
-        // order to reduce retries.
-        return [contract, sorobanAssetContractId];
+        return loadStellarRuntime().then(stellarRuntime =>
+            getXlmAssetLogoContractAddresses(contract, stellarRuntime),
+        );
     }
 
     return [getContractAddressForNetworkSymbol(symbol, contract)];

--- a/suite-native/icons/src/TokenIcon.test.tsx
+++ b/suite-native/icons/src/TokenIcon.test.tsx
@@ -35,24 +35,35 @@ describe('TokenIcon', () => {
     const renderTokenIcon = (props: React.ComponentProps<typeof TokenIcon>) =>
         renderWithBasicProvider(<TokenIcon {...props} />);
 
-    it('shows a placeholder immediately and the correct icon after resolving when a recycled instance receives new props', async () => {
+    it('renders the correct icon synchronously when a recycled instance receives new props', () => {
         const fresh = renderTokenIcon({ symbol: ethSymbol });
-        await act(async () => {});
         const ethSource = fresh.getByHintText(tokenIconHint).props.source;
         fresh.unmount();
 
-        const { getByHintText, queryByHintText, rerender } = renderTokenIcon({
+        const { getByHintText, rerender } = renderTokenIcon({
             symbol: btcSymbol,
         });
-        await act(async () => {});
 
         // simulates FlashList cell recycling: same mounted instance, new asset props
         rerender(<TokenIcon symbol={ethSymbol} />);
 
-        expect(queryByHintText(tokenIconHint)).toBeNull();
-
-        await act(async () => {});
+        // native network icons resolve synchronously, so there is no placeholder frame
         expect(getByHintText(tokenIconHint).props.source).toEqual(ethSource);
+    });
+
+    it('renders a synchronously resolved token icon without a placeholder frame', () => {
+        (getAssetLogoContractAddresses as jest.Mock).mockImplementation(
+            (_symbol: string, contract: string) => [contract],
+        );
+
+        const { getByHintText } = renderTokenIcon({
+            symbol: ethSymbol,
+            contractAddress: contractA,
+        });
+
+        expect(JSON.stringify(getByHintText(tokenIconHint).props.source)).toContain(
+            getTokenIconUrl(contractA),
+        );
     });
 
     it('ignores a stale async url resolution that arrives after the instance was recycled', async () => {
@@ -126,7 +137,6 @@ describe('TokenIcon', () => {
             showNetworkIcon: true,
         });
 
-        // network icon decision is synchronous; token image requires async resolution
         expect(queryByHintText(networkIconHint)).toBeNull();
         await waitFor(() => {
             expect(getByHintText(tokenIconHint)).toBeTruthy();

--- a/suite-native/icons/src/TokenIcon.tsx
+++ b/suite-native/icons/src/TokenIcon.tsx
@@ -126,25 +126,37 @@ const TokenIconComponent = ({ symbol, contractAddress, size = 'small' }: TokenIc
         failed: boolean;
     } | null>(null);
 
-    const resolvedUrls = useAsyncMemo(async (): Promise<(string | number)[]> => {
-        if (isNetworkSymbol(symbol)) {
-            const coingeckoId = getCoingeckoId(symbol);
-            if (coingeckoId && contractAddress) {
-                const logoAddresses = await getAssetLogoContractAddresses(symbol, contractAddress);
-                if (logoAddresses?.length) {
-                    return logoAddresses.map(address =>
-                        getAssetLogoUrl({
-                            coingeckoId,
-                            contractAddress: address,
-                            density: 2,
-                            size: sizeNumber,
-                        }),
-                    );
-                }
-            }
+    // resolves synchronously for everything except the first XLM token after a cold start
+    // so most icons render in the first frame without a placeholder flash
+    const resolvedUrls = useAsyncMemo((): (string | number)[] | Promise<(string | number)[]> => {
+        const fallbackIcon = [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
+
+        if (!isNetworkSymbol(symbol)) {
+            return fallbackIcon;
         }
 
-        return [cryptoIcons[symbol.toLowerCase() as CryptoIconName]];
+        const coingeckoId = getCoingeckoId(symbol);
+        if (!coingeckoId || !contractAddress) {
+            return fallbackIcon;
+        }
+
+        const toLogoUrls = (logoAddresses: string[] | undefined) =>
+            logoAddresses?.length
+                ? logoAddresses.map(address =>
+                      getAssetLogoUrl({
+                          coingeckoId,
+                          contractAddress: address,
+                          density: 2,
+                          size: sizeNumber,
+                      }),
+                  )
+                : fallbackIcon;
+
+        const logoAddresses = getAssetLogoContractAddresses(symbol, contractAddress);
+
+        return logoAddresses instanceof Promise
+            ? logoAddresses.then(toLogoUrls)
+            : toLogoUrls(logoAddresses);
     }, [contractAddress, sizeNumber, symbol]);
 
     const sourceUrls = resolvedUrls ?? [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -16932,6 +16932,7 @@ __metadata:
     "@trezor/env-utils": "workspace:*"
     "@trezor/eslint": "workspace:*"
     "@trezor/icons": "workspace:*"
+    "@trezor/react-utils": "workspace:*"
     "@trezor/theme": "workspace:*"
     "@trezor/type-utils": "workspace:*"
     "@trezor/utils": "workspace:*"


### PR DESCRIPTION
## Description

The `TokenIcon` component has always shown placeholder in the first render frame due to the asynchronous branch for `Stellar` tokens. This PR refactors the `useAsyncMemo` to handle both synchronous and asynchronous values, and it resolves synchronous values synchronously and asynchronous values asynchronously. This change doesn't render placeholders for synchronous icons at all, while keeping the asynchronous fetching of `Stellar` tokens asynchronous.

## Notes for QA

Put `console.log("TokenIcon", key, ":", showPlaceholder ? "PLACEHOLDER" : "icon");` on line 166 in `TokenIcon.tsx` component and observe for which tokens does the component renders placeholders and for which not.

Output:
```
LOG  TokenIcon btc: icon
LOG  TokenIcon eth: icon
LOG  TokenIcon eth:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48: icon
LOG  TokenIcon eth:0xdac17f958d2ee523a2206206994597c13d831ec7: icon
LOG  TokenIcon eth:0x514910771af9ca656af840dff83e8264ecf986ca: icon
LOG  TokenIcon eth:0x1f9840a85d5af5bf1d1762f925bdaddc4201f984: icon
LOG  TokenIcon pol: icon
LOG  TokenIcon pol:0x3c499c542cef5e3811e1192ce70d8cc03d5c3359: icon
LOG  TokenIcon pol:0xd6df932a45c0f255f85145f286ea0b292b21c90b: icon
LOG  TokenIcon pol:0x831753dd7087cac61ab5644b308642cc1c33dc13: icon
LOG  TokenIcon pol:0x7ceb23fd6bc0add59e62ac25578270cff1b9f619: icon
LOG  TokenIcon bsc: icon
LOG  TokenIcon bsc:0x55d398326f99059ff775485246999027b3197955: icon
LOG  TokenIcon bsc:0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82: icon
LOG  TokenIcon bsc:0x2170ed0880ac9a755fd29b2688956bd959f933f8: icon
LOG  TokenIcon bsc:0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d: icon
LOG  TokenIcon eth: icon
LOG  TokenIcon arb:0x912ce59144191c1204e64559fe8253a0e49e6548: icon
LOG  TokenIcon arb:0xaf88d065e77c8cc2239327c5edb3a432268e5831: icon
LOG  TokenIcon arb:0xfc5a1a6eb076a2c7ad06ed22c90d7e710e35ad0a: icon
LOG  TokenIcon arb:0xf97f4df75117a78c1a5a0dbb814af92458539fb4: icon
LOG  TokenIcon eth: icon
LOG  TokenIcon base:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913: icon
LOG  TokenIcon base:0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf: icon
LOG  TokenIcon base:0x940181a94a35a4569e4529a3cdfb74e38fd98631: icon
LOG  TokenIcon base:0xfde4c96c8593536e31f229ea8f37b2ada2699bb2: icon
LOG  TokenIcon eth: icon
LOG  TokenIcon op:0x4200000000000000000000000000000000000042: icon
LOG  TokenIcon op:0x0b2c639c533813f4aa9d7837caf62653d097ff85: icon
LOG  TokenIcon op:0x8700daec35af8ff88c16bdf0418774cb3d7599b4: icon
LOG  TokenIcon op:0x9560e827af36c94d2ac33a39bce1fe78631088db: icon
LOG  TokenIcon eth: icon
LOG  TokenIcon rhc:0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168: icon
LOG  TokenIcon rhc:0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34: icon
LOG  TokenIcon rhc:0xc6911796042b15d7fa4f6cde69e245ddcd3d9c31: icon
LOG  TokenIcon rhc:0xd0601CE157Db5bdC3162BbaC2a2C8aF5320D9EEC: icon
LOG  TokenIcon hype: icon
LOG  TokenIcon hype:0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb: icon
LOG  TokenIcon hype:0xf4d9235269a96aadafc9adae454a0618ebe37949: icon
LOG  TokenIcon hype:0x3073f7aaa4db83f95e9fff17424f71d4751a3073: icon
LOG  TokenIcon hype:0x02c6a2fa58cc01a18b8d9e00ea48d65e4df26c70: icon
LOG  TokenIcon avax: icon
LOG  TokenIcon avax:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e: icon
LOG  TokenIcon avax:0x6e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd: icon
LOG  TokenIcon avax:0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB: icon
LOG  TokenIcon avax:0x8729438eb15e2c8b576fcc6aecda6a148776c0f5: icon
LOG  TokenIcon sol: icon
LOG  TokenIcon sol:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: icon
LOG  TokenIcon sol:JUPyiwrYJFskUPiHa7hkeR8VUtAeFoSYbKedZNsDvCN: icon
LOG  TokenIcon sol:DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263: icon
LOG  TokenIcon sol:HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3: icon
LOG  TokenIcon trx: icon
LOG  TokenIcon trx:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t: icon
LOG  TokenIcon trx:TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4: icon
LOG  TokenIcon trx:TCFLL5dx5ZJdKnWuesXxi1VPwjLVmWZZy9: icon
LOG  TokenIcon trx:TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz: icon
LOG  TokenIcon ada: icon
LOG  TokenIcon ada:8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61446a65644d6963726f555344: icon
LOG  TokenIcon ada:279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b: icon
LOG  TokenIcon ada:5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114494147: icon
LOG  TokenIcon ada:e5a42a1a1d3d1da71b0449663c32798725888d2eb0843c4dabeca05a576f726c644d6f62696c65546f6b656e58: icon
LOG  TokenIcon etc: icon
LOG  TokenIcon etc:0x1953cab0e5bFa6D4a9BaD6E05fD46C1CC6527a5a: icon
LOG  TokenIcon etc:0xde093684c796204224bc081f937aa059d903c52a: icon
LOG  TokenIcon xrp: icon
LOG  TokenIcon xlm: icon
LOG  TokenIcon xlm:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN: PLACEHOLDER
LOG  TokenIcon xlm:AQUA-GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA: PLACEHOLDER
LOG  TokenIcon xlm:yBTC-GBUVRNH4RW4VLHP4C5MOF46RRIRZLAVHYGX45MVSTKA2F6TMR7E7L6NW: PLACEHOLDER
LOG  TokenIcon xlm:EURC-GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2: PLACEHOLDER
LOG  TokenIcon ltc: icon
LOG  TokenIcon bch: icon
LOG  TokenIcon doge: icon
LOG  TokenIcon zec: icon
LOG  TokenIcon xlm:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN: icon
LOG  TokenIcon xlm:AQUA-GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA: icon
LOG  TokenIcon xlm:yBTC-GBUVRNH4RW4VLHP4C5MOF46RRIRZLAVHYGX45MVSTKA2F6TMR7E7L6NW: icon
LOG  TokenIcon xlm:EURC-GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2: icon
LOG  TokenIcon ada:8db269c3ec630e06ae29f74bc39edd1f87c819f1056206e879a1cd61446a65644d6963726f555344: icon
LOG  TokenIcon ada:279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f534e454b: icon
LOG  TokenIcon ada:5d16cc1a177b5d9ba9cfa9793b07e60f1fb70fea1f8aef064415d114494147: icon
LOG  TokenIcon ada:e5a42a1a1d3d1da71b0449663c32798725888d2eb0843c4dabeca05a576f726c644d6f62696c65546f6b656e58: icon
LOG  TokenIcon xlm:yBTC-GBUVRNH4RW4VLHP4C5MOF46RRIRZLAVHYGX45MVSTKA2F6TMR7E7L6NW: icon
LOG  TokenIcon xlm:yBTC-GBUVRNH4RW4VLHP4C5MOF46RRIRZLAVHYGX45MVSTKA2F6TMR7E7L6NW: PLACEHOLDER
```

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30876

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/perf/native/token-icon-synchronous/web/](https://dev.suite.sldev.cz/suite-web/perf/native/token-icon-synchronous/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=perf/native/token-icon-synchronous&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=perf/native/token-icon-synchronous&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=perf/native/token-icon-synchronous&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T09:50:27.926Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T09:49:44.156Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes center on token icon rendering (NonNativeTokenIcon, suite-native TokenIcon) and token utility logic (tokenUtils), plus supporting hook/build files. The main user-visible risk in suite-web E2E is in token selection and display flows, especially trading forms involving ERC-20/SPL tokens. A focused set of token-centric trading tests provides good coverage without running the entire broad static mapping. Native mobile icon changes, unit tests, and build config updates have no corresponding suite-web E2E coverage.

<details><summary><b>Changed files (9)</b></summary>

- `packages/product-components/package.json`
- `packages/product-components/src/components/TokenIcon/NonNativeTokenIcon.tsx`
- `packages/product-components/tsconfig.json`
- `packages/react-utils/src/hooks/useAsyncMemo.test.ts`
- `packages/react-utils/src/hooks/useAsyncMemo.ts`
- `suite-common/wallet-utils/src/tokenUtils.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.ts`
- `suite-native/icons/src/TokenIcon.test.tsx`
- `suite-native/icons/src/TokenIcon.tsx`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — This test explicitly navigates to Buy/Sell/Swap forms from token pages (TUSD on Ethereum, USDC on Ethereum) and asserts the correct cryptocurrency name is displayed. A regression in token symbol/name resolution from tokenUtils.ts or in token icon rendering from NonNativeTokenIcon.tsx could break these token-specific entry points.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — It selects a USDC token sell asset and directly asserts the crypto ticker, fraction-based amounts, and balance validation in the swap form. This exercises token asset selection and token-balance handling that rely on tokenUtils.ts and the token icon component.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/buy-solana-token.test.ts` — The test searches for and selects the Jupiter (JUP) SPL token in the buy asset picker, then completes a buy flow. Token metadata rendering and asset picker behavior are on the critical path, making it a good targeted check for token-related UI changes.
- `suite/e2e/tests/trading/sell-ethereum-token.test.ts` — It sells an ERC-20 USDC token and verifies token-specific amounts in the sell form, confirmation screen, and device prompt. This flow depends on correct token recognition and formatting provided by the changed token utilities and icon components.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — It performs a USDT-to-USDC SPL token swap, relying on token selection, quote display with token symbols, and token amount formatting. This covers token-to-token UI paths likely impacted by the token icon and utility changes.

</details>

⚠️ **Changes with no test coverage (6)**
- `packages/product-components/package.json`
- `packages/product-components/tsconfig.json`
- `packages/react-utils/src/hooks/useAsyncMemo.test.ts`
- `suite-common/wallet-utils/src/tokenUtils.test.ts`
- `suite-native/icons/src/TokenIcon.test.tsx`
- `suite-native/icons/src/TokenIcon.tsx`

_Updated: 2026-08-18T09:50:51.442Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->