### PR TITLE
fix(connect): enforce PIN request before passphrase

### DIFF
--- a/packages/connect/src/device/workflow/validateState.ts
+++ b/packages/connect/src/device/workflow/validateState.ts
@@ -145,6 +145,18 @@ const validateThpDeviceState = async (context: WorkflowContext) => {
         }
     }
 
+    if (!uniqueState && !device.features.unlocked) {
+        // we don't have a sessionId yet and device is locked by pin.
+        // try to get staticSessionId (GetAddress) on the "seedless session" to display PIN matrix on the device.
+        // Failure_InvalidSession is expected here, because seedless session is not authorized to call GetAddress.
+        // This basically means the device is successfully unlocked. (failed successfully)
+        await getStaticSessionId(device).catch(e => {
+            if (e.code !== 'Failure_InvalidSession') {
+                throw e;
+            }
+        });
+    }
+
     if (!uniqueState || (!currentState?.deriveCardano && method.useCardanoDerivation)) {
         const newSessionId = thpState.createNewSessionId();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enforce pin martix before requesting the passphrase

## Notes for QA

- connect TS7 with pin and passphrase protection
- unlock it, load passphrase wallet
- lock it using device button
- go to Receive tab and click on Verify address

Previously:
You were asked for passphrase then for pin

Now:
You are asked for pin then for passphrase


## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed file is a broad device workflow dependency referenced by 134 tests, so a blanket run is unnecessary. The highest-risk regressions are in flows that revalidate device state after reconnect, session changes, passphrase entry, and device disconnection. I recommend running a small, targeted set of passphrase, session, recovery, and disconnected-device tests first; if those pass, confidence is high that the global state validation change is safe.

<details><summary><b>Changed files (1)</b></summary>

- `packages/connect/src/device/workflow/validateState.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (6)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-cancel.test.ts` — This test exercises the passphrase entry flow and its cancellation, directly depending on device workflow state validation to handle a hidden wallet request and clean up state when the prompt is closed.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — It verifies address display behind a passphrase-protected wallet after a device restart and re-entry of the passphrase, which requires re-validation of device state on reconnect.
- `suite/e2e/tests/passphrase/passphrase-reconnection.test.ts` — The test explicitly covers device disconnect/reconnect, passphrase cache behavior, and subsequent address verification, all of which rely on validating device session and passphrase state.
- `suite/e2e/tests/recovery/dry-run.test.ts` — It tests recovery dry-run reinitialization after stopping and restarting the bridge, meaning device state must be revalidated on reconnect before the dry run can proceed.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — This test covers Bridge session stealing/reclaiming across tabs and page reloads, scenarios where connect must validate and re-acquire device state after session changes.
- `suite/e2e/tests/wallet/without-device.test.ts` — It validates disconnected-device handling in the send form and device settings, directly exercising how Suite reacts when device state validation fails due to a missing device.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/passphrase/passphrase-duplicate.test.ts` — Adding a hidden wallet and detecting duplicate passphrases involves validating the current device and wallet state; a regression in state validation could incorrectly allow or reject duplicate wallets.
- `suite/e2e/tests/passphrase/passphrase-numbering.test.ts` — Ejecting and re-adding standard and passphrase wallets depends on consistent device state tracking to assign wallet IDs and display labels correctly.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — This broader passphrase test covers switching between hidden wallets, address verification, and passphrase confirmation mismatches, all of which trigger device state validation paths.
- `suite/e2e/tests/recovery/t2t1-dry-run.test.ts` — It performs a recovery dry run with simulated device disconnect and page reload, so it re-enters the device workflow and revalidates state on reconnect.
- `suite/e2e/tests/settings/forget-device.test.ts` — Forgetting a device across connected/disconnected and Bluetooth states depends on correct device state enumeration and validation before the forget action is enabled.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Sending ETH from a hidden wallet involves device session, passphrase, and address/amount validation on the device; changes to state validation could break the signing prompt or fee display.

</details>

_Updated: 2026-08-17T08:56:20.827Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/thp-pin-soft-locked/web/](https://dev.suite.sldev.cz/suite-web/fix/thp-pin-soft-locked/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/thp-pin-soft-locked&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/thp-pin-soft-locked&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/thp-pin-soft-locked&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-17T08:57:56.412Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-17T08:58:10.940Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->