### PR TITLE
fix(suite-native): fix string variable passing after crowdin sync

### DIFF
--- a/suite-native/module-earn/src/components/HowEarnWorks/yieldPresets.tsx
+++ b/suite-native/module-earn/src/components/HowEarnWorks/yieldPresets.tsx
@@ -140,7 +140,7 @@ export const useHowYieldWorksPreset = ({
                           title: (
                               <Translation
                                   id="earn.howYieldWorksScreen.benefits.fourth.title"
-                                  values={{ bonusRewardTokenSymbol }}
+                                  values={{ bonusRewardTokenName: bonusRewardTokenSymbol }}
                               />
                           ),
                           description: (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the variable passed to the onboarding info steps.

## Notes for QA

Makes sense to check other places to see if translation is not missing somewhere


## Screenshots:


| Before | After 1 | After 2 |
|--------|--------|--------|
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4c486b4a-2765-4158-800a-a489a5f19370" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-14 at 17 28 20" src="https://github.com/user-attachments/assets/733150fd-3059-4339-ba0d-4598d78cd1c3" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-14 at 17 28 35" src="https://github.com/user-attachments/assets/0f2e5f15-7202-43fd-86cb-938c72b81af8" /> |


<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/crowdin-sync-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->