### PR TITLE
fix(suite): show cardano token transfers in tx detail inputs/outputs

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx
@@ -13,7 +13,6 @@ type IODetailsProps = {
     tx: WalletAccountTransaction;
 };
 
-// Not ready for Cardano tokens because they are utxo based
 export const IODetails = ({ tx }: IODetailsProps) => {
     const network = useSelector(state => state.wallet.selectedAccount.network);
     const accountKey = createAccountKey({
@@ -73,6 +72,22 @@ export const IODetails = ({ tx }: IODetailsProps) => {
                         tx={tx}
                         inputs={tx.details.vin?.filter(vin => !vin.isAccountOwned)}
                         outputs={tx.details.vout?.filter(vout => !vout.isAccountOwned)}
+                        isPhishingTransaction={isPhishingTransaction}
+                    />
+                </>
+            );
+        } else if (network?.networkType === 'cardano') {
+            return (
+                <>
+                    <IOGroup
+                        tx={tx}
+                        inputs={tx.details.vin}
+                        outputs={tx.details.vout}
+                        isUtxoBased
+                        isPhishingTransaction={isPhishingTransaction}
+                    />
+                    <TokenSpecificBalanceDetailsRow
+                        tx={tx}
                         isPhishingTransaction={isPhishingTransaction}
                     />
                 </>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { selectFullSelectedAccount } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { type NetworkSymbolExtended } from '@suite-common/wallet-config';
@@ -8,7 +10,7 @@ import { ArrowRightIcon } from '@trezor/icons';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 import { type IODetailsType } from './IODetailsType';
-import { IOItem } from './IOItem';
+import { type AddressOwnership, IOItem } from './IOItem';
 
 export type IOGroupProps = {
     /**
@@ -33,8 +35,35 @@ export const IOGroup = ({
     isPhishingTransaction,
 }: IOGroupProps) => {
     const selectedAccount = useSelector(selectFullSelectedAccount);
+    const accountAddresses = selectedAccount?.account?.addresses;
+    const accountDescriptor = selectedAccount?.account?.descriptor;
 
-    const anonymitySet = selectedAccount?.account?.addresses?.anonymitySet;
+    const ownershipByAddress = useMemo(() => {
+        if (!accountAddresses) return undefined;
+
+        const ownership = new Map<string, AddressOwnership>();
+        accountAddresses.used.forEach(({ address }) => ownership.set(address, 'own'));
+        accountAddresses.unused.forEach(({ address }) => ownership.set(address, 'own'));
+        accountAddresses.change.forEach(({ address }) => ownership.set(address, 'change'));
+
+        return ownership;
+    }, [accountAddresses]);
+
+    // Change counts only on an output; spent as an input it is just one of the account's addresses.
+    // Address-based accounts have no change chain and need case-insensitive matching (EIP-55).
+    const getOwnership = (address?: string, isOutput = false) => {
+        if (!address) return undefined;
+
+        if (!ownershipByAddress) {
+            return address.toLowerCase() === accountDescriptor?.toLowerCase() ? 'own' : undefined;
+        }
+
+        const ownership = ownershipByAddress.get(address);
+
+        return ownership === 'change' && !isOutput ? 'own' : ownership;
+    };
+
+    const anonymitySet = accountAddresses?.anonymitySet;
     const hasInputs = !!inputs?.length;
     const hasOutputs = !!outputs?.length;
 
@@ -66,6 +95,7 @@ export const IOGroup = ({
                             value={input.addresses?.[0]}
                             amount={input.value}
                             isPhishingTransaction={isPhishingTransaction}
+                            ownership={getOwnership(input.addresses?.[0])}
                         />
                     ))}
                 </Column>
@@ -98,6 +128,7 @@ export const IOGroup = ({
                             value={output.addresses?.[0]}
                             amount={output.value}
                             isPhishingTransaction={isPhishingTransaction}
+                            ownership={getOwnership(output.addresses?.[0], true)}
                         />
                     ))}
                 </Column>

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx
@@ -3,18 +3,27 @@ import { type ReactNode } from 'react';
 import { selectFullSelectedAccount } from '@suite/account';
 import { Address } from '@suite/address';
 import { useExternalLink } from '@suite/external-links';
+import { Translation } from '@suite/intl';
 import { type NetworkSymbolExtended, isNetworkSymbol } from '@suite-common/wallet-config';
 import { getExplorerUrl } from '@suite-common/wallet-config/src/getExplorerUrls';
 import { selectExplorer } from '@suite-common/wallet-core';
 import { formatNetworkAmount } from '@suite-common/wallet-utils';
 import { type AnonymitySet } from '@trezor/blockchain-link-types';
-import { Column, Link, Row, Text } from '@trezor/components';
+import { Column, Icon, Link, Row, Text, Tooltip } from '@trezor/components';
+import { ChangeIcon, WalletIcon } from '@trezor/icons';
 
 import { FormattedCryptoAmount } from 'src/components/suite/FormattedCryptoAmount';
 import { UtxoAnonymity } from 'src/components/wallet';
 import { useSelector } from 'src/hooks/suite/useSelector';
 
 const OP_RETURN_REGEX = /^OP_RETURN \(([^)]+)\)/;
+
+const ownershipIcon = {
+    change: { icon: ChangeIcon, tooltip: 'TR_CHANGE_OUTPUT_TOOLTIP' },
+    own: { icon: WalletIcon, tooltip: 'TR_OWN_ADDRESS_TOOLTIP' },
+} as const;
+
+export type AddressOwnership = keyof typeof ownershipIcon;
 
 type IOItem = {
     anonymitySet?: AnonymitySet;
@@ -23,6 +32,7 @@ type IOItem = {
     value?: string;
     amount?: string | ReactNode;
     isPhishingTransaction?: boolean;
+    ownership?: AddressOwnership;
 };
 
 export const IOItem = ({
@@ -32,6 +42,7 @@ export const IOItem = ({
     contractAddress,
     amount,
     isPhishingTransaction,
+    ownership,
 }: IOItem) => {
     const { network } = useSelector(selectFullSelectedAccount);
     const explorer = useSelector(state => selectExplorer(state, network?.symbol));
@@ -46,14 +57,32 @@ export const IOItem = ({
                 {!isOpReturn ? (
                     <>
                         {value && (
-                            <Link href={explorerLink}>
-                                <Address
-                                    value={value}
-                                    isTruncated
-                                    data-testid="@tx-detail/txid-value"
-                                    isCopyAllowed={!isPhishingTransaction}
-                                />
-                            </Link>
+                            <Row gap={6} alignItems="center">
+                                <Link href={explorerLink}>
+                                    <Address
+                                        value={value}
+                                        isTruncated
+                                        data-testid="@tx-detail/txid-value"
+                                        isCopyAllowed={!isPhishingTransaction}
+                                    />
+                                </Link>
+                                {ownership && (
+                                    <Tooltip
+                                        content={
+                                            <Translation id={ownershipIcon[ownership].tooltip} />
+                                        }
+                                        flex="none"
+                                    >
+                                        <Icon
+                                            as={ownershipIcon[ownership].icon}
+                                            size={16}
+                                            intent="neutral"
+                                            priority="secondary"
+                                            data-testid={`@tx-detail/address-ownership/${ownership}`}
+                                        />
+                                    </Tooltip>
+                                )}
+                            </Row>
                         )}
                         <Row gap={8}>
                             {anonymity && <UtxoAnonymity anonymity={anonymity} />}

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx
@@ -64,6 +64,8 @@ export const TokenSpecificBalanceDetailsRow = ({
                     switch (standard) {
                         case 'STELLAR-CLASSIC':
                             return 'Stellar';
+                        case 'BLOCKFROST':
+                            return 'Cardano';
                         default:
                             return standard.toUpperCase();
                     }

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -6832,6 +6832,15 @@ export const messages = defineMessages({
         id: 'TR_ACCOUNT_TOKENS_COUNT',
         defaultMessage: '{count, plural, one {+{count} token} other {+{count} tokens}}',
     },
+    TR_OWN_ADDRESS_TOOLTIP: {
+        id: 'TR_OWN_ADDRESS_TOOLTIP',
+        defaultMessage: 'This is your address.',
+    },
+    TR_CHANGE_OUTPUT_TOOLTIP: {
+        id: 'TR_CHANGE_OUTPUT_TOOLTIP',
+        defaultMessage:
+            'A change address of this account. The remainder of a send normally returns here.',
+    },
     TR_IN_PENDING_TRANSACTION: {
         id: 'TR_IN_PENDING_TRANSACTION',
         defaultMessage: 'In pending transaction',


### PR DESCRIPTION
## Description

- cardano token transfers in tx detail I/O

## Notes for QA

- Cardano account with native tokens: a "Cardano Token Transfers" section appears below the inputs/outputs. ADA-only transactions unchanged.
- Bitcoin-like or Cardano send: change output has the change icon, own inputs the wallet icon, recipient neither.
- EVM/Solana/Stellar/XRP: the account address has the wallet icon wherever it appears, including token and internal transfer rows. No change icon.

## Related Issue

Resolve #8001

## Screenshots:


<img width="1134" height="243" alt="Screenshot 2026-08-18 at 13 30 49" src="https://github.com/user-attachments/assets/da3131c4-1bc4-4fc5-9f28-b1022ab8bbf0" />
<img width="811" height="760" alt="Screenshot 2026-08-18 at 13 30 44" src="https://github.com/user-attachments/assets/c7f8ecf8-f269-4cff-9900-c466f3a55f96" />
<img width="855" height="623" alt="Screenshot 2026-08-18 at 13 30 18" src="https://github.com/user-attachments/assets/f2ce5986-a18b-449c-9b51-a8dac7988a5c" />
<img width="811" height="668" alt="Screenshot 2026-08-18 at 13 30 02" src="https://github.com/user-attachments/assets/b2c8df8b-d7d5-4ed7-82f8-68e5f728fc31" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/8001-cardano-tokens-io-details/web/](https://dev.suite.sldev.cz/suite-web/fix/8001-cardano-tokens-io-details/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/8001-cardano-tokens-io-details&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/8001-cardano-tokens-io-details&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T10:32:00.340Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap ETH to SOL | 🤖 auto |

</details>

_Updated: 2026-08-21T10:30:43.549Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are tightly scoped to the TxDetailModal's IODetails rendering (inputs/outputs and token-specific balance details). The static coverage mapping of 136 tests per file is almost certainly due to transitive imports of a shared modal or transaction component, so broad regression running would be wasteful. The highest-value test is the one that actually opens the transaction details modal after a send; the output-labeling test provides secondary coverage for output rendering behavior. No E2E test in the available descriptions specifically exercises token-specific balance details in the wallet TxDetailModal.

<details><summary><b>Changed files (5)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IODetails.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOGroup.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/IOItem.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/TxDetailModal/Detail/AdvancedTxDetails/IODetails/TokenSpecificBalanceDetailsRow.tsx`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (2)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — This test explicitly navigates to the transaction details modal (@modal/tx-details) after sending Base ETH. The changed IODetails files are the components that render transaction inputs/outputs inside that modal, so this is the most direct E2E coverage for the change.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/metadata/legacy/output-labeling.test.ts` — This test labels transaction outputs and verifies the labels appear in the UI and exported CSV. Since IODetails is responsible for rendering transaction outputs in the detail view, changes to output rendering logic could affect how output labels are displayed or exported.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite/intl/src/messages.ts`

_Updated: 2026-08-21T10:30:35.417Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->