### PR TITLE
feat(e2e): add QR code decoding functionality into receive test

### DIFF
--- a/packages/product-components/src/components/QrCode/QrCode.tsx
+++ b/packages/product-components/src/components/QrCode/QrCode.tsx
@@ -34,13 +34,19 @@ export type QrCodeProps = {
     value: string;
     color?: Color;
     centerIcon?: ReactNode;
+    'data-testid'?: string;
 };
 
-export const QrCode = ({ value, color = 'contentPrimary', centerIcon }: QrCodeProps) => {
+export const QrCode = ({
+    value,
+    color = 'contentPrimary',
+    centerIcon,
+    'data-testid': dataTestId,
+}: QrCodeProps) => {
     const theme = useTheme();
 
     return (
-        <Flex position={{ type: 'relative' }} width="100%" height="100%">
+        <Flex position={{ type: 'relative' }} width="100%" height="100%" data-testid={dataTestId}>
             <QRCodeSVG
                 fgColor={theme[color]}
                 bgColor="transparent"

--- a/scripts/list-outdated-dependencies/qa-dependencies.txt
+++ b/scripts/list-outdated-dependencies/qa-dependencies.txt
@@ -31,3 +31,4 @@ minimist
 ts-jest
 uri-scheme
 xml2js
+zxing-wasm

--- a/suite/e2e/package.json
+++ b/suite/e2e/package.json
@@ -80,6 +80,7 @@
         "react-intl": "^8.1.3",
         "tsx": "^4.21.0",
         "type-fest": "5.5.0",
-        "xvfb-maybe": "^0.2.1"
+        "xvfb-maybe": "^0.2.1",
+        "zxing-wasm": "3.0.0"
     }
 }

--- a/suite/e2e/support/helpers/qrCodeDecoder.ts
+++ b/suite/e2e/support/helpers/qrCodeDecoder.ts
@@ -1,0 +1,11 @@
+import { readBarcodes } from 'zxing-wasm/reader';
+
+export const decodeQrCodes = async (screenshot: Buffer) => {
+    const results = await readBarcodes(screenshot, {
+        formats: ['QRCode'],
+        // Conditional handling of dark theme.
+        tryInvert: true,
+    });
+
+    return results.filter(({ isValid }) => isValid).map(({ text }) => text);
+};

--- a/suite/e2e/support/pageObjects/walletPage.ts
+++ b/suite/e2e/support/pageObjects/walletPage.ts
@@ -50,6 +50,7 @@ export class WalletPage {
     readonly verifyAddressButton: Locator;
     readonly copyAddressButton: Locator;
     readonly receiveAddress: Locator;
+    readonly receiveQrCode: Locator;
     readonly showNextAddressButton: Locator;
     readonly addressCopiedModal: Locator;
     readonly addressCopiedModalVerifyButton: Locator;
@@ -116,6 +117,7 @@ export class WalletPage {
         this.verifyAddressButton = this.page.getByTestId('@wallet/receive/verify-address-button');
         this.copyAddressButton = this.page.getByTestId('@wallet/receive/copy-address-button');
         this.receiveAddress = this.page.getByTestId('@wallet/receive/address');
+        this.receiveQrCode = this.page.getByTestId('@wallet/receive/qr-code');
         this.showNextAddressButton = this.page.getByTestId(
             '@wallet/receive/show-next-address-button',
         );

--- a/suite/e2e/support/testExtends/customMatchers.ts
+++ b/suite/e2e/support/testExtends/customMatchers.ts
@@ -17,6 +17,7 @@ import { getIndexOrThrow } from '@trezor/utils';
 import { formatAddress, formatEvmAddress, isEqualWithOmit, normalizeWhitespace } from '../common';
 import { DeviceFixture } from '../device';
 import type { NormalizedDisplayContent } from '../helpers/displayContentNormalizedParser';
+import { decodeQrCodes } from '../helpers/qrCodeDecoder';
 
 type LineFormats = 'fourTetragrams' | 'evmTetragrams' | 'cardanoTetragrams' | 'fullLine';
 
@@ -337,6 +338,24 @@ export const expect = baseExpect.extend({
             pass: addressValidator.isAddressValid(stripped, symbol),
             message: () =>
                 `expected locator text to be a valid '${symbol}' address, but got '${text}' (stripped: '${stripped}')`,
+        };
+    },
+
+    async toHaveQrCodeValue(
+        locator: Locator,
+        expectedValue: string,
+        options?: { timeout?: number },
+    ) {
+        await baseExpect
+            .poll(async () => await decodeQrCodes(await locator.screenshot()), {
+                timeout: options?.timeout,
+                message: `expected the rendered QR code to decode to '${expectedValue}'`,
+            })
+            .toEqual([expectedValue]);
+
+        return {
+            pass: true,
+            message: () => 'errors are handled in expects above',
         };
     },
 

--- a/suite/e2e/tests/wallet/receive.test.ts
+++ b/suite/e2e/tests/wallet/receive.test.ts
@@ -59,35 +59,49 @@ test.describe('Receive transaction', { tag: ['@T3W1', '@T3T1'] }, () => {
                 }),
             },
             async ({ page, devicePrompt, settingsPage, walletPage }) => {
-                await settingsPage.changeNetworks({ enableNetworks: [coin] });
-                await walletPage.accountButton({ symbol: coin }).click();
-                await walletPage.receiveButton.click();
-                // Intercept writeText before clicking copy — Chromium enforces Permissions-Policy
-                // at the HTTP header level, so navigator.clipboard.readText() is blocked in CI
-                // even when context permissions are granted. Capture the value on write instead.
-                await page.evaluate(() => {
-                    const clipboard = navigator.clipboard as any;
-                    const original = clipboard.writeText.bind(clipboard);
-                    clipboard.writeText = (text: string) => {
-                        (window as any).__clipboardCapture = text;
-
-                        return original(text).catch(() => undefined);
-                    };
+                await test.step(`Enable ${coin.toUpperCase()} and open the receive tab`, async () => {
+                    await settingsPage.changeNetworks({ enableNetworks: [coin] });
+                    await walletPage.accountButton({ symbol: coin }).click();
+                    await walletPage.receiveButton.click();
                 });
-                // Copying is the entry point to verification: it opens the prompt offering to
-                // verify the address that was just copied.
-                await walletPage.copyAddressButton.click();
-                await expect(walletPage.copyToCliboardToast).toBeVisible();
-                await expect(walletPage.addressCopiedModal).toBeVisible();
-                await walletPage.addressCopiedModalVerifyButton.click();
-                const address = await devicePrompt.getAddressFromDisplay();
-                await devicePrompt.waitForPromptAndConfirm();
-                await expect(walletPage.addressCopiedModal).toBeHidden();
-                const clipboardText = await page.evaluate(
-                    () => (window as any).__clipboardCapture as string,
-                );
-                expect.soft(address).toEqual(`${deviceDisplayPrefix}${clipboardText}`);
-                expect.soft(address).toMatch(addressFormat);
+
+                await test.step('Intercept clipboard writes', async () => {
+                    await page.evaluate(() => {
+                        const clipboard = navigator.clipboard as any;
+                        const original = clipboard.writeText.bind(clipboard);
+                        clipboard.writeText = (text: string) => {
+                            (window as any).__clipboardCapture = text;
+
+                            return original(text).catch(() => undefined);
+                        };
+                    });
+                });
+
+                await test.step('Copy the receive address', async () => {
+                    // Copying is the entry point to verification: it opens the prompt offering to
+                    // verify the address that was just copied.
+                    await walletPage.copyAddressButton.click();
+                    await expect(walletPage.copyToCliboardToast).toBeVisible();
+                    await expect(walletPage.addressCopiedModal).toBeVisible();
+                });
+
+                const address = await test.step('Verify the address on the device', async () => {
+                    await walletPage.addressCopiedModalVerifyButton.click();
+                    const displayedAddress = await devicePrompt.getAddressFromDisplay();
+                    await devicePrompt.waitForPromptAndConfirm();
+                    await expect(walletPage.addressCopiedModal).toBeHidden();
+
+                    return displayedAddress;
+                });
+
+                await test.step('Verify the copied address matches the device display and QR code', async () => {
+                    const clipboardText = await page.evaluate(
+                        () => (window as any).__clipboardCapture as string,
+                    );
+                    expect.soft(address).toEqual(`${deviceDisplayPrefix}${clipboardText}`);
+                    expect.soft(address).toMatch(addressFormat);
+                    await expect(walletPage.receiveQrCode).toHaveQrCodeValue(clipboardText);
+                });
             },
         );
     });

--- a/suite/receive/src/CoinQrCode.tsx
+++ b/suite/receive/src/CoinQrCode.tsx
@@ -11,5 +11,9 @@ type CoinQrCodeProps = {
 };
 
 export const CoinQrCode = ({ value, symbol }: CoinQrCodeProps) => (
-    <QrCode value={value} centerIcon={<TokenIcon symbol={symbol} size={COIN_LOGO_SIZE} />} />
+    <QrCode
+        value={value}
+        centerIcon={<TokenIcon symbol={symbol} size={COIN_LOGO_SIZE} />}
+        data-testid="@wallet/receive/qr-code"
+    />
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -17360,6 +17360,7 @@ __metadata:
     tsx: "npm:^4.21.0"
     type-fest: "npm:5.5.0"
     xvfb-maybe: "npm:^0.2.1"
+    zxing-wasm: "npm:3.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

Extends the receive-flow E2E coverage - now also decodes the QR code rendered in the receive modal and compares the address it contains with the clipboard.


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/QR-code-verification/web/](https://dev.suite.sldev.cz/suite-web/QR-code-verification/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=QR-code-verification&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=QR-code-verification&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-20T09:11:35.607Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-20T09:10:17.422Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->