### PR TITLE
Show withdrawal reserve banner when stake max is selected

### DIFF
--- a/suite-native/module-earn/src/components/EarnAmountInputs.tsx
+++ b/suite-native/module-earn/src/components/EarnAmountInputs.tsx
@@ -71,7 +71,11 @@ export const EarnAmountInputs = ({
                 )}
             />
             {isWithdrawalFeesBannerVisible && (
-                <EarnWithdrawalFeesBanner accountKey={accountKey} symbol={symbol} />
+                <EarnWithdrawalFeesBanner
+                    accountKey={accountKey}
+                    symbol={symbol}
+                    isMaxSelected={isMaxSelected}
+                />
             )}
         </VStack>
     );

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.test.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.test.tsx
@@ -1,0 +1,114 @@
+import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
+import { getMaxStakeAmount, networkAmountToSmallestUnit } from '@suite-common/wallet-utils';
+import { Form, useForm } from '@suite-native/forms';
+import { getTranslation } from '@suite-native/intl';
+import {
+    renderHookWithStoreProvider,
+    renderWithStoreProvider,
+} from '@suite-native/test-utils-store';
+
+import {
+    type EarnFormContext,
+    type EarnFormValues,
+    earnFormValidationSchema,
+} from '../earnFormSchema';
+import { EarnWithdrawalFeesBanner } from './EarnWithdrawalFeesBanner';
+
+const SOL_WITHDRAWAL_RESERVE = '0.02';
+
+const translate = ((id: string) => id) as EarnFormContext['translate'];
+
+const renderBanner = ({
+    balance,
+    amount,
+    isMaxSelected,
+}: {
+    balance: string;
+    amount: string;
+    isMaxSelected: boolean;
+}) => {
+    const account = mockWalletAccount({
+        symbol: 'sol',
+        availableBalance: networkAmountToSmallestUnit(balance, 'sol'),
+    });
+
+    const { result } = renderHookWithStoreProvider(() =>
+        useForm<EarnFormValues>({
+            validation: earnFormValidationSchema,
+            mode: 'onTouched',
+            context: { symbol: 'sol', availableBalance: balance, decimals: 9, translate },
+            defaultValues: { amount, fiat: '' },
+        }),
+    );
+    const form = result.current;
+
+    return renderWithStoreProvider(
+        <EarnWithdrawalFeesBanner
+            accountKey={account.key}
+            symbol="sol"
+            isMaxSelected={isMaxSelected}
+        />,
+        {
+            preloadedState: { wallet: { accounts: [account] } },
+            wrapper: ({ children }) => <Form form={form}>{children}</Form>,
+        },
+    );
+};
+
+describe('EarnWithdrawalFeesBanner', () => {
+    it('renders nothing for a manually entered amount that leaves the withdrawal reserve intact', () => {
+        const { toJSON } = renderBanner({ balance: '5', amount: '4', isMaxSelected: false });
+
+        expect(toJSON()).toBeNull();
+    });
+
+    it('recommends the reserve for a manually entered amount that eats into it', () => {
+        const { getByText } = renderBanner({ balance: '5', amount: '4.99', isMaxSelected: false });
+
+        expect(
+            getByText(
+                getTranslation('earn.earnFormScreen.withdrawalFeesRecommendation', {
+                    amount: SOL_WITHDRAWAL_RESERVE,
+                    displaySymbol: 'SOL',
+                }),
+            ),
+        ).toBeTruthy();
+    });
+
+    it('confirms the kept reserve for the stake max amount, which leaves exactly the reserve', () => {
+        const balance = '5';
+        const { getByText } = renderBanner({
+            balance,
+            amount: getMaxStakeAmount({ balance, symbol: 'sol' }),
+            isMaxSelected: true,
+        });
+
+        expect(
+            getByText(
+                getTranslation('earn.earnFormScreen.withdrawalFeesBanner', {
+                    amount: SOL_WITHDRAWAL_RESERVE,
+                    displaySymbol: 'SOL',
+                }),
+            ),
+        ).toBeTruthy();
+    });
+
+    it('recommends the reserve when stake max can only leave the smaller fee buffer', () => {
+        // Below MIN_SOL_BALANCE_FOR_STAKING the max amount reserves the 0.005 fee buffer only.
+        const balance = '1.01';
+        const { getByText } = renderBanner({
+            balance,
+            amount: getMaxStakeAmount({ balance, symbol: 'sol' }),
+            isMaxSelected: true,
+        });
+
+        expect(
+            getByText(
+                getTranslation('earn.earnFormScreen.withdrawalFeesRecommendation', {
+                    amount: SOL_WITHDRAWAL_RESERVE,
+                    displaySymbol: 'SOL',
+                }),
+            ),
+        ).toBeTruthy();
+    });
+});

