### PR TITLE
feat(suite-desktop): adds simulation results to simulation modal

### DIFF
--- a/packages/suite/src/components/tx-simulation/common/components/TxSimulationSuccessResult.tsx
+++ b/packages/suite/src/components/tx-simulation/common/components/TxSimulationSuccessResult.tsx
@@ -1,8 +1,11 @@
 import { TxSimulationResult } from '@suite/tx-simulation/src/common';
-import { EvmTxSimulationAsset } from '@suite/tx-simulation/src/evm';
+import { EvmTxSimulationAsset, TxSimulationCrossChainAsset } from '@suite/tx-simulation/src/evm';
 import { SolanaTxSimulationAsset } from '@suite/tx-simulation/src/solana';
 import { StellarTxSimulationAsset } from '@suite/tx-simulation/src/stellar';
-import { type NetworkTxSimulationResult } from '@suite-common/tx-simulation';
+import {
+    type NetworkTxSimulationResult,
+    getCrossChainAssetDiffs,
+} from '@suite-common/tx-simulation';
 import { type Network } from '@suite-common/wallet-config';
 
 import { TxSimulationContractInfo } from './TxSimulationContractInfo';
@@ -26,17 +29,32 @@ export function TxSimulationSuccessResult({
             }
 
             const { assets_diffs, exposures } = payload.simulation.account_summary;
+            // A bridge leaves the account summary empty — its outcome is reported per chain.
+            const crossChainDiffs = getCrossChainAssetDiffs(
+                payload.simulation,
+                payload.account_address,
+            );
 
             return (
                 <>
                     <TxSimulationResult
-                        isEmpty={assets_diffs.length === 0 && exposures.length === 0}
+                        isEmpty={
+                            assets_diffs.length === 0 &&
+                            exposures.length === 0 &&
+                            crossChainDiffs.length === 0
+                        }
                     >
                         {assets_diffs.map((assetDiff, index) => (
                             <EvmTxSimulationAsset
                                 key={`asset-diff-${index}`}
                                 assetDiff={assetDiff}
                                 network={network}
+                            />
+                        ))}
+                        {crossChainDiffs.map((assetDiff, index) => (
+                            <TxSimulationCrossChainAsset
+                                key={`cross-chain-diff-${index}`}
+                                assetDiff={assetDiff}
                             />
                         ))}
                         {exposures.map((assetExposure, index) => (

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -15,10 +15,12 @@ import {
     useDexExchangeTxSimulation,
     useExchangeIssue,
 } from '@suite-common/trading';
+import { getNetwork } from '@suite-common/wallet-config';
 import { selectAccountByKey } from '@suite-common/wallet-core';
 import { Button, Card, Column, H2 } from '@trezor/components';
 import { useAsyncClickHandler } from '@trezor/react-utils';
 
+import { TxSimulationSuccessResult } from 'src/components/tx-simulation/common/components/TxSimulationSuccessResult';
 import { TRADING_DEX_SOURCE_ORIGIN } from 'src/constants/wallet/trading/txSimulation';
 import { useDispatch, useSelector } from 'src/hooks/suite';
 import { useTradingExchangeTradeActions } from 'src/hooks/wallet/trading/useTradingExchangeTradeActions';
@@ -158,6 +160,14 @@ export const TradingOfferExchange = () => {
                             exchangeQuote={selectedTrade}
                             providers={providers as TradingExchangeProvidersInfoProps}
                             exchange={exchange}
+                        />
+                    )}
+
+                    {sendAccount && simulationResult && (
+                        <TxSimulationSuccessResult
+                            result={simulationResult}
+                            network={getNetwork(sendAccount.symbol)}
+                            targetContract={null}
                         />
                     )}
 

--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -12711,6 +12711,12 @@ export const messages = defineMessages({
         id: 'TR_SIMULATION_NO_ASSETS',
         defaultMessage: 'No changes to your assets were detected.',
     },
+    TR_SIMULATION_CROSS_CHAIN_ASSET: {
+        id: 'TR_SIMULATION_CROSS_CHAIN_ASSET',
+        defaultMessage: '{amount} on {chain}',
+        description:
+            'An asset moving on another chain as part of a bridge, e.g. "1 USDC on Arbitrum".',
+    },
     TR_NETWORK_RESERVE_BANNER: {
         id: 'TR_NETWORK_RESERVE_BANNER',
         defaultMessage: "We've reserved {amount} {displaySymbol} to cover any extra network fees.",

--- a/suite/tx-simulation/src/evm/components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset.tsx
+++ b/suite/tx-simulation/src/evm/components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset.tsx
@@ -1,0 +1,65 @@
+import { Translation } from '@suite/intl';
+import { type CrossChainAssetDiff, getNetworkByBlockaidChain } from '@suite-common/tx-simulation';
+import { IconCircle, Row } from '@trezor/components';
+import { CoinsIcon } from '@trezor/icons';
+import { TokenIcon } from '@trezor/product-components';
+
+import { TxSimulationAssetRow } from '../../../common';
+
+type CrossChainTransfer = CrossChainAssetDiff['in'][number];
+
+interface TxSimulationCrossChainAssetProps {
+    assetDiff: CrossChainAssetDiff;
+}
+
+export function TxSimulationCrossChainAsset({ assetDiff }: TxSimulationCrossChainAssetProps) {
+    const { asset, chain } = assetDiff;
+    // Blockaid reports on more chains than Suite holds, so fall back to its own chain name.
+    const network = getNetworkByBlockaidChain(chain);
+
+    const summary = (transfer: CrossChainTransfer) =>
+        transfer.summary ?? `${transfer.value ?? transfer.raw_value} ${asset.symbol ?? ''}`.trim();
+
+    const renderTransfers = (
+        transfers: ReadonlyArray<CrossChainTransfer>,
+        intent: 'brand' | 'critical',
+        prefix: '+' | '-',
+        testIdPart: string,
+    ) =>
+        transfers.map((transfer, index) => (
+            <TxSimulationAssetRow
+                key={`${testIdPart}-${index}`}
+                intent={intent}
+                fiatAmount={
+                    transfer.usd_price
+                        ? { prefix, value: transfer.usd_price, currency: 'USD' }
+                        : undefined
+                }
+                dataTestId={`@sign-message-modal/tx-simulation-cross-chain-${testIdPart}-${index}`}
+            >
+                <Translation
+                    id="TR_SIMULATION_CROSS_CHAIN_ASSET"
+                    values={{ amount: summary(transfer), chain: network?.name ?? chain }}
+                />
+            </TxSimulationAssetRow>
+        ));
+
+    return (
+        <Row columnGap={8} padding={{ horizontal: 16, vertical: 12 }}>
+            {network && asset.symbol ? (
+                <TokenIcon
+                    symbol={network.symbol}
+                    contractAddress={'address' in asset ? asset.address : undefined}
+                    size={32}
+                    placeholder={asset.name ?? asset.symbol}
+                    customLogoUrl={asset.logo_url}
+                />
+            ) : (
+                <IconCircle icon={CoinsIcon} size={32} intent="neutral" />
+            )}
+
+            {renderTransfers(assetDiff.out, 'critical', '-', 'out')}
+            {renderTransfers(assetDiff.in, 'brand', '+', 'in')}
+        </Row>
+    );
+}

--- a/suite/tx-simulation/src/evm/index.ts
+++ b/suite/tx-simulation/src/evm/index.ts
@@ -1,3 +1,4 @@
 export { EvmInsufficientGasWarning } from './components/EvmInsufficientGasWarning';
 export { EvmTxSimulationDisclaimer } from './components/EvmTxSimulationDisclaimer';
 export { EvmTxSimulationAsset } from './components/EvmTxSimulationAsset/EvmTxSimulationAsset';
+export { TxSimulationCrossChainAsset } from './components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset';


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Renders the cross-chain outcome on desktop. A bridge leaves `account_summary` empty, so the Connect popup previously showed the empty state; `TxSimulationCrossChainAsset` now renders each destination-chain movement, labelled with its chain (falling back to Blockaid's own chain name for chains Suite has no network for — e.g. `hyperliquid`, which is HyperCore rather than the `hyperevm` we map).

Also wires the swap confirm step, which had no simulation at all on desktop — the shared hooks had zero call sites outside `suite-native`.

## Notes for QA

The only supported route is through the https://app.hyperliquid.xyz/trade (deposit, withdraw)

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31353

## Screenshots:

| Deposit (reported to blockaid) | Withdraw |
|--------|--------|
| <img width="795" height="707" alt="Screenshot 2026-08-18 at 11 05 39" src="https://github.com/user-attachments/assets/b91d8cce-b0b3-425e-a42e-aeed104a09ef" /> | <img width="807" height="660" alt="Screenshot 2026-08-18 at 10 43 40" src="https://github.com/user-attachments/assets/cae8b370-2c09-45d2-b01d-2bfa65957ada" /> |


<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain-desktop/web/](https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain-desktop/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockaid-crosschain-desktop&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockaid-crosschain-desktop&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T00:03:45.369Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T00:02:40.197Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set focuses on transaction simulation rendering for EVM/Solana/Stellar, cross-chain asset diffs, trading offer exchange simulation, connect-popup transaction simulation, and earn yield stablecoin simulation. The highest E2E risk sits in swap confirmation flows, connect-popup EVM signing, and the yield deposit simulation. A small, targeted suite covering a DEX swap, a Solana token swap, a cross-chain EVM-to-Solana swap, connect EVM signing, and the yield deposit test provides strong confidence. Stellar and native mobile changes lack matching E2E coverage and should be validated through unit tests or manual QA.

<details><summary><b>Changed files (63)</b></summary>

- `jest.config.native.js`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationDisclaimer.tsx`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationSuccessResult.tsx`
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`
- `suite-common/trading/src/utils/exchange/getExchangeIssue.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/client.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getAssetDiffTransferAmount.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts`
- `suite-common/tx-simulation/src/utils/index.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/evm/components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset.tsx`
- `suite/tx-simulation/src/evm/index.ts`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAsset.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/solana/index.ts`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAsset.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/stellar/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — This Solana SPL-token swap exercises the Solana-specific tx-simulation components and the changed trading simulation helpers (getSimulatedReceiveAmount, composeDexTxSimulationAction, getExchangeIssue) in the offer confirmation flow.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — The LI.FI DEX swap directly uses the changed TradingOfferExchange component and DEX tx-simulation utilities (composeDexTxSimulationAction, getSimulatedReceiveAmount, getExchangeIssue, getTxSimulationRiskSummary) while reviewing slippage, minimum received, and fees.
- `suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts` — Cross-chain ERC-20-to-Solana-token swap covers EVM and Solana cross-chain asset-diff rendering, exercising getCrossChainAssetDiffs and both EVM/Solana tx-simulation components in the TradingOfferExchange confirmation path.
- `suite/e2e/tests/trezor-connect/ethereumSignTransaction.test.ts` — Connect-popup EVM transaction signing triggers the changed useTxSimulationPopupCall hook, ConnectPopupTxSimulationModalInner, and EVM tx-simulation components that render simulated asset changes before the user signs.
- `suite/e2e/tests/yield/deposit.test.ts` — Identified by static coverage mapping, this test directly renders the changed EarnYieldTxSimulationModalInner and TxSimulationSuccessResult components, validating the earn stablecoin yield deposit simulation UI path.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Solana-to-Bitcoin cross-chain swap covers an additional outgoing Solana direction and cross-chain asset-diff display, complementing the Solana token swap tests and increasing confidence in the Solana tx-simulation changes.

</details>

⚠️ **Changes with no test coverage (36)**
- `jest.config.native.js`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAsset.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/stellar/index.ts`

_Updated: 2026-08-21T00:04:00.278Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->