### PR TITLE
fix(suite-desktop): do not turn on Sentry in --offline-mode

### DIFF
--- a/packages/suite-desktop-core/src/libs/sentry.ts
+++ b/packages/suite-desktop-core/src/libs/sentry.ts
@@ -11,6 +11,7 @@ import { TorStatus } from '@suite/tor-types';
 
 import type { Store } from './store';
 import type { MainThreadEmitter } from '../modules';
+import { hasSwitch } from './process-switches';
 
 interface InitSentryParams {
     mainThreadEmitter: MainThreadEmitter;
@@ -19,6 +20,8 @@ interface InitSentryParams {
 
 const ELECTRON_MAIN_SENTRY_CONFIG = {
     ...SENTRY_CONFIG,
+    // Force turn off Sentry in offline mode, because prevent noise from Sentry (blocked domains).
+    enabled: SENTRY_CONFIG.enabled && !hasSwitch('offline-mode'),
     // Important: must be a function to keep default Sentry integrations; an array would mean ONLY those specific integrations.
     integrations: defaults => [
         ...defaults.filter(i => i.name !== 'MainProcessSession'),


### PR DESCRIPTION
## Description

Remove some noise from sentry by turning it off in offline mode.

All fetch requests fail with `Request blocked, not whitelisted domain`, which is intended – in `offline-mode` we want to allow localhost but disallow all external domains. But it does a lot of noise in Sentry. 

## Related Issue

Related: https://satoshilabs.sentry.io/issues/6597340445/

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The only changed file is a global error-reporting module in the desktop core main process with no static test coverage. The main risk is a startup crash or main-process failure caused by changes to Sentry initialization. A single Electron smoke test that verifies the desktop app launches and initializes provides the most targeted safety net; no other tests are likely to surface a Sentry-specific regression.

<details><summary><b>Changed files (1)</b></summary>

- `packages/suite-desktop-core/src/libs/sentry.ts`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — Sentry.ts lives in the desktop core main-process code and is typically initialized during Electron app startup. This test launches the Electron Suite app and verifies it initializes successfully (window title, bridge running, app initialized), so it acts as a smoke test for any Sentry regression that would crash or prevent the main process from starting.

</details>

_Updated: 2026-08-18T10:02:07.415Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/turn-off-sentry-in-offline-mode/web/](https://dev.suite.sldev.cz/suite-web/fix/turn-off-sentry-in-offline-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/turn-off-sentry-in-offline-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/turn-off-sentry-in-offline-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T10:03:55.874Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->