--- a/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
+++ b/suite-native/module-earn/src/components/EarnWithdrawalFeesBanner.tsx
@@ -12,9 +12,14 @@ import { BigNumber } from '@trezor/utils';
 type EarnWithdrawalFeesBannerProps = {
     accountKey: AccountKey;
     symbol: NetworkSymbol;
+    isMaxSelected: boolean;
 };
 
-export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalFeesBannerProps) => {
+export const EarnWithdrawalFeesBanner = ({
+    accountKey,
+    symbol,
+    isMaxSelected,
+}: EarnWithdrawalFeesBannerProps) => {
     const account = useSelector((state: AccountsRootState) =>
         selectAccountByKey(state, accountKey),
     );
@@ -22,24 +27,27 @@ export const EarnWithdrawalFeesBanner = ({ accountKey, symbol }: EarnWithdrawalF
 
     const limits = getStakingLimitsByNetworkSymbol(symbol);
 
-    if (!limits || !account) return null;
+    if (!limits || !account || hasError || !amountValue) return null;
 
     const { displaySymbol } = getNetwork(symbol);
     const formattedBalance = formatNetworkAmount(account.availableBalance, symbol);
 
-    const isVisible =
-        !hasError &&
-        !!amountValue &&
-        new BigNumber(formattedBalance).minus(amountValue).lt(limits.MIN_FOR_WITHDRAWALS);
+    const isBelowWithdrawalReserve = new BigNumber(formattedBalance)
+        .minus(amountValue)
+        .lt(limits.MIN_FOR_WITHDRAWALS);
 
-    if (!isVisible) return null;
+    if (!isBelowWithdrawalReserve && !isMaxSelected) return null;
 
     return (
         <BannerInline
-            intent="warning"
+            intent={isBelowWithdrawalReserve ? 'warning' : 'info'}
             title={
                 <Translation
-                    id="earn.earnFormScreen.withdrawalFeesRecommendation"
+                    id={
+                        isBelowWithdrawalReserve
+                            ? 'earn.earnFormScreen.withdrawalFeesRecommendation'
+                            : 'earn.earnFormScreen.withdrawalFeesBanner'
+                    }
                     values={{
                         amount: limits.MIN_FOR_WITHDRAWALS.toString(),
                         displaySymbol,


### PR DESCRIPTION
## Description

Tapping "Stake max" on mobile never showed the withdrawal reserve banner, which was gated on the remaining balance being strictly below the reserve, something max never is, since it leaves exactly the reserve. It now mirrors the desktop and confirms the kept reserve when max is selected.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/29575

## Screenshots:
<img width="1286" height="2366" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-18 at 09 58 57" src="https://github.com/user-attachments/assets/a0f5ad13-c41a-40fe-9741-e5d3f2976db5" />
<img width="1284" height="2350" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-18 at 09 59 02" src="https://github.com/user-attachments/assets/c6de19b5-d8b5-4514-991d-b728f2fea0a5" />
<img width="1290" height="2351" alt="Simulator Screenshot - iPhone 16 Plus - 2026-08-18 at 10 07 23" src="https://github.com/user-attachments/assets/1a0d6eae-0b1b-4721-b368-47d66d5fbf5c" />