### PR TITLE
chore(scripts): pin coinjoin github release

### DIFF
--- a/packages/suite-data/files/bin/coinjoin/update.sh
+++ b/packages/suite-data/files/bin/coinjoin/update.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-RELEASE_URL="https://github.com/trezor/WalletWasabi/releases/latest/download"
+# Pinned version is older than June 2025, so SHA256 checksum digest is not available from Github API.
+PINNED_VERSION="release/v15.0"
+RELEASE_URL="https://github.com/trezor/WalletWasabi/releases/download/$PINNED_VERSION"
 RELEASE_NAME="WabiSabiClientLibrary"
 
 DIST="./files/bin/coinjoin"


### PR DESCRIPTION
## Description

Pin release of https://github.com/trezor/WalletWasabi/releases 
This update script hasn't been run in years, and likely might not ever be run again, but it pops up in security analyses, so why not :shrug: 

<!-- LLM-TEST-SELECTOR:DETAILS:START -->
<details>
<summary><h3>🤖 LLM Test Recommendations</h3></summary>

<!-- LLM-TEST-SELECTOR:START -->
**Summary:** No relevant source file changes detected against origin/develop.

_No test recommendations found._

_Updated: 2026-08-19T12:11:08.973Z_
<!-- LLM-TEST-SELECTOR:END -->
</details>
<!-- LLM-TEST-SELECTOR:DETAILS:END -->

<!-- PREVIEW-LINKS:SECTION:START -->
## 🌐 Preview deployments

<!-- PREVIEW-LINK:SUITE-WEB:START -->
🌐 **Suite Web preview:** [https://dev.suite.sldev.cz/suite-web/chore/pin-cj-update.sh/web/](https://dev.suite.sldev.cz/suite-web/chore/pin-cj-update.sh/web/)
<!-- PREVIEW-LINK:SUITE-WEB:END -->
<!-- PREVIEW-LINKS:SECTION:END -->

<!-- CURRENTS-LINKS:SECTION:START -->
## 🔍 Currents Test Results

<!-- CURRENTS-LINK:WEB:START -->
🔍 **Suite web test results:** [View in Currents](https://app.currents.dev/projects/Og0NOQ/runs?branch=chore/pin-cj-update.sh&lookback=7)
<!-- CURRENTS-LINK:WEB:END -->
<!-- CURRENTS-LINK:DESKTOP:START -->
🔍 **Suite desktop test results:** [View in Currents](https://app.currents.dev/projects/4ytF0E/runs?branch=chore/pin-cj-update.sh&lookback=7)
<!-- CURRENTS-LINK:DESKTOP:END -->
<!-- CURRENTS-LINKS:SECTION:END -->

<!-- QUARANTINE-LIST:HEADING:START -->
## 🔒 Quarantined E2E Tests
<!-- QUARANTINE-LIST:HEADING:END -->

<!-- QUARANTINE-LIST:desktop:START -->
<details><summary>Trezor Suite (desktop) — 0 test(s)</summary>

_No quarantined tests_ ✅

</details>

_Updated: 2026-08-19T12:14:49.229Z • 0 test(s) total_
<!-- QUARANTINE-LIST:desktop:END -->

<!-- QUARANTINE-LIST:web:START -->
<details><summary>Trezor Suite (web) — 2 test(s)</summary>

| Test | Type |
|------|------|
| Trading - DEX swap (LI.FI) > User can swap ETH to USDC via LI.FI DEX | 🤖 auto |
| Quarantine test: "TrezorConnect webextension -> Suite Web,second call after popup was closed by user should work" | 🙋 manual |

</details>

_Updated: 2026-08-19T12:13:57.675Z • 2 test(s) total_
<!-- QUARANTINE-LIST:web:END -->