### PR TITLE
fix(connect): trim whitespaces in settings `appName` and `hostName`

### DIFF
--- a/packages/connect-common/src/data/connectSettings.test.ts
+++ b/packages/connect-common/src/data/connectSettings.test.ts
@@ -1,4 +1,4 @@
-import { corsValidator, parseConnectSettings } from './connectSettings';
+import { corsValidator, parseConnectSettings, parseManifest } from './connectSettings';
 
 describe('data/connectSettings', () => {
     describe('parseConnectSettings enabledNetworks', () => {
@@ -18,6 +18,108 @@ describe('data/connectSettings', () => {
                 // @ts-expect-error intentionally malformed input
                 parseConnectSettings({ enabledNetworks: 'ada' }).enabledNetworks,
             ).toBeUndefined();
+        });
+    });
+
+    describe('parseManifest', () => {
+        const baseManifest = {
+            email: 'test@test.com',
+            appUrl: 'https://test.com',
+            appName: 'Test App',
+        };
+
+        it('returns undefined when manifest is undefined', () => {
+            expect(parseManifest(undefined)).toBeUndefined();
+        });
+
+        it('returns undefined when email is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, email: 123 })).toBeUndefined();
+        });
+
+        it('returns undefined when appUrl is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appUrl: null })).toBeUndefined();
+        });
+
+        it('returns undefined when appName is not a string', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appName: 42 })).toBeUndefined();
+        });
+
+        it('returns undefined when appIcon is not a string or undefined', () => {
+            // @ts-expect-error intentionally malformed input
+            expect(parseManifest({ ...baseManifest, appIcon: 123 })).toBeUndefined();
+        });
+
+        it('accepts appIcon as undefined', () => {
+            expect(parseManifest({ ...baseManifest, appIcon: undefined })).toEqual({
+                ...baseManifest,
+                appIcon: undefined,
+            });
+        });
+
+        it('accepts appIcon as a string', () => {
+            expect(parseManifest({ ...baseManifest, appIcon: 'icon.png' })).toEqual({
+                ...baseManifest,
+                appIcon: 'icon.png',
+            });
+        });
+
+        it('returns a valid manifest with all fields', () => {
+            expect(parseManifest(baseManifest)).toEqual({
+                email: 'test@test.com',
+                appUrl: 'https://test.com',
+                appName: 'Test App',
+                appIcon: undefined,
+            });
+        });
+
+        it('trims leading whitespace from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: '  Test App' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('trims trailing whitespace from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test App  ' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('collapses multiple spaces in the middle of appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test   App' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('handles combined leading, trailing, and multiple middle spaces in appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: '  Test   App  ' })?.appName).toBe(
+                'Test App',
+            );
+        });
+
+        it('returns undefined when appName is an empty string', () => {
+            expect(parseManifest({ ...baseManifest, appName: '' })).toBeUndefined();
+        });
+
+        it('returns undefined when appName is only whitespace', () => {
+            expect(parseManifest({ ...baseManifest, appName: '   ' })).toBeUndefined();
+        });
+
+        it('strips control characters from appName', () => {
+            expect(parseManifest({ ...baseManifest, appName: 'Test\x00App\x1F' })?.appName).toBe(
+                'TestApp',
+            );
+        });
+
+        it('returns undefined when appName is only control characters', () => {
+            expect(parseManifest({ ...baseManifest, appName: '\x00\x1F\x7F' })).toBeUndefined();
+        });
+
+        it('accepts long appName without length limit', () => {
+            const longName = 'A'.repeat(200);
+            expect(parseManifest({ ...baseManifest, appName: longName })?.appName).toBe(longName);
         });
     });
 

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -1,5 +1,6 @@
 // origin: https://github.com/trezor/connect/blob/develop/src/js/data/ConnectSettings.js
 
+import { sanitizeName } from './sanitizeName';
 import { parseThpSettings } from './thpSettings';
 import { VERSION } from './version';
 import { DEFINITIONS_CHANNELS } from '../types/definitions';
@@ -25,10 +26,13 @@ export const parseManifest = (manifest?: Manifest) => {
     if (typeof manifest.appName !== 'string') return;
     if (typeof manifest.appIcon !== 'undefined' && typeof manifest.appIcon !== 'string') return;
 
+    const appName = sanitizeName(manifest.appName);
+    if (!appName) return;
+
     return {
         email: manifest.email,
         appUrl: manifest.appUrl,
-        appName: manifest.appName,
+        appName,
         appIcon: manifest.appIcon,
     };
 };

