### PR TITLE
refactor(suite-native): extract getDecreaseOutputId function for clarity

### DIFF
--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx
@@ -12,8 +12,8 @@ import { selectStablecoinYieldTxReview } from '@suite-common/wallet-core';
 import { type FormState } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputsOptional,
+    getDecreaseOutputId,
     getTxValidityTimeoutInMs,
-    isRbfBumpFeeTransaction,
 } from '@suite-common/wallet-utils';
 import TrezorConnect from '@trezor/connect';
 import { type Deferred } from '@trezor/utils';
@@ -98,13 +98,7 @@ export const TransactionReviewModalBody = ({
         };
     }, [deadline, dispatch, isSending, shouldCheckTxTimeValidity]);
 
-    const isBumpFeeRbfAction =
-        precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
-
-    const decreaseOutputId =
-        isBumpFeeRbfAction && precomposedTx.useNativeRbf
-            ? precomposedForm?.setMaxOutputId
-            : undefined;
+    const decreaseOutputId = getDecreaseOutputId(precomposedTx, precomposedForm);
 
     const outputs = constructTransactionReviewOutputsOptional({
         account,

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx
@@ -21,6 +21,7 @@ import {
     type YieldClaimReward,
 } from '@suite-common/wallet-types';
 import {
+    getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
     isEvmApprovalTx,
@@ -127,10 +128,7 @@ export const TransactionReviewModalBodyInner = ({
     const isBumpFeeRbfAction =
         precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
 
-    const decreaseOutputId =
-        isBumpFeeRbfAction && precomposedTx.useNativeRbf
-            ? precomposedForm?.setMaxOutputId
-            : undefined;
+    const decreaseOutputId = getDecreaseOutputId(precomposedTx, precomposedForm);
 
     const buttonRequestsCount = useSelector((state: DeviceRootState) =>
         selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId),

--- a/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
+++ b/packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx
@@ -14,6 +14,7 @@ import {
 } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputsOptional,
+    getDecreaseOutputId,
     getStakeType,
     getTxValidityTimeoutInMs,
     isRbfBumpFeeTransaction,
@@ -69,10 +70,7 @@ export const TransactionReviewModalContent = ({
     const isBumpFeeRbfAction =
         precomposedTx !== undefined && isRbfBumpFeeTransaction(precomposedTx);
 
-    const decreaseOutputId =
-        isBumpFeeRbfAction && precomposedTx.useNativeRbf
-            ? precomposedForm?.setMaxOutputId
-            : undefined;
+    const decreaseOutputId = getDecreaseOutputId(precomposedTx, precomposedForm);
 
     const buttonRequestsCount = useSelector((state: DeviceRootState) =>
         selectSendFormReviewButtonRequestsCount(state, symbol, decreaseOutputId),

--- a/suite-common/wallet-utils/src/transactionUtils.test.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.test.ts
@@ -1,6 +1,11 @@
 import { testMocks } from '@suite-common/test-utils';
 import { type NetworkFeature, asNetworkSymbol } from '@suite-common/wallet-config';
-import { type WalletAccountTransaction, asAccountDescriptor } from '@suite-common/wallet-types';
+import {
+    type FormState,
+    type GeneralPrecomposedTransactionFinal,
+    type WalletAccountTransaction,
+    asAccountDescriptor,
+} from '@suite-common/wallet-types';
 
 import * as fixtures from './__fixtures__/transactionUtils';
 import {
@@ -10,6 +15,7 @@ import {
     findChainedTransactions,
     generateTransactionMonthKey,
     getAccountTransactions,
+    getDecreaseOutputId,
     getEvmNonceInfo,
     getEvmNonceInfoFromConfirmedNonce,
     getEvmNonceStatus,
@@ -88,6 +94,20 @@ const rbfParams: WalletAccountTransaction['rbfParams'] = {
     feeRate: '1',
     baseFee: 144,
 };
+
+const buildBumpFeeRbfTx = (useNativeRbf: boolean): GeneralPrecomposedTransactionFinal =>
+    ({
+        rbfType: 'bump-fee',
+        useNativeRbf,
+    }) as unknown as GeneralPrecomposedTransactionFinal;
+
+const buildCancelRbfTx = (): GeneralPrecomposedTransactionFinal =>
+    ({
+        rbfType: 'cancel',
+    }) as unknown as GeneralPrecomposedTransactionFinal;
+
+const buildNonRbfTx = (): GeneralPrecomposedTransactionFinal =>
+    ({}) as unknown as GeneralPrecomposedTransactionFinal;
 
 describe('transaction utils', () => {
     describe('parseTransactionDateKey', () => {
@@ -1042,6 +1062,34 @@ describe('transaction utils', () => {
             });
 
             expect(getTargetAmount(selfTarget, transaction)).toBeNull();
+        });
+    });
+
+    describe('getDecreaseOutputId', () => {
+        const precomposedForm = { setMaxOutputId: 2 } as unknown as FormState;
+
+        it('returns the form setMaxOutputId for a native RBF bump-fee transaction', () => {
+            expect(getDecreaseOutputId(buildBumpFeeRbfTx(true), precomposedForm)).toBe(2);
+        });
+
+        it('returns undefined when the transaction is undefined', () => {
+            expect(getDecreaseOutputId(undefined, precomposedForm)).toBeUndefined();
+        });
+
+        it('returns undefined for a bump-fee transaction that is not native RBF', () => {
+            expect(getDecreaseOutputId(buildBumpFeeRbfTx(false), precomposedForm)).toBeUndefined();
+        });
+
+        it('returns undefined for a cancel RBF transaction', () => {
+            expect(getDecreaseOutputId(buildCancelRbfTx(), precomposedForm)).toBeUndefined();
+        });
+
+        it('returns undefined for a non-RBF transaction', () => {
+            expect(getDecreaseOutputId(buildNonRbfTx(), precomposedForm)).toBeUndefined();
+        });
+
+        it('returns undefined when the form is missing', () => {
+            expect(getDecreaseOutputId(buildBumpFeeRbfTx(true), undefined)).toBeUndefined();
         });
     });
 });

--- a/suite-common/wallet-utils/src/transactionUtils.ts
+++ b/suite-common/wallet-utils/src/transactionUtils.ts
@@ -7,6 +7,7 @@ import {
     type Account,
     type AccountKey,
     type ChainedTransactions,
+    type FormState,
     type GeneralPrecomposedTransactionFinal,
     type PrecomposedTransactionFinal,
     type PrecomposedTransactionFinalBumpFeeRbf,
@@ -343,6 +344,14 @@ export const isRbfBumpFeeTransaction = (
 export const isRbfCancelTransaction = (
     tx: GeneralPrecomposedTransactionFinal,
 ): tx is PrecomposedTransactionFinalCancelRbf => isRbfTransaction(tx) && tx.rbfType === 'cancel';
+
+export const getDecreaseOutputId = (
+    precomposedTx: GeneralPrecomposedTransactionFinal | undefined,
+    precomposedForm: FormState | null | undefined,
+) =>
+    precomposedTx && isRbfBumpFeeTransaction(precomposedTx) && precomposedTx.useNativeRbf
+        ? precomposedForm?.setMaxOutputId
+        : undefined;
 
 /* Convert date to string in YYYY-MM-DD format */
 const generateTransactionDateKey = (d: Date) =>

--- a/suite-native/transaction-management/src/selectors.ts
+++ b/suite-native/transaction-management/src/selectors.ts
@@ -23,11 +23,11 @@ import {
 } from '@suite-common/wallet-types';
 import {
     constructTransactionReviewOutputs,
+    getDecreaseOutputId,
     getFormDraftKey,
     getIsUpdatedSendFlow,
     getTransactionReviewOutputState,
     isClearSignedEvmTradingSwapTransaction,
-    isRbfBumpFeeTransaction,
 } from '@suite-common/wallet-utils';
 import { BigNumber, isNotNullOrUndefined } from '@trezor/utils';
 
@@ -88,10 +88,7 @@ const selectSendReviewButtonRequestsCount = (
     const account = selectAccountByKey(state, accountKey);
     const precomposedTx = selectSendPrecomposedTx(state);
 
-    const decreaseOutputId =
-        precomposedTx && isRbfBumpFeeTransaction(precomposedTx) && precomposedTx.useNativeRbf
-            ? precomposedForm?.setMaxOutputId
-            : undefined;
+    const decreaseOutputId = getDecreaseOutputId(precomposedTx, precomposedForm);
 
     return selectSendFormReviewButtonRequestsCount(state, account?.symbol, decreaseOutputId);
 };
@@ -122,10 +119,7 @@ export const selectTransactionReviewOutputs = createSendMemoizedSelector(
             return null;
         }
 
-        const decreaseOutputId =
-            isRbfBumpFeeTransaction(precomposedTx) && precomposedTx.useNativeRbf
-                ? precomposedForm?.setMaxOutputId
-                : undefined;
+        const decreaseOutputId = getDecreaseOutputId(precomposedTx, precomposedForm);
 
         const outputs = constructTransactionReviewOutputs({
             account,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- just an implementation of missed comment
<!--- Describe your changes in detail -->

## Notes for QA

<!--- Unless already specified in a linked issue, please specify any relevant information or steps for the QA team to focus on during testing (e.g., areas most affected, special scenarios to cover, manual test instructions, known side effects, or things that do not need to be tested). -->

## Related Issue

Resolve <!--- link the issue here -->

## Screenshots:

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=commit-selector-antipattern&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=commit-selector-antipattern&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/commit-selector-antipattern/web/](https://dev.suite.sldev.cz/suite-web/commit-selector-antipattern/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Send - Solana > Send max | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T08:33:46.068Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Passphrase reconnection > after device is reconnected passphrase needs to be confirmed | 🤖 auto |

</details>

_Updated: 2026-08-19T08:33:44.815Z • 1 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** The changes are concentrated in the transaction review modal UI and shared transaction utilities, so the highest-risk regressions are in send, swap, sell, and staking flows that render transaction outputs for device confirmation. The recommended set covers the major transaction types (BTC, EVM, EVM-L2, Solana, Cardano) and representative trading/staking flows while keeping the list short. The native mobile selectors file and the unit test file have no Playwright E2E coverage.

<details><summary><b>Changed files (6)</b></summary>

- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBody.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewModalBodyInner.tsx`
- `packages/suite/src/components/suite/modals/ReduxModal/TransactionReviewModal/TransactionReviewOutputList/TransactionReviewModalContent.tsx`
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-common/wallet-utils/src/transactionUtils.ts`
- `suite-native/transaction-management/src/selectors.ts`

</details>

**Recommended tests (12)**

<details><summary>🔴 <b>High priority (11)</b></summary>

- `suite/e2e/tests/wallet/send-base.test.ts` — Directly exercises the EVM send review modal on Base, verifying recipient address, amount, gas limit, max fee per gas, max priority fee per gas, and total/fee display on the device prompt — all rendered by TransactionReviewModal components.
- `suite/e2e/tests/wallet/send-doge.test.ts` — Validates the send review flow for Dogecoin, including device prompt output for amount, total, fee, and recipient address; also tests edge-case amount handling that may depend on transactionUtils formatting.
- `suite/e2e/tests/wallet/send-eth.test.ts` — Core EVM send flow that opens the transaction review modal and asserts device prompt values for address, amount, gas limit, fee rate, priority fee, and max fee — directly touching the changed review modal and transactionUtils.
- `suite/e2e/tests/wallet/send-form-regtest.test.ts` — Tests Bitcoin send review with multiple outputs, locktime, and OP_RETURN data, which directly exercises how TransactionReviewModal renders varied output types and amounts.
- `suite/e2e/tests/wallet/send-sol.test.ts` — Exercises the Solana send-max review flow, asserting the review modal and device prompt show correct total amount, fee, and recipient address before signing.
- `suite/e2e/tests/trading/sell-bitcoin.test.ts` — Sell flow initiates a send transaction to a provider and verifies the device prompt shows the correct destination address, crypto amount, and fee — all rendered through the transaction review modal.
- `suite/e2e/tests/staking/ada/stake.test.ts` — Cardano staking flow reaches the transaction review modal and asserts device confirmation screens for stake key registration, delegation, vote delegation, pool ID, fee, and network details.
- `suite/e2e/tests/staking/eth/initial-stake.test.ts` — ETH staking flow confirms the stake transaction on device and verifies the review modal/device prompt shows the correct staking amount and fee, directly exercising the changed review components.
- `suite/e2e/tests/staking/eth/unstake.test.ts` — ETH unstake and claim flows both pass through the transaction review modal, asserting device prompts display correct unstake/claim amounts and fees.
- `suite/e2e/tests/trading/swap-eth-to-sol.test.ts` — Cross-chain swap review flow asserts the confirmation modal and device prompt render the correct recipient address, send amount, and maximum fee before signing.
- `suite/e2e/tests/trading/swap-sol-to-btc.test.ts` — Solana-to-Bitcoin swap reviews send address, amount, and Solana fee on the device prompt, directly covering the transaction review modal output rendering.

</details>

<details><summary>🟡 <b>Medium priority (1)</b></summary>

- `suite/e2e/tests/wallet/send-form-ltc.test.ts` — LTC send flow tests spending a MimbleWimble peg-out output and confirming on device; less central than BTC/EVM/SOL sends but still exercises the review modal.

</details>

⚠️ **Changes with no test coverage (2)**
- `suite-common/wallet-utils/src/transactionUtils.test.ts`
- `suite-native/transaction-management/src/selectors.ts`

_Updated: 2026-08-19T08:35:04.588Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->