### PR TITLE
feat(tx-simulation): adds primitives for cross-chain simulation results parsing

### DIFF
--- a/jest.config.native.js
+++ b/jest.config.native.js
@@ -47,7 +47,6 @@ module.exports = {
         '<rootDir>/../../suite-native/test-utils/src/mocks/everstakeJestSetup.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/TextEncoderMock.js',
         '<rootDir>/../../suite-native/test-utils/src/mocks/randomUUIDMock.js',
-        '<rootDir>/../../suite-common/tx-simulation/src/jestSetup.ts',
         '<rootDir>/../../node_modules/@shopify/react-native-skia/jestSetup.js',
         '<rootDir>/../../node_modules/@shopify/flash-list/jestSetup.js',
         '<rootDir>/../../node_modules/react-native-gesture-handler/jestSetup.js',

--- a/packages/suite/jest.config.js
+++ b/packages/suite/jest.config.js
@@ -37,7 +37,6 @@ module.exports = {
     ],
     setupFiles: [
         'jest-canvas-mock', // for lottie-react
-        require('path').resolve(__dirname, '../../suite-common/tx-simulation/src/jestSetup.ts'),
     ],
     setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     moduleNameMapper: {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
@@ -187,7 +187,11 @@ describe('TradingOfferExchange', () => {
         renderOfferExchange();
 
         expect(screen.getByTestId('info-item-receive')).toHaveTextContent('1100');
-        expect(mockGetSimulatedReceiveAmount).toHaveBeenCalledWith(undefined, TETHER_CRYPTO_ID);
+        expect(mockGetSimulatedReceiveAmount).toHaveBeenCalledWith(
+            undefined,
+            ETHEREUM_CRYPTO_ID,
+            TETHER_CRYPTO_ID,
+        );
     });
 
     it('prefers the simulated receive amount over the quote one', () => {

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -86,6 +86,7 @@ export const TradingOfferExchange = () => {
 
     const simulatedReceiveAmount = getSimulatedReceiveAmount(
         simulationResult,
+        selectedTrade.send,
         selectedTrade.receive,
     );
     const hasIssueToResolve = isSimulationEnabled && issue !== null;

--- a/suite-common/trading/jest.config.js
+++ b/suite-common/trading/jest.config.js
@@ -4,9 +4,6 @@ module.exports = {
     ...baseConfig,
     testEnvironment: 'jsdom',
 
-    // The Blockaid client (via @suite-common/tx-simulation) needs its node fetch shim
-    // registered before any test module imports it.
-    setupFiles: [require('path').resolve(__dirname, '../tx-simulation/src/jestSetup.ts')],
     setupFilesAfterEnv: [require('path').resolve(__dirname, '../../packages/suite/jest.setup.js')],
     moduleNameMapper: {
         ...baseConfig.moduleNameMapper,

--- a/suite-common/trading/src/hooks/useExchangeIssue.test.ts
+++ b/suite-common/trading/src/hooks/useExchangeIssue.test.ts
@@ -23,12 +23,12 @@ jest.mock('./useExchangeFiatDeviation', () => ({
 const mockUseDexExchangeTxSimulation = jest.mocked(useDexExchangeTxSimulation);
 const mockUseExchangeFiatDeviation = jest.mocked(useExchangeFiatDeviation);
 
-// Contract-less receive crypto id so the NATIVE asset diff of the simulation matches it.
+// Same-chain, so the NATIVE diff below is genuinely the receive asset.
 const selectedQuote: ExchangeTrade = {
     exchange: 'changelly',
-    receive: 'bitcoin' as CryptoId,
+    receive: 'ethereum' as CryptoId,
     receiveStringAmount: '0.0609979',
-    send: 'litecoin' as CryptoId,
+    send: `ethereum--0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48` as CryptoId,
     sendStringAmount: '12',
 };
 const account = accountEth as Account;

--- a/suite-common/trading/src/hooks/useExchangeIssue.ts
+++ b/suite-common/trading/src/hooks/useExchangeIssue.ts
@@ -36,7 +36,11 @@ export const useExchangeIssue = ({
         data: simulationResult,
     } = useDexExchangeTxSimulation({ account, isEnabled, sourceOrigin });
 
-    const simulatedReceiveAmount = getSimulatedReceiveAmount(simulationResult, quote?.receive);
+    const simulatedReceiveAmount = getSimulatedReceiveAmount(
+        simulationResult,
+        quote?.send,
+        quote?.receive,
+    );
 
     const fiatDeviation = useExchangeFiatDeviation({
         fiatCurrency,

--- a/suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts
+++ b/suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts
@@ -1,0 +1,54 @@
+import { type ExchangeTrade } from 'invity-api';
+
+import { type Account } from '@suite-common/wallet-types';
+
+import { composeDexTxSimulationAction } from './composeDexTxSimulationAction';
+import { accountEth } from '../../__fixtures__/utils';
+
+const sourceOrigin = 'trezor-suite://trading-dex-swap';
+
+const dexQuote = {
+    isDex: true,
+    dexTx: {
+        from: '0x0000000000000000000000000000000000001234',
+        to: '0x000000000000000000000000000000000000abcd',
+        value: '1',
+        data: '0xdeadbeef',
+    },
+} as ExchangeTrade;
+
+const compose = (quote: ExchangeTrade | undefined, account: Account | undefined) =>
+    composeDexTxSimulationAction({ quote, account, sourceOrigin });
+
+describe('composeDexTxSimulationAction', () => {
+    it('returns null for a non-DEX quote', () => {
+        expect(compose({ ...dexQuote, isDex: false }, accountEth as Account)).toBeNull();
+    });
+
+    it('returns null without an account', () => {
+        expect(compose(dexQuote, undefined)).toBeNull();
+    });
+
+    it('composes an ethereumSignTransaction action for an EVM swap', () => {
+        expect(compose(dexQuote, accountEth as Account)).toMatchObject({
+            method: 'ethereumSignTransaction',
+            fromAddress: dexQuote.dexTx?.from,
+            sourceOrigin,
+            payload: { transaction: { to: dexQuote.dexTx?.to, chainId: 1 } },
+        });
+    });
+
+    it.each(['etc', 'thod'] as const)('returns null for %s, which Blockaid cannot scan', symbol => {
+        expect(compose(dexQuote, { ...accountEth, symbol } as Account)).toBeNull();
+    });
+
+    it('returns null for a network without simulation support', () => {
+        expect(
+            compose(dexQuote, {
+                ...accountEth,
+                networkType: 'bitcoin',
+                symbol: 'btc',
+            } as Account),
+        ).toBeNull();
+    });
+});

--- a/suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts
+++ b/suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts
@@ -1,5 +1,6 @@
 import { type ExchangeTrade } from 'invity-api';
 
+import { isBlockaidSupportedNetwork } from '@suite-common/tx-simulation';
 import { getNetwork } from '@suite-common/wallet-config';
 import { type Account, type TxSimulationAction } from '@suite-common/wallet-types';
 import { fromEther } from '@suite-common/wallet-utils';
@@ -21,7 +22,7 @@ export const composeDexTxSimulationAction = ({
     account,
     sourceOrigin,
 }: ComposeDexTxSimulationActionParams): TxSimulationAction | null => {
-    if (!quote?.isDex || !account) {
+    if (!quote?.isDex || !account || !isBlockaidSupportedNetwork(account.symbol)) {
         return null;
     }
 

--- a/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
+++ b/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts
@@ -37,36 +37,37 @@ const createSimulationResult = (
         },
     }) as unknown as NetworkTxSimulationResult;
 
+const sendQuote: CryptoId = `ethereum--${USDC_CONTRACT}` as CryptoId;
 const nativeQuoteReceive: CryptoId = 'ethereum' as CryptoId;
 const tokenQuoteReceive: CryptoId = `ethereum--${USDC_CONTRACT}` as CryptoId;
 
 describe('getSimulatedReceiveAmount', () => {
     it('returns null without a simulation result', () => {
-        expect(getSimulatedReceiveAmount(undefined, nativeQuoteReceive)).toBeNull();
+        expect(getSimulatedReceiveAmount(undefined, sendQuote, nativeQuoteReceive)).toBeNull();
     });
 
     it('returns null without a quote', () => {
         const result = createSimulationResult([nativeAssetDiff]);
 
-        expect(getSimulatedReceiveAmount(result, undefined)).toBeNull();
+        expect(getSimulatedReceiveAmount(result, sendQuote, undefined)).toBeNull();
     });
 
     it('returns null when the simulation errored', () => {
         const result = createSimulationResult([nativeAssetDiff], { simulationStatus: 'Error' });
 
-        expect(getSimulatedReceiveAmount(result, nativeQuoteReceive)).toBeNull();
+        expect(getSimulatedReceiveAmount(result, sendQuote, nativeQuoteReceive)).toBeNull();
     });
 
     it('returns the incoming native amount for a native receive asset', () => {
         const result = createSimulationResult([usdcAssetDiff, nativeAssetDiff]);
 
-        expect(getSimulatedReceiveAmount(result, nativeQuoteReceive)).toBe('1');
+        expect(getSimulatedReceiveAmount(result, sendQuote, nativeQuoteReceive)).toBe('1');
     });
 
     it('matches an ERC20 receive asset by contract address case-insensitively', () => {
         const result = createSimulationResult([nativeAssetDiff, usdcAssetDiff]);
 
-        expect(getSimulatedReceiveAmount(result, tokenQuoteReceive)).toBe('250');
+        expect(getSimulatedReceiveAmount(result, sendQuote, tokenQuoteReceive)).toBe('250');
     });
 
     it('prefers exact raw_value math over the float-derived value', () => {
@@ -79,7 +80,7 @@ describe('getSimulatedReceiveAmount', () => {
             },
         ]);
 
-        expect(getSimulatedReceiveAmount(result, tokenQuoteReceive)).toBe('0.971813');
+        expect(getSimulatedReceiveAmount(result, sendQuote, tokenQuoteReceive)).toBe('0.971813');
     });
 
     it('sums multiple incoming transfers of the receive asset', () => {
@@ -91,7 +92,7 @@ describe('getSimulatedReceiveAmount', () => {
             },
         ]);
 
-        expect(getSimulatedReceiveAmount(result, tokenQuoteReceive)).toBe('300.5');
+        expect(getSimulatedReceiveAmount(result, sendQuote, tokenQuoteReceive)).toBe('300.5');
     });
 
     it('falls back to value when the asset decimals are unknown', () => {
@@ -103,19 +104,19 @@ describe('getSimulatedReceiveAmount', () => {
             },
         ]);
 
-        expect(getSimulatedReceiveAmount(result, tokenQuoteReceive)).toBe('250');
+        expect(getSimulatedReceiveAmount(result, sendQuote, tokenQuoteReceive)).toBe('250');
     });
 
     it('returns null when the receive asset has no incoming transfer', () => {
         const result = createSimulationResult([{ ...nativeAssetDiff, in: [] }]);
 
-        expect(getSimulatedReceiveAmount(result, nativeQuoteReceive)).toBeNull();
+        expect(getSimulatedReceiveAmount(result, sendQuote, nativeQuoteReceive)).toBeNull();
     });
 
     it('returns null when only other assets changed', () => {
         const result = createSimulationResult([usdcAssetDiff]);
 
-        expect(getSimulatedReceiveAmount(result, nativeQuoteReceive)).toBeNull();
+        expect(getSimulatedReceiveAmount(result, sendQuote, nativeQuoteReceive)).toBeNull();
     });
 
     it('returns null when an incoming transfer cannot be valued', () => {
@@ -127,6 +128,92 @@ describe('getSimulatedReceiveAmount', () => {
             },
         ]);
 
-        expect(getSimulatedReceiveAmount(result, tokenQuoteReceive)).toBeNull();
+        expect(getSimulatedReceiveAmount(result, sendQuote, tokenQuoteReceive)).toBeNull();
+    });
+
+    describe('cross-chain (bridge) swaps', () => {
+        const SOL_USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+        const ACCOUNT = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+        const ethSend: CryptoId = 'ethereum' as CryptoId;
+        const solReceive: CryptoId = 'solana' as CryptoId;
+        const solUsdcReceive: CryptoId = `solana--${SOL_USDC_MINT}` as CryptoId;
+
+        const createBridgeResult = (
+            crossChainDiffs: unknown[],
+            assetsDiffs: unknown[] = [],
+        ): NetworkTxSimulationResult =>
+            ({
+                method: 'ethereumSignTransaction',
+                payload: {
+                    needsDisclaimer: false,
+                    chain: 'ethereum',
+                    account_address: ACCOUNT,
+                    simulation: {
+                        status: 'Success',
+                        transaction_actions: ['bridge'],
+                        account_summary: { assets_diffs: assetsDiffs },
+                        cross_chain_asset_diffs: { [ACCOUNT]: crossChainDiffs },
+                    },
+                },
+            }) as unknown as NetworkTxSimulationResult;
+
+        const solNativeDiff = {
+            asset_type: 'NATIVE',
+            asset: { type: 'NATIVE', decimals: 9 },
+            chain: 'solana',
+            in: [{ raw_value: '1500000000', value: '1.5' }],
+            out: [],
+        };
+
+        const ethRefundDiff = {
+            asset_type: 'NATIVE',
+            asset: { type: 'NATIVE', chain_id: 1, chain_name: 'ethereum', decimals: 18 },
+            in: [{ raw_value: '0xde0b6b3a7640000', value: '1' }],
+            out: [],
+        };
+
+        it('reads a native receive asset from the destination chain', () => {
+            const result = createBridgeResult([solNativeDiff]);
+
+            expect(getSimulatedReceiveAmount(result, ethSend, solReceive)).toBe('1.5');
+        });
+
+        it('never falls back to the source chain native asset', () => {
+            const result = createBridgeResult([], [ethRefundDiff]);
+
+            expect(getSimulatedReceiveAmount(result, ethSend, solReceive)).toBeNull();
+        });
+
+        it('prefers the bridged asset over an incoming source-chain asset', () => {
+            const result = createBridgeResult([solNativeDiff], [ethRefundDiff]);
+
+            expect(getSimulatedReceiveAmount(result, ethSend, solReceive)).toBe('1.5');
+        });
+
+        it('matches a bridged token by its destination-chain mint', () => {
+            const splDiff = {
+                asset_type: 'FUNGIBLE',
+                asset: { type: 'FUNGIBLE', address: SOL_USDC_MINT, decimals: 6 },
+                chain: 'solana',
+                in: [{ raw_value: '250000000', value: '250' }],
+                out: [],
+            };
+
+            expect(
+                getSimulatedReceiveAmount(createBridgeResult([splDiff]), ethSend, solUsdcReceive),
+            ).toBe('250');
+        });
+
+        it('returns null when the simulation reported no cross-chain movement', () => {
+            const result = {
+                method: 'ethereumSignTransaction',
+                payload: {
+                    needsDisclaimer: false,
+                    simulation: { status: 'Success', account_summary: { assets_diffs: [] } },
+                },
+            } as unknown as NetworkTxSimulationResult;
+
+            expect(getSimulatedReceiveAmount(result, ethSend, solReceive)).toBeNull();
+        });
     });
 });

--- a/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts
+++ b/suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts
@@ -2,12 +2,15 @@ import { type CryptoId } from 'invity-api';
 
 import {
     type AccountSummary,
+    type CrossChainAssetDiff,
     type NetworkTxSimulationResult,
+    type TransactionSimulation,
     getAssetDiffTransferAmount,
+    getCrossChainAssetDiffs,
 } from '@suite-common/tx-simulation';
 import { BigNumber } from '@trezor/utils';
 
-import { parseCryptoId } from '../../utils';
+import { isCrossChainTrade, parseCryptoId } from '../../utils';
 
 type EvmAssetDiff = AccountSummary['assets_diffs'][number];
 type ReceiveAssetDiff = Extract<EvmAssetDiff, { asset_type: 'ERC20' | 'NATIVE' }>;
@@ -27,6 +30,18 @@ const isReceiveAssetDiff = (
     return assetDiff.asset_type === 'NATIVE';
 };
 
+const findCrossChainReceiveDiff = (
+    simulation: TransactionSimulation,
+    accountAddress: string | undefined,
+    contractAddress: string | undefined,
+) =>
+    getCrossChainAssetDiffs(simulation, accountAddress).find(diff =>
+        contractAddress
+            ? 'address' in diff.asset &&
+              diff.asset.address.toLowerCase() === contractAddress.toLowerCase()
+            : !('address' in diff.asset),
+    );
+
 /**
  * Extract how much of the quote's receive asset the user gets according to
  * a successful Blockaid simulation. Returns a decimal string in main units,
@@ -35,27 +50,35 @@ const isReceiveAssetDiff = (
  */
 export const getSimulatedReceiveAmount = (
     result: NetworkTxSimulationResult | undefined,
+    quoteSendCryptoId: CryptoId | undefined,
     quoteReceiveCryptoId: CryptoId | undefined,
 ): string | null => {
     const simulation = result?.payload.simulation;
 
-    if (!quoteReceiveCryptoId || simulation?.status !== 'Success') {
+    if (!result || !quoteReceiveCryptoId || simulation?.status !== 'Success') {
         return null;
     }
 
     const { contractAddress } = parseCryptoId(quoteReceiveCryptoId);
-    const assetDiff = simulation.account_summary.assets_diffs.find(
-        (diff): diff is ReceiveAssetDiff => isReceiveAssetDiff(diff, contractAddress),
-    );
 
-    if (!assetDiff || assetDiff.in.length === 0) {
+    // Matching a bridged receive against the source chain picks that chain's native asset.
+    const receiveDiff: ReceiveAssetDiff | CrossChainAssetDiff | undefined = isCrossChainTrade(
+        quoteSendCryptoId,
+        quoteReceiveCryptoId,
+    )
+        ? findCrossChainReceiveDiff(simulation, result.payload.account_address, contractAddress)
+        : simulation.account_summary.assets_diffs.find((diff): diff is ReceiveAssetDiff =>
+              isReceiveAssetDiff(diff, contractAddress),
+          );
+
+    if (!receiveDiff || receiveDiff.in.length === 0) {
         return null;
     }
 
-    const decimals = 'decimals' in assetDiff.asset ? assetDiff.asset.decimals : undefined;
+    const decimals = 'decimals' in receiveDiff.asset ? receiveDiff.asset.decimals : undefined;
     let total = new BigNumber(0);
 
-    for (const transfer of assetDiff.in) {
+    for (const transfer of receiveDiff.in) {
         const amount = getAssetDiffTransferAmount(transfer, decimals);
 
         // Do not display a partial amount when any incoming transfer cannot be valued.

--- a/suite-common/tx-simulation/jest.config.js
+++ b/suite-common/tx-simulation/jest.config.js
@@ -2,6 +2,4 @@ const baseConfig = require('../../jest.config.base.swc');
 
 module.exports = {
     ...baseConfig,
-    // The Blockaid client needs its node fetch shim registered before any test module imports it.
-    setupFiles: [require('path').resolve(__dirname, 'src/jestSetup.ts')],
 };

--- a/suite-common/tx-simulation/package.json
+++ b/suite-common/tx-simulation/package.json
@@ -12,7 +12,7 @@
         "test:unit": "yarn g:jest"
     },
     "dependencies": {
-        "@blockaid/client": "0.65.0",
+        "@blockaid/client": "1.5.0",
         "@suite-common/react-query": "workspace:^",
         "@suite-common/wallet-config": "workspace:^",
         "@suite-common/wallet-constants": "workspace:*",

--- a/suite-common/tx-simulation/src/chains.test.ts
+++ b/suite-common/tx-simulation/src/chains.test.ts
@@ -1,0 +1,39 @@
+import { networks } from '@suite-common/wallet-config';
+
+import { isBlockaidSupportedNetwork, resolveBlockaidEvmChain } from './chains';
+
+describe('resolveBlockaidEvmChain', () => {
+    it.each([
+        [networks.eth.chainId, 'ethereum'],
+        [networks.hype.chainId, 'hyperevm'],
+        [networks.rhc.chainId, 'robinhood'],
+        [networks.tsep.chainId, 'ethereum-sepolia'],
+    ])('maps chainId %i to %s', (chainId, expected) => {
+        expect(resolveBlockaidEvmChain(chainId)).toBe(expected);
+    });
+
+    it('defaults to Ethereum mainnet when the chainId is unknown to the payload', () => {
+        expect(resolveBlockaidEvmChain(undefined)).toBe('ethereum');
+    });
+
+    it.each([
+        ['Ethereum Classic', networks.etc.chainId],
+        ['Ethereum Hoodi', networks.thod.chainId],
+    ])('has no chain for %s', (_name, chainId) => {
+        expect(resolveBlockaidEvmChain(chainId)).toBeNull();
+    });
+
+    it('returns null for a chainId Suite does not know', () => {
+        expect(resolveBlockaidEvmChain(1234567)).toBeNull();
+    });
+});
+
+describe('isBlockaidSupportedNetwork', () => {
+    it.each(['eth', 'hype', 'tsep'] as const)('supports %s', symbol => {
+        expect(isBlockaidSupportedNetwork(symbol)).toBe(true);
+    });
+
+    it.each(['etc', 'thod', 'btc', 'sol'] as const)('does not support %s', symbol => {
+        expect(isBlockaidSupportedNetwork(symbol)).toBe(false);
+    });
+});

--- a/suite-common/tx-simulation/src/chains.ts
+++ b/suite-common/tx-simulation/src/chains.ts
@@ -1,0 +1,45 @@
+import { type TransactionScanSupportedChain } from '@blockaid/client/resources/evm';
+
+import {
+    type Network,
+    type NetworkConfig,
+    type NetworkSymbol,
+    getNetwork,
+    getNetworkByEvmChainId,
+    networks,
+} from '@suite-common/wallet-config';
+
+type EvmChainId = Extract<NetworkConfig, { networkType: 'ethereum' }>['chainId'];
+
+const BLOCKAID_EVM_CHAIN_BY_CHAIN_ID = {
+    [networks.eth.chainId]: 'ethereum',
+    [networks.op.chainId]: 'optimism',
+    [networks.bsc.chainId]: 'bsc',
+    [networks.pol.chainId]: 'polygon',
+    [networks.base.chainId]: 'base',
+    [networks.arb.chainId]: 'arbitrum',
+    [networks.rhc.chainId]: 'robinhood',
+    [networks.hype.chainId]: 'hyperevm',
+    [networks.avax.chainId]: 'avalanche',
+    [networks.tsep.chainId]: 'ethereum-sepolia',
+    // Blockaid has no Ethereum Classic chain; the old 'ethereumClassic' value is rejected.
+    [networks.etc.chainId]: null,
+    [networks.thod.chainId]: null, // Hoodi is not a supported testnet
+} as const satisfies Readonly<Record<EvmChainId, TransactionScanSupportedChain | null>>;
+
+export const resolveBlockaidEvmChain = (chainId: number | undefined = networks.eth.chainId) =>
+    BLOCKAID_EVM_CHAIN_BY_CHAIN_ID[chainId as EvmChainId] ?? null;
+
+export const getNetworkByBlockaidChain = (chain: string): Network | undefined => {
+    const entry = Object.entries(BLOCKAID_EVM_CHAIN_BY_CHAIN_ID).find(
+        ([, blockaidChain]) => blockaidChain === chain,
+    );
+
+    return entry ? getNetworkByEvmChainId(Number(entry[0])) : undefined;
+};
+
+export const isBlockaidSupportedNetwork = (symbol: NetworkSymbol): boolean => {
+    const network = getNetwork(symbol);
+
+    return network.networkType === 'ethereum' && resolveBlockaidEvmChain(network.chainId) !== null;
+};

--- a/suite-common/tx-simulation/src/client.ts
+++ b/suite-common/tx-simulation/src/client.ts
@@ -3,4 +3,7 @@ import Blockaid from '@blockaid/client';
 export const client = new Blockaid({
     baseURL: 'https://cdn.trezor.io/dynamic/blockaid/',
     apiKey: '-', // placeholder, actually handled by proxy
+    // Looked up per request instead of at construction time, so importing this module never depends
+    // on a global fetch already being there (jsdom test environments have none).
+    fetch: (...args) => globalThis.fetch(...args),
 });

--- a/suite-common/tx-simulation/src/constants.ts
+++ b/suite-common/tx-simulation/src/constants.ts
@@ -1,4 +1,8 @@
-import { type TransactionSimulationError } from '@blockaid/client/resources/evm';
+import {
+    type InsufficientFundsErrorDetails,
+    type InvalidAddressErrorDetails,
+    type UnsupportedEip712MessageErrorDetails,
+} from './types';
 
 export const TX_SIMULATION_ERROR_CODE = {
     insufficientFunds: 'GENERAL_INSUFFICIENT_FUNDS',
@@ -6,7 +10,7 @@ export const TX_SIMULATION_ERROR_CODE = {
     unsupportedEip712Message: 'UNSUPPORTED_EIP712_MESSAGE',
 } as const satisfies Record<
     string,
-    | TransactionSimulationError.GeneralInsufficientFundsErrorDetails['code']
-    | TransactionSimulationError.GeneralInvalidAddressErrorDetails['code']
-    | TransactionSimulationError.UnsupportedEip712MessageErrorDetails['code']
+    | InsufficientFundsErrorDetails['code']
+    | InvalidAddressErrorDetails['code']
+    | UnsupportedEip712MessageErrorDetails['code']
 >;

--- a/suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts
+++ b/suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts
@@ -1,8 +1,7 @@
-import type { TransactionScanResponse } from '@blockaid/client/resources/evm';
-
 import { commonQueryKeys, useQuery } from '@suite-common/react-query';
 
 import { client } from '../client';
+import { type TransactionScanResponse } from '../types';
 import { type GetTxSimulationParams } from '../utils';
 
 type TxSimulationCommonResult = { needsDisclaimer: boolean };

--- a/suite-common/tx-simulation/src/index.ts
+++ b/suite-common/tx-simulation/src/index.ts
@@ -1,6 +1,10 @@
 export * from './client';
 export type * from './types';
-export { getSimulationErrorRiskLevel, areTxSimulationMethods } from './utils';
+export {
+    getSimulationErrorRiskLevel,
+    areTxSimulationMethods,
+    isBlockaidSupportedNetwork,
+} from './utils';
 export { getAssetDiffTransferAmount } from './utils/getAssetDiffTransferAmount';
 export {
     getTxSimulationRiskSummary,
@@ -16,7 +20,6 @@ export {
 } from './hooks/useNetworkTxSimulation';
 export { useTxSimulation } from './hooks/useTxSimulation';
 
-export type { AccountSummary, TransactionSimulation } from '@blockaid/client/resources/evm';
 export { TX_METHODS_WITH_FEES } from './config';
 export {
     computeGasFeeInWei,

--- a/suite-common/tx-simulation/src/index.ts
+++ b/suite-common/tx-simulation/src/index.ts
@@ -1,11 +1,9 @@
 export * from './client';
 export type * from './types';
-export {
-    getSimulationErrorRiskLevel,
-    areTxSimulationMethods,
-    isBlockaidSupportedNetwork,
-} from './utils';
+export { getNetworkByBlockaidChain, isBlockaidSupportedNetwork } from './chains';
+export { getSimulationErrorRiskLevel, areTxSimulationMethods } from './utils';
 export { getAssetDiffTransferAmount } from './utils/getAssetDiffTransferAmount';
+export { type CrossChainAssetDiff, getCrossChainAssetDiffs } from './utils/getCrossChainAssetDiffs';
 export {
     getTxSimulationRiskSummary,
     type TxSimulationRiskSummary,

--- a/suite-common/tx-simulation/src/jestSetup.ts
+++ b/suite-common/tx-simulation/src/jestSetup.ts
@@ -1,1 +1,0 @@
-import '@blockaid/client/shims/node';

--- a/suite-common/tx-simulation/src/types.ts
+++ b/suite-common/tx-simulation/src/types.ts
@@ -1,15 +1,23 @@
-import type { NativeAddressAssetBalanceChangeDiff } from '@blockaid/client/resources';
-import type { AccountSummary } from '@blockaid/client/resources/evm';
+import type { JsonRpcScanResponse } from '@blockaid/client/resources/evm';
 
-export type EvmAssetDiff =
-    | AccountSummary.Erc20AddressAssetBalanceChangeDiff
-    | AccountSummary.Erc721AddressAssetBalanceChangeDiff
-    | AccountSummary.Erc1155AddressAssetBalanceChangeDiff
-    | NativeAddressAssetBalanceChangeDiff;
+// The SDK inlines a `RoutersEvm*`-prefixed copy of every shared type per endpoint, so this is the
+// one place that names them. Everything else in the repo imports the aliases below.
+export type TransactionScanResponse = JsonRpcScanResponse;
 
-export type EvmAssetExposure =
-    | AccountSummary.Erc20AddressExposure
-    | AccountSummary.Erc721AddressExposure
-    | AccountSummary.Erc1155AddressExposure;
+export type TransactionSimulation = JsonRpcScanResponse.RoutersEvmResponseTransactionSimulation;
+export type TransactionSimulationError =
+    JsonRpcScanResponse.RoutersEvmResponseTransactionSimulationError;
+export type TransactionValidation = JsonRpcScanResponse.RoutersEvmResponseTransactionValidation;
 
-export type { TransactionScanResponse } from '@blockaid/client/resources';
+export type TransactionScanFeature = TransactionValidation['features'][number];
+
+export type AccountSummary = TransactionSimulation['account_summary'];
+export type EvmAssetDiff = AccountSummary['assets_diffs'][number];
+export type EvmAssetExposure = AccountSummary['exposures'][number];
+
+export type InsufficientFundsErrorDetails =
+    JsonRpcScanResponse.RoutersEvmResponseTransactionSimulationError.RoutersEvmResponseGeneralInsufficientFundsErrorDetails;
+export type InvalidAddressErrorDetails =
+    JsonRpcScanResponse.RoutersEvmResponseTransactionSimulationError.RoutersEvmResponseGeneralInvalidAddressErrorDetails;
+export type UnsupportedEip712MessageErrorDetails =
+    JsonRpcScanResponse.RoutersEvmResponseTransactionSimulationError.RoutersEvmResponseUnsupportedEip712MessageErrorDetails;

--- a/suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts
+++ b/suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts
@@ -1,0 +1,70 @@
+import { type TransactionSimulation } from '../types';
+import { getCrossChainAssetDiffs } from './getCrossChainAssetDiffs';
+
+const ACCOUNT = '0x9eA3721B5Bf3b64b4418c38B603154d2D597FAE3';
+const BRIDGE_CONTRACT = '0x1111222233334444555566667777888899990000';
+
+const hyperliquidOut = {
+    chain: 'hyperliquid',
+    asset_type: 'FUNGIBLE',
+    asset: { type: 'ERC20', address: '0x6d1e7cde53ba9467b783cb7c530ce054', decimals: 8 },
+    in: [],
+    out: [{ value: '1.0', raw_value: '0x5f5e100' }],
+};
+
+const arbitrumIn = {
+    chain: 'arbitrum',
+    asset_type: 'FUNGIBLE',
+    asset: { type: 'ERC20', address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831', decimals: 6 },
+    in: [{ usd_price: '0.99968199999999996', value: '1.0', raw_value: '0xf4240' }],
+    out: [],
+};
+
+const createSimulation = (crossChainAssetDiffs: unknown): TransactionSimulation =>
+    ({
+        status: 'Success',
+        account_summary: { assets_diffs: [], exposures: [] },
+        transaction_actions: ['bridge'],
+        cross_chain_asset_diffs: crossChainAssetDiffs,
+    }) as unknown as TransactionSimulation;
+
+describe('getCrossChainAssetDiffs', () => {
+    it('returns both legs of the bridge for the scanned account', () => {
+        const simulation = createSimulation({
+            [ACCOUNT]: [hyperliquidOut, arbitrumIn],
+            [BRIDGE_CONTRACT]: [{ ...hyperliquidOut, in: hyperliquidOut.out, out: [] }],
+        });
+
+        expect(getCrossChainAssetDiffs(simulation, ACCOUNT)).toEqual([hyperliquidOut, arbitrumIn]);
+    });
+
+    it('ignores the bridge contracts', () => {
+        const simulation = createSimulation({
+            [BRIDGE_CONTRACT]: [hyperliquidOut],
+        });
+
+        expect(getCrossChainAssetDiffs(simulation, ACCOUNT)).toEqual([]);
+    });
+
+    it('matches the account address regardless of checksum casing', () => {
+        const simulation = createSimulation({ [ACCOUNT]: [arbitrumIn] });
+
+        expect(getCrossChainAssetDiffs(simulation, ACCOUNT.toLowerCase())).toEqual([arbitrumIn]);
+    });
+
+    it('tolerates the array shape the SDK types declare', () => {
+        const simulation = createSimulation([{ address: ACCOUNT, obj: [arbitrumIn] }]);
+
+        expect(getCrossChainAssetDiffs(simulation, ACCOUNT)).toEqual([arbitrumIn]);
+    });
+
+    it.each([undefined, null])('returns nothing when the field is %s', diffs => {
+        expect(getCrossChainAssetDiffs(createSimulation(diffs), ACCOUNT)).toEqual([]);
+    });
+
+    it('returns nothing without an account address', () => {
+        const simulation = createSimulation({ [ACCOUNT]: [arbitrumIn] });
+
+        expect(getCrossChainAssetDiffs(simulation, undefined)).toEqual([]);
+    });
+});

--- a/suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts
+++ b/suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts
@@ -1,0 +1,34 @@
+import { type TransactionSimulation } from '../types';
+
+export type CrossChainAssetDiff = NonNullable<
+    TransactionSimulation['cross_chain_asset_diffs']
+>[number]['obj'][number];
+
+type CrossChainAssetDiffsByAddress = Record<string, CrossChainAssetDiff[]>;
+
+export const getCrossChainAssetDiffs = (
+    simulation: TransactionSimulation,
+    accountAddress: string | undefined,
+): CrossChainAssetDiff[] => {
+    // The SDK types an array here; the API actually returns an address-keyed map.
+    const diffs: unknown = simulation.cross_chain_asset_diffs;
+
+    if (!diffs || !accountAddress) {
+        return [];
+    }
+
+    const byAddress: CrossChainAssetDiffsByAddress = Array.isArray(diffs)
+        ? Object.fromEntries(
+              (diffs as ReadonlyArray<{ address: string; obj: CrossChainAssetDiff[] }>).map(
+                  ({ address, obj }) => [address, obj],
+              ),
+          )
+        : (diffs as CrossChainAssetDiffsByAddress);
+
+    // Bridge contracts get their own entries, with the movements mirrored.
+    const key = Object.keys(byAddress).find(
+        address => address.toLowerCase() === accountAddress.toLowerCase(),
+    );
+
+    return key ? (byAddress[key] ?? []) : [];
+};

--- a/suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts
@@ -1,0 +1,41 @@
+import { type TxSimulationAction } from '@suite-common/wallet-types';
+
+import { getTxSimulationParams } from './getTxSimulationParams';
+
+const sourceOrigin = 'https://app.uniswap.org';
+const fromAddress = '0x0000000000000000000000000000000000001234';
+
+const createEvmAction = (chainId: number): TxSimulationAction => ({
+    method: 'ethereumSignTransaction',
+    fromAddress,
+    sourceOrigin,
+    payload: {
+        path: "m/44'/60'/0'/0/0",
+        transaction: {
+            to: '0x000000000000000000000000000000000000abcd',
+            value: '0x0',
+            data: '0x',
+            chainId,
+            nonce: '0',
+            gasLimit: '0x0',
+            gasPrice: '0x0',
+        },
+    },
+});
+
+describe('getTxSimulationParams', () => {
+    it('returns null without an action', () => {
+        expect(getTxSimulationParams(null)).toBeNull();
+    });
+
+    it('resolves the Blockaid chain name from the EVM chainId', () => {
+        expect(getTxSimulationParams(createEvmAction(999))?.params).toMatchObject({
+            chain: 'hyperevm',
+            account_address: fromAddress,
+        });
+    });
+
+    it('returns null for an EVM chain Blockaid cannot scan', () => {
+        expect(getTxSimulationParams(createEvmAction(61))).toBeNull();
+    });
+});

--- a/suite-common/tx-simulation/src/utils/getTxSimulationParams.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationParams.ts
@@ -1,41 +1,23 @@
 import { type JsonRpcScanParams } from '@blockaid/client/resources/evm';
 
-import { type NetworkConfig, type NetworkType, networks } from '@suite-common/wallet-config';
 import { U_INT_32 } from '@suite-common/wallet-constants';
 import { type TxSimulationAction, type TxSimulationMethod } from '@suite-common/wallet-types';
 
-import { type BlockaidSupportedNetwork } from '../constants';
-
-type ChainId = Extract<NetworkConfig, { networkType: 'ethereum'; testnet: false }>['chainId'];
-
-// Maps EVM chainId to Blockaid's canonical chain name.
-const BLOCKAID_EVM_CHAIN_BY_CHAIN_ID = {
-    [networks.eth.chainId]: 'ethereum',
-    [networks.op.chainId]: 'optimism',
-    [networks.bsc.chainId]: 'bsc',
-    [networks.etc.chainId]: 'ethereumClassic',
-    [networks.pol.chainId]: 'polygon',
-    [networks.base.chainId]: 'base',
-    [networks.arb.chainId]: 'arbitrum',
-    [networks.rhc.chainId]: 'robinhood',
-    [networks.hype.chainId]: 'hyperevm',
-    [networks.avax.chainId]: 'avalanche',
-} as const satisfies Readonly<Record<ChainId, string>>;
-
-export const isBlockaidSupportedNetwork = (
-    network: NetworkType,
-): network is BlockaidSupportedNetwork => ['solana', 'ethereum'].includes(network);
-
-const resolveBlockaidEvmChain = (chainId: number | undefined = 1) =>
-    BLOCKAID_EVM_CHAIN_BY_CHAIN_ID[chainId as keyof typeof BLOCKAID_EVM_CHAIN_BY_CHAIN_ID];
+import { resolveBlockaidEvmChain } from '../chains';
 
 function transformPayloadOfEthereumSignTransaction({
     payload: { transaction },
     fromAddress,
     sourceOrigin,
 }: TxSimulationMethod<'ethereumSignTransaction'>) {
+    const chain = resolveBlockaidEvmChain(transaction.chainId);
+
+    if (!chain) {
+        return null;
+    }
+
     return {
-        chain: resolveBlockaidEvmChain(transaction.chainId),
+        chain,
         data: {
             method: 'eth_sendTransaction',
             params: [
@@ -65,10 +47,16 @@ function transformPayloadOfEthereumSignTypedData({
     fromAddress,
     sourceOrigin,
 }: TxSimulationMethod<'ethereumSignTypedData'>) {
+    const chain = resolveBlockaidEvmChain(
+        data.domain.chainId ? Number(data.domain.chainId) : undefined,
+    );
+
+    if (!chain) {
+        return null;
+    }
+
     return {
-        chain: resolveBlockaidEvmChain(
-            data.domain.chainId ? Number(data.domain.chainId) : undefined,
-        ),
+        chain,
         data: {
             method: 'eth_signTypedData_v4',
             params: [fromAddress, JSON.stringify(data)],
@@ -93,16 +81,16 @@ export function getTxSimulationParams(action: TxSimulationAction | null) {
     }
 
     switch (action.method) {
-        case 'ethereumSignTransaction':
-            return {
-                method: action.method,
-                params: transformPayloadOfEthereumSignTransaction(action),
-            } as const;
-        case 'ethereumSignTypedData':
-            return {
-                method: action.method,
-                params: transformPayloadOfEthereumSignTypedData(action),
-            } as const;
+        case 'ethereumSignTransaction': {
+            const params = transformPayloadOfEthereumSignTransaction(action);
+
+            return params && ({ method: action.method, params } as const);
+        }
+        case 'ethereumSignTypedData': {
+            const params = transformPayloadOfEthereumSignTypedData(action);
+
+            return params && ({ method: action.method, params } as const);
+        }
         default:
             return null;
     }

--- a/suite-common/tx-simulation/src/utils/getTxSimulationParams.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationParams.ts
@@ -1,8 +1,10 @@
 import { type JsonRpcScanParams } from '@blockaid/client/resources/evm';
 
-import { type NetworkConfig, networks } from '@suite-common/wallet-config';
+import { type NetworkConfig, type NetworkType, networks } from '@suite-common/wallet-config';
 import { U_INT_32 } from '@suite-common/wallet-constants';
 import { type TxSimulationAction, type TxSimulationMethod } from '@suite-common/wallet-types';
+
+import { type BlockaidSupportedNetwork } from '../constants';
 
 type ChainId = Extract<NetworkConfig, { networkType: 'ethereum'; testnet: false }>['chainId'];
 
@@ -19,6 +21,10 @@ const BLOCKAID_EVM_CHAIN_BY_CHAIN_ID = {
     [networks.hype.chainId]: 'hyperevm',
     [networks.avax.chainId]: 'avalanche',
 } as const satisfies Readonly<Record<ChainId, string>>;
+
+export const isBlockaidSupportedNetwork = (
+    network: NetworkType,
+): network is BlockaidSupportedNetwork => ['solana', 'ethereum'].includes(network);
 
 const resolveBlockaidEvmChain = (chainId: number | undefined = 1) =>
     BLOCKAID_EVM_CHAIN_BY_CHAIN_ID[chainId as keyof typeof BLOCKAID_EVM_CHAIN_BY_CHAIN_ID];

--- a/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts
@@ -2,8 +2,7 @@ import type {
     TransactionSimulation,
     TransactionSimulationError,
     TransactionValidation,
-} from '@blockaid/client/resources/evm';
-
+} from '../types';
 import { getTxSimulationRiskSummary } from './getTxSimulationRiskSummary';
 
 const createValidation = (

--- a/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts
+++ b/suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts
@@ -3,7 +3,7 @@ import type {
     TransactionScanResponse,
     TransactionSimulationError,
     TransactionValidation,
-} from '@blockaid/client/resources/evm';
+} from '../types';
 
 export type TxSimulationValidationSummary = {
     riskLevel: Extract<TransactionValidation['result_type'], 'Malicious' | 'Warning'>;

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx
@@ -21,7 +21,11 @@ export const ExchangeToAccountTradePreviewCard = ({
     const { toValue } = useChangeStringsExtractor(quote);
     const { isLoading: isSimulationLoading, data: simulationResult } = useDexExchangeTxSimulation();
 
-    const simulatedReceiveAmount = getSimulatedReceiveAmount(simulationResult, quote?.receive);
+    const simulatedReceiveAmount = getSimulatedReceiveAmount(
+        simulationResult,
+        quote?.send,
+        quote?.receive,
+    );
 
     return (
         <TradingAccountCard

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,18 +1824,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@blockaid/client@npm:0.65.0":
-  version: 0.65.0
-  resolution: "@blockaid/client@npm:0.65.0"
-  dependencies:
-    "@types/node": "npm:^18.11.18"
-    "@types/node-fetch": "npm:^2.6.4"
-    abort-controller: "npm:^3.0.0"
-    agentkeepalive: "npm:^4.2.1"
-    form-data-encoder: "npm:1.7.2"
-    formdata-node: "npm:^4.3.2"
-    node-fetch: "npm:^2.6.7"
-  checksum: 10/ff8a8197886e50763b707acdd2250e9c6255a77391cff2bd17360919bc5c5b7962bd9795ee2868cdf33a36febdbcc52508b530605b67c5dc5f2a4fdb56b2aee4
+"@blockaid/client@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@blockaid/client@npm:1.5.0"
+  bin:
+    blockaid-client: bin/cli
+  checksum: 10/1a743064ffe7b7f665b29ef8cf138709d5571e659f4bf77a01a8993292e51bf9bb1386360fa3101e7ba65821a819ea269908ceb800f4f9ba90ef33a8a43a422e
   languageName: node
   linkType: hard
 
@@ -11108,7 +11102,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@suite-common/tx-simulation@workspace:suite-common/tx-simulation"
   dependencies:
-    "@blockaid/client": "npm:0.65.0"
+    "@blockaid/client": "npm:1.5.0"
     "@suite-common/react-query": "workspace:^"
     "@suite-common/wallet-config": "workspace:^"
     "@suite-common/wallet-constants": "workspace:*"
@@ -18599,16 +18593,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.6.4":
-  version: 2.6.13
-  resolution: "@types/node-fetch@npm:2.6.13"
-  dependencies:
-    "@types/node": "npm:*"
-    form-data: "npm:^4.0.4"
-  checksum: 10/944d52214791ebba482ca1393a4f0d62b0dbac5f7343ff42c128b75d5356d8bcefd4df77771b55c1acd19d118e16e9bd5d2792819c51bc13402d1c87c0975435
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:22.13.10":
   version: 22.13.10
   resolution: "@types/node@npm:22.13.10"
@@ -20504,15 +20488,6 @@ __metadata:
   bin:
     agent-cli-detector: dist/cli.js
   checksum: 10/b9d47517834f932ebd07825f0ec019e2ef9c099b8a9c2113c7d2bb094f6e6b1c720c537da7eb1f2ca676f81ac788e90ef1ea11dd461b884c9989e78a5d567964
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.2.1":
-  version: 4.6.0
-  resolution: "agentkeepalive@npm:4.6.0"
-  dependencies:
-    humanize-ms: "npm:^1.2.1"
-  checksum: 10/80c546bd88dd183376d6a29e5598f117f380b1d567feb1de184241d6ece721e2bdd38f179a1674276de01780ccae229a38c60a77317e2f5ad2f1818856445bd7
   languageName: node
   linkType: hard
 
@@ -29074,14 +29049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data-encoder@npm:1.7.2":
-  version: 1.7.2
-  resolution: "form-data-encoder@npm:1.7.2"
-  checksum: 10/227bf2cea083284411fd67472ccc22f5cb354ca92c00690e11ff5ed942d993c13ac99dea365046306200f8bd71e1a7858d2d99e236de694b806b1f374a4ee341
-  languageName: node
-  linkType: hard
-
-"form-data@npm:4.0.6, form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+"form-data@npm:4.0.6, form-data@npm:^4.0.0, form-data@npm:^4.0.5":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -29091,16 +29059,6 @@ __metadata:
     hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
   checksum: 10/de6614c8537c92fa5fa3ee7e827758f98f5a9c033f348b7de81855ef36e5cb867e75d9f405d9483ab8d724a4a20d4e79926a299fa8dbba38f530eb659f0884e4
-  languageName: node
-  linkType: hard
-
-"formdata-node@npm:^4.3.2":
-  version: 4.4.1
-  resolution: "formdata-node@npm:4.4.1"
-  dependencies:
-    node-domexception: "npm:1.0.0"
-    web-streams-polyfill: "npm:4.0.0-beta.3"
-  checksum: 10/29622f75533107c1bbcbe31fda683e6a55859af7f48ec354a9800591ce7947ed84cd3ef2b2fcb812047a884f17a1bac75ce098ffc17e23402cd373e49c1cd335
   languageName: node
   linkType: hard
 
@@ -30891,15 +30849,6 @@ __metadata:
   version: 8.0.1
   resolution: "human-signals@npm:8.0.1"
   checksum: 10/903389a018b16f330c5e0f6e8b76d592c79552152ea892f249e5290e71c790f5722dc9b740fedd4bdef30566754a69012aaed97a6a528da0d417fad990a6f515
-  languageName: node
-  linkType: hard
-
-"humanize-ms@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "humanize-ms@npm:1.2.1"
-  dependencies:
-    ms: "npm:^2.0.0"
-  checksum: 10/9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
   languageName: node
   linkType: hard
 
@@ -36914,7 +36863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:2.1.3, ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
+"ms@npm:2.1.3, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -37463,7 +37412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-domexception@npm:1.0.0, node-domexception@npm:^1.0.0":
+"node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
   checksum: 10/e332522f242348c511640c25a6fc7da4f30e09e580c70c6b13cb0be83c78c3e71c8d4665af2527e869fc96848924a4316ae7ec9014c091e2156f41739d4fa233
@@ -47138,13 +47087,6 @@ __metadata:
   version: 2.0.1
   resolution: "web-namespaces@npm:2.0.1"
   checksum: 10/b6d9f02f1a43d0ef0848a812d89c83801d5bbad57d8bb61f02eb6d7eb794c3736f6cc2e1191664bb26136594c8218ac609f4069722c6f56d9fc2d808fa9271c6
-  languageName: node
-  linkType: hard
-
-"web-streams-polyfill@npm:4.0.0-beta.3":
-  version: 4.0.0-beta.3
-  resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
-  checksum: 10/dcdef67de57d83008f9dc330662b65ba4497315555dd0e4e7bcacb132ffdf8a830eaab8f74ad40a4a44f542461f51223f406e2a446ece1cc29927859b1405853
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bottom of a 3-PR stack adding cross-chain (bridge) transaction-simulation support.

I had to bump blockaid dependency to get types and perform some migration in the first commit. Migration included removal of node-fetch in favor of browser version, so some of the changes related to that. 

Second one adds generic utils to parse asset diffs. And related tests. Also includes fix for the supported chain 

## Notes for QA

No functional changes

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31351



<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain/web/](https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockaid-crosschain&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockaid-crosschain&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/blockaid-crosschain&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T12:02:52.459Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T12:02:55.889Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set is concentrated in trading offer exchange UI and DEX/cross-chain transaction simulation. The highest risk is broken DEX confirmation values (minimum received, slippage, simulated fees) and incorrect issue rendering in the swap offer screen. A small set of DEX and representative CEX swap E2Es provides good coverage; the broad tx-simulation files are global dependencies and do not justify a wider regression run on their own.

<details><summary><b>Changed files (25)</b></summary>

- `jest.config.native.js`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/client.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (4)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This CEX swap test passes through the TradingOfferExchange confirmation screen and exercises provider details, fee rendering, and device-prompt amounts. Changes to TradingOfferExchange.tsx and useExchangeIssue.ts would directly surface here as broken offer summaries or missing issue warnings.
- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — The DEX token-approval flow relies on transaction simulation to show the spending limit, approval fee, and risk details in the approval modal and on the device. This is a strong proxy for the changed tx-simulation client, hook, and params utilities, which are not directly referenced by many E2E tests.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — This is the only E2E test that exercises a DEX (LI.FI) swap end-to-end, including slippage, minimum received, and EVM transaction simulation values shown on the confirmation and device prompts. The changed composeDexTxSimulationAction and getSimulatedReceiveAmount utilities directly compute these values.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — A Solana-to-Bitcoin CEX swap that covers the TradingOfferExchange confirmation flow and Solana-specific fee/address handling. It complements the EVM DEX tests by ensuring the offer exchange component still works for a non-EVM send chain.

</details>

<details><summary>🟡 <b>Medium priority (2)</b></summary>

- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Custom Ethereum gas-fee handling in the swap flow shares the EVM transaction precomposition and fee-summary infrastructure touched by tx-simulation. A regression could appear in the gas limit, max fee, or priority fee assertions on the device prompt.
- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This live Solana-token swap uses real rather than fully mocked quotes and exercises the same TradingOfferExchange confirmation UI. It can catch regressions in offer rendering, success status, and account labels that mocked tests might hide.

</details>

⚠️ **Changes with no test coverage (12)**
- `jest.config.native.js`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`

_Updated: 2026-08-19T12:07:16.115Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->