### PR TITLE
fix(suite-native): show account detail actions by balance

### DIFF
--- a/suite-native/module-accounts-management/src/components/AccountDetailActionButtons.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailActionButtons.tsx
@@ -1,0 +1,133 @@
+import { useSelector } from 'react-redux';
+
+import { useNavigation } from '@react-navigation/native';
+
+import { useServices } from '@suite-common/dependency-injection';
+import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
+import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
+import { Box, Button, HStack } from '@suite-native/atoms';
+import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
+import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { Translation } from '@suite-native/intl';
+import {
+    ReceiveStackRoutes,
+    type RootStackParamList,
+    RootStackRoutes,
+    SendStackRoutes,
+    type StackNavigationProps,
+} from '@suite-native/navigation';
+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
+
+import {
+    selectHasAccountOrTokenSpendableBalance,
+    selectIsNetworkSendFlowEnabled,
+} from '../selectors';
+
+type AccountDetailActionButtonsProps = {
+    accountKey: AccountKey;
+    tokenContract?: TokenAddress;
+};
+
+type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
+
+export const AccountDetailActionButtons = ({
+    accountKey,
+    tokenContract,
+}: AccountDetailActionButtonsProps) => {
+    const { analytics } = useServices(selectNativeAnalyticsDep);
+    const navigation = useNavigation<NavigationProp>();
+
+    const account = useSelector((state: AccountsRootState) =>
+        selectAccountByKey(state, accountKey),
+    );
+    const token = useSelector((state: TokensRootState) =>
+        selectAccountTokenInfo(state, accountKey, tokenContract),
+    );
+    const isNetworkSendFlowEnabled = useSelector((state: FeatureFlagsRootState) =>
+        selectIsNetworkSendFlowEnabled(state, account?.symbol),
+    );
+    const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
+    const hasFirmwareAuthenticityCheckHardFailed = useSelector(
+        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
+    );
+    const hasSelectedAssetSpendableBalance = useSelector(
+        (state: AccountsRootState & TokensRootState) =>
+            selectHasAccountOrTokenSpendableBalance(state, accountKey, tokenContract),
+    );
+
+    if (!account) return null;
+
+    const handleReceive = () => {
+        analytics.report({
+            type: events.receiveFlowEnteredEvent.name,
+            payload: {
+                location: 'accountDetail',
+                assetSymbol: account.symbol,
+                tokenSymbol: token?.symbol,
+                tokenContract,
+            },
+        });
+        navigation.navigate(RootStackRoutes.ReceiveStack, {
+            screen: ReceiveStackRoutes.ReceiveAddress,
+            params: {
+                accountKey,
+                tokenContract,
+                closeActionType: 'close',
+            },
+        });
+    };
+
+    const handleSend = () => {
+        analytics.report({
+            type: events.sendFlowEnteredEvent.name,
+            payload: {
+                location: 'accountDetail',
+                assetSymbol: account.symbol,
+                tokenSymbol: token?.symbol,
+                tokenContract,
+            },
+        });
+        navigation.navigate(RootStackRoutes.SendStack, {
+            screen: SendStackRoutes.SendOutputs,
+            params: {
+                accountKey,
+                tokenContract,
+            },
+        });
+    };
+
+    const isReceiveButtonDisplayed = !hasFirmwareAuthenticityCheckHardFailed;
+    const isSendButtonDisplayed =
+        isNetworkSendFlowEnabled && !isPortfolioTrackerDevice && hasSelectedAssetSpendableBalance;
+
+    if (!isReceiveButtonDisplayed && !isSendButtonDisplayed) return null;
+
+    return (
+        <HStack flex={1} spacing="sp12">
+            {isReceiveButtonDisplayed && (
+                <Box flex={1}>
+                    <Button
+                        iconLeft="arrowLineDown"
+                        onPress={handleReceive}
+                        testID="@account-detail/receive-button"
+                    >
+                        <Translation id="transactions.receive" />
+                    </Button>
+                </Box>
+            )}
+            {isSendButtonDisplayed && (
+                <Box flex={1}>
+                    <Button
+                        iconLeft="arrowLineUp"
+                        onPress={handleSend}
+                        testID="@account-detail/send-button"
+                    >
+                        <Translation id="transactions.send" />
+                    </Button>
+                </Box>
+            )}
+        </HStack>
+    );
+};

