### PR TITLE
fix(transport): webusb crash on reload

### DIFF
--- a/packages/transport-common/src/api/usb.ts
+++ b/packages/transport-common/src/api/usb.ts
@@ -609,5 +609,11 @@ export class UsbApi extends AbstractApi {
             this.usbInterface.ondisconnect = null;
         }
         this.abortController.abort();
+        // try to close opened devices. this is not guaranteed to succeed, but it is better than nothing.
+        this.devices.forEach(d => {
+            if (d.device.opened) {
+                d.device.close().catch(() => {});
+            }
+        });
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

if you reload the page while using webusb device (while there is some active communication, device is opened)
the browser will crash on the next attempt of `device.claimInterface`.

TrezorConnect handles window `beforeunload` event and disposes itself - this will call `.dispose` on the active transport => usb transport will try to close opened devices.

## Notes for QA

This happens on linux, but maybe somewhere else as well, model doesnt matter

## Screenshots:
<img width="1907" height="983" alt="Screenshot from 2026-08-12 18-38-06" src="https://github.com/user-attachments/assets/db8e872f-4a74-4643-b78f-a264a8881c5e" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/webusb-crash/web/](https://dev.suite.sldev.cz/suite-web/fix/webusb-crash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/webusb-crash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/webusb-crash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T09:38:21.210Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T09:39:12.428Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change in the USB transport API has broad potential reach, but the highest-risk areas are device connection/disconnect detection, Bridge session management, and WebUSB transport selection. Running these four targeted tests covers those critical paths without invoking the full suite mapped to this shared file.

<details><summary><b>Changed files (1)</b></summary>

- `packages/transport-common/src/api/usb.ts`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test asserts the TransportType analytics event reports the correct bridge transport type/version and exercises device connect/disconnect lifecycle, so a USB transport change is directly observable here.
- `suite/e2e/tests/suite/bridge.test.ts` — The test explicitly navigates to the Bridge page, opts into WebUSB transport, and verifies the WebUSB connect-device prompt, making it a direct exercise of the USB/WebUSB code path.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test validates Bridge session stealing, reclaiming, and takeover across tabs, which depends on USB/BridgeTransport session enumeration and acquire/release behavior.
- `suite/e2e/tests/wallet/without-device.test.ts` — It powers off the device and checks disconnected status, connection modal, and disconnected banner, directly testing USB disconnect detection and transport error handling.

</details>

_Updated: 2026-08-13T09:36:39.480Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->