### PR TITLE
feat(suite-native): implement cross-chain simulation results

### DIFF
--- a/suite-native/intl/src/messages.ts
+++ b/suite-native/intl/src/messages.ts
@@ -640,6 +640,7 @@ export const messages = {
             protocol: 'Protocol',
             address: 'Address',
             contractFunction: 'Contract function',
+            crossChainAsset: '{amount} on {chain}',
         },
         optional: 'Optional',
         alwaysAllow: 'Always allow for this app',

--- a/suite-native/module-trading/package.json
+++ b/suite-native/module-trading/package.json
@@ -76,6 +76,7 @@
         "@suite-native/trading-slippage": "workspace:*",
         "@suite-native/trading-state": "workspace:*",
         "@suite-native/transaction-management": "workspace:*",
+        "@suite-native/tx-simulation": "workspace:*",
         "@trezor/analytics-uploader": "workspace:*",
         "@trezor/blockchain-link-types": "workspace:*",
         "@trezor/connect": "workspace:*",

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx
@@ -18,6 +18,7 @@ import { ExchangeEIP712Info } from './ExchangeEIP712Info';
 import { ExchangeFromAccountTradePreviewCard } from './ExchangeFromAccountTradePreviewCard';
 import { ExchangeInfo } from './ExchangeInfo';
 import { ExchangePreviewIssueBanner } from './ExchangePreviewIssueBanner';
+import { ExchangeSimulationPreviewCard } from './ExchangeSimulationPreviewCard';
 import { ExchangeToAccountTradePreviewCard } from './ExchangeToAccountTradePreviewCard';
 import { LastErrorMessage } from '../../general/Error/LastErrorMessage';
 
