### PR TITLE
fix(suite): cap tron max fee limit

### DIFF
--- a/packages/connect/src/data/defaultFeeLevels.ts
+++ b/packages/connect/src/data/defaultFeeLevels.ts
@@ -169,10 +169,10 @@ const STELLAR_FEE_INFO: FeeInfoWithLevels = {
 const TRON_FEE_INFO: FeeInfoWithLevels = {
     blockTime: 3,
     defaultFees: [{ label: 'normal', feePerUnit: '-1', blocks: -1 }],
-    minFee: -1,
-    maxFee: -1,
-    minPriorityFee: -1,
-    dustLimit: -1,
+    minFee: 1, // fee_limit in SUN, any positive value is accepted by the network
+    maxFee: 15_000_000_000, // network cap on fee_limit: 15 000 TRX in SUN (chain parameter getMaxFeeLimit)
+    minPriorityFee: -1, // unknown/unused
+    dustLimit: -1, // unknown/unused
 };
 
 const MISC_FEE_LEVELS: Record<string, FeeInfoWithLevels> = {

--- a/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx
+++ b/packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx
@@ -12,8 +12,10 @@ import { BigNumber } from '@trezor/utils';
 import { InputError } from 'src/components/wallet';
 
 import { FEE_LIMIT } from './constants';
+import { useFeesContext } from '../../context/FeesContext';
 
 export const CustomFeeTron = () => {
+    const { feeInfo } = useFeesContext();
     const locale = useSelector(selectLanguage);
     const { translationString } = useTranslation();
 
@@ -21,6 +23,7 @@ export const CustomFeeTron = () => {
     const { errors } = useFormState<FormState>();
 
     const estimatedFeeLimit = getValues('estimatedFeeLimit');
+    const { maxFee, minFee } = feeInfo;
 
     useEffect(() => {
         if (getValues(FEE_LIMIT) === '' && estimatedFeeLimit) {
@@ -35,6 +38,16 @@ export const CustomFeeTron = () => {
             integer: (value: string) => {
                 if (!isInteger(value)) {
                     return translationString('CUSTOM_FEE_IS_NOT_INTEGER');
+                }
+            },
+            range: (value: string) => {
+                const customFee = new BigNumber(value);
+
+                if (customFee.isGreaterThan(maxFee) || customFee.isLessThan(minFee)) {
+                    return translationString('CUSTOM_FEE_NOT_IN_RANGE', {
+                        minFee: new BigNumber(minFee).toString(),
+                        maxFee: new BigNumber(maxFee).toString(),
+                    });
                 }
             },
             feeLimit: (value: string) => {


### PR DESCRIPTION
## Description

Cap Tron max fee limit to `15,000 TRX` (`15,000,000,000 SUN`) as per the [Tron documentation](https://developers.tron.network/docs/paying-for-resources#fee_limit-caller-side-energy-budget-cap).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30405

## Screenshots:

<img width="100%" alt="Screenshot 2026-08-13 at 13 22 10" src="https://github.com/user-attachments/assets/8f9daf66-1610-47c9-98db-1f9bd22d483e" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** This change set modifies a Connect default fee-level data file and a Tron-specific custom fee UI component. Risk is concentrated in transaction flows that rely on fee calculations or custom fee inputs, particularly BTC/ETH send and trading flows. The Tron custom fee component appears to have no direct functional coverage in the provided E2E suite, so validation of that change depends on manual or lower-level tests. Running the selected fee-focused tests provides high confidence for the defaultFeeLevels change while keeping the suite small.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/data/defaultFeeLevels.ts`
- `packages/suite/src/components/wallet/Fees/CollapsibleFees/CustomFee/CustomFeeTron.tsx`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Directly exercises custom Bitcoin fee rate selection during swap signing and asserts the fee rate appears correctly in the device prompt. A change to default fee levels could alter how custom fee rates are computed or rendered.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Directly exercises custom Ethereum gas parameters (gas limit, max fee per gas, max priority fee per gas) during swap signing and asserts precise fee values on the device prompt and emulator. Strongly tied to fee-level infrastructure.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Directly exercises custom Ethereum gas fee inputs in the send form and verifies calculated max fee and gas limit values on both the Suite prompt and hardware device display. Highly sensitive to fee-level data changes.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Verifies Bitcoin network fee calculation and display during a sell transaction's device confirmation step. Shares fee calculation infrastructure even though the test focuses on the sell flow.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Uses custom Ethereum gas fee parameters in a sell flow and checks fee-related values during device confirmation. Shares send/trading fee infrastructure with the changed files.
- `suite/e2e/tests/trading/sell-inputs.test.ts` — Covers custom fee rate input for Bitcoin sell transactions and fee-related validation. A regression in default fee handling could affect how custom fees are applied in this form.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Verifies transaction fee display in the device prompt during a Dogecoin send. Changes to default fee levels could affect the fee amount shown.
- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — Covers the LTC send flow including broadcast mode and device confirmation where fees are displayed. Shares transaction fee infrastructure.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Exercises max fee calculation and display during a Solana send, including device prompt fee verification. Changes to fee-level defaults could influence the computed max fee.

</details>

_Updated: 2026-08-18T09:49:09.558Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/tron-max-fee-limit-range/web/](https://dev.suite.sldev.cz/suite-web/fix/tron-max-fee-limit-range/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/tron-max-fee-limit-range&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/tron-max-fee-limit-range&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/tron-max-fee-limit-range&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T09:50:05.410Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T09:49:33.434Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->