### PR TITLE
fix(suite-native-31250): prevent fiat value discrepancy when switching assets

### DIFF
--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveAmountInput.test.tsx
@@ -2,7 +2,7 @@ import { FeatureFlag, featureFlagsInitialState } from '@suite-native/feature-fla
 import { Form } from '@suite-native/forms';
 import { getTranslation } from '@suite-native/intl';
 import { act, fireEvent } from '@suite-native/test-utils-store';
-import { mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
+import { btcAsset, mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
 import {
@@ -50,8 +50,13 @@ describe('ExchangeReceiveAmountInput', () => {
 
     it('should render receiveCryptoAmount form value', () => {
         act(() => {
+            form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', usdcAsset);
-            form.setValue('quote', mercuryoFixedWorstQuote);
+            form.setValue('quote', {
+                ...mercuryoFixedWorstQuote,
+                send: btcAsset.cryptoId,
+                receive: usdcAsset.cryptoId,
+            });
         });
 
         const { getByLabelText } = renderExchangeReceiveAmountInput();

--- a/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
+++ b/suite-native/module-trading/src/components/exchange/receive/ExchangeReceiveContent.test.tsx
@@ -5,7 +5,7 @@ import {
     renderHookWithStoreProvider,
     renderWithStoreProvider,
 } from '@suite-native/test-utils-store';
-import { mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
+import { btcAsset, mercuryoFixedWorstQuote, usdcAsset } from '@suite-native/trading-fixtures';
 import { type ExchangeFormType } from '@suite-native/trading-types';
 
 import { ExchangeReceiveContent } from './ExchangeReceiveContent';
@@ -57,8 +57,13 @@ describe('ExchangeReceiveContent', () => {
 
     it('should render all components', () => {
         act(() => {
+            form.setValue('sendAsset', btcAsset);
             form.setValue('receiveAsset', usdcAsset);
-            form.setValue('quote', mercuryoFixedWorstQuote);
+            form.setValue('quote', {
+                ...mercuryoFixedWorstQuote,
+                send: btcAsset.cryptoId,
+                receive: usdcAsset.cryptoId,
+            });
         });
         const { getByText, getByLabelText } = renderExchangeReceiveContent();
 

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.test.tsx
@@ -20,6 +20,7 @@ import {
     cexdirectCreditCardBuyQuote,
     eth1NormalAccount,
     eth2legacyAccount,
+    ethAsset,
     getInitializedTradingState,
     mercuryoApplePayBuyQuote,
     mercuryoCreditCardBuyQuote,
@@ -253,6 +254,20 @@ describe('useBuyForm', () => {
 
             expect(result.current.getValues('cryptoValue')).toEqual('0.001000168');
             expect(result.current.getValues('fiatValue')).toEqual('10');
+        });
+
+        it('should not update cryptoValue from a quote for a different asset', () => {
+            const store = getInitializedStore();
+            const { result } = renderUseTradingBuyForm(store);
+
+            initFormAndQuotes(result.current, store);
+
+            act(() => {
+                result.current.setValue('asset', ethAsset);
+                result.current.setValue('cryptoValue', undefined);
+            });
+
+            expect(result.current.getValues('cryptoValue')).toBeUndefined();
         });
 
         it('should update fiatAmount when selected quote is changed and user inserted cryptoAmount and truncate it to 3 decimals', () => {

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -95,6 +95,12 @@ const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) 
     );
 
     useEffect(() => {
+        const isQuoteMatchingAsset = quote && quote.receiveCurrency === asset?.cryptoId;
+
+        if (!isQuoteMatchingAsset) {
+            return;
+        }
+
         const [amountInCrypto, fiatValue, cryptoValue] = getValues([
             'amountInCrypto',
             'fiatValue',
@@ -121,7 +127,7 @@ const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) 
                     : truncatedCryptoAmount;
             setValue('cryptoValue', value);
         }
-    }, [quote, isAmountInSats, symbol, getValues, setValue]);
+    }, [asset?.cryptoId, quote, isAmountInSats, symbol, getValues, setValue]);
 };
 
 const useValidations = (

--- a/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
+++ b/suite-native/module-trading/src/hooks/buy/useBuyForm.ts
@@ -95,9 +95,7 @@ const useBuyQuoteChangeEffect = ({ control, getValues, setValue }: BuyFormType) 
     );
 
     useEffect(() => {
-        const isQuoteMatchingAsset = quote && quote.receiveCurrency === asset?.cryptoId;
-
-        if (!isQuoteMatchingAsset) {
+        if (quote && quote.receiveCurrency !== asset?.cryptoId) {
             return;
         }
 

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.test.ts
@@ -17,6 +17,7 @@ import {
     btcAsset,
     cexdirectFloatingQuote,
     eth1NormalAccount,
+    ethAsset,
     exchangeCexdirect,
     exchangeQuotes,
     invityDexQuote,
@@ -204,16 +205,34 @@ describe('useExchangeForm', () => {
         it('should set receiveCryptoAmount based on selected quote', () => {
             const { result } = renderUseExchangeForm();
             act(() => {
+                result.current.setValue('sendAsset', usdcAsset);
+                result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });
 
             expect(result.current.getValues('receiveCryptoAmount')).toBe('0.00089118');
         });
 
+        it('should clear receiveCryptoAmount when receive asset does not match selected quote', () => {
+            const { result } = renderUseExchangeForm();
+            act(() => {
+                result.current.setValue('sendAsset', usdcAsset);
+                result.current.setValue('receiveAsset', btcAsset);
+                store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
+            });
+
+            act(() => {
+                result.current.setValue('receiveAsset', ethAsset);
+            });
+
+            expect(result.current.getValues('receiveCryptoAmount')).toBeUndefined();
+        });
+
         it('should set receiveCryptoAmount in sats when using BTC and amount in sats', () => {
             store = getInitializedStore(PROTO.AmountUnit.SATOSHI);
             const { result } = renderUseExchangeForm();
             act(() => {
+                result.current.setValue('sendAsset', usdcAsset);
                 result.current.setValue('receiveAsset', btcAsset);
                 store.dispatch(tradingExchangeActions.saveQuotes(exchangeQuotes));
             });

--- a/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
+++ b/suite-native/module-trading/src/hooks/exchange/useExchangeForm.ts
@@ -97,9 +97,11 @@ const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) =
         selectIsAmountInSats(state, symbol),
     );
 
+    const isQuoteMatchingAsset = selectedQuote && selectedQuote.receive === receiveAsset?.cryptoId;
+    const amount = selectedQuote?.receiveStringAmount;
+
     useEffect(() => {
-        const amount = selectedQuote?.receiveStringAmount;
-        if (!amount) {
+        if (!isQuoteMatchingAsset || !amount) {
             setValue('receiveCryptoAmount', undefined, { shouldValidate: true });
 
             return;
@@ -110,7 +112,15 @@ const useExchangeQuoteChangeEffect = ({ control, setValue }: ExchangeFormType) =
                 ? convertAmountUnitsToSubunits(amount, getNetwork(symbol).decimals)
                 : amount;
         setValue('receiveCryptoAmount', value, { shouldValidate: true });
-    }, [selectedQuote, isAmountInSats, symbol, setValue]);
+    }, [
+        selectedQuote,
+        isQuoteMatchingAsset,
+        amount,
+        receiveAsset?.cryptoId,
+        isAmountInSats,
+        symbol,
+        setValue,
+    ]);
 };
 
 const useDexQuoteApprovalInfoChangeEffect = ({


### PR DESCRIPTION
## Description

- Prevents buy form crypto values from updating when the selected quote belongs to a different asset.
- Clears exchange receive amounts when the selected asset no longer matches the quote.

## Notes for QA

- Verify buy and exchange flows when switching assets after a quote is loaded.
- Confirm stale crypto amounts are cleared and matching quote amounts remain displayed.

## Related Issue

Resolve: https://github.com/trezor/trezor-suite/issues/31250

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/31250-buy-form-fiat-value-discrepancy-when-switching-assets&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->