### PR TITLE
fix(blockchain-link): preserve decimals: 0 for indivisible ERC-20 tokens

### DIFF
--- a/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
@@ -1,6 +1,8 @@
 import type {
     AccountAddresses,
+    BlockbookAccountInfo,
     BlockbookTransaction,
+    TokenInfo,
     Transaction,
 } from '@trezor/blockchain-link-types';
 import type { DeepPartial } from '@trezor/type-utils';
@@ -133,6 +135,20 @@ export const filterTokenTransfers = [
         ],
     },
     {
+        description: 'decimals: 0 is preserved (indivisible token, not treated as missing)',
+        addresses: 'B',
+        transfers: [{ ...tIn, from: 'A', to: 'B', decimals: 0 }],
+        parsed: [
+            {
+                ...tOut,
+                decimals: 0,
+                type: 'recv',
+                from: 'A',
+                to: 'B',
+            },
+        ],
+    },
+    {
         description: 'addresses as unexpected object (number)',
         addresses: 1,
         transfers: tokenTransfers,
@@ -179,6 +195,63 @@ export const filterTokenTransfers = [
         addresses: 'A',
         transfers: ['A', null, 1, {}],
         parsed: [],
+    },
+];
+
+type BlockbookAccountToken = NonNullable<BlockbookAccountInfo['tokens']>[number];
+
+const erc20Balance = {
+    type: 'ERC20',
+    standard: 'ERC20',
+    contract: '0x0',
+    name: 'Token name',
+    symbol: 'TN',
+    transfers: 1,
+    balance: '5',
+    decimals: 6,
+} satisfies BlockbookAccountToken;
+
+// `decimals` is declared as required (see the `it is optional #14796` note on the generated
+// `Token`), but older Blockbook instances really do omit it — which is what the default exists for.
+// The type cannot express that, so the omission has to be cast in.
+const { decimals: _decimals, ...erc20BalanceWithoutDecimals } = erc20Balance;
+const erc20BalanceMissingDecimals = erc20BalanceWithoutDecimals as BlockbookAccountToken;
+
+export const transformTokenInfo: {
+    description: string;
+    tokens: BlockbookAccountInfo['tokens'];
+    parsed: TokenInfo[] | undefined;
+}[] = [
+    {
+        description: 'decimals: 0 is preserved (indivisible token, not treated as missing)',
+        tokens: [{ ...erc20Balance, decimals: 0 }],
+        parsed: [{ ...erc20Balance, decimals: 0 }],
+    },
+    {
+        description: 'missing decimals falls back to the ERC-20 convention (18)',
+        tokens: [erc20BalanceMissingDecimals],
+        parsed: [{ ...erc20BalanceWithoutDecimals, decimals: 18 }],
+    },
+    {
+        description: 'decimals are taken as reported',
+        tokens: [erc20Balance],
+        parsed: [erc20Balance],
+    },
+    {
+        description: 'XPUBAddress entries are skipped',
+        tokens: [
+            {
+                type: 'XPUBAddress',
+                name: 'A',
+                path: "m/44'/0'/0'/0/0",
+                transfers: 1,
+                decimals: 8,
+                balance: '0',
+                totalSent: '0',
+                totalReceived: '0',
+            },
+        ],
+        parsed: undefined,
     },
 ];
 

--- a/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
+++ b/packages/blockchain-link-utils/src/__fixtures__/blockbook.ts
@@ -211,9 +211,6 @@ const erc20Balance = {
     decimals: 6,
 } satisfies BlockbookAccountToken;
 
-// `decimals` is declared as required (see the `it is optional #14796` note on the generated
-// `Token`), but older Blockbook instances really do omit it — which is what the default exists for.
-// The type cannot express that, so the omission has to be cast in.
 const { decimals: _decimals, ...erc20BalanceWithoutDecimals } = erc20Balance;
 const erc20BalanceMissingDecimals = erc20BalanceWithoutDecimals as BlockbookAccountToken;
 

--- a/packages/blockchain-link-utils/src/blockbook.test.ts
+++ b/packages/blockchain-link-utils/src/blockbook.test.ts
@@ -1,5 +1,5 @@
 import * as fixtures from './__fixtures__/blockbook';
-import { filterTokenTransfers, transformTransaction } from './blockbook';
+import { filterTokenTransfers, transformTokenInfo, transformTransaction } from './blockbook';
 
 describe('blockbook/utils', () => {
     describe('filterTokenTransfers', () => {
@@ -8,6 +8,14 @@ describe('blockbook/utils', () => {
                 // @ts-expect-error incorrect params
                 const transfers = filterTokenTransfers(f.addresses, f.transfers);
                 expect(transfers).toEqual(f.parsed);
+            });
+        });
+    });
+
+    describe('transformTokenInfo', () => {
+        fixtures.transformTokenInfo.forEach(f => {
+            it(f.description, () => {
+                expect(transformTokenInfo(f.tokens)).toEqual(f.parsed);
             });
         });
     });

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -25,8 +25,6 @@ import {
 } from './utils';
 
 // ERC-20 default when a token does not expose decimals(); avoids breaking amount formatting.
