### PR TITLE
Add timeout to staking batch request

### DIFF
--- a/suite-common/earn-staking-api/src/staking/services/index.ts
+++ b/suite-common/earn-staking-api/src/staking/services/index.ts
@@ -41,6 +41,7 @@ export const getStakingBatch: (
 ) => Promise<StakingBatch> = earnHttpClient('/', {
     method: 'GET',
     schema: stakingBatchResponse,
+    timeout: 60_000,
 });
 
 export const getStakingStats: (


### PR DESCRIPTION
## Description

Adds a 60s timeout to the staking batch request so a stalled connection can no longer leave `isLoading` stuck and block all future staking data refreshes.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30031