--- a/packages/connect-common/src/data/connectSettings.ts
+++ b/packages/connect-common/src/data/connectSettings.ts
@@ -22,8 +22,7 @@ export const parseManifest = (manifest?: Manifest) => {
     if (!manifest) return;
     if (typeof manifest.email !== 'string') return;
     if (typeof manifest.appUrl !== 'string') return;
-    // todo [connect10]: appName should become required
-    if (typeof manifest.appName !== 'undefined' && typeof manifest.appName !== 'string') return;
+    if (typeof manifest.appName !== 'string') return;
     if (typeof manifest.appIcon !== 'undefined' && typeof manifest.appIcon !== 'string') return;
 
     return {

--- a/packages/connect-common/src/data/sanitizeName.ts
+++ b/packages/connect-common/src/data/sanitizeName.ts
@@ -1,0 +1,18 @@
+export const MAX_NAME_LENGTH = 100;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_REGEX = /[\x00-\x1F\x7F]/g;
+
+export const sanitizeName = (name: string, maxLength?: number): string | undefined => {
+    const sanitized = name.replace(CONTROL_CHARS_REGEX, '').replace(/\s+/g, ' ').trim();
+
+    if (sanitized.length === 0) {
+        return undefined;
+    }
+
+    if (maxLength !== undefined && sanitized.length > maxLength) {
+        return undefined;
+    }
+
+    return sanitized;
+};

--- a/packages/connect-common/src/data/thpSettings.test.ts
+++ b/packages/connect-common/src/data/thpSettings.test.ts
@@ -98,4 +98,86 @@ describe('data/thpSettings', () => {
         });
         expect(result).toEqual({ appName, pairingMethods, knownCredentials: [] });
     });
