### PR TITLE
test(suite): fix strings in swap tests

### DIFF
--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -161,7 +161,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@webOnly', '@T3T1', '@T3W1'
             await expect(device).toShowOnDisplay({
                 T3W1: {
                     header: { title: deviceReview.providerTitle },
-                    body: [[deviceReview.providerName]],
+                    body: [[suiteProviderName]],
                     actions: { right_button: deviceReview.confirmButton },
                 },
             });

--- a/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-to-btc.test.ts
@@ -99,7 +99,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
                 T3W1: {
                     header: { title: 'Send' },
                     body: [
-                        ['Amount:'],
+                        ['Amount'],
                         [formattedSendAmount],
                         ['Transaction fee'],
                         device.wrapText(`${solanaFee} SOL`, { wrapByWords: true }),

--- a/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
+++ b/suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts
@@ -101,7 +101,7 @@ test.describe('Trading - Swap', { tag: ['@T3W1', '@T3T1'] }, () => {
                 T3W1: {
                     header: { title: 'Send' },
                     body: [
-                        ['Amount:'],
+                        ['Amount'],
                         [formattedSendAmount],
                         ['Max fees and rent'],
                         device.wrapText(`${reviewFee} SOL`, { wrapByWords: true }),

--- a/suite/e2e/tests/wallet/send-sol.test.ts
+++ b/suite/e2e/tests/wallet/send-sol.test.ts
@@ -118,7 +118,7 @@ test.describe('Send - Solana', { tag: ['@webOnly', '@T3T1', '@T3W1'] }, () => {
                     [Model.T3W1]: {
                         header: { title: 'Send' },
                         body: [
-                            ['Amount:'],
+                            ['Amount'],
                             amountWrapped,
                             ['Transaction fee'],
                             device.wrapText(`${maxFee} SOL`, { wrapByWords: true }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updated tests to be according to latest changes in device prompt on device display

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test-fix-8-17/web/](https://dev.suite.sldev.cz/suite-web/test-fix-8-17/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test-fix-8-17&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test-fix-8-17&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-17T14:11:35.502Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-17T14:11:03.602Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->