--- a/suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx
+++ b/suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx
@@ -11,6 +11,7 @@ import { VStack } from '@suite-native/atoms';
 import { selectIsUnrecognizedToken } from '@suite-native/tokens';
 import { TransactionsEmptyState } from '@suite-native/transactions';
 
+import { AccountDetailActionButtons } from './AccountDetailActionButtons';
 import { AssetPriceCard } from './AssetPriceCard';
 
 type AccountDetailEmptyStateProps = {
@@ -35,7 +36,8 @@ export const AccountDetailEmptyState = ({
 
     return (
         <VStack spacing="sp24">
-            <TransactionsEmptyState accountKey={accountKey} />
+            <TransactionsEmptyState />
+            <AccountDetailActionButtons accountKey={accountKey} tokenContract={tokenContract} />
             {isPriceCardDisplayed && (
                 <AssetPriceCard accountKey={accountKey} tokenContract={tokenContract} />
             )}

--- a/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
+++ b/suite-native/module-accounts-management/src/components/TransactionListHeader.tsx
@@ -1,9 +1,6 @@
 import { memo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { useNavigation } from '@react-navigation/native';
-
-import { useServices } from '@suite-common/dependency-injection';
 import { selectIsPortfolioTrackerDevice } from '@suite-common/device';
 import { type TokenDefinitionsRootState } from '@suite-common/token-definitions';
 import {
@@ -14,18 +11,8 @@ import {
     useDisplayBaseCurrency,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { events, selectNativeAnalyticsDep } from '@suite-native/analytics';
-import { Box, Button, HStack, Text, VStack } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
-import { type FeatureFlagsRootState } from '@suite-native/feature-flags';
+import { Box, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import {
-    ReceiveStackRoutes,
-    type RootStackParamList,
-    RootStackRoutes,
-    SendStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
 import {
     type TokensRootState,
     selectAccountTokenInfo,
@@ -33,10 +20,10 @@ import {
 } from '@suite-native/tokens';
 import { selectHasAccountAnyTransactionsForToken } from '@suite-native/transactions';
 
-import { selectIsNetworkSendFlowEnabled } from '../selectors';
 import { AccountDiscoveryFailedBanner } from './AccountBanners/AccountDiscoveryFailedBanner';
 import { SolanaLimitedHistoryBanner } from './AccountBanners/SolanaLimitedHistoryBanner';
 import { StellarLimitedHistoryBanner } from './AccountBanners/StellarLimitedHistoryBanner';
+import { AccountDetailActionButtons } from './AccountDetailActionButtons';
 import { AccountDetailGraph } from './AccountDetailGraph';
 import { AssetPriceCard } from './AssetPriceCard';
 import { StellarTokenActions } from './StellarTokenActions';
@@ -53,8 +40,6 @@ type TransactionListHeaderContentProps = {
     accountKey: AccountKey;
     tokenContract?: TokenAddress;
 };
-
-type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
 
 const TransactionListHeaderContent = ({
     accountKey,
@@ -85,25 +70,16 @@ const TransactionListHeaderContent = ({
 
 export const TransactionListHeader = memo(
     ({ accountKey, tokenContract }: TransactionListHeaderProps) => {
-        const { analytics } = useServices(selectNativeAnalyticsDep);
-        const navigation = useNavigation<NavigationProp>();
-
         const account = useSelector((state: AccountsRootState) =>
             selectAccountByKey(state, accountKey),
         );
         const { shallDisplayBaseCurrency } = useDisplayBaseCurrency(account?.symbol);
 
-        const hasAccountTransactions = useSelector(
+        const hasSelectedAssetTransactions = useSelector(
             (state: AccountsRootState & TransactionsRootState) =>
                 selectHasAccountAnyTransactionsForToken(state, accountKey, tokenContract),
         );
-        const isNetworkSendFlowEnabled = useSelector((state: FeatureFlagsRootState) =>
-            selectIsNetworkSendFlowEnabled(state, account?.symbol),
-        );
         const isPortfolioTrackerDevice = useSelector(selectIsPortfolioTrackerDevice);
-        const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-            selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
-        );
         const token = useSelector((state: TokensRootState) =>
             selectAccountTokenInfo(state, accountKey, tokenContract),
         );
@@ -114,51 +90,9 @@ export const TransactionListHeader = memo(
 
         if (!account) return null;
 
-        const handleReceive = () => {
-            analytics.report({
-                type: events.receiveFlowEnteredEvent.name,
-                payload: {
-                    location: 'accountDetail',
-                    assetSymbol: account.symbol,
-                    tokenSymbol: token?.symbol,
-                    tokenContract,
-                },
-            });
-            navigation.navigate(RootStackRoutes.ReceiveStack, {
-                screen: ReceiveStackRoutes.ReceiveAddress,
-                params: {
-                    accountKey,
-                    tokenContract,
-                    closeActionType: 'close',
-                },
-            });
-        };
-
-        const handleSend = () => {
-            analytics.report({
-                type: events.sendFlowEnteredEvent.name,
-                payload: {
-                    location: 'accountDetail',
-                    assetSymbol: account.symbol,
-                    tokenSymbol: token?.symbol,
-                    tokenContract,
-                },
-            });
-            navigation.navigate(RootStackRoutes.SendStack, {
-                screen: SendStackRoutes.SendOutputs,
-                params: {
-                    accountKey,
-                    tokenContract,
-                },
-            });
-        };
-
         const isPriceCardDisplayed =
-            shallDisplayBaseCurrency && !isUnrecognizedToken && hasAccountTransactions;
+            shallDisplayBaseCurrency && !isUnrecognizedToken && hasSelectedAssetTransactions;
         const isStellarAccount = account.networkType === 'stellar';
-
-        const isSendButtonDisplayed = isNetworkSendFlowEnabled && !isPortfolioTrackerDevice;
-        const isReceiveButtonDisplayed = !hasFirmwareAuthenticityCheckHardFailed;
         const isStellarTokenActionsDisplayed = isStellarAccount && !isPortfolioTrackerDevice;
 
         return (
@@ -177,31 +111,13 @@ export const TransactionListHeader = memo(
                         <YieldVaultBanner accountKey={accountKey} tokenContract={tokenContract} />
                     )}
 
-                    {hasAccountTransactions && (
-                        <HStack paddingTop="sp8" paddingHorizontal="sp16" flex={1} spacing="sp12">
-                            {isReceiveButtonDisplayed && (
-                                <Box flex={1}>
-                                    <Button
-                                        iconLeft="arrowLineDown"
-                                        onPress={handleReceive}
-                                        testID="@account-detail/receive-button"
-                                    >
-                                        <Translation id="transactions.receive" />
-                                    </Button>
-                                </Box>
-                            )}
-                            {isSendButtonDisplayed && (
-                                <Box flex={1}>
-                                    <Button
-                                        iconLeft="arrowLineUp"
-                                        onPress={handleSend}
-                                        testID="@account-detail/send-button"
-                                    >
-                                        <Translation id="transactions.send" />
-                                    </Button>
-                                </Box>
-                            )}
-                        </HStack>
+                    {hasSelectedAssetTransactions && (
+                        <Box paddingTop="sp8" paddingHorizontal="sp16">
+                            <AccountDetailActionButtons
+                                accountKey={accountKey}
+                                tokenContract={tokenContract}
+                            />
+                        </Box>
                     )}
                     {isPriceCardDisplayed && (
                         <AssetPriceCard accountKey={accountKey} tokenContract={tokenContract} />
@@ -214,12 +130,12 @@ export const TransactionListHeader = memo(
                     )}
                     {isStellarAccount && <StellarLimitedHistoryBanner />}
                     {account.networkType === 'solana' && <SolanaLimitedHistoryBanner />}
-                    {account.networkType === 'tron' && !tokenContract && hasAccountTransactions && (
-                        <TronResources accountKey={accountKey} />
-                    )}
+                    {account.networkType === 'tron' &&
+                        !tokenContract &&
+                        hasSelectedAssetTransactions && <TronResources accountKey={accountKey} />}
                 </VStack>
 
-                {hasAccountTransactions && (
+                {hasSelectedAssetTransactions && (
                     <Box marginTop="sp52" marginHorizontal="sp16">
                         <Text variant="headline-sm">
                             <Translation id="transactions.title" />

--- a/suite-native/module-accounts-management/src/selectors.test.ts
+++ b/suite-native/module-accounts-management/src/selectors.test.ts
@@ -1,0 +1,82 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type Account, type TokenAddress } from '@suite-common/wallet-types';
+import { mockAccountToken, mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { type TokensRootState } from '@suite-native/tokens';
+
+import { selectHasAccountOrTokenSpendableBalance } from './selectors';
+
+const ethSymbol = asNetworkSymbol('eth');
+const tokenContract = '0x4d224452801aced8b2f0aebe155379bb5d594381' as TokenAddress;
+
+const getState = (account: Account): TokensRootState =>
+    ({
+        wallet: {
+            accounts: [account],
+        },
+    }) as unknown as TokensRootState;
+
+describe('selectHasAccountOrTokenSpendableBalance', () => {
+    it('returns true for a native account with positive available balance', () => {
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            availableBalance: '1',
+        });
+
+        expect(selectHasAccountOrTokenSpendableBalance(getState(account), account.key)).toBe(true);
+    });
+
+    it('returns false for a native account without available balance', () => {
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            availableBalance: '0',
+        });
+
+        expect(selectHasAccountOrTokenSpendableBalance(getState(account), account.key)).toBe(false);
+    });
+
+    it('returns true for a token with positive balance', () => {
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            availableBalance: '0',
+            tokens: [
+                mockAccountToken({
+                    contract: tokenContract,
+                    balance: '1',
+                }),
+            ],
+        });
+
+        expect(
+            selectHasAccountOrTokenSpendableBalance(getState(account), account.key, tokenContract),
+        ).toBe(true);
+    });
+
+    it('returns false for a token without balance', () => {
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            availableBalance: '1',
+            tokens: [
+                mockAccountToken({
+                    contract: tokenContract,
+                    balance: '0',
+                }),
+            ],
+        });
+
+        expect(
+            selectHasAccountOrTokenSpendableBalance(getState(account), account.key, tokenContract),
+        ).toBe(false);
+    });
+
+    it('returns false when the selected token is missing', () => {
+        const account = mockWalletAccount({
+            symbol: ethSymbol,
+            availableBalance: '1',
+            tokens: [],
+        });
+
+        expect(
+            selectHasAccountOrTokenSpendableBalance(getState(account), account.key, tokenContract),
+        ).toBe(false);
+    });
+});

--- a/suite-native/module-accounts-management/src/selectors.ts
+++ b/suite-native/module-accounts-management/src/selectors.ts
@@ -11,13 +11,13 @@ import {
     selectAccountUnrecognizedTokens,
 } from '@suite-common/wallet-core';
 import { type AccountKey, type TokenAddress } from '@suite-common/wallet-types';
-import { tryGetAccountIdentity } from '@suite-common/wallet-utils';
+import { isPositiveBalance, tryGetAccountIdentity } from '@suite-common/wallet-utils';
 import {
     FeatureFlag,
     type FeatureFlagsRootState,
     selectIsFeatureFlagEnabled,
 } from '@suite-native/feature-flags';
-import { type TokensRootState } from '@suite-native/tokens';
+import { type TokensRootState, selectAccountTokenInfo } from '@suite-native/tokens';
 import { deepEqual } from '@trezor/utils';
 
 import { type AccountAssetsTab } from './components/AccountAssets/types';
@@ -68,6 +68,24 @@ export const selectAssetTabOfAccountToken = (
         return 'hidden';
 
     return 'tokens';
+};
+
+export const selectHasAccountOrTokenSpendableBalance = (
+    state: AccountsRootState & TokensRootState,
+    accountKey: AccountKey,
+    tokenContract?: TokenAddress,
+): boolean => {
+    const account = selectAccountByKey(state, accountKey);
+
+    if (!account) return false;
+
+    if (tokenContract) {
+        const token = selectAccountTokenInfo(state, accountKey, tokenContract);
+
+        return isPositiveBalance(token?.balance ?? '0');
+    }
+
+    return isPositiveBalance(account.availableBalance);
 };
 
 export const selectIsNetworkSendFlowEnabled = (

--- a/suite-native/transactions/package.json
+++ b/suite-native/transactions/package.json
@@ -32,7 +32,6 @@
         "@suite-common/wallet-types": "workspace:*",
         "@suite-common/wallet-utils": "workspace:*",
         "@suite-native/atoms": "workspace:*",
-        "@suite-native/device": "workspace:*",
         "@suite-native/feature-feedback": "workspace:*",
         "@suite-native/formatters": "workspace:*",
         "@suite-native/icons": "workspace:*",

--- a/suite-native/transactions/src/components/TransactionList.tsx
+++ b/suite-native/transactions/src/components/TransactionList.tsx
@@ -309,7 +309,7 @@ export const TransactionList = ({
                 ListEmptyComponent={
                     shouldDeferEmptyState
                         ? null
-                        : (listEmptyComponent ?? <TransactionsEmptyState accountKey={accountKey} />)
+                        : (listEmptyComponent ?? <TransactionsEmptyState />)
                 }
                 ListHeaderComponent={listHeaderComponent}
                 ListFooterComponent={

--- a/suite-native/transactions/src/components/TransactionsEmptyState.tsx
+++ b/suite-native/transactions/src/components/TransactionsEmptyState.tsx
@@ -1,61 +1,20 @@
-import { useSelector } from 'react-redux';
-
-import { useNavigation } from '@react-navigation/native';
-
-import { type AccountKey } from '@suite-common/wallet-types';
-import { Box, Button, Text, VStack } from '@suite-native/atoms';
-import { selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice } from '@suite-native/device';
+import { Box, Text, VStack } from '@suite-native/atoms';
 import { Translation } from '@suite-native/intl';
-import {
-    ReceiveStackRoutes,
-    type RootStackParamList,
-    RootStackRoutes,
-    type StackNavigationProps,
-} from '@suite-native/navigation';
 
 import { NoTransactionsSvg } from './NoTransactionsSvg';
 
-type NavigationProp = StackNavigationProps<RootStackParamList, RootStackRoutes.AccountDetail>;
-
-export const TransactionsEmptyState = ({ accountKey }: { accountKey: AccountKey }) => {
-    const navigation = useNavigation<NavigationProp>();
-    const hasFirmwareAuthenticityCheckHardFailed = useSelector(
-        selectHasFirmwareAuthenticityCheckHardFailedForSelectedDevice,
-    );
-    const showReceiveButton = !hasFirmwareAuthenticityCheckHardFailed;
-
-    const handleReceive = () => {
-        navigation.navigate(RootStackRoutes.ReceiveStack, {
-            screen: ReceiveStackRoutes.ReceiveAddress,
-            params: {
-                accountKey,
-                closeActionType: 'close',
-            },
-        });
-    };
-
-    return (
-        <VStack marginHorizontal="sp16" spacing="sp32">
-            <Box alignItems="center">
-                <NoTransactionsSvg />
-                <VStack alignItems="center">
-                    <Text textAlign="center" variant="headline-sm">
-                        <Translation id="transactions.emptyState.title" />
-                    </Text>
-                    <Text textAlign="center" color="contentSecondary">
-                        <Translation id="transactions.emptyState.subtitle" />
-                    </Text>
-                </VStack>
-            </Box>
-            {showReceiveButton && (
-                <Button
-                    iconLeft="arrowLineDown"
-                    onPress={handleReceive}
-                    testID="@account-detail/receive-button"
-                >
-                    <Translation id="transactions.emptyState.button" />
-                </Button>
-            )}
-        </VStack>
-    );
-};
+export const TransactionsEmptyState = () => (
+    <VStack marginHorizontal="sp16" spacing="sp32">
+        <Box alignItems="center">
+            <NoTransactionsSvg />
+            <VStack alignItems="center">
+                <Text textAlign="center" variant="headline-sm">
+                    <Translation id="transactions.emptyState.title" />
+                </Text>
+                <Text textAlign="center" color="contentSecondary">
+                    <Translation id="transactions.emptyState.subtitle" />
+                </Text>
+            </VStack>
+        </Box>
+    </VStack>
+);

--- a/suite-native/transactions/tsconfig.json
+++ b/suite-native/transactions/tsconfig.json
@@ -46,7 +46,6 @@
             "path": "../../suite-common/wallet-utils"
         },
         { "path": "../atoms" },
-        { "path": "../device" },
         { "path": "../feature-feedback" },
         { "path": "../formatters" },
         { "path": "../icons" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14535,7 +14535,6 @@ __metadata:
     "@suite-common/wallet-types": "workspace:*"
     "@suite-common/wallet-utils": "workspace:*"
     "@suite-native/atoms": "workspace:*"
-    "@suite-native/device": "workspace:*"
     "@suite-native/feature-feedback": "workspace:*"
     "@suite-native/formatters": "workspace:*"
     "@suite-native/icons": "workspace:*"


### PR DESCRIPTION
## Description

Fixes the mobile token detail action buttons so Send is based on the selected account/token spendable balance instead of whether the selected token has transactions in the currently loaded transaction page.

The account detail action buttons are now shared between the transaction header and empty-state layout, keeping Receive and Send next to each other in both states. The generic transactions empty state is display-only again, while account-detail navigation and analytics live in `AccountDetailActionButtons`.

Root cause: `TransactionListHeader` reused `selectHasAccountAnyTransactionsForToken`, which only scans fetched transactions. Tokens with balance but no loaded token transaction therefore lost or misplaced actions until more transactions were loaded.

## Notes for QA

Check mobile account detail token screens where the token has a positive balance but no token transactions in the initially loaded page. Receive and Send should appear next to each other in the empty-state button area, and Send should not depend on pressing Load more.

Also check a token/account with transactions to confirm the same action row appears in the header.

## Related Issue

Resolve #31314

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=juriczech/31314-regression&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=juriczech/31314-regression&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=juriczech/31314-regression&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** All changed files are in suite-native (mobile) modules — AccountDetailActionButtons, AccountDetailEmptyState, TransactionListHeader, related selectors, and the transactions package components. The candidate test list consists entirely of suite/e2e web/desktop tests, none of which exercise the native mobile UI or the changed selectors. No web E2E regression is expected from these mobile-only changes. The appropriate validation is native mobile unit/integration tests (e.g., the included selectors.test.ts), not the web E2E suite.

<details><summary><b>Changed files (9)</b></summary>

- `suite-native/module-accounts-management/src/components/AccountDetailActionButtons.tsx`
- `suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx`
- `suite-native/module-accounts-management/src/components/TransactionListHeader.tsx`
- `suite-native/module-accounts-management/src/selectors.test.ts`
- `suite-native/module-accounts-management/src/selectors.ts`
- `suite-native/transactions/package.json`
- `suite-native/transactions/src/components/TransactionList.tsx`
- `suite-native/transactions/src/components/TransactionsEmptyState.tsx`
- `suite-native/transactions/tsconfig.json`

</details>

_No test recommendations found._

⚠️ **Changes with no test coverage (9)**
- `suite-native/module-accounts-management/src/components/AccountDetailActionButtons.tsx`
- `suite-native/module-accounts-management/src/components/AccountDetailEmptyState.tsx`
- `suite-native/module-accounts-management/src/components/TransactionListHeader.tsx`
- `suite-native/module-accounts-management/src/selectors.test.ts`
- `suite-native/module-accounts-management/src/selectors.ts`
- `suite-native/transactions/package.json`
- `suite-native/transactions/src/components/TransactionList.tsx`
- `suite-native/transactions/src/components/TransactionsEmptyState.tsx`
- `suite-native/transactions/tsconfig.json`

_Updated: 2026-08-18T11:19:50.230Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/juriczech/31314-regression/web/](https://dev.suite.sldev.cz/suite-web/juriczech/31314-regression/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T11:23:15.464Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T11:21:12.945Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->