### PR TITLE
fix(suite): build buy redirect url from receive account [26.8]

### DIFF
--- a/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
+++ b/packages/suite/src/actions/wallet/trading/buy/selectBuyQuoteThunk.ts
@@ -8,6 +8,7 @@ import {
     cryptoIdToNetworkSymbolAndContractAddress,
     selectTradingBuyInfo,
     selectTradingBuyQuotesRequest,
+    selectTradingBuyReceiveAccount,
     selectTradingBuyReceiveAddress,
     selectTradingCoinInfoByCryptoId,
     selectTradingFormAccount,
@@ -24,6 +25,7 @@ export const selectBuyQuoteThunk = createThunk(
         const quotesRequest = selectTradingBuyQuotesRequest(getState());
         const receiveAddress = selectTradingBuyReceiveAddress(getState());
         const account = selectTradingFormAccount(getState(), 'buy');
+        const receiveAccount = selectTradingBuyReceiveAccount(getState());
 
         const provider = buyInfo && quote.exchange ? buyInfo.providerInfos[quote.exchange] : null;
 
@@ -33,7 +35,7 @@ export const selectBuyQuoteThunk = createThunk(
 
         const returnUrl = await createQuoteLink(
             { ...quotesRequest, paymentMethod: quote.paymentMethod },
-            account,
+            receiveAccount ?? account,
         );
 
         const { symbol: cryptoNetworkSymbol, contractAddress: cryptoContractAddress } =

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.test.tsx
@@ -35,6 +35,7 @@ jest.mock('@suite-common/trading', () => {
 });
 
 const ACCOUNT = mockWalletAccount({ symbol: 'btc' });
+const RECEIVE_ACCOUNT = mockWalletAccount({ symbol: 'eth' });
 const BITCOIN_CRYPTO_ID = 'bitcoin' as CryptoId;
 const EURO_FIAT_CURRENCY = 'EUR' as FiatCurrencyCode;
 
@@ -59,19 +60,21 @@ type StateOverrides = {
     receiveAddress?: string;
     isLoading?: boolean;
     accountKey?: AccountKey;
+    receiveAccountKey?: AccountKey;
     accounts?: Account[];
 };
 
-const DEFAULTS: Required<StateOverrides> = {
+const DEFAULTS = {
     selectedQuote: SELECTED_QUOTE,
     receiveAddress: 'bc1qreceive',
     isLoading: false,
     accountKey: ACCOUNT.key,
+    receiveAccountKey: undefined,
     accounts: [ACCOUNT],
-};
+} satisfies StateOverrides;
 
 const buildState = (overrides: StateOverrides = {}) => {
-    const { selectedQuote, receiveAddress, isLoading, accountKey, accounts } = {
+    const { selectedQuote, receiveAddress, isLoading, accountKey, receiveAccountKey, accounts } = {
         ...DEFAULTS,
         ...overrides,
     };
@@ -85,7 +88,7 @@ const buildState = (overrides: StateOverrides = {}) => {
                     receiveAddress,
                     isLoading,
                     tradingAccountKey: accountKey,
-                    receiveAccountKey: undefined,
+                    receiveAccountKey,
                     buyInfo: undefined,
                 },
                 sell: {
@@ -176,6 +179,34 @@ describe('useTradingBuyConfirm', () => {
             await result.current.confirmTrade();
 
             expect(mockConfirmTradeThunk).not.toHaveBeenCalled();
+        });
+
+        it('uses the receive account, not the form account, for the trade and return url', async () => {
+            const { result } = renderConfirm({
+                receiveAccountKey: RECEIVE_ACCOUNT.key,
+                accounts: [ACCOUNT, RECEIVE_ACCOUNT],
+            });
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    account: RECEIVE_ACCOUNT,
+                    returnUrl: expect.stringContaining(
+                        `detail/${RECEIVE_ACCOUNT.symbol}/${RECEIVE_ACCOUNT.accountType}/${RECEIVE_ACCOUNT.index}/`,
+                    ),
+                }),
+            );
+        });
+
+        it('falls back to the form account when there is no Suite receive account', async () => {
+            const { result } = renderConfirm();
+
+            await result.current.confirmTrade();
+
+            expect(mockConfirmTradeThunk).toHaveBeenCalledWith(
+                expect.objectContaining({ account: ACCOUNT }),
+            );
         });
     });
 });

