### PR TITLE
fix(suite-desktop-core): sanitize domains added to whitelist

### DIFF
--- a/packages/suite-desktop-core/src/libs/validateWhitelistedHostname.test.ts
+++ b/packages/suite-desktop-core/src/libs/validateWhitelistedHostname.test.ts
@@ -1,0 +1,102 @@
+import {
+    validateWhitelistedHostname,
+    validateWhitelistedHostnames,
+} from './validateWhitelistedHostname';
+
+describe(validateWhitelistedHostname.name, () => {
+    it.each([
+        {
+            hostname: 'trezor.io',
+            result: 'trezor.io',
+        },
+        {
+            hostname: 'API.TREZOR.IO',
+            result: 'api.trezor.io',
+        },
+        {
+            hostname: 'localhost',
+            result: 'localhost',
+        },
+        {
+            hostname: '127.0.0.1',
+            result: '127.0.0.1',
+        },
+        {
+            hostname: '[::1]',
+            result: '[::1]',
+        },
+    ])('accepts $hostname', ({ hostname, result }) => {
+        const warn = jest.fn();
+
+        expect(
+            validateWhitelistedHostname({
+                hostname,
+                warn,
+            }),
+        ).toBe(result);
+
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        {
+            hostname: '',
+            expectedWarning: 'Ignoring empty hostname.',
+        },
+        {
+            hostname: 'com',
+            expectedWarning: 'Ignoring hostname "com" because it is single-label.',
+        },
+        {
+            hostname: '.com',
+            expectedWarning: 'Ignoring hostname ".com" because it starts or ends with a dot.',
+        },
+        {
+            hostname: 'trezor.io.',
+            expectedWarning: 'Ignoring hostname "trezor.io." because it starts or ends with a dot.',
+        },
+        {
+            hostname: '*.trezor.io',
+            expectedWarning:
+                'Ignoring hostname "*.trezor.io" because it contains invalid characters.',
+        },
+        {
+            hostname: '-trezor.io',
+            expectedWarning:
+                'Ignoring hostname "-trezor.io" because it contains invalid characters.',
+        },
+        {
+            hostname: 'foo..trezor.io',
+            expectedWarning:
+                'Ignoring hostname "foo..trezor.io" because it contains invalid characters.',
+        },
+    ])('rejects $hostname', ({ hostname, expectedWarning }) => {
+        const warn = jest.fn();
+
+        expect(
+            validateWhitelistedHostname({
+                hostname,
+                warn,
+            }),
+        ).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(expectedWarning);
+    });
+});
+
+describe(validateWhitelistedHostnames.name, () => {
+    it('filters invalid hostnames and keeps valid ones normalized', () => {
+        const warn = jest.fn();
+
+        expect(
+            validateWhitelistedHostnames({
+                hostnames: ['TREZOR.IO', 'com', '127.0.0.1', '.org'],
+                warn,
+            }),
+        ).toEqual(['trezor.io', '127.0.0.1']);
+
+        expect(warn.mock.calls).toEqual([
+            ['Ignoring hostname "com" because it is single-label.'],
+            ['Ignoring hostname ".org" because it starts or ends with a dot.'],
+        ]);
+    });
+});

--- a/packages/suite-desktop-core/src/libs/validateWhitelistedHostname.ts
+++ b/packages/suite-desktop-core/src/libs/validateWhitelistedHostname.ts
@@ -1,0 +1,64 @@
+import { isIP } from 'net';
+
+const HOSTNAME_LABEL_REGEXP = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+type ValidateWhitelistedHostnameParams = {
+    hostname: string;
+    warn?: (message: string) => void;
+};
+
+const getIPAddressCandidate = (hostname: string): string =>
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+export const validateWhitelistedHostname = ({
+    hostname,
+    warn,
+}: ValidateWhitelistedHostnameParams): string | undefined => {
+    const normalizedHostname = hostname.trim().toLowerCase();
+
+    if (normalizedHostname === '') {
+        warn?.(`Ignoring empty hostname.`);
+
+        return;
+    }
+
+    const ipAddressCandidate = getIPAddressCandidate(normalizedHostname);
+
+    if (isIP(ipAddressCandidate) !== 0) return normalizedHostname;
+    if (normalizedHostname === 'localhost') return normalizedHostname;
+
+    if (normalizedHostname.startsWith('.') || normalizedHostname.endsWith('.')) {
+        warn?.(`Ignoring hostname "${hostname}" because it starts or ends with a dot.`);
+
+        return;
+    }
+
+    const hostnameLabels = normalizedHostname.split('.');
+
+    if (hostnameLabels.length < 2) {
+        warn?.(`Ignoring hostname "${hostname}" because it is single-label.`);
+
+        return;
+    }
+
+    if (hostnameLabels.some(label => label === '' || !HOSTNAME_LABEL_REGEXP.test(label))) {
+        warn?.(`Ignoring hostname "${hostname}" because it contains invalid characters.`);
+
+        return;
+    }
+
+    return normalizedHostname;
+};
+
+type ValidateWhitelistedHostnamesParams = {
+    hostnames: string[];
+    warn?: (message: string) => void;
+};
+
+export const validateWhitelistedHostnames = ({
+    hostnames,
+    warn,
+}: ValidateWhitelistedHostnamesParams): string[] =>
+    hostnames
+        .map(hostname => validateWhitelistedHostname({ hostname, warn }))
+        .filter(item => item !== undefined);

