### PR TITLE
fix(suite): update fee info handling in yield deposit and withdraw

### DIFF
--- a/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
+++ b/packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts
@@ -7,6 +7,7 @@ import {
     blockchainActions,
     feesActions,
     transactionsActions,
+    updateFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { analyzeTransactions } from '@suite-common/wallet-utils/src/__fixtures__/transactionUtils';
 import { type BlockchainBlock, type BlockchainNotification } from '@trezor/connect-common';
@@ -494,7 +495,7 @@ export const onConnect: OnConnectFixture[] = [
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 0,
     },
     {
@@ -507,7 +508,7 @@ export const onConnect: OnConnectFixture[] = [
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 0,
     },
     {
@@ -525,7 +526,7 @@ export const onConnect: OnConnectFixture[] = [
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 1,
     },
     {
@@ -542,7 +543,7 @@ export const onConnect: OnConnectFixture[] = [
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 1,
     },
     {
@@ -550,14 +551,15 @@ export const onConnect: OnConnectFixture[] = [
         initialState: {
             accounts: [{ symbol: 'btc', history: {} }],
         },
-        // order: subscribe > estimateFee
-        connect: [undefined, { success: false }],
+        // order: estimateFee > subscribe > estimateFee
+        connect: [{ success: false }, undefined, { success: false }],
         symbol: 'btc',
         actions: [
+            { type: updateFeeInfoThunk.rejected.type },
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 1,
     },
     {
@@ -565,14 +567,15 @@ export const onConnect: OnConnectFixture[] = [
         initialState: {
             accounts: [{ symbol: 'eth', history: {}, deviceState: 'abc' }],
         },
-        // order: subscribe > subscribe > estimateFee
-        connect: [undefined, undefined, { success: false }],
+        // order: estimateFee > subscribe > subscribe > estimateFee
+        connect: [{ success: false }, undefined, undefined, { success: false }],
         symbol: 'eth',
         actions: [
+            { type: updateFeeInfoThunk.rejected.type },
             { type: blockchainActions.synced.type },
             { type: blockchainActions.connected.type },
         ],
-        blockchainEstimateFee: 0,
+        blockchainEstimateFee: 1,
         blockchainSubscribe: 2,
     },
 ];

--- a/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts
@@ -8,14 +8,14 @@ import {
     buildYieldUnsignedTransaction,
     buildYieldWithdrawCalldata,
     estimateYieldFeeLevel,
-    selectRawNetworkFeeInfo,
+    getOrFetchRawFeeInfoThunk,
 } from '@suite-common/wallet-core';
 import { ethereumGetCurrentNonceThunk } from '@suite-common/wallet-core/src/send/sendFormEthereumThunks';
 import { type Account } from '@suite-common/wallet-types';
 import { getAccountIdentity, getConvertedOrDefaultFeeInfo } from '@suite-common/wallet-utils';
 import { type Result, err, ok } from '@trezor/type-utils';
 
-import type { AppState, Dispatch } from 'src/types/suite';
+import type { Dispatch } from 'src/types/suite';
 
 export type ComposeYieldWithdrawTransactionParams = {
     account: Account & { networkType: 'ethereum' };
@@ -23,7 +23,6 @@ export type ComposeYieldWithdrawTransactionParams = {
     amount: string;
     flowType: YieldWithdrawFlowType;
     dispatch: Dispatch;
-    getState: () => AppState;
 };
 
 export const composeYieldWithdrawTransaction = async ({
@@ -32,7 +31,6 @@ export const composeYieldWithdrawTransaction = async ({
     amount,
     flowType,
     dispatch,
-    getState,
 }: ComposeYieldWithdrawTransactionParams): Promise<Result<string, YieldFeeEstimationError>> => {
     const { vault } = flowData;
 
@@ -83,14 +81,18 @@ export const composeYieldWithdrawTransaction = async ({
 
     const gasLimit = estimatedFeeLevel.payload.feeLimit;
 
+    const rawFeeInfo = await dispatch(
+        getOrFetchRawFeeInfoThunk({ networkSymbol: account.symbol }),
+    ).unwrap();
+
     const feeInfo = getConvertedOrDefaultFeeInfo({
         networkType: account.networkType,
-        feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+        feeInfo: rawFeeInfo,
     });
     const normalLevel = feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
 
     if (!normalLevel) {
-        throw new Error(`Fee info is not available.`);
+        return err('fee-estimation-failed');
     }
 
     const unsignedTx = buildYieldUnsignedTransaction({

--- a/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
+++ b/packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts
@@ -59,7 +59,6 @@ export const submitYieldWithdrawThunk = createThunk(
                 amount,
                 flowType,
                 dispatch,
-                getState,
             });
 
             if (!composeResult.success) {

--- a/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
+++ b/packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx
@@ -13,6 +13,7 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useFetchFees } from 'src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees';
 import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldDepositContext } from './useYieldDepositContext';
@@ -70,6 +71,8 @@ export const YieldDepositForm = () => {
         setMaxAmount,
         flow,
     } = useYieldDepositContext();
+
+    useFetchFees({ networkSymbol: account.symbol });
 
     const {
         isDisabled: isWrapDisabled,

--- a/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
+++ b/packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx
@@ -10,6 +10,7 @@ import { getApyBreakdown } from '@suite-common/wallet-utils';
 import { Banner, Column, Text } from '@trezor/components';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
+import { useFetchFees } from 'src/components/wallet/Fees/CollapsibleFees/hooks/useFetchFees';
 import { useMessageSystemWrappedNative } from 'src/hooks/suite/useMessageSystemWrappedNative';
 
 import { useYieldWithdrawContext } from './useYieldWithdrawContext';
@@ -52,6 +53,8 @@ export const YieldWithdrawForm = () => {
         setMaxAmount,
         flow,
     } = useYieldWithdrawContext();
+
+    useFetchFees({ networkSymbol: account.symbol });
 
     const {
         isDisabled: isUnwrapDisabled,

--- a/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
+++ b/suite-common/wallet-core/src/blockchain/blockchainThunks.ts
@@ -47,7 +47,11 @@ import {
     fetchAndUpdateAccountThunk,
     reportWalletBalanceThunk,
 } from '../accounts/accountsThunks';
-import { preloadFeeInfoThunk } from '../fees/feesThunks';
+import {
+    type GetOrFetchRawFeeInfoThunkState,
+    getOrFetchRawFeeInfoThunk,
+    preloadFeeInfoThunk,
+} from '../fees/feesThunks';
 import {
     type WalletSettingsRootState,
     selectBitcoinAmountUnit,
@@ -322,7 +326,8 @@ export const syncAccountsWithBlockchainThunk = createThunk<
     },
 );
 
-type OnBlockchainConnectThunkState = SyncAccountsWithBlockchainThunkState;
+type OnBlockchainConnectThunkState = SyncAccountsWithBlockchainThunkState &
+    GetOrFetchRawFeeInfoThunkState;
 type OnBlockchainConnectThunkDeps = {
     services: AnalyticsDep & GetIsWindowVisibleDep & GetTradedAccountKeysDep;
 };
@@ -337,6 +342,8 @@ export const onBlockchainConnectThunk = createThunk<
 >(`${BLOCKCHAIN_MODULE_PREFIX}/onBlockchainConnectThunk`, async (symbol, { dispatch }) => {
     const network = getNetworkOptional(symbol.toLowerCase());
     if (!network) return;
+
+    await dispatch(getOrFetchRawFeeInfoThunk({ networkSymbol: network.symbol }));
 
     await dispatch(
         subscribeBlockchainThunk({ symbol: network.symbol, fiatRates: true, onConnect: true }),

--- a/suite-common/wallet-core/src/fees/feesThunks.test.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.test.ts
@@ -3,15 +3,27 @@ import { combineReducers } from '@reduxjs/toolkit';
 import { deviceInitialState, prepareDeviceReducer } from '@suite-common/device';
 import { configureMockStore, extraDependenciesCommonMock } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { type FeeInfo } from '@suite-common/wallet-types';
+import { type FeeInfo, type FeesState } from '@suite-common/wallet-types';
+import TrezorConnect from '@trezor/connect';
 
 import { DEFAULT_FEE_INFO } from './feesConstants';
 import { feesReducer } from './feesReducer';
-import { updateFeeInfoThunk } from './feesThunks';
+import { getOrFetchRawFeeInfoThunk, updateFeeInfoThunk } from './feesThunks';
 import { blockchainInitialState, prepareBlockchainReducer } from '../blockchain/blockchainReducer';
+
+jest.mock('@trezor/connect', () => {
+    const actual = jest.requireActual('@trezor/connect');
+
+    return {
+        ...actual,
+        __esModule: true,
+        default: { ...actual.default, blockchainEstimateFee: jest.fn() },
+    };
+});
 
 const blockchainReducer = prepareBlockchainReducer(extraDependenciesCommonMock);
 const trxSymbol = asNetworkSymbol('trx');
+const ethSymbol = asNetworkSymbol('eth');
 const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 
 const tronFeeInfo: FeeInfo = {
@@ -23,7 +35,16 @@ const tronFeeInfo: FeeInfo = {
     levels: [{ label: 'normal', feePerUnit: '1000', blocks: -1 }],
 };
 
-const initStore = (feeInfo?: FeeInfo) =>
+const ethFeeInfo: FeeInfo = {
+    blockHeight: 200,
+    blockTime: 12,
+    minFee: 1,
+    maxFee: 100,
+    minPriorityFee: 1,
+    levels: [{ label: 'normal', feePerUnit: '3000000000', blocks: 2 }],
+};
+
+const initStore = (fees: FeesState = {}) =>
     configureMockStore({
         reducer: combineReducers({
             device: deviceReducer,
@@ -35,7 +56,7 @@ const initStore = (feeInfo?: FeeInfo) =>
         preloadedState: {
             device: deviceInitialState,
             wallet: {
-                fees: feeInfo ? { trx: { status: 'preloaded', data: feeInfo } } : {},
+                fees,
                 blockchain: blockchainInitialState,
             },
         },
@@ -43,7 +64,7 @@ const initStore = (feeInfo?: FeeInfo) =>
 
 describe(updateFeeInfoThunk.name, () => {
     it('fulfills with existing data for tron instead of fetching', async () => {
-        const store = initStore(tronFeeInfo);
+        const store = initStore({ trx: { status: 'preloaded', data: tronFeeInfo } });
         const response = await store.dispatch(updateFeeInfoThunk({ networkSymbol: trxSymbol }));
 
         expect(response.meta.requestStatus).toBe('fulfilled');
@@ -60,5 +81,62 @@ describe(updateFeeInfoThunk.name, () => {
 
         expect(response.meta.requestStatus).toBe('fulfilled');
         expect(response.payload).toEqual({ ...DEFAULT_FEE_INFO, blockHeight: 0 });
+    });
+});
+
+describe(getOrFetchRawFeeInfoThunk.name, () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns stored fee info without fetching', async () => {
+        const store = initStore({ eth: { status: 'preloaded', data: ethFeeInfo } });
+
+        const response = await store.dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: ethSymbol }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(response.payload).toEqual(ethFeeInfo);
+        expect(TrezorConnect.blockchainEstimateFee).not.toHaveBeenCalled();
+    });
+
+    it('fetches and stores fee info when it is missing', async () => {
+        (TrezorConnect.blockchainEstimateFee as jest.Mock).mockResolvedValue({
+            success: true,
+            payload: {
+                blockTime: 12,
+                minFee: 1,
+                maxFee: 100,
+                levels: [{ label: 'normal', feePerUnit: '3000000000', blocks: 2 }],
+            },
+        });
+        const store = initStore();
+
+        const response = await store.dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: ethSymbol }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(response.payload).toMatchObject({
+            levels: [expect.objectContaining({ label: 'normal', feePerUnit: '3000000000' })],
+        });
+        expect(store.getState().wallet.fees[ethSymbol]?.status).toBe('loaded');
+    });
+
+    it('returns undefined when fee info is missing and the fetch fails', async () => {
+        (TrezorConnect.blockchainEstimateFee as jest.Mock).mockResolvedValue({
+            success: false,
+            payload: { error: 'error' },
+        });
+        const store = initStore();
+
+        const response = await store.dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: ethSymbol }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+        expect(response.payload).toBeUndefined();
+        expect(store.getState().wallet.fees[ethSymbol]?.status).toBe('error');
     });
 });

--- a/suite-common/wallet-core/src/fees/feesThunks.ts
+++ b/suite-common/wallet-core/src/fees/feesThunks.ts
@@ -122,3 +122,28 @@ export const updateFeeInfoThunk = createThunk<
         return fulfillWithValue(data);
     },
 );
+
+export type GetOrFetchRawFeeInfoThunkState = UpdateFeeInfoThunkState;
+
+interface GetOrFetchRawFeeInfoThunkProps {
+    networkSymbol: NetworkSymbol;
+}
+
+export const getOrFetchRawFeeInfoThunk = createThunk<
+    FeeInfo | undefined,
+    GetOrFetchRawFeeInfoThunkProps,
+    { state: GetOrFetchRawFeeInfoThunkState }
+>(
+    `${FEES_MODULE_PREFIX}/getOrFetchRawFeeInfoThunk`,
+    async ({ networkSymbol }, { dispatch, getState }) => {
+        const rawFeeInfo = selectRawNetworkFeeInfo(getState(), networkSymbol);
+
+        if (rawFeeInfo) {
+            return rawFeeInfo;
+        }
+
+        await dispatch(updateFeeInfoThunk({ networkSymbol }));
+
+        return selectRawNetworkFeeInfo(getState(), networkSymbol);
+    },
+);

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from '@reduxjs/toolkit';
 
+import { deviceInitialState } from '@suite-common/device';
 import { configureMockStore } from '@suite-common/test-utils';
 import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { type FeeInfo, asAccountDescriptor } from '@suite-common/wallet-types';
@@ -9,6 +10,7 @@ import { BigNumber } from '@trezor/utils';
 import { composeYieldDepositTransactionThunk } from './stablecoinYieldDepositThunks';
 import { accountsInitialState } from '../../accounts/accountsReducer';
 import { fetchAllowance } from '../../allowance/fetchAllowance';
+import { blockchainInitialState } from '../../blockchain/blockchainReducer';
 import { feesReducer } from '../../fees/feesReducer';
 import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
 import { transactionsInitialState } from '../../transactions/transactionsReducer';
@@ -72,15 +74,19 @@ const ethFeeInfo: FeeInfo = {
 const initStore = () =>
     configureMockStore({
         reducer: combineReducers({
+            device: () => deviceInitialState,
             wallet: combineReducers({
                 accounts: () => accountsInitialState,
+                blockchain: () => blockchainInitialState,
                 fees: feesReducer,
                 transactions: () => transactionsInitialState,
             }),
         }),
         preloadedState: {
+            device: deviceInitialState,
             wallet: {
                 accounts: accountsInitialState,
+                blockchain: blockchainInitialState,
                 fees: { eth: { status: 'loaded', data: ethFeeInfo } },
                 transactions: transactionsInitialState,
             },

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts
@@ -13,7 +13,10 @@ import { BigNumber } from '@trezor/utils';
 import { getApprovalRequestAmount } from './stablecoinYieldApprovalThunks';
 import { type AccountsRootState } from '../../accounts/accountsReducer';
 import { fetchAllowance } from '../../allowance/fetchAllowance';
-import { type FeesRootState, selectRawNetworkFeeInfo } from '../../fees/feesReducer';
+import {
+    type GetOrFetchRawFeeInfoThunkState,
+    getOrFetchRawFeeInfoThunk,
+} from '../../fees/feesThunks';
 import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
 import { type TransactionsRootState } from '../../transactions/transactionsReducerTypes';
 import { STABLECOIN_YIELD_PREFIX } from '../stablecoinYieldConstants';
@@ -65,7 +68,7 @@ type ComposeYieldDepositTransactionPayload = {
     amount: string;
 };
 type ComposeYieldDepositTransactionThunkState = AccountsRootState &
-    FeesRootState &
+    GetOrFetchRawFeeInfoThunkState &
     TransactionsRootState;
 
 export const composeYieldDepositTransactionThunk = createThunk<
@@ -76,7 +79,7 @@ export const composeYieldDepositTransactionThunk = createThunk<
     }
 >(
     `${YIELD_DEPOSIT_THUNK_PREFIX}/composeDepositTransaction`,
-    async ({ flowData, amount }, { dispatch, getState }) => {
+    async ({ flowData, amount }, { dispatch }) => {
         const { account, token, vault } = flowData;
 
         if (account.networkType !== 'ethereum') {
@@ -149,9 +152,13 @@ export const composeYieldDepositTransactionThunk = createThunk<
             return { type: 'error', reason: 'fee-estimation-failed' } as const;
         }
 
+        const rawFeeInfo = await dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: account.symbol }),
+        ).unwrap();
+
         const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
-            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+            feeInfo: rawFeeInfo,
         });
         const normalLevel =
             feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];

--- a/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
+++ b/suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts
@@ -14,7 +14,10 @@ import { BigNumber } from '@trezor/utils';
 import { accountsActions } from '../../accounts/accountsActions';
 import { type AccountsRootState } from '../../accounts/accountsReducer';
 import { selectAccountByKey } from '../../accounts/accountsSelectors';
-import { type FeesRootState, selectRawNetworkFeeInfo } from '../../fees/feesReducer';
+import {
+    type GetOrFetchRawFeeInfoThunkState,
+    getOrFetchRawFeeInfoThunk,
+} from '../../fees/feesThunks';
 import { ethereumGetCurrentNonceThunk } from '../../send/sendFormEthereumThunks';
 import { type TransactionsRootState } from '../../transactions/transactionsReducerTypes';
 import { STABLECOIN_YIELD_PREFIX } from '../stablecoinYieldConstants';
@@ -58,7 +61,7 @@ type ComposeYieldUnwrapTransactionPayload = {
     unwrapAmount: string;
 };
 export type ComposeYieldWrapTransactionThunkState = AccountsRootState &
-    FeesRootState &
+    GetOrFetchRawFeeInfoThunkState &
     TransactionsRootState;
 
 /**
@@ -74,7 +77,7 @@ export const composeYieldWrapTransactionThunk = createThunk<
     }
 >(
     `${YIELD_WRAP_THUNK_PREFIX}/composeWrapTransaction`,
-    async ({ account, token, wrapAmount }, { dispatch, getState }) => {
+    async ({ account, token, wrapAmount }, { dispatch }) => {
         if (account.networkType !== 'ethereum') {
             return { type: 'error', reason: 'unsupported-network' } as const;
         }
@@ -119,9 +122,13 @@ export const composeYieldWrapTransactionThunk = createThunk<
             ? estimatedFeeLevel.payload.feeLimit
             : WETH_DEPOSIT_BACKUP_GAS_LIMIT;
 
+        const rawFeeInfo = await dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: account.symbol }),
+        ).unwrap();
+
         const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
-            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+            feeInfo: rawFeeInfo,
         });
         const normalLevel =
             feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];
@@ -224,7 +231,7 @@ export const trackWrappedNativeTokenThunk = createThunk<
 );
 
 export type ComposeYieldUnwrapTransactionThunkState = AccountsRootState &
-    FeesRootState &
+    GetOrFetchRawFeeInfoThunkState &
     TransactionsRootState;
 
 /**
@@ -239,7 +246,7 @@ export const composeYieldUnwrapTransactionThunk = createThunk<
     }
 >(
     `${YIELD_WRAP_THUNK_PREFIX}/composeUnwrapTransaction`,
-    async ({ account, token, unwrapAmount }, { dispatch, getState }) => {
+    async ({ account, token, unwrapAmount }, { dispatch }) => {
         if (account.networkType !== 'ethereum') {
             return { type: 'error', reason: 'unsupported-network' } as const;
         }
@@ -281,9 +288,13 @@ export const composeYieldUnwrapTransactionThunk = createThunk<
             return { type: 'error', reason: 'fee-estimation-failed' } as const;
         }
 
+        const rawFeeInfo = await dispatch(
+            getOrFetchRawFeeInfoThunk({ networkSymbol: account.symbol }),
+        ).unwrap();
+
         const feeInfo = getConvertedOrDefaultFeeInfo({
             networkType: account.networkType,
-            feeInfo: selectRawNetworkFeeInfo(getState(), account.symbol),
+            feeInfo: rawFeeInfo,
         });
         const normalLevel =
             feeInfo.levels.find(level => level.label === 'normal') ?? feeInfo.levels[0];


### PR DESCRIPTION
## Description

`preloadFeeInfoThunk` only loads fee info for networks enabled at startup. When a network is enabled later, fee-dependent flows (stablecoin yield deposit/withdraw) composed against empty fee state and failed.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31254

## Screenshots

https://github.com/user-attachments/assets/ee77e774-921a-48b0-8505-9a85c5de5fae

https://github.com/user-attachments/assets/a85a851e-c10a-4889-9693-692fcebbdd2a

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in the stablecoin-yield deposit/withdraw/wrap feature and in shared blockchain/fee thunks. There are no E2E tests that directly exercise the stablecoin-yield transaction flow, so coverage relies on unit tests and the check-links smoke test for the affected /earn/yield routes. To guard against regressions in the shared thunks, run a representative discovery test and a representative Ethereum fee-calculation test.

<details><summary><b>Changed files (11)</b></summary>

- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/composeYieldWithdrawTransaction.ts`
- `packages/suite/src/actions/wallet/stablecoin-yield/submitYieldWithdrawThunk.ts`
- `packages/suite/src/components/earn/yield/deposit/YieldDepositForm.tsx`
- `packages/suite/src/components/earn/yield/withdraw/YieldWithdrawForm.tsx`
- `suite-common/wallet-core/src/blockchain/blockchainThunks.ts`
- `suite-common/wallet-core/src/fees/feesThunks.test.ts`
- `suite-common/wallet-core/src/fees/feesThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldWrapThunks.ts`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/general/check-links.test.ts` — This test navigates to the /earn/yield/deposit, /earn/yield/withdraw, /earn/yield/claim, and /earn/yield/wrap routes and verifies the pages load and links are not broken. Because the PR changes YieldDepositForm, YieldWithdrawForm, and the underlying stablecoin-yield thunks, check-links provides a concrete smoke test that the affected yield pages still render.
- `suite/e2e/tests/wallet/discovery.test.ts` — This test activates multiple coin networks and asserts the discovery process starts and completes successfully. Since blockchainThunks.ts drives discovery and backend synchronization, changes there could break this flow, making discovery.test.ts a representative regression guard for the shared blockchain infrastructure.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test fills an Ethereum send form with custom gas fees and verifies max fee, fee rate, and device display values. Because feesThunks.ts is changed and underlies fee estimation for Ethereum transactions, this test directly exercises the fee infrastructure that could be affected.

</details>

⚠️ **Changes with no test coverage (3)**
- `packages/suite/src/actions/wallet/__fixtures__/blockchainActions.ts`
- `suite-common/wallet-core/src/fees/feesThunks.test.ts`
- `suite-common/wallet-core/src/stablecoin-yield/thunks/stablecoinYieldDepositThunks.test.ts`

_Updated: 2026-08-18T11:34:04.800Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-missing-fee-info/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-missing-fee-info/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-missing-fee-info&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-missing-fee-info&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-missing-fee-info&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T11:56:59.830Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T11:57:15.048Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->