### PR TITLE
fix(suite): clear stale amount errors when switching trading asset

### DIFF
--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx
@@ -132,6 +132,28 @@ describe('useTradingCryptoAssetChange', () => {
         expect(setAccountOnChange).toHaveBeenCalledWith(OTHER_ACCOUNT);
     });
 
+    it('onCryptoCurrencyChange clears the stale amount validation errors', async () => {
+        const { result } = renderCryptoAssetChange(buildSelect(ACCOUNT.key));
+
+        act(() => {
+            result.current.methods.setError('outputs.0.amount', {
+                type: 'limits',
+                message: 'Minimum is X ETH',
+            });
+            result.current.methods.setError('outputs.0.fiat', {
+                type: 'minFiat',
+                message: 'Minimum is X USD',
+            });
+        });
+
+        await act(async () => {
+            await result.current.change.onCryptoCurrencyChange(buildSelect(OTHER_ACCOUNT.key));
+        });
+
+        expect(result.current.methods.formState.errors.outputs?.[0]?.amount).toBeUndefined();
+        expect(result.current.methods.formState.errors.outputs?.[0]?.fiat).toBeUndefined();
+    });
+
     it('onCryptoCurrencyChange is a no-op when the same asset is reselected', async () => {
         const { result, setAccountOnChange } = renderCryptoAssetChange(buildSelect(ACCOUNT.key));
 

--- a/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.ts
+++ b/packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.ts
@@ -4,6 +4,7 @@ import { type UseFormReturn, useWatch } from 'react-hook-form';
 import {
     TRADING_FORM_CRYPTO_TOKEN,
     TRADING_FORM_OUTPUT_AMOUNT,
+    TRADING_FORM_OUTPUT_AMOUNT_FIELDS,
     TRADING_FORM_OUTPUT_CURRENCY,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_OUTPUT_MAX,
@@ -50,7 +51,7 @@ export const useTradingCryptoAssetChange = <T extends TradingSellExchangeFormPro
     setAccountOnChange,
 }: UseTradingCryptoAssetChangeProps<T>) => {
     // TODO: drop this cast via capability callbacks instead of methods: UseFormReturn<T>
-    const { getValues, setValue, control } =
+    const { getValues, setValue, clearErrors, control } =
         methods as unknown as UseFormReturn<TradingSellExchangeFormProps>;
 
     const sendCryptoSelect = useWatch({ control, name: TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT });
@@ -71,6 +72,7 @@ export const useTradingCryptoAssetChange = <T extends TradingSellExchangeFormPro
         setValue(TRADING_FORM_OUTPUT_FIAT, '');
         setValue(TRADING_FORM_OUTPUT_AMOUNT, '');
         setValue(TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT, selected);
+        clearErrors(TRADING_FORM_OUTPUT_AMOUNT_FIELDS);
         setAmountLimits(undefined);
         setComposedLevels(undefined);
 

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx
@@ -8,6 +8,7 @@ import {
     TRADING_FORM_CRYPTO_CURRENCY_SELECT,
     TRADING_FORM_CRYPTO_INPUT,
     TRADING_FORM_FIAT_INPUT,
+    TRADING_FORM_INPUT_AMOUNT_FIELDS,
     type TradingBuyType,
     isCountrySubdivisionRequired,
     selectTradingBuyQuotes,
@@ -42,7 +43,7 @@ export const TradingBuyFormInputs = () => {
     const { networkModuleRepository } = useServices(selectNetworkModuleRepositoryDep);
 
     const { device } = useDevice();
-    const { setAmountLimits, getValues, setValue } = context;
+    const { setAmountLimits, getValues, setValue, clearErrors } = context;
     const {
         [TRADING_FORM_CRYPTO_CURRENCY_SELECT]: cryptoSelect,
         [TRADING_FORM_CRYPTO_INPUT]: cryptoInput,
@@ -56,16 +57,18 @@ export const TradingBuyFormInputs = () => {
     // `useTradingBuyForm` has many re-rendering issues, use refs to avoid them
     const setAmountLimitsRef = useCurrentRef(setAmountLimits);
     const setValueRef = useCurrentRef(setValue);
+    const clearErrorsRef = useCurrentRef(clearErrors);
 
     const handleCryptoSelect = useCallback<TradingFormInputBuyAssetProps['onAssetSelect']>(
         asset => {
             setValueRef.current(TRADING_FORM_CRYPTO_INPUT, '', { shouldDirty: true });
             setValueRef.current(TRADING_FORM_FIAT_INPUT, '', { shouldDirty: true });
             setValueRef.current(TRADING_FORM_CRYPTO_CURRENCY_SELECT, asset, { shouldDirty: true });
+            clearErrorsRef.current(TRADING_FORM_INPUT_AMOUNT_FIELDS);
             setAmountLimitsRef.current(undefined);
             dispatch(tradingActions.setModalCryptoCurrency(asset.id));
         },
-        [dispatch, setAmountLimitsRef, setValueRef],
+        [dispatch, setAmountLimitsRef, setValueRef, clearErrorsRef],
     );
 
     const supportedNetworks = networkModuleRepository.getSupportedNetworks();

--- a/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx
@@ -5,6 +5,7 @@ import { useServices } from '@suite-common/dependency-injection';
 import { selectNetworkModuleRepositoryDep } from '@suite-common/networks';
 import {
     TRADING_FORM_OUTPUT_AMOUNT,
+    TRADING_FORM_OUTPUT_AMOUNT_FIELDS,
     TRADING_FORM_OUTPUT_FIAT,
     TRADING_FORM_PROVIDER_SELECT,
     TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT,
@@ -75,7 +76,7 @@ export const TradingExchangeFormInputs = () => {
         () => getDisplayComposedLevels(selectedQuote, composedLevels),
         [selectedQuote, composedLevels],
     );
-    const { getValues, setValue } = useFormContext<TradingExchangeFormProps>();
+    const { getValues, setValue, clearErrors } = useFormContext<TradingExchangeFormProps>();
     const {
         [TRADING_FORM_SEND_CRYPTO_CURRENCY_SELECT]: sendCryptoSelect,
         [TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT]: receiveCryptoSelect,
@@ -108,6 +109,7 @@ export const TradingExchangeFormInputs = () => {
     // `useTradingExchangeForm` has some re-rendering issues, use refs to avoid them
     const setAmountLimitsRef = useCurrentRef(setAmountLimits);
     const setValueRef = useCurrentRef(setValue);
+    const clearErrorsRef = useCurrentRef(clearErrors);
 
     const onCryptoCurrencyChangeRef = useCurrentRef(helpers.onCryptoCurrencyChange);
     const handleSellAssetSelect = useCallback<TradingFormInputSellAssetProps['onAssetSelect']>(
@@ -124,11 +126,12 @@ export const TradingExchangeFormInputs = () => {
             setValueRef.current(TRADING_FORM_RECEIVE_CRYPTO_CURRENCY_SELECT, asset, {
                 shouldDirty: true,
             });
+            clearErrorsRef.current(TRADING_FORM_OUTPUT_AMOUNT_FIELDS);
             setAmountLimitsRef.current(undefined);
             dispatch(tradingActions.setModalCryptoCurrency(asset.id));
             setValueRef.current(TRADING_FORM_PROVIDER_SELECT, undefined, { shouldDirty: true });
         },
-        [dispatch, setAmountLimitsRef, setValueRef],
+        [dispatch, setAmountLimitsRef, setValueRef, clearErrorsRef],
     );
 
     const supportedNetworks = networkModuleRepository.getSupportedNetworks();

--- a/suite-common/trading/src/constants.ts
+++ b/suite-common/trading/src/constants.ts
@@ -53,6 +53,16 @@ export const TRADING_FORM_PAYMENT_METHOD_SELECT = 'paymentMethod';
 export const TRADING_FORM_PROVIDER_SELECT = 'provider';
 export const TRADING_FORM_AMOUNT_IN_CRYPTO = 'amountInCrypto';
 
+export const TRADING_FORM_OUTPUT_AMOUNT_FIELDS = [
+    TRADING_FORM_OUTPUT_AMOUNT,
+    TRADING_FORM_OUTPUT_FIAT,
+] as const;
+
+export const TRADING_FORM_INPUT_AMOUNT_FIELDS = [
+    TRADING_FORM_CRYPTO_INPUT,
+    TRADING_FORM_FIAT_INPUT,
+] as const;
+
 export const TRADING_EXCHANGE_FROM_ADDRESS = 'fromAddress';
 
 export const TRADING_BUY_RECEIVE_ADDRESS = 'receiveAddress';

--- a/suite-common/trading/src/reducers/buyReducer.ts
+++ b/suite-common/trading/src/reducers/buyReducer.ts
@@ -88,6 +88,9 @@ const tradingBuySlice = createSlice({
             state: TradingBuyState,
             action: PayloadAction<AccountKey | undefined>,
         ) {
+            if (action.payload !== state.tradingAccountKey) {
+                state.amountLimits = undefined;
+            }
             state.tradingAccountKey = action.payload;
         },
         setReceiveAccountKey(

--- a/suite-common/trading/src/reducers/exchangeReducer.ts
+++ b/suite-common/trading/src/reducers/exchangeReducer.ts
@@ -80,6 +80,9 @@ const tradingExchangeSlice = createSlice({
             state: TradingExchangeState,
             action: PayloadAction<AccountKey | undefined>,
         ) {
+            if (action.payload !== state.tradingAccountKey) {
+                state.amountLimits = undefined;
+            }
             state.tradingAccountKey = action.payload;
         },
         setReceiveAccountKey(

--- a/suite-common/trading/src/reducers/sellReducer.test.ts
+++ b/suite-common/trading/src/reducers/sellReducer.test.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
 import { configureMockStore } from '@suite-common/test-utils';
+import { type AccountKey } from '@suite-common/wallet-types';
 
 import { sellTradingFixtures } from './__fixtures__/sellTradingReducer';
 import { tradingSellActions, tradingSellReducer } from './sellReducer';
@@ -56,6 +57,42 @@ describe('tradingSellReducer', () => {
             expect(state.quotesRequest).toBeUndefined();
             expect(state.selectedQuote).toBeUndefined();
             expect(state.amountLimits).toBeUndefined();
+        });
+    });
+
+    describe('setTradingAccountKey', () => {
+        const KEY_1 = 'account-1' as AccountKey;
+        const KEY_2 = 'account-2' as AccountKey;
+        const withLimits = () => {
+            let state = tradingSellReducer(
+                undefined,
+                tradingSellActions.setTradingAccountKey(KEY_1),
+            );
+            state = tradingSellReducer(
+                state,
+                tradingSellActions.setAmountLimits({ currency: 'eth' }),
+            );
+
+            return state;
+        };
+
+        it('clears amountLimits when the account key changes', () => {
+            const state = tradingSellReducer(
+                withLimits(),
+                tradingSellActions.setTradingAccountKey(KEY_2),
+            );
+
+            expect(state.tradingAccountKey).toBe(KEY_2);
+            expect(state.amountLimits).toBeUndefined();
+        });
+
+        it('keeps amountLimits when the same account key is set', () => {
+            const state = tradingSellReducer(
+                withLimits(),
+                tradingSellActions.setTradingAccountKey(KEY_1),
+            );
+
+            expect(state.amountLimits).toEqual({ currency: 'eth' });
         });
     });
 });

--- a/suite-common/trading/src/reducers/sellReducer.ts
+++ b/suite-common/trading/src/reducers/sellReducer.ts
@@ -87,6 +87,9 @@ const tradingSellSlice = createSlice({
             state: TradingSellState,
             action: PayloadAction<AccountKey | undefined>,
         ) {
+            if (action.payload !== state.tradingAccountKey) {
+                state.amountLimits = undefined;
+            }
             state.tradingAccountKey = action.payload;
         },
         setIsLoading(state: TradingSellState, action: PayloadAction<boolean>) {


### PR DESCRIPTION
## Description

Minimum/maximum-amount error could show the previous asset's currency (e.g. "Minimum is X ETH" while selling BTC). Two causes fixed:

1. **Redux staleness across navigation (the reported bug).** `amountLimits` is per-account, quote-derived state but `setTradingAccountKey` never reset it. Going from one account's sell form to another's (account detail → Sell) left the old limits in the store, and the fresh form validated against them. Fixed by invalidating `amountLimits` in the sell/buy/exchange `setTradingAccountKey` reducers when the account key changes.

2. **In-form asset switch edge cases.** Asset-change handlers reset the amount and `amountLimits` but not the stored errors, and no existing revalidation covers fiat-input mode, same-account token switches, or the exchange receive-asset switch. Fixed by clearing amount/fiat errors in `onCryptoCurrencyChange` (sell + exchange send), `handleReceiveAssetSelect` (exchange receive), and `handleCryptoSelect` (buy). Cleared field pairs extracted into shared constants.

## Notes for QA

- Sell from ETH account, trigger the minimum error, open a BTC account, then Sell and enter an amount: no leftover ETH error.
- In-form: switch the sell/exchange/buy asset after a min/max error, in both crypto and fiat input modes; error clears/reflects the new asset.
- Unit tests: `sellReducer.test.ts`, `useTradingCryptoAssetChange.test.tsx`.

## Related Issue

Resolve #31190

## Screenshots:

build https://dev.suite.sldev.cz/suite-web/31190-sell-minimum-error/web/accounts/coinmarket/sell/

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set touches trading form inputs, the crypto asset-change hook, and buy/exchange/sell reducers/constants. The highest risk is regressions in form input behavior, asset selection, and quote/reducer integration across buy, sell, and swap flows. The recommended strategy is to run a focused set of trading tests that directly exercise these form components and asset-change logic, plus a few full-flow tests for integration confidence. The 135-test static mappings for the reducers/constants are broad global dependencies and are not used to justify broad coverage.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx`
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.ts`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingBuyFormInputs.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingForm/TradingExchangeFormInputs.tsx`
- `suite-common/trading/src/constants.ts`
- `suite-common/trading/src/reducers/buyReducer.ts`
- `suite-common/trading/src/reducers/exchangeReducer.ts`
- `suite-common/trading/src/reducers/sellReducer.test.ts`
- `suite-common/trading/src/reducers/sellReducer.ts`

</details>

**Recommended tests (11)**

<details><summary>🔴 <b>High priority (8)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — Exercises the full buy form flow including quote fetching, best-offer selection, and confirmation, directly touching TradingBuyFormInputs and the buy trading reducer.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests the buy asset picker with network filtering and live quote behavior, which directly exercises the asset-change hook and buy form inputs.
- `suite/e2e/tests/trading/buy-negative.test.ts` — Focuses on buy form validation, min/max limits, and empty quote states, making it sensitive to changes in buy form inputs and reducer logic.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Covers token selection in the buy form via asset picker and crypto/fiat input switching, directly relevant to the asset-change hook and buy form inputs.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Directly tests sell form input validation, fraction buttons, max calculation, fiat currency changes, and fee handling, exercising the sell reducer and asset-change logic.
- `suite/e2e/tests/trading/sell-solana.test.ts` — Validates the complete sell flow including form fill, quotes, confirmation, send, and status updates, integrating sell form inputs and the sell reducer.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Covers a full swap flow from form fill through device confirmation and status verification, directly using TradingExchangeFormInputs and the exchange reducer.
- `suite/e2e/tests/trading/swap-inputs.test.ts` — Tests swap form asset selection, crypto/fiat inputs, fraction buttons, max amount, and validation, directly exercising TradingExchangeFormInputs and the asset-change hook.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/navigation.test.ts` — Verifies that navigating into buy/sell/swap forms initializes the correct asset, which may be affected by changes to the asset-change hook and form input initialization.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Provides additional coverage of the complete sell flow on a different coin, helping catch sell reducer or form-input regressions not exposed by the Solana sell test.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Covers a cross-chain coin-to-coin swap scenario, complementing the coin-to-token swap test and validating exchange form behavior across different asset types.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/hooks/wallet/trading/form/common/useTradingCryptoAssetChange.test.tsx`
- `suite-common/trading/src/reducers/sellReducer.test.ts`

_Updated: 2026-08-13T21:21:32.688Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31190-sell-minimum-error/web/](https://dev.suite.sldev.cz/suite-web/31190-sell-minimum-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31190-sell-minimum-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=31190-sell-minimum-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T21:23:21.688Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T21:23:15.883Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->