--- a/packages/suite-desktop-core/src/modules/request-interceptor.ts
+++ b/packages/suite-desktop-core/src/modules/request-interceptor.ts
@@ -14,6 +14,10 @@ import { exhaustive } from '@trezor/type-utils';
 import { allowedDomains, localhostDomains } from '../config';
 import type { ModuleInit } from './module';
 import { hasSwitch } from '../libs/process-switches';
+import {
+    validateWhitelistedHostname,
+    validateWhitelistedHostnames,
+} from '../libs/validateWhitelistedHostname';
 
 export const SERVICE_NAME = 'request-interceptor';
 
@@ -67,15 +71,27 @@ export const init: ModuleInit = ({ mainWindowProxy, store, mainThreadEmitter }) 
             case 'ERROR':
                 return;
 
-            case 'SET_WHITELISTED_DOMAINS_FOR_CUSTOM_BACKENDS':
-                mainThreadAllowedDomain.customBackends[event.coin] = event.domains;
+            case 'SET_WHITELISTED_DOMAINS_FOR_CUSTOM_BACKENDS': {
+                mainThreadAllowedDomain.customBackends[event.coin] = validateWhitelistedHostnames({
+                    hostnames: event.domains,
+                    warn: message => logger.warn(SERVICE_NAME, message),
+                });
 
                 return;
+            }
 
-            case 'ADD_WHITELISTED_DOMAIN':
-                mainThreadAllowedDomain.general.push(event.domain);
+            case 'ADD_WHITELISTED_DOMAIN': {
+                const validatedHostname = validateWhitelistedHostname({
+                    hostname: event.domain,
+                    warn: message => logger.warn(SERVICE_NAME, message),
+                });
+
+                if (validatedHostname !== undefined) {
+                    mainThreadAllowedDomain.general.push(validatedHostname);
+                }
 
                 return;
+            }
 
             default:
                 return exhaustive(event);


### PR DESCRIPTION
## Description

Tighter validation of hostnames in `request-interceptor.ts`, see issue.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/220

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/custom-backend-domain-with-single-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/custom-backend-domain-with-single-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/custom-backend-domain-with-single-label/web/](https://dev.suite.sldev.cz/suite-web/fix/custom-backend-domain-with-single-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| stablecoin yield > User can deposit USDC into a yield vault | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-24T13:52:21.055Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-24T13:51:21.530Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes live in suite-desktop-core network/request handling (request interceptor and hostname whitelist validation). No static E2E mapping exists, so coverage was inferred from tests that launch the desktop app or run TrezorConnect in suite-desktop mode. The recommendations focus on desktop network and popup paths where regressions would be immediately visible, with bridge and Connect tests as the highest-value targets.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite-desktop-core/src/libs/validateWhitelistedHostname.test.ts`
- `packages/suite-desktop-core/src/libs/validateWhitelistedHostname.ts`
- `packages/suite-desktop-core/src/modules/request-interceptor.ts`

</details>

**Recommended tests (5)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Launches the Electron desktop app and exercises bridge HTTP status checks and renderer reloads, directly exercising the request-interceptor network-request handling paths in suite-desktop-core.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — Runs TrezorConnect in coreMode 'suite-desktop', which loads Connect popup web content inside the desktop app. Changes to hostname whitelisting or request interception could break popup loading or address-export requests.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — Verifies Connect permissions and connected apps in the desktop app; the permissions modal and app connection flows rely on desktop request/popup handling, making this a strong regression signal for request-interceptor changes.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge-daemon.test.ts` — Tests the desktop bridge daemon lifecycle and background bridge HTTP endpoints, sharing the same desktop network/request infrastructure and providing a secondary signal if bridge requests are affected.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — Exercises Connect popup behavior and app/focus IPC in the desktop app; a regression in request interception or popup window handling could surface here through failed or misbehaved popups.

</details>

_Updated: 2026-08-24T13:50:58.093Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->