### PR TITLE
feat(connect): accept taproot descriptors with h in getAccountInfo

### DIFF
--- a/packages/connect/src/api/getAccountInfo.ts
+++ b/packages/connect/src/api/getAccountInfo.ts
@@ -11,6 +11,7 @@ import type {
 } from '@trezor/connect-common';
 import { ERRORS } from '@trezor/connect-common/src/constants';
 import { fromHardenedPathPart } from '@trezor/crypto-utils';
+import { convertTaprootXpub } from '@trezor/utils';
 
 import { assertBackendSupported, initBlockchain } from '../backend/BlockchainLink';
 import type { MethodContext, MethodMessage, MethodReturnType } from '../core/AbstractMethod';
@@ -221,6 +222,14 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     throw ERRORS.TypedError('Runtime', 'GetAccountInfo: descriptor not found');
                 }
 
+                // Blockbook rejects taproot descriptors that use `h` for hardened
+                // derivation, so send the `'` form to the backend. The response keeps
+                // the original `descriptor` below, so the API returns the same format
+                // the caller provided.
+                const backendDescriptor =
+                    convertTaprootXpub({ xpub: descriptor, direction: 'h-to-apostrophe' }) ??
+                    descriptor;
+
                 // initialize backend
                 const blockchain = await initBlockchain(
                     request.coinInfo,
@@ -232,7 +241,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
 
                 // get account info from backend
                 const info = await blockchain.getAccountInfo({
-                    descriptor,
+                    descriptor: backendDescriptor,
                     details: request.details,
                     tokens: request.tokens,
                     page: request.page,
@@ -257,7 +266,7 @@ export default class GetAccountInfo extends AbstractMethod<'getAccountInfo', Req
                     typeof request.details === 'string' &&
                     request.details !== 'basic'
                 ) {
-                    utxo = await blockchain.getAccountUtxo(descriptor);
+                    utxo = await blockchain.getAccountUtxo(backendDescriptor);
                 }
 
                 if (this.disposed) break;

--- a/packages/utils/src/convertTaprootXpub.test.ts
+++ b/packages/utils/src/convertTaprootXpub.test.ts
@@ -1,0 +1,45 @@
+import { convertTaprootXpub } from './convertTaprootXpub';
+
+describe('convertTaprootXpub', () => {
+    // Same descriptor, once with `h` and once with `'` for the hardened path parts.
+    // Note the xpub body itself contains an `h` (in "...ThRDb8...") which must be
+    // left untouched - only the bracketed path is converted.
+    const withH =
+        '[5c9e228d/86h/0h/0h]tpubDCpt6oCoUgcQEPBUnZS4pijgjNySRDaJH8FyztXHnjxCH3z8jjHKGpX3zwtNs1U8ThRDb8ZbnAnZWc1KNLQx8fasQnk3f9Vaqu3JJXcYCF';
+    const withApostrophe =
+        "[5c9e228d/86'/0'/0']tpubDCpt6oCoUgcQEPBUnZS4pijgjNySRDaJH8FyztXHnjxCH3z8jjHKGpX3zwtNs1U8ThRDb8ZbnAnZWc1KNLQx8fasQnk3f9Vaqu3JJXcYCF";
+
+    it('converts h to apostrophe in the derivation path', () => {
+        expect(convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' })).toEqual(
+            withApostrophe,
+        );
+    });
+
+    it('converts apostrophe to h in the derivation path', () => {
+        expect(convertTaprootXpub({ xpub: withApostrophe, direction: 'apostrophe-to-h' })).toEqual(
+            withH,
+        );
+    });
+
+    it('round-trips', () => {
+        const apostrophe = convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' });
+        expect(apostrophe).not.toBeNull();
+        expect(
+            convertTaprootXpub({ xpub: apostrophe as string, direction: 'apostrophe-to-h' }),
+        ).toEqual(withH);
+    });
+
+    it('only touches the bracketed path, leaving the xpub body unchanged', () => {
+        const out = convertTaprootXpub({ xpub: withH, direction: 'h-to-apostrophe' });
+        expect(out).not.toBeNull();
+        // Everything after the closing bracket (the xpub body, which contains an `h`)
+        // must be identical.
+        expect((out as string).split(']')[1]).toEqual(withH.split(']')[1]);
+    });
+
+    it('returns null for an xpub without a descriptor bracket', () => {
+        expect(
+            convertTaprootXpub({ xpub: 'tpubDCpt6oCoUgcQEPBU', direction: 'h-to-apostrophe' }),
+        ).toBeNull();
+    });
+});


### PR DESCRIPTION
## Description

Internal PR for #31272

Adds conversion for taproot descriptors with h in getAccountInfo

## Notes for QA

N/A, not user facing

## Related Issue

Resolve #16748

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** getAccountInfo is a core Connect API used by Suite's account discovery, so its change has broad but indirect impact. The highest-value E2E checks are multi-coin discovery and adding diverse account types (especially taproot, which also exercises convertTaprootXpub). A small set of medium tests covers custom backends, asset activation, balance updates and XPUB display. convertTaprootXpub.test.ts itself has no static E2E mapping, but the taproot path in add-account-types provides inferred coverage.

<details><summary><b>Changed files (2)</b></summary>

- `packages/connect/src/api/getAccountInfo.ts`
- `packages/utils/src/convertTaprootXpub.test.ts`

</details>

**Recommended tests (6)**

<details><summary>🔴 <b>High priority (2)</b></summary>

- `suite/e2e/tests/wallet/add-account-types.test.ts` — This test adds taproot, segwit, legacy and normal accounts for BTC/LTC and non-BTC coins, then verifies account metadata (symbol, path, type) and analytics events. Changes to getAccountInfo could break account discovery/derivation, and the convertTaprootXpub change directly affects taproot xpub handling used when adding taproot accounts.
- `suite/e2e/tests/wallet/discovery.test.ts` — Discovery is the primary consumer of getAccountInfo: the test enables eight networks and asserts that discovery reaches the complete state and each coin's first account balance appears on the dashboard. A regression in getAccountInfo would likely surface here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/settings/coins-custom-backend.test.ts` — It configures custom Blockbook backends for BTC and ETH and checks whether accounts load or fail with a discovery error. getAccountInfo is invoked against the custom backend, so backend-specific account loading regressions are plausible.
- `suite/e2e/tests/settings/coins.test.ts` — This test activates mainnet/testnet assets and validates dashboard discovery after network enablement. Since getAccountInfo drives the account data returned during discovery, a change there could affect whether the expected empty/loaded states appear.
- `suite/e2e/tests/wallet/coin-balance.test.ts` — It sends regtest BTC to an account and asserts the balance updates correctly. Account balance display depends on getAccountInfo results after transactions, so a change could cause stale or incorrect balances.
- `suite/e2e/tests/wallet/public-keys.test.ts` — The test opens BTC, LTC and ADA accounts, shows the public key (XPUB), and verifies it matches an expected value. getAccountInfo is part of the account metadata path that resolves the displayed public key, so a regression could produce an incorrect XPUB.

</details>

_Updated: 2026-08-18T14:53:20.919Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/pr/gomesalexandre/31272/web/](https://dev.suite.sldev.cz/suite-web/pr/gomesalexandre/31272/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=pr/gomesalexandre/31272&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=pr/gomesalexandre/31272&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 6 test(s)</summary>

| Test | Type |
|------|------|
| TrezorConnect popup web > call cancelled from calling application | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T14:54:10.518Z • 6 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 3 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |

</details>

_Updated: 2026-08-18T14:54:02.513Z • 3 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->