-// Only applies when the field is absent — `0` is a valid value that must be preserved, so never
-// fall back on falsiness here.
 const DEFAULT_TOKEN_DECIMALS = 18;
 
 export const transformServerInfo = (payload: ServerInfo) => ({

--- a/packages/blockchain-link-utils/src/blockbook.ts
+++ b/packages/blockchain-link-utils/src/blockbook.ts
@@ -25,6 +25,8 @@ import {
 } from './utils';
 
 // ERC-20 default when a token does not expose decimals(); avoids breaking amount formatting.
+// Only applies when the field is absent — `0` is a valid value that must be preserved, so never
+// fall back on falsiness here.
 const DEFAULT_TOKEN_DECIMALS = 18;
 
 export const transformServerInfo = (payload: ServerInfo) => ({
@@ -86,7 +88,7 @@ export const filterTokenTransfers = (
             const tokenTransfer = {
                 ...transfer,
                 type,
-                decimals: transfer.decimals || DEFAULT_TOKEN_DECIMALS,
+                decimals: transfer.decimals ?? DEFAULT_TOKEN_DECIMALS,
                 amount: transfer.value || '',
                 standard: transfer.standard,
             };
@@ -399,7 +401,7 @@ export const transformTokenInfo = (
         return arr.concat([
             {
                 ...token,
-                decimals: token.decimals || DEFAULT_TOKEN_DECIMALS,
+                decimals: token.decimals ?? DEFAULT_TOKEN_DECIMALS,
                 standard: token.standard,
             },
         ]);

--- a/suite-common/token-definitions/src/phishing/__fixtures__/phishing.ts
+++ b/suite-common/token-definitions/src/phishing/__fixtures__/phishing.ts
@@ -1,7 +1,14 @@
+import type {
+    RatesByTimestamps,
+    Timestamp,
+    TokenAddress,
+    WalletAccountTransaction,
+} from '@suite-common/wallet-types';
+import { getFiatRateKey } from '@suite-common/wallet-utils';
 import { BigNumber } from '@trezor/utils';
 
 import type { TokenDefinitions } from '../../tokenDefinitionsTypes';
-import { DUST_PHISHING_THRESHOLD } from '../constants';
+import { DUST_PHISHING_THRESHOLD, DUST_PHISHING_THRESHOLD_CURRENCY } from '../constants';
 import { type TransactionWithFiatAmount } from '../types';
 
 const DUST_UNIT = new BigNumber(DUST_PHISHING_THRESHOLD).dividedBy(10);
@@ -888,5 +895,47 @@ export const isPhishingTransactionFixtures = [
         } as unknown as TransactionWithFiatAmount,
         tokenDefinitions: {} as TokenDefinitions,
         result: false,
+    },
+];
+
+const CONTRACT = '0xA' as TokenAddress;
+// on the hour, so roundTimestampToNearestPastHour is a no-op and the rate lookup below hits
+const BLOCK_TIME = 1699999200 as Timestamp;
+
+// 1 whole unit of the token is worth $10
+const historicRates = {
+    [getFiatRateKey('eth', DUST_PHISHING_THRESHOLD_CURRENCY, CONTRACT)]: { [BLOCK_TIME]: 10 },
+} as unknown as RatesByTimestamps;
+
+const transactionWithTokenDecimals = (decimals: number | undefined) =>
+    ({
+        symbol: 'eth',
+        type: 'recv',
+        amount: '0',
+        blockTime: BLOCK_TIME,
+        internalTransfers: [],
+        tokens: [{ amount: '5', contract: CONTRACT, decimals }],
+    }) as unknown as WalletAccountTransaction;
+
+export const getTransactionWithFiatAmountsFixtures = [
+    {
+        // regression: `decimals: 0` used to be read as "missing" and replaced by the network's 18,
+        // understating the amount by 10^18 and making a real transfer look like dust
+        testName: 'decimals: 0 is treated as 0 decimals, not as missing',
+        transaction: transactionWithTokenDecimals(0),
+        historicRates,
+        tokenAmountInFiat: '50', // 5 units * $10
+    },
+    {
+        testName: 'missing decimals falls back to the network decimals',
+        transaction: transactionWithTokenDecimals(undefined),
+        historicRates,
+        tokenAmountInFiat: '0.00000000000000005', // 5 wei * $10, using eth's 18 decimals
+    },
+    {
+        testName: 'reported decimals are used as-is',
+        transaction: transactionWithTokenDecimals(2),
+        historicRates,
+        tokenAmountInFiat: '0.5',
     },
 ];

--- a/suite-common/token-definitions/src/phishing/phishing.test.ts
+++ b/suite-common/token-definitions/src/phishing/phishing.test.ts
@@ -71,7 +71,7 @@ describe('getTransactionWithFiatAmounts', () => {
             test(testName, () => {
                 expect(
                     getTransactionWithFiatAmounts({ transaction, historicRates }).tokens[0]
-                        .amountInFiat,
+                        ?.amountInFiat,
                 ).toBe(tokenAmountInFiat);
             });
         },

--- a/suite-common/token-definitions/src/phishing/phishing.test.ts
+++ b/suite-common/token-definitions/src/phishing/phishing.test.ts
@@ -1,4 +1,5 @@
 import {
+    getTransactionWithFiatAmountsFixtures,
     isDustValuePhishingFixtures,
     isFakeTokenPhishingFixtures,
     isPhishingTransactionFixtures,
@@ -8,6 +9,7 @@ import {
 import { DUST_PHISHING_THRESHOLD } from './constants';
 import { detectors } from './detectors';
 import { isPhishingTransaction } from './phishing';
+import { getTransactionWithFiatAmounts } from './utils';
 
 describe('isDustValuePhishing', () => {
     isDustValuePhishingFixtures.forEach(({ testName, transaction, result }) => {
@@ -61,4 +63,17 @@ describe('isPhishingTransaction', () => {
             ).toBe(result);
         });
     });
+});
+
+describe('getTransactionWithFiatAmounts', () => {
+    getTransactionWithFiatAmountsFixtures.forEach(
+        ({ testName, transaction, historicRates, tokenAmountInFiat }) => {
+            test(testName, () => {
+                expect(
+                    getTransactionWithFiatAmounts({ transaction, historicRates }).tokens[0]
+                        .amountInFiat,
+                ).toBe(tokenAmountInFiat);
+            });
+        },
+    );
 });

--- a/suite-common/token-definitions/src/phishing/utils.ts
+++ b/suite-common/token-definitions/src/phishing/utils.ts
@@ -48,7 +48,7 @@ const getTransactionAmountInFiat = ({
     const roundedTimestamp = roundTimestampToNearestPastHour(transaction.blockTime as Timestamp);
 
     const amountInUnits = subunitsToUnits(
-        decimals
+        decimals !== undefined
             ? {
                   value: asAmountSubunit(new BigNumber(amount)),
                   decimals,


### PR DESCRIPTION
## Description

Token decimals were defaulted with `||`, so a legitimate `decimals: 0` was treated as missing and replaced by `18`. `decimals()` is optional in the ERC-20 spec and `0` is valid for indivisible-unit tokens, so the wrong value then propagated into balances (divided by 10^18), transaction history amounts, and the send form's subunit conversion.

Two `??` fixes:

- `packages/blockchain-link-utils/src/blockbook.ts` — both defaulting sites (token transfers and account token info). Regression from #14796 / #28697, which changed the fallback from `|| 0` to `|| 18`; the previous `|| 0` was accidentally correct for this case. The 0-decimals problem was flagged in review on that PR and merged unaddressed.
- `suite-common/token-definitions/src/phishing/utils.ts` — the dust-phishing fiat amount branched on `decimals` truthiness, so a 0-decimal token fell back to the network's decimals (18 on EVM), understating the value by 10^18 and letting a legitimate transfer be flagged as `DUST_AMOUNT`. This was masked while decimals never arrived as `0`, so fixing blockbook alone would have exposed it.

This is reachable with real data: trezor/blockbook#1579 (closes trezor/blockbook#1577) made Blockbook always send `decimals`, defaulting server-side only when the on-chain value is unavailable — so `0` is now delivered rather than omitted.

Tests: `transformTokenInfo` and `getTransactionWithFiatAmounts` had no coverage at all, so both got fixture-driven tests alongside a `decimals: 0` case for `filterTokenTransfers`. Each new `decimals: 0` case was verified to fail with `||` and pass with `??`.

## Notes for QA

Needs an EVM account holding a **0-decimal ERC-20**. #8030 has a concrete one (SENSO) with the address and transaction.

- Token list: balance shows at full value, not divided by 10^18 (a balance of `5` was rendering as `0.000000000000000005`).
- Transaction history: transfer amounts correct, same factor.
- Send: entering an amount converts against 0 decimals.
- Suspicious-transaction filter: a 0-decimal token transfer of real value is **not** hidden as dust.

No change expected for tokens with normal decimals (6, 8, 18) or for tokens that report no decimals at all — those still default to 18. Worth a regression pass on ordinary ERC-20 balances/history to confirm.

Not covered here: ERC-721/ERC-1155 amount rendering (#31114, #31115) share the same mapping but are a different root cause.

## Related Issue

Resolve #31214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/31214-0-decimal-erc-20-tokens-are-given-18-decimals-scaling-balances-and-amounts-by-1018/web/](https://dev.suite.sldev.cz/suite-web/31214-0-decimal-erc-20-tokens-are-given-18-decimals-scaling-balances-and-amounts-by-1018/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=31214-0-decimal-erc-20-tokens-are-given-18-decimals-scaling-balances-and-amounts-by-1018&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=31214-0-decimal-erc-20-tokens-are-given-18-decimals-scaling-balances-and-amounts-by-1018&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=31214-0-decimal-erc-20-tokens-are-given-18-decimals-scaling-balances-and-amounts-by-1018&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T09:55:52.672Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T10:17:35.077Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in low-level blockchain-link Blockbook utilities and token-definition phishing filters. Because both files are broad dependencies, the strategy is to run the small set of E2E tests that directly configure or assert Blockbook-backed behavior, plus a couple of token-trading flows to cover phishing-utils regressions. This targets the most user-visible failure points without running the full suite.

<details><summary><b>Changed files (6)</b></summary>

- `packages/blockchain-link-utils/src/__fixtures__/blockbook.ts`
- `packages/blockchain-link-utils/src/blockbook.test.ts`
- `packages/blockchain-link-utils/src/blockbook.ts`
- `suite-common/token-definitions/src/phishing/__fixtures__/phishing.ts`
- `suite-common/token-definitions/src/phishing/phishing.test.ts`
- `suite-common/token-definitions/src/phishing/utils.ts`

</details>

**Recommended tests (13)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — This test explicitly configures custom Blockbook backends for BTC/ETH and asserts correct discovery, empty-account loading, and error states. Changes to blockbook.ts or its fixtures can directly alter how custom backend responses are parsed and surfaced in the UI.
- `suite/e2e/tests/wallet/blockbook-discovery.test.ts` — The test is dedicated to verifying that custom Blockbook backends for BTC and LTC successfully drive account discovery and render the dashboard graph. It is one of the most direct E2E validations of the Blockbook integration.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Uses a mocked custom Blockbook backend for Dogecoin and asserts exact send amount, fee, and total values shown on the device prompt. Regressions in blockbook response parsing would directly affect these values.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Relies on a custom LTC Blockbook backend and spends a MimbleWimble peg-out output. Backend data formatting from blockbook.ts is central to the send flow completing successfully.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/settings/coins.test.ts` — Configures a custom Blockbook backend for ETH in the Coins settings and checks the custom backend indicator. It exercises the same backend configuration plumbing touched by blockbook.ts changes.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Uses the blockbookMock to set ETH account state, staking pools, and fiat rates. Any change in how blockbook-formatted account data is parsed could break balance discovery or staking pool calculations.
- `suite/e2e/tests/trading-poc/passthru-swap-eth-to-btc.test.ts` — Runs against a custom ETH Blockbook backend and live swap quotes, verifying composed transactions and device prompt amounts. It is a representative end-to-end flow where blockbook parsing feeds into trading calculations.
- `suite/e2e/tests/trading/buy-solana-token.test.ts` — Selects the Jupiter (JUP) SPL token through the asset picker and completes a buy flow. Changes to phishing token definitions/utils could affect whether the token appears or triggers warnings in the token list.
- `suite/e2e/tests/trading/swap-tokens.test.ts` — Exchanges Solana SPL tokens (USDT to USDC) and depends on token selection and validation. Phishing-utils changes that filter or flag token contracts could alter token availability in this flow.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — Enables regtest and mines funds to a wallet, then asserts balance display and ellipsis handling. Account balance discovery flows through Blockbook-style backend data, so parsing changes could affect results.
- `suite/e2e/tests/wallet/discovery.test.ts` — Activates eight coins and waits for full discovery across multiple backends. If blockbook.ts changes affect account/balance normalization, discovery status or displayed balances could regress.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Sends Bitcoin regtest transactions with locktime and OP_RETURN outputs. The transaction list assertions depend on correct parsing and display of blockbook-formatted transactions and outputs.
- `suite/e2e/tests/wallet/transactions.test.ts` — Cycles through BTC account transaction graph ranges and searches transactions by address. This exercises how blockbook transaction data is rendered in the transaction list and summary.

</details>

⚠️ **Changes with no test coverage (4)**
- `packages/blockchain-link-utils/src/__fixtures__/blockbook.ts`
- `packages/blockchain-link-utils/src/blockbook.test.ts`
- `suite-common/token-definitions/src/phishing/__fixtures__/phishing.ts`
- `suite-common/token-definitions/src/phishing/phishing.test.ts`

_Updated: 2026-08-13T10:16:33.364Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->