### PR TITLE
test(suite): assert the simulated receive amount in the DEX swap e2e

### DIFF
--- a/suite/e2e/support/mocks/trading/tradingMockNew.ts
+++ b/suite/e2e/support/mocks/trading/tradingMockNew.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test';
-import type { ExchangeTrade } from 'invity-api';
+import type { CryptoId, ExchangeTrade } from 'invity-api';
 
+import { getSimulatedReceiveAmount } from '@suite-common/trading';
 import type { BackendType, NetworkSymbol } from '@suite-common/wallet-config';
 
 import { TradingChainBackend, createTradingChainBackend } from './tradingChainBackend';
@@ -12,8 +13,12 @@ export type CapturedLiveTrade = ExchangeTrade & {
     sendAddress: string;
     exchange: string;
     sendStringAmount: string;
+    receive: CryptoId;
     receiveStringAmount: string;
 };
+
+type TxSimulationResult = NonNullable<Parameters<typeof getSimulatedReceiveAmount>[0]>;
+type TxSimulationScan = Omit<TxSimulationResult['payload'], 'needsDisclaimer'>;
 
 type TradeFlow = 'buy' | 'sell' | 'swap';
 type TradeEndpoints = {
@@ -30,6 +35,8 @@ const TRADE_ENDPOINTS: Record<TradeFlow, TradeEndpoints> = {
 const WATCH_POLL_PERIOD = '00:30';
 const WATCH_POLL_TIMEOUT = 35_000;
 const ADVANCE_ATTEMPTS = 5;
+
+const TX_SIMULATION_ENDPOINT = /\/evm\/json-rpc\/scan/;
 
 const MOCK_PROVIDER_STATUS_ORIGIN = 'https://mocked.partner.site/orders';
 const mockProviderStatusPageHtml = (orderId: string) =>
@@ -54,6 +61,7 @@ export class TradingMockNew {
     private flow?: TradeFlow;
     private backend?: TradingChainBackend;
     private capturedTrade: CapturedLiveTrade | null = null;
+    private capturedTxSimulation: TxSimulationResult | null = null;
 
     constructor(private page: Page) {
         assertPassphraseEnv();
@@ -144,11 +152,12 @@ export class TradingMockNew {
         if (
             !trade.exchange ||
             !trade.sendStringAmount ||
+            !trade.receive ||
             !trade.receiveStringAmount ||
             !hasDepositAddress
         ) {
             throw new Error(
-                'Live trade response is missing exchange, sendStringAmount, receiveStringAmount or sendAddress',
+                'Live trade response is missing exchange, sendStringAmount, receive, receiveStringAmount or sendAddress',
             );
         }
 
@@ -161,6 +170,38 @@ export class TradingMockNew {
         }
 
         return this.capturedTrade;
+    }
+
+    // Amount the last captured simulation credits, derived the same way the confirm step derives
+    // the amount it renders. A re-quote refetches the scan, so read this at assertion time.
+    get simulatedReceiveAmount(): string {
+        const amount = getSimulatedReceiveAmount(
+            this.capturedTxSimulation ?? undefined,
+            this.liveTrade.receive,
+        );
+
+        if (!amount) {
+            throw new Error('No captured simulation credits the receive asset of the trade');
+        }
+
+        return amount;
+    }
+
+    // DEX only; the confirm step renders the amount the Blockaid simulation credits instead of the
+    // amount the trade promised. The scan runs untouched, only its result is kept for assertions.
+    @step()
+    async captureTxSimulation() {
+        await this.page.route(TX_SIMULATION_ENDPOINT, async route => {
+            const response = await route.fetch();
+            const scan = (await response.json()) as TxSimulationScan;
+
+            this.capturedTxSimulation = {
+                method: 'ethereumSignTransaction',
+                payload: { ...scan, needsDisclaimer: false },
+            };
+
+            await route.fulfill({ response });
+        });
     }
 
     @step()

--- a/suite/e2e/support/pageObjects/trading/confirmationModal.ts
+++ b/suite/e2e/support/pageObjects/trading/confirmationModal.ts
@@ -24,6 +24,7 @@ export class TradingConfirmationModal {
     readonly exchangeType: Locator;
     readonly transactionId: Locator;
     readonly copyTransactionIdButton: Locator;
+    readonly issueBanner: Locator;
     readonly finishButton: Locator;
     readonly confirmAndSendButton: Locator;
     readonly buyButton: Locator;
@@ -32,6 +33,7 @@ export class TradingConfirmationModal {
     readonly dexMinimumReceivedAmount: Locator;
     readonly dexNetworkFee: Locator;
     readonly dexExchangeType: Locator;
+    readonly dexSimulationSubtitle: Locator;
 
     constructor(
         private readonly page: Page,
@@ -64,6 +66,7 @@ export class TradingConfirmationModal {
         this.copyTransactionIdButton = this.page
             .getByTestId('@trading/form/info')
             .getByRole('button', { name: 'Copy' });
+        this.issueBanner = this.page.getByTestId('@trading/offer/issue-banner');
         this.finishButton = this.page.getByTestId('@trading/offer/continue-transaction-button');
         this.confirmAndSendButton = this.page.getByTestId(
             '@trading/offer/confirm-on-trezor-and-send',
@@ -76,6 +79,7 @@ export class TradingConfirmationModal {
         );
         this.dexNetworkFee = this.page.getByTestId('@trading/offer/info/network-fee');
         this.dexExchangeType = this.page.getByTestId('@trading/offer/info/exchange-dex-type');
+        this.dexSimulationSubtitle = this.page.getByTestId('@trading/offer/simulation-subtitle');
     }
 
     @step()

--- a/suite/e2e/tests/trading/swap-dex-lifi.test.ts
+++ b/suite/e2e/tests/trading/swap-dex-lifi.test.ts
@@ -42,6 +42,7 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
         async ({ onboardingPage, dashboardPage, settingsPage, walletPage, tradingMockNew }) => {
             tradingMockNew.setTradeFlow('swap');
             const ethBackend = await tradingMockNew.startBackend('eth');
+            await tradingMockNew.captureTxSimulation();
 
             await onboardingPage.completeOnboarding();
             await settingsPage.changeNetworks({
@@ -123,11 +124,24 @@ test.describe('Trading - DEX swap (LI.FI)', { tag: ['@T3T1', '@T3W1'] }, () => {
             await expect(tradingPage.confirmation.sendAccount).toHaveText(`from ${accountLabel}`);
             await expect(tradingPage.confirmation.receiveAccount).toHaveText(`to ${accountLabel}`);
             await expect(tradingPage.confirmation.sendCryptoAmount).toHaveText(formattedSendAmount);
-            // REWORK: The receiveCryptoAmount amount is now simulated and differs from trade offer
-            await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
-                // positive amount, optional thousands separators, up to 6 decimals, then the symbol
-                /^(?=.*[1-9])\d{1,3}(,\d{3})*(\.\d{1,6})? USDC$/,
+
+            // The subtitle appears only once the simulation settles, gating the amount assertion
+            // below on the simulated value instead of the skeleton.
+            await expect(tradingPage.confirmation.dexSimulationSubtitle).toHaveTranslation(
+                'TR_SIMULATION_POWERED_BY',
+                { values: { provider: 'Blockaid' } },
             );
+            // Every re-quote refetches the simulation with a freshly credited amount, so the
+            // rendered value is compared against the last captured scan on each attempt.
+            await expect(async () => {
+                await expect(tradingPage.confirmation.receiveCryptoAmount).toHaveText(
+                    `${localizeNumber(tradingMockNew.simulatedReceiveAmount)} USDC`,
+                    { timeout: 2_000 },
+                );
+            }).toPass({ timeout: 15_000 });
+            // The simulation credits close to what the trade promised, so the swap has no issue to
+            // resolve. Were the banner to show up, it would also replace the confirm button below.
+            await expect(tradingPage.confirmation.issueBanner).toBeHidden();
         });
 
         await test.step('Open Confirm & send modal', async () => {


### PR DESCRIPTION
## Description

Repairs the DEX swap e2e for the swap transaction simulation merged in #31329.

The swap confirm step renders the receive amount from a Blockaid simulation, so with the live
service the rendered amount is non-deterministic — #30934 had to loosen the assertion to a regex
(`REWORK` note).

- `TradingMockNew.mockTxSimulation()` routes `**/evm/json-rpc/scan` and serves a benign scan
  crediting 99% of the live trade's receive amount: deterministic, distinguishable from the amount
  the trade promised, and far below the 10% price-impact threshold that would raise the issue banner.
- The first simulation runs on the offer's `dexTx`, before the trade response lands, so the route
  holds its response until the trade is captured — every simulation of the flow then credits the
  same amount.
- `swap-dex-lifi.test.ts` asserts the Blockaid subtitle (which also gates the amount assertion on
  the settled simulation instead of the skeleton) and the exact simulated amount.

Stacked on #30934 — base is `minimalist-mock-phase-B-3`.

## Notes for QA

E2E-only change, no product code touched. `Trading - DEX swap (LI.FI) > User can swap ETH to USDC
via LI.FI DEX` is currently auto-quarantined in Currents, so CI skips it until the quarantine
action is removed.

## Related Issue

Resolve #31331

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/test/31331-swap-simulation-e2e/web/](https://dev.suite.sldev.cz/suite-web/test/31331-swap-simulation-e2e/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=test/31331-swap-simulation-e2e&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=test/31331-swap-simulation-e2e&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T11:56:07.020Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T11:56:05.261Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->