### PR TITLE
chore(scripts): add support for # comments in dependency team lists

### DIFF
--- a/scripts/ci/list-missing-dependencies.sh
+++ b/scripts/ci/list-missing-dependencies.sh
@@ -7,6 +7,12 @@ dependencies_in_lists=()
 dependencies_missing_from_lists=()
 dependencies_listed_but_unused=()
 
+strip_dependency_comment() {
+    local line=$1
+
+    printf '%s\n' "$line" | sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
 normalize_package_name() {
     local package_name=$1
 
@@ -17,12 +23,15 @@ normalize_package_name() {
 
 read_file_into_array() {
     local file=$1
+    local line_without_comment
+
     # Check if the file exists before trying to read it
     if [[ -f $file ]]; then
         while IFS= read -r line || [[ -n "$line" ]]; do
-            # Skip empty lines and lines starting with #
-            if [[ -n "$line" && ! "$line" =~ ^# ]]; then
-                dependencies_in_lists+=("$line")
+            line_without_comment=$(strip_dependency_comment "$line")
+
+            if [[ -n "$line_without_comment" ]]; then
+                dependencies_in_lists+=("$line_without_comment")
             fi
         done < "$file"
     else

--- a/scripts/list-outdated-dependencies/foundation-dependencies.txt
+++ b/scripts/list-outdated-dependencies/foundation-dependencies.txt
@@ -17,7 +17,7 @@
 @evolu/web
 @noble/curves
 @pmmmwh/react-refresh-webpack-plugin
-@react-native-async-storage/async-storage
+@react-native-async-storage/async-storage # peer dependency required by @walletconnect/react-native-compat
 @sentry/browser
 @sentry/core
 @sentry/electron
@@ -68,7 +68,7 @@ prettier
 react-freeze
 react-native-ble-plx
 react-native-mmkv
-react-native-nitro-modules
+react-native-nitro-modules # peer dependency of some packages with mobile native code, they use this to compile
 set.prototype.difference
 set.prototype.intersection
 set.prototype.isdisjointfrom

--- a/scripts/list-outdated-dependencies/list-outdated-dependencies.sh
+++ b/scripts/list-outdated-dependencies/list-outdated-dependencies.sh
@@ -33,4 +33,7 @@ if ! contains "$1" "${domains[@]}"; then
 fi
 
 # Run yarn outdated on target dependencies
-tr '\n' ' ' < "$script_directory/$1-dependencies.txt" | xargs yarn outdated
+sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; /^[[:space:]]*$/d' \
+  "$script_directory/$1-dependencies.txt" |
+  tr '\n' ' ' |
+  xargs yarn outdated


### PR DESCRIPTION
## Description

Tiny QoL improvement for dependency managements: some packages are explicitely instaled, listed in team dependency list file, but it is unclear what they do, unless you dig deep.
→ support commentary for brief introduction "why we have this" for those mysterious dependencies

I tested personally by running:
```
yarn list-outdated foundation
# → reads @react-native-async-storage/async-storage properly

./scripts/ci/list-missing-dependencies.sh
# → succeeds, fails when I remove something
```