--- a/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
+++ b/packages/suite/src/hooks/wallet/trading/useTradingBuyConfirm.ts
@@ -9,6 +9,7 @@ import {
     buyThunks,
     selectTradingAccountKeyByTradeType,
     selectTradingBuyIsLoading,
+    selectTradingBuyReceiveAccount,
     selectTradingBuyReceiveAddress,
     selectTradingBuySelectedQuote,
     tradingBuyActions,
@@ -29,6 +30,7 @@ export const useTradingBuyConfirm = () => {
     const isLoading = useSelector(selectTradingBuyIsLoading);
     const accountKey = useSelector(state => selectTradingAccountKeyByTradeType(state, 'buy'));
     const account = useSelector(state => selectAccountByKey(state, accountKey) ?? undefined);
+    const receiveAccount = useSelector(selectTradingBuyReceiveAccount);
 
     const isReady = !!selectedQuote && !!receiveAddress && !!account;
     const isConfirmDisabled = isLoading || !selectedQuote || !receiveAddress || !account;
@@ -42,7 +44,8 @@ export const useTradingBuyConfirm = () => {
     const confirmTrade = async (): Promise<BuyTrade | undefined> => {
         if (!account || !receiveAddress || !selectedQuote) return;
 
-        const returnUrl = await createTxLink(selectedQuote, account);
+        const tradeAccount = receiveAccount ?? account;
+        const returnUrl = await createTxLink(selectedQuote, tradeAccount);
 
         const processResponseData = (response: BuyTradeResponse) => {
             if (response.tradeForm) {
@@ -68,7 +71,7 @@ export const useTradingBuyConfirm = () => {
                 quote: selectedQuote,
                 address: receiveAddress,
                 returnUrl,
-                account,
+                account: tradeAccount,
                 processResponseData,
                 triggerAnalyticsTradeConfirmation,
             }),

--- a/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
+++ b/packages/suite/src/views/wallet/trading/buy/TradingBuyDetail/TradingBuyDetailContent.tsx
@@ -75,6 +75,7 @@ export const TradingBuyDetailContent = () => {
     };
 
     const receiveAccount = accounts.find(account => account.key === trade?.receiveAccountKey);
+    const waitingStepAccount = receiveAccount ?? account;
 
     useEffect(() => {
         // if tradeStatus hasn't changed, don't send the analytics event
@@ -115,10 +116,10 @@ export const TradingBuyDetailContent = () => {
                         />
                         <Box margin={{ top: 32, bottom: 12 }}>
                             <TradingDetailStepList>
-                                {account && (
+                                {waitingStepAccount && (
                                     <TradingBuyDetailPaymentWaitingForUserStep
                                         trade={trade.data}
-                                        account={account}
+                                        account={waitingStepAccount}
                                         providerName={provider?.brandName || provider?.companyName}
                                     />
                                 )}

--- a/stylelint-local-rules/dimension-token-values.cjs
+++ b/stylelint-local-rules/dimension-token-values.cjs
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import valueParser from 'postcss-value-parser';
-import stylelint from 'stylelint';
+const valueParser = require('postcss-value-parser');
+const stylelint = require('stylelint');
 
 const ruleName = 'trezor/dimension-token-values';
 
@@ -140,7 +140,6 @@ const ruleFunction = primary => (root, result) => {
 ruleFunction.ruleName = ruleName;
 ruleFunction.messages = messages;
 
-const plugin = stylelint.createPlugin(ruleName, ruleFunction);
-plugin.messages = messages;
-
-export default plugin;
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/suite-common/trading/src/selectors/tradingSelectors.test.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.test.ts
@@ -42,6 +42,7 @@ import {
     selectTradingBuyQuotesByPaymentMethod,
     selectTradingBuyQuotesPerPaymentMethod,
     selectTradingBuyQuotesRequest,
+    selectTradingBuyReceiveAccount,
     selectTradingBuySelectedQuote,
     selectTradingBuySupportedCryptoIds,
     selectTradingCoinInfoByCryptoId,
@@ -2362,6 +2363,28 @@ describe('tradingSelectors', () => {
         it('should return supported symbols for exchange', () => {
             expect(selectTradingSupportedSymbols(state, 'exchange', supportedCoins)).toEqual(
                 supportedSymbols,
+            );
+        });
+    });
+
+    describe(selectTradingBuyReceiveAccount.name, () => {
+        it('should return account for receiveAccountKey', () => {
+            state.wallet.trading.buy.receiveAccountKey = accountBtc.key;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBe(accountBtc);
+        });
+
+        it('should return undefined when receiveAccountKey is not set', () => {
+            state.wallet.trading.buy.receiveAccountKey = undefined;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBeUndefined();
+        });
+
+        it('should be stable', () => {
+            state.wallet.trading.buy.receiveAccountKey = accountBtc.key;
+
+            expect(selectTradingBuyReceiveAccount(state)).toBe(
+                selectTradingBuyReceiveAccount(state),
             );
         });
     });

--- a/suite-common/trading/src/selectors/tradingSelectors.ts
+++ b/suite-common/trading/src/selectors/tradingSelectors.ts
@@ -97,9 +97,10 @@ type SelectedAccountRootState = {
     };
 };
 
-export type TradingRootStateWithDeviceAndAccounts = TradingRootState &
+export type TradingRootStateWithAccounts = TradingRootState & AccountsRootState;
+
+export type TradingRootStateWithDeviceAndAccounts = TradingRootStateWithAccounts &
     DeviceRootState &
-    AccountsRootState &
     SelectedAccountRootState;
 
 export type TradingFormAccountRootState = TradingRootStateWithDeviceAndAccounts &
@@ -148,6 +149,8 @@ export type TradingStateSelector = Omit<TradingState, 'buy' | 'exchange' | 'sell
 };
 
 const createMemoizedSelector = createWeakMapSelector.withTypes<TradingRootState>();
+const createMemoizedSelectorWithAccounts =
+    createWeakMapSelector.withTypes<TradingRootStateWithAccounts>();
 const createMemoizedSelectorWithDeviceAndAccounts =
     createWeakMapSelector.withTypes<TradingRootStateWithDeviceAndAccounts>();
 const createMemoizedFormAccountSelector =
@@ -918,6 +921,17 @@ export const selectTradingBuyReceiveAccountKey = (state: TradingRootState) =>
     state.wallet.trading.buy.receiveAccountKey;
 export const selectTradingBuyReceiveAddress = (state: TradingRootState) =>
     state.wallet.trading.buy.receiveAddress;
+
+export const selectTradingBuyReceiveAccount = createMemoizedSelectorWithAccounts(
+    [selectAccounts, selectTradingBuyReceiveAccountKey],
+    (accounts, receiveAccountKey): Account | undefined => {
+        if (!receiveAccountKey) {
+            return undefined;
+        }
+
+        return accounts.find(account => account.key === receiveAccountKey);
+    },
+);
 
 export const selectTradingExchangeAccountKey = (state: TradingRootState) =>
     state.wallet.trading.exchange.tradingAccountKey;


### PR DESCRIPTION
## Description

Backport of #31170 to `release/26.8`, plus a prerequisite CI fix.

**Buy redirect (main change):** buy redirect callbacks and the saved buy trade were tied to the wrong account (e.g. `detail/btc/normal/0/<paymentId>` when buying ETH). `buyAccountKey` is set once when the Buy form opens and never re-synced when the bought crypto changes, so a buy confirmed while the form was opened on a BTC account kept BTC — leaking into the partner return URL, the offers redirect URL, and the trade record (`selectedAccountKey`). Fix: source the account from the receive account (`receiveAccountKey`), which tracks the selected crypto, for the confirm return URL (`useTradingBuyConfirm`), the offers redirect URL (`selectBuyQuoteThunk`), and the buy detail "go to payment" resubmit. Falls back to the form account for non-Suite (external) receive addresses. Cherry-picked from `fd63776`; only conflict was the develop-only `asNetworkSymbol` test helper, resolved to release/26.8's plain-string convention.

**Stylelint CI fix (prerequisite):** `lint:styles` was already broken on `release/26.8` — the plugin file was `dimension-token-values.mjs`, but `.stylelintrc` and its test import `./dimension-token-values.cjs`, which did not exist (incomplete rename). Ported the `.cjs` plugin from `develop` (identical rule logic, only `import`→`require`/`export default`→`module.exports`) and removed the stale `.mjs`. Unrelated to the buy change; included here to get this PR's CI green.

## Notes for QA

- Open the Buy form on a BTC account, switch the bought crypto to ETH, confirm the buy: the return URL, the saved trade, and the buy detail resubmit must all point at the ETH account, not BTC.
- External (non-Suite) receive address still falls back to the form account.
- Stylelint change is tooling-only; `yarn lint:styles` passes and the `dimension-token-values` rule behaves identically.

## Related Issue

Resolve #29566

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix-stylelint-dimension-cjs-release-26.8&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->