### PR TITLE
chore(transport-bluetooth): server - http request index

### DIFF
--- a/packages/transport-bluetooth/src/server/connection_handler.rs
+++ b/packages/transport-bluetooth/src/server/connection_handler.rs
@@ -186,7 +186,16 @@ async fn handle_http_request(
         });
         Ok(response)
     } else {
-        Ok(HyperResponse::new(Full::<Bytes>::from(INDEX_HTML)))
+        // In debug builds serve the UI
+        // Stealth rejection in release builds to avoid fingerprinting the service
+        if cfg!(debug_assertions) {
+            Ok(HyperResponse::new(Full::<Bytes>::from(INDEX_HTML)))
+        } else {
+            Err(ServerError::Io(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "",
+            )))
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A small followup for https://github.com/trezor/trezor-suite/pull/31236


<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-08-19T09:14:48.376Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/bt-server-index/web/](https://dev.suite.sldev.cz/suite-web/chore/bt-server-index/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/bt-server-index&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/bt-server-index&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T09:18:16.970Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 1 test(s)</summary>

| Test | Type |
|------|------|
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T09:17:53.270Z • 1 test(s) total_
<!-- QUARANTINE-LIST:web:END -->