### PR TITLE
fix(suite): stabilize empty selectActiveTransports selector

### DIFF
--- a/packages/suite/src/selectors/suite/suiteSelectors.ts
+++ b/packages/suite/src/selectors/suite/suiteSelectors.ts
@@ -1,5 +1,6 @@
 import { type RouterRootState, selectRouter } from '@suite/router';
 import { type DeviceRootState, selectSelectedDevice } from '@suite-common/device';
+import { returnStableArrayIfEmpty } from '@suite-common/redux-utils';
 import { type TransportInfo } from '@trezor/connect';
 
 import { type SuiteRootState } from 'src/reducers/suite/suiteReducer';
@@ -12,7 +13,7 @@ export const selectSuiteTransports = (state: SuiteRootState) =>
     state.suite.transport?.transports.map(({ type, version }) => ({ type, version }));
 export const selectIsTransportInitialized = (state: SuiteRootState) => !!state.suite.transport;
 export const selectActiveTransports = (state: SuiteRootState) =>
-    state.suite.transport?.transports ?? [];
+    returnStableArrayIfEmpty(state.suite.transport?.transports);
 export const selectHasActiveTransport = (state: SuiteRootState) =>
     !!state.suite.transport?.transports.length;
 export const selectHasTransportOfType = (type: TransportInfo['type']) => (state: SuiteRootState) =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Stabilize selector by returning stable array if empty instead of creating new instances of empty arrays.

## Notes for QA

There should be no change in behavior. You can just double-check that it's still possible to connect Trezor to both web and desktop versions.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad suite selector utility, so the main risk is incorrect reading of suite-level state such as theme, language, autodetect flags, initial-run flags, and analytics/settings values. The recommended tests focus on the user-visible outcomes most sensitive to those selectors: theme/locale autodetect, settings changes, SuiteReady analytics, onboarding initial-run gating, discreet mode, and persisted language migration. Tests that only transitively import the file without exercising these state paths are omitted.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite/src/selectors/suite/suiteSelectors.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — The SuiteReady analytics payload is built from the current suite state (language, fiat, currency, theme, bitcoin unit, enabled networks, custom backends). A change in suiteSelectors could alter what is read from the suite slice and therefore what the event reports.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test explicitly verifies that Suite adopts the browser's preferred color scheme and locale on first load. Those UI values are derived directly from the suite slice selectors, so a regression here would be immediately visible.
- `suite/e2e/tests/settings/general.test.ts` — Changing language, theme, fiat currency, and the analytics toggle in settings relies on reading and updating suite state. The assertions check both the UI and the corresponding analytics events, which are fed by suite selectors.
- `suite/e2e/tests/suite/initial-run.test.ts` — The test validates initial-run/onboarding flag behavior across page reloads. Suite selectors typically expose the initial-run flag and related onboarding state, so any change there could break the decision to show or skip onboarding.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/dashboard/discreet-mode.test.ts` — Discreet-mode state is part of the suite slice and controls balance masking across the dashboard and device switcher. A selector regression could hide or reveal balances incorrectly.
- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — The analytics consent dialog appears based on whether the user is still in the initial onboarding flow. That decision is driven by suite selectors for initial run/consent state, making this a relevant shared flow.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — This test verifies that a Spanish language setting survives a database migration and is reflected in the settings UI. Reading the persisted language value is done through suite selectors, so a selector change could break migration-visible settings.

</details>

_Updated: 2026-08-12T14:30:46.819Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/select-active-transports-stability/web/](https://dev.suite.sldev.cz/suite-web/fix/select-active-transports-stability/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/select-active-transports-stability&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/select-active-transports-stability&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-12T14:33:16.383Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-12T14:32:52.705Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->