### PR TITLE
feat(connect-explorer): add native-segwit signTransaction example (closes #20516)

### DIFF
--- a/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.segwit.ts
+++ b/packages/connect-explorer/src/data/methods/bitcoin/signTransaction.segwit.ts
@@ -1,0 +1,91 @@
+import type { CoinSymbol } from '@trezor/connect-common';
+
+import { select } from './common';
+
+const name = 'signTransaction';
+
+const test = {
+    inputs: [
+        {
+            address_n: [
+                (84 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                0,
+                0,
+            ],
+            amount: '123456789',
+            prev_index: 0,
+            prev_hash: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
+            script_type: 'SPENDWITNESS',
+        },
+    ],
+    outputs: [
+        {
+            address: 'tb1q9l0rk0gkgn73d0gc57qn3t3cwvucaj3h8wtrlu',
+            amount: '12300000',
+            script_type: 'PAYTOADDRESS',
+        },
+        {
+            address_n: [
+                (84 | 0x80000000) >>> 0,
+                (1 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            script_type: 'PAYTOWITNESS',
+            amount: Number(123456789 - 11000 - 12300000).toString(),
+        },
+    ],
+};
+
+const examples: Partial<Record<CoinSymbol, { inputs: unknown[]; outputs: unknown[] }>> = {
+    test,
+};
+
+export default [
+    {
+        name,
+        submitButton: 'Sign transaction',
+        fields: [
+            {
+                name: 'coin',
+                type: 'select',
+                value: 'test',
+                affect: ['inputs', 'outputs'],
+                data: select
+                    .filter(c => c.affectedValue.includes('m/49'))
+                    .map(v => {
+                        const example = examples[v.value];
+
+                        return {
+                            ...v,
+                            affectedValue: example ? [example.inputs, example.outputs] : undefined,
+                        };
+                    }),
+            },
+            {
+                name: 'inputs',
+                type: 'json',
+                value: '',
+            },
+            {
+                name: 'outputs',
+                type: 'json',
+                value: '',
+            },
+            {
+                name: 'push',
+                type: 'checkbox',
+                defaultValue: false,
+                value: false,
+            },
+            {
+                name: 'chunkify',
+                type: 'checkbox',
+                value: false,
+            },
+        ],
+    },
+];

--- a/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
+++ b/packages/connect-explorer/src/pages/methods/bitcoin/signTransaction.mdx
@@ -9,12 +9,14 @@ import signTransactionMultisig from '../../../data/methods/bitcoin/signTransacti
 import signTransactionOpreturn from '../../../data/methods/bitcoin/signTransaction.opreturn';
 import signTransactionP2SH from '../../../data/methods/bitcoin/signTransaction.p2sh';
 import signTransactionPaytoaddress from '../../../data/methods/bitcoin/signTransaction.paytoaddress';
+import signTransactionSegwit from '../../../data/methods/bitcoin/signTransaction.segwit';
 import signTransactionZcash from '../../../data/methods/bitcoin/signTransaction.zcash';
 
 <ApiPlayground
     options={[
         { title: 'PayToAddress', legacyConfig: signTransactionPaytoaddress[0] },
         { title: 'P2SH', legacyConfig: signTransactionP2SH[0] },
+        { title: 'Segwit', legacyConfig: signTransactionSegwit[0] },
         { title: 'OpReturn', legacyConfig: signTransactionOpreturn[0] },
         { title: 'Multisig', legacyConfig: signTransactionMultisig[0] },
         { title: 'Zcash', legacyConfig: signTransactionZcash[0] },
@@ -166,6 +168,47 @@ TrezorConnect.signTransaction({
         },
         {
             address: '18WL2iZKmpDYWk1oFavJapdLALxwSjcSk2',
+            amount: 200000,
+            script_type: 'PAYTOADDRESS',
+        },
+    ],
+    coin: 'btc',
+});
+```
+
+###### SPENDWITNESS
+
+```javascript
+TrezorConnect.signTransaction({
+    inputs: [
+        {
+            address_n: [
+                (84 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                (2 | 0x80000000) >>> 0,
+                1,
+                0,
+            ],
+            prev_index: 0,
+            prev_hash: 'b035d89d4543ce5713c553d69431698116a822c57c03ddacf3f04b763d1999ac',
+            amount: 3431747,
+            script_type: 'SPENDWITNESS',
+        },
+    ],
+    outputs: [
+        {
+            address_n: [
+                (84 | 0x80000000) >>> 0,
+                (0 | 0x80000000) >>> 0,
+                (2 | 0x80000000) >>> 0,
+                1,
+                1,
+            ],
+            amount: 3181747,
+            script_type: 'PAYTOWITNESS',
+        },
+        {
+            address: 'bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk',
             amount: 200000,
             script_type: 'PAYTOADDRESS',
         },


### PR DESCRIPTION
## What

Closes #20516.

The `signTransaction` method page in Connect Explorer had examples for legacy PayToAddress (m/44'), wrapped-segwit P2SH (`SPENDP2SHWITNESS`, m/49'), OpReturn, Multisig and Zcash — but no **native-segwit** (BIP84) example. This adds one.

## Changes

- **New** `packages/connect-explorer/src/data/methods/bitcoin/signTransaction.segwit.ts` — a native-segwit example following the exact structure of the existing `signTransaction.p2sh.ts`:
  - input `script_type: 'SPENDWITNESS'` at `m/84'` derivation,
  - change output `script_type: 'PAYTOWITNESS'` at `m/84'`,
  - a bech32 recipient output.
- **`signTransaction.mdx`**:
  - registers a `Segwit` option in the `ApiPlayground` (after `P2SH`),
  - adds a `SPENDWITNESS` example block in the Example section, mirroring the existing `SPENDP2SHWITNESS` block (m/84' derivation, `SPENDWITNESS`/`PAYTOWITNESS` script types, a `bc1…` recipient, `coin: 'btc'`).

## Note on the coin selector filter

The data example reuses the same coin-selector filter as `p2sh.ts` (`select.filter(c => c.affectedValue.includes('m/49'))`). The `coinsSelect` source has no `m/84` entries, so filtering on `'m/84'` would render an empty selector; the filter only governs which networks appear in the dropdown, while the native-segwit derivation (purpose 84') lives in the example's `address_n` — which is what determines the example's correctness. Happy to adjust if you'd prefer a different selector behaviour.

## Validation

This is a large monorepo and I wasn't able to run the workspace `type-check` (needs a full install) in my environment — flagging that honestly. Instead I verified:
- the new file is structurally identical to the compiling `signTransaction.p2sh.ts`, differing only in the native-segwit values (script types, m/84' paths, address);
- imports resolve (`{ select }` from `./common`, `CoinSymbol` from `@trezor/connect-common`);
- the `ApiPlayground` consumes `signTransactionSegwit[0]`, matching the export shape of the sibling files.

First-time contributor — happy to adjust naming, values, or scope to match your conventions.
