### PR TITLE
feat(suite): show address and balance in walletconnect account select

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx
@@ -1,0 +1,45 @@
+import { AccountLabel } from '@suite/account';
+import { Address } from '@suite/address';
+import { type Account } from '@suite-common/wallet-types';
+import { isUtxoBased } from '@suite-common/wallet-utils';
+import { Column, Row } from '@trezor/components';
+import { TokenIcon } from '@trezor/product-components';
+
+import { CoinBalance } from 'src/components/suite';
+
+// the select menu sizes itself to its content, so the label has to be capped for it not to
+// outgrow the modal on a long custom account label
+const MAX_LABEL_WIDTH = 200;
+
+type WalletConnectAccountOptionProps = {
+    account: Account;
+};
+
+export const WalletConnectAccountOption = ({ account }: WalletConnectAccountOptionProps) => (
+    <Row gap={16} justifyContent="space-between" width="100%">
+        <Row gap={12} flex="1" minWidth={0} overflow="hidden">
+            <TokenIcon symbol={account.symbol} size={24} />
+            <Column alignItems="flex-start" minWidth={0} overflow="hidden">
+                <AccountLabel
+                    account={account}
+                    showAccountTypeBadge
+                    accountTypeBadgeSize="small"
+                    rowProps={{ maxWidth: MAX_LABEL_WIDTH }}
+                />
+                {/* the descriptor of a UTXO account is an xpub, not an address */}
+                {!isUtxoBased(account) && (
+                    <Address
+                        value={account.descriptor}
+                        intent="neutral"
+                        priority="secondary"
+                        typographyStyle="body-sm"
+                        isTruncated
+                    />
+                )}
+            </Column>
+        </Row>
+        <Row flex="none">
+            <CoinBalance value={account.formattedBalance} symbol={account.symbol} />
+        </Row>
+    </Row>
+);

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx
@@ -2,12 +2,12 @@ import { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { AccountLabel } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { goto } from '@suite/router';
 import { TxSimulationBanner } from '@suite/tx-simulation/src/common';
 import { useDappScan } from '@suite-common/tx-simulation';
+import { networkSymbolCollection } from '@suite-common/wallet-config';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
 import { type Account } from '@suite-common/wallet-types';
 import { sortByCoin } from '@suite-common/wallet-utils';
@@ -30,10 +30,12 @@ import {
     Tooltip,
 } from '@trezor/components';
 import { ShieldCheckFilledIcon, ShieldWarningFilledIcon } from '@trezor/icons';
-import { NetworkIcon, TokenIcon } from '@trezor/product-components';
+import { NetworkIcon } from '@trezor/product-components';
 
 import { ConnectAppIcon } from 'src/components/suite/ConnectAppIcon';
 import { useDispatch, useSelector } from 'src/hooks/suite';
+
+import { WalletConnectAccountOption } from './WalletConnectAccountOption';
 
 const NetworkItemWrapper = styled.div<{ $isDisabled: boolean }>`
     display: flex;
@@ -42,6 +44,13 @@ const NetworkItemWrapper = styled.div<{ $isDisabled: boolean }>`
     align-items: center;
     opacity: ${props => (props.$isDisabled ? 0.5 : 1)};
 `;
+
+// networks the dapp requests arrive in its own order, the modal follows the coin settings one
+const getNetworkOrder = (symbol?: string) => {
+    const index = networkSymbolCollection.findIndex(networkSymbol => networkSymbol === symbol);
+
+    return index === -1 ? networkSymbolCollection.length : index;
+};
 
 interface WalletConnectProposalModalProps {
     eventId: number;
@@ -61,6 +70,13 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     ) ?? [],
             ),
         [accounts, pendingProposal?.networks],
+    );
+    const requestedNetworks = useMemo(
+        () =>
+            (pendingProposal?.networks ?? [])
+                .filter(network => network.status !== 'unsupported')
+                .toSorted((a, b) => getNetworkOrder(a.symbol) - getNetworkOrder(b.symbol)),
+        [pendingProposal?.networks],
     );
     const [selectedDefaultAccount, setSelectedDefaultAccount] = useState<Account | null>(
         selectableAccounts[0] || null,
@@ -187,27 +203,22 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                 </Text>
                 <Card>
                     <Row rowGap={8} columnGap={12} flexWrap="wrap">
-                        {pendingProposal.networks
-                            .filter(network => network.status !== 'unsupported')
-                            .map(network => (
-                                <Tooltip
-                                    content={getTooltipContent(network)}
-                                    key={network.namespaceId}
-                                >
-                                    <NetworkItemWrapper $isDisabled={network.status !== 'active'}>
-                                        {network.symbol && (
-                                            <NetworkIcon
-                                                networkSymbol={network.symbol as any}
-                                                size={24}
-                                            />
-                                        )}
-                                        <Text>
-                                            {network.name}
-                                            {network.required && <Text intent="critical">*</Text>}
-                                        </Text>
-                                    </NetworkItemWrapper>
-                                </Tooltip>
-                            ))}
+                        {requestedNetworks.map(network => (
+                            <Tooltip content={getTooltipContent(network)} key={network.namespaceId}>
+                                <NetworkItemWrapper $isDisabled={network.status !== 'active'}>
+                                    {network.symbol && (
+                                        <NetworkIcon
+                                            networkSymbol={network.symbol as any}
+                                            size={24}
+                                        />
+                                    )}
+                                    <Text>
+                                        {network.name}
+                                        {network.required && <Text intent="critical">*</Text>}
+                                    </Text>
+                                </NetworkItemWrapper>
+                            </Tooltip>
+                        ))}
                     </Row>
                 </Card>
 
@@ -215,30 +226,18 @@ export const WalletConnectProposalModal = ({ eventId }: WalletConnectProposalMod
                     <Translation id="TR_DEFAULT_ACCOUNT" />
                 </Text>
                 {selectableAccounts.length > 0 && (
-                    <Card paddingType="none">
-                        <Select
-                            isSearchable={false}
-                            isClearable={false}
-                            size="large"
-                            value={selectedDefaultAccount}
-                            options={selectableAccounts}
-                            formatOptionLabel={(account: Account) => (
-                                <Row gap={8}>
-                                    {account.symbol && (
-                                        <TokenIcon symbol={account.symbol} size={24} />
-                                    )}
-                                    <AccountLabel
-                                        account={account}
-                                        key={account.descriptor}
-                                        showAccountTypeBadge
-                                        accountTypeBadgeSize="small"
-                                    />
-                                </Row>
-                            )}
-                            onChange={(option: Option) => setSelectedDefaultAccount(option)}
-                            closeMenuOnScroll={false}
-                        />
-                    </Card>
+                    <Select
+                        isSearchable={false}
+                        isClearable={false}
+                        size="large"
+                        value={selectedDefaultAccount}
+                        options={selectableAccounts}
+                        formatOptionLabel={(account: Account) => (
+                            <WalletConnectAccountOption account={account} />
+                        )}
+                        onChange={(option: Option) => setSelectedDefaultAccount(option)}
+                        closeMenuOnScroll={false}
+                    />
                 )}
 
                 {(requiredNetworksNotActivated ||

--- a/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { AccountLabel, AccountTypeBadge } from '@suite/account';
 import { Translation } from '@suite/intl';
 import { closeModal } from '@suite/modal';
 import { selectAllAccountsToList } from '@suite-common/wallet-core';
@@ -13,10 +12,11 @@ import {
     switchSelectedAccountThunk,
     walletConnectActions,
 } from '@suite-common/walletconnect';
-import { Column, Modal, type Option, Row, Select } from '@trezor/components';
-import { TokenIcon } from '@trezor/product-components';
+import { Column, Modal, type Option, Select } from '@trezor/components';
 
 import { useSelector } from 'src/hooks/suite';
+
+import { WalletConnectAccountOption } from './WalletConnectAccountOption';
 
 interface WalletConnectSwitchAccountModalProps {
     sessionTopic: string;
@@ -83,15 +83,7 @@ export const WalletConnectSwitchAccountModal = ({
                     value={selectedDefaultAccount}
                     options={selectableAccounts}
                     formatOptionLabel={(account: Account) => (
-                        <Row gap={8}>
-                            {account.symbol && <TokenIcon symbol={account.symbol} size={24} />}
-                            <AccountLabel account={account} key={account.descriptor} />
-                            <AccountTypeBadge
-                                accountType={account.accountType}
-                                networkType={account.networkType}
-                                size="small"
-                            />
-                        </Row>
+                        <WalletConnectAccountOption account={account} />
                     )}
                     onChange={(option: Option) => setSelectedDefaultAccount(option)}
                 />


### PR DESCRIPTION
> [!IMPORTANT]
> NOT READY FOR REVIEW
>
> Preview: https://dev.suite.sldev.cz/suite-web/fix/29699-walletconnect-account-select/web

## Description

Three fixes to the WalletConnect account select, all by composing components that already exist.

**Account options show the address and balance.** A shared `WalletConnectAccountOption` (icon + label + address + balance) replaces the icon-and-label rows that the proposal and switch-account modals each built separately. The address is hidden for UTXO accounts, whose descriptor is an xpub rather than an address — the same condition the trading "receiving account" modal uses. The balance goes through `CoinBalance`, so discreet mode is handled.

**Requested networks are sorted.** They arrived in whatever order the dapp sent. `getNetworkOrder` sorts them by `networkSymbolCollection`, the same ordering `sortByCoin` applies to the account list below, so both lists now follow coin settings. Unknown symbols sort last.

**The select had a double border.** It was wrapped in `<Card paddingType="none">` while `Select` already draws its own border in the control. Card removed; the switch-account modal never had one.

## Notes for QA

- Connect a dapp requesting several networks: the "Requested networks" list follows coin settings order rather than the dapp's, and the "Default account" select has one border.
- Open the select: each option shows the account address and balance. Switching accounts still works, and the chosen account is the one the dapp gets.
- Same select in the switch-account modal (WalletConnect session → switch account).
- Bitcoin account in the list: label and balance, no address line.
- Long custom account label: the menu should not outgrow the modal.
- Discreet mode: balances hidden.

## Related Issue


## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changed files are narrowly scoped WalletConnect modal components. No other E2E test in the suite actually covers WalletConnect behavior; the broad static mappings are noise from shared parent/component imports. Running the WalletConnect analytics event test provides targeted coverage of the proposal approval/rejection and account selection flows touched by these components.

<details><summary><b>Changed files (3)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectAccountOption.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectProposalModal.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/UserContextModal/WalletConnectSwitchAccountModal.tsx`

</details>

**Recommended tests (1)**

<details><summary>🔴 <b>High priority (1)</b></summary>

- `suite/e2e/tests/analytics/wallet-connect-events.test.ts` — This is the only test that directly exercises the WalletConnect user flow, including approving and rejecting connection proposals. Changes to WalletConnectProposalModal, WalletConnectSwitchAccountModal, or WalletConnectAccountOption could alter the proposal/account-selection UI and break the analytics events it asserts.

</details>

_Updated: 2026-08-18T13:07:22.542Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/29699-walletconnect-account-select/web/](https://dev.suite.sldev.cz/suite-web/fix/29699-walletconnect-account-select/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/29699-walletconnect-account-select&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/29699-walletconnect-account-select&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T13:09:44.540Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 5 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T13:09:35.554Z • 5 test(s) total_
<!-- QUARANTINE-LIST:web:END -->