### PR TITLE
feat(suite): add session-only option to show suspicious transactions unblurred

### DIFF
--- a/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx
@@ -1,9 +1,11 @@
 import { Translation } from '@suite/intl';
 import { type PhishingDetectorId } from '@suite-common/token-definitions';
+import { selectIsSuspiciousTransactionsBlurringEnabled } from '@suite-common/wallet-core';
 import { getTxHeaderSymbol, isSupportedEthStakingNetworkSymbol } from '@suite-common/wallet-utils';
 import { Row, TextButton, Tooltip } from '@trezor/components';
 import { HELP_CENTER_ZERO_VALUE_ATTACKS } from '@trezor/urls';
 
+import { useSelector } from 'src/hooks/suite';
 import { type WalletAccountTransaction } from 'src/types/wallet';
 
 import { InstantStakeBadge } from './InstantStakeBadge';
@@ -42,6 +44,10 @@ export const TransactionHeading = ({
     phishingDetectorId,
     dataTestBase,
 }: TransactionHeadingProps) => {
+    const isBlurringEnabled = useSelector(state =>
+        selectIsSuspiciousTransactionsBlurringEnabled(state, transaction.symbol),
+    );
+
     const symbol = getTxHeaderSymbol(transaction);
 
     return (
@@ -67,7 +73,7 @@ export const TransactionHeading = ({
             isActive={isPhishingTransaction}
             hasIcon
         >
-            <BlurWrapper $isBlurred={isPhishingTransaction}>
+            <BlurWrapper $isBlurred={isPhishingTransaction && isBlurringEnabled}>
                 <Row gap={4} data-testid={`${dataTestBase}/heading`}>
                     <TransactionHeader transaction={transaction} isPending={isPending} />
                     {isSupportedEthStakingNetworkSymbol(transaction.symbol) && (

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx
@@ -14,6 +14,7 @@ import {
     type Target,
     selectBaseCurrency,
     selectHistoricFiatRatesByTimestamp,
+    selectIsSuspiciousTransactionsBlurringEnabled,
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type Timestamp, type TokenAddress } from '@suite-common/wallet-types';
@@ -75,6 +76,9 @@ export const TransactionTarget = ({
         selectHistoricFiatRatesByTimestamp(state, fiatRateKey, transaction.blockTime as Timestamp),
     );
     const labelingValueBeingEdited = useSelector(selectLabelingValueBeingEdited);
+    const isBlurringEnabled = useSelector(state =>
+        selectIsSuspiciousTransactionsBlurringEnabled(state, transaction.symbol),
+    );
 
     const suiteSyncOutputLabels = useSelector(state =>
         isSuiteSyncEnabled
@@ -196,7 +200,7 @@ export const TransactionTarget = ({
         <TransactionTargetLayout
             {...baseLayoutProps}
             useHiddenPlaceholder={!isBeingEdited}
-            isPhishingTransaction={isPhishingTransaction}
+            isBlurred={(isPhishingTransaction ?? false) && isBlurringEnabled}
             addressLabel={
                 <Labeling
                     deviceStaticSessionId={transaction.deviceState}

--- a/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
+++ b/packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx
@@ -12,7 +12,7 @@ type TransactionTargetLayoutProps = {
     amount?: ReactNode;
     fiatAmount?: ReactNode;
     useHiddenPlaceholder?: boolean;
-    isPhishingTransaction?: boolean;
+    isBlurred?: boolean;
 };
 
 export const TransactionTargetLayout = ({
@@ -20,7 +20,7 @@ export const TransactionTargetLayout = ({
     amount,
     fiatAmount,
     useHiddenPlaceholder,
-    isPhishingTransaction,
+    isBlurred,
 }: TransactionTargetLayoutProps) => {
     const { isBelowTablet } = useLayoutSize();
 
@@ -39,9 +39,7 @@ export const TransactionTargetLayout = ({
     const amounts = (
         <>
             <Text {...cryptoAmountProps} align="end">
-                {amount && (
-                    <BlurWrapper $isBlurred={isPhishingTransaction ?? false}>{amount}</BlurWrapper>
-                )}
+                {amount && <BlurWrapper $isBlurred={isBlurred ?? false}>{amount}</BlurWrapper>}
             </Text>
             <Text {...commonProps} isTabular align="end">
                 {fiatAmount}

--- a/packages/suite/src/middlewares/wallet/storageMiddleware.ts
+++ b/packages/suite/src/middlewares/wallet/storageMiddleware.ts
@@ -504,7 +504,7 @@ export const storageMiddleware = (api: MiddlewareAPI<Dispatch, AppState>) => {
                 case WALLET_SETTINGS.SET_NETWORK_RESERVE:
                 case WALLET_SETTINGS.SET_AUTO_EJECT:
                 case WALLET_SETTINGS.SET_ADDRESS_DISPLAY_TYPE:
-                case WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS:
+                case WALLET_SETTINGS.SET_SUSPICIOUS_TRANSACTIONS_FILTER:
                     api.dispatch(storageActions.saveWalletSettings());
 
                     break;

--- a/packages/suite/src/storage/CHANGELOG.md
+++ b/packages/suite/src/storage/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Storage changelog
 
+## 26.9.0
+
+- replace `walletSettings.hideSuspiciousTransactions` (per-network boolean) with `walletSettings.suspiciousTransactionsFilter` (per-network filter value)
+
 ## 26.8.0.2
 
 - convert `walletSettings.hideSuspiciousTransactions` from a single boolean to a per-network record

--- a/packages/suite/src/storage/migrations/versions/26.8.0.2.ts
+++ b/packages/suite/src/storage/migrations/versions/26.8.0.2.ts
@@ -1,15 +1,21 @@
 import { createMigration } from '@suite/idb-migration-utils';
+import { type WalletSettings } from '@suite-common/wallet-types';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
+type WalletSettingsWithLegacyHideSuspiciousTransactions = WalletSettings & {
+    hideSuspiciousTransactions?: unknown;
+};
+
 export default createMigration<SuiteDBSchema>('26.8.0.2', async (_db, tx) => {
     const store = tx.objectStore('walletSettings');
-    const settings = await store.get('wallet');
+    // The stored value may still have the old shape, hence the widened type.
+    const settings: WalletSettingsWithLegacyHideSuspiciousTransactions | undefined =
+        await store.get('wallet');
 
     if (!settings) return;
 
-    // The stored value may still have the old shape, hence the widening cast.
-    const { hideSuspiciousTransactions } = settings as { hideSuspiciousTransactions: unknown };
+    const { hideSuspiciousTransactions } = settings;
 
     if (typeof hideSuspiciousTransactions !== 'boolean') return;
 

--- a/packages/suite/src/storage/migrations/versions/26.9.0.test.ts
+++ b/packages/suite/src/storage/migrations/versions/26.9.0.test.ts
@@ -3,9 +3,9 @@ import { type IDBPDatabase, deleteDB, openDB } from 'idb';
 
 import { type SuiteDBSchema } from 'src/storage/definitions';
 
-import migration from './26.8.0.2';
+import migration from './26.9.0';
 
-const DB_NAME = 'suite-idb-test-26.8.0.2';
+const DB_NAME = 'suite-idb-test-26.9.0';
 const INITIAL_VERSION = 1;
 
 const runMigration = () =>
@@ -30,15 +30,15 @@ const createDBWithWalletSettings = async (walletSettings?: Record<string, unknow
     db.close();
 };
 
-describe('migration 26.8.0.2', () => {
+describe('migration 26.9.0', () => {
     beforeEach(async () => {
         await deleteDB(DB_NAME);
     });
 
-    test('converts stored `true` to a record of all enabled networks', async () => {
+    test('converts the boolean record to a filter record, keeping only hiding networks', async () => {
         await createDBWithWalletSettings({
             enabledNetworks: ['btc', 'eth', 'op'],
-            hideSuspiciousTransactions: true,
+            hideSuspiciousTransactions: { btc: true, eth: false },
         });
 
         const migratedDb = await runMigration();
@@ -46,30 +46,13 @@ describe('migration 26.8.0.2', () => {
 
         expect(settings).toEqual({
             enabledNetworks: ['btc', 'eth', 'op'],
-            hideSuspiciousTransactions: { btc: true, eth: true, op: true },
+            suspiciousTransactionsFilter: { btc: 'hideSuspicious' },
         });
 
         migratedDb.close();
     });
 
-    test('converts stored `false` to an empty record', async () => {
-        await createDBWithWalletSettings({
-            enabledNetworks: ['btc', 'eth'],
-            hideSuspiciousTransactions: false,
-        });
-
-        const migratedDb = await runMigration();
-        const settings = await migratedDb.get('walletSettings', 'wallet');
-
-        expect(settings).toEqual({
-            enabledNetworks: ['btc', 'eth'],
-            hideSuspiciousTransactions: {},
-        });
-
-        migratedDb.close();
-    });
-
-    test('leaves settings without the old boolean untouched', async () => {
+    test('leaves settings without the old record untouched', async () => {
         await createDBWithWalletSettings({
             enabledNetworks: ['btc'],
         });

--- a/packages/suite/src/storage/migrations/versions/26.9.0.ts
+++ b/packages/suite/src/storage/migrations/versions/26.9.0.ts
@@ -1,0 +1,33 @@
+import { createMigration } from '@suite/idb-migration-utils';
+import { type NetworkSymbol } from '@suite-common/wallet-config';
+import { type SuspiciousTransactionsFilter, type WalletSettings } from '@suite-common/wallet-types';
+
+import { type SuiteDBSchema } from 'src/storage/definitions';
+
+type WalletSettingsWithLegacyHideSuspiciousTransactions = WalletSettings & {
+    hideSuspiciousTransactions?: Partial<Record<NetworkSymbol, boolean>>;
+};
+
+export default createMigration<SuiteDBSchema>('26.9.0', async (_db, tx) => {
+    const store = tx.objectStore('walletSettings');
+    // The stored value may still have the old shape, hence the widened type.
+    const settings: WalletSettingsWithLegacyHideSuspiciousTransactions | undefined =
+        await store.get('wallet');
+
+    if (!settings) return;
+
+    const { hideSuspiciousTransactions } = settings;
+
+    if (!hideSuspiciousTransactions) return;
+
+    // The per-network `hideSuspiciousTransactions` boolean was replaced by the per-network
+    // `suspiciousTransactionsFilter` value; only enabled entries carry information.
+    settings.suspiciousTransactionsFilter = Object.fromEntries(
+        Object.entries(hideSuspiciousTransactions)
+            .filter(([, isHidden]) => isHidden)
+            .map(([symbol]): [string, SuspiciousTransactionsFilter] => [symbol, 'hideSuspicious']),
+    );
+    delete settings.hideSuspiciousTransactions;
+
+    await store.put(settings, 'wallet');
+});

--- a/packages/suite/src/storage/migrations/versions/index.ts
+++ b/packages/suite/src/storage/migrations/versions/index.ts
@@ -30,3 +30,4 @@ export { default as m26_7_0_2 } from './26.7.0.2';
 export { default as m26_8_0 } from './26.8.0';
 export { default as m26_8_0_1 } from './26.8.0.1';
 export { default as m26_8_0_2 } from './26.8.0.2';
+export { default as m26_9_0 } from './26.9.0';

--- a/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
+++ b/packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx
@@ -5,9 +5,10 @@ import { Translation } from '@suite/intl';
 import { selectHasActiveModal } from '@suite/modal';
 import { type NetworkSymbol } from '@suite-common/wallet-config';
 import {
-    selectIsHideSuspiciousTransactions,
-    toggleHideSuspiciousTransactions,
+    selectSuspiciousTransactionsFilter,
+    setSuspiciousTransactionsFilter,
 } from '@suite-common/wallet-core';
+import { type SuspiciousTransactionsFilter } from '@suite-common/wallet-types';
 import {
     Badge,
     Box,
@@ -28,37 +29,40 @@ import { zIndices } from '@trezor/theme';
 
 import { useDispatch, useSelector } from 'src/hooks/suite';
 
-type FilterValue = boolean | string;
-
-type FilterOption = {
-    value: FilterValue;
+type FilterOption<TValue> = {
+    value: TValue;
     label: ReactNode;
     description?: ReactNode;
     isDefault?: boolean;
 };
 
-type FilterSection = {
+type FilterSection<TValue> = {
     key: string;
     title: ReactNode;
-    options: readonly FilterOption[];
-    value: FilterValue;
-    onChange: (value: FilterValue) => void;
+    options: readonly FilterOption<TValue>[];
+    value: TValue;
+    onChange: (value: TValue) => void;
 };
 
-const suspiciousTransactionsOptions: readonly FilterOption[] = [
+const suspiciousTransactionsOptions: readonly FilterOption<SuspiciousTransactionsFilter>[] = [
     {
-        value: false,
+        value: 'showAll',
         label: <Translation id="TR_SHOW_ALL" />,
         isDefault: true,
     },
     {
-        value: true,
+        value: 'showUnblurred',
+        label: <Translation id="TR_SHOW_UNBLURRED" />,
+        description: <Translation id="TR_SHOW_UNBLURRED_TRANSACTIONS_DESCRIPTION" />,
+    },
+    {
+        value: 'hideSuspicious',
         label: <Translation id="TR_HIDE_SUSPICIOUS" />,
         description: <Translation id="TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION" />,
     },
 ];
 
-const getSectionDefaultValue = (section: FilterSection) =>
+const getSectionDefaultValue = <TValue,>(section: FilterSection<TValue>) =>
     section.options.find(option => option.isDefault)?.value;
 
 type FilterActionProps = {
@@ -67,8 +71,8 @@ type FilterActionProps = {
 
 export const FilterAction = ({ symbol }: FilterActionProps) => {
     const { suspiciousTransactionsTooltipClosed } = useSelector(selectFlags);
-    const suspiciousTransactionsHidden = useSelector(state =>
-        selectIsHideSuspiciousTransactions(state, symbol),
+    const suspiciousTransactionsFilter = useSelector(state =>
+        selectSuspiciousTransactionsFilter(state, symbol),
     );
     const hasActiveModal = useSelector(selectHasActiveModal);
     const dispatch = useDispatch();
@@ -80,18 +84,21 @@ export const FilterAction = ({ symbol }: FilterActionProps) => {
     };
     const dataTest = '@wallet/accounts/hide-scam-transactions';
 
-    const handleToggleSuspiciousTransactionsRequest = (requestedHidden: FilterValue) => {
-        if (requestedHidden === suspiciousTransactionsHidden) return;
-        dispatch(toggleHideSuspiciousTransactions(symbol));
+    const handleSuspiciousTransactionsFilterChange = (
+        requestedFilter: SuspiciousTransactionsFilter,
+    ) => {
+        if (requestedFilter === suspiciousTransactionsFilter) return;
+
+        dispatch(setSuspiciousTransactionsFilter({ symbol, filter: requestedFilter }));
     };
 
-    const filterSections: FilterSection[] = [
+    const filterSections: FilterSection<SuspiciousTransactionsFilter>[] = [
         {
             key: 'suspiciousTransactions',
             title: <Translation id="TR_SUSPICIOUS_TRANSACTIONS" />,
             options: suspiciousTransactionsOptions,
-            value: suspiciousTransactionsHidden,
-            onChange: handleToggleSuspiciousTransactionsRequest,
+            value: suspiciousTransactionsFilter,
+            onChange: handleSuspiciousTransactionsFilterChange,
         },
     ];
 
@@ -178,7 +185,7 @@ export const FilterAction = ({ symbol }: FilterActionProps) => {
                                                 onChange={() => {
                                                     section.onChange(option.value);
                                                 }}
-                                                data-testid={dataTest}
+                                                data-testid={`${dataTest}/${option.value}`}
                                                 verticalAlignment="center"
                                             >
                                                 <Column>

--- a/suite-common/wallet-core/src/settings/walletSettingsActions.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsActions.ts
@@ -1,7 +1,10 @@
 import { createAction } from '@reduxjs/toolkit';
 
 import { type NetworkSymbol } from '@suite-common/wallet-config';
-import { type AddressDisplayOptions } from '@suite-common/wallet-types';
+import {
+    type AddressDisplayOptions,
+    type SuspiciousTransactionsFilter,
+} from '@suite-common/wallet-types';
 import type { BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { type PROTO } from '@trezor/connect';
 
@@ -35,9 +38,9 @@ export const setNetworkReserve = createAction(
     (enabled: boolean) => ({ payload: enabled }),
 );
 
-export const toggleHideSuspiciousTransactions = createAction(
-    WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
-    (symbol: NetworkSymbol) => ({ payload: symbol }),
+export const setSuspiciousTransactionsFilter = createAction(
+    WALLET_SETTINGS.SET_SUSPICIOUS_TRANSACTIONS_FILTER,
+    (payload: { symbol: NetworkSymbol; filter: SuspiciousTransactionsFilter }) => ({ payload }),
 );
 
 export const setAutoEjectEnabled = createAction(
@@ -66,7 +69,7 @@ export type SetBitcoinAmountUnitsAction = {
 export type WalletSettingsAction =
     | ReturnType<typeof changeNetworks>
     | ReturnType<typeof setBaseCurrency>
-    | ReturnType<typeof toggleHideSuspiciousTransactions>
+    | ReturnType<typeof setSuspiciousTransactionsFilter>
     | ReturnType<typeof setAutoEjectEnabled>
     | ReturnType<typeof setMevProtection>
     | ReturnType<typeof setNetworkReserve>

--- a/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsConstants.ts
@@ -2,7 +2,7 @@ const SET_BASE_CURRENCY = '@wallet-settings/set-base-currency';
 const CHANGE_NETWORKS = '@wallet-settings/change-networks';
 const FROM_STORAGE = '@wallet-settings/from-storage';
 const SET_BITCOIN_AMOUNT_UNITS = '@suite/set-bitcoin-amount-units';
-const TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS = '@wallet-settings/toggle-hide-suspicious-transactions';
+const SET_SUSPICIOUS_TRANSACTIONS_FILTER = '@wallet-settings/set-suspicious-transactions-filter';
 const CHANGE_COIN_VISIBILITY = '@wallet-settings/change-coin-visibility';
 const SET_MEV_PROTECTION = '@wallet-settings/set-mev-protection';
 const SET_NETWORK_RESERVE = '@wallet-settings/set-network-reserve';
@@ -14,7 +14,7 @@ export const WALLET_SETTINGS = {
     CHANGE_NETWORKS,
     FROM_STORAGE,
     SET_BITCOIN_AMOUNT_UNITS,
-    TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
+    SET_SUSPICIOUS_TRANSACTIONS_FILTER,
     CHANGE_COIN_VISIBILITY,
     SET_MEV_PROTECTION,
     SET_NETWORK_RESERVE,

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts
@@ -2,6 +2,7 @@ import { deviceInitialState } from '@suite-common/device';
 import { mockSuiteDevice } from '@suite-common/suite-types/mocks';
 import { extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { type NetworkSymbol, asNetworkSymbol } from '@suite-common/wallet-config';
+import { type SuspiciousTransactionsFilter } from '@suite-common/wallet-types';
 import { FirmwareType } from '@trezor/device-utils';
 
 import * as walletSettingsActions from './walletSettingsActions';
@@ -10,6 +11,8 @@ import {
     prepareWalletSettingsReducer,
     selectIsHideSuspiciousTransactions,
     selectIsNetworkReserveSettingsVisible,
+    selectIsSuspiciousTransactionsBlurringEnabled,
+    selectSuspiciousTransactionsFilter,
 } from './walletSettingsReducer';
 
 const initialState = initialWalletSettingsState;
@@ -63,51 +66,84 @@ describe('settings reducer', () => {
         });
     });
 
-    it('TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS toggles the setting only for the given network', () => {
-        const toggledOn = reducer(
+    it('SET_SUSPICIOUS_TRANSACTIONS_FILTER sets the filter only for the given network', () => {
+        const hidden = reducer(
             undefined,
-            walletSettingsActions.toggleHideSuspiciousTransactions(opSymbol),
+            walletSettingsActions.setSuspiciousTransactionsFilter({
+                symbol: opSymbol,
+                filter: 'hideSuspicious',
+            }),
         );
 
-        expect(toggledOn).toEqual({
+        expect(hidden).toEqual({
             ...initialState,
-            hideSuspiciousTransactions: { op: true },
+            suspiciousTransactionsFilter: { op: 'hideSuspicious' },
         });
 
-        const toggledOff = reducer(
-            toggledOn,
-            walletSettingsActions.toggleHideSuspiciousTransactions(opSymbol),
+        const unblurred = reducer(
+            hidden,
+            walletSettingsActions.setSuspiciousTransactionsFilter({
+                symbol: ethSymbol,
+                filter: 'showUnblurred',
+            }),
         );
 
-        expect(toggledOff).toEqual({
+        expect(unblurred).toEqual({
             ...initialState,
-            hideSuspiciousTransactions: { op: false },
+            suspiciousTransactionsFilter: { op: 'hideSuspicious', eth: 'showUnblurred' },
         });
+    });
+
+    it('SET_SUSPICIOUS_TRANSACTIONS_FILTER removes the entry when set back to the default', () => {
+        const hidden = reducer(
+            undefined,
+            walletSettingsActions.setSuspiciousTransactionsFilter({
+                symbol: opSymbol,
+                filter: 'hideSuspicious',
+            }),
+        );
+
+        const reset = reducer(
+            hidden,
+            walletSettingsActions.setSuspiciousTransactionsFilter({
+                symbol: opSymbol,
+                filter: 'showAll',
+            }),
+        );
+
+        expect(reset).toEqual(initialState);
     });
 });
 
-describe('selectIsHideSuspiciousTransactions', () => {
-    const getState = (hideSuspiciousTransactions: Partial<Record<NetworkSymbol, boolean>>) => ({
+describe('suspicious transactions filter selectors', () => {
+    const buildState = (
+        suspiciousTransactionsFilter: Partial<Record<NetworkSymbol, SuspiciousTransactionsFilter>>,
+    ) => ({
         wallet: {
             settings: {
                 ...initialState,
-                hideSuspiciousTransactions,
+                suspiciousTransactionsFilter,
             },
         },
     });
+    const state = buildState({ [opSymbol]: 'hideSuspicious', [ethSymbol]: 'showUnblurred' });
 
-    it('returns true only for networks with the setting enabled', () => {
-        const hideSuspiciousTransactions = { [opSymbol]: true, [ethSymbol]: false };
+    it('selectSuspiciousTransactionsFilter falls back to showAll', () => {
+        expect(selectSuspiciousTransactionsFilter(state, opSymbol)).toBe('hideSuspicious');
+        expect(selectSuspiciousTransactionsFilter(state, ethSymbol)).toBe('showUnblurred');
+        expect(selectSuspiciousTransactionsFilter(state, btcSymbol)).toBe('showAll');
+    });
 
-        expect(
-            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), opSymbol),
-        ).toBe(true);
-        expect(
-            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), ethSymbol),
-        ).toBe(false);
-        expect(
-            selectIsHideSuspiciousTransactions(getState(hideSuspiciousTransactions), btcSymbol),
-        ).toBe(false);
+    it('selectIsHideSuspiciousTransactions returns true only for hiding networks', () => {
+        expect(selectIsHideSuspiciousTransactions(state, opSymbol)).toBe(true);
+        expect(selectIsHideSuspiciousTransactions(state, ethSymbol)).toBe(false);
+        expect(selectIsHideSuspiciousTransactions(state, btcSymbol)).toBe(false);
+    });
+
+    it('selectIsSuspiciousTransactionsBlurringEnabled returns false only for unblurred networks', () => {
+        expect(selectIsSuspiciousTransactionsBlurringEnabled(state, opSymbol)).toBe(true);
+        expect(selectIsSuspiciousTransactionsBlurringEnabled(state, ethSymbol)).toBe(false);
+        expect(selectIsSuspiciousTransactionsBlurringEnabled(state, btcSymbol)).toBe(true);
     });
 });
 

--- a/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
+++ b/suite-common/wallet-core/src/settings/walletSettingsReducer.ts
@@ -13,7 +13,11 @@ import {
     getNetwork,
     networkSymbolCollection,
 } from '@suite-common/wallet-config';
-import { AddressDisplayOptions, type WalletSettings } from '@suite-common/wallet-types';
+import {
+    AddressDisplayOptions,
+    type SuspiciousTransactionsFilter,
+    type WalletSettings,
+} from '@suite-common/wallet-types';
 import { isBaseCurrencyWithSats } from '@suite-common/wallet-utils';
 import { PROTO } from '@trezor/connect';
 
@@ -33,7 +37,7 @@ export const createMemoizedSelector = createWeakMapSelector.withTypes<WalletSett
 const initialState: WalletSettingsState = {
     localCurrency: 'usd',
     enabledNetworks: [],
-    hideSuspiciousTransactions: {},
+    suspiciousTransactionsFilter: {},
     bitcoinAmountUnit: PROTO.AmountUnit.BITCOIN,
     mevProtection: true,
     networkReserve: true,
@@ -45,7 +49,7 @@ export const initialWalletSettingsState: WalletSettingsState = initialState;
 export const walletSettingsPersistedWhitelist: Array<keyof WalletSettingsState> = [
     'localCurrency',
     'enabledNetworks',
-    'hideSuspiciousTransactions',
+    'suspiciousTransactionsFilter',
     'bitcoinAmountUnit',
     'mevProtection',
     'networkReserve',
@@ -95,14 +99,17 @@ export const prepareWalletSettingsReducer = createReducerWithExtraDeps(
             },
         );
         builder.addCase(
-            WALLET_SETTINGS.TOGGLE_HIDE_SUSPICIOUS_TRANSACTIONS,
+            WALLET_SETTINGS.SET_SUSPICIOUS_TRANSACTIONS_FILTER,
             (
                 state,
-                action: ReturnType<typeof walletSettingsActions.toggleHideSuspiciousTransactions>,
+                action: ReturnType<typeof walletSettingsActions.setSuspiciousTransactionsFilter>,
             ) => {
-                const symbol = action.payload;
-                state.hideSuspiciousTransactions[symbol] =
-                    !state.hideSuspiciousTransactions[symbol];
+                const { symbol, filter } = action.payload;
+                if (filter === 'showAll') {
+                    delete state.suspiciousTransactionsFilter[symbol];
+                } else {
+                    state.suspiciousTransactionsFilter[symbol] = filter;
+                }
             },
         );
         builder.addCase(
@@ -124,10 +131,19 @@ export const selectEnabledNetworks = (state: WalletSettingsRootState) =>
     returnStableArrayIfEmpty(state.wallet.settings.enabledNetworks);
 export const selectBaseCurrency = (state: WalletSettingsRootState) =>
     state.wallet.settings.localCurrency;
+export const selectSuspiciousTransactionsFilter = (
+    state: WalletSettingsRootState,
+    symbol: NetworkSymbol,
+): SuspiciousTransactionsFilter =>
+    state.wallet.settings.suspiciousTransactionsFilter[symbol] ?? 'showAll';
 export const selectIsHideSuspiciousTransactions = (
     state: WalletSettingsRootState,
     symbol: NetworkSymbol,
-) => Boolean(state.wallet.settings.hideSuspiciousTransactions[symbol]);
+) => selectSuspiciousTransactionsFilter(state, symbol) === 'hideSuspicious';
+export const selectIsSuspiciousTransactionsBlurringEnabled = (
+    state: WalletSettingsRootState,
+    symbol: NetworkSymbol,
+) => selectSuspiciousTransactionsFilter(state, symbol) !== 'showUnblurred';
 export const selectBitcoinAmountUnit = (state: WalletSettingsRootState) =>
     state.wallet.settings.bitcoinAmountUnit;
 export const selectIsDeviceAutoEjectEnabled = (state: WalletSettingsRootState) =>

--- a/suite-common/wallet-types/src/settings.ts
+++ b/suite-common/wallet-types/src/settings.ts
@@ -17,10 +17,12 @@ export const WalletType = {
 
 export type WalletType = (typeof WalletType)[keyof typeof WalletType];
 
+export type SuspiciousTransactionsFilter = 'showAll' | 'hideSuspicious' | 'showUnblurred';
+
 export interface WalletSettings {
     localCurrency: BaseCurrencyCode;
     enabledNetworks: NetworkSymbol[];
-    hideSuspiciousTransactions: Partial<Record<NetworkSymbol, boolean>>;
+    suspiciousTransactionsFilter: Partial<Record<NetworkSymbol, SuspiciousTransactionsFilter>>;
     bitcoinAmountUnit: PROTO.AmountUnit;
     mevProtection: boolean;
     networkReserve: boolean;

--- a/suite-native/state/src/reducers.ts
+++ b/suite-native/state/src/reducers.ts
@@ -206,7 +206,7 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
         reducer: walletSettingsReducer,
         persistedKeys: walletSettingsPersistedWhitelist,
         key: 'walletSettings',
-        version: 4,
+        version: 5,
         migrations: {
             1: initialMigrateAppSettingsAndDiscoveryConfig({
                 mmkvStorage: deps.mmkvStorage,
@@ -235,6 +235,13 @@ export const prepareRootReducers = (deps: PrepareRootReducersDeps) => {
                 }
 
                 return oldState;
+            },
+            5: (oldState: any /* FIXME */) => {
+                if (!oldState) return oldState;
+
+                const { hideSuspiciousTransactions: _, ...rest } = oldState;
+
+                return rest;
             },
         },
         storage: deps.mmkvStorage,

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -139,6 +139,14 @@ export const messages = defineMessages({
         defaultMessage: 'Crypto moves fast. Our filters may not always be 100% up to date.',
         id: 'TR_HIDE_SUSPICIOUS_TRANSACTIONS_DESCRIPTION',
     },
+    TR_SHOW_UNBLURRED: {
+        defaultMessage: 'Show unblurred',
+        id: 'TR_SHOW_UNBLURRED',
+    },
+    TR_SHOW_UNBLURRED_TRANSACTIONS_DESCRIPTION: {
+        defaultMessage: "Suspicious transactions stay flagged but aren't blurred.",
+        id: 'TR_SHOW_UNBLURRED_TRANSACTIONS_DESCRIPTION',
+    },
     TR_ACCOUNT_IS_EMPTY_TITLE: {
         defaultMessage: 'No transactions',
         id: 'TR_ACCOUNT_IS_EMPTY_TITLE',


### PR DESCRIPTION
## Description

Adds a **Show unblurred** option to the Suspicious transactions filter in the transaction list. It removes the blur from suspicious transactions so they can be inspected.

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/28747

## Screenshots:

<img width="377" height="372" alt="image" src="https://github.com/user-attachments/assets/3653387a-3761-4cbc-8aa4-226cec58003f" />

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set carries two main risk areas: regressions in transaction list rendering (TransactionItem/TransactionTarget components) and incorrect database or wallet-settings migration/persistence. The recommended set focuses on transaction list tests and DB migration tests, with output labeling as a narrower check for labeled transaction targets. No e2e coverage exists for the native reducer or the changed translation catalog.

<details><summary><b>Changed files (17)</b></summary>

- `packages/suite/src/components/wallet/TransactionItem/TransactionHeading.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTarget/TransactionTarget.tsx`
- `packages/suite/src/components/wallet/TransactionItem/TransactionTargetLayout.tsx`
- `packages/suite/src/middlewares/wallet/storageMiddleware.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.2.test.ts`
- `packages/suite/src/storage/migrations/versions/26.8.0.2.ts`
- `packages/suite/src/storage/migrations/versions/26.9.0.test.ts`
- `packages/suite/src/storage/migrations/versions/26.9.0.ts`
- `packages/suite/src/storage/migrations/versions/index.ts`
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `suite-common/wallet-core/src/settings/walletSettingsActions.ts`
- `suite-common/wallet-core/src/settings/walletSettingsConstants.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.test.ts`
- `suite-common/wallet-core/src/settings/walletSettingsReducer.ts`
- `suite-common/wallet-types/src/settings.ts`
- `suite-native/state/src/reducers.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/suite/db-migration.test.ts` — This test explicitly verifies migration of the autoEject setting from the legacy suiteSettings store path to the new walletSettings path, directly exercising the changed storage migrations, storageMiddleware, and walletSettingsReducer/types.
- `suite/e2e/tests/wallet/pagination.test.ts` — Navigates paginated BTC legacy transaction lists and asserts that specific transaction addresses render correctly, which directly depends on TransactionTarget and TransactionTargetLayout rendering.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — Verifies pending transaction group headings and transaction items in the list, including send/receive/self labels that are rendered by TransactionHeading and TransactionTarget components.
- `suite/e2e/tests/wallet/transactions.test.ts` — Searches transactions by BTC address and verifies transaction summary rendering, both of which rely on TransactionItem components displaying transaction targets and headings correctly.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — Adds labels to transaction outputs and asserts they appear in the UI and CSV export, meaning TransactionTarget must render labeled outputs correctly.
- `suite/e2e/tests/suite/db-locale-migration.test.ts` — Validates that user settings persist across Suite version upgrades, exercising the storage migration infrastructure that was changed.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/views/wallet/transactions/TransactionList/TransactionListActions/FilterAction.tsx`
- `suite-native/state/src/reducers.ts`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-21T15:34:08.509Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/unblur-suspicious-transactions/web/](https://dev.suite.sldev.cz/suite-web/feat/unblur-suspicious-transactions/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/unblur-suspicious-transactions&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/unblur-suspicious-transactions&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/unblur-suspicious-transactions&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T15:36:14.956Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T15:35:14.079Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->