### PR TITLE
chore(connect): separate rootPubKeys per check type

### DIFF
--- a/packages/connect/src/api/authenticateDevice.ts
+++ b/packages/connect/src/api/authenticateDevice.ts
@@ -174,7 +174,12 @@ export default class AuthenticateDevice extends AbstractMethod<
                 authenticityProof;
             const isAvailable = signature && certificates.length > 0;
             if (isAvailable) {
-                return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
+                return await verifyAuthenticityProof({
+                    proofType: 'optiga',
+                    ...commonParams,
+                    certificates,
+                    signature,
+                });
             }
 
             // all devices capable of 'authenticateDevice' (see src/data/config.ts) have Optiga, so it's always required
@@ -188,7 +193,12 @@ export default class AuthenticateDevice extends AbstractMethod<
             const isAvailable = signature && certificates.length > 0;
             const isRequired = hasTropicAbility;
             if (isAvailable) {
-                return await verifyAuthenticityProof({ ...commonParams, certificates, signature });
+                return await verifyAuthenticityProof({
+                    proofType: 'tropic',
+                    ...commonParams,
+                    certificates,
+                    signature,
+                });
             }
 
             return isRequired ? { valid: false, error: 'RESPONSE_PAYLOAD_MISSING' } : null;
@@ -200,6 +210,7 @@ export default class AuthenticateDevice extends AbstractMethod<
             const isRequired = !unavailableCapabilities['mcuDeviceAuthentication'];
             if (isAvailable) {
                 return await verifyAuthenticityProof({
+                    proofType: 'mcu',
                     ...commonParams,
                     certificates,
                     signature,

--- a/packages/device-authenticity/mocks/mockDeviceAuthenticityData.ts
+++ b/packages/device-authenticity/mocks/mockDeviceAuthenticityData.ts
@@ -83,6 +83,7 @@ export const BLACKLIST_CONFIG: DeviceAuthenticityBlacklistConfig = {
 };
 
 export const defaultOptigaProps: VerifyAuthenticityProofParams = {
+    proofType: 'optiga',
     certificates: [DEVICE_CERT_OPTIGA, CA_CERT_OPTIGA],
     signature: SIGNATURE_OPTIGA,
     signedData: prepareDeviceAuthenticityData({ payload: Buffer.from(CHALLENGE, 'hex') }),
@@ -93,6 +94,7 @@ export const defaultOptigaProps: VerifyAuthenticityProofParams = {
 
 export const defaultTropicProps: VerifyAuthenticityProofParams = {
     ...defaultOptigaProps,
+    proofType: 'tropic',
     certificates: [DEVICE_CERT_TROPIC, CA_CERT_TROPIC],
     signature: SIGNATURE_TROPIC,
     deviceModel: 'T3W1',
@@ -100,6 +102,7 @@ export const defaultTropicProps: VerifyAuthenticityProofParams = {
 
 export const defaultMCUProps: VerifyAuthenticityProofParams = {
     ...defaultTropicProps,
+    proofType: 'mcu',
     certificates: [DEVICE_CERT_MCU],
     signature: SIGNATURE_MCU,
 };

--- a/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts
@@ -372,6 +372,31 @@ export const verifyAuthenticityProofFixtures: Fixture[] = [
     ...matchRootPubKeyToCertificateFixtures,
     // Error detail scenarios — invalid inputs caught and wrapped in result objects.
     {
+        description:
+            'fails with ROOT_PUBKEY_NOT_FOUND for optiga certificates with tropic proof type',
+        params: {
+            ...defaultOptigaProps,
+            proofType: 'tropic',
+        },
+        result: { valid: false, error: 'INVALID_DEVICE_CERTIFICATE' },
+    },
+    {
+        description: 'fails with ROOT_PUBKEY_NOT_FOUND for tropic certificates with MCU proof type',
+        params: {
+            ...defaultTropicProps,
+            proofType: 'mcu',
+        },
+        result: { valid: false, error: 'INVALID_DEVICE_CERTIFICATE' },
+    },
+    {
+        description: 'fails with ROOT_PUBKEY_NOT_FOUND for MCU certificates with optiga proof type',
+        params: {
+            ...defaultMCUProps,
+            proofType: 'optiga',
+        },
+        result: { valid: false, error: 'INVALID_DEVICE_CERTIFICATE' },
+    },
+    {
         description: 'fails with INVALID_DEVICE_MODEL for unknown device model',
         params: {
             ...defaultOptigaProps,

--- a/packages/device-authenticity/src/constants.ts
+++ b/packages/device-authenticity/src/constants.ts
@@ -1,0 +1,13 @@
+import type { ProofType } from './types';
+import type { AlgorithmName } from './x509certificate';
+
+/**
+ * Aligns with deviceAuthenticityConfig.ts, where rootPubKeys are separated per check type:
+ * rootPubKeysOptiga | rootPubKeysTropic | rootPubKeysMLDSA.
+ * Each of these contains only keys for the respective curve.
+ */
+export const EXPECTED_ALGORITHM_NAME_PER_PROOF_TYPE: Record<ProofType, AlgorithmName> = {
+    optiga: 'P-256',
+    tropic: 'Ed25519',
+    mcu: 'MLDSA44',
+};

--- a/packages/device-authenticity/src/index.ts
+++ b/packages/device-authenticity/src/index.ts
@@ -18,3 +18,4 @@ export { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBl
 export { deviceAuthenticityConfig } from './config/deviceAuthenticityConfig';
 export { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
 export { AuthenticateDeviceParams } from './authenticateDeviceParams';
+export { EXPECTED_ALGORITHM_NAME_PER_PROOF_TYPE } from './constants';

--- a/packages/device-authenticity/src/types.ts
+++ b/packages/device-authenticity/src/types.ts
@@ -3,6 +3,8 @@ import { type MessagesSchema as PROTO } from '@trezor/protobuf';
 import type { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBlacklistConfigTypes';
 import type { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
 
+export type ProofType = 'optiga' | 'tropic' | 'mcu';
+
 export type VerifySignature = (
     rawKey: Buffer,
     data: Uint8Array,
@@ -15,6 +17,7 @@ export type PrepareDeviceAuthenticityDataParams = {
 };
 
 export type VerifyAuthenticityProofParams = {
+    proofType: ProofType;
     certificates: string[];
     signature: string;
     signedData: Uint8Array;

--- a/packages/device-authenticity/src/utils.test.ts
+++ b/packages/device-authenticity/src/utils.test.ts
@@ -1,0 +1,86 @@
+import { deviceAuthenticityConfig } from './config/deviceAuthenticityConfig';
+import { getRootPubKeys } from './utils';
+
+describe(getRootPubKeys.name, () => {
+    it('returns Optiga production keys for T2B1 by default', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'optiga',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T2B1',
+            }),
+        ).toEqual(deviceAuthenticityConfig.T2B1.rootPubKeysOptiga);
+    });
+
+    it('returns Optiga production and debug keys for T2B1 when debug keys are allowed', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'optiga',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T2B1',
+                allowDebugKeys: true,
+            }),
+        ).toEqual([
+            ...deviceAuthenticityConfig.T2B1.rootPubKeysOptiga,
+            ...deviceAuthenticityConfig.T2B1.debug!.rootPubKeysOptiga,
+        ]);
+    });
+
+    it('returns Tropic production keys for T3W1 by default', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'tropic',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T3W1',
+            }),
+        ).toEqual(deviceAuthenticityConfig.T3W1.rootPubKeysTropic);
+    });
+
+    it('returns Tropic production and debug keys for T3W1 when debug keys are allowed', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'tropic',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T3W1',
+                allowDebugKeys: true,
+            }),
+        ).toEqual([
+            ...deviceAuthenticityConfig.T3W1.rootPubKeysTropic!,
+            ...deviceAuthenticityConfig.T3W1.debug!.rootPubKeysTropic!,
+        ]);
+    });
+
+    it('returns MCU production keys for T3W1 by default', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'mcu',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T3W1',
+            }),
+        ).toEqual(deviceAuthenticityConfig.T3W1.rootPubKeysMLDSA);
+    });
+
+    it('returns MCU production and debug keys for T3W1 when debug keys are allowed', () => {
+        expect(
+            getRootPubKeys({
+                proofType: 'mcu',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'T3W1',
+                allowDebugKeys: true,
+            }),
+        ).toEqual([
+            ...deviceAuthenticityConfig.T3W1.rootPubKeysMLDSA!,
+            ...deviceAuthenticityConfig.T3W1.debug!.rootPubKeysMLDSA!,
+        ]);
+    });
+
+    it('throws for a device model missing in config', () => {
+        expect(() =>
+            getRootPubKeys({
+                proofType: 'optiga',
+                config: deviceAuthenticityConfig,
+                deviceModel: 'UNKNOWN',
+            }),
+        ).toThrow('Pubkeys for UNKNOWN not found in config');
+    });
+});

