### PR TITLE
feat(trading): analytics for swap simulation issues

### DIFF
--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx
@@ -4,9 +4,12 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { events } from '@suite/analytics';
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
 import { configureMockStore } from '@suite-common/test-utils';
 import {
     type ExchangeIssue,
+    type TradingExchangeStepType,
     exchangeInitialState,
     getSimulatedReceiveAmount,
     initialState as tradingInitialState,
@@ -17,6 +20,7 @@ import { asNetworkSymbol } from '@suite-common/wallet-config';
 import { mockWalletAccount } from '@suite-common/wallet-types/mocks';
 
 import { type AppState } from 'src/reducers/store';
+import { type SuiteServices } from 'src/support/extraDependencies';
 import { renderWithProviders } from 'src/support/test-utils/hooksHelper';
 
 import { TradingOfferExchange } from './TradingOfferExchange';
@@ -24,6 +28,7 @@ import { extraDependenciesDesktopMock } from '../../../../../../../mocks/extraDe
 import { mockInitialAppState } from '../../../../../../../mocks/mockInitialAppState';
 
 const mockSendTransaction = jest.fn(() => Promise.resolve(true));
+const mockSignDataAndConfirm = jest.fn(() => Promise.resolve());
 const mockGoto = jest.fn((payload: unknown) => ({ type: 'test/goto', payload }));
 
 jest.mock('@suite/device', () => ({
@@ -52,7 +57,7 @@ jest.mock('src/hooks/wallet/trading/useTradingExchangeTradeActions', () => ({
     useTradingExchangeTradeActions: () => ({
         account: mockWalletAccount({ symbol: asNetworkSymbol('eth') }),
         sendTransaction: mockSendTransaction,
-        signDataAndConfirm: jest.fn(),
+        signDataAndConfirm: mockSignDataAndConfirm,
     }),
 }));
 
@@ -99,6 +104,11 @@ const CROSS_CHAIN_QUOTE: ExchangeTrade = {
     receive: 'bitcoin' as CryptoId,
 };
 
+const SIGN_DATA_QUOTE: ExchangeTrade = {
+    ...SELECTED_QUOTE,
+    signData: { type: 'eip712-typed-data', data: {} },
+};
+
 const PRICE_IMPACT_ISSUE: ExchangeIssue = {
     type: 'price-impact',
     severity: 'warning',
@@ -112,6 +122,7 @@ type SimulationOverrides = {
     simulatedReceiveAmount?: string | null;
     simulationError?: Error | null;
     selectedQuote?: ExchangeTrade;
+    formStep?: TradingExchangeStepType;
 };
 
 const renderOfferExchange = ({
@@ -121,6 +132,7 @@ const renderOfferExchange = ({
     simulatedReceiveAmount = null,
     simulationError = null,
     selectedQuote = SELECTED_QUOTE,
+    formStep = exchangeInitialState.formStep,
 }: SimulationOverrides = {}) => {
     mockUseDexExchangeTxSimulation.mockReturnValue({
         isEnabled: isSimulationEnabled,
@@ -143,13 +155,21 @@ const renderOfferExchange = ({
                 ...mockInitialAppState.wallet,
                 trading: {
                     ...tradingInitialState,
-                    exchange: { ...exchangeInitialState, selectedQuote },
+                    exchange: { ...exchangeInitialState, selectedQuote, formStep },
                 },
             },
         } satisfies AppState,
     });
 
-    renderWithProviders(store, extraDependenciesDesktopMock.services, <TradingOfferExchange />);
+    const report = jest.fn();
+    const services: SuiteServices = {
+        ...extraDependenciesDesktopMock.services,
+        analytics: mockDesktopAnalytics(report),
+    };
+
+    renderWithProviders(store, services, <TradingOfferExchange />);
+
+    return { report };
 };
 
 describe('TradingOfferExchange', () => {
@@ -157,17 +177,10 @@ describe('TradingOfferExchange', () => {
         jest.clearAllMocks();
     });
 
-    it('reviews a DEX swap under the swap title', () => {
-        renderOfferExchange();
+    it.each([true, false])('reviews a swap under the swap title (isDex: %s)', isDex => {
+        renderOfferExchange({ selectedQuote: { ...SELECTED_QUOTE, isDex } });
 
         expect(screen.getByText('TR_TRADING_REVIEW_SWAP')).toBeInTheDocument();
-    });
-
-    it('keeps the original title for a CEX trade', () => {
-        renderOfferExchange({ selectedQuote: { ...SELECTED_QUOTE, isDex: false } });
-
-        expect(screen.getByText('TR_SELL_CONFIRM_SEND_STEP')).toBeInTheDocument();
-        expect(screen.queryByText('TR_TRADING_REVIEW_SWAP')).not.toBeInTheDocument();
     });
 
     it('shows the quote receive amount until the simulation provides its own', () => {
@@ -232,10 +245,64 @@ describe('TradingOfferExchange', () => {
     });
 
     it('sends the transaction from continue anyway inside the banner', async () => {
-        renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
+        const { report } = renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
 
         await userEvent.click(screen.getByTestId('@trading/offer/continue-anyway'));
 
         expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradeExchangeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'confirm-and-send',
+                slippage: undefined,
+            },
+        });
+    });
+
+    it('reports the shown issue', () => {
+        const { report } = renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
+
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradingExchangeIssueEvent.name,
+            payload: {
+                issue: 'price-impact-warning',
+                isSimulation: true,
+            },
+        });
+    });
+
+    it('reports leaving for the trade form as a cancellation', async () => {
+        const { report } = renderOfferExchange({ issue: PRICE_IMPACT_ISSUE });
+
+        await userEvent.click(screen.getByTestId('@trading/offer/back-to-trade-form'));
+
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradeExchangeEvent.name,
+            payload: {
+                action: 'cancel',
+                step: 'confirm-and-send',
+                slippage: undefined,
+            },
+        });
+    });
+
+    it('reports continuing on the sign data step', async () => {
+        const { report } = renderOfferExchange({
+            selectedQuote: SIGN_DATA_QUOTE,
+            formStep: 'SIGN_DATA',
+        });
+
+        await userEvent.click(screen.getByTestId('@trading/offer/confirm-on-trezor-and-send'));
+
+        expect(mockSignDataAndConfirm).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradeExchangeEvent.name,
+            payload: {
+                action: 'continue',
+                step: 'confirm-and-send',
+                slippage: undefined,
+            },
+        });
     });
 });

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx
@@ -1,4 +1,4 @@
-import { events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { type TradeExchangeAction, events, selectDesktopAnalyticsDep } from '@suite/analytics';
 import { useDevice } from '@suite/device';
 import { Translation } from '@suite/intl';
 import { goto } from '@suite/router';
@@ -28,6 +28,7 @@ import { tradingGetAmountLabels } from 'src/utils/wallet/trading/tradingUtils';
 import { TradingOfferExchangeDetails } from './TradingOfferExchangeDetails';
 import { TradingOfferExchangeIssueBanner } from './TradingOfferExchangeIssueBanner';
 import { TradingOfferExchangeSimulationSubtitle } from './TradingOfferExchangeSimulationSubtitle';
+import { useExchangeIssueAnalytics } from './useExchangeIssueAnalytics';
 import { TradingInfoItem } from '../TradingInfo/TradingInfoItem';
 
 export const TradingOfferExchange = () => {
@@ -65,7 +66,9 @@ export const TradingOfferExchange = () => {
         error: simulationError,
         data: simulationResult,
     } = useDexExchangeTxSimulation(txSimulationParams);
-    const { issue, isSimulationEnabled } = useExchangeIssue(txSimulationParams);
+    const { issue, isSimulationEnabled, isSimulation } = useExchangeIssue(txSimulationParams);
+
+    useExchangeIssueAnalytics({ issue, isSimulationLoading, isSimulation });
 
     const isConfirmDisabled =
         isLoading || !selectedQuote || !sendAccount || !device?.connected || isSimulationLoading;
@@ -77,11 +80,8 @@ export const TradingOfferExchange = () => {
     }
 
     const providers = exchangeInfo?.providerInfos;
-
     const amountLabels = tradingGetAmountLabels({ type: 'exchange', amountInCrypto: false });
-
     const { exchange, signData } = selectedTrade;
-
     const isSignData = formStep === 'SIGN_DATA' && !!signData;
 
     const simulatedReceiveAmount = getSimulatedReceiveAmount(
@@ -90,17 +90,11 @@ export const TradingOfferExchange = () => {
     );
     const hasIssueToResolve = isSimulationEnabled && issue !== null;
 
-    const titleTranslationId = selectedTrade.isDex
-        ? 'TR_TRADING_REVIEW_SWAP'
-        : 'TR_SELL_CONFIRM_SEND_STEP';
-
-    const confirmAndSend = async () => {
-        const result = await sendTransaction();
-
+    const reportConfirmAndSendStep = (action: TradeExchangeAction) => {
         analytics.report({
             type: events.tradeExchangeEvent.name,
             payload: {
-                action: result ? 'continue' : 'cancel',
+                action,
                 step: 'confirm-and-send',
                 slippage: selectedTrade.swapSlippage,
             },
@@ -109,13 +103,19 @@ export const TradingOfferExchange = () => {
 
     const onConfirmAndSendClick = async () => {
         if (isSignData) {
+            reportConfirmAndSendStep('continue');
             await signDataAndConfirm();
-        } else {
-            await confirmAndSend();
+
+            return;
         }
+
+        const result = await sendTransaction();
+
+        reportConfirmAndSendStep(result ? 'continue' : 'cancel');
     };
 
     const onBackToTradeFormClick = () => {
+        reportConfirmAndSendStep('cancel');
         dispatch(goto({ routeName: 'wallet-trading-exchange', preserveParams: true }));
     };
 
@@ -125,7 +125,7 @@ export const TradingOfferExchange = () => {
                 <Column gap={20}>
                     <Column gap={4} alignItems="start">
                         <H2 typographyStyle="headline-sm">
-                            <Translation id={titleTranslationId} />
+                            <Translation id="TR_TRADING_REVIEW_SWAP" />
                         </H2>
                         <TradingOfferExchangeSimulationSubtitle
                             isSimulationEnabled={isSimulationEnabled}

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.test.tsx
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.test.tsx
@@ -1,0 +1,125 @@
+import '@suite-common/test-utils/globalOverrides';
+
+import { events } from '@suite/analytics';
+import { mockDesktopAnalytics } from '@suite/analytics/mocks';
+import { configureMockStore } from '@suite-common/test-utils';
+import { type ExchangeIssue } from '@suite-common/trading';
+
+import { type AppState } from 'src/reducers/store';
+import { type SuiteServices } from 'src/support/extraDependencies';
+import { renderHookWithProviders } from 'src/support/test-utils/hooksHelper';
+
+import { getTradingExchangeIssue, useExchangeIssueAnalytics } from './useExchangeIssueAnalytics';
+import { extraDependenciesDesktopMock } from '../../../../../../../mocks/extraDependenciesDesktopMock';
+import { mockInitialAppState } from '../../../../../../../mocks/mockInitialAppState';
+
+const HIGH_RISK_ISSUE: ExchangeIssue = {
+    type: 'high-risk',
+    severity: 'critical',
+    validation: { riskLevel: 'Malicious', features: [] },
+};
+
+const PRICE_IMPACT_ISSUE: ExchangeIssue = {
+    type: 'price-impact',
+    severity: 'warning',
+    deviation: 0.12,
+};
+
+type IssueAnalyticsProps = {
+    issue: ExchangeIssue | null;
+    isSimulationLoading: boolean;
+    isSimulation: boolean;
+};
+
+const renderIssueAnalytics = (initialProps: IssueAnalyticsProps) => {
+    const report = jest.fn();
+    const services: SuiteServices = {
+        ...extraDependenciesDesktopMock.services,
+        analytics: mockDesktopAnalytics(report),
+    };
+
+    const { rerender } = renderHookWithProviders(
+        configureMockStore({ preloadedState: mockInitialAppState satisfies AppState }),
+        services,
+        (props: IssueAnalyticsProps) => useExchangeIssueAnalytics(props),
+        { initialProps },
+    );
+
+    return { report, rerender };
+};
+
+describe('getTradingExchangeIssue', () => {
+    it('flattens a price impact issue with its severity', () => {
+        expect(getTradingExchangeIssue(PRICE_IMPACT_ISSUE)).toBe('price-impact-warning');
+        expect(getTradingExchangeIssue({ ...PRICE_IMPACT_ISSUE, severity: 'critical' })).toBe(
+            'price-impact-critical',
+        );
+    });
+
+    it('keeps the other issue types as they are', () => {
+        expect(getTradingExchangeIssue(HIGH_RISK_ISSUE)).toBe('high-risk');
+        expect(
+            getTradingExchangeIssue({
+                type: 'high-risk-with-price-impact',
+                severity: 'critical',
+                validation: { riskLevel: 'Malicious', features: [] },
+                deviation: 0.99,
+            }),
+        ).toBe('high-risk-with-price-impact');
+        expect(getTradingExchangeIssue({ type: 'slippage-too-low', severity: 'warning' })).toBe(
+            'slippage-too-low',
+        );
+    });
+});
+
+describe('useExchangeIssueAnalytics', () => {
+    it('reports the issue once, no matter how often the card re-renders', () => {
+        const { report, rerender } = renderIssueAnalytics({
+            issue: HIGH_RISK_ISSUE,
+            isSimulationLoading: false,
+            isSimulation: true,
+        });
+
+        rerender({ issue: HIGH_RISK_ISSUE, isSimulationLoading: false, isSimulation: true });
+
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradingExchangeIssueEvent.name,
+            payload: {
+                issue: 'high-risk',
+                isSimulation: true,
+            },
+        });
+    });
+
+    it('waits for the simulation instead of reporting the quote-derived issue first', () => {
+        const { report, rerender } = renderIssueAnalytics({
+            issue: PRICE_IMPACT_ISSUE,
+            isSimulationLoading: true,
+            isSimulation: false,
+        });
+
+        expect(report).not.toHaveBeenCalled();
+
+        rerender({ issue: HIGH_RISK_ISSUE, isSimulationLoading: false, isSimulation: true });
+
+        expect(report).toHaveBeenCalledTimes(1);
+        expect(report).toHaveBeenCalledWith({
+            type: events.tradingExchangeIssueEvent.name,
+            payload: {
+                issue: 'high-risk',
+                isSimulation: true,
+            },
+        });
+    });
+
+    it('reports nothing without an issue', () => {
+        const { report } = renderIssueAnalytics({
+            issue: null,
+            isSimulationLoading: false,
+            isSimulation: true,
+        });
+
+        expect(report).not.toHaveBeenCalled();
+    });
+});

--- a/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.ts
+++ b/packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+
+import { type TradingExchangeIssue, events, selectDesktopAnalyticsDep } from '@suite/analytics';
+import { useServices } from '@suite-common/dependency-injection';
+import { type ExchangeIssue } from '@suite-common/trading';
+import { exhaustive } from '@trezor/type-utils';
+
+type UseExchangeIssueAnalyticsParams = {
+    issue: ExchangeIssue | null;
+    isSimulationLoading: boolean;
+    isSimulation: boolean;
+};
+
+export const getTradingExchangeIssue = (
+    issue: ExchangeIssue | null,
+): TradingExchangeIssue | undefined => {
+    if (!issue) {
+        return undefined;
+    }
+
+    switch (issue.type) {
+        case 'price-impact':
+            return `price-impact-${issue.severity}`;
+        case 'high-risk':
+        case 'high-risk-with-price-impact':
+        case 'slippage-too-low':
+            return issue.type;
+        default:
+            return exhaustive(issue);
+    }
+};
+
+export const useExchangeIssueAnalytics = ({
+    issue,
+    isSimulationLoading,
+    isSimulation,
+}: UseExchangeIssueAnalyticsParams) => {
+    const { analytics } = useServices(selectDesktopAnalyticsDep);
+    const issueForAnalytics = getTradingExchangeIssue(issue);
+
+    useEffect(() => {
+        if (isSimulationLoading || !issueForAnalytics) {
+            return;
+        }
+
+        analytics.report({
+            type: events.tradingExchangeIssueEvent.name,
+            payload: {
+                issue: issueForAnalytics,
+                isSimulation,
+            },
+        });
+    }, [analytics, isSimulation, isSimulationLoading, issueForAnalytics]);
+};

--- a/suite/analytics/src/constants.ts
+++ b/suite/analytics/src/constants.ts
@@ -139,6 +139,7 @@ export enum EventType {
     TradeSell = 'trade/sell',
     // eslint-disable-next-line local-rules/analytics-event-name
     TradeStatus = 'trade/status',
+    TradingExchangeIssue = 'trading/exchange-issue',
     TransactionCancel = 'transaction/cancel',
     // eslint-disable-next-line local-rules/analytics-event-name
     TransactionCreated = 'transaction-created',

--- a/suite/analytics/src/events/index.ts
+++ b/suite/analytics/src/events/index.ts
@@ -107,6 +107,7 @@ export { tradeNavigateEvent } from './tradeNavigateEvent';
 export { tradeReceivedQuotesEvent } from './tradeReceivedQuotesEvent';
 export { tradeSellEvent } from './tradeSellEvent';
 export { tradeStatusEvent } from './tradeStatusEvent';
+export { tradingExchangeIssueEvent } from './tradingExchangeIssueEvent';
 export { transactionCancelEvent } from './transactionCancelEvent';
 export { transactionCreatedEvent } from './transactionCreatedEvent';
 export { transactionTimeoutRetryEvent } from './transactionTimeoutRetryEvent';

--- a/suite/analytics/src/events/tradeExchangeEvent.ts
+++ b/suite/analytics/src/events/tradeExchangeEvent.ts
@@ -2,8 +2,10 @@ import type { AttributeDef, EventDef } from '@suite-common/analytics';
 
 import { EventType } from '../constants';
 
+export type TradeExchangeAction = 'continue' | 'cancel';
+
 type Attributes = {
-    action: AttributeDef<'continue' | 'cancel'>;
+    action: AttributeDef<TradeExchangeAction>;
     step: AttributeDef<
         | 'exchange-form'
         | 'receive-address'

--- a/suite/analytics/src/events/tradingExchangeIssueEvent.ts
+++ b/suite/analytics/src/events/tradingExchangeIssueEvent.ts
@@ -1,0 +1,34 @@
+import type { AttributeDef, EventDef } from '@suite-common/analytics';
+
+import { EventType } from '../constants';
+
+export type TradingExchangeIssue =
+    | 'high-risk'
+    | 'high-risk-with-price-impact'
+    | 'slippage-too-low'
+    | 'price-impact-warning'
+    | 'price-impact-critical';
+
+type Attributes = {
+    issue: AttributeDef<TradingExchangeIssue>;
+    isSimulation: AttributeDef<boolean>;
+};
+
+export const tradingExchangeIssueEvent: EventDef<Attributes, EventType.TradingExchangeIssue> = {
+    name: EventType.TradingExchangeIssue,
+    descriptionTrigger: 'An issue is shown on the swap confirm step',
+    changelog: [{ version: '26.9.0', notes: 'added' }],
+
+    attributes: {
+        issue: {
+            changelog: [{ version: '26.9.0', notes: 'added' }],
+            description:
+                'Issue shown on the swap confirm step: `high-risk` | `high-risk-with-price-impact` | `slippage-too-low` | `price-impact-warning` | `price-impact-critical`',
+        },
+        isSimulation: {
+            changelog: [{ version: '26.9.0', notes: 'added' }],
+            description:
+                'Whether the issue was derived from transaction simulation (`true`) or quote data (`false`)',
+        },
+    },
+};

--- a/suite/analytics/src/index.ts
+++ b/suite/analytics/src/index.ts
@@ -24,4 +24,6 @@ export { type DashboardReceiveModalEventSource } from './events/dashboardReceive
 export { type DashboardReceiveModalOptionsEventOption } from './events/dashboardReceiveModalOptionsEvent';
 export { type DashboardSendModalEventSource } from './events/dashboardSendModalEvent';
 export { type DashboardSendModalOptionsEventOption } from './events/dashboardSendModalOptionsEvent';
+export { type TradeExchangeAction } from './events/tradeExchangeEvent';
+export { type TradingExchangeIssue } from './events/tradingExchangeIssueEvent';
 export { type TransactionCreatedEventAction } from './events/transactionCreatedEvent';


### PR DESCRIPTION
## Description

Analytics for the swap confirm step from #31329:

- new `trading/exchange-issue` event (mirrors native) — reported once per shown issue,
  and only once the simulation settles, so a quote-derived issue is never reported
  before the simulated one replaces it. `isSimulation` says which source it came from.
- `trade/exchange` / `confirm-and-send` now also reports `cancel` when the user leaves
  via "Back to trade form", and `continue` on the sign-data step (previously unreported).

## Notes for QA

- Analytics only, no visible change.
- To verify on an EVM DEX swap with the `trading.txSimulation` flag on: price impact /
  high risk / low slippage banner → one `trading/exchange-issue`, "Continue anyway" →
  `continue`, "Back to trade form" → `cancel`.

## Related Issue

Resolve #31330

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/feat/31330-swap-simulation-analytics/web/](https://dev.suite.sldev.cz/suite-web/feat/31330-swap-simulation-analytics/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=feat/31330-swap-simulation-analytics&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=feat/31330-swap-simulation-analytics&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |

</details>

_Updated: 2026-08-19T07:37:52.784Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T07:37:33.796Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes concentrate on the swap/exchange selected-offer UI and its issue analytics. The highest risk is a regression in the swap confirmation modal or selected-offer rendering, so the strategy is to run a representative swap suite covering CEX, DEX, token-to-coin, cross-chain, and custom-fee paths rather than every swap test. The analytics event definitions and unit test files lack direct e2e coverage, so they should be verified through unit tests.

<details><summary><b>Changed files (9)</b></summary>

- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.ts`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/tradeExchangeEvent.ts`
- `suite/analytics/src/events/tradingExchangeIssueEvent.ts`
- `suite/analytics/src/index.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — This test drives the full CEX swap confirmation flow and asserts details in the tradingPage confirmation modal, transaction detail status, and device prompts — all rendered by TradingOfferExchange. A regression in the selected-offer component or its analytics hook would be immediately visible here.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — Covers the DEX swap path through LI.FI, exercising exchange-type labels, slippage, minimum received, provider name, and gas-limit details in the confirmation screen. These DEX-specific fields are part of TradingOfferExchange rendering.
- `suite/e2e/tests/trading/swap-token-to-coin.test.ts` — Exercises a Solana SPL-token-to-BTC swap, verifying the confirmation modal shows the correct token send amount, receive amount, exchange type, provider, and device prompt details. This ensures TradingOfferExchange handles token sell assets correctly.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain EVM-to-Solana swap that validates the confirmation modal fee state, device prompts, toast, and transaction detail status. It shares the same exchange-offer UI path and adds a cross-chain network combination not covered by the high-priority tests.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Sets custom Ethereum gas fees inside the swap flow and checks composedTransactionInfo and device prompt fee fields. This exercises fee handling integrated with the exchange offer confirmation without duplicating the standard swap assertions.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Native Solana-to-BTC swap that covers status transitions, the CONVERTING support banner, and final transaction details. It complements the token-to-coin test by using a native Solana send asset in TradingOfferExchange.

</details>

⚠️ **Changes with no test coverage (7)**
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/TradingOfferExchange.test.tsx`
- `packages/suite/src/views/wallet/trading/common/TradingSelectedOffer/TradingOfferExchange/useExchangeIssueAnalytics.test.tsx`
- `suite/analytics/src/constants.ts`
- `suite/analytics/src/events/index.ts`
- `suite/analytics/src/events/tradeExchangeEvent.ts`
- `suite/analytics/src/events/tradingExchangeIssueEvent.ts`
- `suite/analytics/src/index.ts`

_Updated: 2026-08-19T07:38:28.346Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->