### PR TITLE
feat(suite-native): align Select with new design system spec

### DIFF
--- a/suite-native/atoms/src/Select/Select.tsx
+++ b/suite-native/atoms/src/Select/Select.tsx
@@ -1,13 +1,17 @@
 import { type ReactNode, useMemo, useState } from 'react';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import { Translation } from '@suite-native/intl';
 
 import { Box } from '../Box';
 import { Button } from '../Button/Button';
+import { Hint } from '../Hint';
+import { type TextInputType } from '../Input/Input';
 import { ScreenFooterGradient } from '../ScreenFooterGradient';
 import { BottomSheetModal } from '../Sheet/BottomSheetModal';
 import { useBottomSheetModal } from '../Sheet/hooks/useBottomSheetModal';
 import { VStack } from '../Stack';
+import { Text } from '../Text';
 import { SelectItem, type SelectItemValue } from './SelectItem';
 import { SelectTrigger } from './SelectTrigger';
 
@@ -21,10 +25,13 @@ export type SelectItemType<TItemValue extends SelectItemValue> = {
 export type SelectProps<TItemValue extends SelectItemValue> = {
     title: ReactNode;
     items: SelectItemType<TItemValue>[];
-    value: TItemValue;
+    value: TItemValue | null;
     onSelectItem: (value: TItemValue) => void;
     isConfirmable?: boolean;
-    isLabelShown?: boolean;
+    labelType?: TextInputType;
+    hasError?: boolean;
+    errorMessage?: string;
+    isDisabled?: boolean;
     testID?: string;
 };
 
@@ -34,7 +41,10 @@ export const Select = <TItemValue extends SelectItemValue>({
     value,
     onSelectItem,
     isConfirmable = false,
-    isLabelShown = false,
+    labelType = 'noLabel',
+    hasError = false,
+    errorMessage,
+    isDisabled = false,
     testID,
 }: SelectProps<TItemValue>) => {
     const { bottomSheetRef, openModal, closeModal } = useBottomSheetModal();
@@ -48,6 +58,7 @@ export const Select = <TItemValue extends SelectItemValue>({
     const [isConfirmButtonVisible, setIsConfirmButtonVisible] = useState(false);
 
     const openBottomSheet = () => {
+        if (isDisabled) return;
         setSelectedItemValue(value);
         setIsConfirmButtonVisible(false);
         openModal();
@@ -67,6 +78,14 @@ export const Select = <TItemValue extends SelectItemValue>({
         }
     };
 
+    const handleConfirmSelection = () => {
+        if (selectedItemValue !== null) {
+            confirmSelection(selectedItemValue);
+        }
+    };
+
+    const triggerLabel = labelType === 'innerLabel' ? title : undefined;
+
     return (
         <>
             <BottomSheetModal
@@ -77,7 +96,7 @@ export const Select = <TItemValue extends SelectItemValue>({
                         <>
                             <ScreenFooterGradient />
                             <Box marginHorizontal="sp16" marginBottom="sp16">
-                                <Button onPress={() => confirmSelection(selectedItemValue)}>
+                                <Button onPress={handleConfirmSelection}>
                                     <Translation id="generic.buttons.confirm" />
                                 </Button>
                             </Box>
@@ -100,13 +119,30 @@ export const Select = <TItemValue extends SelectItemValue>({
                     ))}
                 </VStack>
             </BottomSheetModal>
-            <SelectTrigger
-                label={isLabelShown && title}
-                value={selectTriggerItem?.label ?? null}
-                icon={selectTriggerItem?.icon}
-                handlePress={openBottomSheet}
-                testID={testID}
-            />
+            <VStack spacing="sp6">
+                {labelType === 'outsideLabel' && (
+                    <Text variant="body-md" color="contentPrimary">
+                        {title}
+                    </Text>
+                )}
+                <SelectTrigger
+                    labelType={labelType}
+                    label={triggerLabel}
+                    value={selectTriggerItem?.label ?? null}
+                    icon={selectTriggerItem?.icon}
+                    handlePress={openBottomSheet}
+                    hasError={hasError}
+                    isDisabled={isDisabled}
+                    testID={testID}
+                />
+                {hasError && !!errorMessage && (
+                    <Animated.View entering={FadeIn} exiting={FadeOut}>
+                        <Box marginLeft="sp12">
+                            <Hint variant="error">{errorMessage}</Hint>
+                        </Box>
+                    </Animated.View>
+                )}
+            </VStack>
         </>
     );
 };

--- a/suite-native/atoms/src/Select/SelectTrigger.tsx
+++ b/suite-native/atoms/src/Select/SelectTrigger.tsx
@@ -4,53 +4,115 @@ import { Icon } from '@suite-native/icons';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { Box } from '../Box';
+import { type TextInputType } from '../Input/Input';
 import { PressableOpacity } from '../Pressable';
-import { HStack } from '../Stack';
 import { ACCESSIBILITY_FONTSIZE_MULTIPLIER, Text } from '../Text';
 
 type SelectTriggerProps = {
+    labelType?: TextInputType;
     label?: ReactNode;
     value: string | null;
     icon?: ReactNode;
     handlePress: () => void;
+    hasError?: boolean;
+    isDisabled?: boolean;
     testID?: string;
 };
 
-const SELECT_HEIGHT = 58 * ACCESSIBILITY_FONTSIZE_MULTIPLIER;
+const SELECT_MIN_HEIGHT = 56 * ACCESSIBILITY_FONTSIZE_MULTIPLIER;
 
-const selectStyle = prepareNativeStyle(utils => ({
+type SelectStyleProps = {
+    hasError: boolean;
+    isDisabled: boolean;
+};
+
+const selectStyle = prepareNativeStyle<SelectStyleProps>((utils, { hasError, isDisabled }) => ({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
+    paddingHorizontal: utils.spacings.sp16,
+    paddingVertical: utils.spacings.sp6,
     backgroundColor: utils.colors.elementFillField,
-    borderWidth: utils.borders.widths.small,
+    outlineWidth: utils.borders.widths.small,
+    outlineColor: utils.colors.elementBorderField,
     borderRadius: utils.borders.radii.r12,
-    borderColor: utils.colors.elementBorderField,
-    color: utils.colors.contentSecondary,
-    paddingLeft: utils.spacings.sp12,
-    paddingRight: 23.25,
-    height: SELECT_HEIGHT,
+    minHeight: SELECT_MIN_HEIGHT,
+    extend: [
+        {
+            condition: isDisabled,
+            style: {
+                backgroundColor: utils.colors.elementFillFieldDisabled,
+                outlineColor: utils.colors.elementBorderFieldDisabled,
+            },
+        },
+        {
+            condition: hasError && !isDisabled,
+            style: {
+                outlineColor: utils.colors.elementBorderFieldError,
+                outlineWidth: utils.borders.widths.large,
+            },
+        },
+    ],
 }));
 
-export const SelectTrigger = ({ label, value, icon, handlePress, testID }: SelectTriggerProps) => {
+export const SelectTrigger = ({
+    labelType = 'noLabel',
+    label,
+    value,
+    icon,
+    handlePress,
+    hasError = false,
+    isDisabled = false,
+    testID,
+}: SelectTriggerProps) => {
     const { applyStyle } = useNativeStyles();
 
+    const hasValue = value !== null && value !== undefined;
+    const isInnerLabel = labelType === 'innerLabel';
+    const showMinimizedLabel = isInnerLabel && hasValue;
+    const showFullLabel = isInnerLabel && !hasValue;
+
+    const labelColor = isDisabled ? 'contentDisabled' : 'contentTertiary';
+    const valueColor = isDisabled ? 'contentDisabled' : 'contentPrimary';
+
     return (
-        <PressableOpacity onPress={handlePress} style={applyStyle(selectStyle)} testID={testID}>
-            <Box>
-                {label && (
-                    <Text variant="body-xs" color="contentSecondary">
+        <PressableOpacity
+            onPress={handlePress}
+            style={applyStyle(selectStyle, { hasError, isDisabled })}
+            disabled={isDisabled}
+            testID={testID}
+        >
+            <Box flex={1} justifyContent="center">
+                {showFullLabel && (
+                    <Text variant="body-md" color="contentSecondary" numberOfLines={1}>
                         {label}
                     </Text>
                 )}
-                <HStack alignItems="center">
-                    {icon}
-                    <Text numberOfLines={1} ellipsizeMode="tail">
-                        {value}
+                {showMinimizedLabel && (
+                    <Text variant="body-sm" color={labelColor} numberOfLines={1}>
+                        {label}
                     </Text>
-                </HStack>
+                )}
+                {hasValue && (
+                    <Box flexDirection="row" alignItems="center">
+                        {icon}
+                        <Text
+                            variant="body-md"
+                            color={valueColor}
+                            numberOfLines={1}
+                            ellipsizeMode="tail"
+                            style={{ flex: 1 }}
+                        >
+                            {value}
+                        </Text>
+                    </Box>
+                )}
             </Box>
-            <Icon size="large" color="contentSecondary" name="caretDown" />
+            <Icon
+                size="large"
+                color={isDisabled ? 'contentDisabled' : 'contentSecondary'}
+                name="caretDown"
+            />
         </PressableOpacity>
     );
 };

--- a/suite-native/atoms/src/stories/Inputs/Select.stories.tsx
+++ b/suite-native/atoms/src/stories/Inputs/Select.stories.tsx
@@ -41,8 +41,11 @@ export const Select: SelectStory = {
     args: {
         title: 'Label',
         value: 'option1',
-        isLabelShown: true,
+        labelType: 'innerLabel',
         isConfirmable: false,
+        hasError: false,
+        errorMessage: 'Something went wrong',
+        isDisabled: false,
         items,
     },
     argTypes: {
@@ -50,13 +53,26 @@ export const Select: SelectStory = {
             control: { type: 'text' },
         },
         value: {
-            options: Object.values(OPTIONS),
+            options: [null, ...Object.values(OPTIONS)],
+            control: {
+                type: 'select',
+                labels: { null: 'Unselected' },
+            },
+        },
+        labelType: {
+            options: ['innerLabel', 'outsideLabel', 'noLabel'],
             control: { type: 'select' },
         },
         isConfirmable: {
             control: { type: 'boolean' },
         },
-        isLabelShown: {
+        hasError: {
+            control: { type: 'boolean' },
+        },
+        errorMessage: {
+            control: { type: 'text' },
+        },
+        isDisabled: {
             control: { type: 'boolean' },
         },
         items: {

--- a/suite-native/module-dev-utils/src/components/EarnEnvironmentSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/EarnEnvironmentSelect.tsx
@@ -31,7 +31,7 @@ export const EarnEnvironmentSelect = () => {
             items={earnWorkerBaseUrlItems}
             value={storedValue ?? defaultEarnYieldWorkerBaseUrl}
             onSelectItem={handleSelectEnvironment}
-            isLabelShown
+            labelType="innerLabel"
         />
     );
 };

--- a/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/FirmwareUpdateChannelSelect.tsx
@@ -38,7 +38,7 @@ export const FirmwareUpdateChannelSelect = () => {
             items={options}
             value={selectedFirmwareChannel}
             onSelectItem={handleSelectEnvironment}
-            isLabelShown
+            labelType="innerLabel"
         />
     );
 };

--- a/suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemAddMessageForm.tsx
@@ -59,7 +59,7 @@ export const MessageSystemAddMessageForm = () => {
                 items={[...CATEGORY_OPTIONS]}
                 value={presetCategory}
                 onSelectItem={handlePreset}
-                isLabelShown
+                labelType="innerLabel"
             />
             {canAddCondition && (
                 <Select<keyof Condition | ''>
@@ -67,7 +67,7 @@ export const MessageSystemAddMessageForm = () => {
                     items={[...availableConditionOptions]}
                     value=""
                     onSelectItem={handleAddCondition}
-                    isLabelShown
+                    labelType="innerLabel"
                 />
             )}
             <Input

--- a/suite-native/module-dev-utils/src/components/MessageSystemConfigSourceSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemConfigSourceSelect.tsx
@@ -30,7 +30,7 @@ export const MessageSystemConfigSourceSelect = () => {
             items={options}
             value={messageSystemConfigSource}
             onSelectItem={handleSelect}
-            isLabelShown
+            labelType="innerLabel"
         />
     );
 };

--- a/suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx
+++ b/suite-native/module-dev-utils/src/components/MessageSystemManagerFilters.tsx
@@ -22,7 +22,7 @@ export const MessageSystemManagerFilters = ({
             items={[...CATEGORY_FILTER_OPTIONS]}
             value={selectedCategory}
             onSelectItem={onCategoryChange}
-            isLabelShown
+            labelType="innerLabel"
         />
         <Box flexDirection="row" justifyContent="space-between" alignItems="center">
             <Text>Show only active</Text>

--- a/suite-native/module-dev-utils/src/components/TradingEnvironmentSelect.tsx
+++ b/suite-native/module-dev-utils/src/components/TradingEnvironmentSelect.tsx
@@ -26,7 +26,7 @@ export const TradingEnvironmentSelect = () => {
             items={tradingEnvironmentItems}
             value={selectedTradingEnvironment}
             onSelectItem={handleSelectEnvironment}
-            isLabelShown
+            labelType="innerLabel"
         />
     );
 };

--- a/suite-native/module-settings/src/components/NetworkBackendCard.tsx
+++ b/suite-native/module-settings/src/components/NetworkBackendCard.tsx
@@ -55,7 +55,7 @@ export const NetworkBackendCard = ({ form }: NetworkBackendCardProps) => {
                     items={serverTypes}
                     value={selectedServerType}
                     onSelectItem={setServerType}
-                    isLabelShown
+                    labelType="innerLabel"
                 />
                 {selectedServerType !== 'default' && (
                     <TextInputField

--- a/suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx
+++ b/suite-native/module-settings/src/components/SuiteSyncRelayUrlCard.tsx
@@ -28,7 +28,7 @@ export const SuiteSyncRelayUrlCard = () => {
                         items={serverTypes}
                         value={server}
                         onSelectItem={setServer}
-                        isLabelShown
+                        labelType="innerLabel"
                     />
                     {server === SUITE_SYNC_SERVER_TYPE_OPTIONS_MAP.custom.value && (
                         <TextInputField


### PR DESCRIPTION
## Description

Reworks the `Select` atom (`SelectTrigger`) to match the new Figma spec (node `2104:754`), mirroring the existing `TextInput` field pattern.

- Replaces the `isLabelShown` boolean with `labelType` (`innerLabel` | `outsideLabel` | `noLabel`), aligning Select with `Input`.
- Adds `hasError`, `errorMessage` and `isDisabled` states. `hasError`/`isDisabled` are **API-only** for now — no caller currently uses them; they're wired for future use.
- Inner label now behaves like the Input inner label: full-size placeholder (`body-md` / `contentSecondary`) when empty, collapsing to a small line (`body-sm`) above the value once selected.
- `value` now accepts `null` to represent an **unselected** state, rendering a blank field body (just the caret), matching the Figma empty states for all three label types.
- Uses `outline` instead of `border` on the trigger so error/disabled state changes never shift layout.
- Migrates all existing callers from `isLabelShown` to `labelType="innerLabel"`.

## Notes for QA

- Storybook → **Atoms/Inputs → Select**: exercise the `labelType`, `hasError`, `errorMessage`, `isDisabled` controls, and the new `value: Unselected` option to preview the empty state across all three label types.
- App screens using Select (Settings → Network backend / Suite sync relay URL, dev-utils selects): confirm the trigger renders the label, opens the bottom sheet, and shows the selection correctly — behavior should be unchanged.

## Related Issue

Resolve #25549

## Screenshots:
<img width="374" height="83" alt="Screenshot 2026-08-14 at 12 58 34" src="https://github.com/user-attachments/assets/1a07be5c-bbdc-4820-a2e2-03aa134d4363" />

<img width="374" height="109" alt="Screenshot 2026-08-14 at 12 58 46" src="https://github.com/user-attachments/assets/5b06021f-b9ad-4d89-a57e-989eefa1aca5" />
<img width="374" height="124" alt="Screenshot 2026-08-14 at 12 58 56" src="https://github.com/user-attachments/assets/87d45140-e1f4-4fb5-b3f4-e58590ecd2f3" />


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/select-component-ds-update&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->