### PR TITLE
chore(message-system): update yield promo banners

### DIFF
--- a/suite-common/message-system/config/config.v1.json
+++ b/suite-common/message-system/config/config.v1.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
-    "timestamp": "2026-08-07T12:00:00+00:00",
-    "sequence": 154,
+    "timestamp": "2026-08-18T12:00:00+00:00",
+    "sequence": 155,
     "actions": [
         {
             "conditions": [
@@ -1547,15 +1547,15 @@
             "conditions": [
                 {
                     "environment": {
-                        "desktop": ">=26.5.1",
+                        "desktop": ">=26.8.1",
                         "mobile": "!",
                         "web": "*"
                     }
                 }
             ],
             "message": {
-                "id": "ab805171-6266-4618-be4f-a7c25d4c19ce",
-                "priority": 3,
+                "id": "27084e46-34ca-43db-8ce7-897b08a33fcf",
+                "priority": 5,
                 "dismissible": true,
                 "variant": "info",
                 "category": "feature",
@@ -1577,7 +1577,47 @@
                 "feature": [
                     {
                         "domain": "dashboard.promoBanner",
-                        "visibleBanner": "stablecoin-yield",
+                        "visibleBanner": "defi-yield",
+                        "flag": true
+                    }
+                ]
+            }
+        },
+        {
+            "conditions": [
+                {
+                    "environment": {
+                        "desktop": ">=26.8.1",
+                        "mobile": "!",
+                        "web": "*"
+                    }
+                }
+            ],
+            "message": {
+                "id": "aa95f6d2-647d-42c6-a250-6900f2a957d0",
+                "priority": 4,
+                "dismissible": true,
+                "variant": "info",
+                "category": "feature",
+                "content": {
+                    "en-GB": "Placehodler",
+                    "en": "Placehodler",
+                    "es": "Placehodler",
+                    "cs": "Placehodler",
+                    "de": "Placehodler",
+                    "fr": "Placehodler",
+                    "it": "Placehodler",
+                    "pt": "Placehodler",
+                    "tr": "Placehodler",
+                    "ru": "Placehodler",
+                    "ja": "Placehodler",
+                    "uk": "Placehodler",
+                    "hu": "Placehodler"
+                },
+                "feature": [
+                    {
+                        "domain": "dashboard.promoBanner",
+                        "visibleBanner": "eth-vault",
                         "flag": true
                     }
                 ]


### PR DESCRIPTION
## Description

- activate `defi-yield`
- activate `eth-vault`
- disable  `stablecoin-yield`

## Notes for QA

Check if the dashboard promo banners are displayed.

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a message-system configuration JSON with no static E2E coverage. Its effects are data-dependent: it could surface, hide, or alter in-app messages/banners. The connect popup webextension test is the only candidate that explicitly references the remote message system mock, so running it provides a sanity check that no unexpected modal or banner interferes with a real user flow. Otherwise, coverage relies on lower-level or manual validation of the config content.

<details><summary><b>Changed files (1)</b></summary>

- `suite-common/message-system/config/config.v1.json`

</details>

**Recommended tests (1)**

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trezor-connect/connectPopupWebextension.test.ts` — This test initializes a remote message system mock (mockRemoteMessageSystem) as part of its Suite Web setup. A change to suite-common/message-system/config/config.v1.json could affect the shape, loading, or suppression of message-system banners/modals, which in turn could interfere with the Connect permissions and address confirmation flows exercised here.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/message-system/config/config.v1.json`

_Updated: 2026-08-18T09:31:44.055Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/message-system-yield-promo-banners-update/web/](https://dev.suite.sldev.cz/suite-web/chore/message-system-yield-promo-banners-update/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/message-system-yield-promo-banners-update&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/message-system-yield-promo-banners-update&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=chore/message-system-yield-promo-banners-update&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T09:33:54.929Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T09:33:23.449Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->