### PR TITLE
perf(suite-native): remove state => state selector anti-pattern

### DIFF
--- a/suite-native/trading-state/src/selectors/buySelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.test.ts
@@ -79,6 +79,14 @@ describe('buySelectors', () => {
             );
         });
 
+        it('should be stable across dispatches that do not change the account', () => {
+            const first = selectBuySelectedReceiveAccount(state);
+            // A dispatch produces a new top-level state reference while the account stays the same.
+            const nextState = { ...state };
+
+            expect(selectBuySelectedReceiveAccount(nextState)).toBe(first);
+        });
+
         it('should return undefined when no account with given key exists', () => {
             state.wallet.trading.buy.tradingAccountKey = mockAccountKey({
                 descriptor: 'unknownAccountKey',

--- a/suite-native/trading-state/src/selectors/buySelectors.ts
+++ b/suite-native/trading-state/src/selectors/buySelectors.ts
@@ -16,7 +16,7 @@ import {
     selectTradingBuySupportedCryptoIds,
     selectValidTradingBuyQuotes,
 } from '@suite-common/trading';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { FeatureFlag, selectIsFeatureFlagEnabled } from '@suite-native/feature-flags';
 import {
     coinInfoToTradeableAsset,
@@ -41,14 +41,18 @@ const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
 
 export const selectTradingBuy = (state: TradingRootState) => state.wallet.trading.buy;
 
-export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccounts(
-    [state => state, selectTradingBuy],
-    (state, { receiveAddress, tradingAccountKey }) => {
-        if (!tradingAccountKey) {
-            return undefined;
-        }
+const selectBuyReceiveAccount = (state: TradingRootState & AccountsRootState) => {
+    const { tradingAccountKey } = selectTradingBuy(state);
 
-        const account = selectAccountByKey(state, tradingAccountKey);
+    return tradingAccountKey ? selectAccountByKey(state, tradingAccountKey) : null;
+};
+
+const selectTradingBuyReceiveAddress = (state: TradingRootState) =>
+    selectTradingBuy(state).receiveAddress;
+
+export const selectBuySelectedReceiveAccount = createMemoizedSelectorWithAccounts(
+    [selectBuyReceiveAccount, selectTradingBuyReceiveAddress],
+    (account, receiveAddress) => {
         if (!account) {
             return undefined;
         }

--- a/suite-native/trading-state/src/selectors/sellSelectors.test.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.test.ts
@@ -287,6 +287,14 @@ describe('sellSelectors', () => {
             expect(selectSellSelectedSendAccount(state)).toBe(selectSellSelectedSendAccount(state));
         });
 
+        it('should be stable across dispatches that do not change the account', () => {
+            const first = selectSellSelectedSendAccount(state);
+            // A dispatch produces a new top-level state reference while the account stays the same.
+            const nextState = { ...state };
+
+            expect(selectSellSelectedSendAccount(nextState)).toBe(first);
+        });
+
         it('should return undefined when no account with given key exists', () => {
             state.wallet.trading.sell.tradingAccountKey = mockAccountKey({
                 descriptor: 'unknownAccountKey',

--- a/suite-native/trading-state/src/selectors/sellSelectors.ts
+++ b/suite-native/trading-state/src/selectors/sellSelectors.ts
@@ -11,7 +11,7 @@ import {
     selectTradingSellInfo,
     selectValidTradingSellQuotes,
 } from '@suite-common/trading';
-import { selectAccountByKey } from '@suite-common/wallet-core';
+import { type AccountsRootState, selectAccountByKey } from '@suite-common/wallet-core';
 import { type FiatCurrencyItem, type SellFormValues } from '@suite-native/trading-types';
 import { unique } from '@trezor/utils';
 
@@ -19,11 +19,7 @@ import {
     selectTradingResidenceCountry,
     selectTradingResidenceCountrySubdivision,
 } from './residenceSelectors';
-import {
-    type TradingRootState,
-    createMemoizedSelector,
-    createMemoizedSelectorWithAccounts,
-} from '../reducers';
+import { type TradingRootState, createMemoizedSelector } from '../reducers';
 
 const DEFAULT_FIAT_CURRENCY_FALLBACK = 'USD';
 export const selectTradingSell = (state: TradingRootState) => state.wallet.trading.sell;
@@ -80,10 +76,11 @@ export const selectSellFormDefaultValues = createMemoizedSelector(
     },
 );
 
-export const selectSellSelectedSendAccount = createMemoizedSelectorWithAccounts(
-    [state => state, selectTradingSell],
-    (state, { tradingAccountKey }) => selectAccountByKey(state, tradingAccountKey) || undefined,
-);
+export const selectSellSelectedSendAccount = (state: TradingRootState & AccountsRootState) => {
+    const { tradingAccountKey } = selectTradingSell(state);
+
+    return selectAccountByKey(state, tradingAccountKey) ?? undefined;
+};
 
 export const selectSellBestQuotesForAvailablePaymentMethods = createMemoizedSelector(
     [selectValidTradingSellQuotes],

--- a/suite-native/transaction-management/src/selectors.test.ts
+++ b/suite-native/transaction-management/src/selectors.test.ts
@@ -1,8 +1,17 @@
 import { asNetworkSymbol } from '@suite-common/wallet-config';
-import { type FeeLevelLabel, type GeneralPrecomposedLevels } from '@suite-common/wallet-types';
+import {
+    type FeeLevelLabel,
+    type FormState,
+    type GeneralPrecomposedLevels,
+} from '@suite-common/wallet-types';
 import { isClearSignedEvmTradingSwapTransaction } from '@suite-common/wallet-utils';
 
-import { ETH_ACCOUNT_KEY, getEthAccount, getWalletState } from './__fixtures__/walletState';
+import {
+    BTC_ACCOUNT_KEY,
+    ETH_ACCOUNT_KEY,
+    getEthAccount,
+    getWalletState,
+} from './__fixtures__/walletState';
 import {
     type TransactionReviewOutputsState,
     selectCustomFeeLevel,
@@ -11,14 +20,23 @@ import {
     selectFormDraftByPrefix,
     selectIsClearSignedTradingSwap,
     selectIsTransactionAlreadySigned,
+    selectTransactionReviewOutputs,
 } from './selectors';
 import { type NativeSendRootState } from './sendFormSlice';
 
 const btcSymbol = asNetworkSymbol('btc');
 
+const mockConstructTransactionReviewOutputs = jest.fn();
+const mockGetTransactionReviewOutputState = jest.fn();
+
 jest.mock('@suite-common/wallet-utils', () => ({
     ...jest.requireActual('@suite-common/wallet-utils'),
     isClearSignedEvmTradingSwapTransaction: jest.fn().mockReturnValue(false),
+    constructTransactionReviewOutputs: (...args: unknown[]) =>
+        mockConstructTransactionReviewOutputs(...args),
+    getTransactionReviewOutputState: (...args: unknown[]) =>
+        mockGetTransactionReviewOutputState(...args),
+    getIsUpdatedSendFlow: () => true,
 }));
 
 const createMockState = (
@@ -299,6 +317,97 @@ describe('transaction-management selectors', () => {
             const result = selectFormDraftByPrefix(state, 'trading-buy', ETH_ACCOUNT_KEY);
 
             expect(result).toEqual(MOCK_DRAFT);
+        });
+    });
+
+    describe('selectTransactionReviewOutputs', () => {
+        const precomposedForm = { outputs: [] } as unknown as FormState;
+
+        const buildState = (buttonRequests: { code: string }[]): TransactionReviewOutputsState =>
+            ({
+                wallet: {
+                    ...getWalletState(),
+                    send: {
+                        ...getWalletState().send,
+                        precomposedTx: { totalSpent: '1', fee: '1' },
+                    },
+                },
+                device: {
+                    selectedDevice: { buttonRequests },
+                },
+            }) as unknown as TransactionReviewOutputsState;
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+            mockConstructTransactionReviewOutputs.mockReturnValue([
+                { type: 'address', value: 'addr' },
+                { type: 'amount', value: '1' },
+            ]);
+            mockGetTransactionReviewOutputState.mockReturnValue('active');
+        });
+
+        it('returns null when the precomposed form is missing', () => {
+            const state = buildState([]);
+
+            expect(
+                selectTransactionReviewOutputs(state, BTC_ACCOUNT_KEY, undefined, null),
+            ).toBeNull();
+        });
+
+        it('maps constructed outputs with their review state', () => {
+            const state = buildState([{ code: 'ButtonRequest_ConfirmOutput' }]);
+
+            expect(
+                selectTransactionReviewOutputs(state, BTC_ACCOUNT_KEY, undefined, precomposedForm),
+            ).toEqual([
+                { type: 'address', value: 'addr', state: 'active' },
+                { type: 'amount', value: '1', state: 'active' },
+            ]);
+        });
+
+        it('does not recompute when only the top-level state reference changes', () => {
+            const state = buildState([{ code: 'ButtonRequest_ConfirmOutput' }]);
+            const first = selectTransactionReviewOutputs(
+                state,
+                BTC_ACCOUNT_KEY,
+                undefined,
+                precomposedForm,
+            );
+
+            // A dispatch produces a new top-level state reference while the relevant slices
+            // (account, device, precomposed transaction) stay the same.
+            const nextState = { ...state };
+            const second = selectTransactionReviewOutputs(
+                nextState,
+                BTC_ACCOUNT_KEY,
+                undefined,
+                precomposedForm,
+            );
+
+            expect(second).toBe(first);
+            expect(mockConstructTransactionReviewOutputs).toHaveBeenCalledTimes(1);
+        });
+
+        it('recomputes when the send review button request count changes', () => {
+            const state = buildState([{ code: 'ButtonRequest_ConfirmOutput' }]);
+            selectTransactionReviewOutputs(state, BTC_ACCOUNT_KEY, undefined, precomposedForm);
+
+            // A new button request arrives on the same device — only the button requests change.
+            const nextState = {
+                ...state,
+                device: {
+                    selectedDevice: {
+                        buttonRequests: [
+                            { code: 'ButtonRequest_ConfirmOutput' },
+                            { code: 'ButtonRequest_SignTx' },
+                        ],
+                    },
+                },
+            } as unknown as TransactionReviewOutputsState;
+            selectTransactionReviewOutputs(nextState, BTC_ACCOUNT_KEY, undefined, precomposedForm);
+
+            expect(mockConstructTransactionReviewOutputs).toHaveBeenCalledTimes(2);
+            expect(mockGetTransactionReviewOutputState).toHaveBeenCalledWith(expect.any(Number), 2);
         });
     });
 });

--- a/suite-native/transaction-management/src/selectors.ts
+++ b/suite-native/transaction-management/src/selectors.ts
@@ -79,12 +79,29 @@ export const selectIsTransactionAlreadySigned = (state: NativeSendRootState) => 
     return isNotNullOrUndefined(serializedTx);
 };
 
+const selectSendReviewButtonRequestsCount = (
+    state: TransactionReviewOutputsState,
+    accountKey: AccountKey,
+    _tokenContract?: TokenAddress,
+    precomposedForm?: FormState | null,
+) => {
+    const account = selectAccountByKey(state, accountKey);
+    const precomposedTx = selectSendPrecomposedTx(state);
+
+    const decreaseOutputId =
+        precomposedTx && isRbfBumpFeeTransaction(precomposedTx) && precomposedTx.useNativeRbf
+            ? precomposedForm?.setMaxOutputId
+            : undefined;
+
+    return selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId);
+};
+
 export const selectTransactionReviewOutputs = createSendMemoizedSelector(
     [
-        state => state,
+        selectSendReviewButtonRequestsCount,
         (
             _state,
-            _accountKey: string,
+            _accountKey: AccountKey,
             _tokenContract?: TokenAddress,
             precomposedForm?: FormState | null,
         ) => precomposedForm,
@@ -93,7 +110,14 @@ export const selectTransactionReviewOutputs = createSendMemoizedSelector(
         selectSelectedDevice,
         selectIsTransactionAlreadySigned,
     ],
-    (state, precomposedForm, precomposedTx, account, device, isTransactionAlreadySigned) => {
+    (
+        sendReviewButtonRequests,
+        precomposedForm,
+        precomposedTx,
+        account,
+        device,
+        isTransactionAlreadySigned,
+    ) => {
         if (!account || !device || !precomposedForm || !precomposedTx) {
             return null;
         }
@@ -102,12 +126,6 @@ export const selectTransactionReviewOutputs = createSendMemoizedSelector(
             isRbfBumpFeeTransaction(precomposedTx) && precomposedTx.useNativeRbf
                 ? precomposedForm?.setMaxOutputId
                 : undefined;
-
-        const sendReviewButtonRequests = selectSendFormReviewButtonRequestsCount(
-            state,
-            account?.symbol,
-            decreaseOutputId,
-        );
 
         const outputs = constructTransactionReviewOutputs({
             account,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Optimize memoized selectors that were using anti-pattern `state => state` as `inputSelector`.

<!--- Describe your changes in detail -->

## Notes for QA
There should be no direct change. Maybe just less re-renders in trading.

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve #30879

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=commit-selector-antipattern&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->