### PR TITLE
feat(suite): improve address book

### DIFF
--- a/packages/suite/src/views/wallet/send/Outputs/DevAddressBook.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/DevAddressBook.tsx
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 
-import { getFirstFreshAddress } from '@suite-common/address';
 import { type Account } from '@suite-common/wallet-types';
-import { isUtxoBased } from '@suite-common/wallet-utils';
-import { Button, ButtonGroup } from '@trezor/components';
+import { Button } from '@trezor/components';
 
 import { useSendFormContext } from 'src/hooks/wallet';
 
@@ -22,13 +20,6 @@ export const DevAddressBook = ({ account, outputId }: DevAddressBookProps) => {
 
     const [isReceiveAddressModalOpen, setIsReceiveAddressModalOpen] = useState(false);
 
-    const fillSelfAddress = () => {
-        const selfAddress = getFirstFreshAddress(account, [], [], isUtxoBased(account));
-        if (selfAddress) {
-            setValue(inputName, selfAddress.address, { shouldValidate: true, shouldDirty: true });
-        }
-    };
-
     const onSelectAddressClick = () => {
         setIsReceiveAddressModalOpen(true);
     };
@@ -41,25 +32,14 @@ export const DevAddressBook = ({ account, outputId }: DevAddressBookProps) => {
 
     return (
         <>
-            <ButtonGroup size="small">
-                <Button
-                    size="small"
-                    priority="secondary"
-                    intent="accentViolet"
-                    onClick={fillSelfAddress}
-                >
-                    To myself
-                </Button>
-
-                <Button
-                    size="small"
-                    priority="secondary"
-                    intent="accentViolet"
-                    onClick={onSelectAddressClick}
-                >
-                    Address book
-                </Button>
-            </ButtonGroup>
+            <Button
+                size="small"
+                priority="secondary"
+                intent="accentViolet"
+                onClick={onSelectAddressClick}
+            >
+                Address book
+            </Button>
 
             {isReceiveAddressModalOpen && (
                 <ReceiveAddressModal

--- a/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountItem.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountItem.tsx
@@ -1,10 +1,11 @@
+import { selectSelectedAccount } from '@suite/account';
 import { Address } from '@suite/address';
 import { useFormatters } from '@suite-common/formatters';
 import { getUnusedAddressFromAccount } from '@suite-common/trading';
 import { selectBaseCurrency } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { BASE_CURRENCY_ZERO, isUtxoBased } from '@suite-common/wallet-utils';
-import { CardList, Column, Icon, Row, Text } from '@trezor/components';
+import { Badge, CardList, Column, Icon, Row, Text } from '@trezor/components';
 import { CaretRightIcon } from '@trezor/icons';
 import { TokenIcon } from '@trezor/product-components';
 
@@ -21,6 +22,7 @@ interface ReceiveAccountItemProps {
 export const ReceiveAccountItem = ({ account, onAccountSelect }: ReceiveAccountItemProps) => {
     const baseCurrency = useSelector(selectBaseCurrency);
     const { BaseCurrencyAmountFormatter } = useFormatters();
+    const selectedAccount = useSelector(selectSelectedAccount);
 
     const { fiatAmount } = useFiatFromCryptoValue({
         amount: account.formattedBalance,
@@ -38,13 +40,21 @@ export const ReceiveAccountItem = ({ account, onAccountSelect }: ReceiveAccountI
                 <TokenIcon size={24} symbol={account.symbol} />
 
                 <Column>
-                    <Text maxWidth={200} as="div">
-                        <AccountLabeling
-                            account={account}
-                            accountTypeBadgeSize="small"
-                            showAccountTypeBadge
-                        />
-                    </Text>
+                    <Row alignItems="center" gap={8}>
+                        <Text maxWidth={200} as="div">
+                            <AccountLabeling
+                                account={account}
+                                accountTypeBadgeSize="small"
+                                showAccountTypeBadge
+                            />
+                        </Text>
+
+                        {account.key === selectedAccount?.key && (
+                            <Badge intent="accentViolet" size="small">
+                                Myself
+                            </Badge>
+                        )}
+                    </Row>
 
                     {!isUtxoBasedNetwork && (
                         <Address

--- a/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModal.tsx
@@ -1,37 +1,57 @@
+import { selectPhysicalDeviceWallets, selectSelectedDevice } from '@suite-common/device';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { selectDeviceAccountsByNetworkSymbol } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
-import { CardList, Column, Modal } from '@trezor/components';
+import { Badge, Column, Modal, Row, Select } from '@trezor/components';
 
+import { WalletLabeling } from 'src/components/suite/labeling/WalletLabeling';
 import { useSelector } from 'src/hooks/suite';
 
-import { ReceiveAccountItem } from './ReceiveAccountItem';
+import { ReceiveAccountModalAccountsList } from './ReceiveAccountModalAccountsList';
 
 interface ReceiveAccountModalProps {
     symbol: NetworkSymbol;
     onAccountSelect: (account: Account) => void;
     onClose: () => void;
+    selectedWallet?: TrezorDevice;
+    onSelectWallet: (wallet?: TrezorDevice) => void;
 }
 
 export const ReceiveAccountModal = ({
     symbol,
     onAccountSelect,
     onClose,
+    selectedWallet,
+    onSelectWallet,
 }: ReceiveAccountModalProps) => {
-    const accounts = useSelector(state => selectDeviceAccountsByNetworkSymbol(state, symbol));
+    const wallets = useSelector(selectPhysicalDeviceWallets);
+    const activeWallet = useSelector(selectSelectedDevice);
 
     return (
         <Modal heading="Receive account" onCancel={onClose} width={600}>
             <Column gap={12}>
-                <CardList>
-                    {accounts.map(account => (
-                        <ReceiveAccountItem
-                            key={account.key}
-                            account={account}
-                            onAccountSelect={onAccountSelect}
-                        />
-                    ))}
-                </CardList>
+                <Select
+                    options={wallets}
+                    value={selectedWallet}
+                    onChange={onSelectWallet}
+                    formatOptionLabel={wallet => (
+                        <Row alignItems="center" gap={12}>
+                            <WalletLabeling device={wallet} shouldUseDeviceLabel />
+                            {wallet.state?.staticSessionId ===
+                                activeWallet?.state?.staticSessionId && (
+                                <Badge intent="accentViolet">Current wallet</Badge>
+                            )}
+                        </Row>
+                    )}
+                />
+
+                {selectedWallet && (
+                    <ReceiveAccountModalAccountsList
+                        wallet={selectedWallet}
+                        symbol={symbol}
+                        onAccountSelect={onAccountSelect}
+                    />
+                )}
             </Column>
         </Modal>
     );

--- a/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModalAccountsList.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModalAccountsList.tsx
@@ -1,0 +1,72 @@
+import { type TrezorDevice } from '@suite-common/suite-types';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { selectAccountsByDeviceStateAndNetworkSymbol } from '@suite-common/wallet-core';
+import { type Account } from '@suite-common/wallet-types';
+import { CardList, CollapsibleBox, Column, Text } from '@trezor/components';
+import { arrayPartition } from '@trezor/utils';
+
+import { useSelector } from 'src/hooks/suite';
+
+import { ReceiveAccountItem } from './ReceiveAccountItem';
+
+interface ReceiveAccountModalAccountsListProps {
+    wallet: TrezorDevice;
+    symbol: NetworkSymbol;
+    onAccountSelect: (account: Account) => void;
+}
+
+export const ReceiveAccountModalAccountsList = ({
+    wallet,
+    symbol,
+    onAccountSelect,
+}: ReceiveAccountModalAccountsListProps) => {
+    const accounts = useSelector(state =>
+        wallet.state
+            ? selectAccountsByDeviceStateAndNetworkSymbol(state, wallet.state, symbol)
+            : [],
+    );
+
+    if (accounts.length === 0) {
+        return (
+            <Column alignItems="center" gap={4} padding={{ vertical: 16 }}>
+                <Text typographyStyle="body-md">Accounts not found</Text>
+                <Text typographyStyle="body-sm" intent="neutral" priority="secondary">
+                    No accounts have been found for this wallet.
+                </Text>
+            </Column>
+        );
+    }
+
+    const [emptyAccounts, nonEmptyAccounts] = arrayPartition(
+        accounts,
+        account => account.balance === '0',
+    );
+
+    return (
+        <Column gap={12}>
+            <CardList>
+                {nonEmptyAccounts.map(account => (
+                    <ReceiveAccountItem
+                        key={account.key}
+                        account={account}
+                        onAccountSelect={onAccountSelect}
+                    />
+                ))}
+            </CardList>
+
+            {emptyAccounts.length > 0 && (
+                <CollapsibleBox heading="Zero-balance accounts">
+                    <CardList>
+                        {emptyAccounts.map(account => (
+                            <ReceiveAccountItem
+                                key={account.key}
+                                account={account}
+                                onAccountSelect={onAccountSelect}
+                            />
+                        ))}
+                    </CardList>
+                </CollapsibleBox>
+            )}
+        </Column>
+    );
+};

--- a/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAddressModal.tsx
+++ b/packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAddressModal.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 
+import { selectSelectedDevice } from '@suite-common/device';
+import { type TrezorDevice } from '@suite-common/suite-types';
 import { getUnusedAddressFromAccount } from '@suite-common/trading';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import { type Account } from '@suite-common/wallet-types';
 import { isUtxoBased } from '@suite-common/wallet-utils';
+
+import { useSelector } from 'src/hooks/suite';
 
 import { ReceiveAccountModal } from './ReceiveAccountModal';
 import { UtxoReceiveAddressModal } from './UtxoReceiveAddressModal';
@@ -19,7 +23,10 @@ export const ReceiveAddressModal = ({
     onAddressSelect,
     onClose,
 }: ReceiveAddressModalProps) => {
+    const activeWallet = useSelector(selectSelectedDevice);
+
     const [utxoAccount, setUtxoAccount] = useState<Account | null>(null);
+    const [wallet, setWallet] = useState<TrezorDevice | undefined>(activeWallet);
 
     const handleOnAddressSelect = (address: string) => {
         onAddressSelect(address);
@@ -50,6 +57,12 @@ export const ReceiveAddressModal = ({
     }
 
     return (
-        <ReceiveAccountModal symbol={symbol} onAccountSelect={onAccountSelect} onClose={onClose} />
+        <ReceiveAccountModal
+            symbol={symbol}
+            onAccountSelect={onAccountSelect}
+            onClose={onClose}
+            selectedWallet={wallet}
+            onSelectWallet={setWallet}
+        />
     );
 };

--- a/suite-common/wallet-core/src/accounts/accountsSelectors.ts
+++ b/suite-common/wallet-core/src/accounts/accountsSelectors.ts
@@ -38,6 +38,23 @@ export const selectAccountsByDeviceState = createMemoizedSelector(
         pipe(getAccountsByDeviceState(accounts, deviceState), returnStableArrayIfEmpty),
 );
 
+export const selectAccountsByDeviceStateAndNetworkSymbol = createMemoizedSelector(
+    [
+        selectAccountsByDeviceState,
+        (
+            _state: AccountsRootState & DeviceRootState,
+            _deviceState: StaticSessionId | DeviceState,
+            networkSymbol: NetworkSymbol,
+        ) => networkSymbol,
+    ],
+    (accounts, networkSymbol) =>
+        pipe(
+            accounts,
+            A.filter(account => account.symbol === networkSymbol),
+            returnStableArrayIfEmpty,
+        ),
+);
+
 export const selectDeviceAccounts = createMemoizedSelector(
     [selectAccounts, selectSelectedDevice],
     (accounts, device) => {


### PR DESCRIPTION
## Description

This PR improves the address book in send form:
- introduces connected devices/wallets switcher
- adds badges to current wallet and current account
- hides zero-balance accounts in a collapsible box
- removes the `To myself` button

## Screenshots:

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 44 21" src="https://github.com/user-attachments/assets/475035c1-fe1b-4aea-8e2e-2c40c314e1e4" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 44 32" src="https://github.com/user-attachments/assets/c41b6223-2a5e-4e9a-8901-e5f6d4868070" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 44 39" src="https://github.com/user-attachments/assets/5f443550-949c-4715-825d-e5c9167e7e46" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 44 45" src="https://github.com/user-attachments/assets/e81a5724-30db-45bf-8486-2fd4ec444387" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 44 56" src="https://github.com/user-attachments/assets/e531cdc5-c51f-49d6-9d21-1b48c08cee02" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 45 10" src="https://github.com/user-attachments/assets/e0511df0-81f0-4963-809a-bd6a88631355" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 45 16" src="https://github.com/user-attachments/assets/ea2989b4-4452-463b-a3bb-c489b7cbb1aa" />

<img width="1512" height="828" alt="Screenshot 2026-08-12 at 14 46 29" src="https://github.com/user-attachments/assets/2c885aba-5cd3-4b90-8330-978f54c19288" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/address-book-improvements/web/](https://dev.suite.sldev.cz/suite-web/feat/address-book-improvements/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/address-book-improvements&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/address-book-improvements&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/address-book-improvements&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T08:00:51.417Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T08:01:06.156Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the send form's receive address/account selection UI and account selectors. The main regression risk is broken selection of destination accounts/addresses in send and trading flows. The recommended strategy focuses on the global send test that directly exercises account selection, plus representative buy and swap tests that select receive accounts, avoiding broad unrelated coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/views/wallet/send/Outputs/DevAddressBook.tsx`
- `packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountItem.tsx`
- `packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModal.tsx`
- `packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAccountModalAccountsList.tsx`
- `packages/suite/src/views/wallet/send/Outputs/ReceiveAddressModal/ReceiveAddressModal.tsx`
- `suite-common/wallet-core/src/accounts/accountsSelectors.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/global-receive-send.test.ts` — This test directly exercises the global send flow including filtering networks, searching, and selecting a specific Bitcoin account as the send destination. This is the most direct coverage of the ReceiveAccountModal/ReceiveAddressModal components and account selection logic changed in this PR.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The buy flow requires selecting a receive address/account for the purchased BTC, which exercises the receive address selection UI. Inferred rather than statically mapped to the changed files.
- `suite/e2e/tests/trading/buy-ethereum.test.ts` — Tests adding a new Suite receive account during the buy flow, which likely opens the receive account/address selection modal and exercises the changed components. Inferred rather than statically mapped.
- `suite/e2e/tests/trading/swap-coin-to-token.test.ts` — Cross-chain SOL-to-USDC swap requires selecting a receive address/account for the destination token, exercising the receive address modal and account selection infrastructure. Inferred rather than statically mapped.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Tests selecting a specific Suite receive account as the swap destination for a token-to-coin swap, directly touching the receive account selection components. Inferred rather than statically mapped.

</details>

_Updated: 2026-08-13T08:01:22.607Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->