### PR TITLE
feat(suite): keep yield flow session when tx is pending

### DIFF
--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -225,25 +225,53 @@ export const useYieldFlow = ({
             return;
         }
 
+        // A session left with an pending transaction survives disposal (see `disposeSession`),
+        // so re-entering the flow rehydrates it: keep its step and pending state so tracking can
+        // resume/reconcile the transaction, instead of starting the flow over.
+        const preservedPendingTransaction = sessionRef.current.action.pendingTransaction;
+
         dispatch(stablecoinYieldActions.initSession({ flowType, flowKey, isWrappedNativeVault }));
-        dispatch(stablecoinYieldActions.resetSession({ flowType, flowKey, isWrappedNativeVault }));
 
-        if (flowType === 'deposit' && isWrappedNativeVault && hasWrappedTokenBalanceRef.current) {
+        if (preservedPendingTransaction) {
+            // The amount card is disabled while a transaction is pending — show its amount.
+            methodsRef.current.reset({
+                amountInput: preservedPendingTransaction.amount,
+                fiatInput: '',
+            });
+        } else {
             dispatch(
-                stablecoinYieldActions.resolveWrappedNativeStep({
-                    flowType,
-                    flowKey,
-                    step: 'wrap',
-                }),
+                stablecoinYieldActions.resetSession({ flowType, flowKey, isWrappedNativeVault }),
             );
-        }
 
-        methodsRef.current.reset({ amountInput: '', fiatInput: '' });
+            if (
+                flowType === 'deposit' &&
+                isWrappedNativeVault &&
+                hasWrappedTokenBalanceRef.current
+            ) {
+                dispatch(
+                    stablecoinYieldActions.resolveWrappedNativeStep({
+                        flowType,
+                        flowKey,
+                        step: 'wrap',
+                    }),
+                );
+            }
+
+            methodsRef.current.reset({ amountInput: '', fiatInput: '' });
+        }
 
         return () => {
             dispatch(stablecoinYieldActions.disposeSession({ flowType, flowKey }));
         };
-    }, [flowKey, flowType, dispatch, isWrappedNativeVault, hasWrappedTokenBalanceRef, methodsRef]);
+    }, [
+        flowKey,
+        flowType,
+        dispatch,
+        isWrappedNativeVault,
+        hasWrappedTokenBalanceRef,
+        methodsRef,
+        sessionRef,
+    ]);
 
     const { allowanceStatus } = session.approval;
 

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts
@@ -432,6 +432,65 @@ describe('stablecoinYieldReducer', () => {
         });
     });
 
+    describe('session lifecycle', () => {
+        it('disposes a session with no pending transaction', () => {
+            const state = stablecoinYieldReducer(
+                initSession('deposit'),
+                stablecoinYieldActions.disposeSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')).toBeUndefined();
+        });
+
+        it('keeps a session whose transaction is still pending when disposed', () => {
+            const pendingTransaction: YieldPendingTransactionState = {
+                type: 'deposit',
+                txid: '0xpendingtxid',
+                amount: '100',
+            };
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.setPendingTx({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        tx: pendingTransaction,
+                    }),
+                ),
+                stablecoinYieldActions.disposeSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toEqual(
+                pendingTransaction,
+            );
+        });
+
+        it('resets a session even while its transaction is still pending', () => {
+            const state = stablecoinYieldReducer(
+                stablecoinYieldReducer(
+                    initSession('deposit'),
+                    stablecoinYieldActions.setPendingTx({
+                        flowType: 'deposit',
+                        flowKey: FLOW_KEY,
+                        tx: { type: 'deposit', txid: '0xpendingtxid', amount: '100' },
+                    }),
+                ),
+                stablecoinYieldActions.resetSession({
+                    flowType: 'deposit',
+                    flowKey: FLOW_KEY,
+                }),
+            );
+
+            expect(getSession(state, 'deposit')?.action.pendingTransaction).toBeNull();
+        });
+    });
+
     describe('txReview', () => {
         const ACCOUNT_KEY = mockAccountKey({
             symbol: ethSymbol,

--- a/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts
@@ -246,7 +246,17 @@ const stablecoinYieldSlice = createSlice({
                 return;
             }
 
-            delete state[flowType][getStablecoinYieldSessionKey(flowKey)];
+            const sessionKey = getStablecoinYieldSessionKey(flowKey);
+
+            // A session tracking a pending transaction must survive its page unmounting:
+            // re-entering the flow resumes/reconciles it (pending panel, duplicate-submit guard,
+            // completion into the next step), and the `replaceTransaction` extraReducer needs it
+            // to follow an RBF. It is dropped once the transaction resolves.
+            if (state[flowType][sessionKey]?.action.pendingTransaction) {
+                return;
+            }
+
+            delete state[flowType][sessionKey];
         },
         resetSession(
             state: StablecoinYieldState,


### PR DESCRIPTION
## Description

Don't reset yield flow session when it contains a pending transaction.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30883

## Screenshots:

https://github.com/user-attachments/assets/bf163279-4fb5-4db9-abe3-78bb3429b881

https://github.com/user-attachments/assets/74430563-2759-45b6-9a76-b5f2132d5368

https://github.com/user-attachments/assets/d17a636b-2cd4-49a4-9dc9-e2669a4563dd


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly scoped to the earn/yield hook (useYieldFlow) and the stablecoin-yield reducer. Only staking tests that open the yield onboarding modal provide plausible E2E coverage for the hook; the stablecoin-yield reducer is covered only by its unit test. Run the two staking tests as a targeted smoke check for yield-flow UI regressions, and rely on the existing unit test for reducer logic validation.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/staking/ada/stake.test.ts` — This test directly opens the 'Staking in a Nutshell' informational modal (yieldNutshellModal component), which is part of the earn/yield flow UI likely orchestrated by useYieldFlow. A regression in the yield flow hook would most likely surface here.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — This test exercises the first-time staking flow and explicitly opens the yieldNutshellModal, making it a direct consumer of the earn/yield flow UI. Changes to useYieldFlow could break the modal transition or staking initiation.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.ts`
- `suite-common/wallet-core/src/stablecoin-yield/stablecoinYieldReducer.test.ts`

_Updated: 2026-08-18T06:40:42.776Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/yield-keep-pending-tx-session/web/](https://dev.suite.sldev.cz/suite-web/feat/yield-keep-pending-tx-session/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/yield-keep-pending-tx-session&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T06:42:37.951Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T06:42:08.321Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->