### PR TITLE
feat(suite-native): add Trezor Connect transport logging debug toggle

### DIFF
--- a/suite-native/config/src/types.ts
+++ b/suite-native/config/src/types.ts
@@ -16,4 +16,5 @@ export type LaunchArguments = {
     isTradingSlip24Enabled?: boolean;
     isN4w1BackupEnabled?: boolean;
     isN4W1BackupEnabled?: boolean;
+    isConnectLoggingEnabled?: boolean;
 };

--- a/suite-native/feature-flags/src/featureFlagsSlice.test.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.test.ts
@@ -23,6 +23,7 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isTradingSlip24Enabled: false,
                 isN4w1BackupEnabled: false,
+                isConnectLoggingEnabled: false,
             });
         });
 
@@ -41,6 +42,7 @@ describe('featureFlagsSlice', () => {
                 isTradingDebugEnabled: false,
                 isTradingSlip24Enabled: false,
                 isN4w1BackupEnabled: false,
+                isConnectLoggingEnabled: false,
             });
         });
     });

--- a/suite-native/feature-flags/src/featureFlagsSlice.ts
+++ b/suite-native/feature-flags/src/featureFlagsSlice.ts
@@ -11,6 +11,7 @@ export const FeatureFlag = {
     IsTradingDebugEnabled: 'isTradingDebugEnabled',
     IsTradingSlip24Enabled: 'isTradingSlip24Enabled',
     IsN4w1BackupEnabled: 'isN4w1BackupEnabled',
+    IsConnectLoggingEnabled: 'isConnectLoggingEnabled',
 } as const;
 
 export type FeatureFlag = (typeof FeatureFlag)[keyof typeof FeatureFlag];
@@ -37,6 +38,8 @@ export const featureFlagsInitialState: FeatureFlagsState = {
     [FeatureFlag.IsTradingSlip24Enabled]:
         process.env.EXPO_PUBLIC_FF_IS_TRADING_SLIP24_ENABLED === 'true',
     [FeatureFlag.IsN4w1BackupEnabled]: process.env.EXPO_PUBLIC_FF_IS_N4W1_BACKUP_ENABLED === 'true',
+    [FeatureFlag.IsConnectLoggingEnabled]:
+        process.env.EXPO_PUBLIC_FF_IS_CONNECT_LOGGING_ENABLED === 'true',
 };
 
 export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
