### PR TITLE
fix(suite-native-31110): prevent trade history items from disappearing

### DIFF
--- a/suite-native/trading-history/src/components/TradingHistory.tsx
+++ b/suite-native/trading-history/src/components/TradingHistory.tsx
@@ -33,7 +33,8 @@ const listFooterStyle = prepareNativeStyle(({ spacings }) => ({
     paddingTop: spacings.sp32,
 }));
 
-const keyExtractor = (item: TradingTransaction) => `${item.key ?? ''}`;
+const keyExtractor = (item: TradingTransaction) =>
+    item.key ?? item.data.orderId ?? `${item.tradeType}-${item.date}`;
 
 export const TradingHistory = () => {
     const navigation = useNavigation();
@@ -109,6 +110,7 @@ export const TradingHistory = () => {
                     }
                     ListFooterComponent={<Footer />}
                     ListFooterComponentStyle={applyStyle(listFooterStyle)}
+                    maintainVisibleContentPosition={{ disabled: true }}
                 />
                 <EdgeFades
                     direction="vertical"


### PR DESCRIPTION
## Description

- Uses stable fallback keys for trade history transactions.
- Disables visible-content position maintenance to prevent list items from disappearing.

## Notes for QA

- Verify trade history remains complete while scrolling and loading transactions.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31110

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31110-trade-history-list-partially-disappearing&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->