### PR TITLE
fix(suite): use discrete mode in yield claim

### DIFF
--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx
@@ -1,4 +1,5 @@
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
+import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -64,10 +65,15 @@ export const EarnYieldClaimRewardsBanner = ({
                         <Skeleton width={50} height={16} animate />
                     ) : (
                         <>
-                            <Text typographyStyle="body-sm-strong">
-                                {!isClaimDisabled && '≈ '}
-                                <BaseCurrencyAmountFormatter value={value} currency={currency} />
-                            </Text>
+                            <HiddenPlaceholder>
+                                <Text typographyStyle="body-sm-strong">
+                                    {!isClaimDisabled && '≈ '}
+                                    <BaseCurrencyAmountFormatter
+                                        value={value}
+                                        currency={currency}
+                                    />
+                                </Text>
+                            </HiddenPlaceholder>
 
                             {tokenRewards.length > 0 && (
                                 <EarnYieldClaimRewardsBannerTokensTooltip

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx
@@ -1,4 +1,5 @@
 import { AccountLabel } from '@suite/account';
+import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { useFormatters } from '@suite-common/formatters';
 import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
@@ -31,12 +32,14 @@ export const EarnYieldClaimRewardsBannerAccountsTooltip = ({
                                 <AccountLabel account={account} showAccountTypeBadge />
                             </Text>
 
-                            <Text align="end">
-                                <BaseCurrencyAmountFormatter
-                                    value={asBaseCurrencyAmount(fiat)}
-                                    currency={currency}
-                                />
-                            </Text>
+                            <HiddenPlaceholder>
+                                <Text align="end">
+                                    <BaseCurrencyAmountFormatter
+                                        value={asBaseCurrencyAmount(fiat)}
+                                        currency={currency}
+                                    />
+                                </Text>
+                            </HiddenPlaceholder>
                         </>
                     ))}
                 </Grid>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx
@@ -4,7 +4,7 @@ import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
 import { type BaseCurrencyCode } from '@trezor/blockchain-link-types';
 import { Grid, Text, Tooltip } from '@trezor/components';
 
-import { FormattedCryptoAmount } from 'src/components/suite';
+import { FormattedCryptoAmount, HiddenPlaceholder } from 'src/components/suite';
 
 import { type TokenRewards } from './hooks/useYieldClaimRewardsData';
 
@@ -32,12 +32,14 @@ export const EarnYieldClaimRewardsBannerTokensTooltip = ({
                                 <FormattedCryptoAmount value={crypto.toString()} symbol={symbol} />
                             </Text>
 
-                            <Text align="end">
-                                <BaseCurrencyAmountFormatter
-                                    value={asBaseCurrencyAmount(fiat)}
-                                    currency={currency}
-                                />
-                            </Text>
+                            <HiddenPlaceholder>
+                                <Text align="end">
+                                    <BaseCurrencyAmountFormatter
+                                        value={asBaseCurrencyAmount(fiat)}
+                                        currency={currency}
+                                    />
+                                </Text>
+                            </HiddenPlaceholder>
                         </>
                     ))}
                 </Grid>

--- a/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
+++ b/packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx
@@ -2,6 +2,7 @@ import { AccountLabel } from '@suite/account';
 import { Address } from '@suite/address';
 import { selectDesktopAnalyticsDep } from '@suite/analytics';
 import { DebugOnlyBadge, selectIsDebugModeActive } from '@suite/debug';
+import { HiddenPlaceholder } from '@suite/discreet-mode';
 import { Translation } from '@suite/intl';
 import { events } from '@suite-common/analytics';
 import { useServices } from '@suite-common/dependency-injection';
@@ -104,11 +105,13 @@ export const EarnYieldClaimSelectAccountModal = ({
                                 ) : undefined
                             }
                         >
-                            <Text typographyStyle="body-md-strong">
-                                {BaseCurrencyAmountFormatter.format(
-                                    accountRewards.totalClaimableFiatAmount,
-                                )}
-                            </Text>
+                            <HiddenPlaceholder>
+                                <Text typographyStyle="body-md-strong">
+                                    {BaseCurrencyAmountFormatter.format(
+                                        accountRewards.totalClaimableFiatAmount,
+                                    )}
+                                </Text>
+                            </HiddenPlaceholder>
                         </Tooltip>
                     </CardList.Item>
                 ))}


### PR DESCRIPTION
## Description

Use discrete mode in Yield claim flow.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/30899

## Screenshots:

<img width="1512" height="787" alt="Screenshot 2026-08-18 at 13 55 39" src="https://github.com/user-attachments/assets/7071a938-5838-498f-ad06-885f16bd4ff5" />

<img width="1512" height="787" alt="Screenshot 2026-08-18 at 13 55 45" src="https://github.com/user-attachments/assets/d057de38-b8d2-4f72-998c-7e532bfbb3af" />

<img width="1512" height="787" alt="Screenshot 2026-08-18 at 13 55 48" src="https://github.com/user-attachments/assets/7006a792-0aff-48a4-9509-f907f27e8c30" />

<img width="1512" height="787" alt="Screenshot 2026-08-18 at 14 03 30" src="https://github.com/user-attachments/assets/bdd9743d-b74b-4f1c-ae8c-eed280525eda" />

<img width="1512" height="787" alt="Screenshot 2026-08-18 at 14 03 36" src="https://github.com/user-attachments/assets/75362e42-24db-48c1-ba2c-5f0d1bb03c51" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-claim-discrete-mode/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-claim-discrete-mode/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are narrow Earn/Yield dashboard components for a claim-rewards banner, account/token tooltips, and an account-selection modal. Static coverage maps each file to 134 tests, which strongly suggests transitive/shared imports rather than direct rendering. The most relevant coverage comes from the staking claim/unstake flows (ADA, ETH, SOL), which share the same 'claim rewards' user intent and state. No analyzed test explicitly exercises the dashboard banner itself, so these recommendations are inferred rather than direct.

<details><summary><b>Changed files (4)</b></summary>

- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBanner.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerAccountsTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimRewardsBannerTokensTooltip.tsx`
- `packages/suite/src/components/earn/dashboard/yield/EarnYieldClaimSelectAccountModal.tsx`

</details>

**Recommended tests (3)**

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/staking/ada/claim.test.ts` — This test exercises the Cardano claim rewards flow (claim rewards button, TR_EARN_CLAIM_REWARDS modal, reward display). The changed EarnYieldClaimRewardsBanner and related tooltip/modal components implement the same claim-rewards entry point, so regressions in the banner or account-selection modal could affect how users reach this flow.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — The test covers the Ethereum claim/unstake flow including claimable balance display and the claim modal. Changes to the claim rewards banner or account-selection modal could impact the state transition from 'claimable rewards' to the claim modal that this flow validates.
- `suite/e2e/tests/staking/sol/unstake.test.ts` — This test validates Solana unstaking and claiming, including claim card visibility and claim modal. It is functionally adjacent to the claim rewards banner components and can catch regressions in claim-rewards state presentation or modal interaction.

</details>

_Updated: 2026-08-18T12:40:27.235Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-claim-discrete-mode&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-claim-discrete-mode&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T12:40:07.896Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T12:40:42.392Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->