### PR TITLE
docs(skills): managing yarn packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,8 @@ enableScripts: false
 approvedGitRepositories: []
 
 # Allow only packages older than 14 days (in minutes). Schema declares that "14d" can be entered, but that doesn't have any effect.
+# Note that it blocks package resolution, not fetching & linking, so it can installs younger packages if already resolved in yarn.lock.
+# Please avoid that, and rather state all exceptions explicitly in npmPreapprovedPackages,
 npmMinimalAgeGate: 20160
 # Skip age gate for experimental, rapidly changing packages
 npmPreapprovedPackages:

--- a/skills/common-tasks/SKILL.md
+++ b/skills/common-tasks/SKILL.md
@@ -5,14 +5,26 @@ description: Dependency management, package creation, and troubleshooting comman
 
 # Common Tasks
 
-## Managing Dependencies
+## Managing npm dependencies via yarn
+
+Prefer existing dependencies. Add a new npm dependency only when no suitable dependency is already available in the repo.
 
 ```bash
 yarn workspace @trezor/package-name add dependency-name
-yarn build:libs  # Rebuild after dependency changes
 ```
 
-## Package Management
+After adding or updating a dependency, run:
+
+```bash
+yarn dedupe
+yarn requirements:verify
+```
+
+Review all changes made by `yarn dedupe` before keeping them.
+Do not bypass `.yarnrc.yml` `npmMinimalAgeGate`.
+If a blocked version is required to fix a bug, add a targeted exception to `npmPreapprovedPackages`.
+
+## Monorepo Package Management
 
 ```bash
 yarn generate-package      # Create new package


### PR DESCRIPTION
## Description

Add a clear, unambigous agent instructions on managing yarn deps.

I have encountered an agent who bypassed the `npmMinimalAgeGate` locally, idk how exactly it did it, but there are multiple ways.
→ inform also in `.yarnrc.yml` how the feature really works (and how to use it properly).