### PR TITLE
fix(connect): verifyTx must not skip amount check for numeric-0 outputs

### DIFF
--- a/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/__fixtures__/signtxVerify.ts
@@ -204,6 +204,21 @@ export default [
         error: 'verifyTx: Wrong output amount at output 0. Requested: 20000, signed: 10000',
     },
     {
+        // numeric 0 is a valid amount (e.g. an ephemeral anchor/P2A-style output) and must
+        // not be treated as "no amount to verify" by a JS truthiness check
+        description: 'Error, amount differ (requested amount is numeric 0)',
+        inputs,
+        outputs: [
+            {
+                address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+                amount: 0,
+                script_type: 'PAYTOADDRESS',
+            },
+        ],
+        tx: '01000000016d20f69067ad1ffd50ee7c0f377dde2c932ccb03e84b5659732da99c20f1f650010000006b483045022100cdf268cb89433f2cdc990ca3f45bf356befe51bbbbd6b57f1ca08ac69298acad022032beef4e1380bd3819c0cbf1b1a70b434a115199d1cbe5c59de8d94f98086452012102a7a079c1ef9916b289c2ff21a992c808d0de3dfcf8a9f163205c5c9e21f55d5cffffffff011027000000000000160014751e76e8199196d454941c45d1b3a323f1433bd600000000',
+        error: 'verifyTx: Wrong output amount at output 0. Requested: 0, signed: 10000',
+    },
+    {
         description: 'Error, wrong length (inputs)',
         inputs: [],
         outputs: [],

--- a/packages/connect/src/api/bitcoin/signtxVerify.ts
+++ b/packages/connect/src/api/bitcoin/signtxVerify.ts
@@ -124,7 +124,7 @@ export const verifyTx = (
         const { outs } = bitcoinTx;
         // @ts-expect-error: indexing with noUncheckedIndexedAccess
         const txOut: (typeof outs)[number] = outs[i];
-        if (output.amount) {
+        if (output.amount != null) {
             if (output.amount.toString() !== txOut.value) {
                 throw ERRORS.TypedError(
                     'Runtime',


### PR DESCRIPTION
Found by inspection, no filed issue.

`verifyTx` (`packages/connect/src/api/bitcoin/signtxVerify.ts`) is the last
client-side check that a device-signed transaction actually matches what the user
requested. It used `if (output.amount)` - a truthiness check - to decide whether
to verify an output's amount:

```ts
if (output.amount) {
    if (output.amount.toString() !== txOut.value) {
        throw ERRORS.TypedError(...)
    }
}
```

`output.amount` is typed `string | number`. A legitimate numeric `0` is falsy in
JS, so the amount check was silently skipped for that output - while string `'0'`
was already handled correctly (it's truthy). A zero-value non-opreturn output is
schema-valid (`Type.Uint()` has no minimum) and is a real current Bitcoin pattern
(e.g. the ephemeral anchor/P2A output standardized in Bitcoin Core 28). If a
transport tampered with that output's on-chain value while leaving the script
untouched, `verifyTx` would return successfully instead of throwing.

## Fix

`if (output.amount) ` -> `if (output.amount != null)`. Treats `undefined` as
"nothing to verify" the same as before, and now correctly verifies numeric `0`.

An empty string would also now enter the check rather than being skipped - that's
unreachable in practice: `amount` is required by the protobuf schema
(`TxOutputType`) and `''` is rejected by param validation (`validateTrezorOutputs`)
before `verifyTx` ever runs, so this is a fail-closed non-issue, not a new gap.

## Testing

Added a fixture case in `__fixtures__/signtxVerify.ts` reusing the existing
"Error, amount differ" transaction hex (known signed output value `10000`) with a
numeric `0` requested amount, expecting `verifyTx` to now throw
`Wrong output amount at output 0. Requested: 0, signed: 10000`.

Guard-validated: reverting just the one-line fix makes exactly the new fixture
fail (`verifyTx` resolves instead of throwing), while all 16 pre-existing fixtures
stay unaffected - confirms the fix is isolated to the numeric-0 case and doesn't
touch the already-correct string-amount paths. Restoring: 17/17 pass.

Repo-wide grep for any internal caller constructing a numeric `amount: 0` output
outside tests/fixtures: none. The only internal constructor of `verifyTx` inputs
(`outputToTrezor`) always emits string amounts, so no existing flow depends on the
old skip-on-0 behavior.

`npx jest signtxVerify.test.ts`: 17/17 pass. `npx eslint` clean on both changed
files. `npx tsc --noEmit` has pre-existing errors unrelated to either file
(verified via `git stash` comparison - byte-identical error output with the fix
stashed out vs applied).
