### PR TITLE
fix(suite-native): handle authorization after PIN

### DIFF
--- a/suite-native/module-authorize-device/src/screens/connect/PinScreen.tsx
+++ b/suite-native/module-authorize-device/src/screens/connect/PinScreen.tsx
@@ -9,16 +9,26 @@ import {
     PinOnKeypad,
     selectDeviceAuthorizationStep,
 } from '@suite-native/device-authorization';
-import { useNavigateToInitialScreen } from '@suite-native/navigation';
+import {
+    type AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes,
+    type StackNavigationProps,
+    useNavigateToInitialScreen,
+} from '@suite-native/navigation';
 import { DeviceModelInternal } from '@trezor/device-utils';
 
 import { ConnectDeviceScreenView } from '../../components/connect/ConnectDeviceScreenView';
 import { PinOnDevice } from '../../components/connect/PinOnDevice';
 
+type NavigationProp = StackNavigationProps<
+    AuthorizeDeviceStackParamList,
+    AuthorizeDeviceStackRoutes.PinMatrix
+>;
+
 export const PinScreen = () => {
     const navigateToInitialScreen = useNavigateToInitialScreen();
     const deviceAuthorizationStep = useSelector(selectDeviceAuthorizationStep);
-    const navigation = useNavigation();
+    const navigation = useNavigation<NavigationProp>();
     const deviceModel = useSelector(selectDeviceModel);
 
     const onSuccess = useCallback(() => {
@@ -29,6 +39,12 @@ export const PinScreen = () => {
         useCallback(() => {
             if (deviceAuthorizationStep === DeviceAuthorizationStep.Idle) {
                 navigation.goBack();
+            } else if (deviceAuthorizationStep === DeviceAuthorizationStep.PassphraseRequested) {
+                navigation.popTo(AuthorizeDeviceStackRoutes.PassphraseForm);
+            } else if (
+                deviceAuthorizationStep === DeviceAuthorizationStep.ContinueOnTrezorRequested
+            ) {
+                navigation.popTo(AuthorizeDeviceStackRoutes.ContinueOnTrezor);
             }
         }, [deviceAuthorizationStep, navigation]),
     );


### PR DESCRIPTION
## Description

Ensures locked devices request PIN before passphrase. After PIN authorization, the mobile app replaces the PIN screen with either the passphrase form or the device-confirmation screen, avoiding the nested navigation race and keeping PIN out of the back stack.

The broader navigation cleanup is tracked in #31320.

## Notes for QA
Succesful pin should correctly redirect to passphrase screen on receive. 

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/mobile-receive-passphrase-redirect&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->