### PR TITLE
test(suite-native): enable authenticity check on T3W1

### DIFF
--- a/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
+++ b/suite-native/app/e2e/pageObjects/deviceOnboardingActions.ts
@@ -1,13 +1,7 @@
 import type { BackupType } from '@suite-common/suite-types';
-import { Model, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
-import {
-    getModelFromEnv,
-    isElementVisible,
-    scrollUntilVisible,
-    wait,
-    waitForVisible,
-} from '../support/utils';
+import { isElementVisible, scrollUntilVisible, wait, waitForVisible } from '../support/utils';
 
 class DeviceOnboardingActions {
     async selectCreateWalletOption() {
@@ -174,11 +168,8 @@ class DeviceOnboardingActions {
 
         await TrezorUserEnvLink.pressYes();
 
-        if (getModelFromEnv() !== Model.T3W1) {
-            // skip device authenticity check on T3W1 because we are using 2-main FW
-            await this.waitForDeviceAuthenticitySuccess();
-            await this.dismissDeviceAuthenticitySuccess();
-        }
+        await this.waitForDeviceAuthenticitySuccess();
+        await this.dismissDeviceAuthenticitySuccess();
 
         await TrezorUserEnvLink.pressYes();
 

--- a/suite-native/app/e2e/tests/deviceOnboarding.test.ts
+++ b/suite-native/app/e2e/tests/deviceOnboarding.test.ts
@@ -1,13 +1,11 @@
-import { Model, TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
+import { TrezorUserEnvLink } from '@trezor/trezor-user-env-link';
 
 import { btcCoinEnabled } from '../fixtures/btcCoinEnabled';
-import { deviceChecksDisabledState } from '../fixtures/deviceChecksDisabledState';
 import { deviceChecksEnabledState } from '../fixtures/deviceChecksEnabledState';
 import { onboardingCompletedState } from '../fixtures/onboardingCompletedState';
 import { onDeviceOnboarding } from '../pageObjects/deviceOnboardingActions';
 import { onHome } from '../pageObjects/homeActions';
 import { openApp, preparePreloadedReduxState, prepareTrezorEmulator } from '../support/setup';
-import { getModelFromEnv } from '../support/utils';
 
 const finishOnboardingFlow = async () => {
     // Create Pin
@@ -24,7 +22,7 @@ const finishOnboardingFlow = async () => {
 
 const preloadedState = preparePreloadedReduxState(
     onboardingCompletedState,
-    getModelFromEnv() === Model.T3W1 ? deviceChecksDisabledState : deviceChecksEnabledState, // skip device checks on T3W1 because we are using 2-main FW
+    deviceChecksEnabledState,
     btcCoinEnabled,
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Follow up for https://github.com/trezor/trezor-suite/pull/28790

Device authenticity is available in `2-latest` (2.12.4)

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:NATIVE-ANDROID:START -->
🔍 **Suite native android test results:** [View in Currents](https://app.currents.dev/projects/iUe1Y4/runs?branch=test/native-enable-device-authenticity&lookback=7)
<!-- CURRENTS-LINK:NATIVE-ANDROID:END -->
<!-- CURRENTS-LINKS:SECTION:END -->