### PR TITLE
fix(suite): use correct tx review modal labels for yield withdraw/redeem

### DIFF
--- a/suite/intl/src/messages.ts
+++ b/suite/intl/src/messages.ts
@@ -10442,11 +10442,11 @@ export const messages = defineMessages({
     },
     TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE: {
         id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_TITLE',
-        defaultMessage: 'Redeem',
+        defaultMessage: 'Withdraw',
     },
     TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION: {
         id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_DESCRIPTION',
-        defaultMessage: 'Review details to redeem from vault.',
+        defaultMessage: 'Review details to withdraw from vault.',
     },
     TR_EARN_YIELD_REVIEW_REDEEM_TITLE: {
         id: 'TR_EARN_YIELD_REVIEW_REDEEM_TITLE',
@@ -10474,7 +10474,7 @@ export const messages = defineMessages({
     },
     TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT: {
         id: 'TR_EARN_YIELD_REVIEW_WITHDRAW_AMOUNT',
-        defaultMessage: 'Redeem amount',
+        defaultMessage: 'Withdraw amount',
     },
     TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT: {
         id: 'TR_EARN_YIELD_REVIEW_REDEEM_AMOUNT',


### PR DESCRIPTION
## Description

Use `Withdraw ...` labels for withdraw and `Redeem ...` labels for redeem in Yield transaction review modal.

Crowdin updated.

## Related Issue

Resolve https://github.com/trezor/trezor-suite/issues/31300

## Screenshots:

<img width="1512" height="841" alt="Screenshot 2026-08-18 at 14 23 39" src="https://github.com/user-attachments/assets/08e6c657-09f6-484f-be2d-ec0289e7a33e" />

<img width="1512" height="841" alt="Screenshot 2026-08-18 at 14 24 00" src="https://github.com/user-attachments/assets/d749c204-e178-400d-8eb3-1287cd168d06" />

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-tx-review-modal-labels/web/](https://dev.suite.sldev.cz/suite-web/fix/yield-withdraw-tx-review-modal-labels/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/yield-withdraw-tx-review-modal-labels&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/yield-withdraw-tx-review-modal-labels&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T12:32:08.405Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T12:31:52.512Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** messages.ts is the central source of translated strings, so changes can break any test that asserts exact translation keys or rendered text. No static coverage was available, so I inferred a representative smoke set that exercises message strings across onboarding, settings, wallet, trading, staking, metadata, TrezorConnect, and browser-gate flows. These tests directly reference specific keys and provide broad, high-value coverage without running the full suite.

<details><summary><b>Changed files (1)</b></summary>

- `suite/intl/src/messages.ts`

</details>

**Recommended tests (20)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/backup/t2t1-fail.test.ts` — The test asserts that the dashboard and device settings render the exact translation keys TR_FAILED_BACKUP and TR_BACKUP_RECOVERY_SEED_FAILED_DESC, which are defined in messages.ts. A change there would directly break these user-visible error messages.
- `suite/e2e/tests/metadata/suite-sync/unsupported-device.test.ts` — It verifies the TR_SUITE_SYNC_UNSUPPORTED_DEVICE_BANNER banner is shown and hidden, so any rename, removal, or text change of that message in messages.ts would fail this test.
- `suite/e2e/tests/onboarding/get-started-modal.test.ts` — The test checks that the post-onboarding dashboard displays the exact translation keys TR_YOUR_WALLET_IS_READY_WHAT and TR_DASHBOARD_MODAL_ACTIVATE_ASSETS_TITLE, making it a direct smoke test of onboarding message strings.
- `suite/e2e/tests/passphrase/passphrase.test.ts` — It asserts the passphrase mismatch dialog renders TR_PASSPHRASE_MISMATCH, TR_PASSPHRASE_MISMATCH_DESCRIPTION, and TR_PASSPHRASE_WALLET strings, all sourced from messages.ts.
- `suite/e2e/tests/settings/autodetect.test.ts` — This test compares the rendered analytics heading text against expected English and Spanish translations, with source hints pointing directly at TR_ONBOARDING_DATA_COLLECTION_HEADING in messages.ts.
- `suite/e2e/tests/settings/coins.test.ts` — It validates the dashboard empty state strings TR_YOUR_WALLET_IS_READY_WHAT, TR_DASHBOARD_ACTIVATE_ASSETS_DESC, and TR_DASHBOARD_GET_STARTED, which come from messages.ts.
- `suite/e2e/tests/settings/forget-device.test.ts` — The forget-device modal assertions depend on TR_FORGET_DEVICE_MODAL_HEADING, TR_FORGET_DEVICE_MODAL_FINISH_HEADING, and related bullet translation keys defined in messages.ts.
- `suite/e2e/tests/staking/staking-form.test.ts` — It checks staking form validation messages such as TR_BUY_VALIDATION_ERROR_MINIMUM_CRYPTO, AMOUNT_IS_NOT_IN_RANGE_DECIMALS, AMOUNT_IS_NOT_ENOUGH, and TR_STAKE_LEFT_AMOUNT_FOR_WITHDRAWAL from messages.ts.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — The test asserts several trading UI translation keys, including TR_CONTINUE, TR_TRADING_BUY_VIA, TR_BUY_DETAIL_WAITING_FOR_USER_TITLE, and TR_BUY_DETAIL_SUCCESS_TITLE, all originating in messages.ts.
- `suite/e2e/tests/trezor-connect/permissions.test.ts` — It checks the permissions modal renders TR_CONNECT_MODAL_REMEMBER and that the forget action uses TR_FORGET, both of which are defined in messages.ts.
- `suite/e2e/tests/wallet/send-eth.test.ts` — The test verifies the Ethereum fee section displays the TR_GAS_LIMIT translation string from messages.ts, so a message change would directly break this send-flow assertion.

</details>

<details><summary>🟡 <b>Medium priority (9)</b></summary>

- `suite/e2e/tests/browser/safari.test.ts` — It asserts exact unsupported-browser strings such as 'Your browser is not supported' and 'Continue at my own risk', which are rendered from messages.ts.
- `suite/e2e/tests/metadata/suite-sync/multi-wallet.test.ts` — It checks the TR_SUITE_SYNC_KEYS_NEEDED_BANNER translation key in the Suite Sync banner, covering another metadata message path from messages.ts.
- `suite/e2e/tests/onboarding/t3t1/t3t1-create-wallet-offline.test.ts` — It verifies the offline banner text using TR_YOU_WERE_DISCONNECTED_DOT and a firmware revision message from messages.ts during onboarding.
- `suite/e2e/tests/passphrase/passphrase-cardano.test.ts` — It checks the TOAST_VERIFY_ADDRESS_ERROR toast message, sourced from messages.ts, when address verification fails with a wrong passphrase.
- `suite/e2e/tests/staking/ada/stake.test.ts` — It relies on numerous staking and Earn modal translation keys such as TR_EARN_STAKING_IN_A_NUTSHELL and TR_EARN_STAKE_TOKEN, which are defined in messages.ts.
- `suite/e2e/tests/trading/swap-history.test.ts` — It asserts trading history translation keys TR_TRADING_LAST_TRANSACTIONS, TR_TRADING_TRADE_HISTORY_COUNTER, and TR_TRADING_TRANS_ID from messages.ts.
- `suite/e2e/tests/trezor-connect/getAddress.test.ts` — It checks that the verify button shows the TR_VERIFYING translation text during on-device address verification, a string from messages.ts.
- `suite/e2e/tests/trezor-connect/silentMode.test.ts` — It verifies the silent-mode checkbox label uses TR_CONNECT_APP_SILENT_MODE from messages.ts.
- `suite/e2e/tests/wallet/transactions.test.ts` — It asserts date-range labels TR_DATE_DAY_LONG, TR_DATE_WEEK_LONG, TR_DATE_MONTH_LONG, TR_DATE_YEAR_LONG, and TR_ALL, all from messages.ts.

</details>

_Updated: 2026-08-18T12:34:06.568Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->