### PR TITLE
chore(github): don't add mobile label on crowdin sync PRs

### DIFF
--- a/.github/workflows/bot-crowdin-sync.yml
+++ b/.github/workflows/bot-crowdin-sync.yml
@@ -99,10 +99,12 @@ jobs:
             PR_TITLE="Crowdin translations update [DESKTOP]"
             PR_BODY="Automatically generated PR for updating DESKTOP crowdin translations from ${{ env.SOURCE_BRANCH }} branch."
             COMMIT_SCOPE="suite"
+            PLATFORM_LABEL_ARGS="--label desktop"
           else
             PR_TITLE="Crowdin translations update [MOBILE]"
             PR_BODY="Automatically generated PR for updating MOBILE crowdin translations from ${{ env.SOURCE_BRANCH }} branch."
             COMMIT_SCOPE="suite-native"
+            PLATFORM_LABEL_ARGS=""
           fi
 
           if [[ "${{ env.SOURCE_BRANCH }}" == release/* ]] || [[ "${{ env.SOURCE_BRANCH }}" == release-native/* ]]; then
@@ -125,5 +127,5 @@ jobs:
             --body "${PR_BODY}" \
             --base ${{ env.SOURCE_BRANCH }} \
             --label translations \
-            --label ${{ github.event.inputs.platform }} \
+            ${PLATFORM_LABEL_ARGS} \
             --label no-project


### PR DESCRIPTION
## Summary
- The `bot-crowdin-sync` workflow tagged the PRs it opens with a platform label (`desktop` or `mobile`).
- This drops the `mobile` label while keeping the `desktop` one, everything else in the workflow is unchanged.

## Notes for QA
- [ ] Trigger the "[Bot] Crowdin translations update" workflow with `platform: mobile` and confirm the resulting PR has no `mobile` label (still has `translations` and `no-project`).
- [ ] Trigger it with `platform: desktop` and confirm the resulting PR still has the `desktop` label.

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/crowdin-sync-no-mobile-label/web/](https://dev.suite.sldev.cz/suite-web/chore/crowdin-sync-no-mobile-label/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/crowdin-sync-no-mobile-label&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/crowdin-sync-no-mobile-label&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 7 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-14T14:44:19.729Z • 7 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-14T14:44:03.630Z • 6 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->