### PR TITLE
chore(suite-desktop): more details in request-interceptor logging

### DIFF
--- a/packages/request-manager/src/index.ts
+++ b/packages/request-manager/src/index.ts
@@ -1,6 +1,11 @@
 export { TorController } from './controller';
 export { TorControllerExternal } from './controllerExternal';
 export { createInterceptor } from './interceptor';
-export type { InterceptedEvent, BootstrapEvent, TorControllerStatus } from './types';
+export type {
+    ValidateRequestCallback,
+    InterceptedEvent,
+    BootstrapEvent,
+    TorControllerStatus,
+} from './types';
 export { TOR_CONTROLLER_STATUS } from './types';
 export { TorIdentities } from './torIdentities';

--- a/packages/request-manager/src/interceptor.ts
+++ b/packages/request-manager/src/interceptor.ts
@@ -9,7 +9,7 @@ import { interceptNetSocketConnect } from './interceptor/interceptNetSocketConne
 import { interceptTlsConnect } from './interceptor/interceptTlsConnect';
 import { interceptWebSocket } from './interceptor/interceptWebSocket';
 import { TorIdentities } from './torIdentities';
-import { type InterceptorOptions } from './types';
+import type { InterceptorOptions, ValidateRequestCallback } from './types';
 
 /**
  * Create an interceptor that can be used to intercept and manage network requests made from a Node.js environment.
@@ -21,11 +21,14 @@ export const createInterceptor = (interceptorOptions: InterceptorOptions) => {
     const torIdentities = new TorIdentities(interceptorOptions.getTorSettings);
     const context = { ...interceptorOptions, requestPool, torIdentities };
 
-    const validateRequest = ({ hostname }: { hostname: string }) => {
+    const validateRequest: ValidateRequestCallback = ({ hostname, fullUrl, interceptType }) => {
         // FYI for main electron session, the base list of whitelisted domains is in 'packages/suite-desktop-core/src/config.ts'
         if (!isWhitelistedHost(hostname, context.getWhitelistedDomains())) {
             // Sometimes the error is not reported correctly so for debug reasons we log it as well
-            console.error(`Request blocked, not whitelisted domain: ${hostname}`);
+            console.error(`Request blocked, not whitelisted domain: ${hostname}`, {
+                fullUrl,
+                interceptType,
+            });
 
             throw new Error(`Request blocked, not whitelisted domain: ${hostname}`);
         }

--- a/packages/request-manager/src/interceptor/interceptFetch.ts
+++ b/packages/request-manager/src/interceptor/interceptFetch.ts
@@ -25,19 +25,22 @@ export const interceptFetch: Interceptor = ({ context, validateRequest }) => {
             );
         }
 
+        let fullUrl: string | undefined;
         let hostname = 'unknown';
         if (typeof url === 'object' && 'hostname' in url) {
             // case url type of URL
+            fullUrl = url.toString();
             hostname = url.hostname;
         } else if (typeof url === 'object' && 'url' in url) {
             // case url type of globalThis.Request
-            hostname = url.url;
+            fullUrl = hostname = url.url;
         } else if (typeof url === 'string') {
             // case url type of string
+            fullUrl = url;
             hostname = new URL(url).hostname;
         }
 
-        validateRequest({ hostname });
+        validateRequest({ hostname, fullUrl, interceptType: 'fetch' });
 
         return originalFetch(url, options);
     };

--- a/packages/request-manager/src/interceptor/interceptNetConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptNetConnect.ts
@@ -32,7 +32,7 @@ export const interceptNetConnect: Interceptor = ({ context, validateRequest }) =
             hostname = typeof callback === 'string' ? callback : options.toString();
         }
 
-        validateRequest({ hostname });
+        validateRequest({ hostname, interceptType: 'netConnect' });
 
         context.handler({
             type: 'INTERCEPTED_REQUEST',

--- a/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptNetSocketConnect.ts
@@ -78,7 +78,7 @@ export const interceptNetSocketConnect: Interceptor = ({ context, validateReques
         }
 
         const hostname = details.split(':')[0] ?? '';
-        validateRequest({ hostname });
+        validateRequest({ hostname, interceptType: 'netSocketConnect' });
 
         context.handler({
             type: 'INTERCEPTED_REQUEST',

--- a/packages/request-manager/src/interceptor/interceptTlsConnect.ts
+++ b/packages/request-manager/src/interceptor/interceptTlsConnect.ts
@@ -39,7 +39,7 @@ export const interceptTlsConnect: Interceptor = ({ context, validateRequest }) =
         // This is here for defensive reasons, the original `tls.connect` implementation (AFAIK)
         // uses net.connect to create new socket, and it already contains the interception logic.
         // But to be 100% sure, lets do the check here as well.
-        validateRequest({ hostname });
+        validateRequest({ hostname, interceptType: 'tlsConnect' });
 
         return originalTlsConnect(...(args as Parameters<typeof tls.connect>));
     };

--- a/packages/request-manager/src/interceptor/interceptWebSocket.ts
+++ b/packages/request-manager/src/interceptor/interceptWebSocket.ts
@@ -17,7 +17,7 @@ export const interceptWebSocket: Interceptor = ({ context, validateRequest }) =>
             const urlString = url.toString();
             const { hostname } = new URL(urlString);
 
-            validateRequest({ hostname });
+            validateRequest({ hostname, fullUrl: urlString, interceptType: 'webSocket' });
 
             if (context.getTorSettings().running) {
                 const agent = context.torIdentities.getIdentity(

--- a/packages/request-manager/src/interceptor/interceptorTypes.ts
+++ b/packages/request-manager/src/interceptor/interceptorTypes.ts
@@ -1,6 +1,6 @@
 import { type createRequestPool } from '../httpPool';
 import { type TorIdentities } from '../torIdentities';
-import { type InterceptorOptions } from '../types';
+import { type InterceptorOptions, type ValidateRequestCallback } from '../types';
 
 export type InterceptorContext = InterceptorOptions & {
     requestPool: ReturnType<typeof createRequestPool>;
@@ -9,5 +9,5 @@ export type InterceptorContext = InterceptorOptions & {
 
 export type Interceptor = (params: {
     context: InterceptorContext;
-    validateRequest: ({ hostname }: { hostname: string }) => void;
+    validateRequest: ValidateRequestCallback;
 }) => void;

--- a/packages/request-manager/src/interceptor/overloadHttpRequest.ts
+++ b/packages/request-manager/src/interceptor/overloadHttpRequest.ts
@@ -3,6 +3,7 @@ import type http from 'http';
 import { getWeakRandomId, isWhitelistedHost } from '@trezor/utils';
 
 import { type InterceptorContext } from './interceptorTypes';
+import { type ValidateRequestCallback } from '../types';
 
 const PROXY_AUTH_KEY = 'proxy-authorization';
 
@@ -51,7 +52,7 @@ type OverloadHttpRequestParams = {
     url: string | URL | http.RequestOptions;
     options?: http.RequestOptions | RequestCallback;
     callback?: unknown;
-    validateRequest: (params: { hostname: string }) => void;
+    validateRequest: ValidateRequestCallback;
 };
 
 const resolveHostname = (url: string | URL | http.RequestOptions) => {
@@ -171,8 +172,9 @@ export const overloadHttpRequest = ({
     validateRequest,
 }: OverloadHttpRequestParams) => {
     const hostname = resolveHostname(url);
+    const fullUrl = typeof url === 'string' ? url : url.toString();
 
-    validateRequest({ hostname });
+    validateRequest({ hostname, fullUrl, interceptType: protocol });
 
     if (isWhitelistedHost(hostname, context.notRequiredTorDomainsList)) {
         return;

--- a/packages/request-manager/src/interceptor/overloadWebsocketHandshake.ts
+++ b/packages/request-manager/src/interceptor/overloadWebsocketHandshake.ts
@@ -2,6 +2,7 @@ import type http from 'http';
 
 import { isWhitelistedHost } from '@trezor/utils';
 
+import { type ValidateRequestCallback } from '../types';
 import { type InterceptorContext } from './interceptorTypes';
 import { overloadHttpRequest } from './overloadHttpRequest';
 
@@ -11,7 +12,7 @@ type OverloadWebsocketHandshakeParams = {
     url: string | URL | http.RequestOptions;
     options?: http.RequestOptions | ((r: http.IncomingMessage) => void);
     callback?: unknown;
-    validateRequest: (params: { hostname: string }) => void;
+    validateRequest: ValidateRequestCallback;
 };
 
 export const overloadWebsocketHandshake = ({

--- a/packages/request-manager/src/types.ts
+++ b/packages/request-manager/src/types.ts
@@ -82,6 +82,14 @@ export type InterceptorOptions = {
     getWhitelistedDomains: () => string[];
 };
 
+type ValidateRequestParams = {
+    hostname: string;
+    fullUrl?: string;
+    interceptType:
+        'netSocketConnect' | 'netConnect' | 'http' | 'https' | 'tlsConnect' | 'fetch' | 'webSocket';
+};
+export type ValidateRequestCallback = ({ hostname }: ValidateRequestParams) => void;
+
 export const TOR_CONTROLLER_STATUS = {
     Bootstrapping: 'Bootstrapping',
     Stopped: 'Stopped',


### PR DESCRIPTION
## Description

There is a lot of spam `Request blocked, not whitelisted domain: api.coingecko.com`.
That's from `request-interceptor` from **Electron Main** process, not from Renderer.
I did not find any cause in suite.

- [This](https://github.com/trezor/trezor-suite/blob/18fa2fa2792c702e41bbbc94cd7ef062f75ff4b9/suite-common/fiat-services/src/coingecko.ts) calls it from _Renderer_ behind our CDN proxy, not directly
- [This](https://github.com/trezor/trezor-suite/blob/b6021a6b1f938fc2589a7979f37e1a3fa55dcde5/suite-common/token-definitions/scripts/constants/index.ts) and [this](https://github.com/trezor/trezor-suite/blob/dae2581b2ed973192bbbc052b81c9ca8a374fe6b/suite-common/icons/scripts/constants/index.ts) is only in scripts (CI)
- Nothing in connect or any other part of electron main
- Not even `rg coingecko` in `node_modules` shown anything.

Could be connect-popup, who knows.

:point_right: but to make this debugging easier (and similar stuff in future), log more context data in the intercepts. 

[Testing event sent locally](https://satoshilabs.sentry.io/issues/7678578550/events/9c9882bea184414bb23119b6aebf7ea7/?referrer=event-or-group-header) – contains additional data 


## Notes for QA

N/A, only logging is affected.

## Related Issue

Related: https://satoshilabs.sentry.io/issues/6597340445/

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/request-interceptor-error-logging/web/](https://dev.suite.sldev.cz/suite-web/chore/request-interceptor-error-logging/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/request-interceptor-error-logging&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/request-interceptor-error-logging&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T14:17:26.646Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T14:17:17.659Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes touch the low-level network interception layer used by the desktop app for HTTP, TLS, net sockets, fetch, and WebSocket traffic. The highest-value tests are those that exercise real outbound network paths: custom blockbook backends and analytics event transmission. Bridge lifecycle, transport session management, Suite Sync relay sync, and trading API calls provide additional coverage of the patched network stack without broadening the suite excessively.

<details><summary><b>Changed files (11)</b></summary>

- `packages/request-manager/src/index.ts`
- `packages/request-manager/src/interceptor.ts`
- `packages/request-manager/src/interceptor/interceptFetch.ts`
- `packages/request-manager/src/interceptor/interceptNetConnect.ts`
- `packages/request-manager/src/interceptor/interceptNetSocketConnect.ts`
- `packages/request-manager/src/interceptor/interceptTlsConnect.ts`
- `packages/request-manager/src/interceptor/interceptWebSocket.ts`
- `packages/request-manager/src/interceptor/interceptorTypes.ts`
- `packages/request-manager/src/interceptor/overloadHttpRequest.ts`
- `packages/request-manager/src/interceptor/overloadWebsocketHandshake.ts`
- `packages/request-manager/src/types.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/analytics/events.test.ts` — This test verifies that analytics HTTP events are emitted and checks SuiteReady fields that depend on custom backends and enabled networks. request-manager's fetch/http/tls interceptors sit between Suite and those outbound analytics/backend endpoints, so a regression in request routing or payload capture would directly break its assertions.
- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — It toggles networks and configures correct/wrong custom blockbook backend URLs, then asserts discovery succeeds or fails against those backends. Blockbook discovery uses HTTP/TLS and WebSocket connections that are patched by request-manager's overloadHttpRequest, interceptTlsConnect, interceptWebSocket, and overloadWebsocketHandshake, making this a direct end-to-end coverage path.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/bridge-tor/spawn-bridge.test.ts` — This desktop-only test launches Suite and verifies the bundled bridge starts and that the app reconnects after an external bridge restart. Those reconnections rely on Node-level HTTP/TLS calls from the app to the local bridge that request-manager intercepts, so a regression could cause the app to lose bridge connectivity.
- `suite/e2e/tests/metadata/suite-sync/update-and-remove-labels.test.ts` — It enables Suite Sync and performs CRUD operations on wallet/account/address/output labels, syncing them to the Evolu relay server over HTTP. request-manager's fetch/http interceptors could block or corrupt that outbound sync traffic, so this test validates the full label sync network path.
- `suite/e2e/tests/suite/multiple-sessions.test.ts` — The test exercises BridgeTransport session enumeration and acquisition when another client steals the bridge session. Those transport calls travel through Node net/http sockets that request-manager patches (interceptNetConnect, interceptNetSocketConnect, overloadHttpRequest), so interceptor regressions could break session takeover/recovery behavior.
- `suite/e2e/tests/trading/buy-bitcoin.test.ts` — It requests buy quotes, submits a trade, and polls watch status over the trading API. request-manager's fetch/http interception changes could alter how those outbound requests are routed or what payloads reach the (mocked) trading endpoints, making this a representative trading network-flow test.

</details>

_Updated: 2026-08-18T14:21:32.912Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->