### PR TITLE
fix(suite): emit in-flow wrap/unwrap error analytics

### DIFF
--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts
@@ -49,6 +49,11 @@ const dispatchUnwrap = (report: jest.Mock) =>
         .unwrap();
 
 describe('submitUnwrapNativeTokenThunk', () => {
+    beforeAll(() => {
+        // The thunk logs every caught failure; the expected ones would clutter the test output.
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockComposeYieldUnwrapTransactionThunk.mockImplementation(() => () => ({
@@ -160,6 +165,92 @@ describe('submitUnwrapNativeTokenThunk', () => {
         expect(report).not.toHaveBeenCalledWith(
             expect.objectContaining({ type: events.yieldUnwrapEvent.name }),
         );
+    });
+
+    describe('in-flow failure analytics', () => {
+        const yieldFlow = {
+            flowKey: 'yield-flow',
+            flowType: 'redeem',
+            vaultId: 'vault-1',
+        } as const;
+
+        const dispatchInFlowUnwrap = (report: jest.Mock) =>
+            buildStore(report)
+                .dispatch(
+                    submitUnwrapNativeTokenThunk({
+                        account,
+                        token,
+                        unwrapAmount: '1',
+                        yieldFlow,
+                    }),
+                )
+                .unwrap();
+
+        const expectWithdrawError = (report: jest.Mock, errorMessage: string) => {
+            expect(report).toHaveBeenCalledWith({
+                type: events.yieldWithdrawEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    operation: 'redeem',
+                    networkSymbol: 'eth',
+                    vaultId: 'vault-1',
+                    errorMessage,
+                },
+            });
+            expect(report).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.yieldUnwrapEvent.name }),
+            );
+        };
+
+        it('reports a compose failure on the withdraw event', async () => {
+            const report = jest.fn();
+            mockComposeYieldUnwrapTransactionThunk.mockImplementation(() => () => ({
+                unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
+            }));
+
+            await dispatchInFlowUnwrap(report);
+
+            expectWithdrawError(report, 'unwrap-fee-estimation-failed');
+        });
+
+        it('reports a device rejection on the withdraw event', async () => {
+            const report = jest.fn();
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+            );
+            mockSendYieldTransaction.mockResolvedValue(undefined);
+
+            await dispatchInFlowUnwrap(report);
+
+            expectWithdrawError(report, 'unwrap-submit-failed');
+        });
+
+        it('reports a thrown signing failure on the withdraw event', async () => {
+            const report = jest.fn();
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+            );
+            mockSendYieldTransaction.mockRejectedValue(new Error('boom'));
+
+            await dispatchInFlowUnwrap(report);
+
+            expectWithdrawError(report, 'unwrap-submit-failed');
+        });
+
+        it('reports no withdraw error once the unwrap is broadcast', async () => {
+            const report = jest.fn();
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+            );
+            mockSendYieldTransaction.mockResolvedValue({ txid: '0xunwrap' });
+
+            await dispatchInFlowUnwrap(report);
+
+            expect(report).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.yieldWithdrawEvent.name }),
+            );
+        });
     });
 
     it('reports the tx-simulation-modal cancel', async () => {

--- a/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts
@@ -28,6 +28,7 @@ type UnwrapNativeTokenPayload = {
     yieldFlow?: {
         flowKey: string;
         flowType: YieldWithdrawFlowType;
+        vaultId?: string;
     };
 };
 
@@ -44,10 +45,27 @@ export const submitUnwrapNativeTokenThunk = createThunk<
 >(
     `${UNWRAP_NATIVE_TOKEN_PREFIX}/submit`,
     async ({ account, token, unwrapAmount, yieldFlow }, { dispatch, getState, extra }) => {
-        // In-flow unwraps are already tracked as yield/withdraw type:'unwrap', so reporting here
-        // too would double-count them.
+        // An in-flow unwrap belongs to the withdraw funnel, so its failures are reported there
+        // rather than as a standalone yield/unwrap. Only the broadcast unwrap transaction is
+        // resolved by `useYieldPendingTransactionTracking`, so these pre-broadcast failures are the
+        // withdraw event's only view of them and cannot double-count. The `unwrap-` prefix keeps
+        // them apart from failures of the withdraw transaction itself.
         const reportError = (errorMessage: string) => {
-            if (yieldFlow) return;
+            if (yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldWithdrawEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        operation: yieldFlow.flowType,
+                        networkSymbol: account.symbol,
+                        vaultId: yieldFlow.vaultId,
+                        errorMessage: `unwrap-${errorMessage}`,
+                    },
+                });
+
+                return;
+            }
 
             extra.services.analytics.report({
                 type: events.yieldUnwrapEvent.name,

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts
@@ -334,6 +334,83 @@ describe('submitWrapNativeTokenThunk', () => {
         );
     });
 
+    describe('in-flow failure analytics', () => {
+        const yieldFlow = {
+            flowKey: 'yield-flow',
+            flowType: 'deposit',
+            vaultId: 'vault-1',
+        } as const;
+
+        const dispatchInFlowWrap = (report: jest.Mock) =>
+            buildStore(report)
+                .dispatch(
+                    submitWrapNativeTokenThunk({ account, token, wrapAmount: '1', yieldFlow }),
+                )
+                .unwrap();
+
+        const expectDepositError = (report: jest.Mock, errorMessage: string) => {
+            expect(report).toHaveBeenCalledWith({
+                type: events.yieldDepositEvent.name,
+                payload: {
+                    type: 'error',
+                    action: 'continue',
+                    networkSymbol: 'eth',
+                    vaultId: 'vault-1',
+                    errorMessage,
+                },
+            });
+            expect(report).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.yieldWrapEvent.name }),
+            );
+        };
+
+        it('reports a compose failure on the deposit event', async () => {
+            const report = jest.fn();
+            mockComposeYieldWrapTransactionThunk.mockImplementation(() => () => ({
+                unwrap: () => Promise.resolve({ type: 'error', reason: 'fee-estimation-failed' }),
+            }));
+
+            await dispatchInFlowWrap(report);
+
+            expectDepositError(report, 'wrap-fee-estimation-failed');
+        });
+
+        it('reports a device rejection on the deposit event', async () => {
+            const report = jest.fn();
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+            );
+            mockSendYieldTransaction.mockResolvedValue(undefined);
+
+            await dispatchInFlowWrap(report);
+
+            expectDepositError(report, 'wrap-submit-failed');
+        });
+
+        it('reports a thrown signing failure on the deposit event', async () => {
+            const report = jest.fn();
+            mockOpenDeferredModal.mockImplementation(
+                () => () => Promise.resolve({ value: true, resolve: jest.fn(), selectedFee: null }),
+            );
+            mockSendYieldTransaction.mockRejectedValue(new Error('boom'));
+
+            await dispatchInFlowWrap(report);
+
+            expectDepositError(report, 'wrap-submit-failed');
+        });
+
+        it('reports no deposit error once the wrap is broadcast', async () => {
+            const report = jest.fn();
+            acceptModalAndSucceed();
+
+            await dispatchInFlowWrap(report);
+
+            expect(report).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: events.yieldDepositEvent.name }),
+            );
+        });
+    });
+
     it('reports the tx-simulation-modal cancel', async () => {
         const report = jest.fn();
 

--- a/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
+++ b/packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts
@@ -31,6 +31,7 @@ type WrapNativeTokenPayload = {
     yieldFlow?: {
         flowKey: string;
         flowType: 'deposit';
+        vaultId?: string;
     };
 };
 
@@ -47,10 +48,26 @@ export const submitWrapNativeTokenThunk = createThunk<
 >(
     `${WRAP_NATIVE_TOKEN_PREFIX}/submit`,
     async ({ account, token, wrapAmount, yieldFlow }, { dispatch, getState, extra }) => {
-        // In-flow wraps are already tracked as yield/deposit type:'wrap', so reporting here too
-        // would double-count them.
+        // An in-flow wrap belongs to the deposit funnel, so its failures are reported there rather
+        // than as a standalone yield/wrap. Only the broadcast wrap transaction is resolved by
+        // `useYieldPendingTransactionTracking`, so these pre-broadcast failures are the deposit
+        // event's only view of them and cannot double-count. The `wrap-` prefix keeps them apart
+        // from failures of the deposit transaction itself.
         const reportError = (errorMessage: string) => {
-            if (yieldFlow) return;
+            if (yieldFlow) {
+                extra.services.analytics.report({
+                    type: events.yieldDepositEvent.name,
+                    payload: {
+                        type: 'error',
+                        action: 'continue',
+                        networkSymbol: account.symbol,
+                        vaultId: yieldFlow.vaultId,
+                        errorMessage: `wrap-${errorMessage}`,
+                    },
+                });
+
+                return;
+            }
 
             extra.services.analytics.report({
                 type: events.yieldWrapEvent.name,

--- a/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
+++ b/packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts
@@ -537,7 +537,7 @@ export const useYieldFlow = ({
                             account,
                             token: wrappedToken,
                             wrapAmount: amount,
-                            yieldFlow: { flowType: 'deposit', flowKey },
+                            yieldFlow: { flowType: 'deposit', flowKey, vaultId: vault.id },
                         }),
                     ).unwrap();
                     txid = result?.txid;
@@ -547,7 +547,7 @@ export const useYieldFlow = ({
                             account,
                             token: wrappedToken,
                             unwrapAmount: amount,
-                            yieldFlow: { flowType, flowKey },
+                            yieldFlow: { flowType, flowKey, vaultId: vault.id },
                         }),
                     ).unwrap();
                     txid = result?.txid;
@@ -592,6 +592,7 @@ export const useYieldFlow = ({
             openDeviceConnectionModal,
             resolveWrappedNativeStep,
             token,
+            vault.id,
         ],
     );
 

--- a/suite-common/analytics/src/events/yieldDepositEvent.ts
+++ b/suite-common/analytics/src/events/yieldDepositEvent.ts
@@ -40,6 +40,7 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
         { version: '26.5.2', notes: 'renamed from yield/supply to yield/deposit' },
         { version: '26.7.1', notes: 'moved to suite-common, reported from mobile as well' },
         { version: '26.8.0', notes: 'added wrap transaction events' },
+        { version: '26.9.0', notes: 'added pre-broadcast wrap-step failures' },
     ],
 
     attributes: {
@@ -77,7 +78,12 @@ export const yieldDepositEvent: EventDef<Attributes, EventType.YieldDeposit> = {
             changelog: [{ version: '26.5.2', notes: 'added' }],
         },
         errorMessage: {
-            changelog: [{ version: '26.5.0', notes: 'added' }],
+            description:
+                'Values prefixed with `wrap-` are failures of the wrap step of a wrapped-native deposit, all of them before the wrap transaction is broadcast: `wrap-submit-failed` (signing failed, or the user rejected the transaction on the device or in the review modal), `wrap-push-failed` (signed but the broadcast failed), and `wrap-<compose reason>` (e.g. `wrap-fee-estimation-failed`) when the transaction could not be composed. A wrap that fails on chain instead reports `on-chain-failure`, as does the deposit transaction itself.',
+            changelog: [
+                { version: '26.5.0', notes: 'added' },
+                { version: '26.9.0', notes: 'added `wrap-` prefixed values' },
+            ],
         },
         apyBreakdown: {
             description:

--- a/suite-common/analytics/src/events/yieldWithdrawEvent.ts
+++ b/suite-common/analytics/src/events/yieldWithdrawEvent.ts
@@ -31,6 +31,7 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
         { version: '26.5.0', notes: 'added' },
         { version: '26.7.1', notes: 'moved to suite-common, reported from mobile as well' },
         { version: '26.8.0', notes: 'added unwrap transaction events' },
+        { version: '26.9.0', notes: 'added pre-broadcast unwrap-step failures' },
     ],
 
     attributes: {
@@ -39,7 +40,7 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
         },
         type: {
             description:
-                'Which step of the withdraw flow the event refers to: `withdraw` = form submit, `tx-simulation-modal` = simulation modal shown (desktop only), `success` / `error` / `leftPending` = withdraw transaction resolution',
+                'Which step of the withdraw flow the event refers to: `withdraw` = form submit, `tx-simulation-modal` = simulation modal shown (desktop only), `success` / `error` / `leftPending` = withdraw transaction resolution. `error` also covers a failure of the unwrap step — see `errorMessage`.',
             changelog: [
                 { version: '26.5.0', notes: 'added' },
                 {
@@ -67,7 +68,12 @@ export const yieldWithdrawEvent: EventDef<Attributes, EventType.YieldWithdraw> =
             changelog: [{ version: '26.5.2', notes: 'added' }],
         },
         errorMessage: {
-            changelog: [{ version: '26.5.0', notes: 'added' }],
+            description:
+                'Values prefixed with `unwrap-` are failures of the unwrap step of a wrapped-native withdraw, all of them before the unwrap transaction is broadcast: `unwrap-submit-failed` (signing failed, or the user rejected the transaction on the device or in the review modal), `unwrap-push-failed` (signed but the broadcast failed), and `unwrap-<compose reason>` (e.g. `unwrap-fee-estimation-failed`) when the transaction could not be composed. An unwrap that fails on chain instead reports `on-chain-failure`, as does the withdraw transaction itself.',
+            changelog: [
+                { version: '26.5.0', notes: 'added' },
+                { version: '26.9.0', notes: 'added `unwrap-` prefixed values' },
+            ],
         },
         apyBreakdown: {
             description:


### PR DESCRIPTION
## Description

Emit error analytics for yield in-flow wrap/unwrap.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30892

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are narrowly focused on yield wrap/unwrap thunks, the `useYieldFlow` hook, and yield deposit/withdraw analytics events. None of the 162 available E2E tests target earn/yield wrapping-unwrapping flows or assert on `yieldDepositEvent`/`yieldWithdrawEvent`; the static coverage mappings pointing to 134 tests are broad barrel-import matches and do not indicate real behavioral coverage. Therefore no E2E tests are recommended here; confidence should come from the accompanying unit tests and manual QA of the yield flows.

<details><summary><b>Changed files (7)</b></summary>

- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.ts`
- `packages/suite/src/components/earn/yield/hooks/useYieldFlow.ts`
- `suite-common/analytics/src/events/yieldDepositEvent.ts`
- `suite-common/analytics/src/events/yieldWithdrawEvent.ts`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (2)**
- `packages/suite/src/actions/wallet/unwrapNativeTokenThunks.test.ts`
- `packages/suite/src/actions/wallet/wrapNativeTokenThunks.test.ts`

_Updated: 2026-08-18T06:38:37.113Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/yield-in-flow-wrap-unwrap-errors-analytics&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-in-flow-wrap-unwrap-errors-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-in-flow-wrap-unwrap-errors-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-in-flow-wrap-unwrap-errors-analytics/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-in-flow-wrap-unwrap-errors-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T06:40:35.969Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T06:40:08.973Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->