### PR TITLE
fix(trading): type compose reject payload via thunk matcher

### DIFF
--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -19,7 +19,7 @@ import { tradingThunks } from './index';
 jest.mock('@suite-common/wallet-core', () => {
     const actualModule = jest.requireActual('@suite-common/wallet-core');
     const actualCompose = actualModule.composeSendFormTransactionFeeLevelsThunk;
-    // RTK `isRejectedWithValue(thunk)` detects async thunks via pending/fulfilled/rejected.
+    // RTK `isRejected(thunk)` detects async thunks via pending/fulfilled/rejected.
     const mockedComposeSendFormTransactionFeeLevelsThunk = Object.assign(jest.fn(), {
         typePrefix: actualCompose.typePrefix,
         pending: actualCompose.pending,

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts
@@ -18,10 +18,18 @@ import { tradingThunks } from './index';
 
 jest.mock('@suite-common/wallet-core', () => {
     const actualModule = jest.requireActual('@suite-common/wallet-core');
+    const actualCompose = actualModule.composeSendFormTransactionFeeLevelsThunk;
+    // RTK `isRejectedWithValue(thunk)` detects async thunks via pending/fulfilled/rejected.
+    const mockedComposeSendFormTransactionFeeLevelsThunk = Object.assign(jest.fn(), {
+        typePrefix: actualCompose.typePrefix,
+        pending: actualCompose.pending,
+        fulfilled: actualCompose.fulfilled,
+        rejected: actualCompose.rejected,
+    });
 
     return {
         ...actualModule,
-        composeSendFormTransactionFeeLevelsThunk: jest.fn(),
+        composeSendFormTransactionFeeLevelsThunk: mockedComposeSendFormTransactionFeeLevelsThunk,
     };
 });
 

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -191,12 +191,12 @@ export const recomposeAndSignTxThunk = createThunk<
             }),
         );
 
-        if (isRejectedWithValue(composedLevels)) {
-            const composeError = composedLevels.payload as { message?: string } | undefined;
+        if (isRejectedWithValue(composeSendFormTransactionFeeLevelsThunk)(composedLevels)) {
+            const composeError = composedLevels.payload;
 
             return rejectWithValue({
                 type: 'sign-tx-error',
-                error: composeError?.message
+                error: composeError.message
                     ? {
                           id: 'TR_TRADING_COMPOSE_FAILED',
                           values: { error: composeError.message },

--- a/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
+++ b/suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts
@@ -1,4 +1,4 @@
-import { isRejectedWithValue } from '@reduxjs/toolkit';
+import { isRejected } from '@reduxjs/toolkit';
 
 import { isApprovalFlowSupported, selectSelectedDevice } from '@suite-common/device';
 import { createThunk } from '@suite-common/redux-utils';
@@ -191,12 +191,12 @@ export const recomposeAndSignTxThunk = createThunk<
             }),
         );
 
-        if (isRejectedWithValue(composeSendFormTransactionFeeLevelsThunk)(composedLevels)) {
+        if (isRejected(composeSendFormTransactionFeeLevelsThunk)(composedLevels)) {
             const composeError = composedLevels.payload;
 
             return rejectWithValue({
                 type: 'sign-tx-error',
-                error: composeError.message
+                error: composeError?.message
                     ? {
                           id: 'TR_TRADING_COMPOSE_FAILED',
                           values: { error: composeError.message },


### PR DESCRIPTION
## Description

Follow-up to #31325. `isRejectedWithValue(composedLevels)` types `payload` as `unknown`, which forced `as { message?: string }`. Pass `composeSendFormTransactionFeeLevelsThunk` so RTK narrows `payload` to `ComposeFeeLevelsError`.

The compose-thunk mock now copies `typePrefix` / `pending` / `fulfilled` / `rejected` so the matcher still recognizes it as an async thunk.

No user-facing behavior change.

## Notes for QA

No functional change. Existing compose-error vs missing-fee-level mapping is unchanged. Unit tests cover the reject paths.

## Related Issue

Follow-up to #31325

## Screenshots:

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/fix/trading-typed-compose-reject/web/](https://dev.suite.sldev.cz/suite-web/fix/trading-typed-compose-reject/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=fix/trading-typed-compose-reject&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=fix/trading-typed-compose-reject&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=fix/trading-typed-compose-reject&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |

</details>

_Updated: 2026-08-18T19:29:34.518Z • 2 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 4 test(s)</summary>

| Test | Type |
|------|------|
| Trading - Swap > Swap SOL USDT token to ETH | 🤖 auto |
| Trading - Swap > Swap SOL to BTC | 🤖 auto |
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-18T19:28:03.136Z • 4 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The change set modifies a common trading thunk responsible for transaction recomposition and signing. Risk is concentrated in trading swap/sell flows where Suite signs provider-directed transactions, especially when custom fees or cross-chain composition are involved. The recommended tests target these signing paths across BTC, ETH, and SOL networks rather than the broader set of 134 statically mapped tests, most of which do not exercise this thunk directly.

<details><summary><b>Changed files (2)</b></summary>

- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.ts`

</details>

**Recommended tests (9)**

<details><summary>🔴 <b>High priority (5)</b></summary>

- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — This test exercises the full sell send flow where Suite must recompose the BTC transaction and present address/amount/fee on the device for signing. A change to recomposeAndSignTxThunk would directly surface here as a signing or fee-display regression.
- `suite/e2e/tests/trading/sell-ethereum.test.ts` — Tests ETH sell with custom gas fees (gas limit, max fee per gas, max priority fee per gas) and device signing. The thunk's recomposition logic for EVM fees is directly exercised by this flow.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain swap from ETH to SOL requires recomposing an EVM send transaction to the provider and signing it on device. This covers both network-specific recomposition and the end-to-end signing path.
- `suite/e2e/tests/trading/swap-fees-bitcoin.test.ts` — Explicitly verifies custom fee rate handling in BTC swaps, including total amount = fee + send amount and fee rate display on the device. This directly targets the thunk's recomposition behavior when fees change.
- `suite/e2e/tests/trading/swap-fees-ethereum.test.ts` — Verifies custom Ethereum gas parameters in a swap and checks the computed maximum fee on the device prompt. Any regression in EVM transaction recomposition would be visible here.

</details>

<details><summary>🟡 <b>Medium priority (4)</b></summary>

- `suite/e2e/tests/trading/sell-solana.test.ts` — SOL sell flow triggers a device signing prompt for sending crypto to the provider. It shares the same signing thunk infrastructure and covers a non-EVM/non-BTC network path.
- `suite/e2e/tests/trading/swap-btc-to-eth-token.test.ts` — BTC-to-ETH-token swap exercises UTXO recomposition and cross-chain signing. It complements the fee-focused BTC swap test by covering the standard best-offer signing path.
- `suite/e2e/tests/trading/swap-dex-lifi.test.ts` — DEX swap via LI.FI involves recomposing an Ethereum transaction with DEX-specific gas adjustments and confirming amount/fee on device. It tests a specialized swap path that still relies on the common signing thunk.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — SOL-to-BTC swap exercises Solana transaction recomposition and signing. This adds coverage for another major network's path through the common thunk.

</details>

⚠️ **Changes with no test coverage (1)**
- `suite-common/trading/src/thunks/common/recomposeAndSignTxThunk.test.ts`

_Updated: 2026-08-18T19:29:38.025Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->