### PR TITLE
fix(suite-native): activity center design QA fixes

### DIFF
--- a/suite-native/atoms/src/SubTabs.tsx
+++ b/suite-native/atoms/src/SubTabs.tsx
@@ -58,6 +58,7 @@ const iconSizeBySize = {
 const tabsStyle = prepareNativeStyle<TabsStyleProps>((utils, { paddingHorizontal }) => ({
     gap: utils.spacings.sp12,
     paddingHorizontal: paddingHorizontal ? utils.spacings[paddingHorizontal] : undefined,
+    paddingBottom: utils.spacings.sp2, // To prevent bottom shadow cutoff.
 }));
 
 const tabStyle = prepareNativeStyle<SubTabStyleProps>((utils, { isActive, size }) => ({

--- a/suite-native/module-activity-center/src/components/notifications/ActivityCenterEmptyState.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/ActivityCenterEmptyState.tsx
@@ -1,21 +1,35 @@
 import { Pictogram, Text, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
+import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 type Props = {
     titleId: TxKeyPath;
     subtitleId: TxKeyPath;
 };
 
-export const ActivityCenterEmptyState = ({ titleId, subtitleId }: Props) => (
-    <VStack spacing="sp16" alignItems="center">
-        <Pictogram variant="info" icon="bellZ" />
-        <VStack spacing="sp4" alignItems="center">
-            <Text variant="headline-md" textAlign="center">
-                <Translation id={titleId} />
-            </Text>
-            <Text variant="body-md" color="contentSecondary" textAlign="center">
-                <Translation id={subtitleId} />
-            </Text>
+//Exact value defined by Figma.
+const TOP_PADDING = 94;
+
+const wrapperStyle = prepareNativeStyle(utils => ({
+    alignItems: 'center',
+    gap: utils.spacings.sp16,
+    paddingTop: TOP_PADDING,
+}));
+
+export const ActivityCenterEmptyState = ({ titleId, subtitleId }: Props) => {
+    const { applyStyle } = useNativeStyles();
+
+    return (
+        <VStack style={applyStyle(wrapperStyle)}>
+            <Pictogram variant="info" icon="bellZ" />
+            <VStack spacing="sp4" alignItems="center">
+                <Text variant="headline-md" textAlign="center">
+                    <Translation id={titleId} />
+                </Text>
+                <Text variant="body-md" color="contentSecondary" textAlign="center">
+                    <Translation id={subtitleId} />
+                </Text>
+            </VStack>
         </VStack>
-    </VStack>
-);
+    );
+};

--- a/suite-native/module-activity-center/src/components/notifications/ActivityCenterEmptyState.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/ActivityCenterEmptyState.tsx
@@ -1,35 +1,21 @@
 import { Pictogram, Text, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
-import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 type Props = {
     titleId: TxKeyPath;
     subtitleId: TxKeyPath;
 };
 
-//Exact value defined by Figma.
-const TOP_PADDING = 94;
-
-const wrapperStyle = prepareNativeStyle(utils => ({
-    alignItems: 'center',
-    gap: utils.spacings.sp16,
-    paddingTop: TOP_PADDING,
-}));
-
-export const ActivityCenterEmptyState = ({ titleId, subtitleId }: Props) => {
-    const { applyStyle } = useNativeStyles();
-
-    return (
-        <VStack style={applyStyle(wrapperStyle)}>
-            <Pictogram variant="info" icon="bellZ" />
-            <VStack spacing="sp4" alignItems="center">
-                <Text variant="headline-md" textAlign="center">
-                    <Translation id={titleId} />
-                </Text>
-                <Text variant="body-md" color="contentSecondary" textAlign="center">
-                    <Translation id={subtitleId} />
-                </Text>
-            </VStack>
+export const ActivityCenterEmptyState = ({ titleId, subtitleId }: Props) => (
+    <VStack alignItems="center" spacing="sp16">
+        <Pictogram variant="info" icon="bellZ" />
+        <VStack spacing="sp4" alignItems="center">
+            <Text variant="headline-md" textAlign="center">
+                <Translation id={titleId} />
+            </Text>
+            <Text variant="body-md" color="contentSecondary" textAlign="center">
+                <Translation id={subtitleId} />
+            </Text>
         </VStack>
-    );
-};
+    </VStack>
+);

--- a/suite-native/module-activity-center/src/components/notifications/NotificationList.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/NotificationList.tsx
@@ -51,7 +51,7 @@ export const NotificationList = ({ unseenNotifications, seenNotifications }: Pro
 
     return (
         <Card style={applyStyle(cardStyle)}>
-            <VStack>
+            <VStack spacing="sp12">
                 <NotificationSection
                     titleId="moduleActivityCenter.notifications.sectionNew"
                     notifications={unseenNotifications}

--- a/suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/NotificationsTabContent.tsx
@@ -2,7 +2,6 @@ import { useSelector } from 'react-redux';
 
 import { getSeenAndUnseenNotifications } from '@suite-common/toast-notifications';
 import { selectNonPhishingTransactionNotifications } from '@suite-common/wallet-core';
-import { Box } from '@suite-native/atoms';
 
 import { ActivityCenterEmptyState } from './ActivityCenterEmptyState';
 import { NotificationList } from './NotificationList';
@@ -14,12 +13,10 @@ export const NotificationsTabContent = () => {
 
     if (txNotifications.length === 0) {
         return (
-            <Box flex={1} justifyContent="center" alignItems="center">
-                <ActivityCenterEmptyState
-                    titleId="moduleActivityCenter.notifications.empty.title"
-                    subtitleId="moduleActivityCenter.notifications.empty.subtitle"
-                />
-            </Box>
+            <ActivityCenterEmptyState
+                titleId="moduleActivityCenter.notifications.empty.title"
+                subtitleId="moduleActivityCenter.notifications.empty.subtitle"
+            />
         );
     }
 

--- a/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.tsx
+++ b/suite-native/module-activity-center/src/components/notifications/TransactionNotificationItem.tsx
@@ -108,7 +108,7 @@ export const TransactionNotificationItem = ({ notification, seen, index }: Props
                 <Icon name={iconName} size="mediumLarge" color={contentColor} />
                 <VStack flex={1} spacing="sp2">
                     <Text
-                        variant={seen ? 'body-sm' : 'body-md-strong'}
+                        variant={seen ? 'body-sm' : 'body-sm-strong'}
                         color={contentColor}
                         numberOfLines={1}
                     >

--- a/suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx
+++ b/suite-native/module-activity-center/src/components/releaseNotes/ReleaseNotesTabContent.tsx
@@ -35,7 +35,7 @@ export const ReleaseNotesTabContent = () => {
     const version = getSuiteVersion();
 
     return (
-        <Box paddingVertical="sp16">
+        <Box>
             <View style={applyStyle(headerCardStyle)}>
                 <HStack spacing="sp6" alignItems="center">
                     <Text variant="body-sm" color="contentSecondary">

--- a/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
+++ b/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
@@ -6,7 +6,7 @@ import {
     selectHasUnseenTransactionNotifications,
 } from '@suite-common/toast-notifications';
 import { NotificationDot } from '@suite-native/activity-center';
-import { type SubTabItem, SubTabs, VStack } from '@suite-native/atoms';
+import { Box, type SubTabItem, SubTabs, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 
@@ -48,9 +48,12 @@ export const ActivityCenterScreen = () => {
                 />
             }
         >
-            <VStack spacing="sp16">
+            {/* 0.6 → apx. centered to whole screen, similar in SearchNoResults. It's a crude solution, we could maybe unify it somehow. */}
+            <VStack flex={0.6} spacing="sp16">
                 <SubTabs items={tabs} value={activeTab} onChange={setActiveTab} />
-                <ActivityCenterTabContent activeTab={activeTab} />
+                <Box flex={1}>
+                    <ActivityCenterTabContent activeTab={activeTab} />
+                </Box>
             </VStack>
         </Screen>
     );

--- a/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
+++ b/suite-native/module-activity-center/src/screens/ActivityCenterScreen.tsx
@@ -6,7 +6,7 @@ import {
     selectHasUnseenTransactionNotifications,
 } from '@suite-common/toast-notifications';
 import { NotificationDot } from '@suite-native/activity-center';
-import { Box, type SubTabItem, SubTabs, VStack } from '@suite-native/atoms';
+import { type SubTabItem, SubTabs, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
 import { DynamicScreenHeader, Screen } from '@suite-native/navigation';
 
@@ -48,13 +48,9 @@ export const ActivityCenterScreen = () => {
                 />
             }
         >
-            <VStack flex={1}>
-                <Box>
-                    <SubTabs items={tabs} value={activeTab} onChange={setActiveTab} />
-                </Box>
-                <Box flex={1}>
-                    <ActivityCenterTabContent activeTab={activeTab} />
-                </Box>
+            <VStack spacing="sp16">
+                <SubTabs items={tabs} value={activeTab} onChange={setActiveTab} />
+                <ActivityCenterTabContent activeTab={activeTab} />
             </VStack>
         </Screen>
     );


### PR DESCRIPTION
## Description

Resolves design QA findings reported in the [Figma QA board](https://www.figma.com/design/ZQ1L5eXN7bdDBHZwj2gUnL/Activity?node-id=2517-5275&t=OdbQAkgQ70BTLgx2-4):

- Empty state vertical position adjusted to match Figma (`paddingTop: 94`)
- Unseen notification title uses `body-sm-strong` instead of `body-md-strong`
- Added `sp12` spacing between notification sections (new / seen)
- Removed extra `paddingVertical` from release notes tab header
- Simplified `ActivityCenterScreen` layout — tabs and content separated by `sp16`
- Fixed `SubTabs` shadow being clipped at the bottom edge (`paddingBottom: sp2` on the list content container)


## Related Issue

Relates to #29796

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native/activity-center-design-qa&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->