--- a/packages/device-authenticity/src/utils.ts
+++ b/packages/device-authenticity/src/utils.ts
@@ -3,7 +3,11 @@ import * as crypto from 'crypto';
 import { type MessagesSchema as PROTO } from '@trezor/protobuf';
 
 import type { DeviceAuthenticityBlacklistConfig } from './config/deviceAuthenticityBlacklistConfigTypes';
-import type { DeviceAuthenticityConfig } from './config/deviceAuthenticityConfigTypes';
+import {
+    type CertPubKeys,
+    type DeviceAuthenticityConfig,
+} from './config/deviceAuthenticityConfigTypes';
+import type { ProofType } from './types';
 
 export const getRandomChallenge = () => crypto.randomBytes(32);
 
@@ -22,9 +26,17 @@ export const getCaPubKeyBlacklist = ({
 };
 
 type GetRootPubKeysParams = {
+    proofType: ProofType;
     config: DeviceAuthenticityConfig;
     deviceModel: keyof typeof PROTO.DeviceModelInternal;
     allowDebugKeys?: boolean;
+};
+
+type ModelConfigKey = keyof CertPubKeys;
+const modelConfigKeyPerProofType: Record<ProofType, ModelConfigKey> = {
+    optiga: 'rootPubKeysOptiga',
+    tropic: 'rootPubKeysTropic',
+    mcu: 'rootPubKeysMLDSA',
 };
 
 /**
@@ -32,6 +44,7 @@ type GetRootPubKeysParams = {
  * For simplicity, keys for all curves are combined, though only some of them may pass for each respective certificate/signature.
  */
 export const getRootPubKeys = ({
+    proofType,
     config,
     deviceModel,
     allowDebugKeys,
@@ -41,24 +54,9 @@ export const getRootPubKeys = ({
         throw new Error(`Pubkeys for ${deviceModel} not found in config`);
     }
 
-    const rootPubKeysProdOptiga = modelConfig.rootPubKeysOptiga ?? [];
-    const rootPubKeysProdTropic = modelConfig.rootPubKeysTropic ?? [];
-    const rootPubKeysProdMLDSA = modelConfig.rootPubKeysMLDSA ?? [];
+    const modelConfigKey = modelConfigKeyPerProofType[proofType];
+    const rootPubKeysProd = modelConfig[modelConfigKey] ?? [];
+    const rootPubKeysDebug = modelConfig.debug?.[modelConfigKey] ?? [];
 
-    const rootPubKeysDebugOptiga = modelConfig.debug?.rootPubKeysOptiga ?? [];
-    const rootPubKeysDebugTropic = modelConfig.debug?.rootPubKeysTropic ?? [];
-    const rootPubKeysDebugMLDSA = modelConfig.debug?.rootPubKeysMLDSA ?? [];
-
-    const allRootPubKeysProd = [
-        ...rootPubKeysProdOptiga,
-        ...rootPubKeysProdTropic,
-        ...rootPubKeysProdMLDSA,
-    ];
-    const allRootPubKeysDebug = [
-        ...rootPubKeysDebugOptiga,
-        ...rootPubKeysDebugTropic,
-        ...rootPubKeysDebugMLDSA,
-    ];
-
-    return allowDebugKeys ? [...allRootPubKeysProd, ...allRootPubKeysDebug] : allRootPubKeysProd;
+    return allowDebugKeys ? [...rootPubKeysProd, ...rootPubKeysDebug] : rootPubKeysProd;
 };

--- a/packages/device-authenticity/src/verifyAuthenticityProof.test.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.test.ts
@@ -90,8 +90,13 @@ describe(matchRootPubKeyToCertificate.name, () => {
 
     matchRootPubKeyToCertificateFixtures.forEach(({ description, params, result }) => {
         it(description, async () => {
-            const { config, deviceModel, allowDebugKeys, certificates } = params;
-            const allRootPubKeys = getRootPubKeys({ config, deviceModel, allowDebugKeys });
+            const { proofType, config, deviceModel, allowDebugKeys, certificates } = params;
+            const allRootPubKeys = getRootPubKeys({
+                proofType,
+                config,
+                deviceModel,
+                allowDebugKeys,
+            });
 
             // The last certificate is the one signed by root pub key (caCer for Optiga & Tropic, deviceCert for MCU)
             const signedCertificate = certificates.at(-1);

--- a/packages/device-authenticity/src/verifyAuthenticityProof.ts
+++ b/packages/device-authenticity/src/verifyAuthenticityProof.ts
@@ -1,5 +1,6 @@
 import { bufferUtils } from '@trezor/utils';
 
+import { EXPECTED_ALGORITHM_NAME_PER_PROOF_TYPE } from './constants';
 import { findSubjectContentByOid } from './findSubjectContentByOid';
 import {
     type PrepareDeviceAuthenticityDataParams,
@@ -246,6 +247,7 @@ const verifyOnlyDeviceCertificate = async ({
  * https://github.com/trezor/trezor-firmware/blob/3e0a170eabbd719da7155b754e30139c24a30f17/python/src/trezorlib/authentication.py
  */
 export const verifyAuthenticityProof = async ({
+    proofType,
     certificates,
     signature,
     signedData,
@@ -254,10 +256,10 @@ export const verifyAuthenticityProof = async ({
     config,
     blacklistConfig,
 }: VerifyAuthenticityProofParams): Promise<VerifyAuthenticityProofResult> => {
-    // Parse config with given device model, type of secure element and debug mode.
+    // Parse config with given device model, type of secure element (proofType) and debug mode.
     let allRootPubKeys: string[];
     try {
-        allRootPubKeys = getRootPubKeys({ config, deviceModel, allowDebugKeys });
+        allRootPubKeys = getRootPubKeys({ proofType, config, deviceModel, allowDebugKeys });
     } catch {
         return { valid: false, error: 'INVALID_DEVICE_MODEL' };
     }
@@ -277,6 +279,9 @@ export const verifyAuthenticityProof = async ({
     }
     // For both signing schemes, the 1st certificate is the one expected to be signed by rootPubKey (checked by matchRootPubKeyToCertificate)
     const firstCertAlgName = parsedCertificates[0]?.signatureAlgorithm.algorithmName;
+    if (firstCertAlgName !== EXPECTED_ALGORITHM_NAME_PER_PROOF_TYPE[proofType]) {
+        return { valid: false, error: 'INVALID_DEVICE_CERTIFICATE' };
+    }
 
     if (firstCertAlgName === 'MLDSA44') {
         if (parsedCertificates.length !== 1) {
@@ -295,7 +300,11 @@ export const verifyAuthenticityProof = async ({
                 allRootPubKeys,
             });
         } catch (e) {
-            return { valid: false, error: 'INVALID_DEVICE_CERTIFICATE', errorDetails: e.message };
+            return {
+                valid: false,
+                error: 'INVALID_DEVICE_CERTIFICATE',
+                errorDetails: e.message,
+            };
         }
     }
     if (firstCertAlgName === 'Ed25519' || firstCertAlgName === 'P-256') {


### PR DESCRIPTION
## Description

Cleanup `authenticateDevice` to separate `rootPubKeys` per check type.

## Related Issue

Resolve https://github.com/trezor/trezor-suite-private/issues/221

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/specify-DAC-keys/web/](https://dev.suite.sldev.cz/suite-web/chore/specify-DAC-keys/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/specify-DAC-keys&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/specify-DAC-keys&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/specify-DAC-keys&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T12:59:53.214Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T12:58:45.213Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is narrowly scoped to device authenticity verification. The main user-facing risk is the onboarding authenticity check failing or behaving incorrectly. The dedicated authenticity-check E2E test provides direct coverage of this flow. The broad static mappings for device-authenticity utility files are transitive imports across unrelated tests and do not justify wider E2E selection.

<details><summary><b>Changed files (10)</b></summary>

- `packages/connect/src/api/authenticateDevice.ts`
- `packages/device-authenticity/mocks/mockDeviceAuthenticityData.ts`
- `packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts`
- `packages/device-authenticity/src/constants.ts`
- `packages/device-authenticity/src/index.ts`
- `packages/device-authenticity/src/types.ts`
- `packages/device-authenticity/src/utils.test.ts`
- `packages/device-authenticity/src/utils.ts`
- `packages/device-authenticity/src/verifyAuthenticityProof.test.ts`
- `packages/device-authenticity/src/verifyAuthenticityProof.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/onboarding/authenticity-check.test.ts` — This is the only E2E test that explicitly exercises the device authenticity check during onboarding for T3B1/T3T1 devices. The changed authenticateDevice API and device-authenticity proof verification utilities are the direct implementation of this flow, so any regression in proof verification, constants, or utils would surface here.

</details>

⚠️ **Changes with no test coverage (5)**
- `packages/device-authenticity/mocks/mockDeviceAuthenticityData.ts`
- `packages/device-authenticity/src/__fixtures__/verifyAuthenticityProof.ts`
- `packages/device-authenticity/src/types.ts`
- `packages/device-authenticity/src/utils.test.ts`
- `packages/device-authenticity/src/verifyAuthenticityProof.test.ts`

_Updated: 2026-08-18T12:57:53.636Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->