### PR TITLE
feat(suite-native): always show defi tokens tab with empty message

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -1987,6 +1987,9 @@ export const messages = {
                     'Proceed with caution. This transaction may include hidden or unrecognized tokens.',
                 emptyTitle: 'No hidden tokens',
             },
+            defiTokensSection: {
+                emptyTitle: 'No DeFi tokens',
+            },
         },
         tokenSettings: {
             contractAddress: 'Contract address',

--- a/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/AccountAssetsTabBar.tsx
@@ -1,11 +1,12 @@
-import { type ComponentProps } from 'react';
+import { type ComponentProps, useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
 
+import { type NetworkType } from '@suite-common/wallet-config';
 import { Button } from '@suite-native/atoms';
 import { Translation, type TxKeyPath } from '@suite-native/intl';
 import { prepareNativeStyle, useNativeStyles } from '@trezor/styles-native';
 
-import { type AccountAssetsTab } from './types';
+import { type AccountAssetsFlow, type AccountAssetsTab } from './types';
 import { useActiveTabScroll } from './useActiveTabScroll';
 
 const scrollStyle = prepareNativeStyle(() => ({
@@ -18,69 +19,69 @@ const scrollContentStyle = prepareNativeStyle(({ spacings }) => ({
     paddingVertical: spacings.sp8,
 }));
 
-type TabItem = {
+interface TabItem {
     tab: AccountAssetsTab;
     icon: NonNullable<ComponentProps<typeof Button>['iconLeft']>;
     translationId: TxKeyPath;
     translationValues?: Record<string, number>;
     isVisible: boolean;
-};
+}
 
-type AccountAssetsTabBarProps = {
+interface AccountAssetsTabBarProps {
     activeTab: AccountAssetsTab;
+    flowType: AccountAssetsFlow;
+    networkType?: NetworkType;
     tokenCount: number;
     defiTokenCount: number;
     hiddenTokenCount: number;
-    showInactiveTab: boolean;
     onTabChange: (tab: AccountAssetsTab) => void;
-};
-
-const getTabsConfig = (
-    tokenCount: number,
-    defiTokenCount: number,
-    hiddenTokenCount: number,
-    showInactiveTab: boolean,
-): TabItem[] => [
-    {
-        tab: 'tokens',
-        icon: 'coins',
-        translationId: 'moduleAccountManagement.accountAssetsScreen.tab.tokens',
-        translationValues: { count: tokenCount },
-        isVisible: true,
-    },
-    {
-        tab: 'defi',
-        icon: 'percent',
-        translationId: 'moduleAccountManagement.accountAssetsScreen.tab.defi',
-        translationValues: { count: defiTokenCount },
-        isVisible: defiTokenCount > 0,
-    },
-    {
-        tab: 'hidden',
-        icon: 'eyeSlash',
-        translationId: 'moduleAccountManagement.accountAssetsScreen.tab.hidden',
-        translationValues: { count: hiddenTokenCount },
-        isVisible: true,
-    },
-    {
-        tab: 'inactive',
-        icon: 'coinSlash',
-        translationId: 'moduleAccountManagement.accountAssetsScreen.tab.inactive',
-        isVisible: showInactiveTab,
-    },
-];
+}
 
 export const AccountAssetsTabBar = ({
     activeTab,
+    flowType,
+    networkType,
     tokenCount,
     defiTokenCount,
     hiddenTokenCount,
-    showInactiveTab,
     onTabChange,
 }: AccountAssetsTabBarProps) => {
     const { applyStyle } = useNativeStyles();
     const { scrollViewRef, handleTabLayout, handleScroll, handleScrollViewLayout } =
         useActiveTabScroll(activeTab);
+
+    const tabsConfig: TabItem[] = useMemo(
+        () => [
+            {
+                tab: 'tokens',
+                icon: 'coins',
+                translationId: 'moduleAccountManagement.accountAssetsScreen.tab.tokens',
+                translationValues: { count: tokenCount },
+                isVisible: true,
+            },
+            {
+                tab: 'defi',
+                icon: 'percent',
+                translationId: 'moduleAccountManagement.accountAssetsScreen.tab.defi',
+                translationValues: { count: defiTokenCount },
+                isVisible: networkType === 'ethereum',
+            },
+            {
+                tab: 'hidden',
+                icon: 'eyeSlash',
+                translationId: 'moduleAccountManagement.accountAssetsScreen.tab.hidden',
+                translationValues: { count: hiddenTokenCount },
+                isVisible: true,
+            },
+            {
+                tab: 'inactive',
+                icon: 'coinSlash',
+                translationId: 'moduleAccountManagement.accountAssetsScreen.tab.inactive',
+                isVisible: networkType === 'stellar' && flowType === 'assets',
+            },
+        ],
+        [tokenCount, defiTokenCount, hiddenTokenCount, networkType, flowType],
+    );
 
     return (
         <ScrollView
@@ -93,7 +94,7 @@ export const AccountAssetsTabBar = ({
             scrollEventThrottle={16}
             onLayout={handleScrollViewLayout}
         >
-            {getTabsConfig(tokenCount, defiTokenCount, hiddenTokenCount, showInactiveTab)
+            {tabsConfig
                 .filter(({ isVisible }) => isVisible)
                 .map(({ tab, icon, translationId, translationValues }) => (
                     <View key={tab} onLayout={handleTabLayout(tab)}>

--- a/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountAssets/DefiTokensTab.tsx
@@ -11,6 +11,8 @@ import {
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenInfoBranded } from '@suite-common/wallet-types';
 import { AccountsListTokenItem } from '@suite-native/accounts';
+import { Card, PictogramTitleHeader } from '@suite-native/atoms';
+import { Translation } from '@suite-native/intl';
 import { TokenYieldRateBadge } from '@suite-native/module-earn';
 
 import { type OnSelectAsset } from './types';
@@ -66,6 +68,20 @@ export const DefiTokensTab = ({ accountKey, onSelect }: DefiTokensTabProps) => {
         ),
         [account, onSelect],
     );
+
+    if (listItems.length === 0) {
+        return (
+            <Card>
+                <PictogramTitleHeader
+                    variant="info"
+                    icon="coins"
+                    title={
+                        <Translation id="moduleAccountManagement.accountAssetsScreen.defiTokensSection.emptyTitle" />
+                    }
+                />
+            </Card>
+        );
+    }
 
     if (!account) return null;
 

--- a/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
+++ b/suite-native/module-accounts-management/src/screens/AccountAssetsScreen.tsx
@@ -70,7 +70,6 @@ export const AccountAssetsScreen = ({
     );
 
     const tokenCount = sections.filter(item => item.type === 'token').length;
-    const showInactiveTab = account?.networkType === 'stellar' && flowType === 'assets';
     const isFailed = !!account && isAccountFailed(account);
 
     return (
@@ -83,10 +82,11 @@ export const AccountAssetsScreen = ({
 
                     <AccountAssetsTabBar
                         activeTab={activeTab}
+                        flowType={flowType}
+                        networkType={account?.networkType}
                         tokenCount={tokenCount}
                         defiTokenCount={defiTokenCount}
                         hiddenTokenCount={manuallyHiddenTokens}
-                        showInactiveTab={showInactiveTab}
                         onTabChange={setActiveTab}
                     />
                     <AccountAssetsTabContent


### PR DESCRIPTION
## Description

Always show `DeFi` tokens tab, even when no DeFi tokens are available. Instead, display an empty message in the tab content, same as with unrecognized tokens.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31290

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/native/always-show-defi-tokens-tab&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->