### PR TITLE
fix(suite-native): estimated earn rewards precision

### DIFF
--- a/suite-common/wallet-utils/src/stakingUtils.test.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.test.ts
@@ -2,7 +2,7 @@ import {
     getMaxStakeAmountFixture,
     getUnstakingPeriodInDaysFixture,
 } from './__fixtures__/stakingUtils';
-import { getMaxStakeAmount, getUnstakingPeriodInDays } from './stakingUtils';
+import { calculateRewards, getMaxStakeAmount, getUnstakingPeriodInDays } from './stakingUtils';
 
 describe('getUnstakingPeriodInDays', () => {
     getUnstakingPeriodInDaysFixture.forEach(test => {
@@ -25,5 +25,20 @@ describe('getMaxStakeAmount', () => {
             });
             expect(result).toEqual(test.result);
         });
+    });
+});
+
+describe('calculateRewards', () => {
+    it('returns a full year of rewards at the precision of the inputs, with no float noise', () => {
+        expect(calculateRewards('0.5', 3.21)).toBe('0.01605');
+        expect(calculateRewards('123.456', 2.5)).toBe('3.0864');
+    });
+
+    it('compounds a partial year', () => {
+        expect(Number(calculateRewards('100', 5, 182.5))).toBeCloseTo(2.4695076596, 8);
+    });
+
+    it('returns no rewards for an unknown APY', () => {
+        expect(calculateRewards('0.5', null)).toBe('0');
     });
 });

