### PR TITLE
fix(suite-desktop): load Sentry main process as CommonJS

### DIFF
--- a/packages/suite-desktop-core/webpack/core.webpack.config.ts
+++ b/packages/suite-desktop-core/webpack/core.webpack.config.ts
@@ -146,6 +146,8 @@ const config: webpack.Configuration = {
         mainFields: ['module', 'main'],
         extensions: ['.ts', '.js'],
         alias: {
+            // The ESM build of Sentry 10.67 leaves import.meta.url in the CommonJS output bundle.
+            '@sentry/electron/main$': require.resolve('@sentry/electron/main'),
             '@emurgo/cardano-serialization-lib-nodejs': '@emurgo/cardano-serialization-lib-browser',
             '@trezor/connect$': '@trezor/connect/src/index', // alternative for "module": "src/index" in connect's package.json
         },


### PR DESCRIPTION
## Description

Force `@sentry/electron/main` to resolve through its CommonJS export in the Electron main-process Webpack bundle.

After the Sentry Electron 7.16 update, the ESM dependency graph can leave `import.meta.url` in the development CommonJS output. Electron then classifies `dist/app.js` as an ES module, while Webpack's split-chunk runtime still calls `require()`, causing startup to fail with `ReferenceError: require is not defined in ES module scope`.

The production bundle tree-shakes the problematic Sentry diagnostics path, so this primarily affects `yarn suite:dev:desktop`.

## Notes for QA

Run:

```bash
yarn suite:dev:desktop
```

Verify that the Electron main process starts and the Desktop window opens. The generated `packages/suite-desktop/dist/app.js` should remain a CommonJS-compatible script.

Validated locally with:

- `yarn workspace @trezor/suite-desktop build:app:dev`
- CommonJS script parsing of the generated `app.js`
- focused ESLint and pre-commit hooks

## Related Issue

N/A

## Screenshots:

N/A

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-08-17T12:09:31.773Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/agent/fix-electron-sentry-commonjs/web/](https://dev.suite.sldev.cz/suite-web/agent/fix-electron-sentry-commonjs/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=agent/fix-electron-sentry-commonjs&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=agent/fix-electron-sentry-commonjs&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery after partial recovery" | 🙋 manual |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |

</details>

_Updated: 2026-08-17T12:13:23.372Z • 5 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 8 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Passphrase > basic flow | 🤖 auto |
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Quarantine test: "Recovery - dry run,Recovery with device reconnection" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-17T12:12:45.868Z • 8 test(s) total_
<!-- QUARANTINE-LIST:web:END -->