### PR TITLE
fix(suite-native): show debug vout index only on utxo-based networks

### DIFF
--- a/suite-native/module-transactions/src/components/TransactionAddress.tsx
+++ b/suite-native/module-transactions/src/components/TransactionAddress.tsx
@@ -16,7 +16,7 @@ import { selectIsLabellingAllowed } from '@suite-native/labeling';
 import { TransactionOutputLabelEditable } from '@suite-native/transactions';
 import type { StaticSessionId } from '@trezor/connect';
 
-type TransactionUtxoAddressProps = {
+type TransactionAddressProps = {
     address: string;
     txTargetId: TxTargetId;
     txId: string;
@@ -26,7 +26,7 @@ type TransactionUtxoAddressProps = {
     networkSymbol: NetworkSymbol;
 };
 
-export const TransactionUtxoAddress = ({
+export const TransactionAddress = ({
     deviceStaticSessionId,
     txId,
     txTargetId,
@@ -34,7 +34,7 @@ export const TransactionUtxoAddress = ({
     accountDescriptor,
     networkSymbol,
     showLabels,
-}: TransactionUtxoAddressProps) => {
+}: TransactionAddressProps) => {
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
 
     const account = useSelector((state: AccountsRootState & DeviceRootState) =>

--- a/suite-native/module-transactions/src/components/TransactionDetailAddressesSection.tsx
+++ b/suite-native/module-transactions/src/components/TransactionDetailAddressesSection.tsx
@@ -7,9 +7,9 @@ import { type VinVoutAddress } from '@suite-native/transactions';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
 import { ChangeAddressesHeader } from './ChangeAddressesHeader';
+import { TransactionAddress } from './TransactionAddress';
 import { TransactionDetailStepper } from './TransactionDetailStepper';
 import { SummaryRow } from './TransactionSummaryRow';
-import { TransactionUtxoAddress } from './TransactionUtxoAddress';
 
 type TransactionDetailAddressesSectionProps = {
     transaction: WalletAccountTransaction;
@@ -70,7 +70,7 @@ export const TransactionDetailAddressesSection = ({
                         />
                     </Text>
                     {targetAddresses.slice(0, 2).map(({ address, txTargetId }) => (
-                        <TransactionUtxoAddress
+                        <TransactionAddress
                             key={`target-${txTargetId}`}
                             address={address}
                             txTargetId={txTargetId}
@@ -105,7 +105,7 @@ export const TransactionDetailAddressesSection = ({
                         <Box>
                             <ChangeAddressesHeader addressesCount={changeAddresses.length} />
                             {changeAddresses.map(({ address, txTargetId }) => (
-                                <TransactionUtxoAddress
+                                <TransactionAddress
                                     key={`change-${addressesType}:${txTargetId}`}
                                     address={address}
                                     txTargetId={txTargetId}

--- a/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
+++ b/suite-native/module-transactions/src/components/TransactionUtxoAddress.tsx
@@ -1,7 +1,13 @@
 import { useSelector } from 'react-redux';
 
+import { type DeviceRootState } from '@suite-common/device';
 import type { NetworkSymbol } from '@suite-common/wallet-config';
+import {
+    type AccountsRootState,
+    selectDeviceAccountByDescriptorAndNetworkSymbol,
+} from '@suite-common/wallet-core';
 import { type AccountDescriptor, type TxTargetId } from '@suite-common/wallet-types';
+import { isUtxoBased } from '@suite-common/wallet-utils';
 import { AddressLabel } from '@suite-native/address';
 import { HStack, Text, VStack } from '@suite-native/atoms';
 import { isDebugEnv } from '@suite-native/config';
@@ -31,6 +37,11 @@ export const TransactionUtxoAddress = ({
 }: TransactionUtxoAddressProps) => {
     const isLabellingAllowed = useSelector(selectIsLabellingAllowed);
 
+    const account = useSelector((state: AccountsRootState & DeviceRootState) =>
+        selectDeviceAccountByDescriptorAndNetworkSymbol(state, accountDescriptor, networkSymbol),
+    );
+    const isUtxoBasedAccount = account !== null && isUtxoBased(account);
+
     return (
         <VStack alignItems="flex-start">
             <HStack spacing={4}>
@@ -40,7 +51,9 @@ export const TransactionUtxoAddress = ({
                     fallback={<AddressFormatter key={address} value={address} format="long" />}
                 />
 
-                {isLabellingAllowed && isDebugEnv() && <Text>[{`${txTargetId}`}]</Text>}
+                {isUtxoBasedAccount && isLabellingAllowed && isDebugEnv() && (
+                    <Text>[{`${txTargetId}`}]</Text>
+                )}
             </HStack>
 
             {showLabels && (


### PR DESCRIPTION
## Description

In the mobile transaction detail, the "Transaction overview" section suffixes every From/To address with a bracketed output index (e.g. `[0]`). The index is the transaction target id (vout index), which is meaningful only on UTXO-based networks — on address-based networks (Ethereum, Tron, Solana, Stellar, Ripple) it is always `0` and just noise.

The suffix (shown only in debug builds with labelling allowed) is now rendered only for UTXO-based accounts, reusing the canonical `isUtxoBased` util (account resolved via `selectDeviceAccountByDescriptorAndNetworkSymbol` from the props the component already receives).

Also renames `TransactionUtxoAddress` to `TransactionAddress` — the component renders a From/To address row for all networks, not only UTXO-based ones.

## Notes for QA

- Debug build only (the index was never shown in production builds).
- ETH / SOL / XRP / TRX / XLM transaction detail → Transaction overview: addresses no longer show the `[0]` suffix.
- BTC-like and ADA transaction detail: output indexes still shown as before.
- Output labelling (Add label) is untouched.

## Related Issue

Resolve #31182

## Screenshots:

<img width="389" height="511" alt="Screenshot 2026-08-23 at 8 32 28" src="https://github.com/user-attachments/assets/5a2714ee-988b-4b62-a2a0-14b53767eba5" />

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31182-utxo-index-address-based&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