--- a/suite-common/wallet-utils/src/stakingUtils.ts
+++ b/suite-common/wallet-utils/src/stakingUtils.ts
@@ -330,11 +330,15 @@ export const getOutputTxAmount = (composedLevels?: PrecomposedLevels) => {
 export const calculateRewards = (amount: string, apyPercent: number | null, days = 365) => {
     if (apyPercent === null) return '0';
 
-    const apy = apyPercent / 100;
-    const factor = Math.pow(1 + apy, days / 365) - 1;
-    const currentRewards = new BigNumber(amount).multipliedBy(factor).toString();
+    // Compounding a partial year needs a fractional exponent, which only float `pow` offers. A full
+    // year is just the rate itself, and taking it through `pow` adds noise digits instead
+    // (1.0321 ** 1 - 1 === 0.032100000000000017) that then surface in displayed rewards.
+    const factor =
+        days === 365
+            ? new BigNumber(apyPercent).dividedBy(100)
+            : new BigNumber(Math.pow(1 + apyPercent / 100, days / 365) - 1);
 
-    return currentRewards;
+    return new BigNumber(amount).multipliedBy(factor).toString();
 };
 
 export const getStakingProvidersForAnalytics = (accounts: Account[]): string[] => {

--- a/suite-native/module-earn/src/components/EarnEstimatedRewards.tsx
+++ b/suite-native/module-earn/src/components/EarnEstimatedRewards.tsx
@@ -10,6 +10,7 @@ import { formatEarnAmount } from '../utils/earnAmountUtils';
 type EarnEstimatedRewardsProps = {
     amountValue: string;
     apy: number | null;
+    decimals: number;
     label: ReactNode;
     symbol: string;
 };
@@ -17,12 +18,17 @@ type EarnEstimatedRewardsProps = {
 export const EarnEstimatedRewards = ({
     amountValue,
     apy,
+    decimals,
     label,
     symbol,
 }: EarnEstimatedRewardsProps) => {
     const locale = useSelector(selectSupportedLanguageLocale);
 
-    const rewards = formatEarnAmount({ amount: calculateRewards(amountValue, apy), locale });
+    const rewards = formatEarnAmount({
+        amount: calculateRewards(amountValue, apy),
+        locale,
+        maxDecimals: decimals,
+    });
 
     return (
         <VStack spacing="sp4" paddingHorizontal="sp16">

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -1,6 +1,10 @@
 import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
 
-import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    type NetworkSymbol,
+    getNetwork,
+    getNetworkDisplaySymbol,
+} from '@suite-common/wallet-config';
 import { Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { selectApy, useSelector as useStakingSelector } from '@suite-native/staking';
@@ -62,6 +66,7 @@ export const EarnFormScreenFooter = ({
                             <EarnEstimatedRewards
                                 amountValue={amountValue}
                                 apy={apy}
+                                decimals={getNetwork(symbol).decimals}
                                 label={
                                     <Translation id="earn.earnFormScreen.estimatedRewardsLabel" />
                                 }

--- a/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
@@ -25,6 +25,7 @@ type YieldDepositFlowFooterProps = {
     amountValue: string | undefined;
     apy: number | null;
     approvalAction?: YieldApprovalAction;
+    decimals: number;
     isDisabled: boolean;
     isLoading?: boolean;
     isSkipDisabled?: boolean;
@@ -53,6 +54,7 @@ export const YieldDepositFlowFooter = ({
     amountValue,
     apy,
     approvalAction,
+    decimals,
     isDisabled,
     isLoading = false,
     isSkipDisabled = false,
@@ -84,6 +86,7 @@ export const YieldDepositFlowFooter = ({
                                 <EarnEstimatedRewards
                                     amountValue={amountValue}
                                     apy={apy}
+                                    decimals={decimals}
                                     label={
                                         <Translation id="earn.yieldDepositFlowScreen.estimatedRewardsLabel" />
                                     }

--- a/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx
@@ -390,6 +390,7 @@ export const YieldDepositApprovalScreen = () => {
                     amountValue={amountValue}
                     approvalAction={footerApprovalAction}
                     apy={apy}
+                    decimals={token.decimals}
                     isDisabled={isSubmitDisabled}
                     isLoading={isCheckingApproval}
                     isSkipDisabled={isApprovalPending || isCheckingApproval}

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -406,6 +406,7 @@ export const YieldDepositScreen = () => {
                 <YieldDepositFlowFooter
                     amountValue={amountValue}
                     apy={apy}
+                    decimals={token.decimals}
                     isDisabled={isSubmitDisabled}
                     isLoading={isActionSubmitting}
                     onPress={handleContinue}

--- a/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.test.ts
@@ -48,6 +48,26 @@ describe(formatEarnAmount.name, () => {
             '0.000000000000000001',
         );
     });
+
+    it('never shows more decimals than the token has, so a computed estimate cannot invent digits', () => {
+        expect(
+            formatEarnAmount({
+                amount: '0.0000000000396296292690000246913578',
+                locale: 'en-US',
+                maxDecimals: 18,
+            }),
+        ).toBe('0.000000000039629629');
+    });
+
+    it('rounds a sub-unit estimate to zero rather than showing digits the token cannot hold', () => {
+        expect(
+            formatEarnAmount({
+                amount: '0.000000000000000000000321',
+                locale: 'en-US',
+                maxDecimals: 18,
+            }),
+        ).toBe('0');
+    });
 });
 
 describe(formatEarnTokenAmount.name, () => {

--- a/suite-native/module-earn/src/utils/earnAmountUtils.ts
+++ b/suite-native/module-earn/src/utils/earnAmountUtils.ts
@@ -8,6 +8,8 @@ import { type EarnDepositsCardActiveItem } from '../types';
 type FormatEarnAmountParams = {
     amount: string;
     locale: Locale;
+    /** Precision of the amount's token, so a computed estimate can't show digits it has no room for. */
+    maxDecimals?: number;
 };
 
 type FormatEarnTokenAmountParams = FormatEarnAmountParams & {
@@ -20,14 +22,14 @@ const COIN_BALANCE_DUST_THRESHOLD = new BigNumber('1e-8');
 /**
  * Formats an amount without its symbol, for callers rendering the symbol as a separate element.
  */
-export const formatEarnAmount = ({ amount, locale }: FormatEarnAmountParams) => {
+export const formatEarnAmount = ({ amount, locale, maxDecimals }: FormatEarnAmountParams) => {
     // A fixed decimal cap would round dust-sized deposited and received amounts away to zero.
     const amountBig = new BigNumber(amount);
     const isBelowCoinBalancePrecision =
         !amountBig.isZero() && amountBig.abs().lt(COIN_BALANCE_DUST_THRESHOLD);
 
     return isBelowCoinBalancePrecision
-        ? localizeNumber(amount, locale)
+        ? localizeNumber(amount, locale, 0, maxDecimals)
         : formatCoinBalance(amount, locale);
 };
 


### PR DESCRIPTION
## Description

Follow-up to #31184, which fixed how the *estimated yearly rewards* row is laid out. That PR raised a fair question: why would the row ever show more than 18 decimals for an 18-decimal token like WETH? It shouldn't — and it did, for two independent reasons. This PR removes both, so the ellipsis added in #31184 becomes a safety net rather than the thing doing the work.

**1. `calculateRewards` manufactured noise digits (`suite-common`)**

`Math.pow(1 + apy, 1) - 1` does not round-trip in binary floating point, so a full year of rewards came back with float dirt attached:

| deposit @ APY | before | after |
| --- | --- | --- |
| `0.5` @ 3.21% | `0.01605000000000001` (17 dp) | `0.01605` |
| `123.456` @ 2.5% | `3.08639999999998888896` (**20 dp**) | `3.0864` |
| `0.000000001` @ 3.21% | `3.210000000000002e-11` (26 dp) | `3.21e-11` |

A whole year is just the rate itself and needs no `pow` at all, so the full-year path now takes it directly through `BigNumber`; the partial-year path keeps `pow`, which genuinely needs a fractional exponent. Every current caller either uses the default 365 days or already rounds the result (`calculateGains` → `toFixed(5)`), so desktop staking figures only get more exact.

**2. The estimate could still out-precision the token (`suite-native`)**

Even with exact math, an estimate is a *product*: 1 wei of WETH at 3.21% is `3.21e-25`. `formatEarnAmount`'s dust branch deliberately bypasses the decimal cap (so a real dust *balance* isn't rounded away to `0.00`) and printed all of it. It now takes the token's precision as a cap for that branch, threaded from `token.decimals` in the deposit flow and `getNetwork(symbol).decimals` in the staking form.

What the row renders after both fixes:

| deposit @ APY | rendered |
| --- | --- |
| `0.5` @ 3.21% | `0.01605 ETH` |
| `123.456` @ 2.5% | `3.0864 ETH` |
| `0.000000001` @ 3.21% | `0.0000000000321 ETH` |
| `0.00000000123456789` @ 3.21% | `0.000000000039629629 ETH` (capped at 18) |
| `0.000000000000000001` @ 3.21% | `0 ETH` |

The last case is deliberate: a yearly reward smaller than one wei is zero, and printing digits the token cannot hold would be inventing precision.

## Notes for QA

- **Yield deposit, steps 2 and 3** (approval + deposit) and the **staking form** — the estimated yearly rewards value should read as a short, clean number, with no long tail of `999…` or `000…1` digits. Trying a few amounts (round, long-fraction, dust) covers it fastest.
- **Desktop staking is touched too** via the shared util: the potential/current rewards figures on the staking dashboard card, the account row and the staking banner. Values should be unchanged apart from losing float dirt — they already went through decimal-capped formatters, so no visible change is expected there.
- A sub-wei estimate showing `0 ETH` is expected, not a bug.

## Related Issue

Follow-up to #31184.

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies shared staking utilities and several native earn components. The web E2E risk is concentrated in staking amount/fee calculations and formatting across ADA, ETH, and SOL, so a focused set of staking tests provides the best regression signal. The suite-native earn changes are not covered by the available suite-web Playwright tests and should be validated by the mobile test suite separately.

<details><summary><b>Changed files (9)</b></summary>

- `suite-common/wallet-utils/src/stakingUtils.test.ts`
- `suite-common/wallet-utils/src/stakingUtils.ts`
- `suite-native/module-earn/src/components/EarnEstimatedRewards.tsx`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/utils/earnAmountUtils.test.ts`
- `suite-native/module-earn/src/utils/earnAmountUtils.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (7)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test verifies Cardano staking registration deposit, fee formatting, and post-stake balance calculations, which directly depend on the shared stakingUtils helpers.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — This test asserts deposit return, fee amounts, and unstaked balance updates; a change in stakingUtils could break these numeric/formatting expectations.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test checks ETH staking amounts, pending/staked state transitions, and progress indicator values that are likely computed via stakingUtils.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — This test validates unstake/claim amounts, fee calculations, and final balance updates, making it sensitive to staking calculation changes.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — This test verifies Solana staking amounts, rent/fee formatting, and pending-to-staked transitions, which depend on shared staking utilities.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test checks Solana unstake/claim amounts, fee display, and dashboard state after unstaking; regressions in stakingUtils would be visible here.
- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly exercises staking input validation, percentage/max amount calculations, and crypto/fiat conversions that are likely handled or formatted by stakingUtils.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test covers reward amount display and fee-vs-reward warnings, which share staking amount formatting logic but are less central than stake/unstake flows.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — This test re-uses ETH staking amount calculations and progress indicators already covered by initial stake, providing additional coverage of incremental staking.
- `suite/e2e/tests/staking/sol/rewards.test.ts` — This test validates reward amount updates in the Solana dashboard, which may use shared staking formatting helpers.

</details>

⚠️ **Changes with no test coverage (8)**
- `suite-common/wallet-utils/src/stakingUtils.test.ts`
- `suite-native/module-earn/src/components/EarnEstimatedRewards.tsx`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/screens/YieldDepositApprovalScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/utils/earnAmountUtils.test.ts`
- `suite-native/module-earn/src/utils/earnAmountUtils.ts`

_Updated: 2026-08-13T08:06:04.857Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-estimates-precision/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-estimates-precision/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-estimates-precision&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-estimates-precision&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-estimates-precision&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T08:08:04.918Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T08:07:28.053Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->