### PR TITLE
fix(trading): surface underlying compose error instead of generic missing fee level

### DIFF
--- a/packages/suite-data/files/translations/en-US.json
+++ b/packages/suite-data/files/translations/en-US.json
@@ -2662,6 +2662,7 @@
   "TR_TRADING_CANNOT_CREATE_TRANSACTION": "Unable to create transaction",
   "TR_TRADING_CANNOT_SEND_TRANSACTION": "Unable to send transaction, missing data",
   "TR_TRADING_CEX_TOOLTIP": "Centralized exchange",
+  "TR_TRADING_COMPOSE_FAILED": "Unable to create transaction. {error}",
   "TR_TRADING_CONCIERGE_BENEFIT_EXECUTION_DESCRIPTION": "Lock in your price instantly. Funds typically arrive the next business day.",
   "TR_TRADING_CONCIERGE_BENEFIT_EXECUTION_TITLE": "Expedited execution & settlement",
   "TR_TRADING_CONCIERGE_BENEFIT_PRICING_DESCRIPTION": "Avoid slippage and get a tailored quote for your trade.",

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -345,6 +345,42 @@ describe('recomposeAndSignTxThunk', () => {
         expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(0);
     });
 
+    it('should surface the underlying error when compose is rejected with a message', async () => {
+        const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks();
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { rejectWithValue }) =>
+                    rejectWithValue({
+                        error: 'fee-levels-compose-failed',
+                        message: 'Method_InvalidParameter',
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'address',
+                amount: '0.1',
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('rejected');
+        expect(response.payload).toEqual({
+            type: 'sign-tx-error',
+            error: {
+                id: 'TR_TRADING_COMPOSE_FAILED',
+                values: { error: 'Method_InvalidParameter' },
+            },
+        });
+
+        expect(mockSignAndPushSendFormTransaction).toHaveBeenCalledTimes(0);
+    });
+
     it('should return error when selectedFee is not in composedLevels', async () => {
         const { store, account, tradingFormState, mockSignAndPushSendFormTransaction } = getMocks({
             composedTransactionInfo: {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -191,7 +191,23 @@ export const recomposeAndSignTxThunk = createThunk<
             }),
         );
 
-        if (!selectedFee || isRejectedWithValue(composedLevels)) {
+        if (isRejectedWithValue(composedLevels)) {
+            const composeError = composedLevels.payload as { message?: string } | undefined;
+
+            return rejectWithValue({
+                type: 'sign-tx-error',
+                error: composeError?.message
+                    ? {
+                          id: 'TR_TRADING_COMPOSE_FAILED',
+                          values: { error: composeError.message },
+                      }
+                    : {
+                          id: 'TR_TRADING_MISSING_FEE_LEVEL',
+                      },
+            });
+        }
+
+        if (!selectedFee) {
             return rejectWithValue({
                 type: 'sign-tx-error',
                 error: {

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -344,6 +344,10 @@ export const messages = defineMessages({
         defaultMessage: 'Missing fee level',
         id: 'TR_TRADING_MISSING_FEE_LEVEL',
     },
+    TR_TRADING_COMPOSE_FAILED: {
+        defaultMessage: 'Unable to create transaction. {error}',
+        id: 'TR_TRADING_COMPOSE_FAILED',
+    },
     TR_TRADING_ERROR_WITH_PARTNER_MESSAGE: {
         defaultMessage: '{base} Message from partner: {partnerMessage}',
         id: 'TR_TRADING_ERROR_WITH_PARTNER_MESSAGE',


### PR DESCRIPTION
`recomposeAndSignTxThunk` mapped every rejected re-compose to `TR_TRADING_MISSING_FEE_LEVEL`, discarding the real `ComposeFeeLevelsError` message. Trade-signing failures (e.g. a connect `REVERT opcode executed`, an invalid parameter, missing utxos) all surfaced to the user as the unactionable "Missing fee level", and the true cause was unrecoverable.

Split the guard: when the re-compose rejects with a message, surface it via the new `TR_TRADING_COMPOSE_FAILED` key instead of the generic one. `selectedFee`-missing keeps the original message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Notes for QA
do not test

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The primary risk is in the shared trading transaction signing thunk (recomposeAndSignTxThunk), which is used when swap and sell transactions are signed on the device. A targeted set of cross-chain swap and sell tests across BTC, ETH, and SOL networks provides high confidence. The English translation and messages source changes have no static E2E coverage but are indirectly exercised by these UI flows; translation mismatches would surface as assertion failures.

<details><summary><b>Changed files (4)</b></summary>


- `packages/suite-data/files/translations/en-US.json`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite/intl/src/messages.ts`

</details>

**Recommended tests (10)**

<details><summary>🔴 <b>High priority (10)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-coin-to-token.test.ts` — This live swap test initiates and confirms a Solana send transaction on the hardware device, which directly exercises the recomposeAndSignTxThunk path for real swap trade execution.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — The sell flow triggers a device prompt to sign and send BTC to the provider, directly relying on the trading transaction signing thunk.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test confirms an Ethereum sell transaction on the device, exercising the thunk's ETH signing and fee composition path.
- `suite/e2e/tests/trading/sell-solana.test.ts` — The Solana sell flow signs and sends SOL/USDT to a provider, covering the thunk's Solana transaction recomposition and signing behavior.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Cross-chain BTC to USDC swap requires signing a Bitcoin send transaction, which is handled by the shared trading signing thunk.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This DEX swap confirms an Ethereum transaction on the device after token approval, directly exercising the thunk for swap transaction signing.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain ETH to SOL swap signs and broadcasts an Ethereum transaction, hitting the same recompose/sign thunk code path.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — This test uses custom Bitcoin fees during swap signing and verifies fee-rate display on the device, testing fee recomposition in the thunk.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Custom Ethereum gas parameters are set during a swap and verified on the device, directly covering the thunk's EVM fee recomposition logic.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Cross-chain SOL to BTC swap signs and broadcasts a Solana transaction, exercising the thunk's Solana swap signing path.

</details>

⚠️ **Changes with no test coverage (2)**
- `packages/suite-data/files/translations/en-US.json`
- `suite/intl/src/messages.ts`

_Updated: 2026-08-17T22:10:16.905Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/trading-surface-compose-error/web/](https://dev.suite.sldev.cz/suite-web/trading-surface-compose-error/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=trading-surface-compose-error&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=trading-surface-compose-error&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=trading-surface-compose-error&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-17T22:13:03.615Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-17T22:11:14.813Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->