### PR TITLE
feat(manual-tests): add manual tests for wallet mobile

### DIFF
--- a/packages/e2e-utils/src/enums/testAnnotations.ts
+++ b/packages/e2e-utils/src/enums/testAnnotations.ts
@@ -36,6 +36,8 @@ export enum TestCategory {
     Firmware = 'Firmware',
     CoinJoin = 'CoinJoin',
     Staking = 'Staking',
+    Earn = 'Earn',
+    MEV = 'MEV',
     Solana = 'Solana',
     Engagement = 'Engagement',
     Buy = 'Buy',
@@ -65,6 +67,7 @@ export const TestPriorityColors: Record<TestPriority, string> = {
 export enum TestStream {
     Trends = 'Trends', // do not use for new tests
     Wallet = 'Wallet',
+    Earn = 'Earn',
     Trade = 'Trade',
     Foundation = 'Foundation',
     Engagement = 'Engagement', // do not use for new tests

--- a/suite-native/app/e2e/tests/manual/wallet/assetDetail.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/assetDetail.test.ts
@@ -1,0 +1,31 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Asset detail screen',
+        {
+            testCase: 'The asset detail screen shows balances, price card and graph correctly',
+            prerequisites: [
+                'connected device',
+                'seed with funds on multiple accounts of one network',
+            ],
+            steps: [
+                'Navigate to an asset from the home screen and verify the asset detail opens',
+                'Open the gear icon and verify its content is displayed correctly',
+                'On earnable assets (e.g. ETH, USDT, USDC), verify the Earn badge is displayed',
+                'Verify both the fiat and the asset balance are displayed and match the sum of the accounts',
+                'Verify the price card displays the current price and the price change',
+                'On an asset with no transactions, verify the price card is displayed below the empty transactions state',
+                'Switch the graph timeframe to "All", leave the screen and return, and verify the timeframe is preserved',
+                'Open an account from the asset detail and verify the navigation to the account detail works',
+                'Open an account that has a balance but no recent transactions and check whether the Send button is visible.',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/cancelTransaction.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/cancelTransaction.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Cancel pending EVM transaction',
+        {
+            testCase:
+                'A pending Ethereum transaction can be cancelled by a replacement transaction',
+            prerequisites: ['connected device', 'seed with ETH funds on it'],
+            steps: [
+                'Navigate to an ETH account, send a transaction with a fee low enough to stay pending',
+                'Open the pending transaction detail and verify the cancel option is available',
+                'Start the cancel flow and verify the replacement fee is displayed and is higher than the original fee',
+                'Review the cancel transaction data and sign it on the device',
+                'Verify the original transaction is marked as cancelled once the replacement confirms',
+                'Verify the cancelled transaction is labelled as failed/cancelled in the account history',
+                'Verify the cancel option is not offered on an already confirmed transaction',
+            ],
+            category: TestCategory.ETH,
+            priority: TestPriority.High,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/coinControl.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/coinControl.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Coin control in BTC send',
+        {
+            testCase: 'UTXOs can be manually selected in the BTC send form (coin control)',
+            prerequisites: ['connected device', 'seed with a BTC account with multiple UTXOs'],
+            steps: [
+                'Navigate to the BTC account and open the send form',
+                'Open the coin control section',
+                'Verify all UTXOs are listed with address and amount',
+                'Select specific UTXOs for spending',
+                'Verify the spendable amount is limited to the selected UTXOs',
+                'Fill in the recipient and amount, review and sign the transaction on the device',
+                'Verify only the selected UTXOs were used as inputs in the transaction detail',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/customBackend.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/customBackend.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Custom backend',
+        {
+            testCase:
+                'A custom blockchain backend can be set for a coin and the app connects to it',
+            prerequisites: [
+                'connected device',
+                'seed with funds on it',
+                'URL of a working custom backend (e.g. a Blockbook instance)',
+            ],
+            steps: [
+                'Navigate to Settings > Coins and open the backends screen of an enabled coin (e.g. Bitcoin)',
+                'Select custom backend type and enter the custom backend URL',
+                'Confirm the change and wait for reconnection',
+                'Verify the accounts of the coin still load and sync via the custom backend',
+                'Enter an invalid URL and verify a validation error is shown',
+                'Revert to the default backend and verify the app reconnects',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/dustPhishing.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/dustPhishing.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Dust phishing protection and threshold',
+        {
+            testCase:
+                'Dust phishing protection hides dust transactions and the threshold can be changed',
+            prerequisites: [
+                'connected device',
+                'seed with an account containing dust transactions (very small incoming amounts)',
+            ],
+            steps: [
+                'Navigate to Settings > Security and open the Dust phishing protection screen',
+                'Enable the dust phishing protection',
+                'Navigate to the account with dust transactions',
+                'Verify transactions below the threshold are marked as suspected phishing',
+                'Go back to the dust phishing settings and change the threshold value',
+                'Verify the set of transactions marked as dust changes according to the new threshold',
+                'Disable the protection and verify dust transactions are displayed normally again',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/earnPage.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/earnPage.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Earn page',
+        {
+            testCase: 'The Earn screen lists staking and yield opportunities with APY breakdown',
+            prerequisites: ['connected device', 'seed with ETH and SOL funds on it'],
+            steps: [
+                'Navigate to the Earn screen',
+                'Verify eligible accounts are listed with staking and yield opportunities',
+                'Open the APY detail/breakdown and verify it explains how the APY is composed',
+                'Open the "How staking works" info and verify it is displayed correctly',
+                'Open the "How yield works" info and verify it is displayed correctly',
+                'Tap a staking opportunity and verify the app navigates to the staking flow',
+                'Tap a yield opportunity and verify the app navigates to the yield flow',
+                'With bonus rewards available, verify they are displayed on the Earn screen and can be claimed',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/earnPromoBanners.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/earnPromoBanners.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Earn promo banners on home screen',
+        {
+            testCase:
+                'Earn promo banners are displayed on the home screen and navigate to the right flows',
+            prerequisites: [
+                'connected device',
+                'seed with ETH and SOL funds eligible for earn opportunities',
+            ],
+            steps: [
+                'Open the home screen and verify the earn promo banners are displayed (ETH vault, DeFi yield, SOL staking)',
+                'Tap the banner and verify the app navigates to the corresponding earn flow',
+                'Dismiss a banner and verify it stays hidden after the app is restarted',
+                'Verify earnable assets on the home screen display the Earn badge',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.Medium,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/earnVaultDetail.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/earnVaultDetail.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Earn vault detail screen',
+        {
+            testCase: 'The vault detail screen shows correct vault information and rates',
+            prerequisites: ['connected device', 'seed with a yield-eligible account on it'],
+            steps: [
+                'Navigate to the Earn screen and open a vault detail',
+                'Verify the vault information is displayed correctly (name, token, rate, deposits)',
+                'Verify the rate badge on earnable tokens matches the rate kind (no APY label where a plain rate is used)',
+                'Verify the vault token symbol is displayed in its original casing (not uppercased)',
+                'Open the rate breakdown and verify it explains how the rate is composed',
+                'Start a deposit from the vault detail and verify the app navigates to the deposit flow',
+                'With claimable rewards available, open the claim entry flow and verify the vault association is shown',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.Medium,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/mevProtection.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/mevProtection.test.ts
@@ -1,0 +1,25 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'MEV protection',
+        {
+            testCase: 'MEV protection can be toggled and is applied to Ethereum transactions',
+            prerequisites: ['connected device', 'seed with ETH funds on it'],
+            steps: [
+                'Navigate to Settings > Security and locate the MEV protection toggle',
+                'Enable MEV protection',
+                'Navigate to an ETH account, open the send form and fill in a valid address and amount',
+                'Send a transaction and check that it was sent through MEV',
+                'Go back to Settings > Security and disable MEV protection',
+                'Repeat the send flow and verify that this transaction was sent without the MEV',
+            ],
+            category: TestCategory.MEV,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/networkReserves.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/networkReserves.test.ts
@@ -1,0 +1,25 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Network reserve check',
+        {
+            testCase: 'Network reserve check can be toggled and reserves are respected in send',
+            prerequisites: ['connected device', 'seed with Base/Optimism/RHC/SOL funds on it'],
+            steps: [
+                'Navigate to Settings > Advanced and locate the network reserve check toggle',
+                'Verify the toggle is enabled by default',
+                'Navigate to an Base/Optimism/RHC/SOL account, open the send form and try to send an amount that would break the reserve',
+                'Verify the reserve requirement warning is shown',
+                'Disable the reserve check in Settings and verify the send form no longer enforces it',
+                'Enable the toggle back',
+            ],
+            category: TestCategory.Settings,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/receiveAddressFeatures.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/receiveAddressFeatures.test.ts
@@ -1,0 +1,27 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Receive address history and verification guard',
+        {
+            testCase:
+                'Receive shows previously generated addresses and guards address verification',
+            prerequisites: ['connected device', 'seed with BTC and ETH funds on it'],
+            steps: [
+                'Navigate to a BTC account and open the receive flow',
+                'Generate a fresh address and verify it on the device',
+                'Reopen the receive flow and verify the previously generated addresses are listed in the address history',
+                'Verify a used address is marked as used in the history',
+                'Try to reveal an address without confirming it on the device and verify the verification guard prevents it',
+                'Navigate to an ETH account, open the receive flow and verify the Ethereum receive address info is displayed',
+                'Verify the ETH address stays the same across repeated receive flows',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.High,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/sendFormTrx.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/sendFormTrx.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Send form TRX',
+        {
+            testCase: 'Send form TRX',
+            prerequisites: ['connected device', 'seed with TRX funds on it'],
+            steps: [
+                'Navigate to TRX assets and select an account with funds',
+                'Click Send to open the send form',
+                'Enter a valid address and an amount; verify crypto/fiat values and switching between fields',
+                'Send to a fresh (not yet activated) address and verify the account activation info is shown',
+                'Continue to Review and sign; approve steps and verify prompt to continue on device',
+                'Approve address, amount and total including fee on the device',
+                'Click Send transaction and verify the transaction detail shows Pending',
+            ],
+            category: TestCategory.Device,
+            priority: TestPriority.High,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/stakingEth.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/stakingEth.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'ETH staking full flow - claim, stake, unstake',
+        {
+            testCase: 'The whole Ethereum staking lifecycle works: claim, stake and unstake',
+            prerequisites: [
+                'connected device',
+                'seed with ETH funds on it, with an existing stake and claimable funds',
+                'can be performed on the Hoodi testnet',
+            ],
+            steps: [
+                'Navigate to the Earn screen and open the ETH staking overview',
+                'Start the claim flow, review the transaction data and sign it on the device',
+                'Verify the claim transaction appears and the claimed funds are returned to the available balance',
+                'Start the staking flow',
+                'For first-time staking, verify the consent/acknowledge screen and confirm it',
+                'Fill in the amount to stake, verify crypto/fiat values and the fee',
+                'Review the transaction data, sign it on the device and verify the confirmation screen',
+                'Verify the staking transaction appears in the account and the staked balance updates',
+                'Open the staking management and start the unstake flow',
+                'Fill in the amount, review and sign the unstake transaction on the device',
+                'Verify the pending unstake is displayed in the staking overview',
+            ],
+            category: TestCategory.Staking,
+            priority: TestPriority.Critical,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/stakingSol.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/stakingSol.test.ts
@@ -1,0 +1,34 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'SOL staking full flow - claim, stake, unstake',
+        {
+            testCase: 'The whole Solana staking lifecycle works: claim, stake and unstake',
+            prerequisites: [
+                'connected device',
+                'seed with SOL funds on it, with an existing stake and deactivated (claimable) funds',
+                'can be performed on the Solana devnet',
+            ],
+            steps: [
+                'Navigate to the Earn screen and open the SOL staking overview',
+                'Start the claim flow, review the transaction data and sign it on the device',
+                'Verify the claimed funds are returned to the available balance',
+                'Start the staking flow',
+                'For first-time staking, verify the consent/acknowledge screen and confirm it',
+                'Fill in the amount to stake, verify crypto/fiat values and the fee',
+                'Review the transaction data, sign it on the device and verify the confirmation screen',
+                'Verify the staking transaction appears and the staked balance updates',
+                'Open the staking management and start the unstake flow',
+                'Fill in the amount, review and sign the unstake transaction on the device',
+                'Verify the stake enters the deactivation period',
+            ],
+            category: TestCategory.Staking,
+            priority: TestPriority.Critical,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/tokenManagement.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/tokenManagement.test.ts
@@ -1,0 +1,26 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Token management - hide and unhide a token',
+        {
+            testCase: 'Tokens are listed for an account and can be hidden and unhidden',
+            prerequisites: ['connected device', 'seed with an EVM account holding tokens'],
+            steps: [
+                'Navigate to the EVM account and open its tokens list',
+                'Verify held tokens are listed with balance and fiat value',
+                'Open the token settings of a token and hide it',
+                'Verify the token is no longer displayed in the tokens list',
+                'Unhide the token via the token settings',
+                'Verify the token is displayed in the tokens list again',
+                'Verify unverified/unknown tokens are communicated appropriately',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Medium,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/transactionDetail.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/transactionDetail.test.ts
@@ -1,0 +1,30 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Transaction list and detail',
+        {
+            testCase:
+                'The transaction list and transaction detail sheets show complete information',
+            prerequisites: ['connected device', 'seed with transaction history on it'],
+            steps: [
+                'Navigate to an account with transaction history',
+                'Verify transaction items display type (sent/received/self/wrap/unwrap/approve...), date and crypto/fiat amounts',
+                'Send a small transaction and verify it is displayed as pending until confirmed',
+                'Scroll through the history and verify older transactions keep loading',
+                'Open a transaction detail and verify the overview (status, date, amount) is correct',
+                'Open the inputs & outputs sheet and verify all addresses and amounts are listed',
+                'Open the parameters sheet and verify txid, fee and other parameters are correct',
+                'Open the compare values and verify crypto and historical fiat values are displayed',
+                'For an EVM transaction with data, verify the transaction data is displayed',
+                'Verify the block explorer link opens the transaction in the explorer',
+            ],
+            category: TestCategory.Accounts,
+            priority: TestPriority.Critical,
+            stream: TestStream.Wallet,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/wrapUnwrapNativeToken.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/wrapUnwrapNativeToken.test.ts
@@ -1,0 +1,56 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Standalone wrap native token',
+        {
+            testCase: 'A user can wrap a native token (ETH -> WETH) via the standalone flow',
+            prerequisites: [
+                'connected device with firmware 2.12.4 or newer',
+                'seed with ETH funds on it',
+                'dev mode enabled in the app',
+            ],
+            steps: [
+                'Navigate to an ETH account and open the settings',
+                'Verify the wrap entry point is present and open the wrap flow',
+                'Verify the account balance is displayed in the screen header',
+                'Fill in an amount and verify the crypto/fiat input switching works',
+                'Verify an amount exceeding the balance is rejected with a validation error',
+                'Review the transaction data and sign it on the device',
+                'Verify the complete screen shows the sent amount without a minus sign',
+                'Verify the transaction in the account history carries the wrap label',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.Medium,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+
+    it(
+        'Standalone unwrap native token',
+        {
+            testCase: 'A user can unwrap a wrapped token (WETH -> ETH) via the standalone flow',
+            prerequisites: [
+                'connected device with firmware 2.12.4 or newer',
+                'seed with WETH funds on it',
+            ],
+            steps: [
+                'Navigate to the account holding WETH and open the settings',
+                'Verify the unwrap entry point is present and open the unwrap flow',
+                'Verify the token pair is shown in the screen title and the account balance in the header',
+                'Fill in an amount and verify the crypto/fiat input switching works',
+                'Verify a prefilled amount is revalidated when the balance changes in the meantime',
+                'Review the transaction data and sign it on the device',
+                'Verify the complete screen shows the sent amount without a minus sign',
+                'Verify the transaction in the account history carries the unwrap label',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/xlmTokenActivation.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/xlmTokenActivation.test.ts
@@ -4,7 +4,7 @@ import { it } from '../../../support/wrappedIt';
 
 describe.skip('Manual', () => {
     it(
-        'Send form XLM',
+        'XLM token activation',
         {
             testCase: 'XLM token activation',
             prerequisites: ['connected device', 'seed with funds on it'],

--- a/suite-native/app/e2e/tests/manual/wallet/yieldDepositWithdrawClaim.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/yieldDepositWithdrawClaim.test.ts
@@ -1,0 +1,52 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Yield deposit with approval flow',
+        {
+            testCase:
+                'A user can deposit into a yield opportunity including the token approval step',
+            prerequisites: [
+                'connected device',
+                'seed with a yield-eligible EVM account (e.g. stablecoin without prior approval)',
+            ],
+            steps: [
+                'Navigate to the Earn screen and select a yield opportunity',
+                'For first-time use, verify the consent/acknowledge screen and confirm it',
+                'Start the deposit flow and fill in an amount',
+                'Verify the approval step is required, review the approval transaction data and sign it on the device',
+                'Continue with the deposit, review the transaction data and sign it on the device',
+                'Verify the deposit complete screen and that the position is displayed in the yield overview',
+                'Verify insufficient balance is handled correctly when the amount exceeds the balance',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+
+    it(
+        'Yield withdraw and claim rewards',
+        {
+            testCase: 'A user can withdraw from a yield position and claim rewards',
+            prerequisites: [
+                'connected device',
+                'seed with an active yield position and claimable rewards',
+            ],
+            steps: [
+                'Navigate to the yield position and start the withdraw flow',
+                'Fill in the amount to withdraw, review the transaction and sign it on the device',
+                'Verify the withdraw complete screen and that the funds are returned to the available balance',
+                'Start the claim rewards flow, review the transaction and sign it on the device',
+                'Verify the claim complete screen and that the claimed rewards are reflected in the balance',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});

--- a/suite-native/app/e2e/tests/manual/wallet/yieldWrapUnwrapSteps.test.ts
+++ b/suite-native/app/e2e/tests/manual/wallet/yieldWrapUnwrapSteps.test.ts
@@ -1,0 +1,55 @@
+import { TestCategory, TestPriority, TestStream } from '@trezor/e2e-utils';
+
+import { it } from '../../../support/wrappedIt';
+
+describe.skip('Manual', () => {
+    it(
+        'Yield deposit with wrap step (WETH vault)',
+        {
+            testCase:
+                'Native ETH can be deposited into a WETH vault, with the wrap step included in the deposit flow',
+            prerequisites: [
+                'connected device with firmware 2.12.4 or newer',
+                'seed with native ETH funds (no WETH) on it',
+            ],
+            steps: [
+                'Navigate to the Earn screen and verify the native ETH balance is counted as depositable for the WETH vault',
+                'Verify the vault is communicated as ETH (icon and symbol), not WETH',
+                'Start the deposit flow and fill in an amount higher than the WETH balance',
+                'Verify the wrap step is added to the flow and review its transaction data',
+                'Sign the wrap transaction on the device and verify the flow continues to the deposit step',
+                'Verify no separate approval step is required for the vault deposit',
+                'Review the deposit transaction data and sign it on the device',
+                'Verify the complete screen and that the position is displayed in the yield overview',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+
+    it(
+        'Yield withdraw with unwrap step (WETH vault)',
+        {
+            testCase:
+                'A WETH vault position can be withdrawn with the unwrap step included, ending in native ETH',
+            prerequisites: [
+                'connected device with firmware 2.12.4 or newer',
+                'seed with an active WETH vault position',
+            ],
+            steps: [
+                'Navigate to the yield position and start the withdraw flow',
+                'Use the max button and verify the fiat summary matches the withdrawn amount',
+                'Review the withdraw transaction data and sign it on the device',
+                'Verify the unwrap step follows, review its transaction data and sign it on the device',
+                'Verify the complete screen shows the received amount in ETH without a minus sign',
+                'Verify the native ETH balance increases and the position is removed from the yield overview',
+            ],
+            category: TestCategory.Earn,
+            priority: TestPriority.High,
+            stream: TestStream.Earn,
+        },
+        async () => {},
+    );
+});


### PR DESCRIPTION
## Description

Adds manual test definitions for the mobile Wallet and Earn streams:

- New manual tests covering recent suite-native features: standalone wrap/unwrap, WETH vault wrap/unwrap steps, earn vault detail, earn promo banners, transaction cancellation, receive address features, asset detail, and more.
- Splits tests into Wallet and new Earn streams; adds Earn and MEV test categories to @trezor/e2e-utils.


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The PR changes are entirely within suite-native mobile wallet E2E tests and the shared testAnnotations.ts enum utility. The 145 analyzed candidate tests cover the desktop/web suite and do not include these mobile-specific files, so no desktop tests are recommended. The safest strategy is to run all 20 changed mobile test files directly, which also indirectly exercises the shared annotation enum change.

<details><summary><b>Changed files (21)</b></summary>

- `packages/e2e-utils/src/enums/testAnnotations.ts`
- `suite-native/app/e2e/tests/manual/wallet/assetDetail.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/cancelTransaction.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/coinControl.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/customBackend.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/dustPhishing.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/earnPage.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/earnPromoBanners.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/earnVaultDetail.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/mevProtection.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/networkReserves.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/receiveAddressFeatures.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/sendFormTrx.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/stakingEth.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/stakingSol.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/tokenManagement.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/transactionDetail.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/wrapUnwrapNativeToken.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/xlmTokenActivation.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/yieldDepositWithdrawClaim.test.ts`
- `suite-native/app/e2e/tests/manual/wallet/yieldWrapUnwrapSteps.test.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (20)</b></summary>

- `suite-native/app/e2e/tests/manual/wallet/assetDetail.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/cancelTransaction.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/coinControl.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/customBackend.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/dustPhishing.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/earnPage.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/earnPromoBanners.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/earnVaultDetail.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/mevProtection.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/networkReserves.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/receiveAddressFeatures.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/sendFormTrx.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/stakingEth.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/stakingSol.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/tokenManagement.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/transactionDetail.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/wrapUnwrapNativeToken.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/xlmTokenActivation.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/yieldDepositWithdrawClaim.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.
- `suite-native/app/e2e/tests/manual/wallet/yieldWrapUnwrapSteps.test.ts` — This mobile wallet E2E test file was directly modified in the PR; running it validates that the changes work correctly.

</details>

_Updated: 2026-08-27T10:11:39.379Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/wallet-manual-tests-mobile/web/](https://dev.suite.sldev.cz/suite-web/wallet-manual-tests-mobile/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=wallet-manual-tests-mobile&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=wallet-manual-tests-mobile&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=wallet-manual-tests-mobile&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |

</details>

_Updated: 2026-08-27T10:09:32.035Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Discovery > go to wallet settings page, activate all coins and see that there is equal number of records on dashboard | 🤖 auto |
| Quarantine test: "TrezorConnect popup web,call cancelled from calling application" | 🙋 manual |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |
| Quarantine test: "Recovery T2T1 - dry run,Recovery after partial recovery" | 🙋 manual |

</details>

_Updated: 2026-08-27T10:09:25.702Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->