+
+    describe('trims whitespace from name fields', () => {
+        const pairingMethods = ['CodeEntry' as const];
+
+        it('trims appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '  My  App  ', pairingMethods },
+            });
+            expect(result.appName).toBe('My App');
+        });
+
+        it('trims appName when falling back to manifest', () => {
+            const result = parseThpSettings({
+                manifest: {
+                    appName: '  Manifest  App  ',
+                    appUrl: 'https://test.com',
+                    email: 'test@test.com',
+                },
+            });
+            expect(result.appName).toBe('Manifest App');
+        });
+
+        it('trims hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: '  My  Host  ', pairingMethods },
+            });
+            expect(result.hostName).toBe('My Host');
+        });
+    });
+
+    describe('rejects invalid name fields', () => {
+        const pairingMethods = ['CodeEntry' as const];
+
+        it('drops empty appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops whitespace-only appName from thp settings', () => {
+            const result = parseThpSettings({
+                thp: { appName: '   ', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops appName with only control characters', () => {
+            const result = parseThpSettings({
+                thp: { appName: '\x00\x1F', pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('strips control characters from appName', () => {
+            const result = parseThpSettings({
+                thp: { appName: 'My\x00App', pairingMethods },
+            });
+            expect(result.appName).toBe('MyApp');
+        });
+
+        it('drops appName exceeding 100 characters', () => {
+            const result = parseThpSettings({
+                thp: { appName: 'A'.repeat(101), pairingMethods },
+            });
+            expect(result.appName).toBeUndefined();
+        });
+
+        it('drops empty hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: '   ', pairingMethods },
+            });
+            expect(result.hostName).toBeUndefined();
+        });
+
+        it('strips control characters from hostName', () => {
+            const result = parseThpSettings({
+                thp: { hostName: 'My\x00Host', pairingMethods },
+            });
+            expect(result.hostName).toBe('MyHost');
+        });
+    });
 });

--- a/packages/connect-common/src/data/thpSettings.ts
+++ b/packages/connect-common/src/data/thpSettings.ts
@@ -1,3 +1,4 @@
+import { MAX_NAME_LENGTH, sanitizeName } from './sanitizeName';
 import type { ConnectSettings, ThpSettings } from '../types/settings';
 
 export const parseThpSettings = ({ manifest, thp }: Partial<ConnectSettings>): ThpSettings => {
@@ -12,13 +13,13 @@ export const parseThpSettings = ({ manifest, thp }: Partial<ConnectSettings>): T
     }
 
     if (typeof thp?.hostName === 'string') {
-        settings.hostName = thp.hostName;
+        settings.hostName = sanitizeName(thp.hostName, MAX_NAME_LENGTH);
     }
 
     if (typeof thp?.appName === 'string') {
-        settings.appName = thp.appName;
+        settings.appName = sanitizeName(thp.appName, MAX_NAME_LENGTH);
     } else if (typeof manifest?.appName === 'string') {
-        settings.appName = manifest?.appName;
+        settings.appName = sanitizeName(manifest.appName, MAX_NAME_LENGTH);
     }
 
     if (Array.isArray(thp?.knownCredentials)) {

--- a/suite-common/test-utils/__mocks__/@trezor/connect.ts
+++ b/suite-common/test-utils/__mocks__/@trezor/connect.ts
@@ -70,7 +70,13 @@ const init = (params: any): Promise<void> => mockResponse('init', params);
 
 const call = (params: CallMethodPayload) => {
     if (params?.__info) {
-        connect.default.init({ manifest: { email: '', appUrl: '' } });
+        connect.default.init({
+            manifest: {
+                email: 'email@trezor.io',
+                appUrl: 'https://trezor.io',
+                appName: 'Test App',
+            },
+        });
 
         // call actual implementation
         return connect.default[params.method](params).finally(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- manifest `appName` is required in connect@10
- Strips control characters (\x00–\x1F, \x7F)
- Collapses whitespace and trims
- Rejects empty strings (including whitespace-only)
- Rejects names exceeding 100 characters (thpSettings only - this is displayed on Trezor)

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in foundational Connect configuration modules (connectSettings, thpSettings) and a name-sanitization utility, plus the Connect unit-test mock. The main user-visible regression risks are broken TrezorConnect permission/initialization flows and THP device pairing during onboarding. The recommended e2e tests target those integration paths; unit tests already cover the changed modules directly, so this targeted set balances confidence with runtime cost.

<details><summary><b>Changed files (6)</b></summary>

- `packages/connect-common/src/data/connectSettings.test.ts`
- `packages/connect-common/src/data/connectSettings.ts`
- `packages/connect-common/src/data/sanitizeName.ts`
- `packages/connect-common/src/data/thpSettings.test.ts`
- `packages/connect-common/src/data/thpSettings.ts`
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`

</details>

**Recommended tests (7)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Directly exercises TrezorConnect permission grants, the 'remember' setting, and the Connect settings page for forgetting apps. Changes to connectSettings.ts or the connect mock could alter how permissions are persisted or displayed.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Tests the Connect silent-mode permission setting and its effect on Suite window focus. This is a Connect settings behavior directly tied to permission initialization and the connect mock.
- `suite/e2e/tests/trezor-connect/upfrontPermissions.test.ts` — Validates TrezorConnect.init with requestedPermissions, which is a core connectSettings concern. A regression here would break declared-permission grants across Connect calls.
- `suite/e2e/tests/onboarding/initial-run.test.ts` — Covers the THP (Trezor Host Protocol) pairing flow during initial onboarding and reloads. Changes to thpSettings.ts could affect pairing-code handling or device connection prompts.
- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — Explicitly exercises the THP pairing flow (onboardingPage.pairTHP) during T3W1 wallet creation. Directly relevant to thpSettings changes that impact pairing or device initialization.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/onboarding/analytics-consent.test.ts` — Handles the THP pairing code flow while onboarding from a deep-linked route. Shares THP infrastructure with the high-priority onboarding tests but exercises a less central path.
- `suite/e2e/tests/trezor-connect/connectPopupWeb.test.ts` — End-to-end Connect popup flow including permissions, address export, and cancellation. A good integration sanity check for connectSettings changes, though broader than the settings-specific tests above.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/connect-common/src/data/sanitizeName.ts`
- `suite-common/test-utils/__mocks__/@trezor/connect.ts`

_Updated: 2026-09-08T08:17:16.386Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/connect-manifest-appname/web/](https://dev.suite.sldev.cz/suite-web/fix/connect-manifest-appname/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/connect-manifest-appname&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/connect-manifest-appname&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/connect-manifest-appname&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-09-08T08:16:37.322Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Staking - Cardano > Stake Cardano | 🤖 auto |
| Suite Sync - Update and Remove Labels > Update and remove labels syncs correctly to relay | 🤖 auto |
| Quarantine test: "Suite Sync - Quota Manager top-up,Exceeded wallet limit is topped up from the device pool" | 🙋 manual |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-09-08T08:16:24.919Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->