@@ -65,6 +66,7 @@ export const ExchangePreviewView = memo(
                 <AnimatedVStack layout={LinearTransition} spacing="sp16">
                     <ExchangeFromAccountTradePreviewCard quote={quote} />
                     <ExchangeToAccountTradePreviewCard quote={quote} />
+                    <ExchangeSimulationPreviewCard />
                     {hasEIP712SignData ? (
                         <ExchangeEIP712Info exchange={quote?.exchange}>
                             <SlippagePicker onSlippageConfirmed={onSlippageConfirmed} />

--- a/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx
+++ b/suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx
@@ -1,0 +1,27 @@
+import { useSelector } from 'react-redux';
+
+import { getNetwork } from '@suite-common/wallet-config';
+import { Card } from '@suite-native/atoms';
+import { selectExchangeSelectedSendAccount } from '@suite-native/trading-state';
+import { TxSimulationAssetRows } from '@suite-native/tx-simulation';
+
+import { useDexExchangeTxSimulation } from '../../../hooks/exchange/useDexExchangeTxSimulation';
+
+export const ExchangeSimulationPreviewCard = () => {
+    const account = useSelector(selectExchangeSelectedSendAccount);
+    const { data: simulationResult } = useDexExchangeTxSimulation();
+
+    if (!account || !simulationResult) {
+        return null;
+    }
+
+    return (
+        <Card noPadding>
+            <TxSimulationAssetRows
+                result={simulationResult}
+                network={getNetwork(account.symbol)}
+                assetVariant="wrap"
+            />
+        </Card>
+    );
+};

--- a/suite-native/module-trading/tsconfig.json
+++ b/suite-native/module-trading/tsconfig.json
@@ -85,6 +85,7 @@
         { "path": "../trading-slippage" },
         { "path": "../trading-state" },
         { "path": "../transaction-management" },
+        { "path": "../tx-simulation" },
         {
             "path": "../../packages/analytics-uploader"
         },

--- a/suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx
+++ b/suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx
@@ -7,7 +7,7 @@ import { Box, Text, type TextProps } from '@suite-native/atoms';
 type EvmTxSimulationAssetAmountProps = {
     fiatAmount?: BaseCurrencyAmount;
     fiatSign?: ReactNode;
-    summary?: string;
+    summary?: ReactNode;
     summaryColor: TextProps['color'];
 };
 

--- a/suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx
+++ b/suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx
@@ -8,16 +8,7 @@ import {
     useTxSimulation,
 } from '@suite-common/tx-simulation';
 import { type TxSimulationAction } from '@suite-common/wallet-types';
-import {
-    BannerFull,
-    Box,
-    Button,
-    Card,
-    Divider,
-    HStack,
-    Loader,
-    VStack,
-} from '@suite-native/atoms';
+import { BannerFull, Button, Card, HStack, Loader, VStack } from '@suite-native/atoms';
 import { useCopyToClipboard } from '@suite-native/clipboard';
 import { Translation } from '@suite-native/intl';
 
@@ -31,11 +22,8 @@ import {
 } from './EvmTxSimulationInfoPresets';
 import { EvmTxSimulationInfoSection } from './EvmTxSimulationInfoSection';
 import { EvmTxSimulationRowInfoItems } from './EvmTxSimulationRowInfoItems';
-import { EvmTxSimulationStackedAsset } from './EvmTxSimulationStackedAsset';
 import { EvmTxSimulationStackedInfoItems } from './EvmTxSimulationStackedInfoItems';
-import { EvmTxSimulationWrappedAsset } from './EvmTxSimulationWrappedAsset';
-import { SolanaTxSimulationAsset } from './SolanaTxSimulationAsset';
-import { StellarTxSimulationAsset } from './StellarTxSimulationAsset';
+import { TxSimulationAssetRows } from './TxSimulationAssetRows';
 import { TxSimulationRiskBanner } from './TxSimulationRiskBanner';
 
 type EvmTxSimulationReviewContentProps = {
@@ -139,8 +127,6 @@ export function EvmTxSimulationReviewContent({
                   transaction: action.payload.transaction,
               })
             : [];
-    const EvmTxSimulationAssetComponent =
-        assetVariant === 'wrap' ? EvmTxSimulationWrappedAsset : EvmTxSimulationStackedAsset;
 
     return (
         <VStack spacing="sp16">
@@ -164,31 +150,12 @@ export function EvmTxSimulationReviewContent({
                         <VStack>
                             {title}
                             <Card noPadding>
-                                {evmSimulation.account_summary.assets_diffs.map(
-                                    (assetDiff, index) => (
-                                        <Box key={`diff-${index}`}>
-                                            {areAssetDividersDisplayed && index > 0 && <Divider />}
-                                            <EvmTxSimulationAssetComponent
-                                                assetDiff={assetDiff}
-                                                network={network}
-                                            />
-                                        </Box>
-                                    ),
-                                )}
-                                {evmSimulation.account_summary.exposures.map(
-                                    (assetExposure, index) => (
-                                        <Box key={`exposure-${index}`}>
-                                            {areAssetDividersDisplayed &&
-                                                (index > 0 ||
-                                                    evmSimulation.account_summary.assets_diffs
-                                                        .length > 0) && <Divider />}
-                                            <EvmTxSimulationAssetComponent
-                                                assetExposure={assetExposure}
-                                                network={network}
-                                            />
-                                        </Box>
-                                    ),
-                                )}
+                                <TxSimulationAssetRows
+                                    result={simulationData}
+                                    network={network}
+                                    areAssetDividersDisplayed={areAssetDividersDisplayed}
+                                    assetVariant={assetVariant}
+                                />
 
                                 {targetContract && (
                                     <EvmTxSimulationInfoSection
@@ -223,15 +190,12 @@ export function EvmTxSimulationReviewContent({
                         <VStack>
                             {title}
                             <Card noPadding>
-                                {solanaAssetDiffs.map((assetDiff, index) => (
-                                    <Box key={`solana-diff-${index}`}>
-                                        {areAssetDividersDisplayed && index > 0 && <Divider />}
-                                        <SolanaTxSimulationAsset
-                                            assetDiff={assetDiff}
-                                            network={network}
-                                        />
-                                    </Box>
-                                ))}
+                                <TxSimulationAssetRows
+                                    result={simulationData}
+                                    network={network}
+                                    areAssetDividersDisplayed={areAssetDividersDisplayed}
+                                    assetVariant={assetVariant}
+                                />
                             </Card>
                         </VStack>
                     )}
@@ -240,15 +204,12 @@ export function EvmTxSimulationReviewContent({
                         <VStack>
                             {title}
                             <Card noPadding>
-                                {stellarAssetDiffs.map((assetDiff, index) => (
-                                    <Box key={`stellar-diff-${index}`}>
-                                        {areAssetDividersDisplayed && index > 0 && <Divider />}
-                                        <StellarTxSimulationAsset
-                                            assetDiff={assetDiff}
-                                            network={network}
-                                        />
-                                    </Box>
-                                ))}
+                                <TxSimulationAssetRows
+                                    result={simulationData}
+                                    network={network}
+                                    areAssetDividersDisplayed={areAssetDividersDisplayed}
+                                    assetVariant={assetVariant}
+                                />
                             </Card>
                         </VStack>
                     )}

--- a/suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx
+++ b/suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx
@@ -1,0 +1,119 @@
+import {
+    type NetworkTxSimulationResult,
+    getCrossChainAssetDiffs,
+    isTxSimulationResultWithMethods,
+} from '@suite-common/tx-simulation';
+import { type Network } from '@suite-common/wallet-config';
+import { Box, Divider } from '@suite-native/atoms';
+
+import { EvmTxSimulationStackedAsset } from './EvmTxSimulationStackedAsset';
+import { EvmTxSimulationWrappedAsset } from './EvmTxSimulationWrappedAsset';
+import { SolanaTxSimulationAsset } from './SolanaTxSimulationAsset';
+import { StellarTxSimulationAsset } from './StellarTxSimulationAsset';
+import { TxSimulationCrossChainAsset } from './TxSimulationCrossChainAsset';
+
+export type TxSimulationAssetRowsProps = {
+    result: NetworkTxSimulationResult;
+    network: Network;
+    areAssetDividersDisplayed?: boolean;
+    assetVariant?: 'stack' | 'wrap';
+};
+
+export function TxSimulationAssetRows({
+    result,
+    network,
+    areAssetDividersDisplayed = true,
+    assetVariant = 'stack',
+}: TxSimulationAssetRowsProps) {
+    const EvmAsset =
+        assetVariant === 'wrap' ? EvmTxSimulationWrappedAsset : EvmTxSimulationStackedAsset;
+
+    if (
+        isTxSimulationResultWithMethods(
+            ['ethereumSignTypedData', 'ethereumSignTransaction'] as const,
+            result,
+        )
+    ) {
+        const { simulation } = result.payload;
+
+        if (simulation?.status !== 'Success') {
+            return null;
+        }
+
+        const { assets_diffs: assetsDiffs, exposures } = simulation.account_summary;
+        // A bridge leaves the account summary empty — its outcome is reported per chain.
+        const crossChainDiffs = getCrossChainAssetDiffs(simulation, result.payload.account_address);
+
+        return (
+            <>
+                {assetsDiffs.map((assetDiff, index) => (
+                    <Box key={`diff-${index}`}>
+                        {areAssetDividersDisplayed && index > 0 && <Divider />}
+                        <EvmAsset assetDiff={assetDiff} network={network} />
+                    </Box>
+                ))}
+                {crossChainDiffs.map((assetDiff, index) => (
+                    <Box key={`cross-chain-diff-${index}`}>
+                        {areAssetDividersDisplayed && (index > 0 || assetsDiffs.length > 0) && (
+                            <Divider />
+                        )}
+                        <TxSimulationCrossChainAsset assetDiff={assetDiff} />
+                    </Box>
+                ))}
+                {exposures.map((assetExposure, index) => (
+                    <Box key={`exposure-${index}`}>
+                        {areAssetDividersDisplayed && (index > 0 || assetsDiffs.length > 0) && (
+                            <Divider />
+                        )}
+                        <EvmAsset assetExposure={assetExposure} network={network} />
+                    </Box>
+                ))}
+            </>
+        );
+    }
+
+    if (isTxSimulationResultWithMethods(['solanaSignTransaction'] as const, result)) {
+        const assetDiffs = result.payload.result?.simulation?.account_summary.account_assets_diff;
+
+        if (!assetDiffs) {
+            return null;
+        }
+
+        return (
+            <>
+                {assetDiffs.map((assetDiff, index) => (
+                    <Box key={`solana-diff-${index}`}>
+                        {areAssetDividersDisplayed && index > 0 && <Divider />}
+                        <SolanaTxSimulationAsset assetDiff={assetDiff} network={network} />
+                    </Box>
+                ))}
+            </>
+        );
+    }
+
+    const stellarSimulation = isTxSimulationResultWithMethods(
+        ['stellarSignTransaction'] as const,
+        result,
+    )
+        ? result.payload.simulation
+        : undefined;
+    const stellarAssetDiffs =
+        stellarSimulation?.status === 'Success'
+            ? stellarSimulation.account_summary.account_assets_diffs
+            : undefined;
+
+    if (!stellarAssetDiffs) {
+        return null;
+    }
+
+    return (
+        <>
+            {stellarAssetDiffs.map((assetDiff, index) => (
+                <Box key={`stellar-diff-${index}`}>
+                    {areAssetDividersDisplayed && index > 0 && <Divider />}
+                    <StellarTxSimulationAsset assetDiff={assetDiff} network={network} />
+                </Box>
+            ))}
+        </>
+    );
+}

--- a/suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx
+++ b/suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx
@@ -1,0 +1,70 @@
+import { type CrossChainAssetDiff, getNetworkByBlockaidChain } from '@suite-common/tx-simulation';
+import { asBaseCurrencyAmount } from '@suite-common/wallet-types';
+import { HStack, VStack } from '@suite-native/atoms';
+import { Icon, TokenIcon } from '@suite-native/icons';
+import { Translation } from '@suite-native/intl';
+import { BigNumber } from '@trezor/utils';
+
+import { EvmTxSimulationAssetAmount } from './EvmTxSimulationAssetAmount';
+
+type CrossChainTransfer = CrossChainAssetDiff['in'][number];
+
+type TxSimulationCrossChainAssetProps = {
+    assetDiff: CrossChainAssetDiff;
+};
+
+export const TxSimulationCrossChainAsset = ({ assetDiff }: TxSimulationCrossChainAssetProps) => {
+    const { asset, chain } = assetDiff;
+    // Blockaid reports on more chains than Suite holds, so fall back to its own chain name.
+    const network = getNetworkByBlockaidChain(chain);
+
+    const renderTransfers = (
+        transfers: ReadonlyArray<CrossChainTransfer>,
+        fiatSign: string,
+        summaryColor: 'contentBrand' | 'contentCritical',
+        key: string,
+    ) =>
+        transfers.map((transfer, index) => (
+            <HStack key={`${key}-${index}`} alignItems="center" spacing="sp8">
+                <EvmTxSimulationAssetAmount
+                    fiatAmount={
+                        transfer.usd_price
+                            ? asBaseCurrencyAmount(new BigNumber(transfer.usd_price))
+                            : undefined
+                    }
+                    fiatSign={fiatSign}
+                    summary={
+                        <Translation
+                            id="moduleConnectPopup.simulation.crossChainAsset"
+                            values={{
+                                amount:
+                                    transfer.summary ??
+                                    `${transfer.value ?? transfer.raw_value} ${asset.symbol ?? ''}`.trim(),
+                                chain: network?.name ?? chain,
+                            }}
+                        />
+                    }
+                    summaryColor={summaryColor}
+                />
+            </HStack>
+        ));
+
+    return (
+        <HStack spacing="sp12" padding="sp16" alignItems="center">
+            {network && asset.symbol ? (
+                <TokenIcon
+                    symbol={network.symbol}
+                    contractAddress={'address' in asset ? asset.address : undefined}
+                    size="small"
+                    showNetworkIcon
+                />
+            ) : (
+                <Icon name="coins" size="small" />
+            )}
+            <VStack flex={1} spacing="sp8">
+                {renderTransfers(assetDiff.out, '- ', 'contentCritical', 'out')}
+                {renderTransfers(assetDiff.in, '+ ', 'contentBrand', 'in')}
+            </VStack>
+        </HStack>
+    );
+};

--- a/suite-native/tx-simulation/src/components/index.ts
+++ b/suite-native/tx-simulation/src/components/index.ts
@@ -2,6 +2,7 @@ export * from './EvmInsufficientGasWarning';
 export * from './EvmTxSimulationStackedAsset';
 export * from './EvmTxSimulationWrappedAsset';
 export * from './EvmTxSimulationReviewContent';
+export * from './TxSimulationAssetRows';
 export * from './TxSimulationRiskBanner';
 export * from './SolanaTxSimulationAsset';
 export * from './StellarTxSimulationAsset';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13523,6 +13523,7 @@ __metadata:
     "@suite-native/trading-state": "workspace:*"
     "@suite-native/trading-types": "workspace:*"
     "@suite-native/transaction-management": "workspace:*"
+    "@suite-native/tx-simulation": "workspace:*"
     "@trezor/analytics-uploader": "workspace:*"
     "@trezor/blockchain-link-types": "workspace:*"
     "@trezor/connect": "workspace:*"


### PR DESCRIPTION
Top of the stack, on top of #31347 and the desktop PR.

> [!IMPORTANT]
>  Not tested, AI coded and waiting for desktop PR to be finalized. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=feat/blockaid-crosschain-native&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/blockaid-crosschain-native&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/blockaid-crosschain-native&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain-native/web/](https://dev.suite.sldev.cz/suite-web/feat/blockaid-crosschain-native/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 3 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap coin to token > Swap Solana to USDC | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-21T00:04:07.534Z • 3 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-21T00:03:55.956Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set refactors transaction simulation across DEX/cross-chain trading and earn/yield flows, and adds Solana/Stellar connect-popup simulation hooks. The highest regression risk is in DEX swap simulation (LI.FI) and the earn/yield simulation modal UI. A focused run of the DEX and cross-chain swap tests plus the yield deposit test covers the changed code paths without falling back to the full suite. No e2e coverage exists for the new Solana/Stellar connect-popup hooks or the mobile/native simulation components.

<details><summary><b>Changed files (71)</b></summary>

- `jest.config.native.js`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationDisclaimer.tsx`
- `packages/suite/src/components/tx-simulation/common/components/TxSimulationSuccessResult.tsx`
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/components/tx-simulation/earn-stablecoin/EarnYieldTxSimulationModalInner.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts`
- `suite-common/connect-popup/src/methodHooks/index.ts`
- `suite-common/connect-popup/src/methodHooks/solanaSignTransaction.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.ts`
- `suite-common/trading/src/thunks/exchange/sendDexTransactionThunk.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.ts`
- `suite-common/trading/src/utils/exchange/exchangeUtils.ts`
- `suite-common/trading/src/utils/exchange/getExchangeIssue.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/client.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/hooks/useNetworkTxSimulation.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getAssetDiffTransferAmount.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.ts`
- `suite-common/tx-simulation/src/utils/index.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/evm/components/TxSimulationCrossChainAsset/TxSimulationCrossChainAsset.tsx`
- `suite/tx-simulation/src/evm/index.ts`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAsset.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/solana/index.ts`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAsset.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/stellar/index.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test exercises the DEX token-approval flow that is built on the changed DEX simulation/thunk code (composeDexTxSimulationAction, sendDexTransactionThunk, useExchangeIssue). A regression in approval simulation or allowance calculation would block the entire LI.FI swap path and is immediately user-visible.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Directly covers the LI.FI DEX swap end-to-end path, including slippage, minimum received, and transaction confirmation screens that rely on the changed DEX simulation utilities (composeDexTxSimulationAction, getSimulatedReceiveAmount) and exchange-issue logic.
- `suite/e2e/tests/yield/deposit.test.ts` — Inferred from static coverage: this is the only e2e test that references the changed EarnYieldTxSimulationModalInner and TxSimulationSuccessResult components. Changes to the earn/yield simulation success UI would be caught only here.

</details>

<details><summary>🟡 <b>Medium priority (6)</b></summary>

- `suite/e2e/tests/trading-live/live-swap-spl-token-to-coin.test.ts` — Covers a live Solana SPL-token-to-coin swap that displays offer details, send amounts, and cross-chain receive values. It exercises the changed trading simulation/issue helpers and Solana asset-diff rendering path.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — Exercises a coin-to-token swap where offer confirmation and transaction detail values depend on the same exchange-issue and simulated-amount utilities that were modified.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain ETH-to-SOL swap uses receive-amount simulation and exchange-issue warnings; a regression in cross-chain asset diff calculation or issue detection would surface here.
- `suite/e2e/tests/trading/swap-eth-token-to-sol-token.test.ts` — Cross-chain ERC-20-to-SPL token swap is a high-complexity path that relies on cross-chain asset diffs and simulated receive amounts; changes to those utilities are likely to affect this flow.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — SOL-to-BTC cross-chain swap displays provider quotes, send/receive amounts, and transaction status; it shares the changed exchange-issue and simulation infrastructure and the Solana simulation UI components.
- `suite/e2e/tests/trading/swap-sol-token-to-eth.test.ts` — SPL-token-to-ETH swap exercises the Solana token simulation display together with the trading offer exchange logic that was changed.

</details>

⚠️ **Changes with no test coverage (51)**
- `jest.config.native.js`
- `packages/suite/src/components/tx-simulation/connect-popup/ConnectPopupTxSimulationModalInner.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `suite-common/connect-popup/package.json`
- `suite-common/connect-popup/src/hooks/useTxSimulationPopupCall.ts`
- `suite-common/connect-popup/src/methodHooks/stellarSignTransaction.ts`
- `suite-common/connect-popup/tsconfig.json`
- `suite-common/trading/package.json`
- `suite-common/trading/src/__fixtures__/utils.ts`
- `suite-common/trading/src/hooks/useExchangeIssue.test.ts`
- `suite-common/trading/src/utils/exchange/composeDexTxSimulationAction.test.ts`
- `suite-common/trading/src/utils/exchange/getSimulatedReceiveAmount.test.ts`
- `suite-common/trading/tsconfig.json`
- `suite-common/tx-simulation/package.json`
- `suite-common/tx-simulation/src/chains.test.ts`
- `suite-common/tx-simulation/src/chains.ts`
- `suite-common/tx-simulation/src/constants.ts`
- `suite-common/tx-simulation/src/index.ts`
- `suite-common/tx-simulation/src/jestSetup.ts`
- `suite-common/tx-simulation/src/types.ts`
- `suite-common/tx-simulation/src/utils/getCrossChainAssetDiffs.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationParams.test.ts`
- `suite-common/tx-simulation/src/utils/getTxSimulationRiskSummary.test.ts`
- `suite-common/tx-simulation/tsconfig.json`
- `suite-common/wallet-types/package.json`
- `suite-common/wallet-types/src/transactionSimulation.ts`
- `suite-common/wallet-types/tsconfig.json`
- `suite-native/intl/src/messages.ts`
- `suite-native/module-trading/package.json`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangePreviewView.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeSimulationPreviewCard.tsx`
- `suite-native/module-trading/src/components/exchange/ExchangePreview/ExchangeToAccountTradePreviewCard.tsx`
- `suite-native/module-trading/src/screens/TradingExchangePreviewScreen.test.tsx`
- `suite-native/module-trading/tsconfig.json`
- `suite-native/tx-simulation/src/components/EvmTxSimulationAssetAmount.tsx`
- `suite-native/tx-simulation/src/components/EvmTxSimulationReviewContent.tsx`
- `suite-native/tx-simulation/src/components/SolanaTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/StellarTxSimulationAsset.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationAssetRows.tsx`
- `suite-native/tx-simulation/src/components/TxSimulationCrossChainAsset.tsx`
- `suite-native/tx-simulation/src/components/index.ts`
- `suite/intl/src/messages.ts`
- `suite/tx-simulation/src/evm/index.ts`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAsset.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationAsset/SolanaTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/solana/components/SolanaTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/solana/index.ts`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAsset.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationAsset/StellarTxSimulationAssetLogo.tsx`
- `suite/tx-simulation/src/stellar/components/StellarTxSimulationDisclaimer.tsx`
- `suite/tx-simulation/src/stellar/index.ts`

_Updated: 2026-08-21T00:05:21.175Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->