@@ -47,6 +50,7 @@ export const featureFlagsPersistedKeys: Array<keyof FeatureFlagsState> = [
     FeatureFlag.IsTradingDebugEnabled,
     FeatureFlag.IsTradingSlip24Enabled,
     FeatureFlag.IsN4w1BackupEnabled,
+    FeatureFlag.IsConnectLoggingEnabled,
 ];
 
 export const featureFlagsSlice = createSlice({

--- a/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
+++ b/suite-native/module-dev-utils/src/components/FeatureFlagsCard.tsx
@@ -15,6 +15,7 @@ const featureFlagsTitleMap = {
     [FeatureFlagEnum.IsTradingDebugEnabled]: '💰 Trading Debug Mode',
     [FeatureFlagEnum.IsTradingSlip24Enabled]: '💰 Trading SLIP-24',
     [FeatureFlagEnum.IsN4w1BackupEnabled]: 'N4W1 Backup',
+    [FeatureFlagEnum.IsConnectLoggingEnabled]: '🪵 Trezor Connect logs',
 } as const satisfies Record<FeatureFlagEnum, string>;
 
 const FeatureFlag = ({ featureFlag }: { featureFlag: FeatureFlagEnum }) => {

--- a/suite-native/state/src/extraDependencies.ts
+++ b/suite-native/state/src/extraDependencies.ts
@@ -28,6 +28,7 @@ import { createAccountRefreshThrottle } from '@suite-common/wallet-core';
 import { analytics } from '@suite-native/analytics';
 import { forgetBluetoothDeviceThunk } from '@suite-native/bluetooth';
 import { selectTokenDefinitionsEnabledNetworks } from '@suite-native/discovery';
+import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import { selectSupportedLanguageLocale } from '@suite-native/intl';
 import { reportSecurityCheck } from '@suite-native/sentry';
 import { type NativeServices } from '@suite-native/services';
@@ -99,10 +100,14 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
     });
     const addressValidator = createAddressValidator({ networkModuleRepository });
 
-    const createLogger: ConnectSettings['createLogger'] = (prefix: string) =>
-        initLog(prefix, false);
+    // Gate connect's component loggers (Core/Device/DeviceCommands/@trezor/transport) and the
+    // native transport logger below on a persisted debug flag. Read at call time so a connect
+    // (re)init picks up the current toggle; RN routes the enabled logs to console/Metro.
+    const isConnectLoggingEnabled = () =>
+        selectIsFeatureFlagEnabled(deps.getState(), FeatureFlag.IsConnectLoggingEnabled);
 
-    const logger = createLogger('native-transport');
+    const createLogger: ConnectSettings['createLogger'] = (prefix: string) =>
+        initLog(prefix, isConnectLoggingEnabled());
 
     return {
         networkModuleRepository,
@@ -134,8 +139,10 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
         createLogger,
         // Native constructs its per-device-type transports directly (single platform, no
         // web/desktop split) and returns the enabled ones as ready-made instances.
-        createTransports: () =>
-            (transports ?? []).map(name => {
+        createTransports: () => {
+            const logger = createLogger('native-transport');
+
+            return (transports ?? []).map(name => {
                 switch (name) {
                     case 'BridgeTransport':
                         return new BridgeTransport({ port: 21328, id: 'bridge', logger });
@@ -144,14 +151,18 @@ export const createNativeCompositionRoot = (deps: NativeAppDeps): NativeServices
                     case 'NativeBluetoothTransport':
                         return new NativeBluetoothTransport({ id: 'native-bluetooth', logger });
                 }
-            }),
+            });
+        },
         accountRefreshThrottle: createAccountRefreshThrottle(deps.getState),
         getLanguage: toGetter(deps.getState, selectSupportedLanguageLocale),
         getTokenDefinitionsEnabledNetworks: toGetter(
             deps.getState,
             selectTokenDefinitionsEnabledNetworks,
         ),
-        getDebugSettings: toGetter(deps.getState, () => ({ transports })),
+        getDebugSettings: toGetter(deps.getState, state => ({
+            transports,
+            showConnectLogs: selectIsFeatureFlagEnabled(state, FeatureFlag.IsConnectLoggingEnabled),
+        })),
         getTradingEnvironment: toGetter(deps.getState, selectTradingEnvironment),
         getTradedAccountKeys: toGetter(deps.getState, selectTradedAccountKeys),
         // This getter is not used in native app, but it is used in @suite-common/trading in loadInitialDataThunk.


### PR DESCRIPTION
## Description

Mobile's `createLogger` (in the native composition root) was hardwired to `initLog(prefix, false)`, so Trezor Connect's component loggers (`Core` / `Device` / `DeviceCommands` / `@trezor/transport`) and the native transport logger **never printed** — there was no way to debug the Connect transport layer on device.

This wires the logger to a persisted debug toggle, mirroring the web app's `showConnectLogs` switch, using the native-idiomatic feature-flag + Dev Utils pattern.

## Changes

- **`feature-flags`** — new `IsConnectLoggingEnabled` flag (`isConnectLoggingEnabled`), defaulting from `EXPO_PUBLIC_FF_IS_CONNECT_LOGGING_ENABLED`, added to `featureFlagsPersistedKeys` so the toggle survives the app restart a Connect re-init needs.
- **`state/extraDependencies`** — `createLogger` now reads the flag at call time; the `native-transport` logger is built inside `createTransports` so it reflects the current toggle at Connect-init time; `getDebugSettings` now returns `showConnectLogs`, keeping `TrezorConnect.init({ debug })` consistent with the logger.
- **`module-dev-utils`** — added "🪵 Trezor Connect logs" to the Feature Flags card.
- **`config/types`** — added `isConnectLoggingEnabled?` to `LaunchArguments` (needed so the E2E `selectIsFeatureFlagEnabled` override type-checks).
- **tests** — updated `featureFlagsSlice` initial-state assertions.

## How to use

Enable **Dev Utils → Feature Flags → 🪵 Trezor Connect logs**, then restart the app (the flag is persisted and read at Connect init). Enabled logs go to `console`, so they appear in Metro / the native debugger.

## Notes

- A feature flag was chosen over a dedicated debug-settings screen because native has no `showConnectLogs` settings infra — feature flags + Dev Utils is the native equivalent of web's debug switch.
- The toggle takes effect on the next Connect init (app restart), same as web, since the logger's `enabled` state is captured when Connect initializes.

## Testing

- `yarn type-check` — passed (95 affected native projects)
- `yarn eslint` on changed files — clean
- `@suite-native/feature-flags` unit tests — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/mobile-connect-logs&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->