### PR TITLE
chore(nix): drop unused Android SDK platforms and build-tools

### DIFF
--- a/.nix/android.nix
+++ b/.nix/android.nix
@@ -2,13 +2,16 @@
 
 let
   androidComposition = pkgs.androidenv.composeAndroidPackages {
-    platformVersions = [ "31" "34" "35" "36" ];
-    buildToolsVersions = [ "31.0.0" "34.0.0" "35.0.0" "36.0.0" ];
+    # 34 is the Pixel_6_API_34 emulator image; 36 is RN/Expo compileSdk.
+    platformVersions = [ "34" "36" ];
+    # 36 is RN's default; 35 is still requested by native modules (e.g. quick-crypto).
+    buildToolsVersions = [ "35.0.0" "36.0.0" ];
     includeEmulator = true;
     includeSystemImages = true;
     systemImageTypes = [ "google_apis" ];
     abiVersions = [ "x86_64" ];
     includeNDK = true;
+    # 27.1 is RN's default; 27.0 is still requested by expo-sqlite.
     ndkVersions = [ "27.1.12297006" "27.0.12077973" ];
     cmakeVersions = [ "3.22.1" ];
   };


### PR DESCRIPTION
## Description
Trim unused Android SDK platforms/build-tools from the Nix Android shell. Keep API 34 (emulator), 36 (compileSdk), build-tools 35 (native modules), and both NDK 27.0/27.1.

## Notes for QA
Nix-only. No app QA.

## Related Issue
N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-08-13T13:04:27.406Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/cursor/trim-android-nix-sdk/web/](https://dev.suite.sldev.cz/suite-web/cursor/trim-android-nix-sdk/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=cursor/trim-android-nix-sdk&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=cursor/trim-android-nix-sdk&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T13:07:36.193Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T13:07:00.787Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->