### PR TITLE
feat(connect): accept taproot descriptors with h in getAccountInfo

### DIFF
--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -11,6 +11,7 @@ import type {
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
+import { convertTaprootXpub } from '@trezor/utils';
 
 import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
@@ -222,6 +223,14 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     throw ERRORS.TypedError('Runtime', 'GetAccountInfo: descriptor not found');
                 }
 
+                // Blockbook rejects taproot descriptors that use `h` for hardened
+                // derivation, so send the `'` form to the backend. The response keeps
+                // the original `descriptor` below, so the API returns the same format
+                // the caller provided.
+                const backendDescriptor =
+                    convertTaprootXpub({ xpub: descriptor, direction: 'h-to-apostrophe' }) ??
+                    descriptor;
+
                 // initialize backend
                 const blockchain = await initBlockchain(
                     request.coinInfo,
@@ -233,7 +242,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
 
                 // get account info from backend
                 const info = await blockchain.getAccountInfo({
-                    descriptor,
+                    descriptor: backendDescriptor,
                     details: request.details,
                     tokens: request.tokens,
                     page: request.page,
@@ -258,7 +267,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     typeof request.details === 'string' &&
                     request.details !== 'basic'
                 ) {
-                    utxo = await blockchain.getAccountUtxo(descriptor);
+                    utxo = await blockchain.getAccountUtxo(backendDescriptor);
                 }
 
                 if (this.disposed) break;

--- a/packages/utils/src/convertTaprootXpub.test.ts
+++ b/packages/utils/src/convertTaprootXpub.test.ts
@@ -1,0 +1,45 @@
+import { convertTaprootXpub } from './convertTaprootXpub';
+
+describe('convertTaprootXpub', () => {
+    // Same descriptor, once with `h` and once with `'` for the hardened path parts.
+    // Note the xpub body itself contains an `h` (in "...ThRDb8...") which must be
+    // left untouched - only the bracketed path is converted.
+    const withH =
+        '[5c9e228d/86h/0h/0h]tpubDCpt6oCoUgcQEPBUnZS4pijgjNySRDaJH8FyztXHnjxCH3z8jjHKGpX3zwtNs1U8ThRDb8ZbnAnZWc1KNLQx8fasQnk3f9Vaqu3JJXcYCF';
+    const withApostrophe =
+        "[5c9e228d/86'/0'/0']tpubDCpt6oCoUgcQEPBUnZS4pijgjNySRDaJH8FyztXHnjxCH3z8jjHKGpX3zwtNs1U8ThRDb8ZbnAnZWc1KNLQx8fasQnk3f9Vaqu3JJXcYCF";
+
+    it('converts h to apostrophe in the derivation path', () => {
+        expect(convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' })).toEqual(
+            withApostrophe,
+        );
+    });
+
+    it('converts apostrophe to h in the derivation path', () => {
+        expect(convertTaprootXpub({ xpub: withApostrophe, direction: 'apostrophe-to-h' })).toEqual(
+            withH,
+        );
+    });
+
+    it('round-trips', () => {
+        const apostrophe = convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' });
+        expect(apostrophe).not.toBeNull();
+        expect(
+            convertTaprootXpub({ xpub: apostrophe as string, direction: 'apostrophe-to-h' }),
+        ).toEqual(withH);
+    });
+
+    it('only touches the bracketed path, leaving the xpub body unchanged', () => {
+        const out = convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' });
+        expect(out).not.toBeNull();
+        // Everything after the closing bracket (the xpub body, which contains an `h`)
+        // must be identical.
+        expect((out as string).split(']')[1]).toEqual(withH.split(']')[1]);
+    });
+
+    it('returns null for an xpub without a descriptor bracket', () => {
+        expect(
+            convertTaprootXpub({ xpub: 'tpubDCpt6oCoUgcQEPBU', direction: 'h-to-apostrophe' }),
+        ).toBeNull();
+    });
+});


### PR DESCRIPTION
closes #16748

## Description

Blockbook rejects taproot xpubs that use `h` for hardened derivation instead of `'`. `getAccountInfo` now converts the descriptor to the apostrophe form for the backend request, while keeping the caller's original descriptor in the response - so the API returns the same format it was given.

The conversion already existed in `@trezor/utils`' `convertTaprootXpub`; it just wasn't wired into `getAccountInfo`. A `backendDescriptor` (`h`→`'`) is now used for the `getAccountInfo` and `getAccountUtxo` backend calls. `convertTaprootXpub` returns `null` for a plain xpub with no descriptor bracket (falls back to the original), and returns a descriptor that already uses `'` unchanged, so non-taproot and already-apostrophe inputs are unaffected. The response keeps the original `descriptor`, preserving the caller's format.

Also adds the previously-missing unit test for `convertTaprootXpub`: `h`↔`'` round-trip, path-only conversion (the xpub body is left intact even when it contains an `h`), and `null` for a non-descriptor xpub.

## Notes for QA

Backend-request formatting only, inside `@trezor/connect`'s `getAccountInfo`/`getAccountUtxo` - no UI surface. Covered by the added unit test for `convertTaprootXpub` plus existing `getAccountInfo` coverage; no manual QA steps beyond the automated suite.

## Related Issue

Resolve #16748

## Screenshots:

N/A - backend request formatting only, no UI change.

## receipts

```
yarn workspace @trezor/utils test:unit convertTaprootXpub  →  5 passed, 5 total
yarn workspace @trezor/connect type-check                  →  exit 0
eslint (getAccountInfo.ts + convertTaprootXpub.test.ts)    →  exit 0
```