### PR TITLE
Feat: bluetooth server authorization

### DIFF
--- a/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
+++ b/packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'crypto';
+
 import { isDevEnv } from '@suite-common/suite-utils';
 import { isWindows } from '@trezor/env-utils';
 
@@ -7,24 +9,32 @@ import { getSwitchValue } from '../process-switches';
 export class BluetoothProcess extends BaseProcess {
     private readonly port;
     private readonly debug;
+    private readonly token;
 
     constructor(port = 21327) {
         const debug = isDevEnv || getSwitchValue('log-level') === 'debug';
+        const token = randomBytes(32).toString('hex');
 
         super('bluetooth', 'trezor-bluetooth', {
             autoRestart: 0,
             env: {
                 TREZOR_BLUETOOTH_PORT: port.toString(),
+                TREZOR_BLUETOOTH_AUTH_TOKEN: token,
             },
             stdio: debug && !isWindows() ? 'inherit' : undefined,
         });
 
         this.port = port;
         this.debug = debug;
+        this.token = token;
     }
 
     getUrl() {
         return `http://localhost:${this.port}/`;
+    }
+
+    getToken() {
+        return this.token;
     }
 
     async status(): Promise<Status> {

--- a/packages/suite-desktop-core/src/modules/bluetooth.ts
+++ b/packages/suite-desktop-core/src/modules/bluetooth.ts
@@ -40,6 +40,8 @@ export const init: ModuleInit = () => {
         error: (...args) => logger.error(SERVICE_NAME, args as string[]),
     };
 
+    const createHeaders = (token: string) => ({ Authorization: `Bearer ${token}` });
+
     const lazyBluetooth = createLazy(
         async () => {
             const [port] = await getFreePort();
@@ -49,6 +51,7 @@ export const init: ModuleInit = () => {
             const client = new BluetoothIpc({
                 url: process.getUrl(),
                 logger: desktopLogger,
+                headers: createHeaders(process.getToken()),
             });
 
             return { process, client };
@@ -69,6 +72,7 @@ export const init: ModuleInit = () => {
                   id: 'BluetoothTransport',
                   url: api.process.getUrl(),
                   logger: desktopLogger,
+                  headers: createHeaders(api.process.getToken()),
                   // writeWithResponse: isMacOs(),
                   // writeWithDelay: isWindows(),
               })

--- a/packages/transport-bluetooth/src/client/transport.ts
+++ b/packages/transport-bluetooth/src/client/transport.ts
@@ -12,13 +12,14 @@ export class BluetoothTransport extends AbstractApiTransport {
     private wsApi: BluetoothApi;
 
     constructor(params: BluetoothTransportParams) {
-        const { url, logger, writeWithResponse, writeWithDelay, ...rest } = params;
+        const { url, logger, writeWithResponse, writeWithDelay, headers, ...rest } = params;
 
         const api = new BluetoothApi({
             url,
             logger,
             writeWithResponse,
             writeWithDelay,
+            headers,
         });
         api.on('transport-interface-error', ({ error }) => {
             this.emit('transport-error', error);

--- a/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
+++ b/packages/transport-bluetooth/src/client/trezor-bluetooth.ts
@@ -70,6 +70,7 @@ export class TrezorBluetooth extends WebsocketClient<NotificationEvent> {
     createWebsocket() {
         return this.initWebsocket({
             url: this.settings.url,
+            headers: this.settings.headers,
         });
     }
 

--- a/packages/transport-bluetooth/src/client/types.ts
+++ b/packages/transport-bluetooth/src/client/types.ts
@@ -8,6 +8,7 @@ export interface TrezorBluetoothSettings {
     timeout?: number;
     writeWithResponse?: boolean;
     writeWithDelay?: boolean;
+    headers?: Record<string, string>;
 }
 
 export type BluetoothInfo = {

--- a/packages/transport-bluetooth/src/main.rs
+++ b/packages/transport-bluetooth/src/main.rs
@@ -12,8 +12,13 @@ async fn main() {
 
     match server::start_server(&addr).await {
         // Ok should not happen as start_server runs indefinitely unless there's an error
-        Ok(_) => Err("Server unexpectedly stopped".to_string()),
-        Err(err) => Err(format!("Server start error {:?}", err)),
+        Ok(_) => {
+            eprintln!("Server unexpectedly stopped");
+            std::process::exit(1);
+        }
+        Err(err) => {
+            eprintln!("Server start error: {:?}", err);
+            std::process::exit(1);
+        }
     }
-    .expect("Server unexpectedly stopped")
 }

--- a/packages/transport-bluetooth/src/server/connection_handler.rs
+++ b/packages/transport-bluetooth/src/server/connection_handler.rs
@@ -131,11 +131,29 @@ async fn handle_http_request(
     peer: String,
     req: hyper::Request<Incoming>,
     manager: AdapterManager,
+    ws_token: Arc<Option<String>>,
 ) -> Result<HyperResponse<Full<Bytes>>, ServerError> {
-    // TODO: cors check like trezord-go and node-bridge
-    // let = req.headers().get("origin");
-
     if hyper_tungstenite::is_upgrade_request(&req) {
+        if let Some(ref expected_token) = *ws_token {
+            let is_token_valid = req
+                .headers()
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.strip_prefix("Bearer "))
+                .is_some_and(|token| token == expected_token);
+
+            if !is_token_valid {
+                info!("Missing or invalid websocket Authorization token");
+                info!("- Peer: {peer}");
+
+                // Stealth rejection: return error to close connection without sending response
+                return Err(ServerError::Io(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionReset,
+                    "",
+                )));
+            }
+        }
+
         let (response, websocket) = match hyper_tungstenite::upgrade(req, None) {
             Ok(r) => r,
             Err(e) => {
@@ -176,6 +194,21 @@ pub async fn start_server(address: &str) -> Result<(), ServerError> {
     let tcp_listener = TcpListener::bind(&address).await?;
     info!("Version: {} Listening on: {}", utils::APP_VERSION, address);
 
+    let ws_token = Arc::new(match std::env::var("TREZOR_BLUETOOTH_AUTH_TOKEN") {
+        Ok(token) if !token.trim().is_empty() => Some(token),
+        _ => {
+            if cfg!(debug_assertions) {
+                log::warn!("WebSocket auth disabled");
+                None
+            } else {
+                return Err(ServerError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "TREZOR_BLUETOOTH_AUTH_TOKEN is missing",
+                )));
+            }
+        }
+    });
+
     let manager = AdapterManager::new().await?;
 
     let mut http = hyper::server::conn::http1::Builder::new();
@@ -185,8 +218,9 @@ pub async fn start_server(address: &str) -> Result<(), ServerError> {
         let (stream, _) = tcp_listener.accept().await?;
         let peer = stream.peer_addr()?;
         let manager = manager.clone();
+        let ws_token = ws_token.clone();
         let service = hyper::service::service_fn(move |req| {
-            handle_http_request(peer.to_string(), req, manager.clone())
+            handle_http_request(peer.to_string(), req, manager.clone(), ws_token.clone())
         });
 
         let connection = http


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add authentication to  `trezor-bluetooth` websocket server

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are all Bluetooth-related: desktop Bluetooth process/module and the transport-bluetooth client. Only a few candidate tests touch Bluetooth/THP flows. The forget-device test is the strongest direct coverage for Bluetooth pairing/unpairing state, while the T3W1 onboarding create-wallet test provides inferred coverage of THP/BT device pairing. No other E2E tests in the set specifically target Bluetooth functionality.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite-desktop-core/src/libs/processes/BluetoothProcess.ts`
- `packages/suite-desktop-core/src/modules/bluetooth.ts`
- `packages/transport-bluetooth/src/client/transport.ts`
- `packages/transport-bluetooth/src/client/trezor-bluetooth.ts`
- `packages/transport-bluetooth/src/client/types.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/settings/forget-device.test.ts` — This is the only candidate test that explicitly exercises Bluetooth state and pairing/unpairing logic for TS7 (T3W1) devices, including mocking Bluetooth history and verifying unpair behavior. A regression in the desktop Bluetooth module or process would likely surface here.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/onboarding/t3w1/t3w1-create-wallet.test.ts` — This test exercises THP (Trezor Host Protocol) device pairing during T3W1 onboarding; THP can run over Bluetooth, so changes to the transport-bluetooth client could affect this flow. Coverage is inferred from the LLM analysis rather than static mapping.

</details>

_Updated: 2026-08-13T16:50:47.271Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/bt-server-authorization/web/](https://dev.suite.sldev.cz/suite-web/feat/bt-server-authorization/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/bt-server-authorization&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/bt-server-authorization&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-13T16:52:07.497Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-13T16:51:32.681Z • 4 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->