### PR TITLE
fix(suite-native): native app crash on withdraw

### DIFF
--- a/suite-common/wallet-core/src/accounts/accountsThunks.ts
+++ b/suite-common/wallet-core/src/accounts/accountsThunks.ts
@@ -255,7 +255,7 @@ export const fetchAndUpdateAccountThunk = createThunk<
                     if ((freshTx.tokens?.length ?? 0) > 0) return freshTx;
                     const fakeMatch = accountTxs.find(
                         t =>
-                            t.txid === freshTx.txid &&
+                            t?.txid === freshTx.txid &&
                             'deadline' in t &&
                             (t.tokens?.length ?? 0) > 0,
                     );

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -430,6 +430,30 @@ describe('transaction utils', () => {
                 ).toEqual(f.result);
             });
         });
+
+        // The stored list is written by index (see transactionsReducer `addTransaction`), so a
+        // partially paginated account holds empty slots. `getAccountTransactions` passes that array
+        // through unfiltered.
+        it('confirms a pre-pending tx even when the known list has empty slots', () => {
+            const known = [
+                { blockHeight: undefined, blockHash: '1', txid: '1', deadline: 5 },
+                { blockHeight: 3, blockHash: '3', txid: '3' },
+                undefined,
+                { blockHeight: 2, blockHash: '2', txid: '2' },
+            ];
+
+            const fresh = [
+                { blockHeight: 4, blockHash: '1', txid: '1' },
+                { blockHeight: 3, blockHash: '3', txid: '3' },
+                { blockHeight: 2, blockHash: '2', txid: '2' },
+            ];
+
+            expect(analyzeTransactions(fresh as any, known as any, { blockHeight: 4 })).toEqual({
+                newTransactions: [{ blockHeight: 4, blockHash: '1', txid: '1' }],
+                add: [{ blockHeight: 4, blockHash: '1', txid: '1' }],
+                remove: [{ blockHeight: undefined, blockHash: '1', txid: '1', deadline: 5 }],
+            });
+        });
     });
 
     describe('enhanceTransaction', () => {

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -718,7 +718,12 @@ export const analyzeTransactions = (
         };
     }
 
-    const [knownPrepending, knownRest] = arrayPartition(known, tx => 'deadline' in tx);
+    // The stored list is written by index (transactionsReducer `addTransaction`), so a partially
+    // paginated account has empty slots and reaches here unfiltered via `getAccountTransactions`.
+    const [knownPrepending, knownRest] = arrayPartition(
+        known.filter(isNotNullOrUndefined),
+        tx => 'deadline' in tx,
+    );
 
     const removePrepending = knownPrepending.filter(
         tx => (tx.deadline && tx.deadline < blockHeight) || fresh.find(fTx => fTx.txid === tx.txid),
@@ -735,7 +740,7 @@ export const analyzeTransactions = (
     }
 
     // make sure the known transactions are sorted properly
-    const knownSorted = knownRest.filter(isNotNullOrUndefined).sort(sortByBlockHeight);
+    const knownSorted = [...knownRest].sort(sortByBlockHeight);
     // run thru all fresh txs
     fresh.forEach((tx, i) => {
         const height = tx.blockHeight;

--- a/suite-native/atoms/src/Input/Input.tsx
+++ b/suite-native/atoms/src/Input/Input.tsx
@@ -9,8 +9,6 @@ import {
 import { type TextInput as GHTextInput } from 'react-native-gesture-handler';
 import Animated, {
     Easing,
-    FadeIn,
-    FadeOut,
     interpolate,
     useAnimatedStyle,
     useSharedValue,
@@ -24,12 +22,11 @@ import { Icon, type IconName, isIconName } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 import { nativeSpacings } from '@trezor/theme';
 
+import { AnimatedBox } from '../AnimatedBox';
 import { Box } from '../Box';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Text } from '../Text';
 
-const LABEL_ANIMATION_DURATION = 200;
-const labelEnteringAnimation = FadeIn.duration(LABEL_ANIMATION_DURATION);
-const labelExitingAnimation = FadeOut.duration(LABEL_ANIMATION_DURATION);
+const PLACEHOLDER_ANIMATION_DURATION = 200;
 
 type InputBaseProps = {
     value: string;
@@ -226,6 +223,23 @@ const useInputLabelAnimationStyles = ({
     };
 };
 
+/**
+ * The placeholder stays mounted and only fades. Mounting and unmounting a view that has an
+ * `exiting` animation makes Reanimated defer its removal, so a re-mount within the animation
+ * duration crashes Fabric with "addViewAt: failed to insert view".
+ */
+const usePlaceholderAnimatedStyle = (isPlaceholderVisible: boolean) => {
+    const opacity = useSharedValue(0);
+
+    useEffect(() => {
+        opacity.value = withTiming(isPlaceholderVisible ? 1 : 0, {
+            duration: PLACEHOLDER_ANIMATION_DURATION,
+        });
+    }, [isPlaceholderVisible, opacity]);
+
+    return useAnimatedStyle(() => ({ opacity: opacity.value }));
+};
+
 export const Input = forwardRef<TextInput, InputProps>(
     (
         {
@@ -269,6 +283,7 @@ export const Input = forwardRef<TextInput, InputProps>(
         };
 
         const shouldShowPlaceholder = !!placeholder && S.isEmpty(value);
+        const animatedPlaceholderStyle = usePlaceholderAnimatedStyle(shouldShowPlaceholder);
 
         return (
             <>
@@ -299,14 +314,14 @@ export const Input = forwardRef<TextInput, InputProps>(
                             {label}
                         </Animated.Text>
                     )}
-                    {shouldShowPlaceholder && (
-                        <Animated.View
-                            entering={labelEnteringAnimation}
-                            exiting={labelExitingAnimation}
-                            style={applyStyle(placeholderStyle)}
+                    {!!placeholder && (
+                        <AnimatedBox
+                            aria-hidden={!shouldShowPlaceholder}
+                            pointerEvents="none"
+                            style={[applyStyle(placeholderStyle), animatedPlaceholderStyle]}
                         >
                             <Text color="contentSecondary">{placeholder}</Text>
-                        </Animated.View>
+                        </AnimatedBox>
                     )}
                     <Box flexDirection="row" alignItems="center">
                         <InputComponent

--- a/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
+++ b/suite-native/module-earn/src/components/EarnFormScreenFooter.tsx
@@ -1,7 +1,7 @@
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { SlideInDown } from 'react-native-reanimated';
 
 import { type NetworkSymbol, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
+import { AnimatedBox, Box, Button, ScreenFooterGradient } from '@suite-native/atoms';
 import { Translation, useTranslate } from '@suite-native/intl';
 import { selectApy, useSelector as useStakingSelector } from '@suite-native/staking';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
@@ -53,7 +53,7 @@ export const EarnFormScreenFooter = ({
     const isRewardsBoxVisible = !!amountValue && !isDisabled;
 
     return (
-        <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+        <AnimatedBox entering={SlideInDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
                 {isRewardsBoxVisible && (
@@ -71,7 +71,6 @@ export const EarnFormScreenFooter = ({
                     </Box>
                 )}
                 <Button
-                    key={`${buttonIntent}-${buttonPriority}`}
                     accessibilityRole="button"
                     accessibilityLabel={translate('generic.validateForm')}
                     intent={buttonIntent}
@@ -83,6 +82,6 @@ export const EarnFormScreenFooter = ({
                     <Translation id="generic.buttons.continue" />
                 </Button>
             </Box>
-        </Animated.View>
+        </AnimatedBox>
     );
 };

--- a/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx
@@ -1,7 +1,7 @@
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { SlideInDown } from 'react-native-reanimated';
 
 import { type YieldApprovalAction } from '@suite-common/wallet-core';
-import { Box, Button, ScreenFooterGradient, VStack } from '@suite-native/atoms';
+import { AnimatedBox, Box, Button, ScreenFooterGradient, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath, useTranslate } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -72,7 +72,7 @@ export const YieldDepositFlowFooter = ({
         apy !== null;
 
     return (
-        <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+        <AnimatedBox entering={SlideInDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
                 <VStack spacing="sp12">
@@ -117,6 +117,6 @@ export const YieldDepositFlowFooter = ({
                     )}
                 </VStack>
             </Box>
-        </Animated.View>
+        </AnimatedBox>
     );
 };

--- a/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
+++ b/suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx
@@ -44,6 +44,7 @@ type YieldPendingTransactionModalProps = {
     amountTokenSymbol?: TokenSymbol;
     fee?: string;
     isExploreDisabled?: boolean;
+    onDismiss?: () => void;
     onExplorePress: () => void;
     pendingLabel?: ReactNode;
     ref: BottomSheetModalRef;
@@ -96,6 +97,7 @@ export const YieldPendingTransactionModal = ({
     amountTokenSymbol,
     fee,
     isExploreDisabled,
+    onDismiss,
     onExplorePress,
     pendingLabel = <Translation id="moduleTrading.tradingConfirmationScreen.pending" />,
     ref,
@@ -140,6 +142,7 @@ export const YieldPendingTransactionModal = ({
     return (
         <BottomSheetModal
             ref={ref}
+            onDismiss={onDismiss}
             bottomSheetCustomProps={{
                 backdropComponent: renderBackdrop,
                 enableDynamicSizing: false,

--- a/suite-native/module-earn/src/components/YieldWrappedNativeStepFooter.tsx
+++ b/suite-native/module-earn/src/components/YieldWrappedNativeStepFooter.tsx
@@ -1,7 +1,7 @@
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { SlideInDown } from 'react-native-reanimated';
 
 import { type WrappedNativeFlowType } from '@suite-common/wallet-core';
-import { Box, Button, ScreenFooterGradient, VStack } from '@suite-native/atoms';
+import { AnimatedBox, Box, Button, ScreenFooterGradient, VStack } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
@@ -26,6 +26,7 @@ type YieldWrappedNativeStepFooterProps = {
     flowType: WrappedNativeFlowType;
     isSkipFirst?: boolean;
     isSubmitDisabled: boolean;
+    isSubmitLoading?: boolean;
     onSkip?: () => void;
     onSubmit: () => void;
     spentSymbol: string;
@@ -35,6 +36,7 @@ export const YieldWrappedNativeStepFooter = ({
     flowType,
     isSkipFirst = false,
     isSubmitDisabled,
+    isSubmitLoading = false,
     onSkip,
     onSubmit,
     spentSymbol,
@@ -53,7 +55,7 @@ export const YieldWrappedNativeStepFooter = ({
     );
 
     return (
-        <Animated.View entering={SlideInDown} exiting={SlideOutDown}>
+        <AnimatedBox entering={SlideInDown}>
             <ScreenFooterGradient />
             <Box style={applyStyle(screenFooterStyle)}>
                 <VStack spacing="sp8">
@@ -61,6 +63,7 @@ export const YieldWrappedNativeStepFooter = ({
                     <Button
                         onPress={onSubmit}
                         isDisabled={isSubmitDisabled}
+                        isLoading={isSubmitLoading}
                         testID={`@yield-${flowType}-step/submit-button`}
                     >
                         <Translation
@@ -71,6 +74,6 @@ export const YieldWrappedNativeStepFooter = ({
                     {!isSkipFirst && skipButton}
                 </VStack>
             </Box>
-        </Animated.View>
+        </AnimatedBox>
     );
 };

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts
@@ -226,10 +226,32 @@ describe('usePreparedTxFees', () => {
         expect(store.getState().wallet.formDrafts[FORM_DRAFT_KEY]).toEqual(FORM_DRAFT);
     });
 
-    it('propagates isFeeEstimationError from a failed compose', async () => {
-        const composeTransaction = jest
-            .fn()
-            .mockResolvedValue({ type: 'error', isFeeEstimationError: true });
+    it('surfaces an error for every failed compose', async () => {
+        const composeTransaction = jest.fn().mockResolvedValue({ type: 'error' });
+        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+
+        await settleDebounce();
+
+        expect(result.current.hasFeeEstimationError).toBe(true);
+        expect(result.current.preparedTx).toBeNull();
+        // A failure must never leave the submit button waiting on a spinner instead.
+        expect(result.current.isFeePreparing).toBe(false);
+    });
+
+    it('surfaces an error when the base fee preview cannot be built', async () => {
+        buildFeePreviewMock.mockReturnValue(null);
+        const composeTransaction = jest.fn().mockResolvedValue(composeReady());
+        const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
+
+        await settleDebounce();
+
+        expect(result.current.hasFeeEstimationError).toBe(true);
+        expect(result.current.preparedTx).toBeNull();
+        expect(result.current.isFeePreparing).toBe(false);
+    });
+
+    it('surfaces an error when the compose function throws', async () => {
+        const composeTransaction = jest.fn().mockRejectedValue(new Error('compose exploded'));
         const { result } = renderPreparedTxFees(createProps({ composeTransaction }));
 
         await settleDebounce();

--- a/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
+++ b/suite-native/module-earn/src/hooks/usePreparedTxFees.ts
@@ -40,7 +40,7 @@ export type ComposedTxBase = {
 };
 
 export type ComposeTxResult<TComposed extends ComposedTxBase> =
-    { type: 'ready'; transaction: TComposed } | { type: 'error'; isFeeEstimationError: boolean };
+    { type: 'ready'; transaction: TComposed } | { type: 'error' };
 
 export type PreparedTx<TComposed extends ComposedTxBase> = {
     amount: string;
@@ -60,8 +60,8 @@ type UsePreparedTxFeesParams<TComposed extends ComposedTxBase> = {
     amount: string | undefined;
     /**
      * Composes the base transaction for the debounced amount. Must not throw — map failures to
-     * the `error` result (with `isFeeEstimationError` deciding whether the retryable
-     * fee-estimation alert is shown).
+     * the `error` result. Every error is surfaced as a retryable alert; a failure that only
+     * disables the submit button leaves the user with no way to proceed.
      */
     composeTransaction: (amount: string) => Promise<ComposeTxResult<TComposed>>;
     /** Empty string marks a missing draft context; the store is then only cleared, never written. */
@@ -154,7 +154,7 @@ export const usePreparedTxFees = <TComposed extends ComposedTxBase>({
             try {
                 result = await composeTransaction(composeAmount);
             } catch {
-                result = { type: 'error', isFeeEstimationError: false };
+                result = { type: 'error' };
             }
 
             if (requestId !== requestIdRef.current) {
@@ -162,10 +162,7 @@ export const usePreparedTxFees = <TComposed extends ComposedTxBase>({
             }
 
             if (result.type !== 'ready') {
-                if (result.isFeeEstimationError) {
-                    setHasFeeEstimationError(true);
-                }
-
+                setHasFeeEstimationError(true);
                 clearFeeState();
 
                 return;
@@ -175,7 +172,9 @@ export const usePreparedTxFees = <TComposed extends ComposedTxBase>({
                 result.transaction.unsignedTransaction,
             );
 
+            // A transaction that composed but cannot be priced is a failure, not a pending state.
             if (!baseFeePreview) {
+                setHasFeeEstimationError(true);
                 clearFeeState();
 
                 return;

--- a/suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts
+++ b/suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts
@@ -48,7 +48,7 @@ export const useWrappedNativeTokenFees = ({
             const wrappedNative = account ? WRAPPED_NATIVE[account.symbol] : undefined;
 
             if (!account || !wrappedNative) {
-                return { type: 'error', isFeeEstimationError: false };
+                return { type: 'error' };
             }
 
             try {
@@ -77,7 +77,7 @@ export const useWrappedNativeTokenFees = ({
                 ).unwrap();
 
                 if (result.type !== 'action-ready') {
-                    return { type: 'error', isFeeEstimationError: true };
+                    return { type: 'error' };
                 }
 
                 const spentToken =
@@ -102,7 +102,7 @@ export const useWrappedNativeTokenFees = ({
                     },
                 };
             } catch {
-                return { type: 'error', isFeeEstimationError: true };
+                return { type: 'error' };
             }
         },
         [account, dispatch, flowType],

--- a/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldDepositFees.ts
@@ -40,7 +40,7 @@ export const useYieldDepositFees = ({
     const composeTransaction = useCallback(
         async (composeAmount: string): Promise<ComposeTxResult<ComposedDepositTransaction>> => {
             if (!flowData) {
-                return { type: 'error', isFeeEstimationError: false };
+                return { type: 'error' };
             }
 
             try {
@@ -49,11 +49,7 @@ export const useYieldDepositFees = ({
                 ).unwrap();
 
                 if (result.type !== 'action-ready') {
-                    return {
-                        type: 'error',
-                        isFeeEstimationError:
-                            result.type === 'error' && result.reason === 'fee-estimation-failed',
-                    };
+                    return { type: 'error' };
                 }
 
                 return {
@@ -66,7 +62,7 @@ export const useYieldDepositFees = ({
                     },
                 };
             } catch {
-                return { type: 'error', isFeeEstimationError: false };
+                return { type: 'error' };
             }
         },
         [dispatch, flowData],

--- a/suite-native/module-earn/src/hooks/useYieldPendingSheet.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingSheet.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { type YieldPendingTransactionState } from '@suite-common/wallet-core';
+import { usePreviousDefined } from '@trezor/react-utils';
+
+// Generous next to the ~250ms dismissal: this only backstops a dismissal that never reports.
+const SHEET_DISMISS_TIMEOUT_MS = 1_000;
+
+/**
+ * Sequences the pending-transaction sheet against the flow step that replaces the screen under it.
+ *
+ * `completeAction` clears the pending transaction and advances the step in a single reducer, so the
+ * sheet starts dismissing in the very commit that would replace the screen. @gorhom/bottom-sheet
+ * does not drop a still-open sheet's native views on unmount — the portal holds them while it
+ * animates closed — so replacing the screen in that window corrupts the native view tree and
+ * crashes Fabric with "addViewAt: failed to insert view".
+ *
+ * Callers keep the sheet rendered from `displayedPendingTransaction`, hold their
+ * `navigation.replace` while `isSheetPresented`, and pass `handleSheetDismissed` to the sheet.
+ */
+export const useYieldPendingSheet = (
+    actionPendingTransaction: YieldPendingTransactionState | undefined,
+) => {
+    const previousPendingTransaction = usePreviousDefined(actionPendingTransaction);
+    const isPending = !!actionPendingTransaction;
+    const [isSheetPresented, setIsSheetPresented] = useState(false);
+
+    useEffect(() => {
+        if (isPending) {
+            setIsSheetPresented(true);
+        }
+    }, [isPending]);
+
+    // The sheet may never report its dismissal — it is only opened while the screen is focused, and
+    // the portal owns the teardown either way. Without this the flow strands the user on a finished
+    // transaction.
+    useEffect(() => {
+        if (!isSheetPresented || isPending) {
+            return undefined;
+        }
+
+        const timeout = setTimeout(() => setIsSheetPresented(false), SHEET_DISMISS_TIMEOUT_MS);
+
+        return () => clearTimeout(timeout);
+    }, [isPending, isSheetPresented]);
+
+    const handleSheetDismissed = useCallback(() => setIsSheetPresented(false), []);
+
+    return {
+        // Keeps the sheet's values after the store clears them, so it can stay rendered while it
+        // dismisses rather than vanishing mid-animation.
+        displayedPendingTransaction: actionPendingTransaction ?? previousPendingTransaction,
+        isSheetPresented,
+        handleSheetDismissed,
+    };
+};

--- a/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
+++ b/suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts
@@ -5,6 +5,8 @@ import { type AccountKey } from '@suite-common/wallet-types';
 import { useBottomSheetModal } from '@suite-native/atoms';
 import { useTransactionDetails } from '@suite-native/transaction-management';
 
+import { useYieldPendingSheet } from './useYieldPendingSheet';
+
 type YieldPendingTransactionType = YieldPendingTransactionState['type'];
 
 type UseYieldPendingTransactionParams = {
@@ -40,17 +42,21 @@ export const useYieldPendingTransaction = ({
         pendingTransaction,
         transactionType,
     );
+    const { displayedPendingTransaction, isSheetPresented, handleSheetDismissed } =
+        useYieldPendingSheet(matchingPendingTransaction);
     const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey: accountKey ?? null,
-        txid: matchingPendingTransaction?.txid ?? null,
+        txid: displayedPendingTransaction?.txid ?? null,
     });
+    // Built from the retained transaction so the sheet keeps its values while it dismisses.
     const pendingModalProps =
-        matchingPendingTransaction !== undefined
+        displayedPendingTransaction !== undefined
             ? {
-                  fee: matchingPendingTransaction.fee,
+                  fee: displayedPendingTransaction.fee,
                   isExploreDisabled: !explorerUrl,
+                  onDismiss: handleSheetDismissed,
                   onExplorePress: openInBlockchain,
-                  submittedAt: new Date(matchingPendingTransaction.submittedAt ?? 0),
+                  submittedAt: new Date(displayedPendingTransaction.submittedAt ?? 0),
               }
             : null;
 
@@ -71,6 +77,8 @@ export const useYieldPendingTransaction = ({
     }, [matchingPendingTransaction, openPendingBottomSheet]);
 
     return {
+        displayedPendingTransaction,
+        isSheetPresented,
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: matchingPendingTransaction,

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 
 import { asEvmAddress } from '@suite-common/calldata';
 import { buildStablecoinYieldTransactionReview } from '@suite-common/earn-stablecoin';
@@ -20,6 +20,7 @@ import {
     selectConvertedNetworkFeeInfo,
     selectDeepCopyOfFormDraft,
     selectFormDraft,
+    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import {
     type FeeInfo,
@@ -73,8 +74,8 @@ type UseYieldWithdrawFeesResult = {
 };
 
 // Only the inputs that should trigger a fresh (network) fee composition. The fee context
-// (feeInfo, selected/custom fee, flowData) is read from refs at compose time instead, so it can't
-// re-trigger the effect — most importantly the fee draft that the compose itself writes.
+// (selected/custom fee, flowData) is read from refs at compose time and fee info is fetched by the
+// compose itself, so neither can re-trigger the effect — most importantly the fee draft it writes.
 type ComposeWithdrawFeeParams = {
     amount: string;
     flowType: YieldWithdrawFlowType;
@@ -201,20 +202,6 @@ const getYieldWithdrawFeeState = (formDraft: FormState | null | undefined) => {
     };
 };
 
-const getWithdrawFeeInfoRevision = (feeInfo: FeeInfo | null | undefined) =>
-    feeInfo?.levels
-        .map(({ baseFeePerGas, blocks, feePerUnit, label, maxFeePerGas, maxPriorityFeePerGas }) =>
-            [label, feePerUnit, blocks, maxFeePerGas, maxPriorityFeePerGas, baseFeePerGas].join(
-                ':',
-            ),
-        )
-        .join('|') ?? '';
-
-const isWithdrawFeeInfoReady = (feeInfo: FeeInfo | null | undefined) =>
-    !!feeInfo?.levels.some(
-        feeLevel => feeLevel.label !== 'normal' || feeLevel.maxFeePerGas || feeLevel.blocks !== -1,
-    );
-
 const composeYieldWithdrawTransaction = async ({
     amount,
     dispatch,
@@ -312,6 +299,7 @@ export const useYieldWithdrawFees = ({
     isEnabled,
 }: UseYieldWithdrawFeesParams): UseYieldWithdrawFeesResult => {
     const dispatch = useDispatch();
+    const store = useStore<FeesRootState>();
     const debounce = useDebounce();
     const requestIdRef = useRef(0);
     const [preparedAction, setPreparedAction] = useState<PreparedYieldWithdrawAction | null>(null);
@@ -327,9 +315,6 @@ export const useYieldWithdrawFees = ({
         () => (flowKey ? getYieldWithdrawFormDraftKey(flowKey) : ''),
         [flowKey],
     );
-    const feeInfo = useSelector((state: FeesRootState) =>
-        selectConvertedNetworkFeeInfo(state, flowData?.account.symbol),
-    );
     const formDraft = useSelector((state: FormDraftRootState) =>
         formDraftKey ? selectFormDraft<FormState>(state, formDraftKey) : undefined,
     );
@@ -342,8 +327,6 @@ export const useYieldWithdrawFees = ({
     // changes (which would otherwise loop: compose -> stores draft -> draft change -> compose ...).
     const flowDataRef = useRef(flowData);
     flowDataRef.current = flowData;
-    const feeInfoRef = useRef(feeInfo);
-    feeInfoRef.current = feeInfo;
     const feeStateRef = useRef(feeState);
     feeStateRef.current = feeState;
     const selectedFeeLevel = feeLevels[selectedFee];
@@ -355,33 +338,41 @@ export const useYieldWithdrawFees = ({
         isLoading: isComposingWithdrawFee,
     });
 
-    // `formDraftKey` is truthy only once the flow is resolved (so flowData is available), and
-    // `hasFeeInfo` flips compose back on when fee info finishes loading without re-triggering on
-    // every fee-info identity change.
-    const feeInfoRevision = useMemo(() => getWithdrawFeeInfoRevision(feeInfo), [feeInfo]);
-    const hasFeeInfo = isWithdrawFeeInfoReady(feeInfo);
     const composeWithdrawFee = useCallback(
         async (params: ComposeWithdrawFeeParams, requestId: number) => {
             const { amount: withdrawAmount, formDraftKey: withdrawFormDraftKey } = params;
             const withdrawFlowData = flowDataRef.current;
-            const withdrawFeeInfo = feeInfoRef.current;
             const currentFlowType = params.flowType;
             const { customFee: withdrawCustomFee, selectedFee: withdrawSelectedFee } =
                 feeStateRef.current;
 
-            if (!withdrawFlowData || !withdrawFeeInfo) {
-                if (requestId === requestIdRef.current) {
-                    dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
-                    setPreparedAction(null);
-                    setIsComposingWithdrawFee(false);
-                }
-
-                return;
-            }
-
             try {
                 if (requestId !== requestIdRef.current) {
                     return;
+                }
+
+                if (!withdrawFlowData) {
+                    throw new Error('Yield withdraw flow data is not available.');
+                }
+
+                // There is no background fee-info sync on mobile (desktop has one) and `fees` is not
+                // persisted, so levels are refreshed before composing. The refresh is best-effort —
+                // a failed one still composes from the stored levels, only missing fee info fails.
+                await dispatch(
+                    updateFeeInfoThunk({ networkSymbol: withdrawFlowData.account.symbol }),
+                );
+
+                if (requestId !== requestIdRef.current) {
+                    return;
+                }
+
+                const withdrawFeeInfo = selectConvertedNetworkFeeInfo(
+                    store.getState(),
+                    withdrawFlowData.account.symbol,
+                );
+
+                if (!withdrawFeeInfo) {
+                    throw new Error('Fee info is not available.');
                 }
 
                 const composeResult = await composeYieldWithdrawTransaction({
@@ -452,6 +443,7 @@ export const useYieldWithdrawFees = ({
                     : undefined;
 
                 if (!isFinalPrecomposedTransaction(selectedFeeTransaction)) {
+                    setHasFeeEstimationError(true);
                     dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
                     setPreparedAction(null);
 
@@ -475,6 +467,7 @@ export const useYieldWithdrawFees = ({
                 });
             } catch {
                 if (requestId === requestIdRef.current) {
+                    setHasFeeEstimationError(true);
                     dispatch(formDraftActions.removeDraft({ key: withdrawFormDraftKey }));
                     setPreparedAction(null);
                 }
@@ -484,7 +477,7 @@ export const useYieldWithdrawFees = ({
                 }
             }
         },
-        [dispatch, setHasFeeEstimationError],
+        [dispatch, setHasFeeEstimationError, store],
     );
 
     useEffect(() => {
@@ -493,7 +486,7 @@ export const useYieldWithdrawFees = ({
 
         setHasFeeEstimationError(false);
 
-        if (!isEnabled || !amount || !formDraftKey || !hasFeeInfo) {
+        if (!isEnabled || !amount || !formDraftKey) {
             setIsComposingWithdrawFee(false);
             setPreparedAction(null);
 
@@ -522,10 +515,8 @@ export const useYieldWithdrawFees = ({
         debounce,
         dispatch,
         feeEstimationRetryKey,
-        feeInfoRevision,
         flowType,
         formDraftKey,
-        hasFeeInfo,
         isEnabled,
         setHasFeeEstimationError,
     ]);

--- a/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
+++ b/suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useNavigation } from '@react-navigation/native';
@@ -67,6 +67,7 @@ export const useYieldWithdrawReview = ({
 }: UseYieldWithdrawReviewParams): UseYieldWithdrawReviewResult => {
     const dispatch = useDispatch();
     const navigation = useNavigation<NavigationProps>();
+    const isPushingRef = useRef(false);
     const { showReviewAlert } = useShowPushTransactionFailedDuringReviewAlert('yield-withdraw');
     const showDeviceDisconnectedAlert = useShowDeviceDisconnectedDuringEarnReviewAlert();
     const handleReviewError = useHandleEarnReviewError('yield-withdraw', navigation);
@@ -184,10 +185,15 @@ export const useYieldWithdrawReview = ({
     ]);
 
     const handleWithdrawSubmitted = useCallback(async () => {
-        if (withdrawStatus !== 'signed') {
+        // `withdrawStatus` is captured state, so two presses in the same frame both pass this
+        // check. The second push finds the review data already discarded by the first and rejects
+        // with "Transaction not found.", which surfaces as "not submitted" for a broadcast that
+        // did go out. Broadcasting has to be idempotent per signed transaction.
+        if (withdrawStatus !== 'signed' || isPushingRef.current) {
             return;
         }
 
+        isPushingRef.current = true;
         setWithdrawActionStatus('sending');
 
         const pushResponse = await dispatch(
@@ -198,6 +204,9 @@ export const useYieldWithdrawReview = ({
             }),
         );
 
+        // Released once the push settles, so a deliberate retry after a failure still works —
+        // only concurrent invocations are blocked.
+        isPushingRef.current = false;
         setWithdrawActionStatus('idle');
         const isPushRejected = isRejected(pushResponse);
 

--- a/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositScreen.tsx
@@ -407,7 +407,7 @@ export const YieldDepositScreen = () => {
                     amountValue={amountValue}
                     apy={apy}
                     isDisabled={isSubmitDisabled}
-                    isLoading={isActionSubmitting}
+                    isLoading={isActionSubmitting || depositFee.isPreparingDepositFee}
                     onPress={handleContinue}
                     shouldKeepEstimatedRewardsVisible={isApprovalInsufficient}
                     tokenSymbol={wrappedNativeSymbol ?? tokenSymbol}

--- a/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx
@@ -305,6 +305,7 @@ export const YieldDepositWrapScreen = () => {
                 <YieldWrappedNativeStepFooter
                     flowType="wrap"
                     isSubmitDisabled={isSubmitDisabled}
+                    isSubmitLoading={wrapFee.isFeePreparing}
                     onSkip={hasWrappedTokenBalance && !isWrapPending ? handleSkip : undefined}
                     onSubmit={simulation.handleSubmit}
                     spentSymbol={nativeSymbol}

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -572,7 +572,11 @@ export const YieldWithdrawScreen = () => {
                 <>
                     <ScreenFooterGradient />
                     <Box style={applyStyle(screenFooterStyle)}>
-                        <Button isDisabled={isSubmitDisabled} onPress={handleContinue}>
+                        <Button
+                            isDisabled={isSubmitDisabled}
+                            isLoading={isComposingWithdrawFee}
+                            onPress={handleContinue}
+                        >
                             <Translation id="generic.buttons.continue" />
                         </Button>
                     </Box>
@@ -717,7 +721,7 @@ export const YieldWithdrawScreen = () => {
                         <YieldFeeEstimationErrorAlert onRetry={retryFeeEstimation} />
                     )}
 
-                    {isWithdrawReviewReady && (
+                    {!!withdrawFeeFormDraft && (
                         <FeeSelector
                             accountKey={account.key}
                             tokenContract={route.params.tokenContract}

--- a/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx
@@ -64,6 +64,7 @@ import { useMessageSystemYield } from '../hooks/useMessageSystemYield';
 import { useNavigateBackAnalytics } from '../hooks/useNavigateBackAnalytics';
 import { useResolvedYieldFlowData } from '../hooks/useResolvedYieldFlowData';
 import { useShowYieldTransactionFailureAlert } from '../hooks/useShowYieldTransactionFailureAlert';
+import { useYieldPendingSheet } from '../hooks/useYieldPendingSheet';
 import { useYieldPendingTransactionTracking } from '../hooks/useYieldPendingTransactionTracking';
 import { useYieldSession } from '../hooks/useYieldSession';
 import { useYieldWithdrawFees } from '../hooks/useYieldWithdrawFees';
@@ -272,9 +273,11 @@ export const YieldWithdrawScreen = () => {
     const pendingTransaction = session?.action.pendingTransaction ?? null;
     const { actionPendingTransaction } = splitYieldPendingTransaction(pendingTransaction, flowType);
     const isWithdrawPending = !!actionPendingTransaction;
+    const { displayedPendingTransaction, isSheetPresented, handleSheetDismissed } =
+        useYieldPendingSheet(actionPendingTransaction);
     const { explorerUrl, openInBlockchain } = useTransactionDetails({
         accountKey: account?.key ?? null,
-        txid: actionPendingTransaction?.txid ?? null,
+        txid: displayedPendingTransaction?.txid ?? null,
     });
     const isSubmitDisabled =
         !amount ||
@@ -312,6 +315,12 @@ export const YieldWithdrawScreen = () => {
     }, [closePendingBottomSheet, isFocused, isWithdrawPending, openPendingBottomSheet]);
 
     useEffect(() => {
+        // Replacing the screen while the sheet is still dismissing crashes Fabric — see
+        // `useYieldPendingSheet`.
+        if (isSheetPresented) {
+            return;
+        }
+
         if (session?.step === 'unwrap') {
             navigation.replace(YieldStackRoutes.YieldWithdrawUnwrap, {
                 ...route.params,
@@ -327,7 +336,7 @@ export const YieldWithdrawScreen = () => {
                 withdrawFlowType: flowType,
             });
         }
-    }, [flowType, navigation, route.params, session?.step]);
+    }, [flowType, isSheetPresented, navigation, route.params, session?.step]);
 
     const getSharesAmountFromAssetAmount = useCallback(
         (value: string) => {
@@ -743,19 +752,20 @@ export const YieldWithdrawScreen = () => {
                     />
                 </VStack>
             </VStack>
-            {actionPendingTransaction && (
+            {displayedPendingTransaction && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
                     accountSymbol={account.symbol}
-                    amount={actionPendingTransaction.amount}
+                    amount={displayedPendingTransaction.amount}
                     amountLabel={<Translation id="earn.yieldWithdrawFlowScreen.amountToWithdraw" />}
                     amountTokenContract={activeUnitTokenContract}
                     amountTokenSymbol={activeUnitSymbol}
-                    fee={actionPendingTransaction.fee}
+                    fee={displayedPendingTransaction.fee}
                     isExploreDisabled={!explorerUrl}
+                    onDismiss={handleSheetDismissed}
                     onExplorePress={openInBlockchain}
-                    submittedAt={new Date(actionPendingTransaction.submittedAt ?? 0)}
+                    submittedAt={new Date(displayedPendingTransaction.submittedAt ?? 0)}
                     title={<Translation id="earn.yieldWithdrawFlowScreen.withdrawPendingTitle" />}
                     vaultName={vaultTokenName}
                     vaultTokenContract={vaultTokenContract}

--- a/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
@@ -164,6 +164,8 @@ export const YieldWithdrawUnwrapScreen = () => {
     } = form.form;
 
     const {
+        displayedPendingTransaction,
+        isSheetPresented,
         pendingBottomSheetRef,
         pendingModalProps,
         pendingTransaction: unwrapPendingTransaction,
@@ -205,6 +207,12 @@ export const YieldWithdrawUnwrapScreen = () => {
             return;
         }
 
+        // Replacing the screen while the sheet is still dismissing crashes Fabric — see
+        // `useYieldPendingSheet`.
+        if (isSheetPresented) {
+            return;
+        }
+
         if (session?.step === 'action') {
             navigation.replace(YieldStackRoutes.YieldWithdraw, {
                 ...route.params,
@@ -220,7 +228,7 @@ export const YieldWithdrawUnwrapScreen = () => {
                 withdrawFlowType: flowType,
             });
         }
-    }, [flowType, isFocused, navigation, route.params, session?.step]);
+    }, [flowType, isFocused, isSheetPresented, navigation, route.params, session?.step]);
 
     const handleSkip = useCallback(() => {
         if (!flowKey || isUnwrapPending) {
@@ -419,17 +427,18 @@ export const YieldWithdrawUnwrapScreen = () => {
                     </VStack>
                 </Form>
             </Box>
-            {unwrapPendingTransaction && pendingModalProps && (
+            {displayedPendingTransaction && pendingModalProps && (
                 <YieldPendingTransactionModal
                     ref={pendingBottomSheetRef}
                     accountLabel={accountLabel}
                     accountSymbol={account.symbol}
-                    amount={unwrapPendingTransaction.amount}
+                    amount={displayedPendingTransaction.amount}
                     amountLabel={<Translation id="earn.unwrapNativeToken.amountToUnwrap" />}
                     amountTokenContract={wrappedTokenContract}
                     amountTokenSymbol={wrappedTokenSymbol}
                     fee={pendingModalProps.fee}
                     isExploreDisabled={pendingModalProps.isExploreDisabled}
+                    onDismiss={pendingModalProps.onDismiss}
                     onExplorePress={pendingModalProps.onExplorePress}
                     submittedAt={pendingModalProps.submittedAt}
                     title={<Translation id="earn.yieldWithdrawFlowScreen.unwrapPendingTitle" />}

--- a/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
+++ b/suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx
@@ -331,6 +331,7 @@ export const YieldWithdrawUnwrapScreen = () => {
                     flowType="unwrap"
                     isSkipFirst
                     isSubmitDisabled={isSubmitDisabled}
+                    isSubmitLoading={unwrapFee.isFeePreparing}
                     onSkip={isUnwrapPending ? undefined : handleSkip}
                     onSubmit={simulation.handleSubmit}
                     spentSymbol={wrappedTokenSymbol}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A couple of candidates of AI-assisted debugging session. In the end it's [probably the issue](https://github.com/software-mansion/react-native-reanimated/pull/9976) with react-native-reanimated. Together with that issue seemed to be hiding in the code for matching of pending transaction ids. With the help of coding agent I found working code but the nature of bug still remains quite unclear for me.

## Notes for QA

App shouldn't crash on earn/staking flows

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31221

## Screenshots


https://github.com/user-attachments/assets/453f791a-8c5b-408d-9021-697d7fd554fa

https://github.com/user-attachments/assets/9e76902e-1de3-43b7-99fc-72e45ce61365


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is dominated by suite-native mobile earn module files that are not exercised by the suite Playwright E2E suite. Only two shared common files (accountsThunks.ts and transactionUtils.ts) have plausible suite impact. I recommend a minimal sanity set covering account creation and transaction sending/staking to catch regressions in shared code, while the native mobile changes require separate native test coverage.

<details><summary><b>Changed files (20)</b></summary>

- `suite-common/wallet-core/src/accounts/accountsThunks.ts`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`
- `suite-native/atoms/src/Input/Input.tsx`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx`
- `suite-native/module-earn/src/components/YieldWrappedNativeStepFooter.tsx`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingSheet.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx`

</details>

**Recommended tests (4)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test explicitly adds accounts of various types and asserts the accountsNewAccountEvent analytics payload with correct symbol/path. It directly exercises the account creation thunk logic in suite-common/wallet-core/src/accounts/accountsThunks.ts, making it the strongest suite-side signal for regressions in that shared file.
- `suite/e2e/tests/wallet/pending-transactions.test.ts` — This test sends multi-output Bitcoin transactions, mines blocks, and asserts pending/confirmed transaction state transitions. These flows rely heavily on suite-common/wallet-utils/src/transactionUtils.ts for transaction construction and status handling, which is especially relevant because the PR also touches native earn pending-transaction hooks.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking is the closest suite equivalent to the native earn yield deposit flow being modified. It constructs and signs a contract transaction and exercises composed transaction state, providing a cross-check that shared transaction utilities still behave correctly for earn-like operations.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test covers the EVM send flow with custom gas fees and device signing. It is a focused end-to-end check that transaction utility functions for fee calculation and EVM transaction composition still work after changes to transactionUtils.ts.

</details>

⚠️ **Changes with no test coverage (18)**
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-native/atoms/src/Input/Input.tsx`
- `suite-native/module-earn/src/components/EarnFormScreenFooter.tsx`
- `suite-native/module-earn/src/components/YieldDepositFlowFooter.tsx`
- `suite-native/module-earn/src/components/YieldPendingTransactionModal.tsx`
- `suite-native/module-earn/src/components/YieldWrappedNativeStepFooter.tsx`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.test.ts`
- `suite-native/module-earn/src/hooks/usePreparedTxFees.ts`
- `suite-native/module-earn/src/hooks/useWrappedNativeTokenFees.ts`
- `suite-native/module-earn/src/hooks/useYieldDepositFees.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingSheet.ts`
- `suite-native/module-earn/src/hooks/useYieldPendingTransaction.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawFees.ts`
- `suite-native/module-earn/src/hooks/useYieldWithdrawReview.ts`
- `suite-native/module-earn/src/screens/YieldDepositScreen.tsx`
- `suite-native/module-earn/src/screens/YieldDepositWrapScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawScreen.tsx`
- `suite-native/module-earn/src/screens/YieldWithdrawUnwrapScreen.tsx`

_Updated: 2026-08-17T13:56:24.900Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/native-withdraw-crash/web/](https://dev.suite.sldev.cz/suite-web/fix/native-withdraw-crash/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/native-withdraw-crash&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/native-withdraw-crash&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/native-withdraw-crash&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-17T13:56:20.917Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-17T13:56:56.939Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->