### PR TITLE
fix(trading): preserve Tron approve calldata in DEX trades

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -115,7 +115,8 @@ export const TransactionReviewModalBodyInner = ({
     const routeName = useSelector(state => state.router.route?.name);
     const tradingToken = useSelector(selectTradingComposedTransactionInfo).composed?.token;
 
-    const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
+    const isApprovalTx =
+        networkType === 'ethereum' && isEvmApprovalTx(precomposedForm.transactionData);
     // A contract call's single "address" row is the contract, not a payment recipient, so the
     // step-back heuristic below must not treat its ConfirmOutput as a re-confirmed output. A vault
     // deposit otherwise matches every condition and walks the review backwards mid-signing.

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx
@@ -100,17 +100,20 @@ export const TransactionReviewOutputList = ({
 
     const isStaking = stakeType;
 
-    const isApprovalTx = isEvmApprovalTx(precomposedForm.transactionData);
+    const isEthereum = networkType === 'ethereum';
+    const isApprovalTx = isEthereum && isEvmApprovalTx(precomposedForm.transactionData);
 
     // Resolved from the full context, not the calldata alone, so a WETH deposit()/withdraw() is
     // classified as wrap/unwrap — the review rows for those mirror the device's clear-signing
     // screens and need to know which of the two it is.
-    const evmTxType = getEvmTransactionPurpose({
-        networkSymbol: symbol,
-        to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
-            ?.address,
-        data: precomposedForm.transactionData,
-    });
+    const evmTxType = isEthereum
+        ? getEvmTransactionPurpose({
+              networkSymbol: symbol,
+              to: precomposedTx.outputs.find(o => 'address' in o && typeof o.address === 'string')
+                  ?.address,
+              data: precomposedForm.transactionData,
+          })
+        : undefined;
 
     const isYieldOperation = isEvmYieldTxByTextSignature(evmTxType) || evmTxType === 'claim';
 

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -29,6 +29,7 @@ const deviceReducer = prepareDeviceReducer(extraDependenciesCommonMock);
 const tradingReducer = prepareTradingReducer(extraDependenciesCommonMock);
 const trxSymbol = asNetworkSymbol('trx');
 const ethSymbol = asNetworkSymbol('eth');
+const polSymbol = asNetworkSymbol('pol');
 const btcFeeData = {
     blockHeight: 890366,
     blockTime: 10,
@@ -60,6 +61,10 @@ const fees: FeesState = {
         data: btcFeeData,
     },
     [trxSymbol]: {
+        status: 'loaded',
+        data: btcFeeData,
+    },
+    [polSymbol]: {
         status: 'loaded',
         data: btcFeeData,
     },
@@ -832,6 +837,122 @@ describe('recomposeAndSignTxThunk', () => {
         expect(mockSignAndPushSendFormTransaction.mock.calls[0][0].formState.feeLimit).toBe(
             '64285',
         );
+    });
+
+    it('should not attach a token for a Tron approve transaction so the approve calldata is preserved', async () => {
+        const { store, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                selectedFee: 'normal',
+                composed: {
+                    feePerByte: '100',
+                    estimatedFeeLimit: '6428500',
+                    feeLimit: '64285',
+                    token: { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' } as TokenInfo,
+                    fee: '6428500',
+                    outputs: [],
+                },
+            },
+        });
+
+        const account = { ...accountBtc, symbol: 'trx', networkType: 'tron' } as Account;
+        const tronApproveCalldata =
+            '0x095ea7b3000000000000000000000000c6594cd50c39ba5f23538fdc3b8492c95edb6fe1000000000000000000000000000000000000000000000000000000000133e122';
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: { txid: 'txid' },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            feeLimit: '120000',
+                            estimatedFeeLimit: '12000000',
+                            fee: '12000000',
+                            outputs: [{ amount: '0' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+                amount: '0',
+                transactionData: tronApproveCalldata,
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+
+        const { formState } = (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock)
+            .mock.calls[0][0];
+        expect(formState.outputs[0].token).toBeNull();
+        expect(formState.transactionData).toBe(tronApproveCalldata);
+    });
+
+    it('should attach the token for an EVM approve transaction (approval flow)', async () => {
+        const tokenContract = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+        const { store, tradingFormState } = getMocks({
+            composedTransactionInfo: {
+                selectedFee: 'normal',
+                composed: {
+                    feePerByte: '10',
+                    estimatedFeeLimit: '1000',
+                    feeLimit: '1000',
+                    token: { contract: tokenContract } as TokenInfo,
+                    fee: '1000',
+                    outputs: [],
+                },
+            },
+        });
+
+        const account = { ...accountBtc, symbol: 'pol', networkType: 'ethereum' } as Account;
+        const approveCalldata =
+            '0x095ea7b3000000000000000000000000c6594cd50c39ba5f23538fdc3b8492c95edb6fe1000000000000000000000000000000000000000000000000000000000133e122';
+
+        const mockSignAndPushSendFormTransaction = jest.fn().mockResolvedValueOnce({
+            success: true,
+            payload: { txid: 'txid' },
+        });
+
+        (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock).mockImplementationOnce(
+            createThunk(
+                composeSendFormTransactionFeeLevelsThunk.typePrefix,
+                (_, { fulfillWithValue }) =>
+                    fulfillWithValue({
+                        normal: {
+                            type: 'final',
+                            outputs: [{ amount: '0' }],
+                        },
+                    }),
+            ),
+        );
+
+        const response = await store.dispatch(
+            tradingThunks.recomposeAndSignTxThunk({
+                account,
+                address: tokenContract,
+                amount: '0',
+                transactionData: approveCalldata,
+                tradingFormState,
+                signAndPushSendFormTransaction: mockSignAndPushSendFormTransaction,
+            }),
+        );
+
+        expect(response.meta.requestStatus).toBe('fulfilled');
+
+        const { formState } = (composeSendFormTransactionFeeLevelsThunk as unknown as jest.Mock)
+            .mock.calls[0][0];
+        expect(formState.outputs[0].token).toBe(tokenContract);
+        expect(formState.transactionData).toBe(approveCalldata);
     });
 
     it('should create payment requests when SLIP24 is active and conditions are met', async () => {

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -113,11 +113,11 @@ export const recomposeAndSignTxThunk = createThunk<
             });
         }
 
-        // Token is being used for approval transactions unless on firmware < 2.9.0.
-        // Otherwise if transactionData is present, token is not used as details are in the transactionData.
         const shouldIncludeToken =
             !transactionData ||
-            (isApprovalFlowSupported(device) && isEvmApprovalTx(transactionData));
+            (network.networkType === 'ethereum' &&
+                isApprovalFlowSupported(device) &&
+                isEvmApprovalTx(transactionData));
 
         // prepare the fee levels, set custom values from composed
         // WORKAROUND: sendFormEthereumActions and sendFormRippleActions use form outputs instead of composed transaction data

--- a/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
+++ b/suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts
@@ -1,10 +1,17 @@
+import { isRejected } from '@reduxjs/toolkit';
+
 import { createThunk } from '@suite-common/redux-utils';
-import { getNetworkDisplaySymbol } from '@suite-common/wallet-config';
-import { ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT } from '@suite-common/wallet-constants';
+import { getNetwork, getNetworkDisplaySymbol } from '@suite-common/wallet-config';
+import {
+    DEFAULT_PAYMENT,
+    DEFAULT_VALUES,
+    ETH_CONTRACT_CALL_BACKUP_GAS_LIMIT,
+} from '@suite-common/wallet-constants';
 import {
     type Account,
     type FeeInfo,
     type FeeLevelLabel,
+    type FormState,
     type PrecomposedLevels,
 } from '@suite-common/wallet-types';
 import { findToken, getAccountIdentity } from '@suite-common/wallet-utils';
@@ -16,6 +23,7 @@ import { ALLOWANCE_MODULE_PREFIX } from './allowanceConstants';
 import { buildAllowanceTransaction } from './buildAllowanceTransaction';
 import { ETHEREUM_ADJUST_GAS_LIMIT } from '../fees/feesUtils';
 import { type ComposeFeeLevelsError } from '../send/sendFormTypes';
+import { composeTronTransactionFeeLevelsThunk } from '../send/tron/sendFormTronThunks';
 
 export interface ComposeAllowanceTransactionThunkParams {
     feeInfo: FeeInfo;
@@ -37,7 +45,10 @@ export const composeAllowanceTransactionThunk = createThunk<
     { rejectValue: ComposeFeeLevelsError }
 >(
     `${ALLOWANCE_MODULE_PREFIX}/composeAllowanceTransactionThunk`,
-    async ({ feeInfo, account, contract, selectedFee, customFee, data }, { rejectWithValue }) => {
+    async (
+        { feeInfo, account, contract, selectedFee, customFee, data },
+        { dispatch, rejectWithValue },
+    ) => {
         const token = findToken(account.tokens, contract);
 
         if (!token) {
@@ -45,6 +56,29 @@ export const composeAllowanceTransactionThunk = createThunk<
                 error: 'fee-levels-compose-failed',
                 message: 'Token not found in account tokens.',
             });
+        }
+
+        if (account.networkType === 'tron') {
+            const formState: FormState = {
+                ...DEFAULT_VALUES,
+                outputs: [{ ...DEFAULT_PAYMENT, address: contract, amount: '0', token: null }],
+                transactionData: data,
+                options: ['broadcast'],
+                selectedUtxos: [],
+            };
+
+            const response = await dispatch(
+                composeTronTransactionFeeLevelsThunk({
+                    formState,
+                    composeContext: { account, network: getNetwork(account.symbol), feeInfo },
+                }),
+            );
+
+            if (isRejected(response)) {
+                return rejectWithValue(response.payload ?? { error: 'fee-levels-compose-failed' });
+            }
+
+            return response.payload;
         }
 
         const estimatedFee = await TrezorConnect.blockchainEstimateFee({

--- a/suite-common/wallet-core/src/send/tron/calculate.test.ts
+++ b/suite-common/wallet-core/src/send/tron/calculate.test.ts
@@ -1,0 +1,49 @@
+import { asNetworkSymbol } from '@suite-common/wallet-config';
+import { type ExternalOutput } from '@suite-common/wallet-types';
+import { type TokenInfo } from '@trezor/connect';
+
+import { calculate } from './calculate';
+import { calculateRawContractCall } from './calculateRawContractCall';
+import { calculateTrc20Transfer } from './calculateTrc20Transfer';
+import { calculateTrxTransfer } from './calculateTrxTransfer';
+import { type EstimateFeeLevel } from './types';
+
+jest.mock('./calculateRawContractCall');
+jest.mock('./calculateTrc20Transfer');
+jest.mock('./calculateTrxTransfer');
+
+const trxSymbol = asNetworkSymbol('trx');
+const output = {
+    type: 'payment',
+    address: 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr',
+    amount: '0',
+} as ExternalOutput;
+const feeLevel = { feePerTx: '0', feePerUnit: '0', feeLimit: '0' } as EstimateFeeLevel;
+const token = { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' } as TokenInfo;
+
+describe('calculate – input routing', () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it('routes to raw contract call when userCallDataHex is present, even if a token is set', () => {
+        calculate('1000', output, feeLevel, trxSymbol, 300, false, token, false, '095ea7b3aa');
+
+        expect(calculateRawContractCall).toHaveBeenCalledTimes(1);
+        expect(calculateTrc20Transfer).not.toHaveBeenCalled();
+        expect(calculateTrxTransfer).not.toHaveBeenCalled();
+    });
+
+    it('routes to TRC-20 transfer when only a token is present', () => {
+        calculate('1000', output, feeLevel, trxSymbol, 300, false, token, false, undefined);
+
+        expect(calculateTrc20Transfer).toHaveBeenCalledTimes(1);
+        expect(calculateRawContractCall).not.toHaveBeenCalled();
+    });
+
+    it('routes to TRX transfer when neither token nor calldata is present', () => {
+        calculate('1000', output, feeLevel, trxSymbol, 300, false, undefined, false, undefined);
+
+        expect(calculateTrxTransfer).toHaveBeenCalledTimes(1);
+        expect(calculateRawContractCall).not.toHaveBeenCalled();
+        expect(calculateTrc20Transfer).not.toHaveBeenCalled();
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/calculate.ts
+++ b/suite-common/wallet-core/src/send/tron/calculate.ts
@@ -18,22 +18,22 @@ export const calculate = (
     isNewAccount?: boolean,
     userCallDataHex?: string,
 ): PrecomposedTransaction => {
+    if (userCallDataHex) {
+        return calculateRawContractCall(
+            availableBalance,
+            output,
+            feeLevel,
+            networkSymbol,
+            bytes,
+            hasMemo,
+        );
+    }
     if (token) {
         return calculateTrc20Transfer(
             availableBalance,
             output,
             feeLevel,
             token,
-            networkSymbol,
-            bytes,
-            hasMemo,
-        );
-    }
-    if (userCallDataHex) {
-        return calculateRawContractCall(
-            availableBalance,
-            output,
-            feeLevel,
             networkSymbol,
             bytes,
             hasMemo,

--- a/suite-common/wallet-core/src/send/tron/resolveCalldata.test.ts
+++ b/suite-common/wallet-core/src/send/tron/resolveCalldata.test.ts
@@ -1,0 +1,41 @@
+import { type TokenInfo } from '@trezor/connect';
+
+import { resolveCalldata } from './resolveCalldata';
+
+const token = { contract: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t' } as TokenInfo;
+
+describe('resolveCalldata', () => {
+    it('returns explicit calldata when userCallDataHex is present, ignoring the token', () => {
+        const result = resolveCalldata({
+            token,
+            outputAddress: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+            amountInSubunits: '20177186',
+            userCallDataHex: '095ea7b3deadbeef',
+        });
+
+        expect(result).toEqual({ data: '095ea7b3deadbeef' });
+    });
+
+    it('encodes a TRC-20 transfer when only a token is present', () => {
+        const result = resolveCalldata({
+            token,
+            outputAddress: 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr',
+            amountInSubunits: '1000000',
+            userCallDataHex: '',
+        });
+
+        expect(result).toHaveProperty('data');
+        expect((result as { data: string }).data).toMatch(/^a9059cbb/);
+    });
+
+    it('returns null data for a plain TRX transfer', () => {
+        const result = resolveCalldata({
+            token: undefined,
+            outputAddress: 'TVDGpn4hCSzJ5nkHPLetk8KQBtwaTppnkr',
+            amountInSubunits: '1000000',
+            userCallDataHex: '',
+        });
+
+        expect(result).toEqual({ data: null });
+    });
+});

--- a/suite-common/wallet-core/src/send/tron/resolveCalldata.ts
+++ b/suite-common/wallet-core/src/send/tron/resolveCalldata.ts
@@ -15,6 +15,8 @@ export const resolveCalldata = ({
     amountInSubunits: string;
     userCallDataHex: string;
 }): CalldataResult => {
+    if (userCallDataHex) return { data: userCallDataHex };
+
     if (token) {
         const result = Calldata.tron.trc20.transfer.encode({
             to: outputAddress,
@@ -24,8 +26,6 @@ export const resolveCalldata = ({
 
         return { data: result.data.slice(2) };
     }
-
-    if (userCallDataHex) return { data: userCallDataHex };
 
     return { data: null };
 };

--- a/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
+++ b/suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts
@@ -72,10 +72,13 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
         const amountForEstimation =
             isSendMax || !('amount' in output) || !output.amount ? fallbackAmount : output.amount;
 
+        const userCallDataHex = formState.transactionData
+            ? formState.transactionData.replace(/^0x/, '')
+            : '';
+
         const ownerHex = tronUtils.tronAddressToHex(account.descriptor);
-        const recipientHex = token
-            ? tronUtils.tronAddressToHex(token.contract)
-            : tronUtils.tronAddressToHex(to);
+        const contractRecipient = userCallDataHex || !token ? to : token.contract;
+        const recipientHex = tronUtils.tronAddressToHex(contractRecipient);
 
         if (!ownerHex || !recipientHex) {
             return rejectWithValue({
@@ -88,10 +91,6 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
         // to what we'd get with real block data.
         const DUMMY_BLOCK_HASH = '0'.repeat(64);
         const DUMMY_BLOCK_HEIGHT = 0;
-
-        const userCallDataHex = formState.transactionData
-            ? formState.transactionData.replace(/^0x/, '')
-            : '';
 
         const calldata = resolveCalldata({
             token,
@@ -152,7 +151,7 @@ export const composeTronTransactionFeeLevelsThunk = createThunk<
                       symbol: account.symbol,
                       identity: getAccountIdentity(account),
                       from: account.descriptor,
-                      to: token ? token.contract : to,
+                      to: contractRecipient,
                       data: calldata.data,
                   })
                 : computeBandwidthFeeLevel({
@@ -253,9 +252,8 @@ export const signTronSendFormTransactionThunk = createThunk<
             (token || userCallDataHex) && feeLimitSource ? Number(feeLimitSource) : undefined;
 
         const ownerHex = tronUtils.tronAddressToHex(selectedAccount.descriptor);
-        const recipientHex = token
-            ? tronUtils.tronAddressToHex(token.contract)
-            : tronUtils.tronAddressToHex(output.address);
+        const contractRecipient = userCallDataHex || !token ? output.address : token.contract;
+        const recipientHex = tronUtils.tronAddressToHex(contractRecipient);
 
         if (!ownerHex || !recipientHex) {
             return rejectWithValue({

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.test.ts
@@ -20,6 +20,7 @@ import {
 
 const ethSymbol = asNetworkSymbol('eth');
 const bscSymbol = asNetworkSymbol('bsc');
+const trxSymbol = asNetworkSymbol('trx');
 
 const buildPrecomposedTx = (to: string | undefined): GeneralPrecomposedTransactionFinal =>
     ({
@@ -348,6 +349,29 @@ describe('constructTransactionReviewOutputs', () => {
             expect.arrayContaining([
                 expect.objectContaining({ type: 'swap_intent', value: 'swap' }),
             ]),
+        );
+    });
+
+    it('renders the raw data row for a Tron approve instead of treating it as an EVM approval', () => {
+        const tronAccount = mockWalletAccount({ symbol: trxSymbol, accountType: 'normal' });
+
+        const outputs = constructTransactionReviewOutputs({
+            account: tronAccount,
+            device,
+            decreaseOutputId: undefined,
+            precomposedForm: buildFormState({ transactionData: ERC20_APPROVE_DATA }),
+            precomposedTx: buildPrecomposedTransaction({
+                to: '0x0000000000000000000000000000000000001234',
+            }),
+        });
+
+        expect(outputs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ type: 'data', value: ERC20_APPROVE_DATA }),
+            ]),
+        );
+        expect(outputs).not.toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'approve_data' })]),
         );
     });
 

--- a/suite-common/wallet-utils/src/reviewTransactionUtils.ts
+++ b/suite-common/wallet-utils/src/reviewTransactionUtils.ts
@@ -434,7 +434,8 @@ const constructNewFlow = ({
     const tronStaking = isTron ? precomposedForm.tronStaking : undefined;
     const isTronStakeFreeze = tronStaking?.kind === 'freeze' || tronStaking?.kind === 'unstake';
     const evmApprovalTxData = Calldata.evm.erc20.approve.decode(precomposedForm.transactionData);
-    const isEvmApproval = isEvmApprovalTx(precomposedForm.transactionData);
+    const isEvmApproval =
+        account.networkType === 'ethereum' && isEvmApprovalTx(precomposedForm.transactionData);
     const stakeType = getStakeType(precomposedForm);
 
     const { networkType, symbol } = account;


### PR DESCRIPTION
## Description

Fixes Tron DEX trading: the token approval step showed no fee and could not be signed, and a Tron approve elsewhere composed a TRC20 transfer to the token contract instead of the approve call.

Two selector-only assumptions leaked non-EVM transactions into EVM code paths (`isEvmApprovalTx` / `getEvmTransactionPurpose` match the `0x095ea7b3` selector alone, which Tron approve calldata shares), and the allowance (approve/revoke) flow had no Tron support at all.

- `composeAllowanceTransactionThunk`: the DEX approval modal composed and estimated fees only via the EVM path (`buildAllowanceTransaction`, gas x gwei). On Tron this produced a bogus fee that exceeded balance, so no final fee level existed: no fee shown, could not submit. Route Tron accounts through `composeTronTransactionFeeLevelsThunk` with the approve calldata; signing already routes Tron via `signTronSendFormTransactionThunk`. This is the fix for the "no fee / approval doesn't go through" report.
- `resolveCalldata` / `calculate` / `sendFormTronThunks` (Tron): check `userCallDataHex` before `token` for the calldata, the contract recipient, and the fee-estimation target, so an explicit approve calldata is never replaced by a token-derived transfer (load-bearing for the allowance path, which sets both a token and calldata).
- `recomposeAndSignTxThunk`: gate the approval-flow token branch to `networkType === 'ethereum'` (the firmware approval flow is EVM-only) so the DEX swap recompose path can't attach a token to a Tron approve.
- Transaction review: gate the approval and `evmTxType` classification to `networkType === 'ethereum'`, so a Tron approve renders as a generic contract call (raw data row) instead of an empty EVM-approval view, matching what the device clear-signs.

## Notes for QA

- Reproduce with a Tron account holding a TRC20 token: start an exchange DEX quote that needs approval (status `APPROVAL_REQ`, e.g. lifi Tron to Solana). Before: the approve modal shows no fee and the button can't submit. After: a Tron fee is shown, the approve signs, and the device shows the approve contract call (not a transfer).
- Regression check EVM DEX approvals (ETH and another EVM chain): approve/revoke modal fees, signing, and the review approve rows (spender, amount) unchanged.
- Regression check plain Tron TRX send and TRC20 token send.

## Related Issue

Resolve

## Screenshots:

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes primarily affect transaction review UI components, trading recompose/sign logic, token allowance composition, and TRON send calculations. The highest regression risk lies in the transaction review modal rendering and trading swap/sell flows. A focused set of send, cross-chain swap, and token approval tests covers the most critical paths, while TRON-specific changes have no corresponding e2e coverage in this test suite.

<details><summary><b>Changed files (12)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewOutputList.tsx`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`
- `suite-common/wallet-core/src/allowance/composeAllowanceTransactionThunk.ts`
- `suite-common/wallet-core/src/send/tron/calculate.test.ts`
- `suite-common/wallet-core/src/send/tron/calculate.ts`
- `suite-common/wallet-core/src/send/tron/resolveCalldata.test.ts`
- `suite-common/wallet-core/src/send/tron/resolveCalldata.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.test.ts`
- `suite-common/wallet-utils/src/reviewTransactionUtils.ts`

</details>

**Recommended tests (8)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/swap-dex-lifi-approval.test.ts` — This test directly exercises the token approval flow, which uses the changed composeAllowanceTransactionThunk, and renders the transaction review modal components (TransactionReviewModalBodyInner/TransactionReviewOutputList) during the approval confirmation.
- `suite/e2e/tests/wallet/send-eth.test.ts` — This test walks through a complete Ethereum send transaction, including custom gas fees, and displays the transaction review modal with amount/fee/address details, directly covering the changed review modal components and reviewTransactionUtils.
- `suite/e2e/tests/wallet/send-base.test.ts` — This test covers an EVM L2 (Base) send transaction with custom fees and verifies the transaction review modal output on both the app UI and the device display, exercising the changed review modal and review utilities.
- `suite/e2e/tests/wallet/send-sol.test.ts` — This test covers a Solana send transaction including the Review & Send modal, device prompt output values, and fee display, which relies on the changed transaction review modal components and reviewTransactionUtils.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — This test covers a cross-chain swap flow that triggers the changed recomposeAndSignTxThunk and displays the transaction review modal with recipient address, amount, and fee verification before signing.

</details>

<details><summary>🟡 <b>Medium priority (3)</b></summary>

- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — This test exercises Bitcoin send transactions with multiple outputs and OP_RETURN data, which stresses the TransactionReviewOutputList rendering of varied output types and the review modal.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — This test covers the sell trading flow for Ethereum, which uses recomposeAndSignTxThunk to build and sign the send transaction, and displays the transaction review details before device confirmation.
- `suite/e2e/tests/trading/swap-coins.test.ts` — This test covers a SOL-to-BTC swap through the full trading flow, including recomposeAndSignTxThunk for transaction creation and the transaction review modal before broadcasting.

</details>

⚠️ **Changes with no test coverage (3)**
- `suite-common/wallet-core/src/send/tron/calculate.ts`
- `suite-common/wallet-core/src/send/tron/resolveCalldata.ts`
- `suite-common/wallet-core/src/send/tron/sendFormTronThunks.ts`

_Updated: 2026-08-18T23:43:47.799Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/tron-approve-calldata-fix/web/](https://dev.suite.sldev.cz/suite-web/tron-approve-calldata-fix/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=tron-approve-calldata-fix&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=tron-approve-calldata-fix&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=tron-approve-calldata-fix&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T23:44:32.764Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-08-18T23:44:12.538Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->