### PR TITLE
fix(suite): prefill fiat input from approve step in deposit flow

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts
@@ -81,6 +81,27 @@ describe('useYieldFiatInput', () => {
         expect(result.current.methods.getValues('amountInput')).toBe('0.1');
     });
 
+    it('fills the fiat display when resetting to an amount in fiat mode', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+        act(() => result.current.fiat.resetAmounts('0.1'));
+
+        expect(result.current.methods.getValues('amountInput')).toBe('0.1');
+        expect(result.current.methods.getValues('fiatInput')).toBe('333.34');
+    });
+
+    it('clears both fields when resetting to an empty amount', () => {
+        const { result } = renderYieldFiatInput();
+
+        act(() => result.current.fiat.fiatToggle?.onToggle());
+        act(() => result.current.fiat.fiatToggle?.onFiatAmountChange('333.33'));
+        act(() => result.current.fiat.resetAmounts(''));
+
+        expect(result.current.methods.getValues('amountInput')).toBe('');
+        expect(result.current.methods.getValues('fiatInput')).toBe('');
+    });
+
     it('converts a typed fiat amount into the crypto source of truth', () => {
         const { result } = renderYieldFiatInput();
 

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts
@@ -39,6 +39,8 @@ export type UseYieldFiatInputResult = {
     // Fills the exact crypto max and, in fiat mode, the rounded-down max fiat display, without
     // switching the active unit.
     setMaxAmount: (cryptoMax: string) => void;
+    // Resets both fields to a crypto amount, filling the fiat display from the current rate.
+    resetAmounts: (cryptoAmount: string) => void;
 };
 
 /**
@@ -128,6 +130,16 @@ export const useYieldFiatInput = ({
           }
         : undefined;
 
+    const resetAmounts = useCallback(
+        (cryptoAmount: string) => {
+            methods.reset({
+                amountInput: cryptoAmount,
+                fiatInput: getYieldFiatInputValue({ amount: cryptoAmount, rate: currentRate }),
+            });
+        },
+        [currentRate, methods],
+    );
+
     const setMaxAmount = useCallback(
         (cryptoMax: string) => {
             methods.setValue('amountInput', cryptoMax, { shouldValidate: true, shouldDirty: true });
@@ -143,5 +155,5 @@ export const useYieldFiatInput = ({
         [currency, currentRate, methods],
     );
 
-    return { fiatToggle, setMaxAmount };
+    return { fiatToggle, setMaxAmount, resetAmounts };
 };

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -184,13 +184,14 @@ export const useYieldFlow = ({
         accountSymbol: account.symbol,
         token,
     });
-    const { fiatToggle, setMaxAmount } = useYieldFiatInput({
+    const { fiatToggle, setMaxAmount, resetAmounts } = useYieldFiatInput({
         methods,
         symbol: rateToken?.symbol,
         tokenAddress: rateToken?.tokenAddress,
         decimals: token?.decimals ?? getNetwork(account.symbol).decimals,
         vaultId: vault.id,
     });
+    const resetAmountsRef = useCurrentRef(resetAmounts);
 
     const getMaxAmount = () => {
         if (flowType === 'deposit') {
@@ -343,10 +344,7 @@ export const useYieldFlow = ({
 
         if (prevStep !== null && prevStep !== nextStep) {
             if (prevStep === 'wrap' && nextStep === 'approve') {
-                methodsRef.current.reset({
-                    amountInput: session.action.amount ?? '',
-                    fiatInput: '',
-                });
+                resetAmountsRef.current(session.action.amount ?? '');
             }
 
             if (nextStep === 'wrap') {
@@ -361,26 +359,22 @@ export const useYieldFlow = ({
                 })
                     ? maxAmount
                     : actionAmount;
-                methodsRef.current.reset({
-                    amountInput: cappedAmount,
-                    fiatInput: '',
-                });
+                resetAmountsRef.current(cappedAmount);
             }
 
             if (prevStep === 'action' && nextStep === 'approve') {
-                methodsRef.current.reset({
-                    amountInput: getYieldModifyAmountInput({
+                resetAmountsRef.current(
+                    getYieldModifyAmountInput({
                         liveAmount: methodsRef.current.getValues('amountInput'),
                         actionAmount: session.action.amount,
                         maxAmount,
                     }),
-                    fiatInput: '',
-                });
+                );
             }
         }
 
         prevStepRef.current = nextStep;
-    }, [session.step, session.action.amount, methodsRef, maxAmount]);
+    }, [session.step, session.action.amount, methodsRef, resetAmountsRef, maxAmount]);
 
     // The withdraw flow's unwrap step must default to the amount just withdrawn (in asset units),
     // not the account's whole wrapped-native balance — otherwise it would sweep in unrelated WETH
@@ -414,11 +408,11 @@ export const useYieldFlow = ({
             unwrapDefaultAmountRef.current === null ||
             currentAmount === unwrapDefaultAmountRef.current
         ) {
-            methodsRef.current.reset({ amountInput: unwrapDefaultAmount, fiatInput: '' });
+            resetAmountsRef.current(unwrapDefaultAmount);
         }
 
         unwrapDefaultAmountRef.current = unwrapDefaultAmount;
-    }, [methodsRef, session.step, unwrapDefaultAmount]);
+    }, [methodsRef, resetAmountsRef, session.step, unwrapDefaultAmount]);
 
     const flow = useMemo(
         () => ({ currentStep: session.step, isWrappedNativeVault }),


### PR DESCRIPTION
## Description

During the deposit flow, when approving a fiat amount, pre-fill the fiat input amount in the next step (deposit).

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30887

## Screenshots:

https://github.com/user-attachments/assets/16fa525f-377e-4d73-a2dd-77a0f4dc05e1

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are localized to staking/earn yield hooks (fiat input handling and flow orchestration). Although the static dependency graph maps these files to 135 tests transitively, the real risk is confined to staking form behavior and the stake/unstake/claim flows. I recommend running the staking-form test plus representative initial-stake tests for ADA, ETH, and SOL, with stake-more/unstake/claim variants at medium priority to catch flow-level regressions without over-broadening the suite.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/staking/staking-form.test.ts` — This test directly exercises the ETH staking form's crypto/fiat input switching, validation, percentage/Max buttons, and amount formatting — the exact surface area of useYieldFiatInput.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Exercises the full Cardano staking flow including deposit/fee display and confirmation, which relies on useYieldFlow for flow orchestration and fiat/crypto amount handling.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — Covers the complete first-time Ethereum staking flow including amount entry, fee review, and transaction progression — directly dependent on the yield flow and input hooks.
- `suite/e2e/tests/staking/sol/initial-stake.test.ts` — Validates the full Solana first-stake flow including amount input, device prompts, and pending-to-staked state transitions driven by the yield flow hooks.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — Tests reward claiming within the Cardano staking flow, a downstream action that shares the same yield flow orchestration and amount-display logic.
- `suite/e2e/tests/staking/ada/unstake.test.ts` — Tests ADA unstaking modal, fee display, and state transitions — related to the yield flow but less focused on the amount-input hook specifically.
- `suite/e2e/tests/staking/eth/stake-more.test.ts` — Exercises the Ethereum 'stake more' flow with existing staked balance, reusing the same staking form and flow hooks as initial stake.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — Tests ETH unstaking and claim flows, which are part of the same yield feature surface and share flow state management.
- `suite/e2e/tests/staking/sol/stake-more.test.ts` — Tests additional SOL staking from an already-staked account, reusing the yield form input and flow orchestration.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — Tests SOL unstaking and claim flows, sharing the yield flow orchestration with the stake flows.

</details>

⚠️ **Changes with no test coverage (1)**
- `packages/suite/src/components/earn/yield/hooks/useYieldFiatInput.test.ts`

_Updated: 2026-08-16T15:09:19.346Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-fiat-input-reset/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-fiat-input-reset/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-fiat-input-reset&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-fiat-input-reset&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-16T15:10:25.152Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-16T15:10:10.462Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->